### PR TITLE
fix: dark-mode error messages, graph handle colors, and smart labels

### DIFF
--- a/.changeset/dark-mode-error-messages-and-handles.md
+++ b/.changeset/dark-mode-error-messages-and-handles.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-Dark mode: keep viewer and iframe error states, graph handles, and JSXGraph labels legible.
+Dark mode: keep viewer, editor, and iframe error states and graph UI legible.
 
-Error banners and renderer-load failures now use theme-aware colors, graph drag handles now follow live dark-mode changes, and smart labels use dark-mode-aware colors on JSXGraph canvases. This also adds dark-mode accessibility coverage for disabled check-work buttons.
+Error banners, renderer-load failures, and editor footer menus now use theme-aware colors, graph drag handles now follow live dark-mode changes, and smart labels use dark-mode-aware colors on JSXGraph canvases. This also adds dark-mode accessibility coverage for disabled check-work buttons.

--- a/.changeset/dark-mode-error-messages-and-handles.md
+++ b/.changeset/dark-mode-error-messages-and-handles.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Dark mode: keep viewer and iframe error states, graph handles, and JSXGraph labels legible.
+
+Error banners and renderer-load failures now use theme-aware colors, graph drag handles keep their dark-mode colors and layering on first render, and smart labels plus disabled check-work controls stay readable on dark canvases.

--- a/.changeset/dark-mode-error-messages-and-handles.md
+++ b/.changeset/dark-mode-error-messages-and-handles.md
@@ -8,4 +8,4 @@
 
 Dark mode: keep viewer and iframe error states, graph handles, and JSXGraph labels legible.
 
-Error banners and renderer-load failures now use theme-aware colors, graph drag handles keep their dark-mode colors and layering on first render, and smart labels plus disabled check-work controls stay readable on dark canvases.
+Error banners and renderer-load failures now use theme-aware colors, graph drag handles now follow live dark-mode changes, and smart labels use dark-mode-aware colors on JSXGraph canvases. This also adds dark-mode accessibility coverage for disabled check-work buttons.

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -305,6 +305,15 @@ export function DoenetViewer({
                     fontSize: "1.3em",
                     marginLeft: "20px",
                     marginTop: "20px",
+                    backgroundColor:
+                        resolvedTheme === "dark"
+                            ? "#7f1d1d"
+                            : "hsl(0, 54%, 82%)",
+                    color: resolvedTheme === "dark" ? "white" : "black",
+                    borderWidth: 3,
+                    borderStyle: "solid",
+                    borderColor: "#c1292e",
+                    padding: "0.5em",
                 }}
             >
                 {errorIcon} {inErrorState}
@@ -794,6 +803,15 @@ export const DoenetEditor = React.forwardRef<
                     fontSize: "1.3em",
                     marginLeft: "20px",
                     marginTop: "20px",
+                    backgroundColor:
+                        resolvedTheme === "dark"
+                            ? "#7f1d1d"
+                            : "hsl(0, 54%, 82%)",
+                    color: resolvedTheme === "dark" ? "white" : "black",
+                    borderWidth: 3,
+                    borderStyle: "solid",
+                    borderColor: "#c1292e",
+                    padding: "0.5em",
                 }}
             >
                 {errorIcon} {inErrorState}

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -424,6 +424,27 @@ div.jxgbox input[type="checkbox"] {
     padding: 1px 7px 1px 7px;
 }
 
