### PR TITLE
fix(a11y): fix docs contrast failures and add cypress-axe test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,58 @@ jobs:
               env:
                   WIREIT_CACHE: "local"
 
+            # Upload the static export so the accessibility test job can serve it.
+            - name: Upload docs static export
+              uses: actions/upload-artifact@v7
+              with:
+                  name: docs-out
+                  path: ./packages/docs-nextra/out/
+
+    test-docs-cypress:
+        name: Docs Accessibility (Cypress + axe)
+        runs-on: ubuntu-latest
+        needs: build-docs
+        strategy:
+            matrix:
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
+        steps:
+            - uses: actions/checkout@v6
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm ci
+
+            - name: Download docs static export
+              uses: actions/download-artifact@v8
+              with:
+                  name: docs-out
+                  path: ./packages/docs-nextra/out/
+
+            - name: Start docs server
+              run: |
+                  npx serve -l 3000 packages/docs-nextra/out/ > /tmp/docs-serve.log 2>&1 &
+                  echo $! > /tmp/docs-serve.pid
+
+            - name: Wait for docs server
+              run: npx wait-on http://localhost:3000 --timeout 30000
+
+            - name: Run docs accessibility tests
+              run: npm run test-cypress-docs-all -w packages/docs-cypress
+
+            - name: Upload screenshots on failure
+              if: failure()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: docs-cypress-screenshots
+                  path: ./packages/docs-cypress/cypress/screenshots
+                  if-no-files-found: ignore
+
     lint-ts:
         name: Lint Typescript Code
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,7 @@ jobs:
 
             - name: Start docs server
               run: |
-                  npm exec serve -- -l 3000 packages/docs-nextra/out/ > /tmp/docs-serve.log 2>&1 &
+                  npm exec serve -- --no-port-switching -l 3000 packages/docs-nextra/out/ > /tmp/docs-serve.log 2>&1 &
                   echo $! > /tmp/docs-serve.pid
 
             - name: Wait for docs server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,11 +438,11 @@ jobs:
 
             - name: Start docs server
               run: |
-                  npx serve -l 3000 packages/docs-nextra/out/ > /tmp/docs-serve.log 2>&1 &
+                  npm exec serve -- -l 3000 packages/docs-nextra/out/ > /tmp/docs-serve.log 2>&1 &
                   echo $! > /tmp/docs-serve.pid
 
             - name: Wait for docs server
-              run: npx wait-on http://localhost:3000 --timeout 30000
+              run: npm exec wait-on -- http://localhost:3000 --timeout 30000
 
             - name: Run docs accessibility tests
               run: npm run test-cypress-docs-all -w packages/docs-cypress

--- a/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
+++ b/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
@@ -181,8 +181,10 @@ npm run test-cypress-docs-fast-fail -w packages/docs-cypress
 ### 4. Stop the serve server when done
 
 ```bash
-lsof -ti:3000 | xargs kill
+lsof -ti:3000 | xargs -r kill
 ```
+
+(`-r` / `--no-run-if-empty` silences the error when nothing is listening on port 3000.)
 
 ### Common failure: "cannot verify http://localhost:3000"
 

--- a/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
+++ b/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
@@ -160,7 +160,7 @@ Use `npm exec serve` to host it (it handles clean URLs — `/reference/document`
 resolves to `out/reference/document.html` automatically):
 
 ```bash
-npm exec serve -- -l 3000 packages/docs-nextra/out/ &
+npm exec serve -- --no-port-switching -l 3000 packages/docs-nextra/out/ &
 npm exec wait-on -- http://localhost:3000
 ```
 
@@ -187,6 +187,8 @@ lsof -ti:3000 | xargs kill
 ### Common failure: "cannot verify http://localhost:3000"
 
 The serve server is not running.  Start it (step 2) before running Cypress.
+If port 3000 is already occupied, `serve` now exits instead of silently
+switching to another port, so free the port and restart the command.
 
 ### Common failure: colour-contrast violations after style changes
 

--- a/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
+++ b/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
@@ -131,6 +131,69 @@ npm run preview -w @doenet/test-cypress -- --host 127.0.0.1 --port 4173 --strict
 
 4. Re-run Cypress with fast-fail settings.
 
