### PR TITLE
fix: resolve self-referential copy in label/text context gracefully

### DIFF
--- a/.changeset/point-label-self-reference.md
+++ b/.changeset/point-label-self-reference.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Point labels: fix self-references like `<label>$a</label>` so they render the point coordinates instead of a circular dependency error.
+
+When a point label references its own point without an explicit prop, DoenetML now falls back to the point's public label/text state in label and text contexts while preserving the existing circular-dependency error outside those contexts.
+
+Closes #1333.

--- a/.changeset/point-label-self-reference.md
+++ b/.changeset/point-label-self-reference.md
@@ -6,8 +6,8 @@
 "doenet-vscode-extension": patch
 ---
 
-Fix self-referential references in `<label>` and `<text>` contexts (e.g. `<label>$a</label>` inside component `a`) so they render a meaningful value instead of a circular dependency error.
+Fix self-referential references in recognized rendering contexts (for example `<label>$a</label>` inside component `a`) so they render a meaningful value instead of a circular dependency error.
 
-When a component references itself without an explicit prop inside its own `<label>` or `<text>`, DoenetML now falls back to the component's public `latex` or `text` state variable (depending on context) rather than showing an error. The existing circular-dependency error is preserved for self-references outside label/text contexts.
+When a component references itself without an explicit prop inside a recognized rendering context, DoenetML now falls back to the component's public `value` state variable rather than showing an error. For `<point>`, that means using its public coordinates value. This applies in contexts such as `<label>`, `<text>`, `<math>`, `<m>`, `<md>`, `<boolean>`, `<number>`, and the corresponding list variants. The existing circular-dependency error is preserved outside those contexts.
 
 Closes #1333.

--- a/.changeset/point-label-self-reference.md
+++ b/.changeset/point-label-self-reference.md
@@ -6,8 +6,8 @@
 "doenet-vscode-extension": patch
 ---
 
-Point labels: fix self-references like `<label>$a</label>` so they render the point coordinates instead of a circular dependency error.
+Fix self-referential references in `<label>` and `<text>` contexts (e.g. `<label>$a</label>` inside component `a`) so they render a meaningful value instead of a circular dependency error.
 
-When a point label references its own point without an explicit prop, DoenetML now falls back to the point's public label/text state in label and text contexts while preserving the existing circular-dependency error outside those contexts.
+When a component references itself without an explicit prop inside its own `<label>` or `<text>`, DoenetML now falls back to the component's public `latex` or `text` state variable (depending on context) rather than showing an error. The existing circular-dependency error is preserved for self-references outside label/text contexts.
 
 Closes #1333.

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -7,6 +7,8 @@ import {
     returnDefaultGetArrayKeysFromVarName,
 } from "../../utils/stateVariables";
 