+/*
+ * Smart-label dark-mode overrides.
+ *
+ * `.smart-label-pure`: transparent background with hardcoded black text.
+ *   On a dark JSXGraph canvas this produces invisible text — switch to
+ *   canvas-text color so it adapts to the theme.
+ *
+ * `.smart-label-outline`: white bubble on the dark canvas is jarring.
+ *   Use an elevated-surface background consistent with other dark-mode
+ *   popover surfaces, with a theme-aware border and text.
+ */
+[data-theme="dark"] .smart-label-pure {
+    color: var(--canvasText);
+}
+
+[data-theme="dark"] .smart-label-outline {
+    background-color: #2d2d2d;
+    border-color: var(--canvasText);
+    color: var(--canvasText);
+}
+
 /* Fix: Ensure div-based paragraphs maintain standard paragraph spacing */
 .doenet-viewer .para {
     margin-block-start: 1em;

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -516,6 +516,7 @@
 [data-theme="dark"] .editor-panel .footer-menu {
     background-color: var(--canvas);
     border-color: #555;
+    color: var(--canvasText);
 }
 
 /* Responses icon — muted slate instead of medium gray (#667085 fails on #121212) */

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -1570,9 +1570,15 @@ export function DocViewer({
         return (
             <div
                 style={{
+                    backgroundColor: "var(--lightRed)",
+                    color: "var(--canvasText)",
+                    borderWidth: 3,
+                    borderStyle: "solid",
+                    borderColor: "var(--mainRed)",
                     fontSize: "1.3em",
                     marginLeft: "20px",
                     marginTop: "20px",
+                    padding: "0.5em",
                 }}
             >
                 <MdError color="red" fontSize={"24pt"} /> {errMsg}
@@ -1610,12 +1616,16 @@ export function DocViewer({
     if (!coreCreated.current) {
         if (!documentRenderer) {
             noCoreWarning = (
-                <div style={{ backgroundColor: "lightCyan" }}>
+                <div
+                    style={{
+                        backgroundColor: "var(--canvas)",
+                        color: "var(--canvasText)",
+                    }}
+                >
                     <p>Initializing....</p>
                 </div>
             );
         }
-        viewerStyle.backgroundColor = "#F0F0F0";
     }
 
     let errorOverview = null;
@@ -1682,7 +1692,21 @@ class ErrorBoundary extends React.Component<ErrorProps, ErrorState> {
             if (!this.props.coreCreated) {
                 return null;
             } else {
-                return <h1>Something went wrong.</h1>;
+                return (
+                    <div
+                        style={{
+                            backgroundColor: "var(--lightRed)",
+                            color: "var(--canvasText)",
+                            padding: "1em",
+                            textAlign: "center",
+                            borderWidth: 3,
+                            borderStyle: "solid",
+                            borderColor: "var(--mainRed)",
+                        }}
+                    >
+                        <b>Error</b>: Something went wrong.
+                    </div>
+                );
             }
         }
         return this.props.children;

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -483,22 +483,6 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
 
     const inputKey = id + "_input";
 
-    let checkWorkStyle: React.CSSProperties = {
-        cursor: "pointer",
-        padding: "1px 6px 1px 6px",
-    };
-    let checkWorkTabIndex = "0";
-
-    if (disabled) {
-        // Disable the checkWorkButton
-        checkWorkStyle.backgroundColor = getComputedStyle(
-            document.documentElement,
-        ).getPropertyValue("--mainGray");
-        checkWorkStyle.color = "black";
-        checkWorkStyle.cursor = "not-allowed";
-        checkWorkTabIndex = "-1";
-    }
-
     const validationState = calculateValidationState(SVs);
     const { isPending, submitActionWithPending } = useSubmitActionWithDelay({
         actionKey: "submitAnswer",

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -764,16 +764,14 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
             );
 
             if (layerChanged && SVs.curveType === "bezier") {
-                segmentLayer = 10 * SVs.layer + VERTEX_LAYER_OFFSET;
-                throughPointLayer = 10 * SVs.layer + VERTEX_LAYER_OFFSET;
-                controlPointLayer = 10 * SVs.layer + CONTROL_POINT_LAYER_OFFSET;
                 segmentAttributes.current!.layer = segmentLayer;
                 throughPointAttributes.current!.layer = throughPointLayer;
                 controlPointAttributes.current!.layer = controlPointLayer;
             }
 
+            const handleColor = resolveHandleColor(darkMode);
+
             if (SVs.curveType === "bezier") {
-                const handleColor = resolveHandleColor(darkMode);
                 segmentAttributes.current!.strokeColor = handleColor;
                 segmentAttributes.current!.highlightStrokeColor = handleColor;
                 throughPointAttributes.current!.highlightFillColor =

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -772,17 +772,23 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                 controlPointAttributes.current!.layer = controlPointLayer;
             }
 
-            const handleColor = resolveHandleColor(darkMode);
-            segmentAttributes.current!.strokeColor = handleColor;
-            segmentAttributes.current!.highlightStrokeColor = handleColor;
-            throughPointAttributes.current!.highlightFillColor = handleColor;
-            throughPointAttributes.current!.highlightStrokeColor = handleColor;
-            throughPointAlwaysVisible.current!.fillcolor = handleColor;
-            throughPointAlwaysVisible.current!.strokecolor = handleColor;
-            controlPointAttributes.current!.fillColor = handleColor;
-            controlPointAttributes.current!.strokeColor = handleColor;
-            controlPointAttributes.current!.highlightFillColor = handleColor;
-            controlPointAttributes.current!.highlightStrokeColor = handleColor;
+            if (SVs.curveType === "bezier") {
+                const handleColor = resolveHandleColor(darkMode);
+                segmentAttributes.current!.strokeColor = handleColor;
+                segmentAttributes.current!.highlightStrokeColor = handleColor;
+                throughPointAttributes.current!.highlightFillColor =
+                    handleColor;
+                throughPointAttributes.current!.highlightStrokeColor =
+                    handleColor;
+                throughPointAlwaysVisible.current!.fillcolor = handleColor;
+                throughPointAlwaysVisible.current!.strokecolor = handleColor;
+                controlPointAttributes.current!.fillColor = handleColor;
+                controlPointAttributes.current!.strokeColor = handleColor;
+                controlPointAttributes.current!.highlightFillColor =
+                    handleColor;
+                controlPointAttributes.current!.highlightStrokeColor =
+                    handleColor;
+            }
 
             let lineColor =
                 darkMode === "dark"

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -15,7 +15,7 @@ import { JXGCurve, JXGLine, JXGPoint } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { resolveLineColor } from "./utils/styleColors";
+import { resolveLineColor, resolveHandleColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { syncLabelStrokeColor, syncLayer } from "./utils/jsxgraph";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
@@ -300,12 +300,13 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                 });
             });
 
+            const handleColor = resolveHandleColor(darkMode);
             segmentAttributes.current = {
                 visible: false,
                 withLabel: false,
                 fixed: true,
-                strokeColor: "var(--graphHandle)",
-                highlightStrokeColor: "var(--graphHandle)",
+                strokeColor: handleColor,
+                highlightStrokeColor: handleColor,
                 layer: 10 * SVs.layer + VERTEX_LAYER_OFFSET,
                 strokeWidth: 1,
                 highlightStrokeWidth: 1,
@@ -316,8 +317,8 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                 fixed: false,
                 fillColor: "none",
                 strokeColor: "none",
-                highlightFillColor: "var(--graphHandle)",
-                highlightStrokeColor: "var(--graphHandle)",
+                highlightFillColor: handleColor,
+                highlightStrokeColor: handleColor,
                 strokeWidth: 1,
                 highlightStrokeWidth: 1,
                 layer: 10 * SVs.layer + VERTEX_LAYER_OFFSET,
@@ -325,8 +326,8 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                 showInfoBox: SVs.showCoordsWhenDragging,
             };
             throughPointAlwaysVisible.current = {
-                fillcolor: "var(--graphHandle)",
-                strokecolor: "var(--graphHandle)",
+                fillcolor: handleColor,
+                strokecolor: handleColor,
             };
             throughPointHoverVisible.current = {
                 fillcolor: "none",
@@ -337,10 +338,10 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                 visible: false,
                 withLabel: false,
                 fixed: false,
-                fillColor: "var(--graphHandle)",
-                strokeColor: "var(--graphHandle)",
-                highlightFillColor: "var(--graphHandle)",
-                highlightStrokeColor: "var(--graphHandle)",
+                fillColor: handleColor,
+                strokeColor: handleColor,
+                highlightFillColor: handleColor,
+                highlightStrokeColor: handleColor,
                 strokeWidth: 1,
                 highlightStrokeWidth: 1,
                 layer: 10 * SVs.layer + CONTROL_POINT_LAYER_OFFSET,

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -17,7 +17,11 @@ import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
 import { resolveLineColor, resolveHandleColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
-import { syncLabelStrokeColor, syncLayer } from "./utils/jsxgraph";
+import {
+    syncLabelStrokeColor,
+    syncLayer,
+    syncVisPropValues,
+} from "./utils/jsxgraph";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
@@ -768,6 +772,18 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                 controlPointAttributes.current!.layer = controlPointLayer;
             }
 
+            const handleColor = resolveHandleColor(darkMode);
+            segmentAttributes.current!.strokeColor = handleColor;
+            segmentAttributes.current!.highlightStrokeColor = handleColor;
+            throughPointAttributes.current!.highlightFillColor = handleColor;
+            throughPointAttributes.current!.highlightStrokeColor = handleColor;
+            throughPointAlwaysVisible.current!.fillcolor = handleColor;
+            throughPointAlwaysVisible.current!.strokecolor = handleColor;
+            controlPointAttributes.current!.fillColor = handleColor;
+            controlPointAttributes.current!.strokeColor = handleColor;
+            controlPointAttributes.current!.highlightFillColor = handleColor;
+            controlPointAttributes.current!.highlightStrokeColor = handleColor;
+
             let lineColor =
                 darkMode === "dark"
                     ? SVs.selectedStyle.lineColorDarkMode
@@ -1063,6 +1079,37 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                         layer: controlPointLayer,
                     });
                 }
+
+                syncVisPropValues(throughPointsJXG.current![i], {
+                    highlightfillcolor: handleColor,
+                    highlightstrokecolor: handleColor,
+                });
+                if (throughPointsJXG.current![i].visProp.fillcolor !== "none") {
+                    syncVisPropValues(throughPointsJXG.current![i], {
+                        fillcolor: handleColor,
+                        strokecolor: handleColor,
+                    });
+                }
+                syncVisPropValues(controlPointsJXG.current![i][0], {
+                    fillcolor: handleColor,
+                    strokecolor: handleColor,
+                    highlightfillcolor: handleColor,
+                    highlightstrokecolor: handleColor,
+                });
+                syncVisPropValues(segmentsJXG.current![i][0], {
+                    strokecolor: handleColor,
+                    highlightstrokecolor: handleColor,
+                });
+                syncVisPropValues(controlPointsJXG.current![i][1], {
+                    fillcolor: handleColor,
+                    strokecolor: handleColor,
+                    highlightfillcolor: handleColor,
+                    highlightstrokecolor: handleColor,
+                });
+                syncVisPropValues(segmentsJXG.current![i][1], {
+                    strokecolor: handleColor,
+                    highlightstrokecolor: handleColor,
+                });
 
                 throughPointsJXG.current![i].coords.setCoordinates(
                     JXG.COORDS_BY_USER,

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -764,6 +764,9 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
             );
 
             if (layerChanged && SVs.curveType === "bezier") {
+                segmentLayer = 10 * SVs.layer + VERTEX_LAYER_OFFSET;
+                throughPointLayer = 10 * SVs.layer + VERTEX_LAYER_OFFSET;
+                controlPointLayer = 10 * SVs.layer + CONTROL_POINT_LAYER_OFFSET;
                 segmentAttributes.current!.layer = segmentLayer;
                 throughPointAttributes.current!.layer = throughPointLayer;
                 controlPointAttributes.current!.layer = controlPointLayer;

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -14,6 +14,7 @@ import {
     syncLayer,
     syncLineFamilyVisibility,
     syncLineStrokeStyle,
+    syncVisPropValues,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
 import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
@@ -433,6 +434,14 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
             }
 
             const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
+            const handleColor = resolveHandleColor(darkMode);
+
+            syncVisPropValues(point1JXG.current, {
+                highlightfillcolor: handleColor,
+            });
+            syncVisPropValues(point2JXG.current, {
+                highlightfillcolor: handleColor,
+            });
 
             syncLineStrokeStyle(lineSegmentJXG.current, {
                 lineColor,

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -22,7 +22,7 @@ import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
-import { resolveLineColor } from "./utils/styleColors";
+import { resolveLineColor, resolveHandleColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
@@ -127,9 +127,7 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
             fillColor: "none",
             strokeColor: "none",
             highlightStrokeColor: "none",
-            highlightFillColor: getComputedStyle(
-                document.documentElement,
-            ).getPropertyValue("--mainGray"),
+            highlightFillColor: resolveHandleColor(darkMode),
             layer: 10 * SVs.layer + VERTEX_LAYER_OFFSET,
             showInfoBox: SVs.showCoordsWhenDragging,
             visible: endpointsVisible,

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -101,6 +101,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
             strokeColor: "none",
             highlightStrokeColor: "none",
             highlightFillColor: resolveHandleColor(darkMode),
+            visible: !verticesFixed.current && !SVs.hidden,
             withLabel: false,
             layer: 10 * SVs.layer + VERTEX_LAYER_OFFSET,
             highlight: true,

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -10,7 +10,11 @@ import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
-import { resolveLineColor, resolveFillColor } from "./utils/styleColors";
+import {
+    resolveLineColor,
+    resolveFillColor,
+    resolveHandleColor,
+} from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
@@ -96,8 +100,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
             fillColor: "none",
             strokeColor: "none",
             highlightStrokeColor: "none",
-            highlightFillColor: "black",
-            visible: !verticesFixed.current && !SVs.hidden,
+            highlightFillColor: resolveHandleColor(darkMode),
             withLabel: false,
             layer: 10 * SVs.layer + VERTEX_LAYER_OFFSET,
             highlight: true,

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -27,6 +27,7 @@ import {
     syncLabelStrokeColor,
     syncLayer,
     syncLineStrokeStyle,
+    syncVisPropValues,
 } from "./utils/jsxgraph";
 import { buildBaseAttributes } from "./utils/buildGraphicalAttributes";
 
@@ -404,6 +405,9 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 }
             }
 
+            const handleColor = resolveHandleColor(darkMode);
+            jsxPointAttributes.current!.highlightFillColor = handleColor;
+
             // add or delete points as required and change data array size
             if (
                 previousNumVertices.current !== null &&
@@ -460,6 +464,9 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 let vertexVisible =
                     verticesVisible &&
                     vertexIndicesDraggable.current.includes(i);
+                syncVisPropValues(polygonJXG.current.vertices[i], {
+                    highlightfillcolor: handleColor,
+                });
                 polygonJXG.current.vertices[i].visProp["visible"] =
                     vertexVisible;
                 polygonJXG.current.vertices[i].visPropCalc["visible"] =

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -124,6 +124,7 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
             strokeColor: "none",
             highlightStrokeColor: "none",
             highlightFillColor: resolveHandleColor(darkMode),
+            layer: 10 * SVs.layer + VERTEX_LAYER_OFFSET,
             showInfoBox: SVs.showCoordsWhenDragging,
         });
         if (verticesFixed.current || SVs.hidden || !validCoords) {

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -10,7 +10,7 @@ import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
-import { resolveLineColor } from "./utils/styleColors";
+import { resolveLineColor, resolveHandleColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
@@ -123,8 +123,7 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
             fillColor: "none",
             strokeColor: "none",
             highlightStrokeColor: "none",
-            highlightFillColor: "black",
-            layer: 10 * SVs.layer + VERTEX_LAYER_OFFSET,
+            highlightFillColor: resolveHandleColor(darkMode),
             showInfoBox: SVs.showCoordsWhenDragging,
         });
         if (verticesFixed.current || SVs.hidden || !validCoords) {

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -23,6 +23,7 @@ import {
     syncLabelStrokeColor,
     syncLayer,
     syncLineStrokeStyle,
+    syncVisPropValues,
 } from "./utils/jsxgraph";
 import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
 
@@ -411,6 +412,9 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
             polylineJXG.current.visProp.highlight = !fixLocation.current;
             polylineJXG.current.isDraggable = !fixLocation.current;
 
+            const handleColor = resolveHandleColor(darkMode);
+            jsxPointAttributes.current!.highlightFillColor = handleColor;
+
             let pointLayer = 10 * SVs.layer + VERTEX_LAYER_OFFSET;
             let layerChanged = syncLayer(
                 polylineJXG.current,
@@ -493,6 +497,9 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
                     let pointVisible =
                         pointsVisible &&
                         vertexIndicesDraggable.current.includes(i);
+                    syncVisPropValues(pointsJXG.current[i], {
+                        highlightfillcolor: handleColor,
+                    });
                     pointsJXG.current[i].visProp["visible"] = pointVisible;
                     pointsJXG.current[i].visPropCalc["visible"] = pointVisible;
                     pointsJXG.current[i].visProp.showinfobox =

--- a/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
@@ -837,6 +837,22 @@ export function syncLineStrokeStyle(
 }
 
 /**
+ * Sync one or more raw `visProp` entries on a JSXGraph object without calling
+ * `setAttribute`, which is often unnecessarily expensive during per-render
+ * updates.
+ */
+export function syncVisPropValues(
+    obj: { visProp: Record<string, any> },
+    values: Record<string, any>,
+): void {
+    for (const [key, value] of Object.entries(values)) {
+        if (obj.visProp[key] !== value) {
+            obj.visProp[key] = value;
+        }
+    }
+}
+
+/**
  * Sync the `withlabel` attribute based on whether `labelForGraph` is
  * non-empty, calling `setAttribute` only when the value actually changes.
  * `previousWithLabelRef` tracks the last applied value across renders.

--- a/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
@@ -31,3 +31,18 @@ export function resolveMarkerColor(
 ): string {
     return darkMode === "dark" ? style.markerColorDarkMode : style.markerColor;
 }
+
+/**
+ * The color used for draggable handles on graph elements (polygon vertices,
+ * polyline vertices, vector/line-segment endpoints, curve control points,
+ * etc.). Mirrors the `--graphHandle` CSS variable so all graph element
+ * renderers stay in sync.
+ *
+ * Note: JSXGraph receives resolved hex values, not CSS variable strings,
+ * because `data-theme` is applied to an inner wrapper div rather than
+ * `<html>`, so `getComputedStyle(document.documentElement)` always reads
+ * the light-mode value regardless of the current theme.
+ */
+export function resolveHandleColor(darkMode: DarkMode): string {
+    return darkMode === "dark" ? "#b0b0b0" : "#404040";
+}

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -132,6 +132,7 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
             strokeColor: "none",
             highlightStrokeColor: "none",
             highlightFillColor: resolveHandleColor(darkMode),
+            layer: pointLayer,
             showInfoBox: SVs.showCoordsWhenDragging,
         });
 

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -24,7 +24,7 @@ import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
-import { resolveLineColor } from "./utils/styleColors";
+import { resolveLineColor, resolveHandleColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
@@ -131,10 +131,7 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
             fillColor: "none",
             strokeColor: "none",
             highlightStrokeColor: "none",
-            highlightFillColor: getComputedStyle(
-                document.documentElement,
-            ).getPropertyValue("--mainGray"),
-            layer: pointLayer,
+            highlightFillColor: resolveHandleColor(darkMode),
             showInfoBox: SVs.showCoordsWhenDragging,
         });
 

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -17,6 +17,7 @@ import {
     syncLabelStrokeColor,
     syncLayer,
     syncLineStrokeStyle,
+    syncVisPropValues,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
 import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
@@ -449,6 +450,14 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
             }
 
             const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
+            const handleColor = resolveHandleColor(darkMode);
+
+            syncVisPropValues(point1JXG.current, {
+                highlightfillcolor: handleColor,
+            });
+            syncVisPropValues(point2JXG.current, {
+                highlightfillcolor: handleColor,
+            });
 
             syncLineStrokeStyle(vectorJXG.current, {
                 lineColor,

--- a/packages/doenetml/src/Viewer/renderersLoadComponent.tsx
+++ b/packages/doenetml/src/Viewer/renderersLoadComponent.tsx
@@ -65,10 +65,11 @@ export function RendererLoadFailed(props: {
             id={props.componentInstructions?.id}
             role="alert"
             style={{
-                backgroundColor: "#ff9999",
-                color: "#222",
+                backgroundColor: "var(--lightRed)",
+                color: "var(--canvasText)",
                 borderWidth: 3,
                 borderStyle: "solid",
+                borderColor: "var(--mainRed)",
                 padding: "0.5em",
                 textAlign: "center",
             }}

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
@@ -458,15 +458,15 @@ describe(
   </curve>
 </graph>`;
 
-        function getVisiblePointFillColors() {
-            return cy.window().then((win) => {
+        function assertVisiblePointFillIncludesColor(expectedColor) {
+            cy.window().should((win) => {
                 const boards = Object.values(win.JXG?.boards ?? {});
                 expect(
                     boards.length,
                     "number of JSXGraph boards",
                 ).to.be.greaterThan(0);
 
-                return boards.flatMap((board) =>
+                const colors = boards.flatMap((board) =>
                     (board.objectsList ?? [])
                         .filter(
                             (obj) =>
@@ -479,6 +479,10 @@ describe(
                             String(obj.visProp.fillcolor).toLowerCase(),
                         ),
                 );
+                expect(
+                    colors,
+                    `visible point fills (expecting ${expectedColor}): ${colors.join(", ")}`,
+                ).to.include(expectedColor);
             });
         }
 
@@ -491,27 +495,15 @@ describe(
                 win.postMessage({ doenetML: DOENETML, darkMode: "light" }, "*");
             });
             cy.get("#g").should("exist");
-            cy.wait(200);
 
-            getVisiblePointFillColors().then((colors) => {
-                expect(
-                    colors,
-                    `light-mode visible point fills ${colors.join(", ")}`,
-                ).to.include("#404040");
-            });
+            assertVisiblePointFillIncludesColor("#404040");
 
             cy.window().then((win) => {
                 win.postMessage({ darkMode: "dark" }, "*");
             });
             cy.get('[data-theme="dark"]').should("exist");
-            cy.wait(200);
 
-            getVisiblePointFillColors().then((colors) => {
-                expect(
-                    colors,
-                    `dark-mode visible point fills ${colors.join(", ")}`,
-                ).to.include("#b0b0b0");
-            });
+            assertVisiblePointFillIncludesColor("#b0b0b0");
         });
     },
 );

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
@@ -448,6 +448,75 @@ describe(
 );
 
 describe(
+    "Graph handles react to live dark-mode changes",
+    { tags: ["@group5"] },
+    () => {
+        const DOENETML = `
+<graph name="g">
+  <curve through="(1,5) (-3,-6) (1,0) (-6,3)">
+    <bezierControls alwaysVisible>(3,-3) (-2,4) (5,3) (3,3)</bezierControls>
+  </curve>
+</graph>`;
+
+        function getVisiblePointFillColors() {
+            return cy.window().then((win) => {
+                const boards = Object.values(win.JXG?.boards ?? {});
+                expect(
+                    boards.length,
+                    "number of JSXGraph boards",
+                ).to.be.greaterThan(0);
+
+                return boards.flatMap((board) =>
+                    (board.objectsList ?? [])
+                        .filter(
+                            (obj) =>
+                                obj?.elType === "point" &&
+                                obj?.visProp?.visible &&
+                                obj?.visProp?.fillcolor &&
+                                obj.visProp.fillcolor !== "none",
+                        )
+                        .map((obj) =>
+                            String(obj.visProp.fillcolor).toLowerCase(),
+                        ),
+                );
+            });
+        }
+
+        it("bezier handles update after a dark-mode toggle", () => {
+            cy.clearIndexedDB();
+            cy.visit("/");
+            cy.get("#testRunner_toggleControls").should("exist");
+
+            cy.window().then((win) => {
+                win.postMessage({ doenetML: DOENETML, darkMode: "light" }, "*");
+            });
+            cy.get("#g").should("exist");
+            cy.wait(200);
+
+            getVisiblePointFillColors().then((colors) => {
+                expect(
+                    colors,
+                    `light-mode visible point fills ${colors.join(", ")}`,
+                ).to.include("#404040");
+            });
+
+            cy.window().then((win) => {
+                win.postMessage({ darkMode: "dark" }, "*");
+            });
+            cy.get('[data-theme="dark"]').should("exist");
+            cy.wait(200);
+
+            getVisiblePointFillColors().then((colors) => {
+                expect(
+                    colors,
+                    `dark-mode visible point fills ${colors.join(", ")}`,
+                ).to.include("#b0b0b0");
+            });
+        });
+    },
+);
+
+describe(
     "Error banner — light and dark mode contrast",
     { tags: ["@group5"] },
     () => {

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
@@ -377,7 +377,7 @@ describe(
         const DOENETML = `
 <p>Enter <m>2</m>: <answer name="ans"><mathInput name="mi" />2</answer></p>
 <p>Enter <m>x+y</m>: <answer name="ans2"><mathInput name="mi2" />x+y</answer></p>
-<p>Limited: <answer name="ans_limited" maxAttempts="1"><mathInput name="mi_limited" />42</answer></p>`;
+<p>Disabled: <answer name="ans_disabled" disabled><mathInput name="mi_disabled" />42</answer></p>`;
 
         beforeEach(() => {
             cy.clearIndexedDB();
@@ -440,12 +440,7 @@ describe(
             checkContrast();
         });
 
-        it("dark mode: disabled check-work button (attempts exhausted)", () => {
-            // Submit once to exhaust the single allowed attempt, leaving the
-            // button in its disabled (gray) state.
-            cy.get("#mi_limited textarea").type("99{enter}", { force: true });
-            cy.get(".check-work-incorrect").should("exist");
-            // After the one attempt the button becomes disabled.
+        it("dark mode: disabled check-work button", () => {
             cy.get(".check-work-unvalidated:disabled").should("exist");
             checkContrast();
         });

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeRendererAccessibility.cy.js
@@ -376,7 +376,8 @@ describe(
     () => {
         const DOENETML = `
 <p>Enter <m>2</m>: <answer name="ans"><mathInput name="mi" />2</answer></p>
-<p>Enter <m>x+y</m>: <answer name="ans2"><mathInput name="mi2" />x+y</answer></p>`;
+<p>Enter <m>x+y</m>: <answer name="ans2"><mathInput name="mi2" />x+y</answer></p>
+<p>Limited: <answer name="ans_limited" maxAttempts="1"><mathInput name="mi_limited" />42</answer></p>`;
 
         beforeEach(() => {
             cy.clearIndexedDB();
@@ -436,6 +437,16 @@ describe(
             cy.get(".check-work-correct").should("exist");
             cy.get("#mi2 textarea").type("99{enter}", { force: true });
             cy.get(".check-work-incorrect").should("exist");
+            checkContrast();
+        });
+
+        it("dark mode: disabled check-work button (attempts exhausted)", () => {
+            // Submit once to exhaust the single allowed attempt, leaving the
+            // button in its disabled (gray) state.
+            cy.get("#mi_limited textarea").type("99{enter}", { force: true });
+            cy.get(".check-work-incorrect").should("exist");
+            // After the one attempt the button becomes disabled.
+            cy.get(".check-work-unvalidated:disabled").should("exist");
             checkContrast();
         });
     },


### PR DESCRIPTION
## Summary

Several dark-mode rendering gaps found and fixed after the comprehensive PR #1382 sweep.

### Error messages invisible in dark mode

The primary reported issue: when DoenetML throws an error (e.g. circular dependency, parse error, core-start failure), the error message div in `DocViewer` had **no color or background set**. In a dark-themed host page, this meant black text on a dark background — invisible.

Fixed locations:
- **`DocViewer` `errMsg` block** (circular deps, parse errors, core-start failures) — now uses `var(--lightRed)`/`var(--canvasText)`/`var(--mainRed)` border, matching the existing `_error.tsx` renderer style
- **`DocViewer` `ErrorBoundary` fallback** (`Something went wrong.`) — same fix
- **`DocViewer` `noCoreWarning`** — replaced hardcoded `lightCyan` background with `var(--canvas)`/`var(--canvasText)`
- **`DocViewer` loading state** — removed hardcoded `#F0F0F0` override (reverts to `var(--canvas)`)
- **`renderersLoadComponent` `RendererLoadFailed`** — replaced `#ff9999`/`#222` with CSS variables; added missing `var(--mainRed)` border
- **`doenetml-iframe` (×2)** — same error-display pattern; fixed using `resolvedTheme` for inline conditional colors (package has no CSS-variable context)

### Graph handle colors and live theme changes

Draggable vertex/endpoint handles across five renderers were using three inconsistent approaches, one of which was silently broken:

- `vector` and `lineSegment` called `getComputedStyle(document.documentElement).getPropertyValue('--mainGray')` — because `data-theme='dark'` is on an inner div (not `<html>`), this **always returned the light-mode value** regardless of theme
- `curve` passed `'var(--graphHandle)'` as a string directly to JSXGraph (unreliable)
- `polygon`/`polyline` used an inline `dark ? 'white' : 'black'` ternary

**Fix:** added `resolveHandleColor(darkMode)` to `styleColors.ts`, mirroring `--graphHandle` (#404040 light / #b0b0b0 dark). All five renderers now use this single function, and their update paths now reapply handle colors when dark mode changes after mount.

### JSXGraph smart labels

- **`.smart-label-pure`**: transparent background + `color: black` was invisible on the dark canvas — dark-mode override now uses `var(--canvasText)`
- **`.smart-label-outline`**: white bubble was jarring on dark canvas — dark-mode override uses `#2d2d2d` elevated surface with `var(--canvasText)`

### EditorViewer footer menu

Added `color: var(--canvasText)` to the existing `[data-theme='dark']` `.footer-menu` override as a belt-and-suspenders guard for portal rendering contexts.

### Dead code removal

`booleanInput.tsx`: removed `checkWorkStyle`/`checkWorkTabIndex` block that was computed but never applied — `createCheckWorkComponent` handles all disabled styling via CSS classes.

### Test coverage

- `darkModeRendererAccessibility.cy.js`: added a disabled check-work button axe test covering the gray disabled state via an explicitly disabled answer, plus the existing correct/incorrect button coverage
- `darkModeRendererAccessibility.cy.js`: added a regression test verifying bezier control handles update from light to dark colors when dark mode toggles after mount

### Changeset

Added a changeset for the user-visible dark-mode fixes in the viewer/editor/iframe surface area.

## How the root cause was found

The original grep searched for explicit hardcoded color values. The `errMsg` bug was missed because (a) the `<div>` had **no color set at all** (absence of styling, not a wrong value) and (b) the `MdError color="red"` was a JSX prop, not a CSS `style` object. This led to a methodology change: also search for elements rendered outside `.doenet-viewer` without explicit color.

Closes #1383

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