+## Documentation Accessibility Tests (`@doenet/docs-cypress`)
+
+`packages/docs-cypress` runs cypress-axe accessibility checks against the
+built documentation site (WCAG 2.x, both light mode and dark mode).
+
+The docs site must be built and served before Cypress runs.
+
+### 1. Build the docs (if not already built or after style/content changes)
+
+```bash
+export NODE_OPTIONS="--max_old_space_size=6114"
+npm run build:docs
+```
+
+This requires the docs prerequisites (doenetml, standalone, iframe) to already
+be built.  If they are missing, build them first:
+
+```bash
+export NODE_OPTIONS="--max_old_space_size=6114"
+npm run build:docs-prereqs && npm run build:docs
+```
+
+### 2. Serve the static export
+
+The docs produces a static export in `packages/docs-nextra/out/`.
+Use `npx serve` to host it (it handles clean URLs — `/reference/document`
+resolves to `out/reference/document.html` automatically):
+
+```bash
+npx serve -l 3000 packages/docs-nextra/out/ &
+npx wait-on http://localhost:3000
+```
+
+Run the server in a background terminal or with `&`.
+
+### 3. Run Cypress in headless mode (non-interactive)
+
+```bash
+npm run test-cypress-docs-all -w packages/docs-cypress
+```
+
+Or fast-fail for quick iteration:
+
+```bash
+npm run test-cypress-docs-fast-fail -w packages/docs-cypress
+```
+
+### 4. Stop the serve server when done
+
+```bash
+lsof -ti:3000 | xargs kill
+```
+
+### Common failure: "cannot verify http://localhost:3000"
+
+The serve server is not running.  Start it (step 2) before running Cypress.
+
+### Common failure: colour-contrast violations after style changes
+
+If you changed `packages/docs-nextra/pages/style.css` or other doc styles,
+rebuild the docs (step 1) before running the tests — Cypress reads the built
+`out/` directory, not the source files.
+
 ## Quick Checklist
 
 1. Use non-interactive commands only.
@@ -140,3 +203,4 @@ npm run preview -w @doenet/test-cypress -- --host 127.0.0.1 --port 4173 --strict
 5. Only after rebuilding and starting preview, run Cypress.
 6. Use `cypress run` (headless), not `cypress open`.
 7. Stop background preview server after tests finish.
+8. For `@doenet/docs-cypress`, build the docs first, then serve `out/` on port 3000, then run Cypress.

--- a/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
+++ b/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
@@ -156,12 +156,12 @@ npm run build:docs-prereqs && npm run build:docs
 ### 2. Serve the static export
 
 The docs produces a static export in `packages/docs-nextra/out/`.
-Use `npx serve` to host it (it handles clean URLs — `/reference/document`
+Use `npm exec serve` to host it (it handles clean URLs — `/reference/document`
 resolves to `out/reference/document.html` automatically):
 
 ```bash
-npx serve -l 3000 packages/docs-nextra/out/ &
-npx wait-on http://localhost:3000
+npm exec serve -- -l 3000 packages/docs-nextra/out/ &
+npm exec wait-on -- http://localhost:3000
 ```
 
 Run the server in a background terminal or with `&`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
                 "rollup-plugin-polyfill-node": "^0.13.0",
                 "rollup-plugin-visualizer": "^6.0.5",
                 "seedrandom": "^3.0.5",
+                "serve": "^14.2.5",
                 "source-map-generator": "^2.0.2",
                 "tailwindcss": "^3.4.19",
                 "ts-morph": "^25.0.1",
@@ -7844,6 +7845,13 @@
                 "node": ">=14.6"
             }
         },
+        "node_modules/@zeit/schemas": {
+            "version": "2.36.0",
+            "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+            "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@zip.js/zip.js": {
             "version": "2.8.11",
             "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
@@ -8009,6 +8017,16 @@
             "dependencies": {
                 "css.escape": "^1.5.0",
                 "platform": "1.3.3"
+            }
+        },
+        "node_modules/ansi-align": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.1.0"
             }
         },
         "node_modules/ansi-colors": {
@@ -9235,6 +9253,109 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
+        "node_modules/boxen": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+            "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-align": "^3.0.1",
+                "camelcase": "^7.0.0",
+                "chalk": "^5.0.1",
+                "cli-boxes": "^3.0.0",
+                "string-width": "^5.1.2",
+                "type-fest": "^2.13.0",
+                "widest-line": "^4.0.1",
+                "wrap-ansi": "^8.0.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/boxen/node_modules/camelcase": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+            "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/boxen/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/boxen/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.1.tgz",
@@ -9374,6 +9495,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/cac": {
@@ -9543,6 +9674,68 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk-template": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+            "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk-template?sponsor=1"
+            }
+        },
+        "node_modules/chalk-template/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/chalk-template/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk-template/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/character-entities": {
@@ -9774,6 +9967,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cli-cursor": {
@@ -10330,6 +10536,65 @@
             "integrity": "sha512-SxT8uFOacRbP3gfi4aVAulr4KzE933eZWBguVBwuVWv3GTGQAToqpq8rFtdbIVgeCOH7RpPuXKQrPPd087b8uA==",
             "dev": true,
             "license": "BSD-2-Clause"
+        },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
+                "debug": "2.6.9",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/compression/node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/compromise": {
             "version": "13.11.4",
@@ -11792,7 +12057,6 @@
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -15209,6 +15473,19 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-port-reachable": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+            "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-stream": {
@@ -20295,6 +20572,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+            "dev": true,
+            "license": "(WTFPL OR MIT)"
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -21196,13 +21480,22 @@
                 "safe-buffer": "^5.1.0"
             }
         },
