### PR TITLE
fix: clear actionsBeforeCoreCreated queue after dispatch to prevent stale setTheme overriding dark mode

### DIFF
--- a/.changeset/prefigure-stale-theme-queue.md
+++ b/.changeset/prefigure-stale-theme-queue.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Viewer: prevent stale queued theme updates from overriding the current theme after reinitializing with Ctrl+S.
+
+This fixes prefigure graphs and other theme-sensitive rendering after switching between light and dark mode without a full page reload.

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -656,9 +656,19 @@ export function DocViewer({
             return;
         }
 
-        // Note: it is possible that core has been terminated, so we need the question mark
-        const actionResult =
-            await coreWorker.current?.dispatchActionJavascript(actionArgs);
+        // Note: it is possible that core has been terminated, so we need the question mark.
+        // If the dispatch rejects (e.g. worker terminated mid-call), resolve the pending
+        // callback as false so the callAction promise settles and lastSkippableAction can
+        // be released — without this, onActionCallbacks would retain the entry forever.
+        let actionResult;
+        try {
+            actionResult =
+                await coreWorker.current?.dispatchActionJavascript(actionArgs);
+        } catch (e) {
+            console.warn("DocViewer: dispatchActionJavascript failed", e);
+            resolveAction({ actionId: actionArgs.args?.actionId });
+            return;
+        }
 
         if (actionResult) {
             resolveAction(actionResult);

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -1305,7 +1305,14 @@ export function DocViewer({
         coreCreated.current = true;
         coreCreationInProgress.current = false;
         preventMoreAnimations.current = false;
-        for (let actionArgs of actionsBeforeCoreCreated.current) {
+        // Snapshot and clear the queue before dispatching so that stale
+        // actions from a previous core lifetime (e.g. an initial setTheme
+        // queued before the first core was created) cannot survive into a
+        // future core reinitialization and override the correctly-initialized
+        // theme or other state.
+        const pendingActions = actionsBeforeCoreCreated.current;
+        actionsBeforeCoreCreated.current = [];
+        for (let actionArgs of pendingActions) {
             executeAction(actionArgs);
         }
         setStage("coreCreated");

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -172,13 +172,16 @@ export function DocViewer({
     const diagnostics = useRef<DiagnosticRecord[]>([]);
     const [hasInitialError, setHasInitialError] = useState(false);
 
-    const actionsBeforeCoreCreated = useRef<
-        {
-            actionName: string;
-            componentIdx: number | undefined;
-            args: Record<string, any>;
-        }[]
-    >([]);
+    type DeferredCoreAction = {
+        actionName: string;
+        componentIdx: number | undefined;
+        args: Record<string, any>;
+    };
+
+    // Actions queued while a new core is still booting. Always clear this
+    // queue after handing its contents off so entries from an earlier core
+    // lifetime cannot leak into a later reinitialization.
+    const actionsBeforeCoreCreated = useRef<DeferredCoreAction[]>([]);
 
     const preventMoreAnimations = useRef(false);
     const animationInfo = useRef<
@@ -244,6 +247,16 @@ export function DocViewer({
         coreWorker.current = null;
         nativeCoreWorker.current = null;
         return disposeCoreWorker(remote, native, { graceful });
+    }
+
+    function clearDeferredCoreActions() {
+        actionsBeforeCoreCreated.current = [];
+    }
+
+    function takeDeferredCoreActions() {
+        const pendingActions = actionsBeforeCoreCreated.current;
+        clearDeferredCoreActions();
+        return pendingActions;
     }
 
     const contextForRenderers = {
@@ -473,7 +486,7 @@ export function DocViewer({
             // in a fresh worker can't hang on a wedged predecessor
             // (Doenet/DoenetApps#2957).
             await teardownCurrentCoreWorker({ graceful: true });
-            actionsBeforeCoreCreated.current = [];
+            clearDeferredCoreActions();
             for (let id in animationInfo.current) {
                 cancelAnimationFrame(id);
             }
@@ -633,11 +646,7 @@ export function DocViewer({
         }
     }
 
-    async function executeAction(actionArgs: {
-        actionName: string;
-        componentIdx: number | undefined;
-        args: Record<string, any>;
-    }) {
+    async function executeAction(actionArgs: DeferredCoreAction) {
         if (!coreCreated.current) {
             // If core has not yet been created,
             // queue the action to be sent once core is created
@@ -1310,8 +1319,7 @@ export function DocViewer({
         // queued before the first core was created) cannot survive into a
         // future core reinitialization and override the correctly-initialized
         // theme or other state.
-        const pendingActions = actionsBeforeCoreCreated.current;
-        actionsBeforeCoreCreated.current = [];
+        const pendingActions = takeDeferredCoreActions();
         for (let actionArgs of pendingActions) {
             executeAction(actionArgs);
         }

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -657,21 +657,32 @@ export function DocViewer({
         }
 
         // Note: it is possible that core has been terminated, so we need the question mark.
-        // If the dispatch rejects (e.g. worker terminated mid-call), resolve the pending
-        // callback as false so the callAction promise settles and lastSkippableAction can
-        // be released — without this, onActionCallbacks would retain the entry forever.
+        // If the dispatch rejects or the worker is absent (optional chaining returns
+        // undefined), settle the pending callAction promise as false so it does not hang
+        // and so lastSkippableAction can be released.
         let actionResult;
         try {
             actionResult =
                 await coreWorker.current?.dispatchActionJavascript(actionArgs);
         } catch (e) {
             console.warn("DocViewer: dispatchActionJavascript failed", e);
-            resolveAction({ actionId: actionArgs.args?.actionId });
+            resolveAction({
+                actionId: actionArgs.args?.actionId,
+                success: false,
+            });
             return;
         }
 
         if (actionResult) {
             resolveAction(actionResult);
+        } else {
+            // coreWorker.current was null/undefined — optional chaining returned
+            // undefined, which is not a throw. Settle the callback as false so the
+            // callAction promise does not hang.
+            resolveAction({
+                actionId: actionArgs.args?.actionId,
+                success: false,
+            });
         }
     }
 
@@ -906,13 +917,19 @@ export function DocViewer({
         resolveAction({ actionId });
     }
 
-    function resolveAction({ actionId }: { actionId?: string }) {
+    function resolveAction({
+        actionId,
+        success = true,
+    }: {
+        actionId?: string;
+        success?: boolean;
+    }) {
         if (!actionId) {
             return;
         }
         const callback = onActionCallbacks.current.get(actionId);
         if (callback) {
-            callback(true);
+            callback(success);
             onActionCallbacks.current.delete(actionId);
         }
 

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -629,7 +629,9 @@ export function DocViewer({
             args,
         };
 
-        executeAction(actionArgs);
+        executeAction(actionArgs).catch((e) => {
+            console.warn("DocViewer: executeAction failed", e);
+        });
 
         if (promiseResolve) {
             // If we were sent promiseResolve as an argument,
@@ -1321,7 +1323,9 @@ export function DocViewer({
         // theme or other state.
         const pendingActions = takeDeferredCoreActions();
         for (let actionArgs of pendingActions) {
-            executeAction(actionArgs);
+            executeAction(actionArgs).catch((e) => {
+                console.warn("DocViewer: deferred executeAction failed", e);
+            });
         }
         setStage("coreCreated");
         initializedCallback?.({ activityId, docId });

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureThemeQueue.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureThemeQueue.cy.js
@@ -1,0 +1,114 @@
+import {
+    installMockPrefigureModule,
+    PREFIGURE_BUILD_URL_PATTERN,
+    visitWithMockPrefigureModule,
+} from "../../support/prefigure";
+
+const PREFIGURE_EDITOR_DOENETML = `
+<text name="ready">ready</text>
+<graph name="g">
+  <line styleNumber="2" through="(1,2) (3,4)" />
+</graph>
+<graph name="prefig" renderer="prefigure" extend="$g" />
+`;
+
+function themeFromBuildRequestBody(body) {
+    const xml = typeof body === "string" ? body : String(body ?? "");
+
+    if (xml.includes('<axes axes="all" stroke="#ffffff" />')) {
+        return "dark";
+    }
+
+    if (xml.includes('<axes axes="all" />')) {
+        return "light";
+    }
+
+    return "unknown";
+}
+
+describe(
+    "PreFigure theme queue refresh regression @group4",
+    { tags: ["@group4"] },
+    () => {
+        beforeEach(() => {
+            cy.clearIndexedDB();
+
+            const modulePath = installMockPrefigureModule({
+                modulePath: "/mock-prefigure-never-ready-theme-queue.js",
+                initDelayMs: 60000,
+                renderLabel: "unused-local-render",
+            });
+
+            visitWithMockPrefigureModule(modulePath);
+
+            cy.get("#testRunner_toggleControls").click();
+            cy.get("#testRunner_showEditor").click();
+            cy.wait(100);
+            cy.get("#testRunner_toggleControls").click();
+        });
+
+        it("does not replay a stale light-theme action after Ctrl+S rebuilds a dark-mode viewer", () => {
+            const requestThemes = [];
+
+            cy.intercept("POST", PREFIGURE_BUILD_URL_PATTERN, (req) => {
+                const theme = themeFromBuildRequestBody(req.body);
+                requestThemes.push(theme);
+
+                req.reply({
+                    statusCode: 200,
+                    headers: { "content-type": "application/json" },
+                    body: {
+                        svg: `<svg xmlns="http://www.w3.org/2000/svg"><text>${theme}-${requestThemes.length}</text></svg>`,
+                        annotationsXml: "<annotations></annotations>",
+                    },
+                });
+            }).as("prefigureBuild");
+
+            cy.window().then((win) => {
+                win.postMessage({ doenetML: PREFIGURE_EDITOR_DOENETML }, "*");
+            });
+
+            cy.get("#ready").should("have.text", "ready");
+            cy.wait("@prefigureBuild");
+            cy.get("#prefig").should("contain.text", "light-1");
+
+            cy.get("#testRunner_toggleControls").click();
+            cy.get("#testRunner_darkMode").click();
+            cy.get("#testRunner_toggleControls").click();
+
+            cy.wrap(null).should(() => {
+                expect(requestThemes).to.include("dark");
+            });
+            cy.get("#prefig").should("contain.text", "dark");
+
+            cy.then(() => requestThemes.length).then((refreshStartIndex) => {
+                cy.get(".cm-content")
+                    .click()
+                    .type("{ctrl}{end}", { force: true })
+                    .type('\n<p name="after">after</p>', { force: true });
+
+                cy.get(".cm-activeLine").type("{ctrl+s}");
+
+                cy.wrap(null).should(() => {
+                    expect(requestThemes.length).to.be.greaterThan(
+                        refreshStartIndex,
+                    );
+                });
+
+                cy.wait(1300);
+
+                cy.then(() => {
+                    const themesAfterRefresh =
+                        requestThemes.slice(refreshStartIndex);
+                    expect(themesAfterRefresh.length).to.be.greaterThan(0);
+                    expect(themesAfterRefresh).to.not.include("light");
+                    expect(themesAfterRefresh.at(-1)).to.equal("dark");
+                });
+
+                cy.get("#prefig").should("contain.text", "dark");
+                cy.get("#prefig").should("not.contain.text", "light");
+                cy.get("#after").should("have.text", "after");
+            });
+        });
+    },
+);


### PR DESCRIPTION
## Problem

After switching between light and dark mode (without a page reload), pressing Ctrl+S to update the viewer caused the prefigure graph axes to render in the wrong mode's colors (e.g. black axes on a dark background, or white axes on a light background).

## Root Cause

`actionsBeforeCoreCreated` — the queue for actions that arrive before the core worker is ready — was **never cleared after being dispatched**.

**Bug sequence:**
1. Page loads in **light** mode. The `setTheme("light")` effect fires before the core is ready, so it gets queued: `actionsBeforeCoreCreated = [setTheme("light")]`.
2. Core created; queued actions dispatched — but the array is **never reset**, remaining `[setTheme("light")]`.
3. User switches to **dark** mode. `setTheme("dark")` dispatches directly to the running core (never touches the queue). Queue stays stale.
4. User presses **Ctrl+S**. `coreCreated` is set to `false`, but the existing worker is **reused** (not torn down), so `reinitializeCoreAndTerminateAnimations` — the only place that previously cleared the queue — is **never called**.
5. New core is initialized correctly with `theme: "dark"` via `generateJavascriptDast`.
6. Core creation completes; stale `setTheme("light")` is dispatched from the queue, **overriding the correct theme**. `prefigureXML` is recomputed with `darkMode: false`, producing black axes on the dark background.

The same bug manifests in the reverse direction: if the user reloads in dark mode, switches to light mode, then presses Ctrl+S, the axes render in white (invisible on a light background).

## Fix

Snapshot and clear `actionsBeforeCoreCreated` **before replaying deferred actions**, so stale entries from a previous core lifetime cannot leak into future reinitializations.

## Additional changes in this PR

- Centralized deferred-action queue handling with a `DeferredCoreAction` type plus `clearDeferredCoreActions` / `takeDeferredCoreActions` helpers.
- Added `.catch()` handlers to fire-and-forget `executeAction` call sites to satisfy AGENTS.md's no-unhandled-promise rule.
- Made `executeAction` resolve pending `callAction` callbacks as `false` when `dispatchActionJavascript` rejects or when `coreWorker.current` is absent and optional chaining returns `undefined`, preventing hung promises.
- Extended `resolveAction` with a `success` parameter (default `true`) so failure paths can resolve callbacks as `false`.
- Added a Cypress regression test covering the light → dark → Ctrl+S stale-queue path for prefigure graphs.

## Release notes

Adds a patch changeset for the viewer and embedded bundles that ship this theme-fix behavior.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
