### PR TITLE
feat: add fillStyle attribute for patterned fills on closed shapes

### DIFF
--- a/.changeset/graph-fill-style-patterns.md
+++ b/.changeset/graph-fill-style-patterns.md
@@ -21,4 +21,6 @@ Closed shapes in graphs (polygon, circle, region, angle) now accept a `fillStyle
 
 Both the JSXGraph interactive renderer and the PreFigure static diagram renderer support all patterns. The hatch lines use the shape's fill color.
 
+Filled circles and polygons also include the hatch wording in their text style descriptions (such as `styleDescription` and `fillStyleDescription`).
+
 Closes #1386.

--- a/.changeset/graph-fill-style-patterns.md
+++ b/.changeset/graph-fill-style-patterns.md
@@ -1,0 +1,24 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+"@doenet/prefigure": patch
+---
+
+Graph: add `fillStyle` style attribute for patterned fills on closed shapes.
+
+Closed shapes in graphs (polygon, circle, region, angle) now accept a `fillStyle` override attribute (or `<styleDefinition fillStyle="...">`) with the following values:
+
+- `solid` (default — existing behavior unchanged)
+- `horizontal` — horizontal line pattern
+- `vertical` — vertical line pattern
+- `diagonal` — diagonal lines (/)
+- `backDiagonal` — back-diagonal lines (\\)
+- `crosshatch` — horizontal + vertical grid
+- `diagonalCrosshatch` — diagonal X-pattern
+
+Both the JSXGraph interactive renderer and the PreFigure static diagram renderer support all patterns. The hatch lines use the shape's fill color.
+
+Closes #1386.

--- a/.changeset/graph-fill-style-patterns.md
+++ b/.changeset/graph-fill-style-patterns.md
@@ -9,7 +9,7 @@
 
 Graph: add `fillStyle` style attribute for patterned fills on closed shapes.
 
-Closed shapes in graphs (polygon, circle, region, angle) now accept a `fillStyle` override attribute (or `<styleDefinition fillStyle="...">`) with the following values:
+Closed shapes in graphs (`polygon`, `circle`, `angle`, `regionBetweenCurves`, and `regionBetweenCurveXAxis`) now accept a `fillStyle` override attribute (or `<styleDefinition fillStyle="...">`) with the following values:
 
 - `solid` (default — existing behavior unchanged)
 - `horizontal` — horizontal line pattern
@@ -19,7 +19,7 @@ Closed shapes in graphs (polygon, circle, region, angle) now accept a `fillStyle
 - `crosshatch` — horizontal + vertical grid
 - `diagonalCrosshatch` — diagonal X-pattern
 
-Both the JSXGraph interactive renderer and the PreFigure static diagram renderer support all patterns. The hatch lines use the shape's fill color.
+Both the JSXGraph interactive renderer and the PreFigure static diagram renderer support all patterns. The hatch lines use the shape's fill color and stay fully opaque so the pattern remains visible.
 
 Filled circles and polygons also include the hatch wording in their text style descriptions (such as `styleDescription` and `fillStyleDescription`).
 

--- a/packages/doenetml-worker-javascript/src/components/Angle.js
+++ b/packages/doenetml-worker-javascript/src/components/Angle.js
@@ -11,6 +11,7 @@ import { returnWrapNonLabelsDescriptionsSugarFunction } from "../utils/label";
 
 export default class Angle extends GraphicalComponent {
     static componentType = "angle";
+    static styleOverrideCategories = ["fill"];
 
     static componentDocs = {
         summary: "An angle defined by three points or a measure",

--- a/packages/doenetml-worker-javascript/src/components/Circle.js
+++ b/packages/doenetml-worker-javascript/src/components/Circle.js
@@ -3,6 +3,13 @@ import {
     returnNumberDisplayStateVariableDefinitions,
 } from "../utils/numberDisplay";
 import { returnGraphControlOrderAttribute } from "../utils/graphical";
+import {
+    buildClosedShapeStyleDescription,
+    buildFillStyleDescription,
+    getBorderDescription,
+    getFillColorWord,
+    getLineColorWord,
+} from "../utils/graphicalStyleDescriptions";
 import Curve from "./Curve";
 import GraphicalComponent from "./abstract/GraphicalComponent";
 
@@ -146,69 +153,25 @@ export default class Circle extends Curve {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let lineColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWordDarkMode;
-                } else {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWord;
-                }
-
-                let borderDescription =
-                    dependencyValues.selectedStyle.lineWidthWord;
-                if (dependencyValues.selectedStyle.lineStyleWord) {
-                    if (borderDescription) {
-                        borderDescription += " ";
-                    }
-                    borderDescription +=
-                        dependencyValues.selectedStyle.lineStyleWord;
-                }
-                if (borderDescription) {
-                    borderDescription += " ";
-                }
-
-                let styleDescription;
-                if (!dependencyValues.filled) {
-                    styleDescription = borderDescription + lineColorWord;
-                } else {
-                    let fillColorWord;
-                    if (
-                        dependencyValues.document?.stateValues.theme === "dark"
-                    ) {
-                        fillColorWord =
-                            dependencyValues.selectedStyle
-                                .fillColorWordDarkMode;
-                    } else {
-                        fillColorWord =
-                            dependencyValues.selectedStyle.fillColorWord;
-                    }
-                    const fillStyleWord =
-                        dependencyValues.selectedStyle.fillStyleWord;
-
-                    if (fillColorWord === lineColorWord) {
-                        styleDescription = "filled " + fillColorWord;
-                        if (fillStyleWord) {
-                            styleDescription += " with " + fillStyleWord;
-                        }
-                        if (borderDescription) {
-                            styleDescription +=
-                                (fillStyleWord ? " and " : " with ") +
-                                borderDescription +
-                                "border";
-                        }
-                    } else {
-                        styleDescription = "filled " + fillColorWord;
-                        if (fillStyleWord) {
-                            styleDescription += " with " + fillStyleWord;
-                        }
-                        styleDescription +=
-                            (fillStyleWord ? " and " : " with ") +
-                            borderDescription +
-                            lineColorWord +
-                            " border";
-                    }
-                }
+                const theme = dependencyValues.document?.stateValues.theme;
+                const lineColorWord = getLineColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const fillColorWord = getFillColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const borderDescription = getBorderDescription(
+                    dependencyValues.selectedStyle,
+                );
+                const styleDescription = buildClosedShapeStyleDescription({
+                    filled: dependencyValues.filled,
+                    lineColorWord,
+                    fillColorWord,
+                    fillStyleWord: dependencyValues.selectedStyle.fillStyleWord,
+                    borderDescription,
+                });
 
                 return { setValue: { styleDescription } };
             },
@@ -236,74 +199,29 @@ export default class Circle extends Curve {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let lineColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWordDarkMode;
-                } else {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWord;
-                }
-
-                let borderDescription =
-                    dependencyValues.selectedStyle.lineWidthWord;
-                if (dependencyValues.selectedStyle.lineStyleWord) {
-                    if (borderDescription) {
-                        borderDescription += " ";
-                    }
-                    borderDescription +=
-                        dependencyValues.selectedStyle.lineStyleWord;
-                }
-                if (borderDescription) {
-                    borderDescription += " ";
-                }
-
-                let styleDescriptionWithNoun;
-                if (!dependencyValues.filled) {
-                    styleDescriptionWithNoun =
-                        borderDescription + lineColorWord + " circle";
-                } else {
-                    let fillColorWord;
-                    if (
-                        dependencyValues.document?.stateValues.theme === "dark"
-                    ) {
-                        fillColorWord =
-                            dependencyValues.selectedStyle
-                                .fillColorWordDarkMode;
-                    } else {
-                        fillColorWord =
-                            dependencyValues.selectedStyle.fillColorWord;
-                    }
-                    const fillStyleWord =
-                        dependencyValues.selectedStyle.fillStyleWord;
-
-                    if (fillColorWord === lineColorWord) {
-                        styleDescriptionWithNoun =
-                            "filled " + fillColorWord + " circle";
-                        if (fillStyleWord) {
-                            styleDescriptionWithNoun +=
-                                " with " + fillStyleWord;
-                        }
-                        if (borderDescription) {
-                            styleDescriptionWithNoun +=
-                                (fillStyleWord ? " and a " : " with a ") +
-                                borderDescription +
-                                "border";
-                        }
-                    } else {
-                        styleDescriptionWithNoun =
-                            "filled " + fillColorWord + " circle";
-                        if (fillStyleWord) {
-                            styleDescriptionWithNoun +=
-                                " with " + fillStyleWord;
-                        }
-                        styleDescriptionWithNoun +=
-                            (fillStyleWord ? " and a " : " with a ") +
-                            borderDescription +
-                            lineColorWord +
-                            " border";
-                    }
-                }
+                const theme = dependencyValues.document?.stateValues.theme;
+                const lineColorWord = getLineColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const fillColorWord = getFillColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const borderDescription = getBorderDescription(
+                    dependencyValues.selectedStyle,
+                );
+                const styleDescriptionWithNoun =
+                    buildClosedShapeStyleDescription({
+                        filled: dependencyValues.filled,
+                        lineColorWord,
+                        fillColorWord,
+                        fillStyleWord:
+                            dependencyValues.selectedStyle.fillStyleWord,
+                        borderDescription,
+                        noun: " circle",
+                        includeBorderArticle: true,
+                    });
 
                 return { setValue: { styleDescriptionWithNoun } };
             },
@@ -327,30 +245,12 @@ export default class Circle extends Curve {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let lineColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWordDarkMode;
-                } else {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWord;
-                }
-
-                let borderStyleDescription =
-                    dependencyValues.selectedStyle.lineWidthWord;
-                if (dependencyValues.selectedStyle.lineStyleWord) {
-                    if (borderStyleDescription) {
-                        borderStyleDescription += " ";
-                    }
-                    borderStyleDescription +=
-                        dependencyValues.selectedStyle.lineStyleWord;
-                }
-
-                if (borderStyleDescription) {
-                    borderStyleDescription += " ";
-                }
-
-                borderStyleDescription += lineColorWord;
+                const borderStyleDescription =
+                    getBorderDescription(dependencyValues.selectedStyle) +
+                    getLineColorWord(
+                        dependencyValues.selectedStyle,
+                        dependencyValues.document?.stateValues.theme,
+                    );
 
                 return { setValue: { borderStyleDescription } };
             },
@@ -378,25 +278,14 @@ export default class Circle extends Curve {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let fillColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    fillColorWord =
-                        dependencyValues.selectedStyle.fillColorWordDarkMode;
-                } else {
-                    fillColorWord =
-                        dependencyValues.selectedStyle.fillColorWord;
-                }
-
-                let fillStyleDescription;
-                if (!dependencyValues.filled) {
-                    fillStyleDescription = "unfilled";
-                } else {
-                    fillStyleDescription = fillColorWord;
-                    if (dependencyValues.selectedStyle.fillStyleWord) {
-                        fillStyleDescription +=
-                            " " + dependencyValues.selectedStyle.fillStyleWord;
-                    }
-                }
+                const fillStyleDescription = buildFillStyleDescription({
+                    filled: dependencyValues.filled,
+                    fillColorWord: getFillColorWord(
+                        dependencyValues.selectedStyle,
+                        dependencyValues.document?.stateValues.theme,
+                    ),
+                    fillStyleWord: dependencyValues.selectedStyle.fillStyleWord,
+                });
 
                 return { setValue: { fillStyleDescription } };
             },

--- a/packages/doenetml-worker-javascript/src/components/Circle.js
+++ b/packages/doenetml-worker-javascript/src/components/Circle.js
@@ -183,18 +183,27 @@ export default class Circle extends Curve {
                         fillColorWord =
                             dependencyValues.selectedStyle.fillColorWord;
                     }
