### PR TITLE
fix: dark mode body background in doenetml-iframe

### DIFF
--- a/.changeset/iframe-dark-mode-body-background.md
+++ b/.changeset/iframe-dark-mode-body-background.md
@@ -1,0 +1,5 @@
+---
+"@doenet/doenetml-iframe": patch
+---
+
+Iframe: fix dark-mode body backgrounds so embedded viewer/editor pages no longer show white footer stripes when the rendered content does not fill the iframe.

--- a/.changeset/iframe-dark-mode-body-background.md
+++ b/.changeset/iframe-dark-mode-body-background.md
@@ -2,4 +2,4 @@
 "@doenet/doenetml-iframe": patch
 ---
 
-Iframe: fix dark-mode body backgrounds so embedded viewer/editor pages no longer show white footer stripes when the rendered content does not fill the iframe.
+Iframe: make embedded viewer/editor body backgrounds follow light, dark, and system theme settings so partially filled iframes no longer show white footer stripes.

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -21,6 +21,7 @@ import {
     DoenetEditorProps,
     createHtmlForDoenetViewer,
     createHtmlForDoenetEditor,
+    setIframeBodyBackground,
 } from "./utils";
 
 export const version: string = IFRAME_VERSION;
@@ -673,6 +674,16 @@ export const DoenetEditor = React.forwardRef<
             pendingActions.current.push(action);
         }
     }, [propsSnapshotStr, srcDoc]);
+
+    // Keep the iframe body's empty margin area aligned with the current
+    // dark-mode setting without reloading the editor document (which would
+    // discard in-progress edits).
+    React.useEffect(() => {
+        const body = ref.current?.contentDocument?.body;
+        if (body) {
+            setIframeBodyBackground(body, doenetEditorProps.darkMode);
+        }
+    }, [doenetEditorProps.darkMode, srcDoc]);
 
     // Push function-prop identity changes into the iframe. We have no live
     // use case for this yet, but supporting it keeps callback semantics

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -416,6 +416,16 @@ export const DoenetEditor = React.forwardRef<
         doenetEditorProps.darkMode ?? "system",
     );
 
+    function syncIframeBodyBackground() {
+        const body = ref.current?.contentDocument?.body;
+        if (body) {
+            setIframeBodyBackground(
+                body,
+                doenetEditorPropsRef.current.darkMode,
+            );
+        }
+    }
+
     React.useImperativeHandle(
         forwardedRef,
         () => ({
@@ -564,6 +574,7 @@ export const DoenetEditor = React.forwardRef<
                     for (const action of queued) {
                         action(editorIframe);
                     }
+                    syncIframeBodyBackground();
                 }
             }
         };
@@ -677,13 +688,10 @@ export const DoenetEditor = React.forwardRef<
 
     // Keep the iframe body's empty margin area aligned with live dark-mode
     // changes without reloading the editor document (which would discard
-    // in-progress edits). Fresh srcDoc content already includes the correct
-    // initial body background.
+    // in-progress edits). iframeReady also re-syncs the body after any
+    // srcDoc rebuild so mount-time darkMode doesn't leak back in.
     React.useEffect(() => {
-        const body = ref.current?.contentDocument?.body;
-        if (body) {
-            setIframeBodyBackground(body, doenetEditorProps.darkMode);
-        }
+        syncIframeBodyBackground();
     }, [doenetEditorProps.darkMode]);
 
     // Push function-prop identity changes into the iframe. We have no live

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -675,15 +675,16 @@ export const DoenetEditor = React.forwardRef<
         }
     }, [propsSnapshotStr, srcDoc]);
 
-    // Keep the iframe body's empty margin area aligned with the current
-    // dark-mode setting without reloading the editor document (which would
-    // discard in-progress edits).
+    // Keep the iframe body's empty margin area aligned with live dark-mode
+    // changes without reloading the editor document (which would discard
+    // in-progress edits). Fresh srcDoc content already includes the correct
+    // initial body background.
     React.useEffect(() => {
         const body = ref.current?.contentDocument?.body;
         if (body) {
             setIframeBodyBackground(body, doenetEditorProps.darkMode);
         }
-    }, [doenetEditorProps.darkMode, srcDoc]);
+    }, [doenetEditorProps.darkMode]);
 
     // Push function-prop identity changes into the iframe. We have no live
     // use case for this yet, but supporting it keeps callback semantics

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -16,43 +16,15 @@ export type DoenetEditorProps = Omit<
     "doenetML" | "width" | "height" | "externalVirtualKeyboardProvided"
 >;
 
