### PR TITLE
fix: color fractionInput boxes by correctness

### DIFF
--- a/.changeset/fraction-input-color-correctness.md
+++ b/.changeset/fraction-input-color-correctness.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+`<fractionInput>` now colors its numerator and denominator input box borders by submitted correctness inside an `<answer>`, matching the correctness feedback already shown by `<mathInput>` and `<textInput>`.
+
+When correctness coloring is enabled, the fraction as a whole also exposes its validation state in accessible text without implying that the numerator and denominator are graded separately.
+
+Closes #1388.

--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -6,12 +6,8 @@
 "doenet-vscode-extension": patch
 ---
 
-Add a `<fractionInput>` component.
+`<fractionInput>` now colors its outline by submitted correctness inside an `<answer>`, matching the correctness feedback already shown by `<mathInput>` and `<textInput>`.
 
-`<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, links two-way to a math child or `bindValueTo` target, and works as the input inside an `<answer>` (with check-work integration).
+When correctness coloring is enabled, the fraction as a whole also exposes its validation state in accessible text without implying that the numerator and denominator are graded separately.
 
-When a `<fractionInput>` is used inside an `<answer>` with correctness coloring enabled, its outline now indicates submitted correctness (correct/incorrect/partial credit), and its numerator and denominator fields expose that validation state in their accessible descriptions.
-
-This also clarifies the `value`/`immediateValue` help-text descriptions for the math inputs (`mathInput`, `matrixInput`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits.
-
-Closes #1342.
+Closes #1388.

--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -10,7 +10,7 @@ Add a `<fractionInput>` component.
 
 `<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, links two-way to a math child or `bindValueTo` target, and works as the input inside an `<answer>` (with check-work integration).
 
-When a `<fractionInput>` is used inside an `<answer>` with correctness coloring enabled, its border now indicates submitted correctness (correct/incorrect/partial credit), and its numerator and denominator fields expose that validation state in their accessible descriptions.
+When a `<fractionInput>` is used inside an `<answer>` with correctness coloring enabled, its outline now indicates submitted correctness (correct/incorrect/partial credit), and its numerator and denominator fields expose that validation state in their accessible descriptions.
 
 This also clarifies the `value`/`immediateValue` help-text descriptions for the math inputs (`mathInput`, `matrixInput`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits.
 

--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -6,8 +6,10 @@
 "doenet-vscode-extension": patch
 ---
 
-`<fractionInput>` now colors its outline by submitted correctness inside an `<answer>`, matching the correctness feedback already shown by `<mathInput>` and `<textInput>`.
+Add a `<fractionInput>` component.
 
-When correctness coloring is enabled, the fraction as a whole also exposes its validation state in accessible text without implying that the numerator and denominator are graded separately.
+`<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, links two-way to a math child or `bindValueTo` target, and works as the input inside an `<answer>` (with check-work integration).
 
-Closes #1388.
+This also clarifies the `value`/`immediateValue` help-text descriptions for the math inputs (`mathInput`, `matrixInput`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits.
+
+Closes #1342.

--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -10,6 +10,8 @@ Add a `<fractionInput>` component.
 
 `<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, links two-way to a math child or `bindValueTo` target, and works as the input inside an `<answer>` (with check-work integration).
 
+When a `<fractionInput>` is used inside an `<answer>` with correctness coloring enabled, its border now indicates submitted correctness (correct/incorrect/partial credit), and its numerator and denominator fields expose that validation state in their accessible descriptions.
+
 This also clarifies the `value`/`immediateValue` help-text descriptions for the math inputs (`mathInput`, `matrixInput`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits.
 
 Closes #1342.

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -951,66 +951,6 @@ export default class FractionComponentInput extends BaseComponent {
             },
         };
 
-        stateVariableDefinitions.additionalAriaDescription = {
-            forRenderer: true,
-            returnDependencies: () => ({
-                parentColorCorrectness: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "colorCorrectness",
-                },
-                parentCreditAchieved: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "creditAchieved",
-                },
-                parentJustSubmitted: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "justSubmitted",
-                },
-                parentNumAttemptsLeft: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "numAttemptsLeft",
-                },
-            }),
-            definition({ dependencyValues }) {
-                let additionalAriaDescription = "";
-
-                if (dependencyValues.parentColorCorrectness) {
-                    let validationState = "unvalidated";
-                    if (
-                        dependencyValues.parentJustSubmitted ||
-                        dependencyValues.parentNumAttemptsLeft < 1
-                    ) {
-                        if (dependencyValues.parentCreditAchieved === 1) {
-                            validationState = "correct";
-                        } else if (
-                            dependencyValues.parentCreditAchieved === 0
-                        ) {
-                            validationState = "incorrect";
-                        } else {
-                            validationState = "partialcorrect";
-                        }
-                    }
-
-                    if (validationState === "correct") {
-                        additionalAriaDescription = "Fraction is correct";
-                    } else if (validationState === "incorrect") {
-                        additionalAriaDescription = "Fraction is incorrect";
-                    } else if (validationState === "partialcorrect") {
-                        additionalAriaDescription =
-                            "Fraction is partially correct";
-                    }
-                }
-
-                return {
-                    setValue: { additionalAriaDescription },
-                };
-            },
-        };
-
         stateVariableDefinitions.includeValidationStateInShortDescription = {
             forRenderer: true,
             returnDependencies: () => ({}),

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -84,27 +84,6 @@ function ensureFraction(mathValue) {
     return me.fromAst(["/", tree, 1]);
 }
 
-function addValidationStateToPartDescription(
-    part,
-    { colorCorrectness, justSubmitted, numAttemptsLeft, creditAchieved },
-) {
-    let shortDescription = part ?? "";
-
-    if (!colorCorrectness || (!justSubmitted && numAttemptsLeft >= 1)) {
-        return shortDescription;
-    }
-
-    if (creditAchieved === 1) {
-        return (shortDescription ? `${shortDescription} ` : "") + "(Correct)";
-    } else if (creditAchieved === 0) {
-        return (shortDescription ? `${shortDescription} ` : "") + "(Incorrect)";
-    }
-
-    return (
-        (shortDescription ? `${shortDescription} ` : "") + "(Partially correct)"
-    );
-}
-
 export class FractionInput extends Input {
     constructor(args) {
         super(args);
@@ -884,34 +863,11 @@ export default class FractionComponentInput extends BaseComponent {
                     dependencyType: "stateVariable",
                     variableName: "part",
                 },
-                colorCorrectness: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "colorCorrectness",
-                },
-                justSubmitted: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "justSubmitted",
-                },
-                numAttemptsLeft: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "numAttemptsLeft",
-                },
-                creditAchieved: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "creditAchieved",
-                },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        shortDescription: addValidationStateToPartDescription(
-                            dependencyValues.part,
-                            dependencyValues,
-                        ),
+                        shortDescription: dependencyValues.part ?? "",
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -951,6 +951,78 @@ export default class FractionComponentInput extends BaseComponent {
             },
         };
 
