### PR TITLE
feat: dark mode for editor authoring UI

### DIFF
--- a/.changeset/dark-mode-editor-authoring-ui.md
+++ b/.changeset/dark-mode-editor-authoring-ui.md
@@ -8,6 +8,6 @@
 
 Editor dark mode: theme the CodeMirror code area, syntax highlighting, autocomplete icons, diagnostics/responses/help panels, viewer controls bar, and resizable handles for WCAG AA contrast in dark mode.
 
-Adds cypress-axe color-contrast coverage for the editor authoring surfaces in dark mode.
+Adds cypress-axe color-contrast coverage for representative editor authoring surfaces in dark mode.
 
 Closes #1366.

--- a/.changeset/dark-mode-editor-authoring-ui.md
+++ b/.changeset/dark-mode-editor-authoring-ui.md
@@ -6,7 +6,7 @@
 "doenet-vscode-extension": patch
 ---
 
-Editor dark mode: theme the CodeMirror code area, syntax highlighting, autocomplete icons, diagnostics/responses panels, and context-help panel for WCAG AA contrast in dark mode.
+Editor dark mode: theme the CodeMirror code area, syntax highlighting, autocomplete icons, diagnostics/responses/help panels, viewer controls bar, and resizable handles for WCAG AA contrast in dark mode.
 
 Adds cypress-axe color-contrast coverage for the editor authoring surfaces in dark mode.
 

