### PR TITLE
fix: inputs inside a choice no longer hidden or stolen in choiceInput

### DIFF
--- a/.changeset/choiceinput-embedded-inputs.md
+++ b/.changeset/choiceinput-embedded-inputs.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-Choice inputs no longer hide text inputs inside choices or steal focus from math inputs nested in non-inline choices.
+Choice inputs no longer hide embedded text inputs or steal focus and activation from interactive inputs nested in non-inline choices.
 
 Closes #1398.

--- a/.changeset/choiceinput-embedded-inputs.md
+++ b/.changeset/choiceinput-embedded-inputs.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-Choice inputs no longer hide embedded text inputs or steal focus and activation from interactive inputs nested in non-inline choices.
+Choice inputs no longer hide embedded text inputs, redirect nested interactive input clicks to the outer choice, or show the outer choice focus ring while those embedded controls are focused.
 
 Closes #1398.

--- a/.changeset/choiceinput-embedded-inputs.md
+++ b/.changeset/choiceinput-embedded-inputs.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Choice inputs no longer hide text inputs inside choices or steal focus from math inputs nested in non-inline choices.
+
+Closes #1398.

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -31,8 +31,8 @@
     position: absolute;
     opacity: 0;
     cursor: pointer;
-    height: 1;
-    width: 1;
+    height: 1px;
+    width: 1px;
 }
 
 .doenet-viewer .radio-container-disabled > input.choiceinput-control {
@@ -151,8 +151,8 @@
     position: absolute;
     opacity: 0;
     cursor: pointer;
-    height: 1;
-    width: 1;
+    height: 1px;
+    width: 1px;
 }
 
 .doenet-viewer .checkbox-container-disabled > input.choiceinput-control {

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -35,7 +35,9 @@
     width: 1px;
 }
 
-.doenet-viewer .radio-container-disabled > input.choiceinput-control {
+.doenet-viewer
+    .radio-container-disabled
+    > input.choiceinput-control[type="radio"] {
     cursor: not-allowed;
 }
 
@@ -155,7 +157,9 @@
     width: 1px;
 }
 