+        stateVariableDefinitions.additionalAriaDescription = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                parentColorCorrectness: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "colorCorrectness",
+                },
+                parentCreditAchieved: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "creditAchieved",
+                },
+                parentJustSubmitted: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "justSubmitted",
+                },
+                parentNumAttemptsLeft: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "numAttemptsLeft",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let additionalAriaDescription = "";
+
+                if (dependencyValues.parentColorCorrectness) {
+                    let validationState = "unvalidated";
+                    if (
+                        dependencyValues.parentJustSubmitted ||
+                        dependencyValues.parentNumAttemptsLeft < 1
+                    ) {
+                        if (dependencyValues.parentCreditAchieved === 1) {
+                            validationState = "correct";
+                        } else if (
+                            dependencyValues.parentCreditAchieved === 0
+                        ) {
+                            validationState = "incorrect";
+                        } else {
+                            validationState = "partialcorrect";
+                        }
+                    }
+
+                    if (validationState === "correct") {
+                        additionalAriaDescription = "Fraction is correct";
+                    } else if (validationState === "incorrect") {
+                        additionalAriaDescription = "Fraction is incorrect";
+                    } else if (validationState === "partialcorrect") {
+                        additionalAriaDescription =
+                            "Fraction is partially correct";
+                    }
+                }
+
+                return {
+                    setValue: { additionalAriaDescription },
+                };
+            },
+        };
+
+        stateVariableDefinitions.includeValidationStateInShortDescription = {
+            forRenderer: true,
+            returnDependencies: () => ({}),
+            definition() {
+                return {
+                    setValue: {
+                        includeValidationStateInShortDescription: false,
+                    },
+                };
+            },
+        };
+
         return stateVariableDefinitions;
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -84,6 +84,27 @@ function ensureFraction(mathValue) {
     return me.fromAst(["/", tree, 1]);
 }
 