--- a/.changeset/dark-mode-editor-authoring-ui.md
+++ b/.changeset/dark-mode-editor-authoring-ui.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor dark mode: theme the CodeMirror code area, syntax highlighting, autocomplete icons, diagnostics/responses panels, and context-help panel for WCAG AA contrast in dark mode.
+
+Adds cypress-axe color-contrast coverage for the editor authoring surfaces in dark mode.
+
+Closes #1366.

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -29,6 +29,7 @@ const CodeMirror = React.memo(function CodeMirror({
     languageServerRef,
     ariaLabel = "DoenetML code editor",
     doenetWorkerUrl,
+    darkMode = "light",
 }: {
     value: string;
     onChange?: (str: string) => void;
@@ -67,6 +68,12 @@ const CodeMirror = React.memo(function CodeMirror({
      * this is rarely an issue.
      */
     doenetWorkerUrl?: string;
+    /**
+     * Resolved theme mode for the editor.  Defaults to `"light"`.  When set
+     * to `"dark"` the CodeMirror color theme, syntax-highlight palette, and
+     * autocomplete icon colors all switch to dark-mode-verified variants.
+     */
+    darkMode?: "dark" | "light";
 }) {
     // Only one language server runs for all documents, so we specify a document id to keep different instances different.
     const [documentId, _] = React.useState(() =>
@@ -97,8 +104,8 @@ const CodeMirror = React.memo(function CodeMirror({
 
     const extensions: Extension[] = React.useMemo(() => {
         const extensions: Extension[] = [
-            syntaxHighlightingExtension,
-            readOnly ? readOnlyColorTheme : colorTheme,
+            syntaxHighlightingExtension(darkMode),
+            readOnly ? readOnlyColorTheme(darkMode) : colorTheme(darkMode),
             EditorView.lineWrapping,
             // Add aria-label to the contenteditable element for accessibility
             EditorView.contentAttributes.of({ "aria-label": ariaLabel }),
@@ -107,12 +114,12 @@ const CodeMirror = React.memo(function CodeMirror({
             extensions.push(tabExtension);
             extensions.push(autoCloseTagExtension);
             extensions.push(lspPlugin(documentId, doenetWorkerUrl));
-            extensions.push(completionIconTheme);
+            extensions.push(completionIconTheme(darkMode));
         } else {
             extensions.push(EditorState.readOnly.of(true));
         }
         return extensions;
-    }, [documentId, readOnly, ariaLabel, doenetWorkerUrl]);
+    }, [documentId, readOnly, ariaLabel, doenetWorkerUrl, darkMode]);
 
     return (
         <div className="mathjax_ignore" style={{ height: "100%" }}>

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -13,6 +13,7 @@ import {
     colorTheme,
     readOnlyColorTheme,
     completionIconTheme,
+    type ThemeMode,
 } from "./extensions/theme";
 
 /**
@@ -73,7 +74,7 @@ const CodeMirror = React.memo(function CodeMirror({
      * to `"dark"` the CodeMirror color theme, syntax-highlight palette, and
      * autocomplete icon colors all switch to dark-mode-verified variants.
      */
-    darkMode?: "dark" | "light";
+    darkMode?: ThemeMode;
 }) {
     // Only one language server runs for all documents, so we specify a document id to keep different instances different.
     const [documentId, _] = React.useState(() =>

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -122,7 +122,11 @@ const CodeMirror = React.memo(function CodeMirror({
     }, [documentId, readOnly, ariaLabel, doenetWorkerUrl, darkMode]);
 
     return (
-        <div className="mathjax_ignore" style={{ height: "100%" }}>
+        <div
+            className="mathjax_ignore"
+            data-theme={darkMode}
+            style={{ height: "100%" }}
+        >
             <ReactCodeMirror
                 style={{ height: "100%" }}
                 value={value}
@@ -155,8 +159,8 @@ const CodeMirror = React.memo(function CodeMirror({
                         }
                     }
                 }}
-                onBlur={() => onBlur && onBlur()}
-                onFocus={() => onFocus && onFocus()}
+                onBlur={onBlur}
+                onFocus={onFocus}
                 height="100%"
                 extensions={extensions}
             />

--- a/packages/codemirror/src/extensions/lsp/tooltip.css
+++ b/packages/codemirror/src/extensions/lsp/tooltip.css
@@ -120,3 +120,17 @@
 [data-theme="dark"] .cm-lint-body code {
     color: #ff7ac6;
 }
+
+/*
+ * Accessibility-diagnostic underlines under code text. The light-mode colors
+ * (#5b21b6, #9061d1) are too dark against the dark canvas (#121212), making
+ * the underlines invisible. Override to the same bright violets used for the
+ * diagnostic heading/icon accents elsewhere in dark mode.
+ */
+[data-theme="dark"] .cm-lintRange.cm-doenet-accessibility-diagnostic-level-1 {
+    text-decoration-color: #c4b5fd;
+}
+
+[data-theme="dark"] .cm-lintRange.cm-doenet-accessibility-diagnostic-level-2 {
+    text-decoration-color: #ddd6fe;
+}

--- a/packages/codemirror/src/extensions/syntax-highlighting.ts
+++ b/packages/codemirror/src/extensions/syntax-highlighting.ts
@@ -8,8 +8,7 @@ import {
 } from "@codemirror/language";
 import { parser } from "@doenet/parser";
 import { styleTags, tags as t } from "@lezer/highlight";
-
-type ThemeMode = "dark" | "light";
+import type { ThemeMode } from "./theme";
 
 const parserWithMetadata = parser.configure({
     props: [

--- a/packages/codemirror/src/extensions/syntax-highlighting.ts
+++ b/packages/codemirror/src/extensions/syntax-highlighting.ts
@@ -78,6 +78,25 @@ const doenetLanguage = LRLanguage.define({
     },
 });
 
-export const syntaxHighlightingExtension = new LanguageSupport(doenetLanguage, [
-    syntaxHighlighting(customHighlightStyle),
+// Dark canvas (#121212) syntax highlight palette — GitHub-dark-inspired.
+// All colors verified for ≥4.5:1 WCAG AA contrast on #121212.
+const darkHighlightStyle = HighlightStyle.define([
+    { tag: t.string, color: "#56d364" }, // green  ~7.1:1 on #121212
+    { tag: t.tagName, color: "#79c0ff" }, // blue   ~10:1 on #121212
+    { tag: t.angleBracket, color: "#79c0ff" }, // blue   ~10:1 on #121212
+    { tag: t.propertyName, color: "#ffa657" }, // orange ~7.4:1 on #121212
+    { tag: t.invalid, color: "#ff7b72" }, // red    ~6.4:1 on #121212
+    { tag: t.blockComment, color: "#8b949e" }, // gray   ~6.5:1 on #121212
+    { tag: t.macroName, color: "#d2a8ff" }, // purple ~9.6:1 on #121212
+    { tag: t.content, color: "#e6edf3" }, // near-white ~16:1 on #121212
+    { tag: t.definitionOperator, color: "#e6edf3" }, // near-white
+    { tag: t.character, color: "#79c0ff" }, // blue   ~10:1 on #121212
 ]);
+
+export function syntaxHighlightingExtension(darkMode: "dark" | "light") {
+    return new LanguageSupport(doenetLanguage, [
+        syntaxHighlighting(
+            darkMode === "dark" ? darkHighlightStyle : customHighlightStyle,
+        ),
+    ]);
+}

--- a/packages/codemirror/src/extensions/syntax-highlighting.ts
+++ b/packages/codemirror/src/extensions/syntax-highlighting.ts
@@ -9,6 +9,8 @@ import {
 import { parser } from "@doenet/parser";
 import { styleTags, tags as t } from "@lezer/highlight";
 
+type ThemeMode = "dark" | "light";
+
 const parserWithMetadata = parser.configure({
     props: [
         indentNodeProp.add({
@@ -55,21 +57,44 @@ const parserWithMetadata = parser.configure({
         }),
     ],
 });
+type SyntaxColors = {
+    string: string;
+    tagName: string;
+    propertyName: string;
+    invalid: string;
+    blockComment: string;
+    macroName: string;
+    content: string;
+};
+
+// Keep the tag-to-color mapping in one place so light/dark palettes can't drift.
+function createHighlightStyle(colors: SyntaxColors) {
+    return HighlightStyle.define([
+        { tag: t.string, color: colors.string },
+        { tag: t.tagName, color: colors.tagName },
+        { tag: t.angleBracket, color: colors.tagName },
+        { tag: t.propertyName, color: colors.propertyName },
+        { tag: t.invalid, color: colors.invalid },
+        { tag: t.blockComment, color: colors.blockComment },
+        { tag: t.macroName, color: colors.macroName },
+        { tag: t.content, color: colors.content },
+        { tag: t.definitionOperator, color: colors.content },
+        { tag: t.character, color: colors.tagName },
+    ]);
+}
+
 // WCAG 2.1 AA compliant color scheme for syntax highlighting
 // All colors have been chosen to meet 4.5:1 contrast ratio on white background
 // and appropriate contrast on dark backgrounds
-const customHighlightStyle = HighlightStyle.define([
-    { tag: t.string, color: "#00732f" }, // Dark green - 4.62:1 on white
-    { tag: t.tagName, color: "#0550ae" }, // Blue - 7.67:1 on white
-    { tag: t.angleBracket, color: "#0550ae" }, // Blue - 7.67:1 on white
-    { tag: t.propertyName, color: "#953800" }, // Burnt orange - 5.17:1 on white
-    { tag: t.invalid, color: "#a80000" }, // Dark red - 6.23:1 on white
-    { tag: t.blockComment, color: "#656d76" }, // Gray - 4.54:1 on white
-    { tag: t.macroName, color: "#6f42c1" }, // Purple - 5.01:1 on white
-    { tag: t.content, color: "#24292f" }, // Near black - 15.3:1 on white
-    { tag: t.definitionOperator, color: "#24292f" }, // Near black - 15.3:1 on white
-    { tag: t.character, color: "#0550ae" }, // Blue - 7.67:1 on white
-]);
+const customHighlightStyle = createHighlightStyle({
+    string: "#00732f", // Dark green - 4.62:1 on white
+    tagName: "#0550ae", // Blue - 7.67:1 on white
+    propertyName: "#953800", // Burnt orange - 5.17:1 on white
+    invalid: "#a80000", // Dark red - 6.23:1 on white
+    blockComment: "#656d76", // Gray - 4.54:1 on white
+    macroName: "#6f42c1", // Purple - 5.01:1 on white
+    content: "#24292f", // Near black - 15.3:1 on white
+});
 const doenetLanguage = LRLanguage.define({
     parser: parserWithMetadata,
     languageData: {
@@ -80,20 +105,17 @@ const doenetLanguage = LRLanguage.define({
 
 // Dark canvas (#121212) syntax highlight palette — GitHub-dark-inspired.
 // All colors verified for ≥4.5:1 WCAG AA contrast on #121212.
-const darkHighlightStyle = HighlightStyle.define([
-    { tag: t.string, color: "#56d364" }, // green  ~7.1:1 on #121212
-    { tag: t.tagName, color: "#79c0ff" }, // blue   ~10:1 on #121212
-    { tag: t.angleBracket, color: "#79c0ff" }, // blue   ~10:1 on #121212
-    { tag: t.propertyName, color: "#ffa657" }, // orange ~7.4:1 on #121212
-    { tag: t.invalid, color: "#ff7b72" }, // red    ~6.4:1 on #121212
-    { tag: t.blockComment, color: "#8b949e" }, // gray   ~6.5:1 on #121212
-    { tag: t.macroName, color: "#d2a8ff" }, // purple ~9.6:1 on #121212
-    { tag: t.content, color: "#e6edf3" }, // near-white ~16:1 on #121212
-    { tag: t.definitionOperator, color: "#e6edf3" }, // near-white
-    { tag: t.character, color: "#79c0ff" }, // blue   ~10:1 on #121212
-]);
+const darkHighlightStyle = createHighlightStyle({
+    string: "#56d364", // green  ~7.1:1 on #121212
+    tagName: "#79c0ff", // blue   ~10:1 on #121212
+    propertyName: "#ffa657", // orange ~7.4:1 on #121212
+    invalid: "#ff7b72", // red    ~6.4:1 on #121212
+    blockComment: "#8b949e", // gray   ~6.5:1 on #121212
+    macroName: "#d2a8ff", // purple ~9.6:1 on #121212
+    content: "#e6edf3", // near-white ~16:1 on #121212
+});
 
-export function syntaxHighlightingExtension(darkMode: "dark" | "light") {
+export function syntaxHighlightingExtension(darkMode: ThemeMode) {
     return new LanguageSupport(doenetLanguage, [
         syntaxHighlighting(
             darkMode === "dark" ? darkHighlightStyle : customHighlightStyle,

--- a/packages/codemirror/src/extensions/syntax-highlighting.ts
+++ b/packages/codemirror/src/extensions/syntax-highlighting.ts
@@ -13,8 +13,10 @@ import type { ThemeMode } from "./theme";
 const parserWithMetadata = parser.configure({
     props: [
         indentNodeProp.add({
-            //fun (unfixable?) glitch: If you modify the document and then create a newline before enough time has passed for a new parse (which is often < 50ms)
-            //the indent wont have time to update and you're going right back to the left side of the screen.
+            // Indentation depends on the latest parse tree. If the user edits
+            // the document and immediately inserts a newline before the parser
+            // catches up (usually within a few tens of milliseconds), the new
+            // line can momentarily fall back to column 0.
             Element(context) {
                 let closed = /^\s*<\//.test(context.textAfter);
                 return (

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -45,10 +45,8 @@ export function colorTheme(darkMode: ThemeMode) {
         },
         ".cm-content": {
             caretColor: "#0e9",
-            borderDownColor: "var(--canvasText)",
         },
         "&.cm-focused .cm-cursor": {
-            backgroundColor: "var(--lightBlue)",
             borderLeftColor: "var(--canvasText)",
         },
         "&.cm-focused .cm-selectionBackground, ::selection": {
@@ -57,7 +55,7 @@ export function colorTheme(darkMode: ThemeMode) {
         "&.cm-focused": {
             color: "var(--canvasText)",
         },
-        "cm-selectionLayer": {
+        ".cm-selectionLayer": {
             backgroundColor: "var(--mainGreen)",
         },
         ".cm-gutters": {
@@ -183,11 +181,9 @@ export function readOnlyColorTheme(darkMode: ThemeMode) {
         },
         ".cm-content": {
             caretColor: "#0e9",
-            borderDownColor: "var(--canvasText)",
             backgroundColor: "#77777720",
         },
         "&.cm-focused .cm-cursor": {
-            backgroundColor: "var(--lightBlue)",
             borderLeftColor: "var(--canvasText)",
         },
         "&.cm-focused .cm-selectionBackground, ::selection": {
@@ -196,7 +192,7 @@ export function readOnlyColorTheme(darkMode: ThemeMode) {
         "&.cm-focused": {
             color: "var(--canvasText)",
         },
-        "cm-selectionLayer": {
+        ".cm-selectionLayer": {
             backgroundColor: "var(--mainGreen)",
         },
         ".cm-gutters": {

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -31,8 +31,9 @@ function getGutterColors(darkMode: ThemeMode) {
  *  - dark:  gutter bg = #1e1e1e (VS Code-style, barely lighter than canvas)
  *           with muted text #8b949e (5.2:1 on #1e1e1e)
  *
- * The dark gutter values are also emitted in editor-viewer.css under
- * `[data-theme="dark"] .cm-gutters` for belt-and-suspenders coverage.
+ * The dark gutter values are also emitted in `editor-viewer.css` under
+ * `[data-theme="dark"] .editor-panel .cm-gutters` for belt-and-suspenders
+ * coverage inside `EditorViewer`.
  */
 export function colorTheme(darkMode: ThemeMode) {
     const gutterColors = getGutterColors(darkMode);

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -1,6 +1,6 @@
 import { EditorView } from "@codemirror/view";
 
-type ThemeMode = "dark" | "light";
+export type ThemeMode = "dark" | "light";
 
 // Shared gutter palette so editable and read-only themes stay aligned per mode.
 function getGutterColors(darkMode: ThemeMode) {
@@ -173,6 +173,8 @@ export function completionIconTheme(darkMode: ThemeMode) {
 export function readOnlyColorTheme(darkMode: ThemeMode) {
     const gutterColors = getGutterColors(darkMode);
     const lineTextColor = darkMode === "dark" ? "#c8c8c8" : "#595959";
+    const activeLineBackgroundColor =
+        darkMode === "dark" ? "#50505020" : "var(--mainGray)";
     return EditorView.theme({
         "&": {
             color: "var(--canvasText)",
@@ -203,7 +205,7 @@ export function readOnlyColorTheme(darkMode: ThemeMode) {
             borderRight: gutterColors.borderRight,
         },
         ".cm-activeLine": {
-            backgroundColor: "var(--mainGray)",
+            backgroundColor: activeLineBackgroundColor,
             color: "var(--canvasText)",
         },
         ".cm-activeLineGutter": {

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -1,125 +1,195 @@
 import { EditorView } from "@codemirror/view";
 
-// WCAG 2.1 AA compliant color theme
-export const colorTheme = EditorView.theme({
-    "&": {
-        color: "var(--canvasText)",
-        height: "100%",
-        //backgroundColor: "var(--canvas)",
-    },
-    ".cm-content": {
-        caretColor: "#0e9",
-        borderDownColor: "var(--canvasText)",
-    },
-    ".cm-editor": {
-        caretColor: "#0e9",
-        backgroundColor: "var(--canvas)",
-    },
-    "&.cm-focused .cm-cursor": {
-        backgroundColor: "var(--lightBlue)",
-        borderLeftColor: "var(--canvasText)",
-    },
-    "&.cm-focused .cm-selectionBackground, ::selection": {
-        backgroundColor: "var(--mainGray)",
-    },
-    "&.cm-focused": {
-        color: "var(--canvasText)",
-    },
-    "cm-selectionLayer": {
-        backgroundColor: "var(--mainGreen)",
-    },
-    ".cm-gutters": {
-        backgroundColor: "var(--mainGray)",
-        // Changed from "black" to ensure proper contrast on gray background
-        // #595959 has 4.54:1 contrast on #e3e3e3 (light mode mainGray)
-        color: "#595959",
-        border: "none",
-    },
-    ".cm-activeLine": {
-        backgroundColor: "#50505020",
-        color: "black",
-    },
-});
+/**
+ * WCAG 2.1 AA compliant color theme for the editable code area.
+ *
+ * `darkMode` switches a handful of colors that cannot be expressed with a
+ * single CSS variable because the light and dark gutters need different
+ * treatments:
+ *  - light: gutter bg = `--mainGray` (#e3e3e3) with text #595959 (4.54:1)
+ *  - dark:  gutter bg = #1e1e1e (VS Code-style, barely lighter than canvas)
+ *           with muted text #8b949e (5.2:1 on #1e1e1e)
+ *
+ * The dark gutter values are also emitted in editor-viewer.css under
+ * `[data-theme="dark"] .cm-gutters` for belt-and-suspenders coverage.
+ */
+export function colorTheme(darkMode: "dark" | "light") {
+    const gutterBg = darkMode === "dark" ? "#1e1e1e" : "var(--mainGray)";
+    const gutterTextColor = darkMode === "dark" ? "#8b949e" : "#595959";
+    const gutterBorder = darkMode === "dark" ? "1px solid #333" : "none";
+    return EditorView.theme({
+        "&": {
+            color: "var(--canvasText)",
+            height: "100%",
+            backgroundColor: "var(--canvas)",
+        },
+        ".cm-content": {
+            caretColor: "#0e9",
+            borderDownColor: "var(--canvasText)",
+        },
+        "&.cm-focused .cm-cursor": {
+            backgroundColor: "var(--lightBlue)",
+            borderLeftColor: "var(--canvasText)",
+        },
+        "&.cm-focused .cm-selectionBackground, ::selection": {
+            backgroundColor: "var(--mainGray)",
+        },
+        "&.cm-focused": {
+            color: "var(--canvasText)",
+        },
+        "cm-selectionLayer": {
+            backgroundColor: "var(--mainGreen)",
+        },
+        ".cm-gutters": {
+            backgroundColor: gutterBg,
+            color: gutterTextColor,
+            border: "none",
+            borderRight: gutterBorder,
+        },
+        ".cm-activeLine": {
+            backgroundColor: "#50505020",
+            // Must be explicit: CodeMirror's base theme sets activeLine color
+            // to a dark value which is invisible on a dark canvas.
+            color: "var(--canvasText)",
+        },
+        // Subtle gutter highlight on the active line — CodeMirror's base
+        // theme uses #e2f2ff (light blue) which is glaring on a dark gutter.
+        ".cm-activeLineGutter": {
+            backgroundColor:
+                darkMode === "dark" ? "#363636" : "var(--lightBlue)",
+        },
+    });
+}
 
-// Left-column glyphs for the autocomplete dropdown, one per DoenetML category.
-// CodeMirror renders these from each completion's `type` via the built-in class
-// `.cm-completionIcon-<type>` (types assigned by `deriveCompletionType` in
-// `@doenet/lsp-tools`). Its base theme only defines glyphs for a fixed set of
-// types (and dims them to 0.6 opacity), so we override the one we reuse
-// (`enum`) and add glyphs for our custom types. Uses EditorView.theme (not
-// baseTheme) so these win over CodeMirror's built-in rules by later injection
-// at equal CSS specificity. Glyph-only (CSS `::after` content) — no image
-// assets. Colors checked for WCAG AA contrast on the dropdown background;
-// opacity bumped to 1 so the color reads clearly.
-export const completionIconTheme = EditorView.theme({
-    ".cm-completionIcon-component::after": { content: '"\\25C8"' }, // ◈
-    ".cm-completionIcon-refproperty::after": { content: '"."' },
-    ".cm-completionIcon-closetag::after": { content: '"/"' },
-    ".cm-completionIcon-enum::after": { content: '"@"' }, // attribute name
-    ".cm-completionIcon-value::after": { content: '"\\25AA"' }, // ▪ (enum value)
-    ".cm-completionIcon-reference::after": { content: '"$"' },
-    ".cm-completionIcon-snippet::after": { content: '"\\274F"' }, // ❏
+/**
+ * Left-column glyphs for the autocomplete dropdown, one per DoenetML category.
+ * CodeMirror renders these from each completion's `type` via the built-in class
+ * `.cm-completionIcon-<type>` (types assigned by `deriveCompletionType` in
+ * `@doenet/lsp-tools`). Its base theme only defines glyphs for a fixed set of
+ * types (and dims them to 0.6 opacity), so we override the one we reuse
+ * (`enum`) and add glyphs for our custom types. Uses EditorView.theme (not
+ * baseTheme) so these win over CodeMirror's built-in rules by later injection
+ * at equal CSS specificity. Glyph-only (CSS `::after` content) — no image
+ * assets.
+ *
+ * Colors are chosen for WCAG AA contrast on the dropdown background surface:
+ *  - light mode: white dropdown → light-tuned palette
+ *  - dark mode:  #2a2a2a dropdown (set by tooltip.css in dark mode) → brighter palette
+ */
+export function completionIconTheme(darkMode: "dark" | "light") {
+    const colors =
+        darkMode === "dark"
+            ? {
+                  // Verified ≥4.5:1 on #2a2a2a (the dark tooltip surface)
+                  component: "#58a6ff", // blue   ~7.6:1
+                  enumAttr: "#3fb950", // green  ~7.0:1
+                  value: "#4dd0e1", // teal   ~8.8:1
+                  reference: "#bc8cff", // purple ~6.5:1
+                  snippet: "#f78166", // orange ~6.3:1
+              }
+            : {
+                  // Verified ≥4.5:1 on white dropdown
+                  component: "#1f6feb", // blue
+                  enumAttr: "#1a7f37", // green
+                  value: "#0e7c86", // teal
+                  reference: "#8250df", // purple
+                  snippet: "#bc4c00", // orange
+              };
 
-    ".cm-completionIcon-component": { color: "#1f6feb", opacity: "1" }, // blue
-    ".cm-completionIcon-enum": { color: "#1a7f37", opacity: "1" }, // green
-    ".cm-completionIcon-value": { color: "#0e7c86", opacity: "1" }, // teal
-    ".cm-completionIcon-reference": { color: "#8250df", opacity: "1" }, // purple
-    ".cm-completionIcon-refproperty": { color: "#8250df", opacity: "1" }, // purple
-    ".cm-completionIcon-snippet": { color: "#bc4c00", opacity: "1" }, // orange
-    ".cm-completionIcon-closetag": { color: "#1f6feb", opacity: "1" }, // blue
+    return EditorView.theme({
+        ".cm-completionIcon-component::after": { content: '"\\25C8"' }, // ◈
+        ".cm-completionIcon-refproperty::after": { content: '"."' },
+        ".cm-completionIcon-closetag::after": { content: '"/"' },
+        ".cm-completionIcon-enum::after": { content: '"@"' }, // attribute name
+        ".cm-completionIcon-value::after": { content: '"\\25AA"' }, // ▪ (enum value)
+        ".cm-completionIcon-reference::after": { content: '"$"' },
+        ".cm-completionIcon-snippet::after": { content: '"\\274F"' }, // ❏
 
-    // The highlighted option has a solid blue background (CodeMirror's
-    // baseTheme: #17c light / #347 dark, with white label text), against which
-    // the category colors above are nearly invisible. Render the glyph white on
-    // the selected row so it stays legible, matching the label. The descendant
-    // selector outranks the single-class color rules above, so it wins
-    // regardless of order.
-    ".cm-tooltip-autocomplete ul li[aria-selected] .cm-completionIcon": {
-        color: "#fff",
-        opacity: "1",
-    },
-});
+        ".cm-completionIcon-component": {
+            color: colors.component,
+            opacity: "1",
+        },
+        ".cm-completionIcon-enum": { color: colors.enumAttr, opacity: "1" },
+        ".cm-completionIcon-value": { color: colors.value, opacity: "1" },
+        ".cm-completionIcon-reference": {
+            color: colors.reference,
+            opacity: "1",
+        },
+        ".cm-completionIcon-refproperty": {
+            color: colors.reference,
+            opacity: "1",
+        },
+        ".cm-completionIcon-snippet": { color: colors.snippet, opacity: "1" },
+        ".cm-completionIcon-closetag": {
+            color: colors.component,
+            opacity: "1",
+        },
 
-// WCAG 2.1 AA compliant read-only color theme
-export const readOnlyColorTheme = EditorView.theme({
-    "&": {
-        color: "var(--canvasText)",
-        height: "100%",
-    },
-    ".cm-content": {
-        caretColor: "#0e9",
-        borderDownColor: "var(--canvasText)",
-        backgroundColor: "#77777720",
-    },
-    ".cm-editor": {
-        caretColor: "#0e9",
-    },
-    "&.cm-focused .cm-cursor": {
-        backgroundColor: "var(--lightBlue)",
-        borderLeftColor: "var(--canvasText)",
-    },
-    "&.cm-focused .cm-selectionBackground, ::selection": {
-        backgroundColor: "var(--mainGray)",
-    },
-    "&.cm-focused": {
-        color: "var(--canvasText)",
-    },
-    "cm-selectionLayer": {
-        backgroundColor: "var(--mainGreen)",
-    },
-    ".cm-gutters": {
-        backgroundColor: "var(--mainGray)",
-        // Changed from "black" to ensure proper contrast on gray background
-        color: "#595959",
-        border: "none",
-    },
-    ".cm-activeLine": {
-        backgroundColor: "var(--mainGray)",
-        color: "black",
-    },
-    ".cm-line": {
-        // Changed from #666666 (3.46:1 on white) to #595959 (4.54:1 on white)
-        // to meet WCAG 2.1 AA requirements (minimum 4.5:1)
-        color: "#595959",
-    },
-});
+        // The highlighted option has a solid blue background (CodeMirror's
+        // baseTheme: #17c light / #347 dark, with white label text), against
+        // which the category colors above are nearly invisible. Render the
+        // glyph white on the selected row so it stays legible, matching the
+        // label. The descendant selector outranks the single-class color rules
+        // above, so it wins regardless of order.
+        ".cm-tooltip-autocomplete ul li[aria-selected] .cm-completionIcon": {
+            color: "#fff",
+            opacity: "1",
+        },
+    });
+}
+
+/**
+ * WCAG 2.1 AA compliant read-only color theme.
+ *
+ * Read-only code gets a tinted content background and muted line text to
+ * distinguish it from the editable area. The muted color differs per mode:
+ *  - light: #595959 (4.54:1 on white)
+ *  - dark:  #c8c8c8 (muted but ~11:1 on the dark canvas #121212)
+ */
+export function readOnlyColorTheme(darkMode: "dark" | "light") {
+    const gutterBg = darkMode === "dark" ? "#1e1e1e" : "var(--mainGray)";
+    const gutterTextColor = darkMode === "dark" ? "#8b949e" : "#595959";
+    const gutterBorder = darkMode === "dark" ? "1px solid #333" : "none";
+    const lineTextColor = darkMode === "dark" ? "#c8c8c8" : "#595959";
+    return EditorView.theme({
+        "&": {
+            color: "var(--canvasText)",
+            height: "100%",
+        },
+        ".cm-content": {
+            caretColor: "#0e9",
+            borderDownColor: "var(--canvasText)",
+            backgroundColor: "#77777720",
+        },
+        "&.cm-focused .cm-cursor": {
+            backgroundColor: "var(--lightBlue)",
+            borderLeftColor: "var(--canvasText)",
+        },
+        "&.cm-focused .cm-selectionBackground, ::selection": {
+            backgroundColor: "var(--mainGray)",
+        },
+        "&.cm-focused": {
+            color: "var(--canvasText)",
+        },
+        "cm-selectionLayer": {
+            backgroundColor: "var(--mainGreen)",
+        },
+        ".cm-gutters": {
+            backgroundColor: gutterBg,
+            color: gutterTextColor,
+            border: "none",
+            borderRight: gutterBorder,
+        },
+        ".cm-activeLine": {
+            backgroundColor: "var(--mainGray)",
+            color: "var(--canvasText)",
+        },
+        ".cm-activeLineGutter": {
+            backgroundColor:
+                darkMode === "dark" ? "#363636" : "var(--lightBlue)",
+        },
+        ".cm-line": {
+            color: lineTextColor,
+        },
+    });
+}

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -55,9 +55,6 @@ export function colorTheme(darkMode: ThemeMode) {
         "&.cm-focused": {
             color: "var(--canvasText)",
         },
-        ".cm-selectionLayer": {
-            backgroundColor: "var(--mainGreen)",
-        },
         ".cm-gutters": {
             backgroundColor: gutterColors.backgroundColor,
             color: gutterColors.textColor,
@@ -191,9 +188,6 @@ export function readOnlyColorTheme(darkMode: ThemeMode) {
         },
         "&.cm-focused": {
             color: "var(--canvasText)",
-        },
-        ".cm-selectionLayer": {
-            backgroundColor: "var(--mainGreen)",
         },
         ".cm-gutters": {
             backgroundColor: gutterColors.backgroundColor,

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -2,7 +2,7 @@ import { EditorView } from "@codemirror/view";
 
 export type ThemeMode = "dark" | "light";
 
-// Shared gutter palette so editable and read-only themes stay aligned per mode.
+// Shared gutter palette used by both the editable and read-only themes to keep colors aligned per mode.
 function getGutterColors(darkMode: ThemeMode) {
     if (darkMode === "dark") {
         return {

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -1,5 +1,26 @@
 import { EditorView } from "@codemirror/view";
 
+type ThemeMode = "dark" | "light";
+
+// Shared gutter palette so editable and read-only themes stay aligned per mode.
+function getGutterColors(darkMode: ThemeMode) {
+    if (darkMode === "dark") {
+        return {
+            backgroundColor: "#1e1e1e",
+            textColor: "#8b949e",
+            borderRight: "1px solid #333",
+            activeLineBackgroundColor: "#363636",
+        };
+    }
+
+    return {
+        backgroundColor: "var(--mainGray)",
+        textColor: "#595959",
+        borderRight: "none",
+        activeLineBackgroundColor: "var(--lightBlue)",
+    };
+}
+
 /**
  * WCAG 2.1 AA compliant color theme for the editable code area.
  *
@@ -13,10 +34,8 @@ import { EditorView } from "@codemirror/view";
  * The dark gutter values are also emitted in editor-viewer.css under
  * `[data-theme="dark"] .cm-gutters` for belt-and-suspenders coverage.
  */
-export function colorTheme(darkMode: "dark" | "light") {
-    const gutterBg = darkMode === "dark" ? "#1e1e1e" : "var(--mainGray)";
-    const gutterTextColor = darkMode === "dark" ? "#8b949e" : "#595959";
-    const gutterBorder = darkMode === "dark" ? "1px solid #333" : "none";
+export function colorTheme(darkMode: ThemeMode) {
+    const gutterColors = getGutterColors(darkMode);
     return EditorView.theme({
         "&": {
             color: "var(--canvasText)",
@@ -41,10 +60,10 @@ export function colorTheme(darkMode: "dark" | "light") {
             backgroundColor: "var(--mainGreen)",
         },
         ".cm-gutters": {
-            backgroundColor: gutterBg,
-            color: gutterTextColor,
+            backgroundColor: gutterColors.backgroundColor,
+            color: gutterColors.textColor,
             border: "none",
-            borderRight: gutterBorder,
+            borderRight: gutterColors.borderRight,
         },
         ".cm-activeLine": {
             backgroundColor: "#50505020",
@@ -55,10 +74,32 @@ export function colorTheme(darkMode: "dark" | "light") {
         // Subtle gutter highlight on the active line — CodeMirror's base
         // theme uses #e2f2ff (light blue) which is glaring on a dark gutter.
         ".cm-activeLineGutter": {
-            backgroundColor:
-                darkMode === "dark" ? "#363636" : "var(--lightBlue)",
+            backgroundColor: gutterColors.activeLineBackgroundColor,
         },
     });
+}
+
+// Shared icon palette so all completion types flip together between modes.
+function getCompletionIconColors(darkMode: ThemeMode) {
+    if (darkMode === "dark") {
+        return {
+            // Verified ≥4.5:1 on #2a2a2a (the dark tooltip surface)
+            component: "#58a6ff", // blue   ~7.6:1
+            enumAttr: "#3fb950", // green  ~7.0:1
+            value: "#4dd0e1", // teal   ~8.8:1
+            reference: "#bc8cff", // purple ~6.5:1
+            snippet: "#f78166", // orange ~6.3:1
+        };
+    }
+
+    return {
+        // Verified ≥4.5:1 on white dropdown
+        component: "#1f6feb", // blue
+        enumAttr: "#1a7f37", // green
+        value: "#0e7c86", // teal
+        reference: "#8250df", // purple
+        snippet: "#bc4c00", // orange
+    };
 }
 
 /**
@@ -76,25 +117,8 @@ export function colorTheme(darkMode: "dark" | "light") {
  *  - light mode: white dropdown → light-tuned palette
  *  - dark mode:  #2a2a2a dropdown (set by tooltip.css in dark mode) → brighter palette
  */
-export function completionIconTheme(darkMode: "dark" | "light") {
-    const colors =
-        darkMode === "dark"
-            ? {
-                  // Verified ≥4.5:1 on #2a2a2a (the dark tooltip surface)
-                  component: "#58a6ff", // blue   ~7.6:1
-                  enumAttr: "#3fb950", // green  ~7.0:1
-                  value: "#4dd0e1", // teal   ~8.8:1
-                  reference: "#bc8cff", // purple ~6.5:1
-                  snippet: "#f78166", // orange ~6.3:1
-              }
-            : {
-                  // Verified ≥4.5:1 on white dropdown
-                  component: "#1f6feb", // blue
-                  enumAttr: "#1a7f37", // green
-                  value: "#0e7c86", // teal
-                  reference: "#8250df", // purple
-                  snippet: "#bc4c00", // orange
-              };
+export function completionIconTheme(darkMode: ThemeMode) {
+    const colors = getCompletionIconColors(darkMode);
 
     return EditorView.theme({
         ".cm-completionIcon-component::after": { content: '"\\25C8"' }, // ◈
@@ -146,10 +170,8 @@ export function completionIconTheme(darkMode: "dark" | "light") {
  *  - light: #595959 (4.54:1 on white)
  *  - dark:  #c8c8c8 (muted but ~11:1 on the dark canvas #121212)
  */
-export function readOnlyColorTheme(darkMode: "dark" | "light") {
-    const gutterBg = darkMode === "dark" ? "#1e1e1e" : "var(--mainGray)";
-    const gutterTextColor = darkMode === "dark" ? "#8b949e" : "#595959";
-    const gutterBorder = darkMode === "dark" ? "1px solid #333" : "none";
+export function readOnlyColorTheme(darkMode: ThemeMode) {
+    const gutterColors = getGutterColors(darkMode);
     const lineTextColor = darkMode === "dark" ? "#c8c8c8" : "#595959";
     return EditorView.theme({
         "&": {
@@ -175,18 +197,17 @@ export function readOnlyColorTheme(darkMode: "dark" | "light") {
             backgroundColor: "var(--mainGreen)",
         },
         ".cm-gutters": {
-            backgroundColor: gutterBg,
-            color: gutterTextColor,
+            backgroundColor: gutterColors.backgroundColor,
+            color: gutterColors.textColor,
             border: "none",
-            borderRight: gutterBorder,
+            borderRight: gutterColors.borderRight,
         },
         ".cm-activeLine": {
             backgroundColor: "var(--mainGray)",
             color: "var(--canvasText)",
         },
         ".cm-activeLineGutter": {
-            backgroundColor:
-                darkMode === "dark" ? "#363636" : "var(--lightBlue)",
+            backgroundColor: gutterColors.activeLineBackgroundColor,
         },
         ".cm-line": {
             color: lineTextColor,

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./CodeMirror";
+export type { ThemeMode } from "./extensions/theme";
 export type { LSP } from "./extensions/lsp/worker";

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -1003,16 +1003,18 @@ export const EditorViewer = React.forwardRef<
 
     if (!showViewer) {
         return (
-            <div
-                style={{
-                    display: "flex",
-                    width: width,
-                    height: height,
-                    border: border,
-                    boxSizing: "border-box",
-                }}
-            >
-                {editorPanel}
+            <div data-theme={darkMode} style={{ display: "contents" }}>
+                <div
+                    style={{
+                        display: "flex",
+                        width: width,
+                        height: height,
+                        border: border,
+                        boxSizing: "border-box",
+                    }}
+                >
+                    {editorPanel}
+                </div>
             </div>
         );
     }
@@ -1043,6 +1045,7 @@ export const EditorViewer = React.forwardRef<
                 accessibilityLevel2Count={accessibilityLevel2Count}
                 isAccessibilityReportOpen={isAccessibilityReportOpen}
                 onToggleAccessibilityReport={toggleAccessibilityReport}
+                darkMode={darkMode}
             />
             <div
                 className="viewer"
@@ -1093,17 +1096,19 @@ export const EditorViewer = React.forwardRef<
     const viewerFirst = viewerLocation === "left" || viewerLocation === "top";
 
     return (
-        <ResizablePanelPair
-            panelA={viewerFirst ? viewerPanel : editorPanel}
-            panelB={viewerFirst ? editorPanel : viewerPanel}
-            preferredDirection={
-                viewerLocation === "bottom" || viewerLocation === "top"
-                    ? "vertical"
-                    : "horizontal"
-            }
-            width={width}
-            height={height}
-            border={border}
-        />
+        <div data-theme={darkMode} style={{ display: "contents" }}>
+            <ResizablePanelPair
+                panelA={viewerFirst ? viewerPanel : editorPanel}
+                panelB={viewerFirst ? editorPanel : viewerPanel}
+                preferredDirection={
+                    viewerLocation === "bottom" || viewerLocation === "top"
+                        ? "vertical"
+                        : "horizontal"
+                }
+                width={width}
+                height={height}
+                border={border}
+            />
+        </div>
     );
 });

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 import { flushSync } from "react-dom";
 import { ResizablePanelPair } from "@doenet/ui-components";
-import { CodeMirror, LSP, type ThemeMode } from "@doenet/codemirror";
+import { CodeMirror, LSP } from "@doenet/codemirror";
 import "@doenet/codemirror/style.css";
 import { DocViewer } from "../Viewer/DocViewer";
 import { DiagnosticsResponseTabContents } from "./DiagnosticsResponseTabs";
@@ -27,7 +27,8 @@ import { EditorFooter } from "./EditorFooter";
 import { ViewerControlsBar } from "./ViewerControlsBar";
 import "./editor-viewer.css";
 import { useTabStore } from "@ariakit/react";
-import { setVariantsFromCallback } from "../utils/variants";
+import type { ResolvedTheme } from "../utils/theme";
+import { setVariantsFromCallback, type VariantsState } from "../utils/variants";
 import type { DiagnosticsSummary } from "./diagnostics";
 import {
     mergeDiagnosticsByType,
@@ -87,7 +88,7 @@ type EditorViewerProps = {
     prefixForIds?: string;
     doenetViewerUrl?: string;
     doenetMediaUrl?: string;
-    darkMode?: ThemeMode;
+    darkMode?: ResolvedTheme;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
     width?: string;
@@ -204,7 +205,7 @@ export const EditorViewer = React.forwardRef<
 
     const [viewerResetNum, setViewerResetNum] = useState(0);
 
-    const [variants, setVariants] = useState({
+    const [variants, setVariants] = useState<VariantsState>({
         index: 1,
         numVariants: 1,
         allPossibleVariants: ["a"],

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -908,6 +908,7 @@ export const EditorViewer = React.forwardRef<
             onSelectedCompletionChange={onSelectedCompletionChange}
             languageServerRef={lspRef}
             doenetWorkerUrl={doenetGlobalConfig.doenetWorkerUrl}
+            darkMode={darkMode}
         />
     );
 

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 import { flushSync } from "react-dom";
 import { ResizablePanelPair } from "@doenet/ui-components";
-import { CodeMirror, LSP } from "@doenet/codemirror";
+import { CodeMirror, LSP, type ThemeMode } from "@doenet/codemirror";
 import "@doenet/codemirror/style.css";
 import { DocViewer } from "../Viewer/DocViewer";
 import { DiagnosticsResponseTabContents } from "./DiagnosticsResponseTabs";
@@ -87,7 +87,7 @@ type EditorViewerProps = {
     prefixForIds?: string;
     doenetViewerUrl?: string;
     doenetMediaUrl?: string;
-    darkMode?: "dark" | "light";
+    darkMode?: ThemeMode;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
     width?: string;

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -135,6 +135,35 @@ type EditorViewerProps = {
     initialOpenTab?: DiagnosticsTabId | null;
 };
 
+type TabVisibilityOptions = Pick<
+    EditorViewerProps,
+    "showDiagnostics" | "showResponses" | "showHelp"
+>;
+
+function firstEnabledTab({
+    showDiagnostics,
+    showResponses,
+    showHelp,
+}: TabVisibilityOptions): DiagnosticsTabId | null {
+    if (showHelp) return "help";
+    if (showDiagnostics) return "errors";
+    if (showResponses) return "responses";
+    return null;
+}
+
+function isTabEnabled(
+    tabId: DiagnosticsTabId,
+    { showDiagnostics, showResponses, showHelp }: TabVisibilityOptions,
+) {
+    if (tabId === "responses") {
+        return showResponses;
+    }
+    if (tabId === "help") {
+        return showHelp;
+    }
+    return showDiagnostics;
+}
+
 /**
  * Combined DoenetML editor/viewer shell with diagnostics, responses, formatting, and variants.
  */
@@ -210,16 +239,7 @@ export const EditorViewer = React.forwardRef<
         numVariants: 1,
         allPossibleVariants: ["a"],
     });
-
-    // First enabled tab in the canonical order (help → errors → responses), or
-    // `null` if no tabs are enabled. Used both for the `initialOpenTab` fallback
-    // and as the tab store's `defaultSelectedId` when the panel mounts closed.
-    function firstEnabledTab(): DiagnosticsTabId | null {
-        if (showHelp) return "help";
-        if (showDiagnostics) return "errors";
-        if (showResponses) return "responses";
-        return null;
-    }
+    const tabVisibility = { showDiagnostics, showResponses, showHelp };
 
     // Resolve `initialOpenTab` once at mount:
     //  - `null`               → panel closed at mount
@@ -240,19 +260,13 @@ export const EditorViewer = React.forwardRef<
         }
         if (initialOpenTab === undefined) {
             return {
-                resolvedInitialOpenTab: firstEnabledTab(),
+                resolvedInitialOpenTab: firstEnabledTab(tabVisibility),
                 initialOpenTabWarning: null,
             };
         }
-        const tabEnabled =
-            initialOpenTab === "responses"
-                ? showResponses
-                : initialOpenTab === "help"
-                  ? showHelp
-                  : showDiagnostics;
-        if (!tabEnabled) {
+        if (!isTabEnabled(initialOpenTab, tabVisibility)) {
             return {
-                resolvedInitialOpenTab: firstEnabledTab(),
+                resolvedInitialOpenTab: firstEnabledTab(tabVisibility),
                 initialOpenTabWarning: `DoenetEditor: initialOpenTab="${initialOpenTab}" is not enabled (showDiagnostics=${showDiagnostics}, showResponses=${showResponses}, showHelp=${showHelp}); falling back to default.`,
             };
         }
@@ -324,7 +338,9 @@ export const EditorViewer = React.forwardRef<
     // store's selectedId is unobservable — `undefined` is fine.
     const tabStore = useTabStore({
         defaultSelectedId:
-            resolvedInitialOpenTab ?? firstEnabledTab() ?? undefined,
+            resolvedInitialOpenTab ??
+            firstEnabledTab(tabVisibility) ??
+            undefined,
     });
     const selectedTabId = tabStore.useState("selectedId");
     const isAccessibilityReportOpen =
@@ -396,13 +412,7 @@ export const EditorViewer = React.forwardRef<
         ref,
         () => ({
             openDiagnosticsTab(tabId: DiagnosticsTabId) {
-                const tabEnabled =
-                    tabId === "responses"
-                        ? showResponses
-                        : tabId === "help"
-                          ? showHelp
-                          : showDiagnostics;
-                if (!tabEnabled) {
+                if (!isTabEnabled(tabId, tabVisibility)) {
                     console.warn(
                         `DoenetEditor: openDiagnosticsTab("${tabId}") ignored — tab is not enabled (showDiagnostics=${showDiagnostics}, showResponses=${showResponses}, showHelp=${showHelp}).`,
                     );

--- a/packages/doenetml/src/EditorViewer/VariantSelect.tsx
+++ b/packages/doenetml/src/EditorViewer/VariantSelect.tsx
@@ -5,27 +5,22 @@ import type { ResolvedTheme } from "../utils/theme";
 import "./variant-select.css";
 
 export default function VariantSelect({
-    size = "sm",
-    menuWidth,
     darkMode = "light",
     array = [],
     onChange = () => {},
     syncIndex, //Optional attribute to keep several variant selects in sync
 }: {
-    size: "sm" | "md" | "lg";
-    menuWidth: string;
     darkMode?: ResolvedTheme;
     array: string[];
     onChange: (index: number) => void;
     syncIndex?: number;
 }) {
     const [index, setIndex] = useState(0);
-    const [value, setValue] = useState(array[index]);
     const [inputValue, setInputValue] = useState("");
+    const value = array[index] ?? "";
 
     function selectIndex(nextIndex: number) {
         setIndex(nextIndex);
-        setValue(array[nextIndex]);
         setInputValue("");
         onChange(nextIndex);
     }
@@ -33,7 +28,7 @@ export default function VariantSelect({
     useEffect(() => {
         if (syncIndex != undefined && index != syncIndex - 1) {
             setIndex(syncIndex - 1);
-            setValue(array[syncIndex - 1]);
+            setInputValue("");
         }
     }, [index, syncIndex, array]);
 
@@ -54,10 +49,11 @@ export default function VariantSelect({
                 >
                     <Ariakit.SelectProvider
                         value={value}
-                        defaultValue={value}
                         setValue={(val) => {
-                            const index = array.indexOf(val);
-                            selectIndex(index);
+                            const nextIndex = array.indexOf(val);
+                            if (nextIndex !== -1) {
+                                selectIndex(nextIndex);
+                            }
                         }}
                     >
                         <Ariakit.Select

--- a/packages/doenetml/src/EditorViewer/VariantSelect.tsx
+++ b/packages/doenetml/src/EditorViewer/VariantSelect.tsx
@@ -64,7 +64,7 @@ export default function VariantSelect({
                         }}
                     >
                         <Ariakit.Select
-                            className="button select-button"
+                            className="doenet-ui-button button select-button"
                             title="Variant"
                         />
                         <Ariakit.SelectPopover
@@ -97,7 +97,7 @@ export default function VariantSelect({
             <Ariakit.Button
                 title="Select next variant"
                 data-test="Next Variant"
-                className="button prev-next-button"
+                className="doenet-ui-button button prev-next-button"
                 disabled={index == array.length - 1}
                 onClick={() => {
                     if (index == array.length - 1) {
@@ -111,7 +111,7 @@ export default function VariantSelect({
             <Ariakit.Button
                 title="Select previous variant"
                 data-test="Previous Variant"
-                className="button prev-next-button"
+                className="doenet-ui-button button prev-next-button"
                 disabled={index < 1}
                 onClick={() => {
                     if (index < 1) {

--- a/packages/doenetml/src/EditorViewer/VariantSelect.tsx
+++ b/packages/doenetml/src/EditorViewer/VariantSelect.tsx
@@ -1,7 +1,7 @@
 import * as Ariakit from "@ariakit/react";
-import type { ThemeMode } from "@doenet/codemirror";
 import React, { useEffect, useState } from "react";
 import { BsCaretDownFill, BsCaretUpFill } from "react-icons/bs";
+import type { ResolvedTheme } from "../utils/theme";
 import "./variant-select.css";
 
 export default function VariantSelect({
@@ -14,7 +14,7 @@ export default function VariantSelect({
 }: {
     size: "sm" | "md" | "lg";
     menuWidth: string;
-    darkMode?: ThemeMode;
+    darkMode?: ResolvedTheme;
     array: string[];
     onChange: (index: number) => void;
     syncIndex?: number;
@@ -22,9 +22,6 @@ export default function VariantSelect({
     const [index, setIndex] = useState(0);
     const [value, setValue] = useState(array[index]);
     const [inputValue, setInputValue] = useState("");
-
-    const [showTooltip, setShowTooltip] = useState(false);
-    const [menuIsOpen, setMenuIsOpen] = useState(false);
 
     function selectIndex(nextIndex: number) {
         setIndex(nextIndex);

--- a/packages/doenetml/src/EditorViewer/VariantSelect.tsx
+++ b/packages/doenetml/src/EditorViewer/VariantSelect.tsx
@@ -1,4 +1,5 @@
 import * as Ariakit from "@ariakit/react";
+import type { ThemeMode } from "@doenet/codemirror";
 import React, { useEffect, useState } from "react";
 import { BsCaretDownFill, BsCaretUpFill } from "react-icons/bs";
 import "./variant-select.css";
@@ -13,7 +14,7 @@ export default function VariantSelect({
 }: {
     size: "sm" | "md" | "lg";
     menuWidth: string;
-    darkMode?: "dark" | "light";
+    darkMode?: ThemeMode;
     array: string[];
     onChange: (index: number) => void;
     syncIndex?: number;

--- a/packages/doenetml/src/EditorViewer/VariantSelect.tsx
+++ b/packages/doenetml/src/EditorViewer/VariantSelect.tsx
@@ -25,6 +25,13 @@ export default function VariantSelect({
     const [showTooltip, setShowTooltip] = useState(false);
     const [menuIsOpen, setMenuIsOpen] = useState(false);
 
+    function selectIndex(nextIndex: number) {
+        setIndex(nextIndex);
+        setValue(array[nextIndex]);
+        setInputValue("");
+        onChange(nextIndex);
+    }
+
     useEffect(() => {
         if (syncIndex != undefined && index != syncIndex - 1) {
             setIndex(syncIndex - 1);
@@ -52,10 +59,7 @@ export default function VariantSelect({
                         defaultValue={value}
                         setValue={(val) => {
                             const index = array.indexOf(val);
-                            setIndex(index);
-                            setValue(val);
-                            setInputValue("");
-                            onChange(index);
+                            selectIndex(index);
                         }}
                     >
                         <Ariakit.Select
@@ -98,11 +102,7 @@ export default function VariantSelect({
                     if (index == array.length - 1) {
                         return;
                     }
-                    const nextIndex = index + 1;
-                    setIndex(nextIndex);
-                    setValue(array[nextIndex]);
-                    setInputValue("");
-                    onChange(nextIndex);
+                    selectIndex(index + 1);
                 }}
             >
                 <BsCaretDownFill />
@@ -116,11 +116,7 @@ export default function VariantSelect({
                     if (index < 1) {
                         return;
                     }
-                    const nextIndex = index - 1;
-                    setIndex(nextIndex);
-                    setValue(array[nextIndex]);
-                    setInputValue("");
-                    onChange(nextIndex);
+                    selectIndex(index - 1);
                 }}
             >
                 <BsCaretUpFill />

--- a/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
+++ b/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
@@ -30,6 +30,7 @@ export function ViewerControlsBar({
     accessibilityLevel2Count,
     isAccessibilityReportOpen,
     onToggleAccessibilityReport,
+    darkMode,
 }: {
     id: string;
     readOnly: boolean;
@@ -44,6 +45,7 @@ export function ViewerControlsBar({
     accessibilityLevel2Count: number;
     isAccessibilityReportOpen: boolean;
     onToggleAccessibilityReport: () => void;
+    darkMode: "dark" | "light";
 }) {
     return (
         <div className="viewer-controls" id={`${id}-viewer-controls`}>
@@ -71,6 +73,7 @@ export function ViewerControlsBar({
                 <VariantSelect
                     size="sm"
                     menuWidth="140px"
+                    darkMode={darkMode}
                     array={variants.allPossibleVariants}
                     syncIndex={variants.index}
                     onChange={(index: number) =>

--- a/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
+++ b/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { ThemeMode } from "@doenet/codemirror";
 import { UiButton } from "@doenet/ui-components";
 import { isMacPlatform } from "@doenet/utils";
 import { RxUpdate } from "react-icons/rx";
@@ -7,12 +6,9 @@ import { BsExclamationTriangleFill } from "react-icons/bs";
 import { AccessibilityStatusButton } from "./AccessibilityStatusButton";
 // @ts-ignore
 import VariantSelect from "./VariantSelect";
-
-type VariantsState = {
-    index: number;
-    numVariants: number;
-    allPossibleVariants: string[];
-};
+import type { ResolvedTheme } from "../utils/theme";
+import { setVariantIndex } from "../utils/variants";
+import type { VariantsState } from "../utils/variants";
 
 /**
  * Header controls above the viewer: update/reset, variant selection, and accessibility status.
@@ -46,7 +42,7 @@ export function ViewerControlsBar({
     accessibilityLevel2Count: number;
     isAccessibilityReportOpen: boolean;
     onToggleAccessibilityReport: () => void;
-    darkMode: ThemeMode;
+    darkMode: ResolvedTheme;
 }) {
     return (
         <div className="viewer-controls" id={`${id}-viewer-controls`}>
@@ -78,11 +74,7 @@ export function ViewerControlsBar({
                     array={variants.allPossibleVariants}
                     syncIndex={variants.index}
                     onChange={(index: number) =>
-                        setVariants((prev) => {
-                            let next = { ...prev };
-                            next.index = index + 1;
-                            return next;
-                        })
+                        setVariantIndex(setVariants, index)
                     }
                 />
             )}

--- a/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
+++ b/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { ThemeMode } from "@doenet/codemirror";
 import { UiButton } from "@doenet/ui-components";
 import { isMacPlatform } from "@doenet/utils";
 import { RxUpdate } from "react-icons/rx";
@@ -45,7 +46,7 @@ export function ViewerControlsBar({
     accessibilityLevel2Count: number;
     isAccessibilityReportOpen: boolean;
     onToggleAccessibilityReport: () => void;
-    darkMode: "dark" | "light";
+    darkMode: ThemeMode;
 }) {
     return (
         <div className="viewer-controls" id={`${id}-viewer-controls`}>

--- a/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
+++ b/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
@@ -4,7 +4,6 @@ import { isMacPlatform } from "@doenet/utils";
 import { RxUpdate } from "react-icons/rx";
 import { BsExclamationTriangleFill } from "react-icons/bs";
 import { AccessibilityStatusButton } from "./AccessibilityStatusButton";
-// @ts-ignore
 import VariantSelect from "./VariantSelect";
 import type { ResolvedTheme } from "../utils/theme";
 import { setVariantIndex } from "../utils/variants";
@@ -68,8 +67,6 @@ export function ViewerControlsBar({
             )}
             {variants.numVariants > 1 && (
                 <VariantSelect
-                    size="sm"
-                    menuWidth="140px"
                     darkMode={darkMode}
                     array={variants.allPossibleVariants}
                     syncIndex={variants.index}

--- a/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
+++ b/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
@@ -330,6 +330,7 @@
 
 /* Muted secondary text — #94a3b8 ≈ 7.7:1 on #121212 */
 [data-theme="dark"] .editor-panel .help-panel-empty,
+[data-theme="dark"] .editor-panel .help-placeholder,
 [data-theme="dark"] .editor-panel .help-kind-label,
 [data-theme="dark"] .editor-panel .help-detail-label,
 [data-theme="dark"] .editor-panel .help-detail-annotation,

--- a/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
+++ b/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
@@ -312,3 +312,60 @@
 .editor-panel .help-docs-link:focus {
     text-decoration: underline;
 }
+
+/* ============================================================
+ * Dark mode overrides for the context-help panel
+ *
+ * Light-mode muted grays (#667085, #475467, #344054) have
+ * insufficient contrast on the dark canvas (#121212):
+ *   #667085 → ~3.9:1 (fails 4.5:1), #344054 → worse.
+ *
+ * Blue accents: var(--mainBlue) = #1a5a99 is only ~1.9:1 on
+ * #121212 in dark mode. Override locally to #79c0ff (~10:1).
+ *
+ * Chip/code backgrounds: var(--mainGray) = #a9a9a9 in dark mode,
+ * which gives only 2.3:1 contrast with white (var(--canvasText)).
+ * Override to an elevated dark surface (#2a2a2a, same as tooltips).
+ * ============================================================ */
+
+/* Muted secondary text — #94a3b8 ≈ 7.7:1 on #121212 */
+[data-theme="dark"] .editor-panel .help-panel-empty,
+[data-theme="dark"] .editor-panel .help-kind-label,
+[data-theme="dark"] .editor-panel .help-detail-label,
+[data-theme="dark"] .editor-panel .help-detail-annotation,
+[data-theme="dark"] .editor-panel .help-suggestions-footer,
+[data-theme="dark"] .editor-panel .help-ref-derived {
+    color: #94a3b8;
+}
+
+/* Slightly stronger muted text — #cbd5e1 ≈ 11.7:1 on #121212 */
+[data-theme="dark"] .editor-panel .help-allowed-values-list dd,
+[data-theme="dark"] .editor-panel .help-style-breakdown-list dt,
+[data-theme="dark"] .editor-panel .help-suggestion-summary {
+    color: #cbd5e1;
+}
+
+/* Blue accent text — #79c0ff ≈ 10:1 on #121212 */
+[data-theme="dark"] .editor-panel a.help-element-name-link,
+[data-theme="dark"] .editor-panel .help-attribute-name,
+[data-theme="dark"] .editor-panel .help-property-name,
+[data-theme="dark"] .editor-panel .help-snippet-name,
+[data-theme="dark"] .editor-panel .help-detail-value,
+[data-theme="dark"] .editor-panel .help-docs-link {
+    color: #79c0ff;
+}
+
+/* Chip and inline-code backgrounds — elevated dark surface so white text passes */
+[data-theme="dark"] .editor-panel .help-snippet-preview,
+[data-theme="dark"] .editor-panel .help-value-item,
+[data-theme="dark"] .editor-panel .help-style-breakdown-list dd,
+[data-theme="dark"] .editor-panel .help-description code,
+[data-theme="dark"] .editor-panel .help-ref-sentence code,
+[data-theme="dark"] .editor-panel .help-ref-derived code,
+[data-theme="dark"] .editor-panel .help-value-description code,
+[data-theme="dark"] .editor-panel .help-suggestions-header code,
+[data-theme="dark"] .editor-panel .help-suggestions-footer code,
+[data-theme="dark"] .editor-panel .help-placeholder code {
+    background: #2a2a2a;
+    color: var(--canvasText);
+}

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -421,6 +421,7 @@
  */
 [data-theme="dark"] .editor-panel .editor-footer {
     background-color: #1e1e1e;
+    color: #cbd5e1;
 }
 
 [data-theme="dark"] .viewer-panel .viewer-controls {
@@ -447,6 +448,18 @@
 [data-theme="dark"] .editor-panel .footer-menu-button:hover,
 [data-theme="dark"] .editor-panel .footer-icons button:hover {
     background-color: rgba(255, 255, 255, 0.12);
+}
+
+/*
+ * Footer copy. Light-mode defaults rely on inherited black text, which falls
+ * below contrast on the dark toolbar. Use the same bright-muted text across
+ * the version stamp, help label, and zero-count badges so the whole footer
+ * reads consistently.
+ */
+[data-theme="dark"] .editor-panel .doenetml-version,
+[data-theme="dark"] .editor-panel .diagnostic-tab-label,
+[data-theme="dark"] .editor-panel .diagnostic-tab-count {
+    color: #cbd5e1;
 }
 
 /*
@@ -539,7 +552,15 @@
     border-color: #444;
 }
 
+[data-theme="dark"] .editor-panel .accessibility-report-intro {
+    color: #cbd5e1;
+}
+
 [data-theme="dark"] .editor-panel .accessibility-report a {
+    color: #79c0ff;
+}
+
+[data-theme="dark"] .editor-panel .accessibility-report a:visited {
     color: #79c0ff;
 }
 

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -372,34 +372,51 @@
  * Scrollbars. Light-mode OS scrollbars are glaring on a dark canvas.
  * `scrollbar-color` is the standard property (Firefox + Chromium ≥121).
  * `::-webkit-scrollbar` rules cover Chromium for full cross-browser support.
- * Applied broadly to any scrollable surface inside the editor wrapper so
- * the diagnostics panel, viewer, and any future scrollable area all match.
+ *
+ * Note: `scrollbar-color` is NOT inherited, so each scroll container must be
+ * targeted directly. The known scroll containers are:
+ *   - `.diagnostics-response-tabs-panels` — the diagnostics/help/responses panel
+ *   - `.viewer-panel .viewer`              — the viewer content area
+ *   - `.cm-scroller`                       — CodeMirror's own scroll container
  */
-[data-theme="dark"] .editor-panel,
-[data-theme="dark"] .viewer-panel .viewer {
+[data-theme="dark"] .editor-panel .diagnostics-response-tabs-panels,
+[data-theme="dark"] .viewer-panel .viewer,
+[data-theme="dark"] .editor-panel .cm-scroller {
     scrollbar-color: #555 #1e1e1e;
 }
 
-[data-theme="dark"] .editor-panel ::-webkit-scrollbar,
-[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar {
+[data-theme="dark"]
+    .editor-panel
+    .diagnostics-response-tabs-panels::-webkit-scrollbar,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar,
+[data-theme="dark"] .editor-panel .cm-scroller::-webkit-scrollbar {
     width: 8px;
     height: 8px;
 }
 
-[data-theme="dark"] .editor-panel ::-webkit-scrollbar-track,
-[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-track {
+[data-theme="dark"]
+    .editor-panel
+    .diagnostics-response-tabs-panels::-webkit-scrollbar-track,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-track,
+[data-theme="dark"] .editor-panel .cm-scroller::-webkit-scrollbar-track {
     background: #1e1e1e;
 }
 
-[data-theme="dark"] .editor-panel ::-webkit-scrollbar-thumb,
-[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-thumb {
+[data-theme="dark"]
+    .editor-panel
+    .diagnostics-response-tabs-panels::-webkit-scrollbar-thumb,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-thumb,
+[data-theme="dark"] .editor-panel .cm-scroller::-webkit-scrollbar-thumb {
     background-color: #555;
     border-radius: 4px;
     border: 2px solid #1e1e1e;
 }
 
-[data-theme="dark"] .editor-panel ::-webkit-scrollbar-thumb:hover,
-[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-thumb:hover {
+[data-theme="dark"]
+    .editor-panel
+    .diagnostics-response-tabs-panels::-webkit-scrollbar-thumb:hover,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-thumb:hover,
+[data-theme="dark"] .editor-panel .cm-scroller::-webkit-scrollbar-thumb:hover {
     background-color: #777;
 }
 

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -539,6 +539,10 @@
     border-color: #444;
 }
 
+[data-theme="dark"] .editor-panel .accessibility-report a {
+    color: #79c0ff;
+}
+
 [data-theme="dark"] .editor-panel .accessibility-report-heading.critical {
     color: #c4b5fd;
 }

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -229,8 +229,7 @@
     margin-right: 0.35rem;
 }
 
-/* TODO: Add dark mode overrides for .diagnostic-entry-message code (background and color)
- * once dark mode is fully supported. See issue #966 (Complete dark mode). */
+/* Dark mode overrides for .diagnostic-entry-message code — see [data-theme="dark"] block below. */
 .editor-panel .diagnostic-entry-message code {
     font-family: monospace;
     background-color: #f5f5f5;
@@ -358,4 +357,213 @@
 
 .update-syntax-menu {
     z-index: 100;
+}
+
+/* ============================================================
+ * Dark mode overrides
+ * All colors below have been verified for WCAG AA contrast on
+ * the dark canvas (#121212) or on their respective surfaces.
+ * The accent palette (error/warning/accessibility) is kept in
+ * sync with the tooltip dark overrides in tooltip.css so that
+ * hover tooltips and panel entries use the same colors.
+ * ============================================================ */
+
+/*
+ * Scrollbars. Light-mode OS scrollbars are glaring on a dark canvas.
+ * `scrollbar-color` is the standard property (Firefox + Chromium ≥121).
+ * `::-webkit-scrollbar` rules cover Chromium for full cross-browser support.
+ * Applied broadly to any scrollable surface inside the editor wrapper so
+ * the diagnostics panel, viewer, and any future scrollable area all match.
+ */
+[data-theme="dark"] .editor-panel,
+[data-theme="dark"] .viewer-panel .viewer {
+    scrollbar-color: #555 #1e1e1e;
+}
+
+[data-theme="dark"] .editor-panel ::-webkit-scrollbar,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+[data-theme="dark"] .editor-panel ::-webkit-scrollbar-track,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-track {
+    background: #1e1e1e;
+}
+
+[data-theme="dark"] .editor-panel ::-webkit-scrollbar-thumb,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-thumb {
+    background-color: #555;
+    border-radius: 4px;
+    border: 2px solid #1e1e1e;
+}
+
+[data-theme="dark"] .editor-panel ::-webkit-scrollbar-thumb:hover,
+[data-theme="dark"] .viewer-panel .viewer::-webkit-scrollbar-thumb:hover {
+    background-color: #777;
+}
+
+/*
+ * Base panel surfaces. `.editor-panel` and its sub-panels have no explicit
+ * background-color in light mode (they rely on the white page default).
+ * In dark mode we must set them explicitly; otherwise the transparent panels
+ * show through to the white document body.
+ */
+[data-theme="dark"] .editor-panel {
+    background-color: var(--canvas);
+    color: var(--canvasText);
+}
+
+/*
+ * Footer and viewer-controls toolbars use `--mainGray` (#a9a9a9 in dark),
+ * producing a stark light band against the near-black canvas. Switch them to
+ * the same dark elevated surface used by the drag handles.
+ */
+[data-theme="dark"] .editor-panel .editor-footer {
+    background-color: #1e1e1e;
+}
+
+[data-theme="dark"] .viewer-panel .viewer-controls {
+    background-color: #1e1e1e;
+}
+
+/*
+ * Footer tab highlight: var(--lightBlue) is a pastel sky-blue that pops
+ * too loudly against the dark #1e1e1e toolbar. Use a subtle white-alpha
+ * wash and keep just the inset blue underline as the selected indicator.
+ */
+[data-theme="dark"]
+    .editor-panel
+    .footer-icons.is-open
+    button[aria-selected="true"] {
+    background-color: rgba(255, 255, 255, 0.15);
+    box-shadow: inset 0 -3px 0 var(--mainBlue);
+}
+
+/*
+ * Hover state on footer buttons: lightBlue also too bright on dark toolbar.
+ */
+[data-theme="dark"] .editor-panel .footer-menu-button:hover,
+[data-theme="dark"] .editor-panel .footer-icons button:hover {
+    background-color: rgba(255, 255, 255, 0.12);
+}
+
+/*
+ * CodeMirror editor area. `@uiw/react-codemirror` injects
+ * `backgroundColor: '#fff'` via its default light theme extension. Our
+ * `colorTheme()` factory already sets `backgroundColor: "var(--canvas)"` on
+ * the same `&` selector, and because our extensions are appended after the
+ * @uiw defaults in the CodeMirror state they should win. The CSS rule below
+ * acts as a belt-and-suspenders override with higher specificity
+ * (attribute(0,1,0) + class(0,0,1) = 0,1,1 beats the generated single-class
+ * theme rules at 0,0,1) so the editor background is guaranteed dark.
+ */
+[data-theme="dark"] .cm-editor {
+    background-color: var(--canvas);
+}
+
+/*
+ * Gutters: in dark mode `--mainGray` = #a9a9a9, which is a stark medium-gray
+ * bar against the near-black canvas. Most dark editors (VS Code, GitHub dark)
+ * use a gutter background barely distinguishable from the code area. Use
+ * #1e1e1e (VS Code-style) so the gutter is subtle, with muted line-number
+ * text at #8b949e (5.2:1 on #1e1e1e — WCAG AA).
+ * Active-line gutter: CodeMirror base theme uses #e2f2ff (light blue), which
+ * is garish on a dark gutter. Use a barely-lighter #2a2a2a instead.
+ */
+[data-theme="dark"] .cm-gutters {
+    background-color: #1e1e1e;
+    color: #8b949e;
+    border-right: 1px solid #333;
+}
+
+[data-theme="dark"] .cm-activeLineGutter {
+    background-color: #363636;
+}
+
+/* Footer popup menu */
+[data-theme="dark"] .editor-panel .footer-menu {
+    background-color: var(--canvas);
+    border-color: #555;
+}
+
+/* Responses icon — muted slate instead of medium gray (#667085 fails on #121212) */
+[data-theme="dark"] .editor-panel .diagnostic-tab-icon.is-responses {
+    color: #9ca3af;
+}
+
+/* Diagnostic icon colors — brightened for dark canvas (#121212) */
+[data-theme="dark"] .editor-panel .diagnostic-tab-icon.is-error,
+[data-theme="dark"] .editor-panel .diagnostic-entry-icon.is-error {
+    color: #ff6b6b;
+}
+
+[data-theme="dark"] .editor-panel .diagnostic-tab-icon.is-warning,
+[data-theme="dark"] .editor-panel .diagnostic-entry-icon.is-warning {
+    color: #ffb454;
+}
+
+[data-theme="dark"] .editor-panel .diagnostic-tab-icon.is-info,
+[data-theme="dark"] .editor-panel .diagnostic-entry-icon.is-info {
+    color: #60a5fa;
+}
+
+[data-theme="dark"]
+    .editor-panel
+    .diagnostic-tab-icon.is-accessibility-critical,
+[data-theme="dark"]
+    .editor-panel
+    .diagnostic-entry-icon.is-accessibility-critical {
+    color: #c4b5fd;
+}
+
+[data-theme="dark"]
+    .editor-panel
+    .diagnostic-tab-icon.is-accessibility-advisory,
+[data-theme="dark"]
+    .editor-panel
+    .diagnostic-entry-icon.is-accessibility-advisory {
+    color: #ddd6fe;
+}
+
+/* Inline code in diagnostic messages */
+[data-theme="dark"] .editor-panel .diagnostic-entry-message code {
+    background-color: #2a2a2a;
+    color: #ff7ac6;
+}
+
+/* Accessibility report card */
+[data-theme="dark"] .editor-panel .accessibility-report-section {
+    background: #1e1e1e;
+    border-color: #444;
+}
+
+[data-theme="dark"] .editor-panel .accessibility-report-heading.critical {
+    color: #c4b5fd;
+}
+
+[data-theme="dark"] .editor-panel .accessibility-report-heading.advisory {
+    color: #ddd6fe;
+}
+
+/* Viewer controls bar — bottom border is nearly invisible on #a9a9a9 (dark mainGray) */
+[data-theme="dark"] .viewer-panel .viewer-controls {
+    border-bottom-color: #555;
+}
+
+/* Accessibility status button chips */
+[data-theme="dark"]
+    .viewer-panel
+    .accessibility-status-button.has-level-1-issues {
+    background: #2d1f4e;
+    color: #c4b5fd;
+    box-shadow: inset 0 0 0 1px #7c3aed;
+}
+
+[data-theme="dark"]
+    .viewer-panel
+    .accessibility-status-button.no-level-1-issues {
+    background: #1a3a2a;
+    color: #6ce9a6;
+    box-shadow: inset 0 0 0 1px #34d399;
 }

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -425,6 +425,7 @@
 
 [data-theme="dark"] .viewer-panel .viewer-controls {
     background-color: #1e1e1e;
+    border-bottom-color: #555;
 }
 
 /*
@@ -544,11 +545,6 @@
 
 [data-theme="dark"] .editor-panel .accessibility-report-heading.advisory {
     color: #ddd6fe;
-}
-
-/* Viewer controls bar — bottom border is nearly invisible on #a9a9a9 (dark mainGray) */
-[data-theme="dark"] .viewer-panel .viewer-controls {
-    border-bottom-color: #555;
 }
 
 /* Accessibility status button chips */

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -458,7 +458,7 @@
  * (attribute(0,1,0) + class(0,0,1) = 0,1,1 beats the generated single-class
  * theme rules at 0,0,1) so the editor background is guaranteed dark.
  */
-[data-theme="dark"] .cm-editor {
+[data-theme="dark"] .editor-panel .cm-editor {
     background-color: var(--canvas);
 }
 
@@ -471,13 +471,13 @@
  * Active-line gutter: CodeMirror base theme uses #e2f2ff (light blue), which
  * is garish on a dark gutter. Use a barely-lighter #2a2a2a instead.
  */
-[data-theme="dark"] .cm-gutters {
+[data-theme="dark"] .editor-panel .cm-gutters {
     background-color: #1e1e1e;
     color: #8b949e;
     border-right: 1px solid #333;
 }
 
-[data-theme="dark"] .cm-activeLineGutter {
+[data-theme="dark"] .editor-panel .cm-activeLineGutter {
     background-color: #363636;
 }
 

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -470,7 +470,7 @@
  * #1e1e1e (VS Code-style) so the gutter is subtle, with muted line-number
  * text at #8b949e (5.2:1 on #1e1e1e — WCAG AA).
  * Active-line gutter: CodeMirror base theme uses #e2f2ff (light blue), which
- * is garish on a dark gutter. Use a barely-lighter #2a2a2a instead.
+ * is garish on a dark gutter. Use a barely-lighter #363636 instead.
  */
 [data-theme="dark"] .editor-panel .cm-gutters {
     background-color: #1e1e1e;

--- a/packages/doenetml/src/EditorViewer/variant-select.css
+++ b/packages/doenetml/src/EditorViewer/variant-select.css
@@ -136,6 +136,37 @@
         box-shadow:
             0 10px 15px -3px rgb(0 0 0 / 0.25),
             0 4px 6px -4px rgb(0 0 0 / 0.1);
+        scrollbar-color: #555 hsl(204 4% 16%);
+    }
+
+    .popover:where(
+            [data-theme="dark"],
+            [data-theme="dark"] *
+        )::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    .popover:where(
+            [data-theme="dark"],
+            [data-theme="dark"] *
+        )::-webkit-scrollbar-track {
+        background: hsl(204 4% 16%);
+    }
+
+    .popover:where(
+            [data-theme="dark"],
+            [data-theme="dark"] *
+        )::-webkit-scrollbar-thumb {
+        background-color: #555;
+        border-radius: 4px;
+        border: 2px solid hsl(204 4% 16%);
+    }
+
+    .popover:where(
+            [data-theme="dark"],
+            [data-theme="dark"] *
+        )::-webkit-scrollbar-thumb:hover {
+        background-color: #777;
     }
 
     .select-item {

--- a/packages/doenetml/src/EditorViewer/variant-select.css
+++ b/packages/doenetml/src/EditorViewer/variant-select.css
@@ -6,88 +6,18 @@
         box-sizing: border-box;
     }
     .button {
-        --border: rgb(0 0 0/13%);
-        --highlight: rgb(255 255 255/20%);
-        --shadow: rgb(0 0 0/10%);
-        display: flex;
-        height: 2.5rem;
-        user-select: none;
-        align-items: center;
-        gap: 0.25rem;
-        white-space: nowrap;
-        border-radius: 0.5rem;
-        border-style: none;
-        background-color: white;
-        padding-left: 1rem;
-        padding-right: 1rem;
-        font-size: 1rem;
-        line-height: 1.5rem;
-        color: black;
-        text-decoration-line: none;
-        outline-width: 2px;
-        outline-offset: 2px;
-        outline-color: hsl(204 100% 40%);
-        box-shadow:
-            inset 0 0 0 1px var(--border),
-            inset 0 2px 0 var(--highlight),
-            inset 0 -1px 0 var(--shadow),
-            0 1px 1px var(--shadow);
-        justify-content: space-between;
-    }
-
-    .button:where([data-theme="dark"], [data-theme="dark"] *) {
-        --border: rgb(255 255 255/10%);
-        --highlight: rgb(255 255 255/5%);
-        --shadow: rgb(0 0 0/25%);
-        background-color: rgb(255 255 255 / 0.05);
-        color: white;
-        box-shadow:
-            inset 0 0 0 1px var(--border),
-            inset 0 -1px 0 1px var(--shadow),
-            inset 0 1px 0 var(--highlight);
-    }
-
-    .button:not(:active):hover {
-        --border: rgb(0 0 0/33%);
-    }
-
-    .button:where([data-theme="dark"], [data-theme="dark"] *):not(
-            :active
-        ):hover {
-        --border: rgb(255 255 255/25%);
-    }
-
-    .button[aria-disabled="true"] {
-        opacity: 0.5;
+        --size: 2.5rem;
+        --outline-offset: 2px;
+        --outline: hsl(204 100% 40%);
     }
 
     .button[data-focus-visible] {
         outline-style: solid;
     }
 
-    .button:active,
-    .button[data-active] {
-        padding-top: 0.125rem;
-        box-shadow:
-            inset 0 0 0 1px var(--border),
-            inset 0 2px 0 var(--border);
-    }
-
-    @media (min-width: 640px) {
-        .button {
-            gap: 0.5rem;
-        }
-    }
-
-    .button:active:where([data-theme="dark"], [data-theme="dark"] *),
-    .button[data-active]:where([data-theme="dark"], [data-theme="dark"] *) {
-        box-shadow:
-            inset 0 0 0 1px var(--border),
-            inset 0 1px 1px 1px var(--shadow);
-    }
-
     .select-button {
         width: 12em;
+        justify-content: space-between;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
         margin-right: 0;

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -39,6 +39,7 @@ import {
     CORE_BOOT_RETRY_DELAY_MS,
     CORE_START_FAILED_MESSAGE,
 } from "./coreWorkerBoot";
+import type { ResolvedTheme } from "../utils/theme";
 
 // Re-export for back-compat: `renderersLoadComponent` was previously defined
 // here, and external consumers may deep-import it from
@@ -48,7 +49,7 @@ export { renderersLoadComponent } from "./renderersLoadComponent";
 export const DocContext = createContext<{
     doenetViewerUrl?: string;
     doenetMediaUrl?: string;
-    darkMode?: "dark" | "light";
+    darkMode?: ResolvedTheme;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
 }>({});
@@ -115,7 +116,7 @@ export function DocViewer({
     prefixForIds?: string;
     doenetViewerUrl?: string;
     doenetMediaUrl?: string;
-    darkMode?: "dark" | "light";
+    darkMode?: ResolvedTheme;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
     initializeCounters?: Record<string, number>;

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -29,7 +29,11 @@ import { useIsOnPage } from "./utils/visibility";
 import { Provider as ReduxProvider } from "react-redux";
 import { store, useAppDispatch } from "./state";
 import { keyboardSlice } from "./state/slices/keyboard";
-import { setVariantsFromCallback } from "./utils/variants";
+import {
+    setVariantIndex,
+    setVariantsFromCallback,
+    type VariantsState,
+} from "./utils/variants";
 import { useResolvedTheme } from "./utils/theme";
 import type { ThemeSetting } from "./utils/theme";
 export type { ThemeSetting, ResolvedTheme } from "./utils/theme";
@@ -156,7 +160,7 @@ export function DoenetViewer({
      */
     onInit?: (elm: HTMLElement) => void;
 }) {
-    const [variants, setVariants] = useState({
+    const [variants, setVariants] = useState<VariantsState>({
         index: 1,
         numVariants: 1,
         allPossibleVariants: ["a"],
@@ -238,11 +242,7 @@ export function DoenetViewer({
                     array={variants.allPossibleVariants}
                     syncIndex={variants.index}
                     onChange={(index: number) =>
-                        setVariants((prev) => {
-                            let next = { ...prev };
-                            next.index = index + 1;
-                            return next;
-                        })
+                        setVariantIndex(setVariants, index)
                     }
                 />
             );

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -236,8 +236,6 @@ export function DoenetViewer({
         if (variants.numVariants > 1) {
             variantSelector = (
                 <VariantSelect
-                    size="sm"
-                    menuWidth="140px"
                     darkMode={resolvedTheme}
                     array={variants.allPossibleVariants}
                     syncIndex={variants.index}

--- a/packages/doenetml/src/utils/variants.ts
+++ b/packages/doenetml/src/utils/variants.ts
@@ -1,5 +1,25 @@
 import React from "react";
 
+export type VariantsState = {
+    index: number;
+    numVariants: number;
+    allPossibleVariants: string[];
+};
+
+/**
+ * Convert the zero-based index emitted by `VariantSelect` back to the 1-based
+ * variant index used by the viewer state.
+ */
+export function setVariantIndex(
+    setVariants: React.Dispatch<React.SetStateAction<VariantsState>>,
+    index: number,
+) {
+    setVariants((prev) => ({
+        ...prev,
+        index: index + 1,
+    }));
+}
+
 /**
  * Set variants state variable from the doenet generatedVariantCallback result.
  *
@@ -9,18 +29,8 @@ import React from "react";
  */
 export function setVariantsFromCallback(
     x: any,
-    variants: {
-        index: number;
-        numVariants: number;
-        allPossibleVariants: string[];
-    },
-    setVariants: React.Dispatch<
-        React.SetStateAction<{
-            index: number;
-            numVariants: number;
-            allPossibleVariants: string[];
-        }>
-    >,
+    variants: VariantsState,
+    setVariants: React.Dispatch<React.SetStateAction<VariantsState>>,
 ) {
     const allPossibleVariants = x.allPossibleVariants;
     if (Array.isArray(allPossibleVariants)) {

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
@@ -2,15 +2,14 @@
  * Dark-mode accessibility coverage for the editor authoring UI.
  *
  * Each case opens the DoenetML editor, switches the harness into dark mode,
- * and runs axe's `color-contrast` rule against the editor panel. This
- * complements `darkModeRendererAccessibility.cy.js`, which covers the viewer
- * pane. Together they enforce WCAG AA contrast across the full
- * `<DoenetEditor>` surface in dark mode.
+ * and runs axe's `color-contrast` rule against representative editor surfaces.
+ * This complements `darkModeRendererAccessibility.cy.js`, which covers the
+ * viewer pane.
  *
  * Surfaces exercised:
  *  - CodeMirror code area (syntax highlighting, gutters, active line)
  *  - Diagnostics / responses / help panel (footer tabs, diagnostic entries,
- *    accessibility report card, context-help content)
+ *    accessibility report card, help-panel shell)
  *  - Viewer controls bar (Update button, accessibility status chip)
  */
 describe("Dark-mode editor accessibility checks", { tags: ["@group5"] }, () => {

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
@@ -10,7 +10,7 @@
  *  - CodeMirror code area (syntax highlighting, gutters, active line)
  *  - Diagnostics / responses / help panel (footer tabs, diagnostic entries,
  *    accessibility report card, help-panel shell)
- *  - Viewer controls bar (Update button, accessibility status chip)
+ *  - Viewer controls bar (Update button, accessibility status chip, variant popover)
  */
 describe("Dark-mode editor accessibility checks", { tags: ["@group5"] }, () => {
     beforeEach(() => {
@@ -40,13 +40,13 @@ describe("Dark-mode editor accessibility checks", { tags: ["@group5"] }, () => {
     }
 
     /**
-     * Assert no color-contrast axe violations inside `selector`.
-     * `selector` defaults to the editor panel; pass `".viewer-panel"` for
-     * the viewer controls bar.
+     * Assert no color-contrast axe violations inside `selectors`.
+     * Defaults to the editor panel; pass viewer-control selectors when a test
+     * opens UI that is portaled outside the panel itself.
      */
-    function expectNoColorContrastViolations(selector = ".editor-panel") {
+    function expectNoColorContrastViolations(selectors = ".editor-panel") {
         cy.checkA11y(
-            [selector],
+            Array.isArray(selectors) ? selectors : [selectors],
             {
                 runOnly: { type: "rule", values: ["color-contrast"] },
                 includedImpacts: ["critical", "serious", "moderate", "minor"],
@@ -113,20 +113,26 @@ describe("Dark-mode editor accessibility checks", { tags: ["@group5"] }, () => {
             `<graph name="g"><point>(1,2)</point></graph>`,
             "#g",
         );
-        cy.wait(300);
-        expectNoColorContrastViolations(".viewer-panel .viewer-controls");
+        cy.get(".accessibility-status-button").click();
+        cy.get(".accessibility-report").should("exist");
+        expectNoColorContrastViolations([
+            ".viewer-panel .viewer-controls",
+            ".accessibility-report",
+        ]);
     });
 
     it("dark mode: viewer controls bar (Update button, variant select)", () => {
         loadEditorInDarkMode(
-            `<problem name="prob">
-  <p>Choose: <choiceInput name="ci">
-    <choice>alpha</choice><choice>beta</choice>
-  </choiceInput></p>
-</problem>`,
-            "#prob",
+            `<selectFromSequence name="s" from="1" to="3" />`,
+            "#s",
         );
-        expectNoColorContrastViolations(".viewer-panel .viewer-controls");
+        cy.get(".variant-select").should("exist");
+        cy.get(".select-button").click();
+        cy.get(".popover").should("exist");
+        expectNoColorContrastViolations([
+            ".viewer-panel .viewer-controls",
+            ".popover",
+        ]);
     });
 
     it("dark mode: footer tab bar (diagnostics summary counts)", () => {

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
@@ -95,8 +95,8 @@ describe("Dark-mode editor accessibility checks", { tags: ["@group5"] }, () => {
             "#p",
         );
         // Open the diagnostics/errors tab if not already open.
-        cy.get('[data-test="errors tab"]').click();
-        cy.wait(100);
+        cy.get('[data-test="footer-tab-errors"]').click();
+        cy.get(".diagnostic-list").should("exist");
         expectNoColorContrastViolations(".editor-panel");
     });
 

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeEditorAccessibility.cy.js
@@ -1,0 +1,142 @@
+/**
+ * Dark-mode accessibility coverage for the editor authoring UI.
+ *
+ * Each case opens the DoenetML editor, switches the harness into dark mode,
+ * and runs axe's `color-contrast` rule against the editor panel. This
+ * complements `darkModeRendererAccessibility.cy.js`, which covers the viewer
+ * pane. Together they enforce WCAG AA contrast across the full
+ * `<DoenetEditor>` surface in dark mode.
+ *
+ * Surfaces exercised:
+ *  - CodeMirror code area (syntax highlighting, gutters, active line)
+ *  - Diagnostics / responses / help panel (footer tabs, diagnostic entries,
+ *    accessibility report card, context-help content)
+ *  - Viewer controls bar (Update button, accessibility status chip)
+ */
+describe("Dark-mode editor accessibility checks", { tags: ["@group5"] }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+        cy.injectAxe();
+        // Open the editor pane in the test harness.
+        cy.get("#testRunner_toggleControls").click();
+        cy.get("#testRunner_showEditor").click();
+        cy.get("#testRunner_toggleControls").click();
+    });
+
+    /**
+     * Load `doenetML` in the editor, switch to dark mode, wait for the
+     * theme attribute and optionally for `settleSelector` to appear.
+     */
+    function loadEditorInDarkMode(doenetML, settleSelector) {
+        cy.window().then((win) => {
+            win.postMessage({ doenetML, darkMode: "dark" }, "*");
+        });
+        cy.get('[data-theme="dark"]').should("exist");
+        if (settleSelector) {
+            cy.get(settleSelector).should("exist");
+        }
+        // Allow MathJax / JSXGraph to settle.
+        cy.wait(200);
+    }
+
+    /**
+     * Assert no color-contrast axe violations inside `selector`.
+     * `selector` defaults to the editor panel; pass `".viewer-panel"` for
+     * the viewer controls bar.
+     */
+    function expectNoColorContrastViolations(selector = ".editor-panel") {
+        cy.checkA11y(
+            [selector],
+            {
+                runOnly: { type: "rule", values: ["color-contrast"] },
+                includedImpacts: ["critical", "serious", "moderate", "minor"],
+            },
+            (violations) => {
+                expect(
+                    violations,
+                    JSON.stringify(
+                        violations.map((v) => ({
+                            id: v.id,
+                            nodes: v.nodes.map((n) => n.html),
+                        })),
+                        null,
+                        2,
+                    ),
+                ).to.have.length(0);
+            },
+            true,
+        );
+    }
+
+    it("dark mode: CodeMirror editor area (editable)", () => {
+        loadEditorInDarkMode(`<p name="p">Hello <em>world</em>.</p>`, "#p");
+        // The editor content area (.cm-editor) must be visible.
+        cy.get(".cm-editor").should("exist");
+        expectNoColorContrastViolations(".editor-panel");
+    });
+
+    it("dark mode: CodeMirror editor area (read-only)", () => {
+        // Switch to read-only mode by toggling the control.
+        cy.get("#testRunner_toggleControls").click();
+        cy.get("#testRunner_readOnly").click();
+        cy.get("#testRunner_toggleControls").click();
+
+        loadEditorInDarkMode(`<p name="p">Read-only content.</p>`, "#p");
+        cy.get(".cm-editor").should("exist");
+        expectNoColorContrastViolations(".editor-panel");
+    });
+
+    it("dark mode: diagnostics panel with warnings and errors", () => {
+        // Load markup that triggers both a warning and an error diagnostic.
+        loadEditorInDarkMode(
+            `<p name="p">Valid paragraph.</p>
+<unknownTag name="bad">This tag does not exist.</unknownTag>`,
+            "#p",
+        );
+        // Open the diagnostics/errors tab if not already open.
+        cy.get('[data-test="errors tab"]').click();
+        cy.wait(100);
+        expectNoColorContrastViolations(".editor-panel");
+    });
+
+    it("dark mode: context-help panel (element help)", () => {
+        loadEditorInDarkMode(`<p name="p">Some text.</p>`, "#p");
+        // The help tab opens by default; wait for it to render.
+        cy.get(".help-panel").should("exist");
+        expectNoColorContrastViolations(".editor-panel");
+    });
+
+    it("dark mode: accessibility report in viewer controls", () => {
+        // Load markup that generates an accessibility diagnostic so the
+        // accessibility status button and report chip appear.
+        loadEditorInDarkMode(
+            `<graph name="g"><point>(1,2)</point></graph>`,
+            "#g",
+        );
+        cy.wait(300);
+        expectNoColorContrastViolations(".viewer-panel .viewer-controls");
+    });
+
+    it("dark mode: viewer controls bar (Update button, variant select)", () => {
+        loadEditorInDarkMode(
+            `<problem name="prob">
+  <p>Choose: <choiceInput name="ci">
+    <choice>alpha</choice><choice>beta</choice>
+  </choiceInput></p>
+</problem>`,
+            "#prob",
+        );
+        expectNoColorContrastViolations(".viewer-panel .viewer-controls");
+    });
+
+    it("dark mode: footer tab bar (diagnostics summary counts)", () => {
+        loadEditorInDarkMode(
+            `<p name="p">Text with <c>inline code</c>.</p>`,
+            "#p",
+        );
+        // Footer tab bar lives inside .editor-panel.
+        cy.get(".editor-footer").should("exist");
+        expectNoColorContrastViolations(".editor-footer");
+    });
+});

--- a/packages/ui-components/src/components/style.css
+++ b/packages/ui-components/src/components/style.css
@@ -166,6 +166,34 @@
     --button-canvas-color: oklch(from var(--button-color) max(l, 0.78) c h);
 }
 
+/*
+ * `.doenet-ui-button` dark mode: override the light-mode defaults under
+ * `[data-theme="dark"]`, the single dark-mode mechanism used throughout
+ * the DoenetEditor context.
+ */
+[data-theme="dark"] .doenet-ui-button {
+    --background: rgb(255 255 255 / 5%);
+    --border: rgb(255 255 255 / 10%);
+    --light: rgb(255 255 255 / 5%);
+    --shadow: rgb(0 0 0 / 25%);
+    --text: white;
+    box-shadow:
+        inset 0 0 0 1px var(--border),
+        inset 0 -1px 0 1px var(--shadow),
+        inset 0 1px 0 var(--light);
+}
+
+[data-theme="dark"] .doenet-ui-button:not(:active):hover {
+    --border: rgb(255 255 255 / 25%);
+}
+
+[data-theme="dark"] .doenet-ui-button:active,
+[data-theme="dark"] .doenet-ui-button[data-active] {
+    box-shadow:
+        inset 0 0 0 1px var(--border),
+        inset 0 1px 1px 1px var(--shadow);
+}
+
 /* Resizable Panel */
 .doenet-resizable-panel-handle {
     box-sizing: border-box;
@@ -194,6 +222,19 @@
     }
 }
 
+/*
+ * In dark mode `--mainGray` = #a9a9a9 — too light against the near-black
+ * canvas. Use a dark elevated surface (#2a2a2a) with a subtle border.
+ */
+[data-theme="dark"] .doenet-resizable-panel-handle {
+    background-color: #2a2a2a;
+    border-color: #444;
+
+    svg {
+        color: #8b949e;
+    }
+}
+
 /* UI Components */
 
 .doenet-ui-button {
@@ -204,23 +245,8 @@
     --shadow: rgb(0 0 0 / 10%);
     --text: black;
 
-    &:where(.dark, .dark *) {
-        --background: rgb(255 255 255 / 5%);
-        --border: rgb(255 255 255 / 10%);
-        --light: rgb(255 255 255 / 5%);
-        --shadow: rgb(0 0 0 / 25%);
-        --text: white;
-        box-shadow:
-            inset 0 0 0 1px var(--border),
-            inset 0 -1px 0 1px var(--shadow),
-            inset 0 1px 0 var(--light);
-    }
-
     &:not(:active):hover {
         --border: rgb(0 0 0 / 33%);
-    }
-    &:where(.dark, .dark *):not(:active):hover {
-        --border: rgb(255 255 255 / 25%);
     }
     @layer theme {
         &[aria-disabled="true"] {
@@ -232,12 +258,6 @@
         box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 2px 0 var(--border);
-    }
-    &:active:where(.dark, .dark *),
-    &[data-active]:where(.dark, .dark *) {
-        box-shadow:
-            inset 0 0 0 1px var(--border),
-            inset 0 1px 1px 1px var(--shadow);
     }
 
     cursor: pointer;


### PR DESCRIPTION
## Summary

Implements dark mode for the DoenetML **editor** authoring surfaces — the remaining piece of #966 after the viewer dark mode landed in #1365. All colors were verified for WCAG AA contrast.

## What changed

### CodeMirror (`@doenet/codemirror`)
- **`theme.ts`**: converted `colorTheme` / `readOnlyColorTheme` / `completionIconTheme` to factory functions accepting `darkMode`. Fixed the commented-out `backgroundColor` bug so the editor surface is no longer always white. Dark gutter uses a VS Code-style palette, and dark autocomplete icon colors were checked against the tooltip surface.
- **`syntax-highlighting.ts`**: added a GitHub-dark `HighlightStyle`; exported as `syntaxHighlightingExtension(darkMode)`.
- **`CodeMirror.tsx`**: added a `darkMode` prop, wired it into the theme/highlighting/icon extensions, and reflected the resolved mode onto the editor root so tooltip/lint popup CSS follows the same source of truth.
- **`lsp/tooltip.css`**: dark overrides for tooltip surfaces and accessibility-diagnostic underline colors.

### Editor panels (`@doenet/doenetml`)
- **`EditorViewer.tsx`**: passes `darkMode` to `<CodeMirror>`, applies the theme attribute on its own wrapper so dark editor/viewer panel styles work even when `EditorViewer` is mounted directly, and centralizes diagnostics-tab enable/default resolution so the footer and imperative API share the same behavior.
- **`editor-viewer.css`**: `[data-theme="dark"]` block for panel backgrounds, footer/viewer-controls bars, footer tab highlight, footer version/help text, diagnostic icon/chip colors, accessibility-report links, scrollbars, and accessibility status chips.
- **`context-help-panel.css`**: `[data-theme="dark"]` block for muted text, blue accents, chip/code backgrounds, and the empty-state help placeholder.
- **`variant-select.css`**: dark scrollbar for the variant popover, with the trigger/stepper buttons reusing the shared `doenet-ui-button` dark theme instead of maintaining a private copy.
- **`ViewerControlsBar.tsx` / `VariantSelect.tsx` / `DocViewer.tsx`**: variant popovers now receive the resolved theme explicitly, editor-side theme typing is unified on `ResolvedTheme`, repeated variant-index update logic is shared via a helper, and `VariantSelect` drops redundant local state/unused props.

### UI components (`@doenet/ui-components`)
- **`style.css`**: `[data-theme="dark"]` rules for `doenet-ui-button` (Update/Reset button and shared variant selector buttons). Removed dead `.dark` / `.dark *` selectors that were never applied.

### Resizable panel handles
- Dark elevated surface (`#2a2a2a`, `#444` border, `#8b949e` grip icon) instead of stark `--mainGray`.

### Tests
- **`darkModeEditorAccessibility.cy.js`** (new): cypress-axe `color-contrast` coverage for representative editor dark-mode surfaces, including the CodeMirror area, diagnostics/footer shell, accessibility report, viewer controls bar, and variant popover.

## Related
- Builds on top of #1365 (viewer dark mode, diagnostic tooltip fixes, accent palette)
- Closes #1366

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