+export const SERIALIZE_ENCOUNTERED_COMPONENT_PREFIX = "Encountered ";
+
 export default class BaseComponent {
     constructor({
         componentIdx,
@@ -1412,7 +1414,9 @@ export default class BaseComponent {
 
     async serialize(parameters = {}) {
         if (parameters.errorIfEncounterComponent?.includes(this.componentIdx)) {
-            throw Error("Encountered " + this.componentIdx);
+            throw Error(
+                `${SERIALIZE_ENCOUNTERED_COMPONENT_PREFIX}${this.componentIdx}`,
+            );
         }
 
         let includeDefiningChildren = true;

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -5,6 +5,7 @@ import {
     verifyReplacementsMatchSpecifiedType,
     addAttributesToSingleReplacement,
     addAttributesToSingleReplacementChange,
+    getSelfReferentialFallbackPropName,
 } from "../../utils/copy";
 import { flattenDeep, flattenLevels, deepClone } from "@doenet/utils";
 import {
@@ -12,104 +13,6 @@ import {
     convertUnresolvedAttributesForComponentType,
 } from "../../utils/dast/convertNormalizedDast";
 import { createNewComponentIndices } from "../../utils/componentIndices";
-
-export function getSelfReferentialFallbackPropName({
-    componentAncestors,
-    componentInfoObjects,
-    replacementSourceComponentType,
-}) {
-    // Walk up ancestors (closest first) through transparent composites
-    // (treatAsComponentForRecursiveReplacements, e.g. <group>) to detect the
-    // rendering context. Stop at any other component type.
-    let contextType = null;
-    for (const ancestor of componentAncestors) {
-        const ancestorClass = ancestor.componentClass;
-        const ancestorType = ancestorClass.componentType;
-        if (
-            componentInfoObjects.isInheritedComponentType({
-                inheritedComponentType: ancestorType,
-                baseComponentType: "label",
-            })
-        ) {
-            contextType = "label";
-            break;
-        }
-        if (
-            componentInfoObjects.isInheritedComponentType({
-                inheritedComponentType: ancestorType,
-                baseComponentType: "text",
-            })
-        ) {
-            contextType = "text";
-            break;
-        }
-        if (
-            componentInfoObjects.isInheritedComponentType({
-                inheritedComponentType: ancestorType,
-                baseComponentType: "math",
-            })
-        ) {
-            contextType = "math";
-            break;
-        }
-        // <m> and <md> are inline-math contexts that prefer latex output.
-        // They extend InlineComponent directly (not math/text), so check explicitly.
-        if (
-            componentInfoObjects.isInheritedComponentType({
-                inheritedComponentType: ancestorType,
-                baseComponentType: "m",
-            }) ||
-            componentInfoObjects.isInheritedComponentType({
-                inheritedComponentType: ancestorType,
-                baseComponentType: "md",
-            })
-        ) {
-            contextType = "latex";
-            break;
-        }
-        if (!ancestorClass.treatAsComponentForRecursiveReplacements) {
-            break;
-        }
-    }
-
-    if (contextType === null) {
-        return undefined;
-    }
-
-    // Determine the preferred createComponentOfType ordering for this context:
-    // - label / latex (m, md): prefer latex-typed, then text-typed
-    // - text:                  prefer text-typed, then latex-typed
-    // - math:                  prefer math-typed, then text-typed
-    const preferredTypes =
-        contextType === "text"
-            ? ["text", "latex"]
-            : contextType === "math"
-              ? ["math", "text"]
-              : ["latex", "text"]; // label, m, md
-
-    // Find the first public state variable whose createComponentOfType matches
-    // a preferred type, in preference order.
-    const publicVarDescriptions =
-        componentInfoObjects.publicStateVariableInfo[
-            replacementSourceComponentType
-        ]?.stateVariableDescriptions;
-
-    if (!publicVarDescriptions) {
-        return undefined;
-    }
-
-    for (const preferredType of preferredTypes) {
-        for (const [varName, varDesc] of Object.entries(
-            publicVarDescriptions,
-        )) {
-            if (varDesc.createComponentOfType === preferredType) {
-                return varName;
-            }
-        }
-    }
-
-    return undefined;
-}
 
 export default class Copy extends CompositeComponent {
     static componentType = "_copy";

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -1569,9 +1569,8 @@ export default class Copy extends CompositeComponent {
                             nComponents,
                         };
                     } catch (innerError) {
-                        // Re-throw the original error so it is handled as
-                        // the circular dependency it actually is.
-                        throw e;
+                        // Fall through to the circular dependency handler below
+                        // so this still reports as the original self-reference.
                     }
                 }
             }

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -1,3 +1,4 @@
+import { SERIALIZE_ENCOUNTERED_COMPONENT_PREFIX } from "./BaseComponent";
 import CompositeComponent from "./CompositeComponent";
 import {
     postProcessCopy,
@@ -11,6 +12,53 @@ import {
     convertUnresolvedAttributesForComponentType,
 } from "../../utils/dast/convertNormalizedDast";
 import { createNewComponentIndices } from "../../utils/componentIndices";
+
+export function getSelfReferentialFallbackPropName({
+    componentAncestors,
+    componentInfoObjects,
+    replacementSourceComponentType,
+}) {
+    let contextType = null;
+    for (const ancestor of componentAncestors) {
+        const ancestorClass = ancestor.componentClass;
+        const ancestorType = ancestorClass.componentType;
+        if (
+            componentInfoObjects.isInheritedComponentType({
+                inheritedComponentType: ancestorType,
+                baseComponentType: "label",
+            })
+        ) {
+            contextType = "label";
+            break;
+        }
+        if (
+            componentInfoObjects.isInheritedComponentType({
+                inheritedComponentType: ancestorType,
+                baseComponentType: "text",
+            })
+        ) {
+            contextType = "text";
+            break;
+        }
+        if (!ancestorClass.treatAsComponentForRecursiveReplacements) {
+            break;
+        }
+    }
+
+    let fallbackPropNames = [];
+    if (contextType === "label") {
+        fallbackPropNames = ["latex", "text"];
+    } else if (contextType === "text") {
+        fallbackPropNames = ["text", "latex"];
+    }
+
+    const publicVarDescriptions =
+        componentInfoObjects.publicStateVariableInfo[
+            replacementSourceComponentType
+        ]?.stateVariableDescriptions;
+
+    return fallbackPropNames.find((name) => publicVarDescriptions?.[name]);
+}
 
 export default class Copy extends CompositeComponent {
     static componentType = "_copy";
@@ -1485,63 +1533,22 @@ export default class Copy extends CompositeComponent {
             // own source component (a self-referential copy, e.g., `$a` inside `a`'s label).
             // If we're inside a label or text context, fall back to displaying a meaningful
             // state variable of the source component rather than showing an error.
-            if (e.message?.startsWith("Encountered ")) {
+            if (e.message?.startsWith(SERIALIZE_ENCOUNTERED_COMPONENT_PREFIX)) {
                 // Walk up the ancestor chain to determine if we're in a label or text context.
                 // ancestor.componentClass gives the class of each ancestor (closest first).
                 // We walk through transparent composites (treatAsComponentForRecursiveReplacements,
                 // e.g. <group>) since they pass their contents into their parent's context
                 // unchanged. Any other component (e.g. <point>, <math>) establishes its own
-                // context, so we stop there — being inside a <label> that is itself inside a
-                // <point> does not count as being in a label context.
-                let contextType = null;
-                for (const ancestor of component.ancestors) {
-                    const ancestorClass = ancestor.componentClass;
-                    const ancestorType = ancestorClass.componentType;
-                    if (
-                        componentInfoObjects.isInheritedComponentType({
-                            inheritedComponentType: ancestorType,
-                            baseComponentType: "label",
-                        })
-                    ) {
-                        contextType = "label";
-                        break;
-                    }
-                    if (
-                        componentInfoObjects.isInheritedComponentType({
-                            inheritedComponentType: ancestorType,
-                            baseComponentType: "text",
-                        })
-                    ) {
-                        contextType = "text";
-                        break;
-                    }
-                    // Only continue through transparent composites (e.g. group).
-                    // Any other component type terminates the context search.
-                    if (
-                        !ancestorClass.treatAsComponentForRecursiveReplacements
-                    ) {
-                        break;
-                    }
-                }
-
+                // context, so we stop there. For example, `$a` inside
+                // `<label><math>$a</math></label>` uses math's context rather than label's.
                 // In a label context: prefer latex (for math rendering), fallback to text.
                 // In a text context: prefer text (for plain output), fallback to latex.
-                // If no label/text context was detected, skip the fallback entirely.
-                const fallbackPropNames =
-                    contextType === "label"
-                        ? ["latex", "text"]
-                        : contextType === "text"
-                          ? ["text", "latex"]
-                          : [];
-
-                const publicVarDescriptions =
-                    componentInfoObjects.publicStateVariableInfo[
-                        replacementSourceComponent.componentType
-                    ]?.stateVariableDescriptions;
-
-                const fallbackPropName = fallbackPropNames.find(
-                    (name) => publicVarDescriptions?.[name],
-                );
+                const fallbackPropName = getSelfReferentialFallbackPropName({
+                    componentAncestors: component.ancestors,
+                    componentInfoObjects,
+                    replacementSourceComponentType:
+                        replacementSourceComponent.componentType,
+                });
 
                 if (fallbackPropName) {
                     try {

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -1485,18 +1485,16 @@ export default class Copy extends CompositeComponent {
         } catch (e) {
             // When the error is "Encountered X", it means this Copy is a descendant of its
             // own source component (a self-referential copy, e.g., `$a` inside `a`'s label).
-            // If we're inside a label or text context, fall back to displaying a meaningful
-            // state variable of the source component rather than showing an error.
+            // In recognized rendering contexts, fall back to the source's public `value`
+            // state variable rather than showing an error.
             if (e.message?.startsWith(SERIALIZE_ENCOUNTERED_COMPONENT_PREFIX)) {
-                // Walk up the ancestor chain to determine if we're in a label or text context.
+                // Walk up the ancestor chain to determine if we're in a recognized context.
                 // ancestor.componentClass gives the class of each ancestor (closest first).
                 // We walk through transparent composites (treatAsComponentForRecursiveReplacements,
                 // e.g. <group>) since they pass their contents into their parent's context
                 // unchanged. Any other component (e.g. <point>, <math>) establishes its own
                 // context, so we stop there. For example, `$a` inside
                 // `<label><math>$a</math></label>` uses math's context rather than label's.
-                // In a label context: prefer latex (for math rendering), fallback to text.
-                // In a text context: prefer text (for plain output), fallback to latex.
                 const fallbackPropName = getSelfReferentialFallbackPropName({
                     componentAncestors: component.ancestors,
                     componentInfoObjects,

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -1481,6 +1481,101 @@ export default class Copy extends CompositeComponent {
             serializedReplacements = res.components;
             nComponents = res.nComponents;
         } catch (e) {
+            // When the error is "Encountered X", it means this Copy is a descendant of its
+            // own source component (a self-referential copy, e.g., `$a` inside `a`'s label).
+            // If we're inside a label or text context, fall back to displaying a meaningful
+            // state variable of the source component rather than showing an error.
+            if (e.message?.startsWith("Encountered ")) {
+                // Walk up the ancestor chain to determine if we're in a label or text context.
+                // ancestor.componentClass gives the class of each ancestor (closest first).
+                // We walk through transparent composites (treatAsComponentForRecursiveReplacements,
+                // e.g. <group>) since they pass their contents into their parent's context
+                // unchanged. Any other component (e.g. <point>, <math>) establishes its own
+                // context, so we stop there — being inside a <label> that is itself inside a
+                // <point> does not count as being in a label context.
+                let contextType = null;
+                for (const ancestor of component.ancestors) {
+                    const ancestorClass = ancestor.componentClass;
+                    const ancestorType = ancestorClass.componentType;
+                    if (
+                        componentInfoObjects.isInheritedComponentType({
+                            inheritedComponentType: ancestorType,
+                            baseComponentType: "label",
+                        })
+                    ) {
+                        contextType = "label";
+                        break;
+                    }
+                    if (
+                        componentInfoObjects.isInheritedComponentType({
+                            inheritedComponentType: ancestorType,
+                            baseComponentType: "text",
+                        })
+                    ) {
+                        contextType = "text";
+                        break;
+                    }
+                    // Only continue through transparent composites (e.g. group).
+                    // Any other component type terminates the context search.
+                    if (
+                        !ancestorClass.treatAsComponentForRecursiveReplacements
+                    ) {
+                        break;
+                    }
+                }
+
+                // In a label context: prefer latex (for math rendering), fallback to text.
+                // In a text context: prefer text (for plain output), fallback to latex.
+                // If no label/text context was detected, skip the fallback entirely.
+                const fallbackPropNames =
+                    contextType === "label"
+                        ? ["latex", "text"]
+                        : contextType === "text"
+                          ? ["text", "latex"]
+                          : [];
+
+                const publicVarDescriptions =
+                    componentInfoObjects.publicStateVariableInfo[
+                        replacementSourceComponent.componentType
+                    ]?.stateVariableDescriptions;
+
+                const fallbackPropName = fallbackPropNames.find(
+                    (name) => publicVarDescriptions?.[name],
+                );
+
+                if (fallbackPropName) {
+                    try {
+                        let fallbackResults = await replacementFromProp({
+                            component,
+                            components,
+                            nComponents,
+                            stateIdInfo,
+                            replacementSource: replacementSourceComponent,
+                            propName: fallbackPropName,
+                            allDoenetMLs,
+                            compositeAttributesObj,
+                            componentInfoObjects,
+                            numComponentsForSource,
+                            publicCaseInsensitiveAliasSubstitutions,
+                        });
+                        diagnostics.push(...fallbackResults.diagnostics);
+                        nComponents = fallbackResults.nComponents;
+                        return {
+                            serializedReplacements:
+                                fallbackResults.serializedReplacements,
+                            propVariablesCopiedByReplacement:
+                                fallbackResults.propVariablesCopiedByReplacement,
+                            diagnostics,
+                            nComponents,
+                        };
+                    } catch (innerError) {
+                        // Re-throw the original error so it is handled as
+                        // the circular dependency it actually is.
+                        throw e;
+                    }
+                }
+            }
+
             console.error("we're calling this circular", e);
             let message = "Circular dependency detected";
             if (component.attributes.createComponentOfType?.primitive) {

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -18,6 +18,9 @@ export function getSelfReferentialFallbackPropName({
     componentInfoObjects,
     replacementSourceComponentType,
 }) {
+    // Walk up ancestors (closest first) through transparent composites
+    // (treatAsComponentForRecursiveReplacements, e.g. <group>) to detect the
+    // rendering context. Stop at any other component type.
     let contextType = null;
     for (const ancestor of componentAncestors) {
         const ancestorClass = ancestor.componentClass;
@@ -40,24 +43,72 @@ export function getSelfReferentialFallbackPropName({
             contextType = "text";
             break;
         }
+        if (
+            componentInfoObjects.isInheritedComponentType({
+                inheritedComponentType: ancestorType,
+                baseComponentType: "math",
+            })
+        ) {
+            contextType = "math";
+            break;
+        }
+        // <m> and <md> are inline-math contexts that prefer latex output.
+        // They extend InlineComponent directly (not math/text), so check explicitly.
+        if (
+            componentInfoObjects.isInheritedComponentType({
+                inheritedComponentType: ancestorType,
+                baseComponentType: "m",
+            }) ||
+            componentInfoObjects.isInheritedComponentType({
+                inheritedComponentType: ancestorType,
+                baseComponentType: "md",
+            })
+        ) {
+            contextType = "latex";
+            break;
+        }
         if (!ancestorClass.treatAsComponentForRecursiveReplacements) {
             break;
         }
     }
 
-    let fallbackPropNames = [];
-    if (contextType === "label") {
-        fallbackPropNames = ["latex", "text"];
-    } else if (contextType === "text") {
-        fallbackPropNames = ["text", "latex"];
+    if (contextType === null) {
+        return undefined;
     }
 
+    // Determine the preferred createComponentOfType ordering for this context:
+    // - label / latex (m, md): prefer latex-typed, then text-typed
+    // - text:                  prefer text-typed, then latex-typed
+    // - math:                  prefer math-typed, then text-typed
+    const preferredTypes =
+        contextType === "text"
+            ? ["text", "latex"]
+            : contextType === "math"
+              ? ["math", "text"]
+              : ["latex", "text"]; // label, m, md
+
+    // Find the first public state variable whose createComponentOfType matches
+    // a preferred type, in preference order.
     const publicVarDescriptions =
         componentInfoObjects.publicStateVariableInfo[
             replacementSourceComponentType
         ]?.stateVariableDescriptions;
 
-    return fallbackPropNames.find((name) => publicVarDescriptions?.[name]);
+    if (!publicVarDescriptions) {
+        return undefined;
+    }
+
+    for (const preferredType of preferredTypes) {
+        for (const [varName, varDesc] of Object.entries(
+            publicVarDescriptions,
+        )) {
+            if (varDesc.createComponentOfType === preferredType) {
+                return varName;
+            }
+        }
+    }
+
+    return undefined;
 }
 
 export default class Copy extends CompositeComponent {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
@@ -6945,4 +6945,22 @@ describe("Point tag tests @group4", async () => {
         await movePoint({ componentIdx: viaGroupIdx, x: 0, y: -1, core });
         await check_labels(0, -1);
     });
+
+    it("self-reference outside label or text context still reports a circular dependency", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<graph>
+  <point name="a">(2,3)
+    <label><math>$a</math></label>
+  </point>
+</graph>
+`,
+        });
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(1);
+        expect(diagnostics.errors[0].message).contain(
+            "Circular dependency detected",
+        );
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
@@ -7014,21 +7014,62 @@ describe("Point tag tests @group4", async () => {
         await check_labels(-1, 4);
     });
 
-    it("self-reference outside a recognized context still reports a circular dependency", async () => {
-        // <number> is not in the recognized context list, so a self-referential
-        // $a inside it does not get a fallback and still errors.
-        const { core } = await createTestCore({
+    it("self-referential point works via number context and via adapted inner point", async () => {
+        // <number> is a recognized context (qualitatively similar to <math>).
+        // An inner <point> also works because point adapts to coords, a math subtype.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
 <graph>
-  <point name="a">(2,3)
-    <label><number>$a</number></label>
+  <point name="viaNumber">(2,3)
+    <label><number>$viaNumber</number></label>
+  </point>
+  <point name="viaInnerPoint">(2,3)
+    <label><point>$viaInnerPoint</point></label>
   </point>
 </graph>
 `,
         });
 
         const diagnostics = getDiagnosticsByType(core);
-        expect(diagnostics.errors.length).eq(1);
+        expect(diagnostics.errors.length).eq(0);
+
+        const viaNumberIdx = await resolvePathToNodeIdx("viaNumber");
+        const viaInnerPointIdx = await resolvePathToNodeIdx("viaInnerPoint");
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const viaNumberLabel = stateVariables[viaNumberIdx].stateValues.label;
+        const viaInnerPointLabel =
+            stateVariables[viaInnerPointIdx].stateValues.label;
+
+        expect(typeof viaNumberLabel).eq("string");
+        expect(viaNumberLabel.length).greaterThan(0);
+        expect(typeof viaInnerPointLabel).eq("string");
+        expect(viaInnerPointLabel.length).greaterThan(0);
+
+        // Labels update when the point moves (inner-point case tracks coords;
+        // number context renders NaN for a non-scalar, which is acceptable)
+        await movePoint({ componentIdx: viaNumberIdx, x: 5, y: -2, core });
+        await movePoint({ componentIdx: viaInnerPointIdx, x: 5, y: -2, core });
+        const sv2 = await core.returnAllStateVariables(false, true);
+        expect(sv2[viaInnerPointIdx].stateValues.label).not.eq(
+            viaInnerPointLabel,
+        );
+    });
+
+    it("self-reference inside a non-sensical context like <answer> still errors", async () => {
+        // Components like <answer> are not in the recognized rendering-context
+        // list and don't make sense inside a <label>. The circular-dependency
+        // error is the expected outcome in such cases.
+        const { core } = await createTestCore({
+            doenetML: `
+<point name="a">(2,3)
+  <label><answer>$a</answer></label>
+</point>
+`,
+        });
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).greaterThan(0);
         expect(diagnostics.errors[0].message).contain(
             "Circular dependency detected",
         );

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
@@ -6946,14 +6946,13 @@ describe("Point tag tests @group4", async () => {
         await check_labels(0, -1);
     });
 
-    it("self-reference outside label or text context still reports a circular dependency", async () => {
+    it("self-reference outside a recognised context still reports a circular dependency", async () => {
+        // <boolean> is not a label/text/math/m/md context, so the fallback is skipped.
         const { core } = await createTestCore({
             doenetML: `
-<graph>
-  <point name="a">(2,3)
-    <label><math>$a</math></label>
-  </point>
-</graph>
+<point name="a">(2,3)
+  <label><boolean>$a</boolean></label>
+</point>
 `,
         });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
@@ -6871,8 +6871,8 @@ describe("Point tag tests @group4", async () => {
         // `<label>$a</label>` inside point `a` should display the point's
         // coordinates (same as `$a.coords`), not an error.
         // Also covers context-aware fallback selection:
-        // - $a directly in <label> → latex fallback (label context)
-        // - $a in <label><group>$a</group></label> → label context through transparent group
+        // - $a directly in <label>
+        // - $a via transparent <group> inside <label>
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
 <graph>
@@ -6946,13 +6946,84 @@ describe("Point tag tests @group4", async () => {
         await check_labels(0, -1);
     });
 
-    it("self-reference outside a recognised context still reports a circular dependency", async () => {
-        // <boolean> is not a label/text/math/m/md context, so the fallback is skipped.
+    it("self-referential point in label works via m, math, boolean contexts", async () => {
+        // <m>, <math>, and <boolean> are all recognized contexts, so a
+        // self-referential $a inside them within a <label> should resolve
+        // to the point's coordinates rather than error.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph>
+  <point name="viaM">(2,3)
+    <label><m>$viaM</m></label>
+  </point>
+  <point name="viaMath">(2,3)
+    <label><math>$viaMath</math></label>
+  </point>
+  <point name="viaBoolean">(2,3)
+    <label><boolean>$viaBoolean</boolean></label>
+  </point>
+  <point name="ref">(2,3)
+    <label>$ref.coords</label>
+  </point>
+</graph>
+`,
+        });
+
+        const viaMIdx = await resolvePathToNodeIdx("viaM");
+        const viaMathIdx = await resolvePathToNodeIdx("viaMath");
+        const viaBooleanIdx = await resolvePathToNodeIdx("viaBoolean");
+        const refIdx = await resolvePathToNodeIdx("ref");
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(0);
+
+        async function check_labels(x: number, y: number) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const viaMLabel = stateVariables[viaMIdx].stateValues.label;
+            const viaMathLabel = stateVariables[viaMathIdx].stateValues.label;
+            const viaBooleanLabel =
+                stateVariables[viaBooleanIdx].stateValues.label;
+
+            // All three should be non-empty strings
+            expect(typeof viaMLabel).eq("string");
+            expect(viaMLabel.length).greaterThan(0);
+            expect(typeof viaMathLabel).eq("string");
+            expect(viaMathLabel.length).greaterThan(0);
+            expect(typeof viaBooleanLabel).eq("string");
+            expect(viaBooleanLabel.length).greaterThan(0);
+
+            // <m> and <math> both render math, so they should match $ref.coords
+            const refLabel = stateVariables[refIdx].stateValues.label;
+            expect(viaMLabel).eq(refLabel);
+            expect(viaMathLabel).eq(refLabel);
+
+            expect(
+                stateVariables[viaMIdx].stateValues.xs.map((v: any) => v.tree),
+            ).eqls([x, y]);
+        }
+
+        await check_labels(2, 3);
+
+        await movePoint({ componentIdx: viaMIdx, x: -1, y: 4, core });
+        await movePoint({ componentIdx: viaMathIdx, x: -1, y: 4, core });
+        await movePoint({ componentIdx: viaBooleanIdx, x: -1, y: 4, core });
+        await movePoint({ componentIdx: refIdx, x: -1, y: 4, core });
+        await check_labels(-1, 4);
+    });
+
+    it("self-reference outside a recognized context still reports a circular dependency", async () => {
+        // <number> is not in the recognized context list, so a self-referential
+        // $a inside it does not get a fallback and still errors.
         const { core } = await createTestCore({
             doenetML: `
-<point name="a">(2,3)
-  <label><boolean>$a</boolean></label>
-</point>
+<graph>
+  <point name="a">(2,3)
+    <label><number>$a</number></label>
+  </point>
+</graph>
 `,
         });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
@@ -6865,4 +6865,85 @@ describe("Point tag tests @group4", async () => {
         expect(p2Latex).contain("0.000000000007");
         expect(p2Latex).contain("2000000000000000000000");
     });
+
+    it("referencing a point directly in its own label works", async () => {
+        // Regression test for: https://github.com/Doenet/DoenetML/issues/1333
+        // `<label>$a</label>` inside point `a` should display the point's
+        // coordinates (same as `$a.coords`), not an error.
+        // Also covers context-aware fallback selection:
+        // - $a directly in <label> → latex fallback (label context)
+        // - $a in <label><group>$a</group></label> → label context through transparent group
+        // - $a in <label><point>$a</point></label> → no label context (point is opaque)
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph>
+  <point name="a">(2,3)
+    <label>$a</label>
+  </point>
+  <point name="ref">(2,3)
+    <label>$ref.coords</label>
+  </point>
+  <point name="viaGroup">(2,3)
+    <label><group>$viaGroup</group></label>
+  </point>
+</graph>
+`,
+        });
+
+        const aIdx = await resolvePathToNodeIdx("a");
+        const refIdx = await resolvePathToNodeIdx("ref");
+        const viaGroupIdx = await resolvePathToNodeIdx("viaGroup");
+
+        async function check_labels(x: number, y: number) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const aLabel = stateVariables[aIdx].stateValues.label;
+            const refLabel = stateVariables[refIdx].stateValues.label;
+            const viaGroupLabel = stateVariables[viaGroupIdx].stateValues.label;
+
+            // $a (self-reference) should give same result as $ref.coords
+            expect(aLabel).eq(refLabel);
+            // $viaGroup inside a transparent <group> should also match
+            expect(viaGroupLabel).eq(refLabel);
+
+            expect(
+                stateVariables[aIdx].stateValues.xs.map((v: any) => v.tree),
+            ).eqls([x, y]);
+            expect(
+                stateVariables[refIdx].stateValues.xs.map((v: any) => v.tree),
+            ).eqls([x, y]);
+            expect(
+                stateVariables[viaGroupIdx].stateValues.xs.map(
+                    (v: any) => v.tree,
+                ),
+            ).eqls([x, y]);
+        }
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(0);
+
+        // Initial state: all points at (2, 3), labels non-empty
+        const initialStateVariables = await core.returnAllStateVariables(
+            false,
+            true,
+        );
+        const initialLabel = initialStateVariables[aIdx].stateValues.label;
+        expect(typeof initialLabel).eq("string");
+        expect(initialLabel.length).greaterThan(0);
+        await check_labels(2, 3);
+
+        // Move point a and verify its label updates
+        await movePoint({ componentIdx: aIdx, x: -4, y: 7, core });
+        await movePoint({ componentIdx: refIdx, x: -4, y: 7, core });
+        await movePoint({ componentIdx: viaGroupIdx, x: -4, y: 7, core });
+        await check_labels(-4, 7);
+
+        // Move again
+        await movePoint({ componentIdx: aIdx, x: 0, y: -1, core });
+        await movePoint({ componentIdx: refIdx, x: 0, y: -1, core });
+        await movePoint({ componentIdx: viaGroupIdx, x: 0, y: -1, core });
+        await check_labels(0, -1);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
@@ -6873,7 +6873,6 @@ describe("Point tag tests @group4", async () => {
         // Also covers context-aware fallback selection:
         // - $a directly in <label> → latex fallback (label context)
         // - $a in <label><group>$a</group></label> → label context through transparent group
-        // - $a in <label><point>$a</point></label> → no label context (point is opaque)
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
 <graph>

--- a/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getSelfReferentialFallbackPropName } from "../../components/abstract/Copy";
 
+// Simple mock: exact-match plus the real-world subtype relationships we need.
 const componentInfoObjects = {
     isInheritedComponentType({
         inheritedComponentType,
@@ -9,25 +10,45 @@ const componentInfoObjects = {
         inheritedComponentType: string;
         baseComponentType: string;
     }) {
-        return inheritedComponentType === baseComponentType;
+        if (inheritedComponentType === baseComponentType) {
+            return true;
+        }
+        // coords extends math, mrow extends m
+        if (
+            baseComponentType === "math" &&
+            inheritedComponentType === "coords"
+        ) {
+            return true;
+        }
+        if (baseComponentType === "m" && inheritedComponentType === "mrow") {
+            return true;
+        }
+        return false;
     },
     publicStateVariableInfo: {
         point: {
             stateVariableDescriptions: {
-                latex: {},
-                text: {},
+                latex: { createComponentOfType: "latex" },
+                text: { createComponentOfType: "text" },
+            },
+        },
+        mathSource: {
+            stateVariableDescriptions: {
+                value: { createComponentOfType: "math" },
+                latex: { createComponentOfType: "latex" },
+                text: { createComponentOfType: "text" },
             },
         },
         textOnly: {
             stateVariableDescriptions: {
-                text: {},
+                text: { createComponentOfType: "text" },
             },
         },
     },
 };
 
 describe("copy self-reference fallback selection", () => {
-    it("prefers latex in label context, including through transparent composites", () => {
+    it("prefers latex-typed var in label context, including through transparent composites", () => {
         expect(
             getSelfReferentialFallbackPropName({
                 componentAncestors: [
@@ -50,7 +71,7 @@ describe("copy self-reference fallback selection", () => {
         ).eq("latex");
     });
 
-    it("prefers text in the closest text context", () => {
+    it("prefers text-typed var in text context", () => {
         expect(
             getSelfReferentialFallbackPropName({
                 componentAncestors: [
@@ -73,7 +94,92 @@ describe("copy self-reference fallback selection", () => {
         ).eq("text");
     });
 
-    it("falls back to text in label context when latex is unavailable", () => {
+    it("prefers math-typed var in math context, falling back to text-typed", () => {
+        // mathSource has value (math-typed) — should prefer it
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "math",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "mathSource",
+            }),
+        ).eq("value");
+
+        // point has no math-typed var — should fall back to text-typed
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "math",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("text");
+    });
+
+    it("prefers latex-typed var in m context (inline math)", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "m",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("latex");
+    });
+
+    it("prefers latex-typed var in md context (display math)", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "md",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("latex");
+    });
+
+    it("treats mrow (subtype of m) as latex context", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "mrow",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("latex");
+    });
+
+    it("falls back to text-typed in label context when no latex-typed var exists", () => {
         expect(
             getSelfReferentialFallbackPropName({
                 componentAncestors: [
@@ -90,13 +196,31 @@ describe("copy self-reference fallback selection", () => {
         ).eq("text");
     });
 
-    it("stops at non-transparent components before reaching label or text", () => {
+    it("returns undefined when no context is detected", () => {
         expect(
             getSelfReferentialFallbackPropName({
                 componentAncestors: [
                     {
                         componentClass: {
-                            componentType: "math",
+                            componentType: "point",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).toBeUndefined();
+    });
+
+    it("stops at non-transparent component before reaching label context", () => {
+        // point is opaque, so the outer label context is invisible
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "point",
                             treatAsComponentForRecursiveReplacements: false,
                         },
                     },

--- a/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { getSelfReferentialFallbackPropName } from "../../components/abstract/Copy";
+
+const componentInfoObjects = {
+    isInheritedComponentType({
+        inheritedComponentType,
+        baseComponentType,
+    }: {
+        inheritedComponentType: string;
+        baseComponentType: string;
+    }) {
+        return inheritedComponentType === baseComponentType;
+    },
+    publicStateVariableInfo: {
+        point: {
+            stateVariableDescriptions: {
+                latex: {},
+                text: {},
+            },
+        },
+        textOnly: {
+            stateVariableDescriptions: {
+                text: {},
+            },
+        },
+    },
+};
+
+describe("copy self-reference fallback selection", () => {
+    it("prefers latex in label context, including through transparent composites", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "group",
+                            treatAsComponentForRecursiveReplacements: true,
+                        },
+                    },
+                    {
+                        componentClass: {
+                            componentType: "label",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("latex");
+    });
+
+    it("prefers text in the closest text context", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "text",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                    {
+                        componentClass: {
+                            componentType: "label",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("text");
+    });
+
+    it("falls back to text in label context when latex is unavailable", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "label",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "textOnly",
+            }),
+        ).eq("text");
+    });
+
+    it("stops at non-transparent components before reaching label or text", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: [
+                    {
+                        componentClass: {
+                            componentType: "math",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                    {
+                        componentClass: {
+                            componentType: "label",
+                            treatAsComponentForRecursiveReplacements: false,
+                        },
+                    },
+                ],
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).toBeUndefined();
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getSelfReferentialFallbackPropName } from "../../components/abstract/Copy";
+import { getSelfReferentialFallbackPropName } from "../../utils/copy";
 
-// Simple mock: exact-match plus the real-world subtype relationships we need.
+// Simple mock of componentInfoObjects.
+// isInheritedComponentType: exact match plus the real-world subtypes we need.
 const componentInfoObjects = {
     isInheritedComponentType({
         inheritedComponentType,
@@ -13,226 +14,167 @@ const componentInfoObjects = {
         if (inheritedComponentType === baseComponentType) {
             return true;
         }
-        // coords extends math, mrow extends m
+        // coords extends math (as in the real codebase)
         if (
             baseComponentType === "math" &&
             inheritedComponentType === "coords"
         ) {
             return true;
         }
+        // mrow extends m
         if (baseComponentType === "m" && inheritedComponentType === "mrow") {
             return true;
         }
         return false;
     },
     publicStateVariableInfo: {
+        // Point: value is an alias to coords (coords-typed, inherits from math)
         point: {
             stateVariableDescriptions: {
+                coords: { createComponentOfType: "coords" },
                 latex: { createComponentOfType: "latex" },
-                text: { createComponentOfType: "text" },
+            },
+            aliases: {
+                value: { target: "coords" },
             },
         },
+        // Math: value is math-typed directly
         mathSource: {
             stateVariableDescriptions: {
                 value: { createComponentOfType: "math" },
                 latex: { createComponentOfType: "latex" },
                 text: { createComponentOfType: "text" },
             },
+            aliases: {},
         },
-        textOnly: {
+        // Text: value is text-typed directly
+        textSource: {
             stateVariableDescriptions: {
-                text: { createComponentOfType: "text" },
+                value: { createComponentOfType: "text" },
             },
+            aliases: {},
+        },
+        // No value at all
+        noValue: {
+            stateVariableDescriptions: {
+                someOther: { createComponentOfType: "boolean" },
+            },
+            aliases: {},
         },
     },
 };
 
-describe("copy self-reference fallback selection", () => {
-    it("prefers latex-typed var in label context, including through transparent composites", () => {
+const makeAncestors = (...types: { type: string; transparent?: boolean }[]) =>
+    types.map(({ type, transparent = false }) => ({
+        componentClass: {
+            componentType: type,
+            treatAsComponentForRecursiveReplacements: transparent,
+        },
+    }));
+
+describe("getSelfReferentialFallbackPropName", () => {
+    it("returns 'value' for point inside label context (coords inherits math)", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "group",
-                            treatAsComponentForRecursiveReplacements: true,
-                        },
-                    },
-                    {
-                        componentClass: {
-                            componentType: "label",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors({ type: "label" }),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
-            }),
-        ).eq("latex");
-    });
-
-    it("prefers text-typed var in text context", () => {
-        expect(
-            getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "text",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                    {
-                        componentClass: {
-                            componentType: "label",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
-                componentInfoObjects,
-                replacementSourceComponentType: "point",
-            }),
-        ).eq("text");
-    });
-
-    it("prefers math-typed var in math context, falling back to text-typed", () => {
-        // mathSource has value (math-typed) — should prefer it
-        expect(
-            getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "math",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
-                componentInfoObjects,
-                replacementSourceComponentType: "mathSource",
             }),
         ).eq("value");
+    });
 
-        // point has no math-typed var — should fall back to text-typed
+    it("returns 'value' for point inside text context", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "math",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors({ type: "text" }),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
             }),
-        ).eq("text");
+        ).eq("value");
     });
 
-    it("prefers latex-typed var in m context (inline math)", () => {
+    it("returns 'value' for point inside math context", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "m",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors({ type: "math" }),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
             }),
-        ).eq("latex");
+        ).eq("value");
     });
 
-    it("prefers latex-typed var in md context (display math)", () => {
+    it("returns 'value' for point inside m context", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "md",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors({ type: "m" }),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
             }),
-        ).eq("latex");
+        ).eq("value");
     });
 
-    it("treats mrow (subtype of m) as latex context", () => {
+    it("returns 'value' for point inside md context", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "mrow",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors({ type: "md" }),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
             }),
-        ).eq("latex");
+        ).eq("value");
     });
 
-    it("falls back to text-typed in label context when no latex-typed var exists", () => {
+    it("walks through transparent composites (group) to find context", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "label",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors(
+                    { type: "group", transparent: true },
+                    { type: "label" },
+                ),
                 componentInfoObjects,
-                replacementSourceComponentType: "textOnly",
+                replacementSourceComponentType: "point",
             }),
-        ).eq("text");
+        ).eq("value");
     });
 
-    it("returns undefined when no context is detected", () => {
+    it("treats mrow (subtype of m) as a recognised context", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "point",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors({ type: "mrow" }),
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("value");
+    });
+
+    it("stops at non-transparent ancestor before reaching label", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: makeAncestors(
+                    { type: "point" },
+                    { type: "label" },
+                ),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
             }),
         ).toBeUndefined();
     });
 
-    it("stops at non-transparent component before reaching label context", () => {
-        // point is opaque, so the outer label context is invisible
+    it("returns undefined when no recognised context ancestor is found", () => {
         expect(
             getSelfReferentialFallbackPropName({
-                componentAncestors: [
-                    {
-                        componentClass: {
-                            componentType: "point",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                    {
-                        componentClass: {
-                            componentType: "label",
-                            treatAsComponentForRecursiveReplacements: false,
-                        },
-                    },
-                ],
+                componentAncestors: makeAncestors({ type: "boolean" }),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
+            }),
+        ).toBeUndefined();
+    });
+
+    it("returns undefined when source has no value state variable", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: makeAncestors({ type: "label" }),
+                componentInfoObjects,
+                replacementSourceComponentType: "noValue",
             }),
         ).toBeUndefined();
     });

--- a/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/copy.test.ts
@@ -136,7 +136,7 @@ describe("getSelfReferentialFallbackPropName", () => {
         ).eq("value");
     });
 
-    it("treats mrow (subtype of m) as a recognised context", () => {
+    it("treats mrow (subtype of m) as a recognized context", () => {
         expect(
             getSelfReferentialFallbackPropName({
                 componentAncestors: makeAncestors({ type: "mrow" }),
@@ -159,10 +159,50 @@ describe("getSelfReferentialFallbackPropName", () => {
         ).toBeUndefined();
     });
 
-    it("returns undefined when no recognised context ancestor is found", () => {
+    it("returns 'value' for point inside boolean context", () => {
         expect(
             getSelfReferentialFallbackPropName({
                 componentAncestors: makeAncestors({ type: "boolean" }),
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("value");
+    });
+
+    it("returns 'value' for point inside mathList context", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: makeAncestors({ type: "mathList" }),
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("value");
+    });
+
+    it("returns 'value' for point inside textList context", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: makeAncestors({ type: "textList" }),
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("value");
+    });
+
+    it("returns 'value' for point inside booleanList context", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: makeAncestors({ type: "booleanList" }),
+                componentInfoObjects,
+                replacementSourceComponentType: "point",
+            }),
+        ).eq("value");
+    });
+
+    it("returns undefined when no recognized context ancestor is found", () => {
+        expect(
+            getSelfReferentialFallbackPropName({
+                componentAncestors: makeAncestors({ type: "point" }),
                 componentInfoObjects,
                 replacementSourceComponentType: "point",
             }),

--- a/packages/doenetml-worker-javascript/src/utils/copy.js
+++ b/packages/doenetml-worker-javascript/src/utils/copy.js
@@ -770,12 +770,12 @@ export function addAttributesToSingleReplacementChange(
 /**
  * When a Copy/Ref with no explicit prop is a descendant of its own source
  * component (a self-referential copy), serializing the source throws. In a
- * recognised rendering context we fall back to the source's `value` state
+ * recognized rendering context we fall back to the source's `value` state
  * variable instead of showing an error — but only when `value` is typed as
  * `math` or `text` (or a component that inherits from one of those).
  *
- * The recognised contexts are any ancestor that inherits from:
- * label, text, math, m, or md.
+ * The recognized contexts are any ancestor that inherits from:
+ * label, text, math, m, md, boolean, mathList, textList, or booleanList.
  *
  * Transparent composites (treatAsComponentForRecursiveReplacements, e.g.
  * <group>) are walked through; any other ancestor type stops the search.
@@ -787,20 +787,30 @@ export function getSelfReferentialFallbackPropName({
     componentInfoObjects,
     replacementSourceComponentType,
 }) {
-    // Determine whether we're inside a recognised rendering context.
-    let inRecognisedContext = false;
+    // Determine whether we're inside a recognized rendering context.
+    let inRecognizedContext = false;
     for (const ancestor of componentAncestors) {
         const ancestorClass = ancestor.componentClass;
         const ancestorType = ancestorClass.componentType;
         if (
-            ["label", "text", "math", "m", "md"].some((base) =>
+            [
+                "label",
+                "text",
+                "math",
+                "m",
+                "md",
+                "boolean",
+                "mathList",
+                "textList",
+                "booleanList",
+            ].some((base) =>
                 componentInfoObjects.isInheritedComponentType({
                     inheritedComponentType: ancestorType,
                     baseComponentType: base,
                 }),
             )
         ) {
-            inRecognisedContext = true;
+            inRecognizedContext = true;
             break;
         }
         // Only continue through transparent composites (e.g. <group>).
@@ -809,7 +819,7 @@ export function getSelfReferentialFallbackPropName({
         }
     }
 
-    if (!inRecognisedContext) {
+    if (!inRecognizedContext) {
         return undefined;
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/copy.js
+++ b/packages/doenetml-worker-javascript/src/utils/copy.js
@@ -775,7 +775,8 @@ export function addAttributesToSingleReplacementChange(
  * `math` or `text` (or a component that inherits from one of those).
  *
  * The recognized contexts are any ancestor that inherits from:
- * label, text, math, m, md, boolean, mathList, textList, or booleanList.
+ * label, text, math, m, md, boolean, number, mathList, numberList,
+ * textList, or booleanList.
  *
  * Transparent composites (treatAsComponentForRecursiveReplacements, e.g.
  * <group>) are walked through; any other ancestor type stops the search.
@@ -800,7 +801,9 @@ export function getSelfReferentialFallbackPropName({
                 "m",
                 "md",
                 "boolean",
+                "number",
                 "mathList",
+                "numberList",
                 "textList",
                 "booleanList",
             ].some((base) =>

--- a/packages/doenetml-worker-javascript/src/utils/copy.js
+++ b/packages/doenetml-worker-javascript/src/utils/copy.js
@@ -766,3 +766,92 @@ export function addAttributesToSingleReplacementChange(
         }
     }
 }
+
+/**
+ * When a Copy/Ref with no explicit prop is a descendant of its own source
+ * component (a self-referential copy), serializing the source throws. In a
+ * recognised rendering context we fall back to the source's `value` state
+ * variable instead of showing an error — but only when `value` is typed as
+ * `math` or `text` (or a component that inherits from one of those).
+ *
+ * The recognised contexts are any ancestor that inherits from:
+ * label, text, math, m, or md.
+ *
+ * Transparent composites (treatAsComponentForRecursiveReplacements, e.g.
+ * <group>) are walked through; any other ancestor type stops the search.
+ *
+ * Returns `"value"` if the fallback applies, otherwise `undefined`.
+ */
+export function getSelfReferentialFallbackPropName({
+    componentAncestors,
+    componentInfoObjects,
+    replacementSourceComponentType,
+}) {
+    // Determine whether we're inside a recognised rendering context.
+    let inRecognisedContext = false;
+    for (const ancestor of componentAncestors) {
+        const ancestorClass = ancestor.componentClass;
+        const ancestorType = ancestorClass.componentType;
+        if (
+            ["label", "text", "math", "m", "md"].some((base) =>
+                componentInfoObjects.isInheritedComponentType({
+                    inheritedComponentType: ancestorType,
+                    baseComponentType: base,
+                }),
+            )
+        ) {
+            inRecognisedContext = true;
+            break;
+        }
+        // Only continue through transparent composites (e.g. <group>).
+        if (!ancestorClass.treatAsComponentForRecursiveReplacements) {
+            break;
+        }
+    }
+
+    if (!inRecognisedContext) {
+        return undefined;
+    }
+
+    // Look up the `value` state variable on the source component.
+    // `value` may be a direct public var or an alias to another var.
+    const publicVarInfo =
+        componentInfoObjects.publicStateVariableInfo[
+            replacementSourceComponentType
+        ];
+    if (!publicVarInfo) {
+        return undefined;
+    }
+
+    // Resolve alias if needed: Point's `value` aliases `coords`, etc.
+    let valueType =
+        publicVarInfo.stateVariableDescriptions?.value?.createComponentOfType;
+    if (valueType === undefined && publicVarInfo.aliases?.value) {
+        const aliasTarget = publicVarInfo.aliases.value.target;
+        valueType =
+            publicVarInfo.stateVariableDescriptions?.[aliasTarget]
+                ?.createComponentOfType;
+    }
+
+    if (!valueType) {
+        return undefined;
+    }
+
+    // Use `value` only when it is math- or text-typed (including subtypes like
+    // coords, which inherits from math). Math and text can adapt to each other,
+    // so no context-specific preference is needed.
+    if (
+        componentInfoObjects.isInheritedComponentType({
+            inheritedComponentType: valueType,
+            baseComponentType: "math",
+        }) ||
+        componentInfoObjects.isInheritedComponentType({
+            inheritedComponentType: valueType,
+            baseComponentType: "text",
+        })
+    ) {
+        return "value";
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
## Summary

Fixes #1333.

When a Copy/Ref with no explicit prop (e.g. `$a`) appears inside the component it references, serializing the source to build the replacement can encounter the copy itself and throw an "Encountered X" error. Before this PR, that path surfaced as a circular-dependency error.

## Fix

When that self-reference happens inside a recognized rendering context, `Copy.createReplacementForSource` now falls back to `replacementFromProp` for the source component's public `value` state variable instead of showing an error.

This covers contexts such as:

- `<label>`
- `<text>`
- `<math>`, `<m>`, `<md>`
- `<boolean>` and `<number>`
- the corresponding list variants (`<mathList>`, `<textList>`, `<booleanList>`, `<numberList>`)

Transparent composites such as `<group>` are traversed when determining the surrounding context. Outside those recognized contexts, the existing circular-dependency error is preserved.

For `<point>`, the fallback uses its public `value`, which aliases `coords`, so self-references like `<label>$a</label>` render the point coordinates and continue updating reactively.

## Tests

- Regression test for a point referencing itself directly in its own label
- Coverage for transparent `<group>` passthrough
- Coverage for additional recognized contexts (`<m>`, `<math>`, `<boolean>`, `<number>`, and adapted inner `<point>`)
- Unit tests for the fallback-prop helper
- Confirmation that unsupported contexts (e.g. `<answer>`) still report the original circular-dependency error

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)