+function addValidationStateToPartDescription(
+    part,
+    { colorCorrectness, justSubmitted, numAttemptsLeft, creditAchieved },
+) {
+    let shortDescription = part ?? "";
+
+    if (!colorCorrectness || (!justSubmitted && numAttemptsLeft >= 1)) {
+        return shortDescription;
+    }
+
+    if (creditAchieved === 1) {
+        return (shortDescription ? `${shortDescription} ` : "") + "(Correct)";
+    } else if (creditAchieved === 0) {
+        return (shortDescription ? `${shortDescription} ` : "") + "(Incorrect)";
+    }
+
+    return (
+        (shortDescription ? `${shortDescription} ` : "") + "(Partially correct)"
+    );
+}
+
 export class FractionInput extends Input {
     constructor(args) {
         super(args);
@@ -863,11 +884,34 @@ export default class FractionComponentInput extends BaseComponent {
                     dependencyType: "stateVariable",
                     variableName: "part",
                 },
+                colorCorrectness: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "colorCorrectness",
+                },
+                justSubmitted: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "justSubmitted",
+                },
+                numAttemptsLeft: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "numAttemptsLeft",
+                },
+                creditAchieved: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "creditAchieved",
+                },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        shortDescription: dependencyValues.part ?? "",
+                        shortDescription: addValidationStateToPartDescription(
+                            dependencyValues.part,
+                            dependencyValues,
+                        ),
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -873,6 +873,84 @@ export default class FractionComponentInput extends BaseComponent {
             },
         };
 