-.doenet-viewer .checkbox-container-disabled > input.choiceinput-control {
+.doenet-viewer
+    .checkbox-container-disabled
+    > input.choiceinput-control[type="checkbox"] {
     cursor: not-allowed;
 }
 

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -84,8 +84,8 @@
 
 /* When a radio button has focus, add a dark blue outline */
 .doenet-viewer
-    .radio-container:focus-within
-    > input.choiceinput-control
+    .radio-container
+    > input.choiceinput-control:focus
     ~ .radio-checkmark {
     outline: 2px solid var(--mainBlue);
     outline-offset: 2px;
@@ -204,8 +204,8 @@
 
 /* When a checkbox has focus, add a dark blue outline */
 .doenet-viewer
-    .checkbox-container:focus-within
-    > input.choiceinput-control
+    .checkbox-container
+    > input.choiceinput-control:focus
     ~ .checkbox-checkmark {
     outline: 2px solid var(--mainBlue);
     outline-offset: 2px;

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -27,7 +27,7 @@
 }
 
 /* Hide the browser's default radio button */
-.doenet-viewer .radio-container input[type="radio"] {
+.doenet-viewer .radio-container > input.choiceinput-control[type="radio"] {
     position: absolute;
     opacity: 0;
     cursor: pointer;
@@ -35,7 +35,7 @@
     width: 1;
 }
 
-.doenet-viewer .radio-container-disabled input {
+.doenet-viewer .radio-container-disabled > input.choiceinput-control {
     cursor: not-allowed;
 }
 
@@ -59,22 +59,34 @@
 }
 
 /* On mouse-over, add a theme-aware blue background color */
-.doenet-viewer .radio-container:hover input ~ .radio-checkmark {
+.doenet-viewer
+    .radio-container:hover
+    > input.choiceinput-control
+    ~ .radio-checkmark {
     background-color: var(--indicatorHoverBlue);
 }
 
 /* On mouse-over of disabled, keep the grey background color */
-.doenet-viewer .radio-container:hover input ~ .radio-checkmark-disabled {
+.doenet-viewer
+    .radio-container:hover
+    > input.choiceinput-control
+    ~ .radio-checkmark-disabled {
     background-color: var(--mainGray);
 }
 
 /* When the radio button is checked, add a blue background */
-.doenet-viewer .radio-container input:checked ~ .radio-checkmark {
+.doenet-viewer
+    .radio-container
+    > input.choiceinput-control:checked
+    ~ .radio-checkmark {
     background-color: var(--mainBlue);
 }
 
 /* When a radio button has focus, add a dark blue outline */
-.doenet-viewer .radio-container:focus-within input ~ .radio-checkmark {
+.doenet-viewer
+    .radio-container:focus-within
+    > input.choiceinput-control
+    ~ .radio-checkmark {
     outline: 2px solid var(--mainBlue);
     outline-offset: 2px;
 }
@@ -87,7 +99,10 @@
 }
 
 /* Show the indicator (dot/circle) when checked */
-.doenet-viewer .radio-container input:checked ~ .radio-checkmark:after {
+.doenet-viewer
+    .radio-container
+    > input.choiceinput-control:checked
+    ~ .radio-checkmark:after {
     display: block;
 }
 
@@ -130,7 +145,9 @@
 }
 
 /* Hide the browser's default checkbox */
-.doenet-viewer .checkbox-container input[type="checkbox"] {
+.doenet-viewer
+    .checkbox-container
+    > input.choiceinput-control[type="checkbox"] {
     position: absolute;
     opacity: 0;
     cursor: pointer;
@@ -138,7 +155,7 @@
     width: 1;
 }
 
-.doenet-viewer .checkbox-container-disabled input {
+.doenet-viewer .checkbox-container-disabled > input.choiceinput-control {
     cursor: not-allowed;
 }
 
@@ -162,22 +179,34 @@
 }
 
 /* On mouse-over, use the theme-aware indicator hover color */
-.doenet-viewer .checkbox-container:hover input ~ .checkbox-checkmark {
+.doenet-viewer
+    .checkbox-container:hover
+    > input.choiceinput-control
+    ~ .checkbox-checkmark {
     background-color: var(--indicatorHoverBlue);
 }
 
 /* On mouse-over of disabled, keep the grey background color */
-.doenet-viewer .checkbox-container:hover input ~ .checkbox-checkmark-disabled {
+.doenet-viewer
+    .checkbox-container:hover
+    > input.choiceinput-control
+    ~ .checkbox-checkmark-disabled {
     background-color: var(--mainGray);
 }
 
 /* When the checkbox is checked, add a dark blue background */
-.doenet-viewer .checkbox-container input:checked ~ .checkbox-checkmark {
+.doenet-viewer
+    .checkbox-container
+    > input.choiceinput-control:checked
+    ~ .checkbox-checkmark {
     background-color: var(--mainBlue);
 }
 
 /* When a checkbox has focus, add a dark blue outline */
-.doenet-viewer .checkbox-container:focus-within input ~ .checkbox-checkmark {
+.doenet-viewer
+    .checkbox-container:focus-within
+    > input.choiceinput-control
+    ~ .checkbox-checkmark {
     outline: 2px solid var(--mainBlue);
     outline-offset: 2px;
 }
@@ -190,7 +219,10 @@
 }
 
 /* Show the checkmark when checked */
-.doenet-viewer .checkbox-container input:checked ~ .checkbox-checkmark:after {
+.doenet-viewer
+    .checkbox-container
+    > input.choiceinput-control:checked
+    ~ .checkbox-checkmark:after {
     display: block;
 }
 

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -27,7 +27,7 @@
 }
 
 /* Hide the browser's default radio button */
-.doenet-viewer .radio-container input {
+.doenet-viewer .radio-container input[type="radio"] {
     position: absolute;
     opacity: 0;
     cursor: pointer;
@@ -130,7 +130,7 @@
 }
 
 /* Hide the browser's default checkbox */
-.doenet-viewer .checkbox-container input {
+.doenet-viewer .checkbox-container input[type="checkbox"] {
     position: absolute;
     opacity: 0;
     cursor: pointer;

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -558,6 +558,39 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
     } else {
         // Non-inline choice input
 
+        // Prevent the wrapping <label> from redirecting focus to the
+        // radio/checkbox when the click originates from an interactive input
+        // (e.g. a <mathInput> or <textInput>) inside the choice content.
+        //
+        // React uses root-level event delegation, so a bubble-phase onClick
+        // fires after the native event has already passed through the <label>
+        // (too late to cancel the label's activation behavior). Using
+        // onClickCapture fires in the capture phase — before the native event
+        // reaches <label> — so calling preventDefault() here marks the event
+        // as cancelled before the label can redirect focus to the radio button.
+        // The event still propagates down to the interactive element, which
+        // receives focus normally.
+        //
+        // The selector covers:
+        //   - text/number/<input> (non-radio/checkbox)
+        //   - <textarea>
+        //   - [contenteditable]
+        //   - .mathInputWrapper — MathQuill's visual spans are regular <span>
+        //     elements; clicking them does not target a native form control, so
+        //     the above selectors miss them. MathQuill focuses its internal
+        //     textarea programmatically. Detecting the wrapper class is the
+        //     reliable way to identify a mathInput click.
+        function preventDefaultIfInput(e: React.MouseEvent) {
+            const target = e.target as HTMLElement;
+            if (
+                target.closest(
+                    'input:not([type="radio"]):not([type="checkbox"]), textarea, [contenteditable], .mathInputWrapper',
+                )
+            ) {
+                e.preventDefault();
+            }
+        }
+
         let inputKey = id;
         let listStyle = {
             listStyleType: "none",
@@ -603,6 +636,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             <label
                                 className={containerClassName}
                                 key={inputKey + "_choice" + (i + 1)}
+                                onClickCapture={preventDefaultIfInput}
                             >
                                 <input
                                     type="radio"
@@ -637,6 +671,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             <label
                                 className={containerClassName}
                                 key={inputKey + "_choice" + (i + 1)}
+                                onClickCapture={preventDefaultIfInput}
                             >
                                 <input
                                     type="checkbox"

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -580,13 +580,32 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         //     the above selectors miss them. MathQuill focuses its internal
         //     textarea programmatically. Detecting the wrapper class is the
         //     reliable way to identify a mathInput click.
-        //   - booleanInput / nested choiceInput containers, whose visible click
-        //     targets are spans or labels rather than their hidden native
-        //     inputs.
+        //   - booleanInput containers
+        //   - inline choiceInput controls rendered by react-select
+        //   - labels associated to embedded controls
+        //
         function preventDefaultIfInput(e: React.MouseEvent) {
             const target = e.target as HTMLElement;
+            const embeddedLabel = target.closest(
+                "label:not(.radio-container):not(.checkbox-container)",
+            ) as HTMLLabelElement | null;
+
+            if (embeddedLabel && embeddedLabel !== e.currentTarget) {
+                const labelledControl =
+                    embeddedLabel.control ||
+                    (embeddedLabel.htmlFor
+                        ? document.getElementById(embeddedLabel.htmlFor)
+                        : null);
+
+                if (labelledControl instanceof HTMLElement) {
+                    e.preventDefault();
+                    labelledControl.focus();
+                    return;
+                }
+            }
+
             const interactiveTarget = target.closest(
-                "input:not(.choiceinput-control), textarea, [contenteditable], .mathInputWrapper, .boolean-container, .radio-container, .checkbox-container",
+                "input:not(.choiceinput-control), textarea, [contenteditable], .mathInputWrapper, .boolean-container, .custom-select",
             );
 
             if (interactiveTarget && interactiveTarget !== e.currentTarget) {

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -572,7 +572,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         // receives focus normally.
         //
         // The selector covers:
-        //   - text/number/<input> (non-radio/checkbox)
+        //   - any nested <input> except the choice input's own control
         //   - <textarea>
         //   - [contenteditable]
         //   - .mathInputWrapper — MathQuill's visual spans are regular <span>
@@ -580,13 +580,16 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         //     the above selectors miss them. MathQuill focuses its internal
         //     textarea programmatically. Detecting the wrapper class is the
         //     reliable way to identify a mathInput click.
+        //   - booleanInput / nested choiceInput containers, whose visible click
+        //     targets are spans or labels rather than their hidden native
+        //     inputs.
         function preventDefaultIfInput(e: React.MouseEvent) {
             const target = e.target as HTMLElement;
-            if (
-                target.closest(
-                    'input:not([type="radio"]):not([type="checkbox"]), textarea, [contenteditable], .mathInputWrapper',
-                )
-            ) {
+            const interactiveTarget = target.closest(
+                "input:not(.choiceinput-control), textarea, [contenteditable], .mathInputWrapper, .boolean-container, .radio-container, .checkbox-container",
+            );
+
+            if (interactiveTarget && interactiveTarget !== e.currentTarget) {
                 e.preventDefault();
             }
         }
@@ -639,6 +642,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                                 onClickCapture={preventDefaultIfInput}
                             >
                                 <input
+                                    className="choiceinput-control"
                                     type="radio"
                                     id={keyBeginning + (i + 1) + "_input"}
                                     name={inputKey}
@@ -674,6 +678,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                                 onClickCapture={preventDefaultIfInput}
                             >
                                 <input
+                                    className="choiceinput-control"
                                     type="checkbox"
                                     id={keyBeginning + (i + 1) + "_input"}
                                     name={inputKey}

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -86,6 +86,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
     >(SVs.selectedIndices);
 
     let selectedIndicesWhenSetState = useRef(null);
+    const embeddedLabelClicksToAllow = useRef(new WeakSet<HTMLElement>());
 
     if (
         !ignoreUpdate &&
@@ -572,8 +573,10 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         // receives focus normally.
         //
         // The selector covers:
-        //   - any nested <input> except the choice input's own control
+        //   - any nested form control except the outer choice input's own
+        //     radio/checkbox
         //   - <textarea>
+        //   - <select> and <button>
         //   - [contenteditable]
         //   - .mathInputWrapper — MathQuill's visual spans are regular <span>
         //     elements; clicking them does not target a native form control, so
@@ -586,8 +589,17 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         //
         function preventDefaultIfInput(e: React.MouseEvent) {
             const target = e.target as HTMLElement;
+            const outerChoiceControl = e.currentTarget.querySelector(
+                ":scope > input.choiceinput-control",
+            );
+
+            if (embeddedLabelClicksToAllow.current.has(target)) {
+                embeddedLabelClicksToAllow.current.delete(target);
+                return;
+            }
+
             const embeddedLabel = target.closest(
-                "label:not(.radio-container):not(.checkbox-container)",
+                "label",
             ) as HTMLLabelElement | null;
 
             if (embeddedLabel && embeddedLabel !== e.currentTarget) {
@@ -597,18 +609,38 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                         ? document.getElementById(embeddedLabel.htmlFor)
                         : null);
 
-                if (labelledControl instanceof HTMLElement) {
+                if (
+                    labelledControl instanceof HTMLElement &&
+                    labelledControl !== outerChoiceControl
+                ) {
                     e.preventDefault();
                     labelledControl.focus();
+
+                    if (
+                        labelledControl instanceof HTMLInputElement &&
+                        (labelledControl.type === "checkbox" ||
+                            labelledControl.type === "radio")
+                    ) {
+                        // Recreate the inner label's native toggle behavior
+                        // without letting the outer choice intercept the
+                        // synthetic click we trigger here.
+                        embeddedLabelClicksToAllow.current.add(labelledControl);
+                        labelledControl.click();
+                    }
+
                     return;
                 }
             }
 
             const interactiveTarget = target.closest(
-                "input:not(.choiceinput-control), textarea, [contenteditable], .mathInputWrapper, .boolean-container, .custom-select",
+                "input, textarea, select, button, [contenteditable], .mathInputWrapper, .boolean-container, .custom-select",
             );
 
-            if (interactiveTarget && interactiveTarget !== e.currentTarget) {
+            if (
+                interactiveTarget &&
+                interactiveTarget !== e.currentTarget &&
+                interactiveTarget !== outerChoiceControl
+            ) {
                 e.preventDefault();
             }
         }

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -572,8 +572,8 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         // receives focus normally.
         //
         // The selector covers:
-        //   - any nested form control except the outer choice input's own
-        //     radio/checkbox
+        //   - any nested form control except choiceInput radio/checkbox
+        //     controls, whose label behavior is handled separately
         //   - <textarea>
         //   - <select> and <button>
         //   - [contenteditable]
@@ -595,7 +595,11 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 "input, textarea, select, button, [contenteditable], .mathInputWrapper, .boolean-container, .custom-select",
             );
 
-            if (interactiveTarget && interactiveTarget !== outerChoiceControl) {
+            if (
+                interactiveTarget &&
+                interactiveTarget !== outerChoiceControl &&
+                !interactiveTarget.classList.contains("choiceinput-control")
+            ) {
                 e.preventDefault();
             }
         }

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -595,11 +595,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 "input, textarea, select, button, [contenteditable], .mathInputWrapper, .boolean-container, .custom-select",
             );
 
-            if (
-                interactiveTarget &&
-                interactiveTarget !== e.currentTarget &&
-                interactiveTarget !== outerChoiceControl
-            ) {
+            if (interactiveTarget && interactiveTarget !== outerChoiceControl) {
                 e.preventDefault();
             }
         }

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -86,7 +86,6 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
     >(SVs.selectedIndices);
 
     let selectedIndicesWhenSetState = useRef(null);
-    const embeddedLabelClicksToAllow = useRef(new WeakSet<HTMLElement>());
 
     if (
         !ignoreUpdate &&
@@ -585,52 +584,12 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         //     reliable way to identify a mathInput click.
         //   - booleanInput containers
         //   - inline choiceInput controls rendered by react-select
-        //   - labels associated to embedded controls
         //
         function preventDefaultIfInput(e: React.MouseEvent) {
             const target = e.target as HTMLElement;
             const outerChoiceControl = e.currentTarget.querySelector(
                 ":scope > input.choiceinput-control",
             );
-
-            if (embeddedLabelClicksToAllow.current.has(target)) {
-                embeddedLabelClicksToAllow.current.delete(target);
-                return;
-            }
-
-            const embeddedLabel = target.closest(
-                "label",
-            ) as HTMLLabelElement | null;
-
-            if (embeddedLabel && embeddedLabel !== e.currentTarget) {
-                const labelledControl =
-                    embeddedLabel.control ||
-                    (embeddedLabel.htmlFor
-                        ? document.getElementById(embeddedLabel.htmlFor)
-                        : null);
-
-                if (
-                    labelledControl instanceof HTMLElement &&
-                    labelledControl !== outerChoiceControl
-                ) {
-                    e.preventDefault();
-                    labelledControl.focus();
-
-                    if (
-                        labelledControl instanceof HTMLInputElement &&
-                        (labelledControl.type === "checkbox" ||
-                            labelledControl.type === "radio")
-                    ) {
-                        // Recreate the inner label's native toggle behavior
-                        // without letting the outer choice intercept the
-                        // synthetic click we trigger here.
-                        embeddedLabelClicksToAllow.current.add(labelledControl);
-                        labelledControl.click();
-                    }
-
-                    return;
-                }
-            }
 
             const interactiveTarget = target.closest(
                 "input, textarea, select, button, [contenteditable], .mathInputWrapper, .boolean-container, .custom-select",

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -573,7 +573,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         //
         // The selector covers:
         //   - any nested form control except choiceInput radio/checkbox
-        //     controls, whose label behavior is handled separately
+        //     controls, whose own click behavior should not be cancelled
         //   - <textarea>
         //   - <select> and <button>
         //   - [contenteditable]

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -435,12 +435,12 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
                 {
                     doenetML: `
     <choiceInput name="radioCi">
-      <choice><textInput name="radioTi" prefill="alpha" /></choice>
+      <choice><textInput name="radioTi" prefill="alpha"><label>radio label</label></textInput></choice>
       <choice>dog</choice>
     </choiceInput>
 
     <choiceInput name="checkboxCi" selectMultiple>
-      <choice><textInput name="checkboxTi" prefill="beta" /></choice>
+      <choice><textInput name="checkboxTi" prefill="beta"><label>checkbox label</label></textInput></choice>
       <choice>cat</choice>
     </choiceInput>
     `,
@@ -455,6 +455,14 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get("#checkboxTi_input")
             .should("be.visible")
             .should("have.value", "beta");
+
+        cy.contains("label", "radio label").click();
+        cy.get("#radioTi_input").should("be.focused");
+        cy.get("#radioCi_choice1_input").should("not.be.checked");
+
+        cy.contains("label", "checkbox label").click();
+        cy.get("#checkboxTi_input").should("be.focused");
+        cy.get("#checkboxCi_choice1_input").should("not.be.checked");
 
         cy.get("#radioTi_input").type("{end}1");
         cy.get("#checkboxTi_input").type("{end}2");

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -459,10 +459,16 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.contains("label", "radio label").click();
         cy.get("#radioTi_input").should("be.focused");
         cy.get("#radioCi_choice1_input").should("not.be.checked");
+        cy.get("#radioCi_choice1_input")
+            .siblings(".radio-checkmark")
+            .should("have.css", "outline-style", "none");
 
         cy.contains("label", "checkbox label").click();
         cy.get("#checkboxTi_input").should("be.focused");
         cy.get("#checkboxCi_choice1_input").should("not.be.checked");
+        cy.get("#checkboxCi_choice1_input")
+            .siblings(".checkbox-checkmark")
+            .should("have.css", "outline-style", "none");
 
         cy.get("#radioTi_input").type("{end}1");
         cy.get("#checkboxTi_input").type("{end}2");
@@ -497,6 +503,9 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         });
         cy.get("#radioMi .mq-editable-field").should("contain.text", "x");
         cy.get("#radioCi_choice1_input").should("not.be.checked");
+        cy.get("#radioCi_choice1_input")
+            .siblings(".radio-checkmark")
+            .should("have.css", "outline-style", "none");
 
         cy.get("#checkboxMi .mq-editable-field").click();
         cy.get("#checkboxMi textarea").should("be.focused").type("y", {
@@ -504,6 +513,9 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         });
         cy.get("#checkboxMi .mq-editable-field").should("contain.text", "y");
         cy.get("#checkboxCi_choice1_input").should("not.be.checked");
+        cy.get("#checkboxCi_choice1_input")
+            .siblings(".checkbox-checkmark")
+            .should("have.css", "outline-style", "none");
     });
 
     it("clicking embedded booleanInputs does not activate non-inline choices", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -630,11 +630,11 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get("#innerRadioCi_choice1_input").click({ force: true });
+        cy.get("#innerRadioCi").contains("red").click();
         cy.get("#innerRadioCi_choice1_input").should("be.checked");
         cy.get("#outerRadioCi_choice1_input").should("not.be.checked");
 
-        cy.get("#innerCheckboxCi_choice2_input").click({ force: true });
+        cy.get("#innerCheckboxCi").contains("mouse").click();
         cy.get("#innerCheckboxCi_choice2_input").should("be.checked");
         cy.get("#outerCheckboxCi_choice1_input").should("not.be.checked");
     });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -429,6 +429,75 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         }
     });
 
+    it("embedded textInputs stay visible inside non-inline choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="radioCi">
+      <choice><textInput name="radioTi" prefill="alpha" /></choice>
+      <choice>dog</choice>
+    </choiceInput>
+
+    <choiceInput name="checkboxCi" selectMultiple>
+      <choice><textInput name="checkboxTi" prefill="beta" /></choice>
+      <choice>cat</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#radioTi_input")
+            .should("be.visible")
+            .should("have.value", "alpha");
+        cy.get("#checkboxTi_input")
+            .should("be.visible")
+            .should("have.value", "beta");
+
+        cy.get("#radioTi_input").type("{end}1");
+        cy.get("#checkboxTi_input").type("{end}2");
+
+        cy.get("#radioTi_input").should("have.value", "alpha1");
+        cy.get("#checkboxTi_input").should("have.value", "beta2");
+    });
+
+    it("clicking embedded mathInputs does not activate non-inline choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="radioCi">
+      <choice><mathInput name="radioMi" /></choice>
+      <choice>dog</choice>
+    </choiceInput>
+
+    <choiceInput name="checkboxCi" selectMultiple>
+      <choice><mathInput name="checkboxMi" /></choice>
+      <choice>cat</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#radioMi .mq-editable-field").click();
+        cy.get("#radioMi textarea").should("be.focused").type("x", {
+            force: true,
+        });
+        cy.get("#radioMi .mq-editable-field").should("contain.text", "x");
+        cy.get("#radioCi_choice1_input").should("not.be.checked");
+
+        cy.get("#checkboxMi .mq-editable-field").click();
+        cy.get("#checkboxMi textarea").should("be.focused").type("y", {
+            force: true,
+        });
+        cy.get("#checkboxMi .mq-editable-field").should("contain.text", "y");
+        cy.get("#checkboxCi_choice1_input").should("not.be.checked");
+    });
+
     it("inline choiceInput menu stays within viewport near bottom", () => {
         cy.viewport(900, 420);
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -547,60 +547,6 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get("#checkboxCi_choice1_input").should("not.be.checked");
     });
 
-    it("embedded booleanInput labels toggle nested controls without activating non-inline choices", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-    <choiceInput name="radioCi">
-      <choice><booleanInput name="radioBi"><label>radio bool label</label></booleanInput></choice>
-      <choice>dog</choice>
-    </choiceInput>
-
-    <choiceInput name="checkboxCi" selectMultiple>
-      <choice><booleanInput name="checkboxBi"><label>checkbox bool label</label></booleanInput></choice>
-      <choice>cat</choice>
-    </choiceInput>
-    `,
-                },
-                "*",
-            );
-        });
-
-        cy.contains("label", "radio bool label").click();
-        cy.get("#radioBi_input").should("be.checked");
-        cy.get("#radioCi_choice1_input").should("not.be.checked");
-
-        cy.contains("label", "checkbox bool label").click();
-        cy.get("#checkboxBi_input").should("be.checked");
-        cy.get("#checkboxCi_choice1_input").should("not.be.checked");
-    });
-
-    it("clicking nested non-inline choiceInputs does not activate outer non-inline choices", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-    <choiceInput name="outerCi">
-      <choice>
-        <choiceInput name="innerCi">
-          <choice>inner alpha</choice>
-          <choice>inner beta</choice>
-        </choiceInput>
-      </choice>
-      <choice>outer dog</choice>
-    </choiceInput>
-    `,
-                },
-                "*",
-            );
-        });
-
-        cy.contains("label", "inner alpha").click();
-        cy.get("#innerCi_choice1_input").should("be.checked");
-        cy.get("#outerCi_choice1_input").should("not.be.checked");
-    });
-
     it("inline choiceInput menu stays within viewport near bottom", () => {
         cy.viewport(900, 420);
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -547,6 +547,59 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get("#checkboxCi_choice1_input").should("not.be.checked");
     });
 
+    it("clicking embedded inline choiceInputs does not activate non-inline choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="radioCi">
+      <choice>
+        <choiceInput inline name="radioInlineCi">
+          <choice>red</choice>
+          <choice>blue</choice>
+        </choiceInput>
+      </choice>
+      <choice>dog</choice>
+    </choiceInput>
+
+    <choiceInput name="checkboxCi" selectMultiple>
+      <choice>
+        <choiceInput inline name="checkboxInlineCi">
+          <choice>cat</choice>
+          <choice>mouse</choice>
+        </choiceInput>
+      </choice>
+      <choice>bird</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#radioInlineCi").click();
+        getOpenInlineChoiceMenu().contains("red").click({ force: true });
+        cy.get("#radioCi_choice1_input").should("not.be.checked");
+        cy.window().then(async (win) => {
+            const stateVariables = await win.returnAllStateVariables1();
+            expect(
+                stateVariables[await win.resolvePath1("radioInlineCi")]
+                    .stateValues.selectedValues,
+            ).eqls(["red"]);
+        });
+
+        cy.get("#checkboxInlineCi").click();
+        getOpenInlineChoiceMenu().contains("mouse").click({ force: true });
+        cy.get("#checkboxCi_choice1_input").should("not.be.checked");
+        cy.window().then(async (win) => {
+            const stateVariables = await win.returnAllStateVariables1();
+            expect(
+                stateVariables[await win.resolvePath1("checkboxInlineCi")]
+                    .stateValues.selectedValues,
+            ).eqls(["mouse"]);
+        });
+    });
+
     it("inline choiceInput menu stays within viewport near bottom", () => {
         cy.viewport(900, 420);
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -547,6 +547,60 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get("#checkboxCi_choice1_input").should("not.be.checked");
     });
 
+    it("embedded booleanInput labels toggle nested controls without activating non-inline choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="radioCi">
+      <choice><booleanInput name="radioBi"><label>radio bool label</label></booleanInput></choice>
+      <choice>dog</choice>
+    </choiceInput>
+
+    <choiceInput name="checkboxCi" selectMultiple>
+      <choice><booleanInput name="checkboxBi"><label>checkbox bool label</label></booleanInput></choice>
+      <choice>cat</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.contains("label", "radio bool label").click();
+        cy.get("#radioBi_input").should("be.checked");
+        cy.get("#radioCi_choice1_input").should("not.be.checked");
+
+        cy.contains("label", "checkbox bool label").click();
+        cy.get("#checkboxBi_input").should("be.checked");
+        cy.get("#checkboxCi_choice1_input").should("not.be.checked");
+    });
+
+    it("clicking nested non-inline choiceInputs does not activate outer non-inline choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="outerCi">
+      <choice>
+        <choiceInput name="innerCi">
+          <choice>inner alpha</choice>
+          <choice>inner beta</choice>
+        </choiceInput>
+      </choice>
+      <choice>outer dog</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.contains("label", "inner alpha").click();
+        cy.get("#innerCi_choice1_input").should("be.checked");
+        cy.get("#outerCi_choice1_input").should("not.be.checked");
+    });
+
     it("inline choiceInput menu stays within viewport near bottom", () => {
         cy.viewport(900, 420);
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -600,6 +600,45 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         });
     });
 
+    it("clicking embedded non-inline choiceInput controls does not activate outer choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="outerRadioCi">
+      <choice>
+        <choiceInput name="innerRadioCi">
+          <choice>red</choice>
+          <choice>blue</choice>
+        </choiceInput>
+      </choice>
+      <choice>dog</choice>
+    </choiceInput>
+
+    <choiceInput name="outerCheckboxCi" selectMultiple>
+      <choice>
+        <choiceInput name="innerCheckboxCi" selectMultiple>
+          <choice>cat</choice>
+          <choice>mouse</choice>
+        </choiceInput>
+      </choice>
+      <choice>bird</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#innerRadioCi_choice1_input").click({ force: true });
+        cy.get("#innerRadioCi_choice1_input").should("be.checked");
+        cy.get("#outerRadioCi_choice1_input").should("not.be.checked");
+
+        cy.get("#innerCheckboxCi_choice2_input").click({ force: true });
+        cy.get("#innerCheckboxCi_choice2_input").should("be.checked");
+        cy.get("#outerCheckboxCi_choice1_input").should("not.be.checked");
+    });
+
     it("inline choiceInput menu stays within viewport near bottom", () => {
         cy.viewport(900, 420);
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -498,6 +498,35 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get("#checkboxCi_choice1_input").should("not.be.checked");
     });
 
