### PR TITLE
fix: Ctrl/Cmd+S should not trigger Reset when no code changes are pending

### DIFF
--- a/.changeset/editor-viewer-ctrl-s-refresh.md
+++ b/.changeset/editor-viewer-ctrl-s-refresh.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-Editor: Ctrl/Cmd+S now refreshes pending source edits when focus is anywhere in the editor-viewer, including the rendered document, without triggering the viewer's Reset behavior when no code changes are pending.
+Editor: Ctrl/Cmd+S now refreshes pending source edits when focus is anywhere in the editor-viewer, including the rendered document, without triggering the viewer's Reset behavior when no code changes are pending. When the button is showing Reset, its tooltip now omits the Ctrl/Cmd+S hint.
 
 The shortcut follows the platform convention used by the code editor — Cmd+S on macOS, Ctrl+S elsewhere — and ignores AltGr/Alt combinations so AltGr+S still inserts a character.

--- a/.changeset/editor-viewer-ctrl-s-refresh.md
+++ b/.changeset/editor-viewer-ctrl-s-refresh.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-Editor: Ctrl/Cmd+S now refreshes the rendered viewer when focus is anywhere in the editor-viewer, including the rendered document (previously the shortcut only fired when focus was in the code editor panel).
+Editor: Ctrl/Cmd+S now refreshes pending source edits when focus is anywhere in the editor-viewer, including the rendered document, without triggering the viewer's Reset behavior when no code changes are pending.
 
 The shortcut follows the platform convention used by the code editor — Cmd+S on macOS, Ctrl+S elsewhere — and ignores AltGr/Alt combinations so AltGr+S still inserts a character.

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -374,12 +374,14 @@ export const EditorViewer = React.forwardRef<
         [activateTab],
     );
 