+        // Mirror the parent fractionInput's correctness state variables so the
+        // mathInput renderer can color each input box's border.
+        stateVariableDefinitions.colorCorrectness = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                parentColorCorrectness: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "colorCorrectness",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        colorCorrectness:
+                            dependencyValues.parentColorCorrectness ?? false,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.creditAchieved = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                parentCreditAchieved: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "creditAchieved",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        creditAchieved:
+                            dependencyValues.parentCreditAchieved ?? 0,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.justSubmitted = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                parentJustSubmitted: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "justSubmitted",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        justSubmitted:
+                            dependencyValues.parentJustSubmitted ?? false,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.numAttemptsLeft = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                parentNumAttemptsLeft: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "numAttemptsLeft",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        numAttemptsLeft:
+                            dependencyValues.parentNumAttemptsLeft ?? Infinity,
+                    },
+                };
+            },
+        };
+
         return stateVariableDefinitions;
     }
 }

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -12,7 +12,6 @@ import {
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { addValidationStateToShortDescription } from "./utils/validationState";
 
 interface FractionInputSVs {
     [key: string]: any;
@@ -23,7 +22,6 @@ interface FractionInputSVs {
     labelPosition?: string;
     forceFullCheckWorkButton: boolean;
     justSubmitted: boolean;
-    colorCorrectness?: boolean;
     shortDescription?: string;
     descriptionChildInd?: number;
     externalLabelRendererIds?: string[];
@@ -76,7 +74,7 @@ export default React.memo(function FractionInput(
         );
     }
 
-    let shortDescription = SVs.shortDescription || undefined;
+    const shortDescription = SVs.shortDescription || undefined;
     const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
     const groupLabelledByIds = [
         hasLabel ? labelId : null,
@@ -84,24 +82,6 @@ export default React.memo(function FractionInput(
     ]
         .filter(Boolean)
         .join(" ");
-
-    const fractionInputStyle: React.CSSProperties = {};
-    if (SVs.colorCorrectness) {
-        if (validationState.current === "correct") {
-            fractionInputStyle.outline = "2px solid var(--mainGreen)";
-            fractionInputStyle.outlineOffset = "2px";
-        } else if (validationState.current === "incorrect") {
-            fractionInputStyle.outline = "2px solid var(--mainRed)";
-            fractionInputStyle.outlineOffset = "2px";
-        } else if (validationState.current === "partialcorrect") {
-            fractionInputStyle.outline = "2px solid var(--mainOrange)";
-            fractionInputStyle.outlineOffset = "2px";
-        }
-        shortDescription = addValidationStateToShortDescription(
-            validationState.current,
-            shortDescription,
-        );
-    }
 
     const descriptionChild =
         SVs.descriptionChildInd !== undefined &&
@@ -142,7 +122,7 @@ export default React.memo(function FractionInput(
                 verticalAlign: "middle",
             }}
         >
-            <div className="fraction-input" id={id} style={fractionInputStyle}>
+            <div className="fraction-input" id={id}>
                 <table
                     aria-labelledby={groupLabelledByIds || undefined}
                     aria-label={

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -23,6 +23,7 @@ interface FractionInputSVs {
     labelPosition?: string;
     forceFullCheckWorkButton: boolean;
     justSubmitted: boolean;
+    colorCorrectness: boolean;
     shortDescription?: string;
     descriptionChildInd?: number;
     externalLabelRendererIds?: string[];

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -12,6 +12,7 @@ import {
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
+import { addValidationStateToShortDescription } from "./utils/validationState";
 
 interface FractionInputSVs {
     [key: string]: any;
@@ -22,6 +23,7 @@ interface FractionInputSVs {
     labelPosition?: string;
     forceFullCheckWorkButton: boolean;
     justSubmitted: boolean;
+    colorCorrectness: boolean;
     shortDescription?: string;
     descriptionChildInd?: number;
     externalLabelRendererIds?: string[];
@@ -74,7 +76,7 @@ export default React.memo(function FractionInput(
         );
     }
 
-    const shortDescription = SVs.shortDescription || undefined;
+    let shortDescription = SVs.shortDescription || undefined;
     const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
     const groupLabelledByIds = [
         hasLabel ? labelId : null,
@@ -100,6 +102,22 @@ export default React.memo(function FractionInput(
         );
     }
 
+    const fractionInputStyle: React.CSSProperties = {};
+
+    if (SVs.colorCorrectness) {
+        if (validationState.current === "correct") {
+            fractionInputStyle.outline = "2px solid var(--mainGreen)";
+        } else if (validationState.current === "incorrect") {
+            fractionInputStyle.outline = "2px solid var(--mainRed)";
+        } else if (validationState.current === "partialcorrect") {
+            fractionInputStyle.outline = "2px solid var(--mainOrange)";
+        }
+        shortDescription = addValidationStateToShortDescription(
+            validationState.current,
+            shortDescription,
+        );
+    }
+
     const labelComponent = hasLabel ? (
         <span
             id={labelId}
@@ -122,7 +140,7 @@ export default React.memo(function FractionInput(
                 verticalAlign: "middle",
             }}
         >
-            <div className="fraction-input" id={id}>
+            <div className="fraction-input" id={id} style={fractionInputStyle}>
                 <table
                     aria-labelledby={groupLabelledByIds || undefined}
                     aria-label={

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -12,6 +12,7 @@ import {
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
+import { addValidationStateToShortDescription } from "./utils/validationState";
 
 interface FractionInputSVs {
     [key: string]: any;
@@ -22,6 +23,7 @@ interface FractionInputSVs {
     labelPosition?: string;
     forceFullCheckWorkButton: boolean;
     justSubmitted: boolean;
+    colorCorrectness?: boolean;
     shortDescription?: string;
     descriptionChildInd?: number;
     externalLabelRendererIds?: string[];
@@ -74,7 +76,7 @@ export default React.memo(function FractionInput(
         );
     }
 
-    const shortDescription = SVs.shortDescription || undefined;
+    let shortDescription = SVs.shortDescription || undefined;
     const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
     const groupLabelledByIds = [
         hasLabel ? labelId : null,
@@ -82,6 +84,24 @@ export default React.memo(function FractionInput(
     ]
         .filter(Boolean)
         .join(" ");
+
+    const fractionInputStyle: React.CSSProperties = {};
+    if (SVs.colorCorrectness) {
+        if (validationState.current === "correct") {
+            fractionInputStyle.outline = "2px solid var(--mainGreen)";
+            fractionInputStyle.outlineOffset = "2px";
+        } else if (validationState.current === "incorrect") {
+            fractionInputStyle.outline = "2px solid var(--mainRed)";
+            fractionInputStyle.outlineOffset = "2px";
+        } else if (validationState.current === "partialcorrect") {
+            fractionInputStyle.outline = "2px solid var(--mainOrange)";
+            fractionInputStyle.outlineOffset = "2px";
+        }
+        shortDescription = addValidationStateToShortDescription(
+            validationState.current,
+            shortDescription,
+        );
+    }
 
     const descriptionChild =
         SVs.descriptionChildInd !== undefined &&
@@ -122,7 +142,7 @@ export default React.memo(function FractionInput(
                 verticalAlign: "middle",
             }}
         >
-            <div className="fraction-input" id={id}>
+            <div className="fraction-input" id={id} style={fractionInputStyle}>
                 <table
                     aria-labelledby={groupLabelledByIds || undefined}
                     aria-label={

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -10,6 +10,7 @@ import {
     calculateValidationState,
     createCheckWorkComponent,
 } from "./utils/checkWork";
+import { addValidationStateToShortDescription } from "./utils/validationState";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
@@ -74,7 +75,7 @@ export default React.memo(function FractionInput(
         );
     }
 
-    const shortDescription = SVs.shortDescription || undefined;
+    let shortDescription = SVs.shortDescription || undefined;
     const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
     const groupLabelledByIds = [
         hasLabel ? labelId : null,
@@ -82,6 +83,13 @@ export default React.memo(function FractionInput(
     ]
         .filter(Boolean)
         .join(" ");
+
+    if (SVs.colorCorrectness) {
+        shortDescription = addValidationStateToShortDescription(
+            validationState.current,
+            shortDescription,
+        );
+    }
 
     const descriptionChild =
         SVs.descriptionChildInd !== undefined &&

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -12,7 +12,6 @@ import {
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { addValidationStateToShortDescription } from "./utils/validationState";
 
 interface FractionInputSVs {
     [key: string]: any;
@@ -23,7 +22,6 @@ interface FractionInputSVs {
     labelPosition?: string;
     forceFullCheckWorkButton: boolean;
     justSubmitted: boolean;
-    colorCorrectness: boolean;
     shortDescription?: string;
     descriptionChildInd?: number;
     externalLabelRendererIds?: string[];
@@ -76,7 +74,7 @@ export default React.memo(function FractionInput(
         );
     }
 
-    let shortDescription = SVs.shortDescription || undefined;
+    const shortDescription = SVs.shortDescription || undefined;
     const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
     const groupLabelledByIds = [
         hasLabel ? labelId : null,
@@ -102,22 +100,6 @@ export default React.memo(function FractionInput(
         );
     }
 
-    const fractionInputStyle: React.CSSProperties = {};
-
-    if (SVs.colorCorrectness) {
-        if (validationState.current === "correct") {
-            fractionInputStyle.outline = "2px solid var(--mainGreen)";
-        } else if (validationState.current === "incorrect") {
-            fractionInputStyle.outline = "2px solid var(--mainRed)";
-        } else if (validationState.current === "partialcorrect") {
-            fractionInputStyle.outline = "2px solid var(--mainOrange)";
-        }
-        shortDescription = addValidationStateToShortDescription(
-            validationState.current,
-            shortDescription,
-        );
-    }
-
     const labelComponent = hasLabel ? (
         <span
             id={labelId}
@@ -140,7 +122,7 @@ export default React.memo(function FractionInput(
                 verticalAlign: "middle",
             }}
         >
-            <div className="fraction-input" id={id} style={fractionInputStyle}>
+            <div className="fraction-input" id={id}>
                 <table
                     aria-labelledby={groupLabelledByIds || undefined}
                     aria-label={

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -380,7 +380,6 @@ interface MathInputSVs {
     shortDescription: string;
     showCheckWork: boolean;
     showPreview: boolean;
-    additionalAriaDescription?: string;
     includeValidationStateInShortDescription?: boolean;
     // Optional because `_matrixComponentInput` reuses this renderer
     // (`rendererType = "mathInput"`) without defining the SV; the
@@ -746,10 +745,8 @@ export default function MathInput(props: UseDoenetRendererProps) {
         }
     }
 
-    const ariaDescription = [hasExplicitLabel ? shortDescription : undefined]
-        .concat(SVs.additionalAriaDescription ?? [])
-        .filter(Boolean)
-        .join(" ");
+    const ariaDescription =
+        hasExplicitLabel && shortDescription ? shortDescription : undefined;
 
     const labelComponent = hasLabel ? (
         <label
@@ -803,7 +800,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
                     }
                     shortDescriptionId={shortDescriptionId}
                     // Supplementary annotations (not primary labels)
-                    aria-description={ariaDescription || undefined}
+                    aria-description={ariaDescription}
                     aria-details={ariaDetailsIds || undefined}
                     config={{
                         autoCommands:

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -380,6 +380,8 @@ interface MathInputSVs {
     shortDescription: string;
     showCheckWork: boolean;
     showPreview: boolean;
+    additionalAriaDescription?: string;
+    includeValidationStateInShortDescription?: boolean;
     // Optional because `_matrixComponentInput` reuses this renderer
     // (`rendererType = "mathInput"`) without defining the SV; the
     // `??` fallback below handles the absent case.
@@ -736,11 +738,18 @@ export default function MathInput(props: UseDoenetRendererProps) {
             mathInputStyle.borderColor = "var(--mainOrange)";
             mathInputStyle.outlineColor = "var(--mainOrange)";
         }
-        shortDescription = addValidationStateToShortDescription(
-            validationState.current,
-            shortDescription,
-        );
+        if (SVs.includeValidationStateInShortDescription !== false) {
+            shortDescription = addValidationStateToShortDescription(
+                validationState.current,
+                shortDescription,
+            );
+        }
     }
+
+    const ariaDescription = [hasExplicitLabel ? shortDescription : undefined]
+        .concat(SVs.additionalAriaDescription ?? [])
+        .filter(Boolean)
+        .join(" ");
 
     const labelComponent = hasLabel ? (
         <label
@@ -794,9 +803,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
                     }
                     shortDescriptionId={shortDescriptionId}
                     // Supplementary annotations (not primary labels)
-                    aria-description={
-                        hasExplicitLabel ? shortDescription : undefined
-                    }
+                    aria-description={ariaDescription || undefined}
                     aria-details={ariaDetailsIds || undefined}
                     config={{
                         autoCommands:

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -51,29 +51,94 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
         cy.get("#pDen").should("have.text", "denominator: 7");
     });
 
-    it("fraction input in answer", () => {
+    it("fraction input in answer shows correctness styling and accessibility text", () => {
         cy.window().then(async (win) => {
+            const correctColor = getCSSVariableAsRGB(win, "--mainGreen");
+            const partialColor = getCSSVariableAsRGB(win, "--mainOrange");
+            const incorrectColor = getCSSVariableAsRGB(win, "--mainRed");
+
             win.postMessage(
                 {
                     doenetML: `
         <answer name="ans">
-            <fractionInput name="frac">
-                <shortDescription>Simplify two tenths</shortDescription>
-            </fractionInput>
-            <award>1/5</award>
+            <label>Simplify two tenths</label>
+            <fractionInput name="frac" />
+            <award><when><math>$frac</math> = <math>1/5</math></when></award>
+            <award credit="0.5"><when><math>$frac</math> = <math>2/5</math></when></award>
         </answer>
         `,
                 },
                 "*",
             );
+
+            function checkFractionPartLabelText(partIndex, expectedText) {
+                cy.get("#frac textarea")
+                    .eq(partIndex)
+                    .should("have.attr", "aria-labelledby")
+                    .then((ariaLabelledBy) => {
+                        const labelIds = ariaLabelledBy.split(" ");
+                        cy.document().then((doc) => {
+                            const hasExpectedLabel = labelIds.some(
+                                (labelId) => {
+                                    const labelElement =
+                                        doc.getElementById(labelId);
+                                    return (
+                                        labelElement &&
+                                        labelElement.textContent.includes(
+                                            expectedText,
+                                        )
+                                    );
+                                },
+                            );
+                            expect(hasExpectedLabel).eq(true);
+                        });
+                    });
+            }
+
+            cy.get("#frac").should(
+                "not.have.css",
+                "outline-color",
+                correctColor,
+            );
+            checkFractionPartLabelText(0, "numerator");
+            checkFractionPartLabelText(1, "denominator");
+
+            cy.get("#frac textarea").eq(0).type("1", { force: true });
+            cy.get("#frac textarea").eq(1).type("5", { force: true });
+            cy.get("#frac_button").should("contain.text", "Check Work").click();
+            cy.get("#frac_button").should("contain.text", "Correct");
+            cy.get("#frac").should("have.css", "outline-color", correctColor);
+            checkFractionPartLabelText(0, "numerator (Correct)");
+            checkFractionPartLabelText(1, "denominator (Correct)");
+
+            cy.get("#frac textarea")
+                .eq(0)
+                .type("{end}{backspace}2{enter}", { force: true });
+            cy.get("#frac_button").click();
+            cy.get("#frac_button").should("contain.text", "50% Correct");
+            cy.get("#frac").should("have.css", "outline-color", partialColor);
+            checkFractionPartLabelText(0, "numerator (Partially correct)");
+            checkFractionPartLabelText(1, "denominator (Partially correct)");
+
+            cy.get("#frac textarea")
+                .eq(1)
+                .type("{end}{backspace}7{enter}", { force: true });
+            cy.get("#frac_button").click();
+            cy.get("#frac_button").should("contain.text", "Incorrect");
+            cy.get("#frac").should("have.css", "outline-color", incorrectColor);
+            checkFractionPartLabelText(0, "numerator (Incorrect)");
+            checkFractionPartLabelText(1, "denominator (Incorrect)");
         });
-
-        cy.get("#frac textarea").eq(0).type("1", { force: true });
-        cy.get("#frac textarea").eq(1).type("5", { force: true });
-
-        cy.get("#frac_button").should("contain.text", "Check Work").click();
-        cy.get("#frac_button").should("contain.text", "Correct");
     });
+
+    function getCSSVariableAsRGB(win, varName) {
+        const el = win.document.createElement("div");
+        el.style.color = `var(${varName})`;
+        win.document.body.appendChild(el);
+        const rgbValue = win.getComputedStyle(el).color;
+        el.remove();
+        return rgbValue;
+    }
 
     it("bindValueTo a math input, two-way", () => {
         cy.window().then(async (win) => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -56,6 +56,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             const correctColor = getCSSVariableAsRGB(win, "--mainGreen");
             const partialColor = getCSSVariableAsRGB(win, "--mainOrange");
             const incorrectColor = getCSSVariableAsRGB(win, "--mainRed");
+            const defaultColor = getCSSVariableAsRGB(win, "--canvasText");
 
             win.postMessage(
                 {
@@ -95,69 +96,44 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
                     });
             }
 
-            function checkFractionPartDescription(expectedText) {
-                const assertion = expectedText ? "have.attr" : "not.have.attr";
-                const args = expectedText
-                    ? ["aria-description", expectedText]
-                    : ["aria-description"];
-
-                cy.get("#frac textarea")
+            function checkInputBoxBorderColor(expectedColor) {
+                cy.get("#frac .mq-editable-field")
                     .eq(0)
-                    .should(assertion, ...args);
-                cy.get("#frac textarea")
+                    .should("have.css", "border-color", expectedColor);
+                cy.get("#frac .mq-editable-field")
                     .eq(1)
-                    .should(assertion, ...args);
+                    .should("have.css", "border-color", expectedColor);
             }
 
-            function checkFractionDescription(expectedText) {
-                cy.get("#frac table").then(($table) => {
-                    const accessibleDescription =
-                        $table.attr("aria-description") ??
-                        $table.attr("aria-label");
-                    expect(accessibleDescription).eq(expectedText);
-                });
-            }
-
-            cy.get("#frac").should(
-                "not.have.css",
-                "outline-color",
-                correctColor,
-            );
+            checkInputBoxBorderColor(defaultColor);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
-            checkFractionPartDescription("");
 
             cy.get("#frac textarea").eq(0).type("1", { force: true });
             cy.get("#frac textarea").eq(1).type("5", { force: true });
             cy.get("#frac_button").should("contain.text", "Check Work").click();
             cy.get("#frac_button").should("contain.text", "Correct");
-            cy.get("#frac").should("have.css", "outline-color", correctColor);
+            checkInputBoxBorderColor(correctColor);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
-            checkFractionPartDescription("Fraction is correct");
-            checkFractionDescription("(Correct)");
 
             cy.get("#frac textarea")
                 .eq(0)
                 .type("{end}{backspace}2{enter}", { force: true });
             cy.get("#frac_button").click();
             cy.get("#frac_button").should("contain.text", "50% Correct");
-            cy.get("#frac").should("have.css", "outline-color", partialColor);
+            checkInputBoxBorderColor(partialColor);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
-            checkFractionPartDescription("Fraction is partially correct");
-            checkFractionDescription("(Partially correct)");
 
             cy.get("#frac textarea")
                 .eq(1)
                 .type("{end}{backspace}7{enter}", { force: true });
             cy.get("#frac_button").click();
             cy.get("#frac_button").should("contain.text", "Incorrect");
-            cy.get("#frac").should("have.css", "outline-color", incorrectColor);
+            checkInputBoxBorderColor(incorrectColor);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
-            checkFractionPartDescription("Fraction is incorrect");
-            checkFractionDescription("(Incorrect)");
         });
     });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -105,7 +105,18 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
                     .should("have.css", "border-color", expectedColor);
             }
 
+            function checkFractionDescription(expectedDescription) {
+                cy.get("#frac table").then(($table) => {
+                    const accessibleDescription =
+                        $table.attr("aria-description") ??
+                        $table.attr("aria-label");
+
+                    expect(accessibleDescription).to.equal(expectedDescription);
+                });
+            }
+
             checkInputBoxBorderColor(defaultColor);
+            checkFractionDescription(undefined);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
 
@@ -114,6 +125,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac_button").should("contain.text", "Check Work").click();
             cy.get("#frac_button").should("contain.text", "Correct");
             checkInputBoxBorderColor(correctColor);
+            checkFractionDescription("(Correct)");
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
 
@@ -123,6 +135,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac_button").click();
             cy.get("#frac_button").should("contain.text", "50% Correct");
             checkInputBoxBorderColor(partialColor);
+            checkFractionDescription("(Partially correct)");
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
 
@@ -132,6 +145,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac_button").click();
             cy.get("#frac_button").should("contain.text", "Incorrect");
             checkInputBoxBorderColor(incorrectColor);
+            checkFractionDescription("(Incorrect)");
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
         });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -95,6 +95,15 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
                     });
             }
 
+            function checkFractionDescription(expectedText) {
+                cy.get("#frac table").then(($table) => {
+                    const accessibleDescription =
+                        $table.attr("aria-description") ??
+                        $table.attr("aria-label");
+                    expect(accessibleDescription).eq(expectedText);
+                });
+            }
+
             cy.get("#frac").should(
                 "not.have.css",
                 "outline-color",
@@ -108,8 +117,9 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac_button").should("contain.text", "Check Work").click();
             cy.get("#frac_button").should("contain.text", "Correct");
             cy.get("#frac").should("have.css", "outline-color", correctColor);
-            checkFractionPartLabelText(0, "numerator (Correct)");
-            checkFractionPartLabelText(1, "denominator (Correct)");
+            checkFractionPartLabelText(0, "numerator");
+            checkFractionPartLabelText(1, "denominator");
+            checkFractionDescription("(Correct)");
 
             cy.get("#frac textarea")
                 .eq(0)
@@ -117,8 +127,9 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac_button").click();
             cy.get("#frac_button").should("contain.text", "50% Correct");
             cy.get("#frac").should("have.css", "outline-color", partialColor);
-            checkFractionPartLabelText(0, "numerator (Partially correct)");
-            checkFractionPartLabelText(1, "denominator (Partially correct)");
+            checkFractionPartLabelText(0, "numerator");
+            checkFractionPartLabelText(1, "denominator");
+            checkFractionDescription("(Partially correct)");
 
             cy.get("#frac textarea")
                 .eq(1)
@@ -126,8 +137,9 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac_button").click();
             cy.get("#frac_button").should("contain.text", "Incorrect");
             cy.get("#frac").should("have.css", "outline-color", incorrectColor);
-            checkFractionPartLabelText(0, "numerator (Incorrect)");
-            checkFractionPartLabelText(1, "denominator (Incorrect)");
+            checkFractionPartLabelText(0, "numerator");
+            checkFractionPartLabelText(1, "denominator");
+            checkFractionDescription("(Incorrect)");
         });
     });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -78,19 +78,19 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
                     .then((ariaLabelledBy) => {
                         const labelIds = ariaLabelledBy.split(" ");
                         cy.document().then((doc) => {
-                            const hasExpectedLabel = labelIds.some(
-                                (labelId) => {
-                                    const labelElement =
-                                        doc.getElementById(labelId);
-                                    return (
-                                        labelElement &&
-                                        labelElement.textContent.includes(
-                                            expectedText,
-                                        )
-                                    );
-                                },
+                            const labelText = labelIds
+                                .map(
+                                    (labelId) =>
+                                        doc.getElementById(labelId)
+                                            ?.textContent ?? "",
+                                )
+                                .join(" ");
+                            expect(labelText).include(expectedText);
+                            expect(labelText).not.include("(Correct)");
+                            expect(labelText).not.include(
+                                "(Partially correct)",
                             );
-                            expect(hasExpectedLabel).eq(true);
+                            expect(labelText).not.include("(Incorrect)");
                         });
                     });
             }

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -95,6 +95,20 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
                     });
             }
 
+            function checkFractionPartDescription(expectedText) {
+                const assertion = expectedText ? "have.attr" : "not.have.attr";
+                const args = expectedText
+                    ? ["aria-description", expectedText]
+                    : ["aria-description"];
+
+                cy.get("#frac textarea")
+                    .eq(0)
+                    .should(assertion, ...args);
+                cy.get("#frac textarea")
+                    .eq(1)
+                    .should(assertion, ...args);
+            }
+
             function checkFractionDescription(expectedText) {
                 cy.get("#frac table").then(($table) => {
                     const accessibleDescription =
@@ -111,6 +125,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             );
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
+            checkFractionPartDescription("");
 
             cy.get("#frac textarea").eq(0).type("1", { force: true });
             cy.get("#frac textarea").eq(1).type("5", { force: true });
@@ -119,6 +134,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac").should("have.css", "outline-color", correctColor);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
+            checkFractionPartDescription("Fraction is correct");
             checkFractionDescription("(Correct)");
 
             cy.get("#frac textarea")
@@ -129,6 +145,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac").should("have.css", "outline-color", partialColor);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
+            checkFractionPartDescription("Fraction is partially correct");
             checkFractionDescription("(Partially correct)");
 
             cy.get("#frac textarea")
@@ -139,6 +156,7 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
             cy.get("#frac").should("have.css", "outline-color", incorrectColor);
             checkFractionPartLabelText(0, "numerator");
             checkFractionPartLabelText(1, "denominator");
+            checkFractionPartDescription("Fraction is incorrect");
             checkFractionDescription("(Incorrect)");
         });
     });


### PR DESCRIPTION
## Summary

When a `<fractionInput>` belongs to an `<answer>` and `colorCorrectness` is true (the default), its numerator and denominator math-input boxes now get correctness-colored borders like other answer inputs. The fraction-level accessible text also exposes the submitted validation state without implying that the numerator and denominator are graded separately.

## Changes

**Worker and renderer updates**
- `packages/doenetml-worker-javascript/src/components/FractionInput.js`
  - Mirrors `colorCorrectness`, `creditAchieved`, `justSubmitted`, and `numAttemptsLeft` from the parent `fractionInput` onto each internal `_fractionInputComponent` so the reused `mathInput` renderer can color each box.
  - Sets `includeValidationStateInShortDescription = false` so the numerator and denominator accessible names stay as just `numerator` / `denominator`.
- `packages/doenetml/src/Viewer/renderers/mathInput.tsx`
  - Adds `includeValidationStateInShortDescription?: boolean` to `MathInputSVs` and skips appending validation text when that flag is `false`.
- `packages/doenetml/src/Viewer/renderers/fractionInput.tsx`
  - Appends the validation state to the fraction-level accessible text while leaving correctness styling to the child math-input boxes.

**Tests and release notes**
- `packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js`
  - Adds Cypress coverage for correct / partial / incorrect border colors, stable numerator and denominator labels, and fraction-level accessible validation text.
- `.changeset/fraction-input-color-correctness.md`
  - Adds a dedicated release note for this follow-up fix.
- `.changeset/fraction-input.md`
  - Restores the original unreleased `<fractionInput>` introduction entry instead of overwriting it.

Closes #1388.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)