+                    const fillStyleWord =
+                        dependencyValues.selectedStyle.fillStyleWord;
 
                     if (fillColorWord === lineColorWord) {
                         styleDescription = "filled " + fillColorWord;
+                        if (fillStyleWord) {
+                            styleDescription += " with " + fillStyleWord;
+                        }
                         if (borderDescription) {
                             styleDescription +=
-                                " with " + borderDescription + "border";
+                                (fillStyleWord ? " and " : " with ") +
+                                borderDescription +
+                                "border";
                         }
                     } else {
-                        styleDescription =
-                            "filled " +
-                            fillColorWord +
-                            " with " +
+                        styleDescription = "filled " + fillColorWord;
+                        if (fillStyleWord) {
+                            styleDescription += " with " + fillStyleWord;
+                        }
+                        styleDescription +=
+                            (fillStyleWord ? " and " : " with ") +
                             borderDescription +
                             lineColorWord +
                             " border";
@@ -265,19 +274,31 @@ export default class Circle extends Curve {
                         fillColorWord =
                             dependencyValues.selectedStyle.fillColorWord;
                     }
+                    const fillStyleWord =
+                        dependencyValues.selectedStyle.fillStyleWord;
 
                     if (fillColorWord === lineColorWord) {
                         styleDescriptionWithNoun =
                             "filled " + fillColorWord + " circle";
+                        if (fillStyleWord) {
+                            styleDescriptionWithNoun +=
+                                " with " + fillStyleWord;
+                        }
                         if (borderDescription) {
                             styleDescriptionWithNoun +=
-                                " with a " + borderDescription + "border";
+                                (fillStyleWord ? " and a " : " with a ") +
+                                borderDescription +
+                                "border";
                         }
                     } else {
                         styleDescriptionWithNoun =
-                            "filled " +
-                            fillColorWord +
-                            " circle with a " +
+                            "filled " + fillColorWord + " circle";
+                        if (fillStyleWord) {
+                            styleDescriptionWithNoun +=
+                                " with " + fillStyleWord;
+                        }
+                        styleDescriptionWithNoun +=
+                            (fillStyleWord ? " and a " : " with a ") +
                             borderDescription +
                             lineColorWord +
                             " border";
@@ -371,6 +392,10 @@ export default class Circle extends Curve {
                     fillStyleDescription = "unfilled";
                 } else {
                     fillStyleDescription = fillColorWord;
+                    if (dependencyValues.selectedStyle.fillStyleWord) {
+                        fillStyleDescription +=
+                            " " + dependencyValues.selectedStyle.fillStyleWord;
+                    }
                 }
 
                 return { setValue: { fillStyleDescription } };

--- a/packages/doenetml-worker-javascript/src/components/Polygon.js
+++ b/packages/doenetml-worker-javascript/src/components/Polygon.js
@@ -1,5 +1,12 @@
 import { returnNumberDisplayAttributeComponentShadowing } from "../utils/numberDisplay";
 import { returnGraphControlOrderAttribute } from "../utils/graphical";
+import {
+    buildClosedShapeStyleDescription,
+    buildFillStyleDescription,
+    getBorderDescription,
+    getFillColorWord,
+    getLineColorWord,
+} from "../utils/graphicalStyleDescriptions";
 import Polyline from "./Polyline";
 
 export default class Polygon extends Polyline {
@@ -113,69 +120,25 @@ export default class Polygon extends Polyline {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let lineColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWordDarkMode;
-                } else {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWord;
-                }
-
-                let borderDescription =
-                    dependencyValues.selectedStyle.lineWidthWord;
-                if (dependencyValues.selectedStyle.lineStyleWord) {
-                    if (borderDescription) {
-                        borderDescription += " ";
-                    }
-                    borderDescription +=
-                        dependencyValues.selectedStyle.lineStyleWord;
-                }
-                if (borderDescription) {
-                    borderDescription += " ";
-                }
-
-                let styleDescription;
-                if (!dependencyValues.filled) {
-                    styleDescription = borderDescription + lineColorWord;
-                } else {
-                    let fillColorWord;
-                    if (
-                        dependencyValues.document?.stateValues.theme === "dark"
-                    ) {
-                        fillColorWord =
-                            dependencyValues.selectedStyle
-                                .fillColorWordDarkMode;
-                    } else {
-                        fillColorWord =
-                            dependencyValues.selectedStyle.fillColorWord;
-                    }
-                    const fillStyleWord =
-                        dependencyValues.selectedStyle.fillStyleWord;
-
-                    if (fillColorWord === lineColorWord) {
-                        styleDescription = "filled " + fillColorWord;
-                        if (fillStyleWord) {
-                            styleDescription += " with " + fillStyleWord;
-                        }
-                        if (borderDescription) {
-                            styleDescription +=
-                                (fillStyleWord ? " and " : " with ") +
-                                borderDescription +
-                                "border";
-                        }
-                    } else {
-                        styleDescription = "filled " + fillColorWord;
-                        if (fillStyleWord) {
-                            styleDescription += " with " + fillStyleWord;
-                        }
-                        styleDescription +=
-                            (fillStyleWord ? " and " : " with ") +
-                            borderDescription +
-                            lineColorWord +
-                            " border";
-                    }
-                }
+                const theme = dependencyValues.document?.stateValues.theme;
+                const lineColorWord = getLineColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const fillColorWord = getFillColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const borderDescription = getBorderDescription(
+                    dependencyValues.selectedStyle,
+                );
+                const styleDescription = buildClosedShapeStyleDescription({
+                    filled: dependencyValues.filled,
+                    lineColorWord,
+                    fillColorWord,
+                    fillStyleWord: dependencyValues.selectedStyle.fillStyleWord,
+                    borderDescription,
+                });
 
                 return { setValue: { styleDescription } };
             },
@@ -203,74 +166,29 @@ export default class Polygon extends Polyline {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let lineColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWordDarkMode;
-                } else {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWord;
-                }
-
-                let borderDescription =
-                    dependencyValues.selectedStyle.lineWidthWord;
-                if (dependencyValues.selectedStyle.lineStyleWord) {
-                    if (borderDescription) {
-                        borderDescription += " ";
-                    }
-                    borderDescription +=
-                        dependencyValues.selectedStyle.lineStyleWord;
-                }
-                if (borderDescription) {
-                    borderDescription += " ";
-                }
-
-                let styleDescriptionWithNoun;
-                if (!dependencyValues.filled) {
-                    styleDescriptionWithNoun =
-                        borderDescription + lineColorWord + " polygon";
-                } else {
-                    let fillColorWord;
-                    if (
-                        dependencyValues.document?.stateValues.theme === "dark"
-                    ) {
-                        fillColorWord =
-                            dependencyValues.selectedStyle
-                                .fillColorWordDarkMode;
-                    } else {
-                        fillColorWord =
-                            dependencyValues.selectedStyle.fillColorWord;
-                    }
-                    const fillStyleWord =
-                        dependencyValues.selectedStyle.fillStyleWord;
-
-                    if (fillColorWord === lineColorWord) {
-                        styleDescriptionWithNoun =
-                            "filled " + fillColorWord + " polygon";
-                        if (fillStyleWord) {
-                            styleDescriptionWithNoun +=
-                                " with " + fillStyleWord;
-                        }
-                        if (borderDescription) {
-                            styleDescriptionWithNoun +=
-                                (fillStyleWord ? " and a " : " with a ") +
-                                borderDescription +
-                                "border";
-                        }
-                    } else {
-                        styleDescriptionWithNoun =
-                            "filled " + fillColorWord + " polygon";
-                        if (fillStyleWord) {
-                            styleDescriptionWithNoun +=
-                                " with " + fillStyleWord;
-                        }
-                        styleDescriptionWithNoun +=
-                            (fillStyleWord ? " and a " : " with a ") +
-                            borderDescription +
-                            lineColorWord +
-                            " border";
-                    }
-                }
+                const theme = dependencyValues.document?.stateValues.theme;
+                const lineColorWord = getLineColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const fillColorWord = getFillColorWord(
+                    dependencyValues.selectedStyle,
+                    theme,
+                );
+                const borderDescription = getBorderDescription(
+                    dependencyValues.selectedStyle,
+                );
+                const styleDescriptionWithNoun =
+                    buildClosedShapeStyleDescription({
+                        filled: dependencyValues.filled,
+                        lineColorWord,
+                        fillColorWord,
+                        fillStyleWord:
+                            dependencyValues.selectedStyle.fillStyleWord,
+                        borderDescription,
+                        noun: " polygon",
+                        includeBorderArticle: true,
+                    });
 
                 return { setValue: { styleDescriptionWithNoun } };
             },
@@ -294,30 +212,12 @@ export default class Polygon extends Polyline {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let lineColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWordDarkMode;
-                } else {
-                    lineColorWord =
-                        dependencyValues.selectedStyle.lineColorWord;
-                }
-
-                let borderStyleDescription =
-                    dependencyValues.selectedStyle.lineWidthWord;
-                if (dependencyValues.selectedStyle.lineStyleWord) {
-                    if (borderStyleDescription) {
-                        borderStyleDescription += " ";
-                    }
-                    borderStyleDescription +=
-                        dependencyValues.selectedStyle.lineStyleWord;
-                }
-
-                if (borderStyleDescription) {
-                    borderStyleDescription += " ";
-                }
-
-                borderStyleDescription += lineColorWord;
+                const borderStyleDescription =
+                    getBorderDescription(dependencyValues.selectedStyle) +
+                    getLineColorWord(
+                        dependencyValues.selectedStyle,
+                        dependencyValues.document?.stateValues.theme,
+                    );
 
                 return { setValue: { borderStyleDescription } };
             },
@@ -345,25 +245,14 @@ export default class Polygon extends Polyline {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let fillColorWord;
-                if (dependencyValues.document?.stateValues.theme === "dark") {
-                    fillColorWord =
-                        dependencyValues.selectedStyle.fillColorWordDarkMode;
-                } else {
-                    fillColorWord =
-                        dependencyValues.selectedStyle.fillColorWord;
-                }
-
-                let fillStyleDescription;
-                if (!dependencyValues.filled) {
-                    fillStyleDescription = "unfilled";
-                } else {
-                    fillStyleDescription = fillColorWord;
-                    if (dependencyValues.selectedStyle.fillStyleWord) {
-                        fillStyleDescription +=
-                            " " + dependencyValues.selectedStyle.fillStyleWord;
-                    }
-                }
+                const fillStyleDescription = buildFillStyleDescription({
+                    filled: dependencyValues.filled,
+                    fillColorWord: getFillColorWord(
+                        dependencyValues.selectedStyle,
+                        dependencyValues.document?.stateValues.theme,
+                    ),
+                    fillStyleWord: dependencyValues.selectedStyle.fillStyleWord,
+                });
 
                 return { setValue: { fillStyleDescription } };
             },

--- a/packages/doenetml-worker-javascript/src/components/Polygon.js
+++ b/packages/doenetml-worker-javascript/src/components/Polygon.js
@@ -150,18 +150,27 @@ export default class Polygon extends Polyline {
                         fillColorWord =
                             dependencyValues.selectedStyle.fillColorWord;
                     }