-    // Shared between the "Update" button click, the Ctrl/Cmd-S keyboard
-    // shortcut, and the imperative `updateRenderedView()` ref method. Reads
-    // via refs and early-returns when nothing has changed so the programmatic
-    // call is a true no-op (no spurious `setResponses([])` re-render). For
-    // the button this guard is invisible (the button is disabled when both
-    // `codeChanged` and `documentInteracted` are false).
+    // Shared between the viewer-controls button and the imperative
+    // `updateRenderedView()` ref method. Reads via refs and early-returns when
+    // nothing has changed so the programmatic call is a true no-op (no
+    // spurious `setResponses([])` re-render). When source is unchanged but the
+    // rendered document has been interacted with, this remounts the viewer to
+    // clear that interaction state. The Ctrl/Cmd-S shortcut reuses this helper
+    // only when `codeChangedRef.current` is true so the shortcut mirrors
+    // "Update", not "Reset".
     const updateViewer = useCallback(() => {
         if (!codeChangedRef.current && !documentInteractedRef.current) {
             return;
@@ -850,9 +852,8 @@ export const EditorViewer = React.forwardRef<
             if (isSaveShortcutKeydown(event)) {
                 event.preventDefault();
                 event.stopPropagation();
-                // Only trigger the update when code has actually changed.
-                // When the button shows "Reset" (documentInteracted only),
-                // Ctrl/Cmd-S should be a no-op rather than resetting the viewer.
+                // Ctrl/Cmd-S mirrors "Update", not "Reset": still suppress the
+                // browser save dialog, but only flush pending source edits.
                 if (codeChangedRef.current) {
                     updateViewer();
                 }

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -850,7 +850,12 @@ export const EditorViewer = React.forwardRef<
             if (isSaveShortcutKeydown(event)) {
                 event.preventDefault();
                 event.stopPropagation();
-                updateViewer();
+                // Only trigger the update when code has actually changed.
+                // When the button shows "Reset" (documentInteracted only),
+                // Ctrl/Cmd-S should be a no-op rather than resetting the viewer.
+                if (codeChangedRef.current) {
+                    updateViewer();
+                }
             }
         };
 

--- a/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
+++ b/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
@@ -50,9 +50,11 @@ export function ViewerControlsBar({
                     data-test="Viewer Update Button"
                     disabled={!codeChanged && !documentInteracted}
                     title={
-                        isMacPlatform()
-                            ? `${updateWord} Viewer cmd+s`
-                            : `${updateWord} Viewer ctrl+s`
+                        codeChanged
+                            ? isMacPlatform()
+                                ? `${updateWord} Viewer cmd+s`
+                                : `${updateWord} Viewer ctrl+s`
+                            : `${updateWord} Viewer`
                     }
                     onClick={onUpdateViewer}
                 >

--- a/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
@@ -116,6 +116,9 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
                 // Fire Ctrl/Cmd+S on the rendered viewer container (focus in
                 // the rendered document, not the code editor panel).
                 triggerSaveShortcutOnViewer({ withModifier: true });
+                cy.get('[data-test="Viewer Update Button"]')
+                    .invoke("attr", "title")
+                    .should("match", /^Update Viewer (cmd|ctrl)\+s$/);
 
                 // The shortcut should have flushed the edit and refreshed the
                 // viewer, exactly like clicking Update.
@@ -142,6 +145,11 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
             "Reset",
         );
         cy.get('[data-test="Viewer Update Button"]').should("not.be.disabled");
+        cy.get('[data-test="Viewer Update Button"]').should(
+            "have.attr",
+            "title",
+            "Reset Viewer",
+        );
 
         cy.get('[data-test="call-count"]')
             .invoke("text")

--- a/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
@@ -2,6 +2,10 @@ import React, { useState } from "react";
 import { DoenetEditor } from "../../../src/doenetml-inline-worker";
 
 const SAMPLE_DOENETML = "<p>hello</p>";
+const INTERACTIVE_DOENETML = `
+<p>What is 1+1? <answer name="ans">2</answer></p>
+<p>Submitted response: <math name="sr" extend="$ans.submittedResponse" /></p>
+`;
 
 type DiagnosticsCall = {
     summary: {
@@ -14,7 +18,7 @@ type DiagnosticsCall = {
     doenetML: string;
 };
 
-function Harness() {
+function Harness({ doenetML = SAMPLE_DOENETML }: { doenetML?: string }) {
     const [calls, setCalls] = useState<DiagnosticsCall[]>([]);
 
     return (
@@ -24,7 +28,7 @@ function Harness() {
                 {calls.length > 0 ? calls[calls.length - 1].doenetML : ""}
             </div>
             <DoenetEditor
-                doenetML={SAMPLE_DOENETML}
+                doenetML={doenetML}
                 addVirtualKeyboard={false}
                 showViewer={true}
                 diagnosticsSummaryCallback={(summary, doenetML) => {
@@ -63,6 +67,30 @@ function dispatchKeydown(
     return event.defaultPrevented;
 }
 
+function appendExtraTextToEditor() {
+    cy.get(".cm-content")
+        .click()
+        .type("{ctrl}{end}", { force: true })
+        .type(" EXTRA", { force: true });
+}
+
+function triggerSaveShortcutOnViewer({
+    withModifier,
+    withShift = false,
+}: {
+    withModifier: boolean;
+    withShift?: boolean;
+}) {
+    cy.get(".viewer").then(($viewer) => {
+        const prevented = dispatchKeydown($viewer[0], {
+            code: "KeyS",
+            withModifier,
+            withShift,
+        });
+        expect(prevented).to.equal(withModifier && !withShift);
+    });
+}
+
 describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
     it("refreshes the viewer (like Update) when fired from the rendered document and prevents the browser save dialog", () => {
         cy.mount(<Harness />);
@@ -83,21 +111,11 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
                 // refresh the viewer. Append plain text (no `<`/`=`) to avoid
                 // triggering autocomplete. Two `.type()` calls so the Ctrl
                 // modifier is released after jumping to the end.
-                cy.get(".cm-content")
-                    .click()
-                    .type("{ctrl}{end}", { force: true })
-                    .type(" EXTRA", { force: true });
+                appendExtraTextToEditor();
 
                 // Fire Ctrl/Cmd+S on the rendered viewer container (focus in
                 // the rendered document, not the code editor panel).
-                cy.get(".viewer").then(($viewer) => {
-                    const prevented = dispatchKeydown($viewer[0], {
-                        code: "KeyS",
-                        withModifier: true,
-                    });
-                    // Browser "save page" dialog must be suppressed.
-                    expect(prevented).to.equal(true);
-                });
+                triggerSaveShortcutOnViewer({ withModifier: true });
 
                 // The shortcut should have flushed the edit and refreshed the
                 // viewer, exactly like clicking Update.
@@ -112,36 +130,40 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
             });
     });
 
-    it("does not refresh the viewer when no code changes are pending", () => {
-        cy.mount(<Harness />);
+    it("does not reset the viewer when the rendered document has been interacted with but no code changes are pending", () => {
+        cy.mount(<Harness doenetML={INTERACTIVE_DOENETML} />);
 
         // Wait for the initial diagnostics callback (from the first render).
         cy.get('[data-test="call-count"]').should("not.have.text", "0");
+        cy.get("#ans textarea").type("2{enter}", { force: true });
+        cy.get("#sr").should("contain.text", "2");
+        cy.get('[data-test="Viewer Update Button"]').should(
+            "contain.text",
+            "Reset",
+        );
+        cy.get('[data-test="Viewer Update Button"]').should("not.be.disabled");
 
         cy.get('[data-test="call-count"]')
             .invoke("text")
-            .then((initialCountText) => {
-                const initialCount = Number(initialCountText);
+            .then((countAfterInteractionText) => {
+                const countAfterInteraction = Number(countAfterInteractionText);
 
-                // Press Ctrl/Cmd+S without making any code changes (Update/Reset
-                // button would show "Reset" if document has been interacted with,
-                // but the shortcut must not trigger a reset in any case when code
-                // hasn't changed).
-                cy.get(".viewer").then(($viewer) => {
-                    const prevented = dispatchKeydown($viewer[0], {
-                        code: "KeyS",
-                        withModifier: true,
-                    });
-                    // Browser "save page" dialog is still suppressed.
-                    expect(prevented).to.equal(true);
-                });
+                // Press Ctrl/Cmd+S in the "Reset" state. The browser save
+                // dialog must still be suppressed, but the viewer state must
+                // remain intact because no source edit is pending.
+                triggerSaveShortcutOnViewer({ withModifier: true });
 
-                // No refresh: the diagnostics callback count must not grow.
+                // No reset: the submitted response, Reset-enabled button state,
+                // and diagnostics callback count must all remain unchanged.
                 cy.wait(500);
+                cy.get("#sr").should("contain.text", "2");
+                cy.get('[data-test="Viewer Update Button"]').should(
+                    "not.be.disabled",
+                );
                 cy.get('[data-test="call-count"]')
                     .invoke("text")
                     .should((text) => {
-                        expect(Number(text)).to.equal(initialCount);
+                        expect(Number(text)).to.equal(countAfterInteraction);
                     });
             });
     });
@@ -160,18 +182,9 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
                 const countAfterInitial = Number(countAfterInitialText);
 
                 // Edit the buffer so a refresh would be observable if it fired.
-                cy.get(".cm-content")
-                    .click()
-                    .type("{ctrl}{end}", { force: true })
-                    .type(" EXTRA", { force: true });
+                appendExtraTextToEditor();
 
-                cy.get(".viewer").then(($viewer) => {
-                    const prevented = dispatchKeydown($viewer[0], {
-                        code: "KeyS",
-                        withModifier: false,
-                    });
-                    expect(prevented).to.equal(false);
-                });
+                triggerSaveShortcutOnViewer({ withModifier: false });
 
                 // No refresh: the diagnostics callback count must not grow.
                 cy.wait(500);
@@ -197,19 +210,11 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
                 const countAfterInitial = Number(countAfterInitialText);
 
                 // Edit the buffer so a refresh would be observable if it fired.
-                cy.get(".cm-content")
-                    .click()
-                    .type("{ctrl}{end}", { force: true })
-                    .type(" EXTRA", { force: true });
+                appendExtraTextToEditor();
 
-                cy.get(".viewer").then(($viewer) => {
-                    const prevented = dispatchKeydown($viewer[0], {
-                        code: "KeyS",
-                        withModifier: true,
-                        withShift: true,
-                    });
-                    // "Save As" must not be hijacked.
-                    expect(prevented).to.equal(false);
+                triggerSaveShortcutOnViewer({
+                    withModifier: true,
+                    withShift: true,
                 });
 
                 // No refresh: the diagnostics callback count must not grow.

--- a/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
@@ -113,16 +113,26 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
                 // modifier is released after jumping to the end.
                 appendExtraTextToEditor();
 
-                // Fire Ctrl/Cmd+S on the rendered viewer container (focus in
-                // the rendered document, not the code editor panel).
-                triggerSaveShortcutOnViewer({ withModifier: true });
                 cy.get('[data-test="Viewer Update Button"]')
                     .invoke("attr", "title")
                     .should("match", /^Update Viewer (cmd|ctrl)\+s$/);
+                // Fire Ctrl/Cmd+S on the rendered viewer container (focus in
+                // the rendered document, not the code editor panel).
+                triggerSaveShortcutOnViewer({ withModifier: true });
 
                 // The shortcut should have flushed the edit and refreshed the
-                // viewer, exactly like clicking Update.
+                // viewer, exactly like clicking Update. Once the refresh
+                // completes there are no pending edits, so the button returns
+                // to its disabled, no-shortcut state.
                 cy.get('[data-test="last-source"]').should("contain", "EXTRA");
+                cy.get('[data-test="Viewer Update Button"]').should(
+                    "be.disabled",
+                );
+                cy.get('[data-test="Viewer Update Button"]').should(
+                    "have.attr",
+                    "title",
+                    "Update Viewer",
+                );
                 cy.get('[data-test="call-count"]')
                     .invoke("text")
                     .then((finalCountText) => {

--- a/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
@@ -112,6 +112,40 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
             });
     });
 
+    it("does not refresh the viewer when no code changes are pending", () => {
+        cy.mount(<Harness />);
+
+        // Wait for the initial diagnostics callback (from the first render).
+        cy.get('[data-test="call-count"]').should("not.have.text", "0");
+
+        cy.get('[data-test="call-count"]')
+            .invoke("text")
+            .then((initialCountText) => {
+                const initialCount = Number(initialCountText);
+
+                // Press Ctrl/Cmd+S without making any code changes (Update/Reset
+                // button would show "Reset" if document has been interacted with,
+                // but the shortcut must not trigger a reset in any case when code
+                // hasn't changed).
+                cy.get(".viewer").then(($viewer) => {
+                    const prevented = dispatchKeydown($viewer[0], {
+                        code: "KeyS",
+                        withModifier: true,
+                    });
+                    // Browser "save page" dialog is still suppressed.
+                    expect(prevented).to.equal(true);
+                });
+
+                // No refresh: the diagnostics callback count must not grow.
+                cy.wait(500);
+                cy.get('[data-test="call-count"]')
+                    .invoke("text")
+                    .should((text) => {
+                        expect(Number(text)).to.equal(initialCount);
+                    });
+            });
+    });
+
     it("does not refresh or prevent default for a plain 'S' keydown without the modifier", () => {
         cy.mount(<Harness />);
 

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewer.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewer.cy.js
@@ -121,7 +121,16 @@ describe("EditorViewer Tests", { tags: ["@group5"] }, function () {
             .should("not.be.disabled")
             .should("contain.text", "Reset");
 
+        // Ctrl+S is a no-op when the button shows "Reset" (no code change
+        // pending) — the viewer should not reset and the input must be preserved.
         cy.get(".cm-activeLine").type("{ctrl+s}");
+        cy.get("#ti_input").should("have.value", "Scrappy");
+        cy.get("[data-test='Viewer Update Button']")
+            .should("not.be.disabled")
+            .should("contain.text", "Reset");
+
+        // Clicking the Reset button still works.
+        cy.get("[data-test='Viewer Update Button']").click();
         cy.get("#ti_input").should("have.value", "");
     });
 


### PR DESCRIPTION
## Summary

When the rendered document had been interacted with but the source was unchanged, the viewer controls switched to **Reset**. Pressing **Ctrl/Cmd+S** in that state incorrectly reused the Reset path inside `updateViewer()`, remounting the viewer and clearing interaction state.

## Changes

- **`packages/doenetml/src/EditorViewer/EditorViewer.tsx`** — Keep suppressing the browser save dialog for **Ctrl/Cmd+S**, but only call `updateViewer()` when source edits are actually pending. Clarified the surrounding comments so it is explicit that the shortcut mirrors **Update**, not **Reset**.
- **`packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx`** — Only show the **Ctrl/Cmd+S** tooltip hint while the button is acting as **Update**. When the button is showing **Reset**, the tooltip now simply reads **Reset Viewer**.
- **`packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx`** — Refactor the shortcut helpers slightly and strengthen the regression coverage. The new test now enters the real **Reset** state by interacting with an answer, verifies **Ctrl/Cmd+S** preserves the submitted response, keeps the Reset button enabled, does not trigger another diagnostics callback, and checks the Reset tooltip text.
- **`.changeset/editor-viewer-ctrl-s-refresh.md`** — Update the unreleased changelog entry so it describes the final shortcut and tooltip behavior.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)