+        "node_modules/range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-            "optional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -21231,8 +21524,7 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
-            "license": "ISC",
-            "optional": true
+            "license": "ISC"
         },
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
@@ -21240,7 +21532,6 @@
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -21892,6 +22183,30 @@
             "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/registry-auth-token": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+            "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/registry-url": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+            "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/rehype-katex": {
             "version": "7.0.1",
@@ -23150,6 +23465,224 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/serve": {
+            "version": "14.2.6",
+            "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+            "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@zeit/schemas": "2.36.0",
+                "ajv": "8.18.0",
+                "arg": "5.0.2",
+                "boxen": "7.0.0",
+                "chalk": "5.0.1",
+                "chalk-template": "0.4.0",
+                "clipboardy": "3.0.0",
+                "compression": "1.8.1",
+                "is-port-reachable": "4.0.0",
+                "serve-handler": "6.1.7",
+                "update-check": "1.5.4"
+            },
+            "bin": {
+                "serve": "build/main.js"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/serve-handler": {
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+            "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.0.0",
+                "content-disposition": "0.5.2",
+                "mime-types": "2.1.18",
+                "minimatch": "3.1.5",
+                "path-is-inside": "1.0.2",
+                "path-to-regexp": "3.3.0",
+                "range-parser": "1.2.0"
+            }
+        },
+        "node_modules/serve-handler/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/serve-handler/node_modules/brace-expansion": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/serve-handler/node_modules/bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/serve-handler/node_modules/content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-handler/node_modules/mime-db": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-handler/node_modules/mime-types": {
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "~1.33.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-handler/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/serve-handler/node_modules/path-to-regexp": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+            "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/serve/node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/serve/node_modules/chalk": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/serve/node_modules/clipboardy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+            "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "arch": "^2.2.0",
+                "execa": "^5.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/serve/node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/serve/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/serve/node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
             }
         },
         "node_modules/set-blocking": {
@@ -25582,6 +26115,17 @@
                 "browserslist": ">= 4.21.0"
             }
         },
+        "node_modules/update-check": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+            "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "registry-auth-token": "3.3.2",
+                "registry-url": "3.1.0"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -26529,6 +27073,76 @@
             "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
             "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
             "license": "MIT"