+type IframeDarkMode =
+    | DoenetViewerProps["darkMode"]
+    | DoenetEditorProps["darkMode"];
 type BodyBackgroundMode = "dark" | "light" | "system";
 
 const DARK_CANVAS = "#121212";
 const LIGHT_CANVAS = "white";
 const BODY_BACKGROUND_ATTRIBUTE = "data-doenet-body-background";
-
-/**
- * Normalize the public dark-mode prop to the subset used for the iframe body.
- */
-function bodyBackgroundMode(
-    darkMode: DoenetViewerProps["darkMode"] | DoenetEditorProps["darkMode"],
-): BodyBackgroundMode {
-    if (darkMode === "dark") {
-        return "dark";
-    }
-    if (darkMode === "system") {
-        return "system";
-    }
-    return "light";
-}
-
-/**
- * Return the stylesheet and attribute value used to theme the iframe body.
- *
- * The body background is controlled via an attribute rather than an inline
- * background-color so `"system"` can switch cleanly with a media query and so
- * the editor can update the body theme in-place without rebuilding the iframe.
- */
-function bodyBackgroundStyle(
-    darkMode: DoenetViewerProps["darkMode"] | DoenetEditorProps["darkMode"],
-): {
-    attributeValue: BodyBackgroundMode;
-    styleBlock: string;
-} {
-    return {
-        attributeValue: bodyBackgroundMode(darkMode),
-        styleBlock: `<style>
+const BODY_BACKGROUND_STYLE_BLOCK = `<style>
 body[${BODY_BACKGROUND_ATTRIBUTE}="light"],
 body[${BODY_BACKGROUND_ATTRIBUTE}="system"] {
     background-color: ${LIGHT_CANVAS};
@@ -65,13 +37,27 @@ body[${BODY_BACKGROUND_ATTRIBUTE}="dark"] {
         background-color: ${DARK_CANVAS};
     }
 }
-</style>`,
-    };
+</style>`;
+
+/**
+ * Normalize the public dark-mode prop to the subset used for the iframe body.
+ */
+function bodyBackgroundMode(darkMode: IframeDarkMode): BodyBackgroundMode {
+    if (darkMode === "dark") {
+        return "dark";
+    }
+    if (darkMode === "system") {
+        return "system";
+    }
+    return "light";
 }
 
+/**
+ * Update the iframe body's theme attribute without rebuilding the document.
+ */
 export function setIframeBodyBackground(
     body: HTMLElement,
-    darkMode: DoenetViewerProps["darkMode"] | DoenetEditorProps["darkMode"],
+    darkMode: IframeDarkMode,
 ) {
     body.setAttribute(BODY_BACKGROUND_ATTRIBUTE, bodyBackgroundMode(darkMode));
 }
@@ -93,8 +79,7 @@ export function createHtmlForDoenetViewer(
     // we pass an extra variable of the props that were specified.
     const doenetViewerPropsSpecified: string[] = Object.keys(doenetViewerProps);
 
-    const { attributeValue: bodyBackground, styleBlock: bgStyleBlock } =
-        bodyBackgroundStyle(doenetViewerProps.darkMode);
+    const bodyBackground = bodyBackgroundMode(doenetViewerProps.darkMode);
 
     // XXX: rather than serving Comlink from the cdn, below, serve it directly
     // TODO: rather than load the Doenet logo from doenet.org, serve it directly
@@ -103,7 +88,7 @@ export function createHtmlForDoenetViewer(
     <head>
         <script type="module" src="${standaloneUrl}"></script>
         <link rel="stylesheet" href="${cssUrl}">
-        ${bgStyleBlock}
+        ${BODY_BACKGROUND_STYLE_BLOCK}
     </head>
     <body style="margin:0" ${BODY_BACKGROUND_ATTRIBUTE}="${bodyBackground}">
         <script type="module">
@@ -148,15 +133,14 @@ export function createHtmlForDoenetEditor(
     // we pass an extra variable of the props that were specified.
     const doenetEditorPropsSpecified: string[] = Object.keys(augmentedProps);
 
-    const { attributeValue: bodyBackground, styleBlock: bgStyleBlock } =
-        bodyBackgroundStyle(doenetEditorProps.darkMode);
+    const bodyBackground = bodyBackgroundMode(doenetEditorProps.darkMode);
 
     return `
     <html style="overflow:hidden">
     <head>
         <script type="module" src="${standaloneUrl}"></script>
         <link rel="stylesheet" href="${cssUrl}">
-        ${bgStyleBlock}
+        ${BODY_BACKGROUND_STYLE_BLOCK}
     </head>
     <body style="margin:0" ${BODY_BACKGROUND_ATTRIBUTE}="${bodyBackground}">
         <script type="module">

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -63,6 +63,19 @@ export function setIframeBodyBackground(
     body.setAttribute(BODY_BACKGROUND_ATTRIBUTE, bodyBackgroundMode(darkMode));
 }
 
+function createIframeHead(standaloneUrl: string, cssUrl: string) {
+    return `
+    <head>
+        <script type="module" src="${standaloneUrl}"></script>
+        <link rel="stylesheet" href="${cssUrl}">
+        ${BODY_BACKGROUND_STYLE_BLOCK}
+    </head>`;
+}
+
+function createIframeBodyOpenTag(darkMode: IframeDarkMode) {
+    return `<body style="margin:0" ${BODY_BACKGROUND_ATTRIBUTE}="${bodyBackgroundMode(darkMode)}">`;
+}
+
 /**
  * Create HTML for a single page document that renders the given DoenetML.
  */
@@ -80,18 +93,12 @@ export function createHtmlForDoenetViewer(
     // we pass an extra variable of the props that were specified.
     const doenetViewerPropsSpecified: string[] = Object.keys(doenetViewerProps);
 
-    const bodyBackground = bodyBackgroundMode(doenetViewerProps.darkMode);
-
     // XXX: rather than serving Comlink from the cdn, below, serve it directly
     // TODO: rather than load the Doenet logo from doenet.org, serve it directly
     return `
     <html style="overflow:hidden">
-    <head>
-        <script type="module" src="${standaloneUrl}"></script>
-        <link rel="stylesheet" href="${cssUrl}">
-        ${BODY_BACKGROUND_STYLE_BLOCK}
-    </head>
-    <body style="margin:0" ${BODY_BACKGROUND_ATTRIBUTE}="${bodyBackground}">
+    ${createIframeHead(standaloneUrl, cssUrl)}
+    ${createIframeBodyOpenTag(doenetViewerProps.darkMode)}
         <script type="module">
             const viewerId = "${id}";
             const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
@@ -134,16 +141,10 @@ export function createHtmlForDoenetEditor(
     // we pass an extra variable of the props that were specified.
     const doenetEditorPropsSpecified: string[] = Object.keys(augmentedProps);
 
-    const bodyBackground = bodyBackgroundMode(doenetEditorProps.darkMode);
-
     return `
     <html style="overflow:hidden">
-    <head>
-        <script type="module" src="${standaloneUrl}"></script>
-        <link rel="stylesheet" href="${cssUrl}">
-        ${BODY_BACKGROUND_STYLE_BLOCK}
-    </head>
-    <body style="margin:0" ${BODY_BACKGROUND_ATTRIBUTE}="${bodyBackground}">
+    ${createIframeHead(standaloneUrl, cssUrl)}
+    ${createIframeBodyOpenTag(doenetEditorProps.darkMode)}
         <script type="module">
             const editorId = "${id}";
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -16,6 +16,37 @@ export type DoenetEditorProps = Omit<
     "doenetML" | "width" | "height" | "externalVirtualKeyboardProvided"
 >;
 
+const DARK_CANVAS = "#121212";
+const LIGHT_CANVAS = "white";
+
+/**
+ * Return an inline style string and optional <style> block that set the body
+ * background colour to match the requested dark-mode setting.
+ *
+ * - "dark"   → always dark
+ * - "light"  → always light (white)
+ * - "system" → follow the OS preference via a CSS media query
+ */
+function bodyBackgroundStyle(darkMode: string | undefined): {
+    inlineStyle: string;
+    styleBlock: string;
+} {
+    if (darkMode === "dark") {
+        return {
+            inlineStyle: `background-color:${DARK_CANVAS}`,
+            styleBlock: "",
+        };
+    }
+    if (darkMode === "system") {
+        return {
+            inlineStyle: `background-color:${LIGHT_CANVAS}`,
+            styleBlock: `<style>@media (prefers-color-scheme: dark) { body { background-color: ${DARK_CANVAS}; } }</style>`,
+        };
+    }
+    // "light" or unset
+    return { inlineStyle: `background-color:${LIGHT_CANVAS}`, styleBlock: "" };
+}
+
 /**
  * Create HTML for a single page document that renders the given DoenetML.
  */
@@ -33,6 +64,9 @@ export function createHtmlForDoenetViewer(
     // we pass an extra variable of the props that were specified.
     const doenetViewerPropsSpecified: string[] = Object.keys(doenetViewerProps);
 
+    const { inlineStyle: bgStyle, styleBlock: bgStyleBlock } =
+        bodyBackgroundStyle((doenetViewerProps as any).darkMode);
+
     // XXX: rather than serving Comlink from the cdn, below, serve it directly
     // TODO: rather tha load the doenet logo from doenet.org, serve it directly
     return `
@@ -40,8 +74,9 @@ export function createHtmlForDoenetViewer(
     <head>
         <script type="module" src="${standaloneUrl}"></script>
         <link rel="stylesheet" href="${cssUrl}">
+        ${bgStyleBlock}
     </head>
-    <body style="margin:0; background-color:white">
+    <body style="margin:0; ${bgStyle}">
         <script type="module">
             const viewerId = "${id}";
             const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
@@ -84,13 +119,17 @@ export function createHtmlForDoenetEditor(
     // we pass an extra variable of the props that were specified.
     const doenetEditorPropsSpecified: string[] = Object.keys(augmentedProps);
 
+    const { inlineStyle: bgStyle, styleBlock: bgStyleBlock } =
+        bodyBackgroundStyle((doenetEditorProps as any).darkMode);
+
     return `
     <html style="overflow:hidden">
     <head>
         <script type="module" src="${standaloneUrl}"></script>
         <link rel="stylesheet" href="${cssUrl}">
+        ${bgStyleBlock}
     </head>
-    <body style="margin:0; background-color:white">
+    <body style="margin:0; ${bgStyle}">
         <script type="module">
             const editorId = "${id}";
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -16,35 +16,64 @@ export type DoenetEditorProps = Omit<
     "doenetML" | "width" | "height" | "externalVirtualKeyboardProvided"
 >;
 
+type BodyBackgroundMode = "dark" | "light" | "system";
+
 const DARK_CANVAS = "#121212";
 const LIGHT_CANVAS = "white";
+const BODY_BACKGROUND_ATTRIBUTE = "data-doenet-body-background";
 
 /**
- * Return an inline style string and optional <style> block that set the body
- * background colour to match the requested dark-mode setting.
- *
- * - "dark"   → always dark
- * - "light"  → always light (white)
- * - "system" → follow the OS preference via a CSS media query
+ * Normalize the public dark-mode prop to the subset used for the iframe body.
  */
-function bodyBackgroundStyle(darkMode: string | undefined): {
-    inlineStyle: string;
-    styleBlock: string;
-} {
+function bodyBackgroundMode(
+    darkMode: DoenetViewerProps["darkMode"] | DoenetEditorProps["darkMode"],
+): BodyBackgroundMode {
     if (darkMode === "dark") {
-        return {
-            inlineStyle: `background-color:${DARK_CANVAS}`,
-            styleBlock: "",
-        };
+        return "dark";
     }
     if (darkMode === "system") {
-        return {
-            inlineStyle: `background-color:${LIGHT_CANVAS}`,
-            styleBlock: `<style>@media (prefers-color-scheme: dark) { body { background-color: ${DARK_CANVAS}; } }</style>`,
-        };
+        return "system";
     }
-    // "light" or unset
-    return { inlineStyle: `background-color:${LIGHT_CANVAS}`, styleBlock: "" };
+    return "light";
+}
+
+/**
+ * Return the stylesheet and attribute value used to theme the iframe body.
+ *
+ * The body background is controlled via an attribute rather than an inline
+ * background-color so `"system"` can switch cleanly with a media query and so
+ * the editor can update the body theme in-place without rebuilding the iframe.
+ */
+function bodyBackgroundStyle(
+    darkMode: DoenetViewerProps["darkMode"] | DoenetEditorProps["darkMode"],
+): {
+    attributeValue: BodyBackgroundMode;
+    styleBlock: string;
+} {
+    return {
+        attributeValue: bodyBackgroundMode(darkMode),
+        styleBlock: `<style>
+body[${BODY_BACKGROUND_ATTRIBUTE}="light"],
+body[${BODY_BACKGROUND_ATTRIBUTE}="system"] {
+    background-color: ${LIGHT_CANVAS};
+}
+body[${BODY_BACKGROUND_ATTRIBUTE}="dark"] {
+    background-color: ${DARK_CANVAS};
+}
+@media (prefers-color-scheme: dark) {
+    body[${BODY_BACKGROUND_ATTRIBUTE}="system"] {
+        background-color: ${DARK_CANVAS};
+    }
+}
+</style>`,
+    };
+}
+
+export function setIframeBodyBackground(
+    body: HTMLElement,
+    darkMode: DoenetViewerProps["darkMode"] | DoenetEditorProps["darkMode"],
+) {
+    body.setAttribute(BODY_BACKGROUND_ATTRIBUTE, bodyBackgroundMode(darkMode));
 }
 
 /**
@@ -58,17 +87,17 @@ export function createHtmlForDoenetViewer(
     cssUrl: string,
 ) {
     // Since function props disappear when stringifying
-    // and we'll have access tot them only via proxying with ComLink,
+    // and we'll have access to them only via proxying with ComLink,
     // whether or not a function prop was specified is masked.
     // Since for some callbacks, we have different behavior whether or not it was specified,
     // we pass an extra variable of the props that were specified.
     const doenetViewerPropsSpecified: string[] = Object.keys(doenetViewerProps);
 
-    const { inlineStyle: bgStyle, styleBlock: bgStyleBlock } =
-        bodyBackgroundStyle((doenetViewerProps as any).darkMode);
+    const { attributeValue: bodyBackground, styleBlock: bgStyleBlock } =
+        bodyBackgroundStyle(doenetViewerProps.darkMode);
 
     // XXX: rather than serving Comlink from the cdn, below, serve it directly
-    // TODO: rather tha load the doenet logo from doenet.org, serve it directly
+    // TODO: rather than load the Doenet logo from doenet.org, serve it directly
     return `
     <html style="overflow:hidden">
     <head>
@@ -76,7 +105,7 @@ export function createHtmlForDoenetViewer(
         <link rel="stylesheet" href="${cssUrl}">
         ${bgStyleBlock}
     </head>
-    <body style="margin:0; ${bgStyle}">
+    <body style="margin:0" ${BODY_BACKGROUND_ATTRIBUTE}="${bodyBackground}">
         <script type="module">
             const viewerId = "${id}";
             const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
@@ -113,14 +142,14 @@ export function createHtmlForDoenetEditor(
     const augmentedProps = { width, height: "100vh", ...doenetEditorProps };
 
     // Since function props disappear when stringifying
-    // and we'll have access tot them only via proxying with ComLink,
+    // and we'll have access to them only via proxying with ComLink,
     // whether or not a function prop was specified is masked.
     // Since for some callbacks, we have different behavior whether or not it was specified,
     // we pass an extra variable of the props that were specified.
     const doenetEditorPropsSpecified: string[] = Object.keys(augmentedProps);
 
-    const { inlineStyle: bgStyle, styleBlock: bgStyleBlock } =
-        bodyBackgroundStyle((doenetEditorProps as any).darkMode);
+    const { attributeValue: bodyBackground, styleBlock: bgStyleBlock } =
+        bodyBackgroundStyle(doenetEditorProps.darkMode);
 
     return `
     <html style="overflow:hidden">
@@ -129,7 +158,7 @@ export function createHtmlForDoenetEditor(
         <link rel="stylesheet" href="${cssUrl}">
         ${bgStyleBlock}
     </head>
-    <body style="margin:0; ${bgStyle}">
+    <body style="margin:0" ${BODY_BACKGROUND_ATTRIBUTE}="${bodyBackground}">
         <script type="module">
             const editorId = "${id}";
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -41,12 +41,13 @@ body[${BODY_BACKGROUND_ATTRIBUTE}="dark"] {
 
 /**
  * Normalize the public dark-mode prop to the subset used for the iframe body.
+ * Omitted values follow the public component default of `"system"`.
  */
 function bodyBackgroundMode(darkMode: IframeDarkMode): BodyBackgroundMode {
     if (darkMode === "dark") {
         return "dark";
     }
-    if (darkMode === "system") {
+    if (darkMode === undefined || darkMode === "system") {
         return "system";
     }
     return "light";

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.darkMode.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.darkMode.cy.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+import { DoenetViewer } from "../../../src/index";
+import {
+    STANDALONE_BLOB_URL,
+    STANDALONE_CSS_BLOB_URL,
+    IFRAME_READY_TIMEOUT,
+} from "./helpers";
+
+const DOENET_ML = "<p>Hello dark mode</p>";
+
+const DARK_BG = "rgb(18, 18, 18)"; // #121212
+const LIGHT_BG = "rgb(255, 255, 255)"; // white
+
+/** Wait for the iframe body to exist, then assert its background-color. */
+function assertBodyBg(expected: string) {
+    cy.get("iframe")
+        .its("0.contentDocument.body", { timeout: IFRAME_READY_TIMEOUT })
+        .should("have.css", "background-color", expected);
+}
+
+describe("DoenetViewer (iframe wrapper) — dark mode body background", () => {
+    it('darkMode="dark" sets iframe body background to #121212', () => {
+        cy.mount(
+            <DoenetViewer
+                doenetML={DOENET_ML}
+                darkMode="dark"
+                standaloneUrl={STANDALONE_BLOB_URL}
+                cssUrl={STANDALONE_CSS_BLOB_URL}
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        assertBodyBg(DARK_BG);
+    });
+
+    it('darkMode="light" sets iframe body background to white', () => {
+        cy.mount(
+            <DoenetViewer
+                doenetML={DOENET_ML}
+                darkMode="light"
+                standaloneUrl={STANDALONE_BLOB_URL}
+                cssUrl={STANDALONE_CSS_BLOB_URL}
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        assertBodyBg(LIGHT_BG);
+    });
+
+    it("darkMode prop change after mount updates iframe body background", () => {
+        function Harness() {
+            const [darkMode, setDarkMode] = useState<"light" | "dark">("light");
+            return (
+                <div>
+                    <button
+                        data-test="toggle"
+                        onClick={() =>
+                            setDarkMode((m) =>
+                                m === "light" ? "dark" : "light",
+                            )
+                        }
+                    >
+                        Toggle
+                    </button>
+                    <DoenetViewer
+                        doenetML={DOENET_ML}
+                        darkMode={darkMode}
+                        standaloneUrl={STANDALONE_BLOB_URL}
+                        cssUrl={STANDALONE_CSS_BLOB_URL}
+                        addVirtualKeyboard={false}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Harness />);
+
+        // Starts light
+        assertBodyBg(LIGHT_BG);
+
+        // Switch to dark
+        cy.get("[data-test=toggle]").click();
+        assertBodyBg(DARK_BG);
+
+        // Switch back to light
+        cy.get("[data-test=toggle]").click();
+        assertBodyBg(LIGHT_BG);
+    });
+});


### PR DESCRIPTION
## Problem

When `darkMode` is active, each DoenetML iframe document could show a white footer stripe at the bottom. The content rendered correctly in dark mode, but the remaining `<body>` area beneath it stayed white.

## Root Cause

`createHtmlForDoenetViewer` and `createHtmlForDoenetEditor` in `packages/doenetml-iframe/src/utils.ts` hardcoded the iframe body background to white.

## Fix

Switched the iframe body background logic to an attribute-driven helper so the generated HTML can theme the `<body>` correctly for all dark-mode settings:

| `darkMode` | Body background |
|---|---|
| `"dark"` | `#121212` |
| `"light"` | `white` |
| `"system"` / omitted | `white` by default, with a `prefers-color-scheme: dark` media query that switches to `#121212` |

Also updated the iframe editor wrapper so live `darkMode` prop changes, plus any iframe document rebuilds on the autodetected-version fallback path, reapply the latest body background in place instead of requiring another reload.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)