+                    const fillStyleWord =
+                        dependencyValues.selectedStyle.fillStyleWord;
 
                     if (fillColorWord === lineColorWord) {
                         styleDescription = "filled " + fillColorWord;
+                        if (fillStyleWord) {
+                            styleDescription += " with " + fillStyleWord;
+                        }
                         if (borderDescription) {
                             styleDescription +=
-                                " with " + borderDescription + "border";
+                                (fillStyleWord ? " and " : " with ") +
+                                borderDescription +
+                                "border";
                         }
                     } else {
-                        styleDescription =
-                            "filled " +
-                            fillColorWord +
-                            " with " +
+                        styleDescription = "filled " + fillColorWord;
+                        if (fillStyleWord) {
+                            styleDescription += " with " + fillStyleWord;
+                        }
+                        styleDescription +=
+                            (fillStyleWord ? " and " : " with ") +
                             borderDescription +
                             lineColorWord +
                             " border";
@@ -232,19 +241,31 @@ export default class Polygon extends Polyline {
                         fillColorWord =
                             dependencyValues.selectedStyle.fillColorWord;
                     }
+                    const fillStyleWord =
+                        dependencyValues.selectedStyle.fillStyleWord;
 
                     if (fillColorWord === lineColorWord) {
                         styleDescriptionWithNoun =
                             "filled " + fillColorWord + " polygon";
+                        if (fillStyleWord) {
+                            styleDescriptionWithNoun +=
+                                " with " + fillStyleWord;
+                        }
                         if (borderDescription) {
                             styleDescriptionWithNoun +=
-                                " with a " + borderDescription + "border";
+                                (fillStyleWord ? " and a " : " with a ") +
+                                borderDescription +
+                                "border";
                         }
                     } else {
                         styleDescriptionWithNoun =
-                            "filled " +
-                            fillColorWord +
-                            " polygon with a " +
+                            "filled " + fillColorWord + " polygon";
+                        if (fillStyleWord) {
+                            styleDescriptionWithNoun +=
+                                " with " + fillStyleWord;
+                        }
+                        styleDescriptionWithNoun +=
+                            (fillStyleWord ? " and a " : " with a ") +
                             borderDescription +
                             lineColorWord +
                             " border";
@@ -338,6 +359,10 @@ export default class Polygon extends Polyline {
                     fillStyleDescription = "unfilled";
                 } else {
                     fillStyleDescription = fillColorWord;
+                    if (dependencyValues.selectedStyle.fillStyleWord) {
+                        fillStyleDescription +=
+                            " " + dependencyValues.selectedStyle.fillStyleWord;
+                    }
                 }
 
                 return { setValue: { fillStyleDescription } };

--- a/packages/doenetml-worker-javascript/src/components/RegionBetweenCurveXAxis.js
+++ b/packages/doenetml-worker-javascript/src/components/RegionBetweenCurveXAxis.js
@@ -2,6 +2,7 @@ import GraphicalComponent from "./abstract/GraphicalComponent";
 
 export default class RegionBetweenCurveXAxis extends GraphicalComponent {
     static componentType = "regionBetweenCurveXAxis";
+    static styleOverrideCategories = ["fill"];
 
     static componentDocs = {
         summary: "A region bounded between a curve and the x-axis",

--- a/packages/doenetml-worker-javascript/src/components/RegionBetweenCurves.js
+++ b/packages/doenetml-worker-javascript/src/components/RegionBetweenCurves.js
@@ -2,6 +2,7 @@ import GraphicalComponent from "./abstract/GraphicalComponent";
 
 export default class RegionBetweenCurves extends GraphicalComponent {
     static componentType = "regionBetweenCurves";
+    static styleOverrideCategories = ["fill"];
 
     static componentDocs = {
         summary: "A region bounded between two curves",

--- a/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { styleAttributes } from "../../utils/prefigure/style";
+
+describe("PreFigure style attributes", () => {
+    it("uses hatch pattern urls for hex fill colors and omits fill-opacity", () => {
+        const attrs = styleAttributes({
+            selectedStyle: {
+                fillColor: "#abcd",
+                fillStyle: "diagonal",
+                fillOpacity: 0.3,
+            },
+            diagnostics: [],
+            warningPrefix: "test",
+        });
+
+        expect(attrs).toContain('fill="url(#doenet-hatch-diagonal-abcd)"');
+        expect(attrs).not.toContain('fill-opacity="0.3"');
+    });
+
+    it("preserves 8-digit hex colors in hatch pattern ids", () => {
+        const attrs = styleAttributes({
+            selectedStyle: {
+                fillColor: "#11223344",
+                fillStyle: "crosshatch",
+            },
+            diagnostics: [],
+            warningPrefix: "test",
+        });
+
+        expect(attrs).toContain(
+            'fill="url(#doenet-hatch-crosshatch-11223344)"',
+        );
+    });
+
+    it("falls back to plain fills when the color is not hex", () => {
+        const attrs = styleAttributes({
+            selectedStyle: {
+                fillColorWord: "blue",
+                fillStyle: "horizontal",
+                fillOpacity: 0.3,
+            },
+            diagnostics: [],
+            warningPrefix: "test",
+        });
+
+        expect(attrs).toContain('fill="blue"');
+        expect(attrs).toContain('fill-opacity="0.3"');
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
@@ -13,7 +13,9 @@ describe("PreFigure style attributes", () => {
             warningPrefix: "test",
         });
 
-        expect(attrs).toContain('fill="url(#doenet-hatch-diagonal-abcd)"');
+        expect(attrs).toContain(
+            'fill="url(#doenet-hatch-diagonal-2361626364)"',
+        );
         expect(attrs).not.toContain('fill-opacity="0.3"');
     });
 
@@ -28,11 +30,11 @@ describe("PreFigure style attributes", () => {
         });
 
         expect(attrs).toContain(
-            'fill="url(#doenet-hatch-crosshatch-11223344)"',
+            'fill="url(#doenet-hatch-crosshatch-233131323233333434)"',
         );
     });
 
-    it("falls back to plain fills when the color is not hex", () => {
+    it("uses hatch pattern urls for named fill colors too", () => {
         const attrs = styleAttributes({
             selectedStyle: {
                 fillColorWord: "blue",
@@ -43,7 +45,9 @@ describe("PreFigure style attributes", () => {
             warningPrefix: "test",
         });
 
-        expect(attrs).toContain('fill="blue"');
-        expect(attrs).toContain('fill-opacity="0.3"');
+        expect(attrs).toContain(
+            'fill="url(#doenet-hatch-horizontal-626c7565)"',
+        );
+        expect(attrs).not.toContain('fill-opacity="0.3"');
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/circle.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/circle.test.ts
@@ -6022,15 +6022,15 @@ $c7.radius
             doenetML: `
     <setup>
         <styleDefinition stylenumber="1" lineColor="blue" fillColor="blue" lineWidth="2" lineStyle="solid" />
-        <styleDefinition stylenumber="2" lineColor="red" fillColor="green" lineWidth="2" lineStyle="solid" />
+        <styleDefinition stylenumber="2" lineColor="red" fillColor="green" lineWidth="2" lineStyle="solid" fillStyle="horizontal" />
 
         <styleDefinition stylenumber="3" lineColor="blue" fillColor="blue" lineWidth="5" lineStyle="solid" />
-        <styleDefinition stylenumber="4" lineColor="red" fillColor="green" lineWidth="1" lineStyle="dotted" />
+        <styleDefinition stylenumber="4" lineColor="red" fillColor="green" lineWidth="1" lineStyle="dotted" fillStyle="diagonalCrosshatch" />
     </setup>
 
     <graph>
       <circle center="(-8,0)" name="c1" />
-      <circle center="(-8,4)" name="c2" filled />
+      <circle center="(-8,4)" name="c2" filled fillStyle="vertical" />
       <circle center="(-4,0)" name="c3" stylenumber="2" />
       <circle center="(-4,4)" name="c4" stylenumber="2" filled />
 
@@ -6115,11 +6115,11 @@ $c7.radius
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st2")].stateValues.value,
-        ).toContain("filled blue");
+        ).toContain("filled blue with vertical lines");
         expect(
             stateVariables[await resolvePathToNodeIdx("stn2")].stateValues
                 .value,
-        ).toContain("filled blue circle");
+        ).toContain("filled blue circle with vertical lines");
         expect(
             stateVariables[await resolvePathToNodeIdx("bst2")].stateValues
                 .value,
@@ -6127,7 +6127,7 @@ $c7.radius
         expect(
             stateVariables[await resolvePathToNodeIdx("fst2")].stateValues
                 .value,
-        ).toContain("blue");
+        ).toContain("blue vertical lines");
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st3")].stateValues.value,
@@ -6147,11 +6147,13 @@ $c7.radius
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st4")].stateValues.value,
-        ).toContain("filled green with red border");
+        ).toContain("filled green with horizontal lines and red border");
         expect(
             stateVariables[await resolvePathToNodeIdx("stn4")].stateValues
                 .value,
-        ).toContain("filled green circle with a red border");
+        ).toContain(
+            "filled green circle with horizontal lines and a red border",
+        );
         expect(
             stateVariables[await resolvePathToNodeIdx("bst4")].stateValues
                 .value,
@@ -6159,7 +6161,7 @@ $c7.radius
         expect(
             stateVariables[await resolvePathToNodeIdx("fst4")].stateValues
                 .value,
-        ).toContain("green");
+        ).toContain("green horizontal lines");
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st5")].stateValues.value,
@@ -6211,11 +6213,15 @@ $c7.radius
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st8")].stateValues.value,
-        ).toContain("filled green with thin dotted red border");
+        ).toContain(
+            "filled green with diagonal cross hatched and thin dotted red border",
+        );
         expect(
             stateVariables[await resolvePathToNodeIdx("stn8")].stateValues
                 .value,
-        ).toContain("filled green circle with a thin dotted red border");
+        ).toContain(
+            "filled green circle with diagonal cross hatched and a thin dotted red border",
+        );
         expect(
             stateVariables[await resolvePathToNodeIdx("bst8")].stateValues
                 .value,
@@ -6223,7 +6229,7 @@ $c7.radius
         expect(
             stateVariables[await resolvePathToNodeIdx("fst8")].stateValues
                 .value,
-        ).toContain("green");
+        ).toContain("green diagonal cross hatched");
     });
 
     it("hideOffGraphIndicator", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/polygon.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/polygon.test.ts
@@ -4837,15 +4837,15 @@ describe("Polygon tag tests @group2", async () => {
     <text>a</text>
     <setup>
         <styleDefinition styleNumber="1" lineColor="blue" fillColor="blue" lineWidth="2" lineStyle="solid" />
-        <styleDefinition styleNumber="2" lineColor="red" fillColor="green" lineWidth="2" lineStyle="solid" />
+        <styleDefinition styleNumber="2" lineColor="red" fillColor="green" lineWidth="2" lineStyle="solid" fillStyle="horizontal" />
 
         <styleDefinition styleNumber="3" lineColor="blue" fillColor="blue" lineWidth="5" lineStyle="solid" />
-        <styleDefinition styleNumber="4" lineColor="red" fillColor="green" lineWidth="1" lineStyle="dotted" />
+        <styleDefinition styleNumber="4" lineColor="red" fillColor="green" lineWidth="1" lineStyle="dotted" fillStyle="backDiagonal" />
     </setup>
 
     <graph>
       <polygon vertices="(0,0) (0,2) (2,0)" name="p1" />
-      <polygon vertices="(3,0) (3,2) (5,0)" name="p2" filled />
+      <polygon vertices="(3,0) (3,2) (5,0)" name="p2" filled fillStyle="crosshatch" />
       <polygon vertices="(0,3) (0,5) (2,3)" name="p3" styleNumber="2" />
       <polygon vertices="(3,3) (3,5) (5,3)" name="p4" styleNumber="2" filled />
 
@@ -4903,16 +4903,16 @@ describe("Polygon tag tests @group2", async () => {
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st2")].stateValues.text,
-        ).eq("filled blue");
+        ).eq("filled blue with cross hatched");
         expect(
             stateVariables[await resolvePathToNodeIdx("stn2")].stateValues.text,
-        ).eq("filled blue polygon");
+        ).eq("filled blue polygon with cross hatched");
         expect(
             stateVariables[await resolvePathToNodeIdx("bst2")].stateValues.text,
         ).eq("blue");
         expect(
             stateVariables[await resolvePathToNodeIdx("fst2")].stateValues.text,
-        ).eq("blue");
+        ).eq("blue cross hatched");
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st3")].stateValues.text,
@@ -4929,16 +4929,16 @@ describe("Polygon tag tests @group2", async () => {
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st4")].stateValues.text,
-        ).eq("filled green with red border");
+        ).eq("filled green with horizontal lines and red border");
         expect(
             stateVariables[await resolvePathToNodeIdx("stn4")].stateValues.text,
-        ).eq("filled green polygon with a red border");
+        ).eq("filled green polygon with horizontal lines and a red border");
         expect(
             stateVariables[await resolvePathToNodeIdx("bst4")].stateValues.text,
         ).eq("red");
         expect(
             stateVariables[await resolvePathToNodeIdx("fst4")].stateValues.text,
-        ).eq("green");
+        ).eq("green horizontal lines");
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st5")].stateValues.text,
@@ -4981,16 +4981,20 @@ describe("Polygon tag tests @group2", async () => {
 
         expect(
             stateVariables[await resolvePathToNodeIdx("st8")].stateValues.text,
-        ).eq("filled green with thin dotted red border");
+        ).eq(
+            "filled green with reverse diagonal lines and thin dotted red border",
+        );
         expect(
             stateVariables[await resolvePathToNodeIdx("stn8")].stateValues.text,
-        ).eq("filled green polygon with a thin dotted red border");
+        ).eq(
+            "filled green polygon with reverse diagonal lines and a thin dotted red border",
+        );
         expect(
             stateVariables[await resolvePathToNodeIdx("bst8")].stateValues.text,
         ).eq("thin dotted red");
         expect(
             stateVariables[await resolvePathToNodeIdx("fst8")].stateValues.text,
-        ).eq("green");
+        ).eq("green reverse diagonal lines");
     });
 
     it("draggable, vertices draggable", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
@@ -255,6 +255,44 @@ describe("Per-component style override tests @group4", async () => {
         expect(C3.stateValues.selectedStyle.fillOpacity).eq(0.3);
     });
 
+    it("fillStyle values flow through to selectedStyle and derive fillStyleWord", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<setup>
+  <styleDefinition styleNumber="2" fillStyle="backDiagonal" />
+</setup>
+<graph>
+  <polygon
+    name="P"
+    vertices="(0,0) (1,0) (1,1)"
+    filled
+    fillStyle="horizontal"
+  />
+  <circle
+    name="C"
+    center="(3,0)"
+    radius="1"
+    filled
+    styleNumber="2"
+  />
+</graph>
+`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const P = stateVariables[await resolvePathToNodeIdx("P")];
+        const C = stateVariables[await resolvePathToNodeIdx("C")];
+
+        expect(P.stateValues.selectedStyle.fillStyle).eq("horizontal");
+        expect(P.stateValues.selectedStyle.fillStyleWord).eq(
+            "horizontal lines",
+        );
+        expect(C.stateValues.selectedStyle.fillStyle).eq("backdiagonal");
+        expect(C.stateValues.selectedStyle.fillStyleWord).eq(
+            "reverse diagonal lines",
+        );
+    });
+
     it("lineWidth/lineStyle overrides flow through to selectedStyle on a parabola", async () => {
         // Same #1231 borrow path as the circle test above, but Parabola opts
         // into only the "line" override category.
@@ -320,16 +358,19 @@ describe("Per-component style override tests @group4", async () => {
         expect(polyAttrs.lineWidth).toBeDefined();
         expect(polyAttrs.lineStyle).toBeDefined();
         expect(polyAttrs.fillOpacity).toBeDefined();
+        expect(polyAttrs.fillStyle).toBeDefined();
         expect(polyAttrs.markerStyle).toBeUndefined();
 
         // Curve is line+fill (closed-curve case); Parabola overrides to line-only
         const Curve = (await import("../../components/Curve.js")).default;
         const curveAttrs = Curve.createAttributesObject();
         expect(curveAttrs.fillOpacity).toBeDefined();
+        expect(curveAttrs.fillStyle).toBeDefined();
         const Parabola = (await import("../../components/Parabola.js")).default;
         const parAttrs = Parabola.createAttributesObject();
         expect(parAttrs.lineWidth).toBeDefined();
         expect(parAttrs.fillOpacity).toBeUndefined();
+        expect(parAttrs.fillStyle).toBeUndefined();
 
         // Subclasses inherit their parent's category:
         // - Triangle/Rectangle/RegularPolygon inherit Polygon's line+fill
@@ -338,8 +379,10 @@ describe("Per-component style override tests @group4", async () => {
         // - CobwebPolyline inherits Polyline's line-only (no fill)
         const Triangle = (await import("../../components/Triangle.js")).default;
         expect(Triangle.createAttributesObject().fillOpacity).toBeDefined();
+        expect(Triangle.createAttributesObject().fillStyle).toBeDefined();
         const Circle = (await import("../../components/Circle.js")).default;
         expect(Circle.createAttributesObject().fillOpacity).toBeDefined();
+        expect(Circle.createAttributesObject().fillStyle).toBeDefined();
         const BestFitLine = (await import("../../components/BestFitLine.js"))
             .default;
         const bflAttrs = BestFitLine.createAttributesObject();

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
@@ -275,6 +275,27 @@ describe("Per-component style override tests @group4", async () => {
     filled
     styleNumber="2"
   />
+  <angle
+    name="A"
+    through="(0,0) (1,0) (1,1)"
+    fillStyle="vertical"
+  />
+  <function name="f">x</function>
+  <regionBetweenCurveXAxis
+    name="RX"
+    function="$f"
+    boundaryValues="0 1"
+    fillStyle="crosshatch"
+  />
+  <function name="f1">x</function>
+  <function name="f2">x^2</function>
+  <regionBetweenCurves
+    name="RB"
+    boundaryValues="0 1"
+    fillStyle="diagonalCrosshatch"
+  >
+    $f1 $f2
+  </regionBetweenCurves>
 </graph>
 `,
         });
@@ -282,6 +303,9 @@ describe("Per-component style override tests @group4", async () => {
         const stateVariables = await core.returnAllStateVariables(false, true);
         const P = stateVariables[await resolvePathToNodeIdx("P")];
         const C = stateVariables[await resolvePathToNodeIdx("C")];
+        const A = stateVariables[await resolvePathToNodeIdx("A")];
+        const RX = stateVariables[await resolvePathToNodeIdx("RX")];
+        const RB = stateVariables[await resolvePathToNodeIdx("RB")];
 
         expect(P.stateValues.selectedStyle.fillStyle).eq("horizontal");
         expect(P.stateValues.selectedStyle.fillStyleWord).eq(
@@ -290,6 +314,14 @@ describe("Per-component style override tests @group4", async () => {
         expect(C.stateValues.selectedStyle.fillStyle).eq("backdiagonal");
         expect(C.stateValues.selectedStyle.fillStyleWord).eq(
             "reverse diagonal lines",
+        );
+        expect(A.stateValues.selectedStyle.fillStyle).eq("vertical");
+        expect(A.stateValues.selectedStyle.fillStyleWord).eq("vertical lines");
+        expect(RX.stateValues.selectedStyle.fillStyle).eq("crosshatch");
+        expect(RX.stateValues.selectedStyle.fillStyleWord).eq("cross hatched");
+        expect(RB.stateValues.selectedStyle.fillStyle).eq("diagonalcrosshatch");
+        expect(RB.stateValues.selectedStyle.fillStyleWord).eq(
+            "diagonal cross hatched",
         );
     });
 
@@ -383,6 +415,27 @@ describe("Per-component style override tests @group4", async () => {
         const Circle = (await import("../../components/Circle.js")).default;
         expect(Circle.createAttributesObject().fillOpacity).toBeDefined();
         expect(Circle.createAttributesObject().fillStyle).toBeDefined();
+        const Angle = (await import("../../components/Angle.js")).default;
+        expect(Angle.createAttributesObject().fillOpacity).toBeDefined();
+        expect(Angle.createAttributesObject().fillStyle).toBeDefined();
+        const RegionBetweenCurveXAxis = (
+            await import("../../components/RegionBetweenCurveXAxis.js")
+        ).default;
+        expect(
+            RegionBetweenCurveXAxis.createAttributesObject().fillOpacity,
+        ).toBeDefined();
+        expect(
+            RegionBetweenCurveXAxis.createAttributesObject().fillStyle,
+        ).toBeDefined();
+        const RegionBetweenCurves = (
+            await import("../../components/RegionBetweenCurves.js")
+        ).default;
+        expect(
+            RegionBetweenCurves.createAttributesObject().fillOpacity,
+        ).toBeDefined();
+        expect(
+            RegionBetweenCurves.createAttributesObject().fillStyle,
+        ).toBeDefined();
         const BestFitLine = (await import("../../components/BestFitLine.js"))
             .default;
         const bflAttrs = BestFitLine.createAttributesObject();

--- a/packages/doenetml-worker-javascript/src/utils/graphicalStyleDescriptions.js
+++ b/packages/doenetml-worker-javascript/src/utils/graphicalStyleDescriptions.js
@@ -1,0 +1,86 @@
+export function getLineColorWord(selectedStyle, theme) {
+    return theme === "dark"
+        ? selectedStyle.lineColorWordDarkMode
+        : selectedStyle.lineColorWord;
+}
+
+export function getFillColorWord(selectedStyle, theme) {
+    return theme === "dark"
+        ? selectedStyle.fillColorWordDarkMode
+        : selectedStyle.fillColorWord;
+}
+
+export function getBorderDescription(selectedStyle) {
+    let borderDescription = selectedStyle.lineWidthWord;
+    if (selectedStyle.lineStyleWord) {
+        if (borderDescription) {
+            borderDescription += " ";
+        }
+        borderDescription += selectedStyle.lineStyleWord;
+    }
+    if (borderDescription) {
+        borderDescription += " ";
+    }
+    return borderDescription;
+}
+
+export function buildClosedShapeStyleDescription({
+    filled,
+    lineColorWord,
+    fillColorWord,
+    fillStyleWord,
+    borderDescription,
+    noun = "",
+    includeBorderArticle = false,
+}) {
+    if (!filled) {
+        return borderDescription + lineColorWord + noun;
+    }
+
+    let styleDescription = `filled ${fillColorWord}${noun}`;
+    if (fillStyleWord) {
+        styleDescription += ` with ${fillStyleWord}`;
+    }
+
+    if (fillColorWord === lineColorWord) {
+        if (borderDescription) {
+            styleDescription +=
+                (fillStyleWord
+                    ? includeBorderArticle
+                        ? " and a "
+                        : " and "
+                    : includeBorderArticle
+                      ? " with a "
+                      : " with ") +
+                borderDescription +
+                "border";
+        }
+        return styleDescription;
+    }
+
+    return (
+        styleDescription +
+        (fillStyleWord
+            ? includeBorderArticle
+                ? " and a "
+                : " and "
+            : includeBorderArticle
+              ? " with a "
+              : " with ") +
+        borderDescription +
+        lineColorWord +
+        " border"
+    );
+}
+
+export function buildFillStyleDescription({
+    filled,
+    fillColorWord,
+    fillStyleWord,
+}) {
+    if (!filled) {
+        return "unfilled";
+    }
+
+    return fillStyleWord ? `${fillColorWord} ${fillStyleWord}` : fillColorWord;
+}

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
@@ -1,7 +1,10 @@
 import { Position } from "../dast/types";
 import { escapeXml, formatNumber, pushWarning } from "./common";
 import type { SelectedStyle } from "./types";
-import type { DiagnosticRecord } from "@doenet/utils";
+import {
+    encodeFillPatternColorToken,
+    type DiagnosticRecord,
+} from "@doenet/utils";
 
 const prefigureDashByLineStyle: Record<string, string | null> = {
     solid: null,
@@ -18,9 +21,6 @@ const prefigurePointStyleByMarkerStyle: Record<string, string> = {
     plus: "plus",
     "double-circle": "double-circle",
 };
-
-const hatchPatternColorRe =
-    /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 
 /**
  * Returns a `selectedStyle` whose color fields hold the dark-mode values when
@@ -98,16 +98,15 @@ export function styleAttributes({
         const usePatternFill =
             !!fill &&
             !!selectedStyle?.fillStyle &&
-            selectedStyle.fillStyle !== "solid" &&
-            hatchPatternColorRe.test(fill);
+            selectedStyle.fillStyle !== "solid";
 
         if (fill) {
             if (usePatternFill) {
                 // Encode fill style + color into a pattern ID that the SVG
                 // post-processor in compiler.ts will resolve into a <pattern> def.
-                const colorHex = fill.replace(/^#/, "").toLowerCase();
+                const colorToken = encodeFillPatternColorToken(fill);
                 attrs.push(
-                    `fill="url(#doenet-hatch-${escapeXml(selectedStyle.fillStyle!)}-${escapeXml(colorHex)})"`,
+                    `fill="url(#doenet-hatch-${escapeXml(selectedStyle.fillStyle!)}-${colorToken})"`,
                 );
             } else {
                 attrs.push(`fill="${escapeXml(fill)}"`);
@@ -123,11 +122,13 @@ export function styleAttributes({
     if (includeFill) {
         const fillOpacity = formatNumber(selectedStyle?.fillOpacity);
         const usePatternFill =
+            !!(
+                selectedStyle?.fillColor ??
+                selectedStyle?.fillColorWord ??
+                ""
+            ) &&
             !!selectedStyle?.fillStyle &&
-            selectedStyle.fillStyle !== "solid" &&
-            hatchPatternColorRe.test(
-                selectedStyle?.fillColor ?? selectedStyle?.fillColorWord ?? "",
-            );
+            selectedStyle.fillStyle !== "solid";
         if (fillOpacity !== null && !usePatternFill) {
             attrs.push(`fill-opacity="${escapeXml(fillOpacity)}"`);
         }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
@@ -19,6 +19,9 @@ const prefigurePointStyleByMarkerStyle: Record<string, string> = {
     "double-circle": "double-circle",
 };
 
+const hatchPatternColorRe =
+    /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
 /**
  * Returns a `selectedStyle` whose color fields hold the dark-mode values when
  * `darkMode` is true, so the rest of the PreFigure conversion (which reads the
@@ -92,14 +95,19 @@ export function styleAttributes({
 
     if (includeFill) {
         const fill = selectedStyle?.fillColor ?? selectedStyle?.fillColorWord;
+        const usePatternFill =
+            !!fill &&
+            !!selectedStyle?.fillStyle &&
+            selectedStyle.fillStyle !== "solid" &&
+            hatchPatternColorRe.test(fill);
+
         if (fill) {
-            const fillStyle = selectedStyle?.fillStyle;
-            if (fillStyle && fillStyle !== "solid") {
+            if (usePatternFill) {
                 // Encode fill style + color into a pattern ID that the SVG
                 // post-processor in compiler.ts will resolve into a <pattern> def.
                 const colorHex = fill.replace(/^#/, "").toLowerCase();
                 attrs.push(
-                    `fill="url(#doenet-hatch-${escapeXml(fillStyle)}-${escapeXml(colorHex)})"`,
+                    `fill="url(#doenet-hatch-${escapeXml(selectedStyle.fillStyle!)}-${escapeXml(colorHex)})"`,
                 );
             } else {
                 attrs.push(`fill="${escapeXml(fill)}"`);
@@ -114,7 +122,13 @@ export function styleAttributes({
 
     if (includeFill) {
         const fillOpacity = formatNumber(selectedStyle?.fillOpacity);
-        if (fillOpacity !== null) {
+        const usePatternFill =
+            !!selectedStyle?.fillStyle &&
+            selectedStyle.fillStyle !== "solid" &&
+            hatchPatternColorRe.test(
+                selectedStyle?.fillColor ?? selectedStyle?.fillColorWord ?? "",
+            );
+        if (fillOpacity !== null && !usePatternFill) {
             attrs.push(`fill-opacity="${escapeXml(fillOpacity)}"`);
         }
     }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
@@ -93,7 +93,17 @@ export function styleAttributes({
     if (includeFill) {
         const fill = selectedStyle?.fillColor ?? selectedStyle?.fillColorWord;
         if (fill) {
-            attrs.push(`fill="${escapeXml(fill)}"`);
+            const fillStyle = selectedStyle?.fillStyle;
+            if (fillStyle && fillStyle !== "solid") {
+                // Encode fill style + color into a pattern ID that the SVG
+                // post-processor in compiler.ts will resolve into a <pattern> def.
+                const colorHex = fill.replace(/^#/, "").toLowerCase();
+                attrs.push(
+                    `fill="url(#doenet-hatch-${escapeXml(fillStyle)}-${escapeXml(colorHex)})"`,
+                );
+            } else {
+                attrs.push(`fill="${escapeXml(fill)}"`);
+            }
         }
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
@@ -35,6 +35,7 @@ export interface SelectedStyle {
     lineOpacity?: number;
     fillOpacity?: number;
     lineStyle?: string;
+    fillStyle?: string;
     markerStyle?: string;
     markerSize?: number;
     markerColor?: string;

--- a/packages/doenetml/src/Viewer/renderers/angle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/angle.tsx
@@ -11,6 +11,7 @@ import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { syncLayer, syncWithLabelToggle } from "./utils/jsxgraph";
+import { getOrInjectPattern } from "./utils/fillPatterns";
 
 interface AngleSVs extends GraphicalSVs {
     numericalPoints: [number, number][];
@@ -73,7 +74,12 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
             fixed: true,
             layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
             radius: SVs.numericalRadius,
-            fillColor: SVs.selectedStyle.fillColor,
+            fillColor: getOrInjectPattern(
+                board.renderer.defs as SVGDefsElement | null,
+                board.container.id,
+                SVs.selectedStyle.fillStyle ?? "solid",
+                SVs.selectedStyle.fillColor,
+            ),
             strokeColor: SVs.selectedStyle.lineColor,
             highlight: false,
             orthoType: SVs.emphasizeRightAngle ? "square" : "sector",
@@ -184,12 +190,14 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
 
             syncLayer(angleJXG.current, SVs.layer, LINE_LAYER_OFFSET);
 
-            if (
-                angleJXG.current.visProp.fillcolor !==
-                SVs.selectedStyle.fillColor
-            ) {
-                angleJXG.current.visProp.fillcolor =
-                    SVs.selectedStyle.fillColor;
+            const angleFillColor = getOrInjectPattern(
+                board.renderer.defs as SVGDefsElement | null,
+                board.container.id,
+                SVs.selectedStyle.fillStyle ?? "solid",
+                SVs.selectedStyle.fillColor,
+            );
+            if (angleJXG.current.visProp.fillcolor !== angleFillColor) {
+                angleJXG.current.visProp.fillcolor = angleFillColor;
             }
             if (
                 angleJXG.current.visProp.strokecolor !==

--- a/packages/doenetml/src/Viewer/renderers/angle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/angle.tsx
@@ -11,7 +11,7 @@ import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { syncLayer, syncWithLabelToggle } from "./utils/jsxgraph";
-import { getOrInjectPattern } from "./utils/fillPatterns";
+import { getPatternFillAttributes } from "./utils/fillPatterns";
 
 interface AngleSVs extends GraphicalSVs {
     numericalPoints: [number, number][];
@@ -67,6 +67,14 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
             return null;
         }
 
+        const fillAttributes = getPatternFillAttributes({
+            defsEl: board.renderer.defs as SVGDefsElement | null,
+            boardId: board.container.id,
+            fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+            fillColor: SVs.selectedStyle.fillColor,
+            fillOpacity: SVs.selectedStyle.fillOpacity,
+        });
+
         var jsxAngleAttributes: Record<string, any> = {
             name: SVs.labelForGraph,
             visible: !SVs.hidden,
@@ -74,12 +82,8 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
             fixed: true,
             layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
             radius: SVs.numericalRadius,
-            fillColor: getOrInjectPattern(
-                board.renderer.defs as SVGDefsElement | null,
-                board.container.id,
-                SVs.selectedStyle.fillStyle ?? "solid",
-                SVs.selectedStyle.fillColor,
-            ),
+            fillColor: fillAttributes.fillColor,
+            fillOpacity: fillAttributes.fillOpacity,
             strokeColor: SVs.selectedStyle.lineColor,
             highlight: false,
             orthoType: SVs.emphasizeRightAngle ? "square" : "sector",
@@ -190,14 +194,23 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
 
             syncLayer(angleJXG.current, SVs.layer, LINE_LAYER_OFFSET);
 
-            const angleFillColor = getOrInjectPattern(
-                board.renderer.defs as SVGDefsElement | null,
-                board.container.id,
-                SVs.selectedStyle.fillStyle ?? "solid",
-                SVs.selectedStyle.fillColor,
-            );
+            const fillAttributes = getPatternFillAttributes({
+                defsEl: board.renderer.defs as SVGDefsElement | null,
+                boardId: board.container.id,
+                fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+                fillColor: SVs.selectedStyle.fillColor,
+                fillOpacity: SVs.selectedStyle.fillOpacity,
+            });
+            const angleFillColor = fillAttributes.fillColor;
             if (angleJXG.current.visProp.fillcolor !== angleFillColor) {
                 angleJXG.current.visProp.fillcolor = angleFillColor;
+            }
+            if (
+                angleJXG.current.visProp.fillopacity !==
+                fillAttributes.fillOpacity
+            ) {
+                angleJXG.current.visProp.fillopacity =
+                    fillAttributes.fillOpacity;
             }
             if (
                 angleJXG.current.visProp.strokecolor !==

--- a/packages/doenetml/src/Viewer/renderers/angle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/angle.tsx
@@ -12,6 +12,7 @@ import { ChoiceInputInlineContext } from "./choiceInput";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { syncLayer, syncWithLabelToggle } from "./utils/jsxgraph";
 import { getPatternFillAttributes } from "./utils/fillPatterns";
+import { resolveLineColor, resolveFillColor } from "./utils/styleColors";
 
 interface AngleSVs extends GraphicalSVs {
     numericalPoints: [number, number][];
@@ -71,7 +72,7 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
             defsEl: board.renderer.defs as SVGDefsElement | null,
             boardId: board.container.id,
             fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
-            fillColor: SVs.selectedStyle.fillColor,
+            fillColor: resolveFillColor(SVs.selectedStyle, darkMode),
             fillOpacity: SVs.selectedStyle.fillOpacity,
         });
 
@@ -84,7 +85,7 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
             radius: SVs.numericalRadius,
             fillColor: fillAttributes.fillColor,
             fillOpacity: fillAttributes.fillOpacity,
-            strokeColor: SVs.selectedStyle.lineColor,
+            strokeColor: resolveLineColor(SVs.selectedStyle, darkMode),
             highlight: false,
             orthoType: SVs.emphasizeRightAngle ? "square" : "sector",
         };
@@ -198,7 +199,7 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
                 defsEl: board.renderer.defs as SVGDefsElement | null,
                 boardId: board.container.id,
                 fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
-                fillColor: SVs.selectedStyle.fillColor,
+                fillColor: resolveFillColor(SVs.selectedStyle, darkMode),
                 fillOpacity: SVs.selectedStyle.fillOpacity,
             });
             const angleFillColor = fillAttributes.fillColor;
@@ -212,12 +213,12 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
                 angleJXG.current.visProp.fillopacity =
                     fillAttributes.fillOpacity;
             }
-            if (
-                angleJXG.current.visProp.strokecolor !==
-                SVs.selectedStyle.lineColor
-            ) {
-                angleJXG.current.visProp.strokecolor =
-                    SVs.selectedStyle.lineColor;
+            const angleLineColor = resolveLineColor(
+                SVs.selectedStyle,
+                darkMode,
+            );
+            if (angleJXG.current.visProp.strokecolor !== angleLineColor) {
+                angleJXG.current.visProp.strokecolor = angleLineColor;
             }
 
             angleJXG.current.name = SVs.labelForGraph;

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -41,6 +41,7 @@ import {
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
 import { buildFilledShapeAttributes } from "./utils/buildGraphicalAttributes";
+import { getOrInjectPattern } from "./utils/fillPatterns";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
@@ -131,6 +132,16 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
         if (!SVs.filled) {
             jsxCircleAttributes.fillColor = "none";
             jsxCircleAttributes.highlightFillColor = "none";
+        } else if (board) {
+            const resolvedFillColor = jsxCircleAttributes.fillColor;
+            const patternFill = getOrInjectPattern(
+                board.renderer.defs as SVGDefsElement | null,
+                board.container.id,
+                SVs.selectedStyle.fillStyle ?? "solid",
+                resolvedFillColor,
+            );
+            jsxCircleAttributes.fillColor = patternFill;
+            jsxCircleAttributes.highlightFillColor = patternFill;
         }
 
         if (SVs.filled) {
@@ -676,9 +687,18 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             syncLayer(circleJXG.current, SVs.layer, LINE_LAYER_OFFSET);
 
             const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
-            const fillColor = SVs.filled
+            const resolvedFillColor = SVs.filled
                 ? resolveFillColor(SVs.selectedStyle, darkMode)
                 : "none";
+            const fillColor =
+                SVs.filled && board
+                    ? getOrInjectPattern(
+                          board.renderer.defs as SVGDefsElement | null,
+                          board.container.id,
+                          SVs.selectedStyle.fillStyle ?? "solid",
+                          resolvedFillColor,
+                      )
+                    : resolvedFillColor;
 
             syncLineStrokeStyle(circleJXG.current, {
                 lineColor,

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -41,7 +41,7 @@ import {
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
 import { buildFilledShapeAttributes } from "./utils/buildGraphicalAttributes";
-import { getOrInjectPattern } from "./utils/fillPatterns";
+import { getPatternFillAttributes } from "./utils/fillPatterns";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
@@ -133,15 +133,17 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             jsxCircleAttributes.fillColor = "none";
             jsxCircleAttributes.highlightFillColor = "none";
         } else if (board) {
-            const resolvedFillColor = jsxCircleAttributes.fillColor;
-            const patternFill = getOrInjectPattern(
-                board.renderer.defs as SVGDefsElement | null,
-                board.container.id,
-                SVs.selectedStyle.fillStyle ?? "solid",
-                resolvedFillColor,
+            Object.assign(
+                jsxCircleAttributes,
+                getPatternFillAttributes({
+                    defsEl: board.renderer.defs as SVGDefsElement | null,
+                    boardId: board.container.id,
+                    fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+                    fillColor: jsxCircleAttributes.fillColor,
+                    fillOpacity: SVs.selectedStyle.fillOpacity,
+                    highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
+                }),
             );
-            jsxCircleAttributes.fillColor = patternFill;
-            jsxCircleAttributes.highlightFillColor = patternFill;
         }
 
         if (SVs.filled) {
@@ -690,15 +692,24 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             const resolvedFillColor = SVs.filled
                 ? resolveFillColor(SVs.selectedStyle, darkMode)
                 : "none";
-            const fillColor =
+            const fillAttributes =
                 SVs.filled && board
-                    ? getOrInjectPattern(
-                          board.renderer.defs as SVGDefsElement | null,
-                          board.container.id,
-                          SVs.selectedStyle.fillStyle ?? "solid",
-                          resolvedFillColor,
-                      )
-                    : resolvedFillColor;
+                    ? getPatternFillAttributes({
+                          defsEl: board.renderer.defs as SVGDefsElement | null,
+                          boardId: board.container.id,
+                          fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+                          fillColor: resolvedFillColor,
+                          fillOpacity: SVs.selectedStyle.fillOpacity,
+                          highlightFillOpacity:
+                              SVs.selectedStyle.fillOpacity * 0.5,
+                      })
+                    : {
+                          fillColor: resolvedFillColor,
+                          fillOpacity: SVs.selectedStyle.fillOpacity,
+                          highlightFillColor: resolvedFillColor,
+                          highlightFillOpacity:
+                              SVs.selectedStyle.fillOpacity * 0.5,
+                      };
 
             syncLineStrokeStyle(circleJXG.current, {
                 lineColor,
@@ -707,19 +718,22 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                 dash: styleToDash(SVs.selectedStyle.lineStyle),
             });
 
-            if (circleJXG.current.visProp.fillcolor !== fillColor) {
-                circleJXG.current.visProp.fillcolor = fillColor;
-                circleJXG.current.visProp.highlightfillcolor = fillColor;
+            if (
+                circleJXG.current.visProp.fillcolor !== fillAttributes.fillColor
+            ) {
+                circleJXG.current.visProp.fillcolor = fillAttributes.fillColor;
+                circleJXG.current.visProp.highlightfillcolor =
+                    fillAttributes.highlightFillColor;
                 circleJXG.current.visProp.hasinnerpoints = SVs.filled;
             }
             if (
                 circleJXG.current.visProp.fillopacity !==
-                SVs.selectedStyle.fillOpacity
+                fillAttributes.fillOpacity
             ) {
                 circleJXG.current.visProp.fillopacity =
-                    SVs.selectedStyle.fillOpacity;
+                    fillAttributes.fillOpacity;
                 circleJXG.current.visProp.highlightfillopacity =
-                    SVs.selectedStyle.fillOpacity * 0.5;
+                    fillAttributes.highlightFillOpacity;
             }
 
             circleJXG.current.name = SVs.labelForGraph;

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -30,7 +30,7 @@ import {
     syncVisPropValues,
 } from "./utils/jsxgraph";
 import { buildBaseAttributes } from "./utils/buildGraphicalAttributes";
-import { getOrInjectPattern } from "./utils/fillPatterns";
+import { getPatternFillAttributes } from "./utils/fillPatterns";
 
 interface PolygonSVs extends DraggableGraphicalSVs {
     numVertices: number;
@@ -97,15 +97,22 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
         const resolvedFillColor = SVs.filled
             ? resolveFillColor(SVs.selectedStyle, darkMode)
             : "none";
-        const fillColor =
+        const fillAttributes =
             SVs.filled && board
-                ? getOrInjectPattern(
-                      board.renderer.defs as SVGDefsElement | null,
-                      board.container.id,
-                      SVs.selectedStyle.fillStyle ?? "solid",
-                      resolvedFillColor,
-                  )
-                : resolvedFillColor;
+                ? getPatternFillAttributes({
+                      defsEl: board.renderer.defs as SVGDefsElement | null,
+                      boardId: board.container.id,
+                      fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+                      fillColor: resolvedFillColor,
+                      fillOpacity: SVs.selectedStyle.fillOpacity,
+                      highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
+                  })
+                : {
+                      fillColor: resolvedFillColor,
+                      fillOpacity: SVs.selectedStyle.fillOpacity,
+                      highlightFillColor: resolvedFillColor,
+                      highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
+                  };
 
         jsxPointAttributes.current = {
             fillColor: "none",
@@ -142,10 +149,10 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
             }),
 
             //specific to polygon
-            fillColor,
-            fillOpacity: SVs.selectedStyle.fillOpacity,
-            highlightFillColor: fillColor,
-            highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
+            fillColor: fillAttributes.fillColor,
+            fillOpacity: fillAttributes.fillOpacity,
+            highlightFillColor: fillAttributes.highlightFillColor,
+            highlightFillOpacity: fillAttributes.highlightFillOpacity,
             vertices: jsxPointAttributes.current,
             borders: jsxBorderAttributes,
         };
@@ -528,15 +535,24 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
             const resolvedFillColor = SVs.filled
                 ? resolveFillColor(SVs.selectedStyle, darkMode)
                 : "none";
-            const fillColor =
+            const fillAttributes =
                 SVs.filled && board
-                    ? getOrInjectPattern(
-                          board.renderer.defs as SVGDefsElement | null,
-                          board.container.id,
-                          SVs.selectedStyle.fillStyle ?? "solid",
-                          resolvedFillColor,
-                      )
-                    : resolvedFillColor;
+                    ? getPatternFillAttributes({
+                          defsEl: board.renderer.defs as SVGDefsElement | null,
+                          boardId: board.container.id,
+                          fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+                          fillColor: resolvedFillColor,
+                          fillOpacity: SVs.selectedStyle.fillOpacity,
+                          highlightFillOpacity:
+                              SVs.selectedStyle.fillOpacity * 0.5,
+                      })
+                    : {
+                          fillColor: resolvedFillColor,
+                          fillOpacity: SVs.selectedStyle.fillOpacity,
+                          highlightFillColor: resolvedFillColor,
+                          highlightFillOpacity:
+                              SVs.selectedStyle.fillOpacity * 0.5,
+                      };
 
             polygonJXG.current.name = SVs.labelForGraph;
 
@@ -547,20 +563,24 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 label.update();
             }
 
-            if (polygonJXG.current.visProp.fillcolor !== fillColor) {
-                polygonJXG.current.visProp.fillcolor = fillColor;
-                polygonJXG.current.visProp.highlightfillcolor = fillColor;
+            if (
+                polygonJXG.current.visProp.fillcolor !==
+                fillAttributes.fillColor
+            ) {
+                polygonJXG.current.visProp.fillcolor = fillAttributes.fillColor;
+                polygonJXG.current.visProp.highlightfillcolor =
+                    fillAttributes.highlightFillColor;
                 polygonJXG.current.visProp.hasinnerpoints = SVs.filled;
             }
 
             if (
                 polygonJXG.current.visProp.fillopacity !==
-                SVs.selectedStyle.fillOpacity
+                fillAttributes.fillOpacity
             ) {
                 polygonJXG.current.visProp.fillopacity =
-                    SVs.selectedStyle.fillOpacity;
+                    fillAttributes.fillOpacity;
                 polygonJXG.current.visProp.highlightfillopacity =
-                    SVs.selectedStyle.fillOpacity * 0.5;
+                    fillAttributes.highlightFillOpacity;
             }
 
             polygonJXG.current.needsUpdate = true;

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -30,6 +30,7 @@ import {
     syncVisPropValues,
 } from "./utils/jsxgraph";
 import { buildBaseAttributes } from "./utils/buildGraphicalAttributes";
+import { getOrInjectPattern } from "./utils/fillPatterns";
 
 interface PolygonSVs extends DraggableGraphicalSVs {
     numVertices: number;
@@ -93,9 +94,18 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
         }
 
         const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
-        const fillColor = SVs.filled
+        const resolvedFillColor = SVs.filled
             ? resolveFillColor(SVs.selectedStyle, darkMode)
             : "none";
+        const fillColor =
+            SVs.filled && board
+                ? getOrInjectPattern(
+                      board.renderer.defs as SVGDefsElement | null,
+                      board.container.id,
+                      SVs.selectedStyle.fillStyle ?? "solid",
+                      resolvedFillColor,
+                  )
+                : resolvedFillColor;
 
         jsxPointAttributes.current = {
             fillColor: "none",
@@ -515,9 +525,18 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
             }
 
             const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
-            const fillColor = SVs.filled
+            const resolvedFillColor = SVs.filled
                 ? resolveFillColor(SVs.selectedStyle, darkMode)
                 : "none";
+            const fillColor =
+                SVs.filled && board
+                    ? getOrInjectPattern(
+                          board.renderer.defs as SVGDefsElement | null,
+                          board.container.id,
+                          SVs.selectedStyle.fillStyle ?? "solid",
+                          resolvedFillColor,
+                      )
+                    : resolvedFillColor;
 
             polygonJXG.current.name = SVs.labelForGraph;
 

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
@@ -8,6 +8,7 @@ import { createFunctionFromDefinition } from "@doenet/utils";
 import { DocContext } from "../DocViewer";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { JXGCurve, JXGElement, JXGPoint } from "./jsxgraph-distrib/types";
+import { getOrInjectPattern } from "./utils/fillPatterns";
 
 interface RegionBetweenCurveXAxisSVs extends GraphicalSVs {
     haveFunction: boolean;
@@ -62,6 +63,12 @@ export default React.memo(function RegionBetweenCurveXAxis(
                 ? SVs.selectedStyle.fillColorDarkMode
                 : SVs.selectedStyle.fillColor;
 
+        fillColor = getOrInjectPattern(
+            board.renderer.defs as SVGDefsElement | null,
+            board.container.id,
+            SVs.selectedStyle.fillStyle ?? "solid",
+            fillColor,
+        );
         // Note: actual content of label is being ignored
         // but, if label is non-empty, then jsxgraph display a label
         // which is an integral sign = value of integral
@@ -156,6 +163,13 @@ export default React.memo(function RegionBetweenCurveXAxis(
                 darkMode === "dark"
                     ? SVs.selectedStyle.fillColorDarkMode
                     : SVs.selectedStyle.fillColor;
+
+            fillColor = getOrInjectPattern(
+                board.renderer.defs as SVGDefsElement | null,
+                board.container.id,
+                SVs.selectedStyle.fillStyle ?? "solid",
+                fillColor,
+            );
 
             if (integralJXG.current.visProp.fillcolor !== fillColor) {
                 integralJXG.current.visProp.fillcolor = fillColor;

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
@@ -8,7 +8,7 @@ import { createFunctionFromDefinition } from "@doenet/utils";
 import { DocContext } from "../DocViewer";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { JXGCurve, JXGElement, JXGPoint } from "./jsxgraph-distrib/types";
-import { getOrInjectPattern } from "./utils/fillPatterns";
+import { getPatternFillAttributes } from "./utils/fillPatterns";
 
 interface RegionBetweenCurveXAxisSVs extends GraphicalSVs {
     haveFunction: boolean;
@@ -58,17 +58,16 @@ export default React.memo(function RegionBetweenCurveXAxis(
             return null;
         }
 
-        let fillColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.fillColorDarkMode
-                : SVs.selectedStyle.fillColor;
-
-        fillColor = getOrInjectPattern(
-            board.renderer.defs as SVGDefsElement | null,
-            board.container.id,
-            SVs.selectedStyle.fillStyle ?? "solid",
-            fillColor,
-        );
+        const fillAttributes = getPatternFillAttributes({
+            defsEl: board.renderer.defs as SVGDefsElement | null,
+            boardId: board.container.id,
+            fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+            fillColor:
+                darkMode === "dark"
+                    ? SVs.selectedStyle.fillColorDarkMode
+                    : SVs.selectedStyle.fillColor,
+            fillOpacity: SVs.selectedStyle.fillOpacity,
+        });
         // Note: actual content of label is being ignored
         // but, if label is non-empty, then jsxgraph display a label
         // which is an integral sign = value of integral
@@ -82,8 +81,8 @@ export default React.memo(function RegionBetweenCurveXAxis(
             fixed: true,
             layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
 
-            fillColor,
-            fillOpacity: SVs.selectedStyle.fillOpacity,
+            fillColor: fillAttributes.fillColor,
+            fillOpacity: fillAttributes.fillOpacity,
             highlight: false,
 
             // don't display points at left and right endpoints along function
@@ -159,28 +158,31 @@ export default React.memo(function RegionBetweenCurveXAxis(
                 integralJXG.current.setAttribute({ layer });
             }
 
-            let fillColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.fillColorDarkMode
-                    : SVs.selectedStyle.fillColor;
+            const fillAttributes = getPatternFillAttributes({
+                defsEl: board.renderer.defs as SVGDefsElement | null,
+                boardId: board.container.id,
+                fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+                fillColor:
+                    darkMode === "dark"
+                        ? SVs.selectedStyle.fillColorDarkMode
+                        : SVs.selectedStyle.fillColor,
+                fillOpacity: SVs.selectedStyle.fillOpacity,
+            });
 
-            fillColor = getOrInjectPattern(
-                board.renderer.defs as SVGDefsElement | null,
-                board.container.id,
-                SVs.selectedStyle.fillStyle ?? "solid",
-                fillColor,
-            );
-
-            if (integralJXG.current.visProp.fillcolor !== fillColor) {
-                integralJXG.current.visProp.fillcolor = fillColor;
+            if (
+                integralJXG.current.visProp.fillcolor !==
+                fillAttributes.fillColor
+            ) {
+                integralJXG.current.visProp.fillcolor =
+                    fillAttributes.fillColor;
             }
 
             if (
                 integralJXG.current.visProp.fillopacity !==
-                SVs.selectedStyle.fillOpacity
+                fillAttributes.fillOpacity
             ) {
                 integralJXG.current.visProp.fillopacity =
-                    SVs.selectedStyle.fillOpacity;
+                    fillAttributes.fillOpacity;
             }
 
             // including both update and full updates for all parts of curve and board

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
@@ -8,7 +8,7 @@ import { DocContext } from "../DocViewer";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { JXGCurve } from "./jsxgraph-distrib/types";
 import { styleToDash } from "./utils/styleToDash";
-import { getOrInjectPattern } from "./utils/fillPatterns";
+import { getPatternFillAttributes } from "./utils/fillPatterns";
 
 interface RegionBetweenCurvesSVs extends GraphicalSVs {
     haveFunctions: boolean;
@@ -64,17 +64,16 @@ export default React.memo(function RegionBetweenCurves(
                 ? SVs.selectedStyle.lineColorDarkMode
                 : SVs.selectedStyle.lineColor;
 
-        let fillColor =
-            darkMode === "dark"
-                ? SVs.selectedStyle.fillColorDarkMode
-                : SVs.selectedStyle.fillColor;
-
-        fillColor = getOrInjectPattern(
-            board.renderer.defs as SVGDefsElement | null,
-            board.container.id,
-            SVs.selectedStyle.fillStyle ?? "solid",
-            fillColor,
-        );
+        const fillAttributes = getPatternFillAttributes({
+            defsEl: board.renderer.defs as SVGDefsElement | null,
+            boardId: board.container.id,
+            fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+            fillColor:
+                darkMode === "dark"
+                    ? SVs.selectedStyle.fillColorDarkMode
+                    : SVs.selectedStyle.fillColor,
+            fillOpacity: SVs.selectedStyle.fillOpacity,
+        });
 
         let jsxAttributes: Record<string, any> = {
             name: SVs.labelForGraph,
@@ -88,8 +87,8 @@ export default React.memo(function RegionBetweenCurves(
             strokeWidth: SVs.selectedStyle.lineWidth,
             dash: styleToDash(SVs.selectedStyle.lineStyle, SVs.dashed),
 
-            fillColor,
-            fillOpacity: SVs.selectedStyle.fillOpacity,
+            fillColor: fillAttributes.fillColor,
+            fillOpacity: fillAttributes.fillOpacity,
             highlight: false,
         };
 
@@ -240,28 +239,29 @@ export default React.memo(function RegionBetweenCurves(
                     SVs.selectedStyle.lineWidth;
             }
 
-            let fillColor =
-                darkMode === "dark"
-                    ? SVs.selectedStyle.fillColorDarkMode
-                    : SVs.selectedStyle.fillColor;
+            const fillAttributes = getPatternFillAttributes({
+                defsEl: board.renderer.defs as SVGDefsElement | null,
+                boardId: board.container.id,
+                fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
+                fillColor:
+                    darkMode === "dark"
+                        ? SVs.selectedStyle.fillColorDarkMode
+                        : SVs.selectedStyle.fillColor,
+                fillOpacity: SVs.selectedStyle.fillOpacity,
+            });
 
-            fillColor = getOrInjectPattern(
-                board.renderer.defs as SVGDefsElement | null,
-                board.container.id,
-                SVs.selectedStyle.fillStyle ?? "solid",
-                fillColor,
-            );
-
-            if (regionJXG.current.visProp.fillcolor !== fillColor) {
-                regionJXG.current.visProp.fillcolor = fillColor;
+            if (
+                regionJXG.current.visProp.fillcolor !== fillAttributes.fillColor
+            ) {
+                regionJXG.current.visProp.fillcolor = fillAttributes.fillColor;
             }
 
             if (
                 regionJXG.current.visProp.fillopacity !==
-                SVs.selectedStyle.fillOpacity
+                fillAttributes.fillOpacity
             ) {
                 regionJXG.current.visProp.fillopacity =
-                    SVs.selectedStyle.fillOpacity;
+                    fillAttributes.fillOpacity;
             }
 
             regionJXG.current.needsUpdate = true;

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
@@ -8,6 +8,7 @@ import { DocContext } from "../DocViewer";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { JXGCurve } from "./jsxgraph-distrib/types";
 import { styleToDash } from "./utils/styleToDash";
+import { getOrInjectPattern } from "./utils/fillPatterns";
 
 interface RegionBetweenCurvesSVs extends GraphicalSVs {
     haveFunctions: boolean;
@@ -67,6 +68,13 @@ export default React.memo(function RegionBetweenCurves(
             darkMode === "dark"
                 ? SVs.selectedStyle.fillColorDarkMode
                 : SVs.selectedStyle.fillColor;
+
+        fillColor = getOrInjectPattern(
+            board.renderer.defs as SVGDefsElement | null,
+            board.container.id,
+            SVs.selectedStyle.fillStyle ?? "solid",
+            fillColor,
+        );
 
         let jsxAttributes: Record<string, any> = {
             name: SVs.labelForGraph,
@@ -236,6 +244,13 @@ export default React.memo(function RegionBetweenCurves(
                 darkMode === "dark"
                     ? SVs.selectedStyle.fillColorDarkMode
                     : SVs.selectedStyle.fillColor;
+
+            fillColor = getOrInjectPattern(
+                board.renderer.defs as SVGDefsElement | null,
+                board.container.id,
+                SVs.selectedStyle.fillStyle ?? "solid",
+                fillColor,
+            );
 
             if (regionJXG.current.visProp.fillcolor !== fillColor) {
                 regionJXG.current.visProp.fillcolor = fillColor;

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
@@ -1,0 +1,92 @@
+/**
+ * SVG fill-pattern support for JSXGraph renderers.
+ *
+ * When a shape's `fillStyle` is not `"solid"`, we inject a `<pattern>` element
+ * into the board's SVG `<defs>` and use the resulting `url(#id)` string as the
+ * `fillColor` attribute on the JSXGraph element.
+ */
+
+type PatternDef = { width: number; height: number; path: string };
+
+/**
+ * Maps each non-solid fillStyle value to its SVG pattern definition.
+ *
+ * Straight patterns (horizontal, vertical, crosshatch) use 8×8 px tiles —
+ * perpendicular spacing 8 px.  Diagonal patterns use 12×12 px tiles so their
+ * perpendicular spacing (12/√2 ≈ 8.5 px) closely matches the straight
+ * patterns and the patterns appear visually similar in density.
+ *
+ * Keys must be all-lowercase (matching the `toLowerCase: true` normalization
+ * applied by the style system).
+ */
+const FILL_PATTERN_DEFS: Record<string, PatternDef> = {
+    horizontal: { width: 8, height: 8, path: "M0,4 L8,4" },
+    vertical: { width: 8, height: 8, path: "M4,0 L4,8" },
+    diagonal: { width: 12, height: 12, path: "M0,12 L12,0" },
+    backdiagonal: { width: 12, height: 12, path: "M0,0 L12,12" },
+    crosshatch: { width: 8, height: 8, path: "M0,4 L8,4 M4,0 L4,8" },
+    diagonalcrosshatch: {
+        width: 12,
+        height: 12,
+        path: "M0,12 L12,0 M0,0 L12,12",
+    },
+};
+
+/**
+ * Returns a stable pattern element ID for a given board + fill style + color.
+ * The color hex is included so different fill colors get different patterns.
+ */
+function buildPatternId(
+    boardId: string,
+    fillStyle: string,
+    colorHex: string,
+): string {
+    // Strip '#' and lowercase so IDs stay valid XML identifiers.
+    const safeColor = colorHex.replace(/^#/, "").toLowerCase();
+    return `doenet-hatch-${boardId}-${fillStyle}-${safeColor}`;
+}
+
+/**
+ * Ensures an SVG `<pattern>` element for the given style + color exists in
+ * `defsEl`, then returns the `url(#…)` CSS reference string.
+ *
+ * If `fillStyle` is `"solid"` or unrecognised, returns `fillColor` unchanged
+ * so callers can always use the return value as the JSXGraph `fillColor`.
+ */
+export function getOrInjectPattern(
+    defsEl: SVGDefsElement | null,
+    boardId: string,
+    fillStyle: string,
+    fillColor: string,
+): string {
+    const def = FILL_PATTERN_DEFS[fillStyle];
+    if (!def || !defsEl) {
+        // Solid fill or no defs available — return the plain color.
+        return fillColor;
+    }
+
+    const id = buildPatternId(boardId, fillStyle, fillColor);
+
+    // Avoid injecting the same pattern twice (e.g. after state updates).
+    if (defsEl.ownerDocument?.getElementById(id)) {
+        return `url(#${id})`;
+    }
+
+    const svgNS = "http://www.w3.org/2000/svg";
+    const pattern = document.createElementNS(svgNS, "pattern");
+    pattern.setAttribute("id", id);
+    pattern.setAttribute("width", String(def.width));
+    pattern.setAttribute("height", String(def.height));
+    pattern.setAttribute("patternUnits", "userSpaceOnUse");
+
+    const path = document.createElementNS(svgNS, "path");
+    path.setAttribute("d", def.path);
+    path.setAttribute("stroke", fillColor);
+    path.setAttribute("stroke-width", "1.5");
+    path.setAttribute("fill", "none");
+
+    pattern.appendChild(path);
+    defsEl.appendChild(pattern);
+
+    return `url(#${id})`;
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
@@ -90,3 +90,44 @@ export function getOrInjectPattern(
 
     return `url(#${id})`;
 }
+
+/**
+ * Resolves fill props for patterned SVG fills. When a non-solid pattern is
+ * successfully injected, the hatch strokes render at full opacity so the
+ * default graph fill opacity does not wash them out.
+ */
+export function getPatternFillAttributes({
+    defsEl,
+    boardId,
+    fillStyle,
+    fillColor,
+    fillOpacity,
+    highlightFillOpacity = fillOpacity * 0.5,
+}: {
+    defsEl: SVGDefsElement | null;
+    boardId: string;
+    fillStyle: string;
+    fillColor: string;
+    fillOpacity: number;
+    highlightFillOpacity?: number;
+}): {
+    fillColor: string;
+    fillOpacity: number;
+    highlightFillColor: string;
+    highlightFillOpacity: number;
+} {
+    const resolvedFillColor = getOrInjectPattern(
+        defsEl,
+        boardId,
+        fillStyle,
+        fillColor,
+    );
+    const usesPatternFill = resolvedFillColor !== fillColor;
+
+    return {
+        fillColor: resolvedFillColor,
+        fillOpacity: usesPatternFill ? 1 : fillOpacity,
+        highlightFillColor: resolvedFillColor,
+        highlightFillOpacity: usesPatternFill ? 1 : highlightFillOpacity,
+    };
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
@@ -1,3 +1,5 @@
+import { encodeFillPatternColorToken } from "@doenet/utils";
+
 /**
  * SVG fill-pattern support for JSXGraph renderers.
  *
@@ -34,16 +36,15 @@ const FILL_PATTERN_DEFS: Record<string, PatternDef> = {
 
 /**
  * Returns a stable pattern element ID for a given board + fill style + color.
- * The color hex is included so different fill colors get different patterns.
+ * The encoded color token is included so different fill colors get different
+ * patterns, even when the authored color is a CSS name or functional notation.
  */
 function buildPatternId(
     boardId: string,
     fillStyle: string,
-    colorHex: string,
+    fillColor: string,
 ): string {
-    // Strip '#' and lowercase so IDs stay valid XML identifiers.
-    const safeColor = colorHex.replace(/^#/, "").toLowerCase();
-    return `doenet-hatch-${boardId}-${fillStyle}-${safeColor}`;
+    return `doenet-hatch-${boardId}-${fillStyle}-${encodeFillPatternColorToken(fillColor)}`;
 }
 
 /**

--- a/packages/prefigure/package.json
+++ b/packages/prefigure/package.json
@@ -38,7 +38,8 @@
             "command": "vite build",
             "dependencies": [
                 "fetch-wheels",
-                "fetch-liblouis"
+                "fetch-liblouis",
+                "../utils:build"
             ],
             "files": [
                 "src/**/*.ts",

--- a/packages/prefigure/src/worker/compiler.ts
+++ b/packages/prefigure/src/worker/compiler.ts
@@ -9,11 +9,20 @@
  */
 
 import { PyodideInterface, loadPyodide } from "pyodide";
+import { decodeFillPatternColorToken } from "@doenet/utils";
 import { prefigBrowserApi } from "./compat-api";
 import { PREFIG_WHEEL_FILENAME } from "./compiler-metadata";
 
 type Options = Parameters<typeof loadPyodide>[0];
 export { PREFIG_WHEEL_FILENAME };
+
+function escapeSvgAttribute(value: string): string {
+    return value
+        .replaceAll("&", "&amp;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
+}
 
 /**
  * SVG path data for each supported hatch fill style. These must stay in sync
@@ -36,17 +45,17 @@ const HATCH_PATTERN_DEFS: Record<string, HatchPatternDef> = {
 };
 
 /**
- * Scans the SVG string for `fill="url(#doenet-hatch-STYLE-COLORHEX)"` references
+ * Scans the SVG string for `fill="url(#doenet-hatch-STYLE-COLORTOKEN)"` references
  * emitted by the PreFigure XML generator and injects the corresponding `<pattern>`
  * definitions into the SVG's `<defs>` section.
  *
  * Returns the SVG string unchanged when no hatch references are found.
  */
 function injectHatchPatterns(svg: string): string {
-    // Match fill="url(#doenet-hatch-STYLE-COLORHEX)" where COLORHEX is 3, 4,
-    // 6, or 8 hex digits.
+    // Match fill="url(#doenet-hatch-STYLE-COLORTOKEN)" where COLORTOKEN is the
+    // UTF-8 hex encoding of the original CSS color string.
     const patternRefRe = new RegExp(
-        'fill="url\\(#(doenet-hatch-([a-z]+)-((?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})))\\)"',
+        'fill="url\\(#(doenet-hatch-([a-z]+)-([0-9a-f]+))\\)"',
         "g",
     );
 
@@ -55,7 +64,7 @@ function injectHatchPatterns(svg: string): string {
 
     let match: RegExpExecArray | null;
     while ((match = patternRefRe.exec(svg)) !== null) {
-        const [, id, style, colorHex] = match;
+        const [, id, style, colorToken] = match;
         if (seen.has(id)) {
             continue;
         }
@@ -66,10 +75,14 @@ function injectHatchPatterns(svg: string): string {
             continue;
         }
 
-        const color = `#${colorHex}`;
+        const color = decodeFillPatternColorToken(colorToken);
+        if (!color) {
+            continue;
+        }
+
         patternDefs.push(
             `<pattern id="${id}" width="${def.width}" height="${def.height}" patternUnits="userSpaceOnUse">` +
-                `<path d="${def.path}" stroke="${color}" stroke-width="1.5" fill="none"/>` +
+                `<path d="${def.path}" stroke="${escapeSvgAttribute(color)}" stroke-width="1.5" fill="none"/>` +
                 `</pattern>`,
         );
     }

--- a/packages/prefigure/src/worker/compiler.ts
+++ b/packages/prefigure/src/worker/compiler.ts
@@ -16,6 +16,83 @@ type Options = Parameters<typeof loadPyodide>[0];
 export { PREFIG_WHEEL_FILENAME };
 
 /**
+ * SVG path data for each supported hatch fill style (8×8 px tile).
+ * These must stay in sync with the patterns defined in
+ * `packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts`.
+ */
+type HatchPatternDef = { width: number; height: number; path: string };
+
+const HATCH_PATTERN_DEFS: Record<string, HatchPatternDef> = {
+    horizontal: { width: 8, height: 8, path: "M0,4 L8,4" },
+    vertical: { width: 8, height: 8, path: "M4,0 L4,8" },
+    diagonal: { width: 12, height: 12, path: "M0,12 L12,0" },
+    backdiagonal: { width: 12, height: 12, path: "M0,0 L12,12" },
+    crosshatch: { width: 8, height: 8, path: "M0,4 L8,4 M4,0 L4,8" },
+    diagonalcrosshatch: {
+        width: 12,
+        height: 12,
+        path: "M0,12 L12,0 M0,0 L12,12",
+    },
+};
+
+/**
+ * Scans the SVG string for `fill="url(#doenet-hatch-STYLE-COLORHEX)"` references
+ * emitted by the PreFigure XML generator and injects the corresponding `<pattern>`
+ * definitions into the SVG's `<defs>` section.
+ *
+ * Returns the SVG string unchanged when no hatch references are found.
+ */
+function injectHatchPatterns(svg: string): string {
+    // Match fill="url(#doenet-hatch-STYLE-COLORHEX)"
+    const patternRefRe =
+        /fill="url\(#(doenet-hatch-([a-z]+)-([0-9a-f]{3,8}))\)"/g;
+
+    const seen = new Set<string>();
+    const patternDefs: string[] = [];
+
+    let match: RegExpExecArray | null;
+    while ((match = patternRefRe.exec(svg)) !== null) {
+        const [, id, style, colorHex] = match;
+        if (seen.has(id)) {
+            continue;
+        }
+        seen.add(id);
+
+        const def = HATCH_PATTERN_DEFS[style];
+        if (!def) {
+            continue;
+        }
+
+        const color = `#${colorHex}`;
+        patternDefs.push(
+            `<pattern id="${id}" width="${def.width}" height="${def.height}" patternUnits="userSpaceOnUse">` +
+                `<path d="${def.path}" stroke="${color}" stroke-width="1.5" fill="none"/>` +
+                `</pattern>`,
+        );
+    }
+
+    if (patternDefs.length === 0) {
+        return svg;
+    }
+
+    // Inject all patterns before the closing </defs> tag.
+    const defsClose = svg.indexOf("</defs>");
+    if (defsClose === -1) {
+        // No <defs> found — insert a fresh <defs> block after the opening <svg ...>.
+        const svgTagEnd = svg.indexOf(">") + 1;
+        return (
+            svg.slice(0, svgTagEnd) +
+            `<defs>${patternDefs.join("")}</defs>` +
+            svg.slice(svgTagEnd)
+        );
+    }
+
+    return (
+        svg.slice(0, defsClose) + patternDefs.join("") + svg.slice(defsClose)
+    );
+}
+
+/**
  * A class for compiling a PreFigure document file using a WASM implementation of python.
  */
 export class PreFigureCompiler {
@@ -149,7 +226,8 @@ for _handler in _prefigure_logger.handlers:
 import prefig
 prefig.engine.build_from_string("${mode}", ${JSON.stringify(source)})
         `);
-        const [svg, annotations] = result;
+        const [rawSvg, annotations] = result;
+        const svg = injectHatchPatterns(rawSvg);
         return { svg, annotations };
     }
 }

--- a/packages/prefigure/src/worker/compiler.ts
+++ b/packages/prefigure/src/worker/compiler.ts
@@ -16,8 +16,8 @@ type Options = Parameters<typeof loadPyodide>[0];
 export { PREFIG_WHEEL_FILENAME };
 
 /**
- * SVG path data for each supported hatch fill style (8×8 px tile).
- * These must stay in sync with the patterns defined in
+ * SVG path data for each supported hatch fill style. These must stay in sync
+ * with the patterns defined in
  * `packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts`.
  */
 type HatchPatternDef = { width: number; height: number; path: string };
@@ -43,9 +43,12 @@ const HATCH_PATTERN_DEFS: Record<string, HatchPatternDef> = {
  * Returns the SVG string unchanged when no hatch references are found.
  */
 function injectHatchPatterns(svg: string): string {
-    // Match fill="url(#doenet-hatch-STYLE-COLORHEX)"
-    const patternRefRe =
-        /fill="url\(#(doenet-hatch-([a-z]+)-([0-9a-f]{3,8}))\)"/g;
+    // Match fill="url(#doenet-hatch-STYLE-COLORHEX)" where COLORHEX is 3, 4,
+    // 6, or 8 hex digits.
+    const patternRefRe = new RegExp(
+        'fill="url\\(#(doenet-hatch-([a-z]+)-((?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})))\\)"',
+        "g",
+    );
 
     const seen = new Set<string>();
     const patternDefs: string[] = [];
@@ -109,7 +112,7 @@ export class PreFigureCompiler {
         }
     }
 
-    private normalizeIndexUrl(pyodide: PyodideInterface): string {
+    _normalizeIndexUrl(pyodide: PyodideInterface): string {
         // Accessing this internal field is currently required to align package
         // downloads with the runtime index URL.
         const rawIndexUrl = (pyodide as any)._api.config.indexURL as string;
@@ -119,7 +122,7 @@ export class PreFigureCompiler {
         return `${rawIndexUrl}/`;
     }
 
-    private async loadPrefigureDependencies(
+    async _loadPrefigureDependencies(
         pyodide: PyodideInterface,
         indexURL: string,
     ) {
@@ -166,7 +169,7 @@ for _handler in _prefigure_logger.handlers:
         }
     }
 
-    private async initialize(options: Options) {
+    async _initialize(options: Options) {
         // Prefer `._pyodide` over creating a new pyodide instance since
         // `._pyodide` was provided by the user.
         const pyodide = (await this._pyodide) || (await loadPyodide(options));
@@ -178,8 +181,8 @@ for _handler in _prefigure_logger.handlers:
         // Python with `import prefigBrowserApi`.
         pyodide.registerJsModule("prefigBrowserApi", prefigBrowserApi);
 
-        const indexURL = this.normalizeIndexUrl(pyodide);
-        await this.loadPrefigureDependencies(pyodide, indexURL);
+        const indexURL = this._normalizeIndexUrl(pyodide);
+        await this._loadPrefigureDependencies(pyodide, indexURL);
 
         this.pyodide = pyodide;
     }
@@ -198,7 +201,7 @@ for _handler in _prefigure_logger.handlers:
             return;
         }
 
-        this.pyodideInitPromise = this.initialize(options).catch((error) => {
+        this.pyodideInitPromise = this._initialize(options).catch((error) => {
             // Allow retries after transient init failures.
             this.pyodideInitPromise = null;
             throw error;

--- a/packages/prefigure/test/compiler.test.ts
+++ b/packages/prefigure/test/compiler.test.ts
@@ -124,7 +124,7 @@ describe("PreFigureCompiler", () => {
         mocks.loadPackageSpy.mockResolvedValue(undefined);
         mocks.runPythonAsyncSpy.mockResolvedValue(undefined);
         mocks.runPythonSpy.mockResolvedValue([
-            '<svg><defs><marker id="m"/></defs><path fill="url(#doenet-hatch-horizontal-1f5dff)"/><path fill="url(#doenet-hatch-horizontal-1f5dff)"/></svg>',
+            '<svg><defs><marker id="m"/></defs><path fill="url(#doenet-hatch-horizontal-23316635646666)"/><path fill="url(#doenet-hatch-horizontal-23316635646666)"/></svg>',
             "",
         ]);
 
@@ -135,12 +135,13 @@ describe("PreFigureCompiler", () => {
         const result = await compiler.compile("svg", "<diagram/>");
 
         expect(result.svg).toContain(
-            '<pattern id="doenet-hatch-horizontal-1f5dff"',
+            '<pattern id="doenet-hatch-horizontal-23316635646666"',
         );
         expect(
-            result.svg.match(/id="doenet-hatch-horizontal-1f5dff"/g),
+            result.svg.match(/id="doenet-hatch-horizontal-23316635646666"/g),
         ).toHaveLength(1);
         expect(result.svg).toContain('<marker id="m"/>');
+        expect(result.svg).toContain('stroke="#1f5dff"');
     });
 
     it("injects hatch patterns even when the svg has no defs block", async () => {
@@ -149,7 +150,7 @@ describe("PreFigureCompiler", () => {
         mocks.loadPackageSpy.mockResolvedValue(undefined);
         mocks.runPythonAsyncSpy.mockResolvedValue(undefined);
         mocks.runPythonSpy.mockResolvedValue([
-            '<svg><path fill="url(#doenet-hatch-diagonalcrosshatch-ff0000)"/></svg>',
+            '<svg><path fill="url(#doenet-hatch-diagonalcrosshatch-23666630303030)"/></svg>',
             "",
         ]);
 
@@ -160,7 +161,7 @@ describe("PreFigureCompiler", () => {
         const result = await compiler.compile("svg", "<diagram/>");
 
         expect(result.svg).toContain(
-            '<defs><pattern id="doenet-hatch-diagonalcrosshatch-ff0000"',
+            '<defs><pattern id="doenet-hatch-diagonalcrosshatch-23666630303030"',
         );
         expect(result.svg).toContain(
             'd="M0,12 L12,0 M0,0 L12,12" stroke="#ff0000"',
@@ -173,7 +174,7 @@ describe("PreFigureCompiler", () => {
         mocks.loadPackageSpy.mockResolvedValue(undefined);
         mocks.runPythonAsyncSpy.mockResolvedValue(undefined);
         mocks.runPythonSpy.mockResolvedValue([
-            '<svg><path fill="url(#doenet-hatch-horizontal-abcd)"/><path fill="url(#doenet-hatch-vertical-11223344)"/></svg>',
+            '<svg><path fill="url(#doenet-hatch-horizontal-2361626364)"/><path fill="url(#doenet-hatch-vertical-233131323233333434)"/></svg>',
             "",
         ]);
 
@@ -184,13 +185,35 @@ describe("PreFigureCompiler", () => {
         const result = await compiler.compile("svg", "<diagram/>");
 
         expect(result.svg).toContain(
-            '<pattern id="doenet-hatch-horizontal-abcd"',
+            '<pattern id="doenet-hatch-horizontal-2361626364"',
         );
         expect(result.svg).toContain('stroke="#abcd"');
         expect(result.svg).toContain(
-            '<pattern id="doenet-hatch-vertical-11223344"',
+            '<pattern id="doenet-hatch-vertical-233131323233333434"',
         );
         expect(result.svg).toContain('stroke="#11223344"');
+    });
+
+    it("injects hatch patterns for named fill colors", async () => {
+        const pyodide = createPyodideMock("https://cdn.example.com/assets/");
+        mocks.loadPyodideSpy.mockResolvedValue(pyodide);
+        mocks.loadPackageSpy.mockResolvedValue(undefined);
+        mocks.runPythonAsyncSpy.mockResolvedValue(undefined);
+        mocks.runPythonSpy.mockResolvedValue([
+            '<svg><path fill="url(#doenet-hatch-crosshatch-626c61636b)"/></svg>',
+            "",
+        ]);
+
+        const { PreFigureCompiler } = await import("../src/worker/compiler");
+        const compiler = new PreFigureCompiler();
+
+        await compiler.init();
+        const result = await compiler.compile("svg", "<diagram/>");
+
+        expect(result.svg).toContain(
+            '<pattern id="doenet-hatch-crosshatch-626c61636b"',
+        );
+        expect(result.svg).toContain('stroke="black"');
     });
 
     it("coalesces concurrent init calls into one initialization", async () => {

--- a/packages/prefigure/test/compiler.test.ts
+++ b/packages/prefigure/test/compiler.test.ts
@@ -167,6 +167,32 @@ describe("PreFigureCompiler", () => {
         );
     });
 
+    it("injects hatch patterns for 4- and 8-digit hex colors", async () => {
+        const pyodide = createPyodideMock("https://cdn.example.com/assets/");
+        mocks.loadPyodideSpy.mockResolvedValue(pyodide);
+        mocks.loadPackageSpy.mockResolvedValue(undefined);
+        mocks.runPythonAsyncSpy.mockResolvedValue(undefined);
+        mocks.runPythonSpy.mockResolvedValue([
+            '<svg><path fill="url(#doenet-hatch-horizontal-abcd)"/><path fill="url(#doenet-hatch-vertical-11223344)"/></svg>',
+            "",
+        ]);
+
+        const { PreFigureCompiler } = await import("../src/worker/compiler");
+        const compiler = new PreFigureCompiler();
+
+        await compiler.init();
+        const result = await compiler.compile("svg", "<diagram/>");
+
+        expect(result.svg).toContain(
+            '<pattern id="doenet-hatch-horizontal-abcd"',
+        );
+        expect(result.svg).toContain('stroke="#abcd"');
+        expect(result.svg).toContain(
+            '<pattern id="doenet-hatch-vertical-11223344"',
+        );
+        expect(result.svg).toContain('stroke="#11223344"');
+    });
+
     it("coalesces concurrent init calls into one initialization", async () => {
         const pyodide = createPyodideMock("https://cdn.example.com/assets/");
         mocks.loadPyodideSpy.mockResolvedValue(pyodide);

--- a/packages/prefigure/test/compiler.test.ts
+++ b/packages/prefigure/test/compiler.test.ts
@@ -118,6 +118,55 @@ describe("PreFigureCompiler", () => {
         });
     });
 
+    it("injects one shared hatch pattern into an existing defs block", async () => {
+        const pyodide = createPyodideMock("https://cdn.example.com/assets/");
+        mocks.loadPyodideSpy.mockResolvedValue(pyodide);
+        mocks.loadPackageSpy.mockResolvedValue(undefined);
+        mocks.runPythonAsyncSpy.mockResolvedValue(undefined);
+        mocks.runPythonSpy.mockResolvedValue([
+            '<svg><defs><marker id="m"/></defs><path fill="url(#doenet-hatch-horizontal-1f5dff)"/><path fill="url(#doenet-hatch-horizontal-1f5dff)"/></svg>',
+            "",
+        ]);
+
+        const { PreFigureCompiler } = await import("../src/worker/compiler");
+        const compiler = new PreFigureCompiler();
+
+        await compiler.init();
+        const result = await compiler.compile("svg", "<diagram/>");
+
+        expect(result.svg).toContain(
+            '<pattern id="doenet-hatch-horizontal-1f5dff"',
+        );
+        expect(
+            result.svg.match(/id="doenet-hatch-horizontal-1f5dff"/g),
+        ).toHaveLength(1);
+        expect(result.svg).toContain('<marker id="m"/>');
+    });
+
+    it("injects hatch patterns even when the svg has no defs block", async () => {
+        const pyodide = createPyodideMock("https://cdn.example.com/assets/");
+        mocks.loadPyodideSpy.mockResolvedValue(pyodide);
+        mocks.loadPackageSpy.mockResolvedValue(undefined);
+        mocks.runPythonAsyncSpy.mockResolvedValue(undefined);
+        mocks.runPythonSpy.mockResolvedValue([
+            '<svg><path fill="url(#doenet-hatch-diagonalcrosshatch-ff0000)"/></svg>',
+            "",
+        ]);
+
+        const { PreFigureCompiler } = await import("../src/worker/compiler");
+        const compiler = new PreFigureCompiler();
+
+        await compiler.init();
+        const result = await compiler.compile("svg", "<diagram/>");
+
+        expect(result.svg).toContain(
+            '<defs><pattern id="doenet-hatch-diagonalcrosshatch-ff0000"',
+        );
+        expect(result.svg).toContain(
+            'd="M0,12 L12,0 M0,0 L12,12" stroke="#ff0000"',
+        );
+    });
+
     it("coalesces concurrent init calls into one initialization", async () => {
         const pyodide = createPyodideMock("https://cdn.example.com/assets/");
         mocks.loadPyodideSpy.mockResolvedValue(pyodide);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -18,6 +18,7 @@ export * from "./math/mathexpressions";
 export * from "./math/rounding";
 export * from "./math/subset-of-reals-operations";
 export * from "./style/colorWords";
+export * from "./style/fillPattern";
 export * from "./style/style";
 export * from "./style/styleDefinitionHelpers";
 export * from "./theme/theme";

--- a/packages/utils/src/style/fillPattern.ts
+++ b/packages/utils/src/style/fillPattern.ts
@@ -1,0 +1,42 @@
+function bytesToHex(bytes: Uint8Array): string {
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+        "",
+    );
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+    if (!/^[0-9a-f]+$/i.test(hex) || hex.length % 2 !== 0) {
+        return null;
+    }
+
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < hex.length; i += 2) {
+        bytes[i / 2] = Number.parseInt(hex.slice(i, i + 2), 16);
+    }
+    return bytes;
+}
+
+/**
+ * Encode an arbitrary CSS color string into a lowercase hex token that is safe
+ * to embed in SVG pattern IDs.
+ */
+export function encodeFillPatternColorToken(color: string): string {
+    const normalizedColor = color.trim().toLowerCase();
+    return bytesToHex(new TextEncoder().encode(normalizedColor));
+}
+
+/**
+ * Decode a color token produced by `encodeFillPatternColorToken`.
+ */
+export function decodeFillPatternColorToken(token: string): string | null {
+    const bytes = hexToBytes(token);
+    if (!bytes) {
+        return null;
+    }
+
+    try {
+        return new TextDecoder().decode(bytes);
+    } catch {
+        return null;
+    }
+}

--- a/packages/utils/src/style/fillPattern.ts
+++ b/packages/utils/src/style/fillPattern.ts
@@ -17,16 +17,19 @@ function hexToBytes(hex: string): Uint8Array | null {
 }
 
 /**
- * Encode an arbitrary CSS color string into a lowercase hex token that is safe
- * to embed in SVG pattern IDs.
+ * Encode an arbitrary CSS color string into a hex token that is safe
+ * to embed in SVG pattern IDs (only `trim()` is applied — the original
+ * case is preserved so CSS custom properties like `var(--MyColor)` round-trip
+ * correctly when the token is decoded back to the stroke color).
  */
 export function encodeFillPatternColorToken(color: string): string {
-    const normalizedColor = color.trim().toLowerCase();
-    return bytesToHex(new TextEncoder().encode(normalizedColor));
+    return bytesToHex(new TextEncoder().encode(color.trim()));
 }
 
 /**
  * Decode a color token produced by `encodeFillPatternColorToken`.
+ * Returns `null` for tokens that are not valid hex or do not decode to
+ * valid UTF-8.
  */
 export function decodeFillPatternColorToken(token: string): string | null {
     const bytes = hexToBytes(token);
@@ -35,7 +38,7 @@ export function decodeFillPatternColorToken(token: string): string | null {
     }
 
     try {
-        return new TextDecoder().decode(bytes);
+        return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
     } catch {
         return null;
     }

--- a/packages/utils/src/style/index.ts
+++ b/packages/utils/src/style/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./colorWords";
 export * from "./colorAccessibility";
+export * from "./fillPattern";
 export * from "./styleContrastAccessibility";
 export * from "./style";
 export * from "./styleDefinitionHelpers";

--- a/packages/utils/src/style/style.ts
+++ b/packages/utils/src/style/style.ts
@@ -168,6 +168,42 @@ export let styleAttributes: StyleAttributes = {
         componentType: "number",
         description: "Opacity of fills, 0 to 1.",
     },
+    fillStyle: {
+        componentType: "text",
+        description: "Fill pattern used inside closed shapes.",
+        toLowerCase: true,
+        validValues: [
+            { value: "solid", description: "Solid fill." },
+            {
+                value: "horizontal",
+                description: "Horizontal line pattern.",
+            },
+            {
+                value: "vertical",
+                description: "Vertical line pattern.",
+            },
+            {
+                value: "diagonal",
+                description: "Diagonal line pattern (/).",
+            },
+            {
+                value: "backDiagonal",
+                description: "Back-diagonal line pattern (\\).",
+            },
+            {
+                value: "crosshatch",
+                description: "Horizontal and vertical crosshatch pattern.",
+            },
+            {
+                value: "diagonalCrosshatch",
+                description: "Diagonal crosshatch pattern (X).",
+            },
+        ],
+    },
+    fillStyleWord: {
+        componentType: "text",
+        description: "Human-readable name of the fill style.",
+    },
     textColor: {
         componentType: "text",
         description: "Text color (light mode).",
@@ -266,6 +302,7 @@ const LINE_OVERRIDE_KEYS = [
 
 const FILL_OVERRIDE_KEYS = [
     "fillOpacity",
+    "fillStyle",
 ] as const satisfies readonly StyleDefinitionKey[];
 
 /**
@@ -287,8 +324,8 @@ export const lineOverrideAttributes: StyleAttributes = Object.fromEntries(
 );
 
 /**
- * Fill toggles for closed-shape components. Only `fillOpacity` is included —
- * it's decorative and not part of the contrast check, unlike `lineOpacity` /
+ * Fill toggles for closed-shape components. `fillOpacity` and `fillStyle` are
+ * both decorative and not part of the contrast check, unlike `lineOpacity` /
  * `markerOpacity`.
  */
 export const fillOverrideAttributes: StyleAttributes = Object.fromEntries(
@@ -614,6 +651,9 @@ function deriveMissingDarkModeColor(
  * - `lineStyle` (text) → `lineStyleWord`: `"dashed"`, `"dotted"`, else `""`.
  * - `markerStyle` (text) → `markerStyleWord`: copies the value, then normalizes
  *   `"circle"` → `"point"` and any `"triangle*"` → `"triangle"`.
+ * - `fillStyle` (text) → `fillStyleWord`: human-readable description of the
+ *   fill pattern (e.g. `"horizontal lines"`, `"cross hatched"`), or `""` for
+ *   `"solid"`.
  *
  * Used both by the styleDefinitions-merge path and by the per-component
  * override path so the two share identical word-derivation rules.
@@ -684,6 +724,24 @@ export function deriveMissingStyleWords(styleDef: StyleDefinition): void {
                 "triangle",
                 markerStylePosition,
             );
+        }
+    }
+
+    if ("fillStyle" in styleDef && !("fillStyleWord" in styleDef)) {
+        const fillStyle = getStyleValueString(styleDef, "fillStyle");
+        if (fillStyle) {
+            const fillStylePosition = styleDef.fillStyle?.position;
+            const fillStyleWordMap: Record<string, string> = {
+                solid: "",
+                horizontal: "horizontal lines",
+                vertical: "vertical lines",
+                diagonal: "diagonal lines",
+                backdiagonal: "reverse diagonal lines",
+                crosshatch: "cross hatched",
+                diagonalcrosshatch: "diagonal cross hatched",
+            };
+            const word = fillStyleWordMap[fillStyle] ?? "";
+            setStyleValue(styleDef, "fillStyleWord", word, fillStylePosition);
         }
     }
 }

--- a/packages/utils/src/style/styleDefinitionHelpers.ts
+++ b/packages/utils/src/style/styleDefinitionHelpers.ts
@@ -49,6 +49,8 @@ export type StyleDefinitionKey =
     | "fillColorDarkMode"
     | "fillColorWordDarkMode"
     | "fillOpacity"
+    | "fillStyle"
+    | "fillStyleWord"
     | "textColor"
     | "textColorWord"
     | "textColorDarkMode"
@@ -110,6 +112,8 @@ export interface ResolvedStyleDefinition {
     fillColorDarkMode: string;
     fillColorWordDarkMode: string;
     fillOpacity: number;
+    fillStyle: string;
+    fillStyleWord: string;
     textColor: string;
     textColorWord: string;
     textColorDarkMode: string;
@@ -298,6 +302,8 @@ export const DEFAULT_STYLE_VALUES = {
     markerSize: 5,
     markerFilled: true,
     fillOpacity: 0.3,
+    fillStyle: "solid",
+    fillStyleWord: "",
     lineColor: "#1f5dff",
     lineColorDarkMode: "#648FFF",
     markerColor: "#1f5dff",

--- a/packages/utils/test/fillPattern.test.ts
+++ b/packages/utils/test/fillPattern.test.ts
@@ -9,8 +9,15 @@ describe("fill-pattern color tokens", () => {
         const color = "RGB(255, 0, 0)";
         const token = encodeFillPatternColorToken(color);
 
-        expect(token).toBe("726762283235352c20302c203029");
-        expect(decodeFillPatternColorToken(token)).toBe("rgb(255, 0, 0)");
+        // Original case is preserved — token decodes back to the trimmed input.
+        expect(token).toBe("524742283235352c20302c203029");
+        expect(decodeFillPatternColorToken(token)).toBe("RGB(255, 0, 0)");
+    });
+
+    it("preserves case for CSS custom properties", () => {
+        const color = "var(--MyBrandColor)";
+        const token = encodeFillPatternColorToken(color);
+        expect(decodeFillPatternColorToken(token)).toBe("var(--MyBrandColor)");
     });
 
     it("rejects malformed tokens", () => {

--- a/packages/utils/test/fillPattern.test.ts
+++ b/packages/utils/test/fillPattern.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+    decodeFillPatternColorToken,
+    encodeFillPatternColorToken,
+} from "../src/style/fillPattern";
+
+describe("fill-pattern color tokens", () => {
+    it("round trips CSS color strings through safe pattern tokens", () => {
+        const color = "RGB(255, 0, 0)";
+        const token = encodeFillPatternColorToken(color);
+
+        expect(token).toBe("726762283235352c20302c203029");
+        expect(decodeFillPatternColorToken(token)).toBe("rgb(255, 0, 0)");
+    });
+
+    it("rejects malformed tokens", () => {
+        expect(decodeFillPatternColorToken("xyz")).toBeNull();
+        expect(decodeFillPatternColorToken("abc")).toBeNull();
+    });
+});

--- a/packages/utils/test/styleDefinitionHelpers.test.ts
+++ b/packages/utils/test/styleDefinitionHelpers.test.ts
@@ -29,6 +29,8 @@ const expectedKeys: (keyof ResolvedStyleDefinition)[] = [
     "fillColorDarkMode",
     "fillColorWordDarkMode",
     "fillOpacity",
+    "fillStyle",
+    "fillStyleWord",
     "textColor",
     "textColorWord",
     "textColorDarkMode",


### PR DESCRIPTION
## Summary

Adds a new `fillStyle` style attribute (and per-component override) for closed graph fills. Supported values:

| Value | Description |
|-------|-------------|
| `solid` | Default solid fill (unchanged behavior) |
| `horizontal` | Horizontal line pattern |
| `vertical` | Vertical line pattern |
| `diagonal` | Diagonal lines (/) |
| `backDiagonal` | Back-diagonal lines (\\) |
| `crosshatch` | Horizontal + vertical grid |
| `diagonalCrosshatch` | Diagonal X-pattern |

## Usage

```xml
<styleDefinition fillStyle="diagonal" />
<polygon vertices="(0,0) (3,0) (1,2)" />

<polygon vertices="(1,0) (4,0) (2,2)" fillStyle="crosshatch" />
```

## Affected components

`polygon`, `circle`, `angle`, `regionBetweenCurves`, `regionBetweenCurveXAxis`

## Renderer support

- **JSXGraph** (interactive): SVG `<pattern>` elements are injected into `board.renderer.defs` at render time. The helper in `fillPatterns.ts` reuses existing patterns by ID to avoid duplicate defs on re-renders.
- **PreFigure** (static diagrams): the worker emits `fill="url(#doenet-hatch-STYLE-COLORTOKEN)"` for patterned fills, encoding the authored CSS fill color into a safe SVG-ID token. `compiler.ts` decodes those tokens and injects matching `<pattern>` definitions into `<defs>`.
- Patterned fills keep hatch lines fully opaque so the pattern stays visible instead of being washed out by the shape `fillOpacity`.

## Additional behavior

- Filled circles and polygons now include hatch wording in their text style descriptions (`styleDescription`, `styleDescriptionWithNoun`, and `fillStyleDescription`).
- Circle/polygon description assembly now uses shared helper logic so fill-style wording stays consistent across both components.
- Added regression coverage for `fillStyle` style-word derivation, circle/polygon style descriptions, per-component overrides on all affected closed shapes, and PreFigure hatch-pattern injection (including 4- and 8-digit hex colors plus named CSS colors).

## Design notes

- Straight patterns (horizontal, vertical, crosshatch) use 8×8 px tiles (~8 px perpendicular spacing). Diagonal patterns use 12×12 px tiles (12/√2 ≈ 8.5 px) so their visual density roughly matches straight ones.
- `fillStyle` follows the same camelCase / `toLowerCase` convention as `markerStyle` (e.g. author writes `backDiagonal`, internal runtime value is `"backdiagonal"`).
- `fillStyle` is added to `FILL_OVERRIDE_KEYS` so it can be set either via `<styleDefinition>` or as a direct per-component attribute.

Closes #1386.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)