+        },
+        "node_modules/widest-line": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+            "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/widest-line/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/widest-line/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/widest-line/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/widest-line/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
         },
         "node_modules/wireit": {
             "version": "0.14.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "./packages/doenetml-prototype",
                 "./packages/docs-nextra",
                 "./packages/vscode-extension/extension",
+                "./packages/docs-cypress",
                 "./packages/*"
             ],
             "dependencies": {
@@ -1859,6 +1860,10 @@
         },
         "node_modules/@doenet/demos": {
             "resolved": "packages/demos",
+            "link": true
+        },
+        "node_modules/@doenet/docs-cypress": {
+            "resolved": "packages/docs-cypress",
             "link": true
         },
         "node_modules/@doenet/docs-nextra": {
@@ -27273,6 +27278,11 @@
             "version": "*",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
+        },
+        "packages/docs-cypress": {
+            "name": "@doenet/docs-cypress",
+            "version": "*",
+            "license": "AGPL-3.0-or-later"
         },
         "packages/docs-nextra": {
             "name": "@doenet/docs-nextra",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
         "rollup-plugin-polyfill-node": "^0.13.0",
         "rollup-plugin-visualizer": "^6.0.5",
         "seedrandom": "^3.0.5",
+        "serve": "^14.2.5",
         "source-map-generator": "^2.0.2",
         "tailwindcss": "^3.4.19",
         "ts-morph": "^25.0.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "./packages/doenetml-prototype",
         "./packages/docs-nextra",
         "./packages/vscode-extension/extension",
+        "./packages/docs-cypress",
         "./packages/*"
     ],
     "scripts": {
@@ -59,7 +60,8 @@
         "test:doenetml-cypress": "npm run test-cypress-all -w packages/doenetml",
         "test:doenetml-iframe-cypress": "npm run test-cypress-all -w packages/doenetml-iframe",
         "version:changesets": "changeset version && npm install --package-lock-only",
-        "version": "npm version -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07 -w @doenet/vscode-extension -w doenet-vscode-extension"
+        "version": "npm version -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07 -w @doenet/vscode-extension -w doenet-vscode-extension",
+        "test:docs-cypress": "npm run test-cypress-docs-all -w packages/docs-cypress"
     },
     "prettier": {
         "tabWidth": 4

--- a/packages/docs-cypress/README.md
+++ b/packages/docs-cypress/README.md
@@ -19,7 +19,7 @@ Then serve the generated `packages/docs-nextra/out/` directory in a separate
 terminal:
 
 ```bash
-npx serve -l 3000 packages/docs-nextra/out/
+npm exec serve -- -l 3000 packages/docs-nextra/out/
 ```
 
 From the repo root, run the tests headlessly:

--- a/packages/docs-cypress/README.md
+++ b/packages/docs-cypress/README.md
@@ -8,14 +8,21 @@ in both light and dark mode.
 
 ## Running the tests
 
-The documentation site must be running before you start Cypress.  Start it
-in a separate terminal:
+Build the static docs export first:
 
 ```bash
-npm run dev -w packages/docs-nextra
+export NODE_OPTIONS="--max_old_space_size=6114"
+npm run build:docs-prereqs && npm run build:docs
 ```
 
-Then, from the repo root, run the tests headlessly:
+Then serve the generated `packages/docs-nextra/out/` directory in a separate
+terminal:
+
+```bash
+npx serve -l 3000 packages/docs-nextra/out/
+```
+
+From the repo root, run the tests headlessly:
 
 ```bash
 npm run test:docs-cypress

--- a/packages/docs-cypress/README.md
+++ b/packages/docs-cypress/README.md
@@ -1,0 +1,35 @@
+# @doenet/docs-cypress
+
+Cypress accessibility tests for the DoenetML documentation site.
+
+Tests use [cypress-axe](https://github.com/component-driven/cypress-axe) to
+run automated WCAG 2.x accessibility checks against live documentation pages
+in both light and dark mode.
+
+## Running the tests
+
+The documentation site must be running before you start Cypress.  Start it
+in a separate terminal:
+
+```bash
+npm run dev -w packages/docs-nextra
+```
+
+Then, from the repo root, run the tests headlessly:
+
+```bash
+npm run test:docs-cypress
+```
+
+Or open the Cypress UI for interactive development:
+
+```bash
+cd packages/docs-cypress
+npx cypress open --config baseUrl=http://localhost:3000
+```
+
+## Test coverage
+
+| File | What it tests |
+|------|---------------|
+| `cypress/e2e/accessibility/docsAccessibility.cy.js` | axe WCAG 2.x rules on key pages in light mode and dark mode; includes a regression test for issue #1368 (attribute pill contrast in dark mode) |

--- a/packages/docs-cypress/README.md
+++ b/packages/docs-cypress/README.md
@@ -19,7 +19,7 @@ Then serve the generated `packages/docs-nextra/out/` directory in a separate
 terminal:
 
 ```bash
-npm exec serve -- -l 3000 packages/docs-nextra/out/
+npm exec serve -- --no-port-switching -l 3000 packages/docs-nextra/out/
 ```
 
 From the repo root, run the tests headlessly:

--- a/packages/docs-cypress/cypress.config.js
+++ b/packages/docs-cypress/cypress.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+    defaultCommandTimeout: 15000,
+    retries: {
+        runMode: 2,
+        openMode: 0,
+    },
+    e2e: {
+        baseUrl: "http://localhost:3000",
+        setupNodeEvents(_on, _config) {},
+    },
+});

--- a/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
+++ b/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
@@ -7,9 +7,10 @@
  * issue (#1368) was specifically a dark-mode contrast failure on attribute
  * reference pages.
  *
- * Running these tests requires the docs site to be running at the baseUrl
- * configured in cypress.config.js (default http://localhost:3000).  Start it
- * with `npm run dev -w packages/docs-nextra` before opening Cypress.
+ * Running these tests requires the built docs site to be served at the
+ * baseUrl configured in cypress.config.js (default http://localhost:3000).
+ * The recommended workflow is `npm run build:docs` followed by
+ * `npx serve -l 3000 packages/docs-nextra/out/`.
  */
 
 /**

--- a/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
+++ b/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
@@ -10,7 +10,7 @@
  * Running these tests requires the built docs site to be served at the
  * baseUrl configured in cypress.config.js (default http://localhost:3000).
  * The recommended workflow is `npm run build:docs` followed by
- * `npx serve -l 3000 packages/docs-nextra/out/`.
+ * `npm exec serve -- -l 3000 packages/docs-nextra/out/`.
  */
 
 /**

--- a/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
+++ b/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
@@ -28,8 +28,12 @@ function enableDarkMode() {
 }
 
 /**
- * Run the full set of axe rules (all WCAG 2.x levels) against the main page
- * content and report any violations with helpful context.
+ * Run WCAG 2.x (A, AA, 2.1 AA) and best-practice axe rules against the main
+ * page content and report any violations with helpful context.
+ *
+ * The `frame-title` rule is disabled: DoenetML live examples are sandboxed
+ * iframes whose internals are covered by the main test-cypress suite, not
+ * by these docs-level checks.
  */
 function checkPageAccessibility() {
     cy.injectAxe();

--- a/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
+++ b/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
@@ -10,7 +10,7 @@
  * Running these tests requires the built docs site to be served at the
  * baseUrl configured in cypress.config.js (default http://localhost:3000).
  * The recommended workflow is `npm run build:docs` followed by
- * `npm exec serve -- -l 3000 packages/docs-nextra/out/`.
+ * `npm exec serve -- --no-port-switching -l 3000 packages/docs-nextra/out/`.
  */
 
 /**

--- a/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
+++ b/packages/docs-cypress/cypress/e2e/accessibility/docsAccessibility.cy.js
@@ -1,0 +1,173 @@
+/**
+ * Accessibility checks for the DoenetML documentation site.
+ *
+ * Each test visits a representative page, optionally switches to dark mode,
+ * and runs axe's colour-contrast (and broader WCAG) rules against the page
+ * content.  The suite covers both light and dark mode because the reported
+ * issue (#1368) was specifically a dark-mode contrast failure on attribute
+ * reference pages.
+ *
+ * Running these tests requires the docs site to be running at the baseUrl
+ * configured in cypress.config.js (default http://localhost:3000).  Start it
+ * with `npm run dev -w packages/docs-nextra` before opening Cypress.
+ */
+
+/**
+ * Enable Nextra's dark mode by injecting the class that the theme reads.
+ * Nextra stores the preference in localStorage and adds `class="dark"` to
+ * `<html>`.  Setting localStorage before page load is the most reliable way
+ * to get the initial render in dark mode.
+ */
+function enableDarkMode() {
+    cy.window().then((win) => {
+        win.localStorage.setItem("theme", "dark");
+    });
+    cy.reload();
+    cy.get("html.dark").should("exist");
+}
+
+/**
+ * Run the full set of axe rules (all WCAG 2.x levels) against the main page
+ * content and report any violations with helpful context.
+ */
+function checkPageAccessibility() {
+    cy.injectAxe();
+    cy.checkA11y(
+        "main",
+        {
+            runOnly: {
+                type: "tag",
+                values: ["wcag2a", "wcag2aa", "wcag21aa", "best-practice"],
+            },
+            // Skip rules that are legitimately inapplicable to docs pages or
+            // are already handled at the Nextra-theme level.
+            rules: {
+                // The docs iframe embeds (DoenetML live examples) are sandboxed
+                // — their internals are tested by the main test-cypress suite.
+                "frame-title": { enabled: false },
+            },
+        },
+        (violations) => {
+            const summary = violations.map((v) => ({
+                id: v.id,
+                impact: v.impact,
+                description: v.description,
+                nodes: v.nodes.map((n) => n.html),
+            }));
+            expect(
+                violations,
+                `axe violations:\n${JSON.stringify(summary, null, 2)}`,
+            ).to.have.length(0);
+        },
+        // false → fail the test (not just log a warning) on violations
+        false,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Light-mode suite
+// ---------------------------------------------------------------------------
+
+describe("Documentation accessibility — light mode", () => {
+    beforeEach(() => {
+        // Ensure light mode is active.
+        cy.clearCookies();
+        cy.clearLocalStorage();
+    });
+
+    it("home page passes axe in light mode", () => {
+        cy.visit("/");
+        cy.get("main").should("exist");
+        checkPageAccessibility();
+    });
+
+    it("quick-start tutorial passes axe in light mode", () => {
+        cy.visit("/tutorials/quickStart");
+        cy.get("main").should("exist");
+        checkPageAccessibility();
+    });
+
+    it("reference page with attribute/prop table (document) passes axe in light mode", () => {
+        cy.visit("/reference/document");
+        // Wait for the AttrPropDisplay component to finish rendering.
+        cy.get(".attr-list, .attr-name-box").should("exist");
+        checkPageAccessibility();
+    });
+
+    it("concepts/essentialConcepts passes axe in light mode", () => {
+        cy.visit("/concepts/essentialConcepts");
+        cy.get("main").should("exist");
+        checkPageAccessibility();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Dark-mode suite  (this is where issue #1368 was reported)
+// ---------------------------------------------------------------------------
+
+describe("Documentation accessibility — dark mode", () => {
+    beforeEach(() => {
+        cy.clearCookies();
+        cy.clearLocalStorage();
+    });
+
+    it("home page passes axe in dark mode", () => {
+        cy.visit("/");
+        enableDarkMode();
+        cy.get("main").should("exist");
+        checkPageAccessibility();
+    });
+
+    it("quick-start tutorial passes axe in dark mode", () => {
+        cy.visit("/tutorials/quickStart");
+        enableDarkMode();
+        cy.get("main").should("exist");
+        checkPageAccessibility();
+    });
+
+    /**
+     * This is the specific page and mode reported in issue #1368.
+     * The attribute name pills (.attr-name-box / .attr-name) previously
+     * rendered blue text (rgb(0,122,255)) on a gray-700 background
+     * (rgb(55,65,81)), giving only ~2.6:1 contrast — well below the
+     * WCAG AA threshold of 4.5:1.
+     */
+    it("reference page attribute pills pass colour-contrast in dark mode (issue #1368)", () => {
+        cy.visit("/reference/document");
+        enableDarkMode();
+        cy.get(".attr-name-box").should("exist");
+        cy.injectAxe();
+        cy.checkA11y(
+            "main",
+            {
+                runOnly: { type: "rule", values: ["color-contrast"] },
+                includedImpacts: ["critical", "serious", "moderate", "minor"],
+            },
+            (violations) => {
+                const summary = violations.map((v) => ({
+                    id: v.id,
+                    nodes: v.nodes.map((n) => n.html),
+                }));
+                expect(
+                    violations,
+                    `colour-contrast violations:\n${JSON.stringify(summary, null, 2)}`,
+                ).to.have.length(0);
+            },
+            false,
+        );
+    });
+
+    it("reference page with attribute/prop table (document) passes full axe in dark mode", () => {
+        cy.visit("/reference/document");
+        enableDarkMode();
+        cy.get(".attr-list, .attr-name-box").should("exist");
+        checkPageAccessibility();
+    });
+
+    it("concepts/essentialConcepts passes axe in dark mode", () => {
+        cy.visit("/concepts/essentialConcepts");
+        enableDarkMode();
+        cy.get("main").should("exist");
+        checkPageAccessibility();
+    });
+});

--- a/packages/docs-cypress/cypress/support/e2e.js
+++ b/packages/docs-cypress/cypress/support/e2e.js
@@ -1,0 +1,13 @@
+import "cypress-axe";
+
+/**
+ * Override `injectAxe` to read axe-core directly from node_modules so the
+ * test works regardless of how the documentation site handles static assets.
+ */
+Cypress.Commands.overwrite("injectAxe", () => {
+    cy.readFile("../../node_modules/axe-core/axe.min.js").then((source) => {
+        cy.window({ log: false }).then((win) => {
+            win.eval(source);
+        });
+    });
+});

--- a/packages/docs-cypress/cypress/support/e2e.js
+++ b/packages/docs-cypress/cypress/support/e2e.js
@@ -5,9 +5,11 @@ import "cypress-axe";
  * test works regardless of how the documentation site handles static assets.
  */
 Cypress.Commands.overwrite("injectAxe", () => {
-    cy.readFile("../../node_modules/axe-core/axe.min.js").then((source) => {
-        cy.window({ log: false }).then((win) => {
-            win.eval(source);
+    return cy
+        .readFile("../../node_modules/axe-core/axe.min.js")
+        .then((source) => {
+            cy.window({ log: false }).then((win) => {
+                win.eval(source);
+            });
         });
-    });
 });

--- a/packages/docs-cypress/package.json
+++ b/packages/docs-cypress/package.json
@@ -11,6 +11,6 @@
         "test": "echo \"No unit tests (run test-cypress-docs or test-cypress-docs-fast-fail)\"",
         "test-cypress-docs": "cypress open --config baseUrl=http://localhost:3000",
         "test-cypress-docs-all": "cypress run -b 'chrome' --headless --config video=false",
-        "test-cypress-docs-fast-fail": "cypress run -b 'chrome' --headless --config 'video=false,retries=0,defaultCommandTimeout=15000'"
+        "test-cypress-docs-fast-fail": "cypress run -b 'chrome' --headless --config video=false,retries=0,defaultCommandTimeout=15000"
     }
 }

--- a/packages/docs-cypress/package.json
+++ b/packages/docs-cypress/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "test": "echo \"No unit tests (run test-cypress-docs or test-cypress-docs-fast-fail)\"",
         "test-cypress-docs": "cypress open --config baseUrl=http://localhost:3000",
-        "test-cypress-docs-all": "cypress run -b 'chrome' --config video=false --headless --config baseUrl=http://localhost:3000",
-        "test-cypress-docs-fast-fail": "cypress run -b 'chrome' --headless --config 'video=false,retries=0,defaultCommandTimeout=15000,baseUrl=http://localhost:3000'"
+        "test-cypress-docs-all": "cypress run -b 'chrome' --headless --config video=false",
+        "test-cypress-docs-fast-fail": "cypress run -b 'chrome' --headless --config 'video=false,retries=0,defaultCommandTimeout=15000'"
     }
 }

--- a/packages/docs-cypress/package.json
+++ b/packages/docs-cypress/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@doenet/docs-cypress",
+    "type": "module",
+    "description": "Cypress accessibility tests for the DoenetML documentation site",
+    "version": "*",
+    "license": "AGPL-3.0-or-later",
+    "homepage": "https://github.com/Doenet/DoenetML#readme",
+    "private": true,
+    "repository": "github:Doenet/DoenetML",
+    "scripts": {
+        "test": "echo \"No unit tests (run test-cypress-docs or test-cypress-docs-fast-fail)\"",
+        "test-cypress-docs": "cypress open --config baseUrl=http://localhost:3000",
+        "test-cypress-docs-all": "cypress run -b 'chrome' --config video=false --headless --config baseUrl=http://localhost:3000",
+        "test-cypress-docs-fast-fail": "cypress run -b 'chrome' --headless --config 'video=false,retries=0,defaultCommandTimeout=15000,baseUrl=http://localhost:3000'"
+    }
+}

--- a/packages/docs-nextra/pages/style.css
+++ b/packages/docs-nextra/pages/style.css
@@ -9,6 +9,34 @@
     margin-top: 1.5rem;
 }
 
+/* ---------------------------------------------------------------------------
+ * Pre-existing Nextra/Shiki contrast fixes
+ * ---------------------------------------------------------------------------
+ * These rules correct WCAG 2.x AA failures that originate in third-party
+ * theme choices (Nextra's primary colour and the GitHub Light Shiki theme)
+ * rather than our own custom styles. They are scoped to light mode only;
+ * dark mode values in both cases already pass by a wide margin.
+ * --------------------------------------------------------------------------- */
+
+/* Nextra's default primary-600 link colour is hsl(212deg 100% 45%)
+ * ≈ rgb(0 107 230), which gives 4.49:1 on the gray-100 (rgb(243 244 246))
+ * background applied to even table rows — just below the 4.5:1 AA threshold
+ * (the exact ratio depends on the browser's HSL rounding).
+ * Lowering the lightness to 40% gives 5.44:1 on gray-100 and 5.99:1 on white,
+ * both well above the threshold. */
+html:not(.dark) .nextra-content ._text-primary-600 {
+    color: hsl(212deg 100% 40%);
+}
+
+/* The GitHub Light Shiki theme uses #22863A (a medium green) for XML/DoenetML
+ * tag-name tokens. That colour gives only 4.35–4.43:1 on Nextra's off-white
+ * backgrounds (rgb(246 248 250) for code blocks, rgb(250 250 250) for the
+ * page body). #1A7E32 is a slightly darker green that gives 4.84–5.15:1
+ * across all relevant light-mode backgrounds. */
+html:not(.dark) .nextra-content code span[style*="--shiki-light:#22863A"] {
+    color: #1a7e32 !important; /* overrides `color: var(--shiki-light)` */
+}
+
 /* Attribute and property names highlighted in blue. */
 .attr-name,
 .prop-name {

--- a/packages/docs-nextra/pages/style.css
+++ b/packages/docs-nextra/pages/style.css
@@ -33,7 +33,7 @@ html:not(.dark) .nextra-content ._text-primary-600 {
  * backgrounds (rgb(246 248 250) for code blocks, rgb(250 250 250) for the
  * page body). #1A7E32 is a slightly darker green that gives 4.84–5.15:1
  * across all relevant light-mode backgrounds. */
-html:not(.dark) .nextra-content code span[style*="--shiki-light:#22863A"] {
+html:not(.dark) .nextra-content code span[style*="--shiki-light:#22863A" i] {
     color: #1a7e32 !important; /* overrides `color: var(--shiki-light)` */
 }
 

--- a/packages/docs-nextra/pages/style.css
+++ b/packages/docs-nextra/pages/style.css
@@ -14,9 +14,12 @@
 .prop-name {
     color: rgb(29, 85, 197);
 }
+/* Dark mode: rgb(0,122,255) on the gray-700 pill gives only ~2.6:1 contrast
+   (fails WCAG AA). Use a lighter blue (Tailwind blue-300) that achieves
+   ~5.7:1 against the rgb(55,65,81) pill background. */
 :is(html[class~="dark"] .nextra-content) .attr-name,
 :is(html[class~="dark"] .nextra-content) .prop-name {
-    color: rgb(0, 122, 255);
+    color: rgb(147, 197, 253);
 }
 
 /* Type label that leads each indented detail paragraph. */
@@ -101,7 +104,12 @@
 /* "(default)" marker after the default keyword value. */
 .attr-default-marker {
     font-style: italic;
-    color: rgb(107, 114, 128);
+    /* gray-600: at least 6.9:1 against any Nextra light-mode background. */
+    color: rgb(75, 85, 99);
+}
+/* Dark mode: gray-400 achieves ~7.4:1 against Nextra dark backgrounds. */
+:is(html[class~="dark"] .nextra-content) .attr-default-marker {
+    color: rgb(156, 163, 175);
 }
 
 /* Small Value/Description table for enumerated (non-boolean) attributes. */
@@ -146,6 +154,12 @@
 .attr-filter-input:focus {
     outline: 2px solid rgb(29, 85, 197);
     outline-offset: -1px;
+}
+/* Dark mode: the light-mode blue (29,85,197) achieves only ~2.8:1 against the
+   dark page background (fails WCAG 1.4.11 non-text contrast of 3:1).
+   Use Tailwind blue-400 which achieves ~7.4:1. */
+:is(html[class~="dark"] .nextra-content) .attr-filter-input:focus {
+    outline-color: rgb(96, 165, 250);
 }
 :is(html[class~="dark"] .nextra-content) .attr-filter-input {
     border-color: rgb(75, 85, 99);
@@ -194,7 +208,12 @@
 }
 .attr-group-count {
     font-weight: 400;
-    color: rgb(107, 114, 128);
+    /* gray-600: at least 6.9:1 against any Nextra light-mode background. */
+    color: rgb(75, 85, 99);
+}
+/* Dark mode: same contrast fix as .attr-default-marker above. */
+:is(html[class~="dark"] .nextra-content) .attr-group-count {
+    color: rgb(156, 163, 175);
 }
 .attr-group-body {
     padding: 0 0.75rem 0.25rem;
@@ -209,5 +228,10 @@
 .attr-filter-empty {
     margin: 0.5em 0 0.5em 0.25em;
     font-style: italic;
-    color: rgb(107, 114, 128);
+    /* gray-600: at least 6.9:1 against any Nextra light-mode background. */
+    color: rgb(75, 85, 99);
+}
+/* Dark mode: same contrast fix as .attr-default-marker above. */
+:is(html[class~="dark"] .nextra-content) .attr-filter-empty {
+    color: rgb(156, 163, 175);
 }

--- a/packages/docs-nextra/pages/tutorials/quickStart.mdx
+++ b/packages/docs-nextra/pages/tutorials/quickStart.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'nextra/components'
 
 # Quick Start Tutorial
 
-### Writing Your First DoenetML Document
+## Writing Your First DoenetML Document
 DoenetML is an easy way to author interactive math activities for the web. In the next few minutes this guide will show you how to make a math assessment that can give your students instant feedback.
 
 Here is an example math question with a place for students to type in and check their answers. Go ahead and answer the question and check your work.
@@ -27,7 +27,7 @@ Simplify
 
 Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
-### Markup Languages
+## Markup Languages
 DoenetML documents are written in plain text; the language is similar to HTML. The parts of the document that are written like `<math>` and `<answer>` are called *tags*. Tags allow you to create everything in your document that isn't just regular written text. Just like HTML, tags are denoted with angle brackets, `<` and `>`. The closing tag includes an extra slash.
 
 Note that the DoenetML code is written on 3 lines, but the rendered version of the question is shown all on 1 line. It can be helpful to break up complex parts of your document onto separate lines to make the code easier to read, and by default this won't move your content onto a new line. If you want to make a new line in the document you can put some of the content in a paragraph `<p>` tag.


### PR DESCRIPTION
Fixes #1368.

## Problem

The DoenetML documentation site had several WCAG 2.x AA contrast failures, most visibly reported in issue #1368 where attribute name pills in dark mode rendered blue text (`rgb(0,122,255)`) on a gray-700 background (`rgb(55,65,81)`), giving a contrast ratio of only ~2.6:1 (AA requires 4.5:1).

A systematic audit of all custom styles and the Nextra/Shiki theme found six failures:

| Element | Mode | Old contrast | Fix | New contrast |
|---|---|---|---|---|
| `.attr-name`/`.prop-name` pill text | dark | 2.57:1 ❌ | `rgb(147,197,253)` (blue-300) | 5.72:1 ✅ |
| `.attr-default-marker` / `.attr-group-count` / `.attr-filter-empty` | light | borderline | gray-600 `rgb(75,85,99)` | 7.56:1 ✅ |
| same three | dark | 3.91:1 ❌ | gray-400 `rgb(156,163,175)` | 7.44:1 ✅ |
| `.attr-filter-input:focus` outline | dark | 2.84:1 ❌ (WCAG 1.4.11) | `rgb(96,165,250)` (blue-400) | 7.43:1 ✅ |
| Nextra primary-600 links in prose tables | light | 4.49:1 ❌ (at-threshold) | `hsl(212deg 100% 40%)` | 5.44:1 ✅ |
| Shiki GitHub-Light green (`#22863A`) for XML tag names | light | 4.35:1 ❌ | `#1a7e32` | 4.84:1 ✅ |

## Content fix

`tutorials/quickStart.mdx` promoted `###` headings to `##` — axe reported a `heading-order` violation because the page jumped from h1 to h3 without an intervening h2.

## New `packages/docs-cypress` package

Adds cypress-axe accessibility tests for the documentation site covering key pages in both light and dark mode. Includes a dedicated regression test for issue #1368.

Run locally (after building the docs):

```bash
npm exec serve -- --no-port-switching -l 3000 packages/docs-nextra/out/ &
npm exec wait-on -- http://localhost:3000
npm run test-cypress-docs-all -w packages/docs-cypress
```

Using `--no-port-switching` keeps `serve` from silently hopping to another port if 3000 is already occupied.

## CI

- `build-docs` now uploads the static `out/` directory as a `docs-out` artifact after building.
- New `test-docs-cypress` job downloads the artifact, serves it with `npm exec serve -- --no-port-switching`, and runs Cypress headlessly.

## `TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md`

Added a new section documenting how to build, serve, and run the docs-cypress tests locally.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