+    it("clicking embedded booleanInputs does not activate non-inline choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="radioCi">
+      <choice><booleanInput name="radioBi" /></choice>
+      <choice>dog</choice>
+    </choiceInput>
+
+    <choiceInput name="checkboxCi" selectMultiple>
+      <choice><booleanInput name="checkboxBi" /></choice>
+      <choice>cat</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#radioBi-container").click();
+        cy.get("#radioBi_input").should("be.checked");
+        cy.get("#radioCi_choice1_input").should("not.be.checked");
+
+        cy.get("#checkboxBi-container").click();
+        cy.get("#checkboxBi_input").should("be.checked");
+        cy.get("#checkboxCi_choice1_input").should("not.be.checked");
+    });
+
     it("inline choiceInput menu stays within viewport near bottom", () => {
         cy.viewport(900, 420);
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -435,12 +435,12 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
                 {
                     doenetML: `
     <choiceInput name="radioCi">
-      <choice><textInput name="radioTi" prefill="alpha"><label>radio label</label></textInput></choice>
+      <choice><textInput name="radioTi" prefill="alpha" /></choice>
       <choice>dog</choice>
     </choiceInput>
 
     <choiceInput name="checkboxCi" selectMultiple>
-      <choice><textInput name="checkboxTi" prefill="beta"><label>checkbox label</label></textInput></choice>
+      <choice><textInput name="checkboxTi" prefill="beta" /></choice>
       <choice>cat</choice>
     </choiceInput>
     `,
@@ -456,14 +456,14 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
             .should("be.visible")
             .should("have.value", "beta");
 
-        cy.contains("label", "radio label").click();
+        cy.get("#radioTi_input").click();
         cy.get("#radioTi_input").should("be.focused");
         cy.get("#radioCi_choice1_input").should("not.be.checked");
         cy.get("#radioCi_choice1_input")
             .siblings(".radio-checkmark")
             .should("have.css", "outline-style", "none");
 
-        cy.contains("label", "checkbox label").click();
+        cy.get("#checkboxTi_input").click();
         cy.get("#checkboxTi_input").should("be.focused");
         cy.get("#checkboxCi_choice1_input").should("not.be.checked");
         cy.get("#checkboxCi_choice1_input")


### PR DESCRIPTION
## Summary

Fixes the embedded-input bugs from issue #1398: interactive inputs inside a `<choice>` of a non-inline `<choiceInput>` could either disappear, show the outer choice's focus ring, or have their focus/activation hijacked by the outer radio/checkbox choice control.

## Bug 1 — embedded `textInput` invisible (CSS)

The CSS rules
```css
.doenet-viewer .radio-container input   { position: absolute; opacity: 0; … }
.doenet-viewer .checkbox-container input { position: absolute; opacity: 0; … }
```
were intended to hide the native radio/checkbox button, but matched descendant `<input>` elements inside the choice container — including a `<textInput>`'s `<input type="text">`.

**Fix:** scope the hidden-control styling to the outer choice control only.

## Bug 2 — clicking embedded interactive controls activates the outer choice

Each non-inline choice is wrapped in a `<label>`. When the user clicks on an embedded interactive control, the browser's label activation behavior can fire a synthetic click on the associated outer radio/checkbox button, stealing focus or toggling the choice.

This affected embedded text inputs, `mathInput` (whose visible target is rendered as ordinary `<span>` elements by MathQuill), `booleanInput`, and nested `choiceInput` controls.

**Fix:** add `onClickCapture` to the outer `<label>` and call `preventDefault()` when the click comes from an embedded interactive control. The guard excludes the outer choice's own hidden control by element identity and also allows nested `choiceInput` radio/checkbox controls to keep their native click behavior.

## Bug 3 — embedded focus triggered the outer choice indicator

The outer choice checkmark/radio outline was still keyed off `focus-within`, so focusing an embedded control made the wrapper look focused even though the hidden choice control itself never received focus.

**Fix:** move the focus-outline selectors to `input.choiceinput-control:focus` so the indicator only lights up when the actual radio/checkbox is focused.

## Additional updates

- Added Cypress coverage for embedded `textInput` visibility and interaction.
- Added Cypress coverage confirming embedded controls do not apply the outer choice focus outline.
- Added Cypress coverage confirming embedded `mathInput` clicks keep focus without selecting the outer choice.
- Added Cypress coverage confirming embedded `booleanInput` clicks toggle the nested control without selecting the outer choice.
- Added Cypress coverage confirming both inline and non-inline nested `choiceInput` controls do not select the outer choice.
- Added a changeset for the user-visible fix.

Closes #1398.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
