### PR TITLE
fix: allow $choice.selected to be referenced inside the same choice

### DIFF
--- a/.changeset/choice-self-referential-selected.md
+++ b/.changeset/choice-self-referential-selected.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix circular dependency when referencing `choice.selected` inside the same `<choice>`.
+
+`$c1.selected` (or a `<conditionalContent>` whose condition references `$c1.selected`) inside `<choice name="c1">` previously threw a "Circular dependency detected" error. The root cause was that `choiceInput.indicesMatchedByBoundValue` always declared a dependency on `choiceChildren.text` even when `bindValueTo` is absent — a dependency that is never used in that case. This created a resolver-blocker cycle:
+
+`allSelectedIndices` → `indicesMatchedByBoundValue` → `c1.text` → composite expansion of `$c1.selected` → `c1.selected` → `childIndicesSelected` → `selectedIndices` → `allSelectedIndices`
+
+The fix makes `indicesMatchedByBoundValue` only declare the `choiceChildren.text` dependency when `bindValueTo` is actually set, breaking the cycle.
+
+Closes #1399.

--- a/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
+++ b/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
@@ -714,29 +714,30 @@ export default class Choiceinput extends Input {
         };
 
         stateVariableDefinitions.indicesMatchedByBoundValue = {
-            // Only pull in choiceChildren.text when bindValueTo is present.
-            // When bindValueTo is absent this variable always returns [],
-            // so the text dependency is unnecessary and causes the cycle
-            // described on hasBoundValue above.
+            // Only pull in bound-value-specific dependencies when
+            // bindValueTo is present. When bindValueTo is absent this
+            // variable always returns [], so those dependencies are
+            // unnecessary and the choiceChildren.text dependency causes the
+            // cycle described on hasBoundValue above.
             stateVariablesDeterminingDependencies: ["hasBoundValue"],
             returnDependencies: ({ stateValues }) => {
                 const deps = {
-                    choiceOrder: {
-                        dependencyType: "stateVariable",
-                        variableName: "choiceOrder",
-                    },
                     bindValueTo: {
                         dependencyType: "attributeComponent",
                         attributeName: "bindValueTo",
                         variableNames: ["value"],
                     },
-                    selectMultiple: {
-                        dependencyType: "stateVariable",
-                        variableName: "selectMultiple",
-                    },
                 };
 
                 if (stateValues.hasBoundValue) {
+                    deps.choiceOrder = {
+                        dependencyType: "stateVariable",
+                        variableName: "choiceOrder",
+                    };
+                    deps.selectMultiple = {
+                        dependencyType: "stateVariable",
+                        variableName: "selectMultiple",
+                    };
                     deps.choiceChildren = {
                         dependencyType: "child",
                         childGroups: ["choices"],

--- a/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
+++ b/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
@@ -690,33 +690,68 @@ export default class Choiceinput extends Input {
             },
         };
 
-        stateVariableDefinitions.indicesMatchedByBoundValue = {
+        // hasBoundValue is used by indicesMatchedByBoundValue to avoid
+        // depending on choiceChildren.text when bindValueTo is absent.
+        // Without this guard, $choice.selected inside a <choice> creates a
+        // circular resolve-blocker:
+        //   allSelectedIndices → indicesMatchedByBoundValue → c1.text
+        //   → ($c1.selected composite) → c1.selected → childIndicesSelected
+        //   → selectedIndices → allSelectedIndices
+        stateVariableDefinitions.hasBoundValue = {
             returnDependencies: () => ({
-                choiceOrder: {
-                    dependencyType: "stateVariable",
-                    variableName: "choiceOrder",
-                },
-                choiceChildren: {
-                    dependencyType: "child",
-                    childGroups: ["choices"],
-                    variableNames: ["text"],
-                },
                 bindValueTo: {
                     dependencyType: "attributeComponent",
                     attributeName: "bindValueTo",
-                    variableNames: ["value"],
-                },
-                selectMultiple: {
-                    dependencyType: "stateVariable",
-                    variableName: "selectMultiple",
                 },
             }),
             definition({ dependencyValues }) {
-                let choiceChildrenOrdered = dependencyValues.choiceOrder.map(
-                    (i) => dependencyValues.choiceChildren[i - 1],
-                );
+                return {
+                    setValue: {
+                        hasBoundValue: dependencyValues.bindValueTo !== null,
+                    },
+                };
+            },
+        };
 
+        stateVariableDefinitions.indicesMatchedByBoundValue = {
+            // Only pull in choiceChildren.text when bindValueTo is present.
+            // When bindValueTo is absent this variable always returns [],
+            // so the text dependency is unnecessary and causes the cycle
+            // described on hasBoundValue above.
+            stateVariablesDeterminingDependencies: ["hasBoundValue"],
+            returnDependencies: ({ stateValues }) => {
+                const deps = {
+                    choiceOrder: {
+                        dependencyType: "stateVariable",
+                        variableName: "choiceOrder",
+                    },
+                    bindValueTo: {
+                        dependencyType: "attributeComponent",
+                        attributeName: "bindValueTo",
+                        variableNames: ["value"],
+                    },
+                    selectMultiple: {
+                        dependencyType: "stateVariable",
+                        variableName: "selectMultiple",
+                    },
+                };
+
+                if (stateValues.hasBoundValue) {
+                    deps.choiceChildren = {
+                        dependencyType: "child",
+                        childGroups: ["choices"],
+                        variableNames: ["text"],
+                    };
+                }
+
+                return deps;
+            },
+            definition({ dependencyValues }) {
                 if (dependencyValues.bindValueTo !== null) {
+                    const choiceChildrenOrdered =
+                        dependencyValues.choiceOrder.map(
+                            (i) => dependencyValues.choiceChildren[i - 1],
+                        );
                     let choiceTexts = choiceChildrenOrdered.map((x) =>
                         x.stateValues.text.toLowerCase().trim(),
                     );

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/choiceinput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/choiceinput.test.ts
@@ -4119,4 +4119,99 @@ ${tagLine}
             stateVariables[await resolvePathToNodeIdx("f")].stateValues.value,
         ).eq(false);
     });
+
+    it("$c1.selected inside c1 does not cause circular dependency (issue #1399)", async () => {
+        // Referencing a choice's own `selected` property inside its content
+        // used to cause a circular resolve-blocker cycle.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<choiceInput name="ci">
+  <choice name="c1">$c1.selected</choice>
+  <choice name="c2">cat</choice>
+</choiceInput>
+`,
+        });
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(0);
+
+        const c1Idx = await resolvePathToNodeIdx("c1");
+        const c2Idx = await resolvePathToNodeIdx("c2");
+        const ciIdx = await resolvePathToNodeIdx("ci");
+
+        let sv = await core.returnAllStateVariables(false, true);
+        // Initially nothing selected
+        expect(sv[c1Idx].stateValues.selected).eq(false);
+        expect(sv[c2Idx].stateValues.selected).eq(false);
+        // c1's text renders $c1.selected = false
+        expect(sv[ciIdx].stateValues.choiceTexts[0].trim()).eq("false");
+
+        // Select c1 (display index 1)
+        await updateSelectedIndices({
+            componentIdx: ciIdx,
+            selectedIndices: [1],
+            core,
+        });
+        sv = await core.returnAllStateVariables(false, true);
+        expect(sv[c1Idx].stateValues.selected).eq(true);
+        expect(sv[c2Idx].stateValues.selected).eq(false);
+        // c1's text now renders $c1.selected = true
+        expect(sv[ciIdx].stateValues.choiceTexts[0].trim()).eq("true");
+
+        // Deselect c1
+        await updateSelectedIndices({
+            componentIdx: ciIdx,
+            selectedIndices: [],
+            core,
+        });
+        sv = await core.returnAllStateVariables(false, true);
+        expect(sv[c1Idx].stateValues.selected).eq(false);
+        expect(sv[ciIdx].stateValues.choiceTexts[0].trim()).eq("false");
+    });
+
+    it("conditionalContent depending on choice.selected inside choice does not cause circular dependency (issue #1399)", async () => {
+        // The discussion post linked from issue #1399 shows conditionalContent
+        // inside a choice whose condition references the choice's own `selected`.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<choiceInput name="ci">
+  <choice name="c1">
+    The expression can be factored
+    <conditionalContent>
+      <case condition="$c1.selected">
+        and it factors further
+      </case>
+      <else>.</else>
+    </conditionalContent>
+  </choice>
+  <choice name="c2">Other choice</choice>
+</choiceInput>
+`,
+        });
+
+        const diagnostics = getDiagnosticsByType(core);
+        expect(diagnostics.errors.length).eq(0);
+
+        const c1Idx = await resolvePathToNodeIdx("c1");
+        const ciIdx = await resolvePathToNodeIdx("ci");
+
+        let sv = await core.returnAllStateVariables(false, true);
+        expect(sv[c1Idx].stateValues.selected).eq(false);
+        // When not selected the else branch renders "."
+        expect(sv[ciIdx].stateValues.choiceTexts[0]).contain(".");
+        expect(sv[ciIdx].stateValues.choiceTexts[0]).not.contain(
+            "factors further",
+        );
+
+        // Select c1
+        await updateSelectedIndices({
+            componentIdx: ciIdx,
+            selectedIndices: [1],
+            core,
+        });
+        sv = await core.returnAllStateVariables(false, true);
+        expect(sv[c1Idx].stateValues.selected).eq(true);
+        // When selected the case branch renders "and it factors further"
+        expect(sv[ciIdx].stateValues.choiceTexts[0]).contain("factors further");
+    });
 });


### PR DESCRIPTION
## Summary

Fixes a \"Circular dependency detected\" error that occurred when a `<choice>` referenced its own `selected` property within its content.

### Simple case (issue body)
```xml
<choiceInput>
  <choice name=\"c1\">$c1.selected</choice>
</choiceInput>
```

### Complex case (linked discussion)
```xml
<choice name=\"choice4\">
  The expression can be factored
  <conditionalContent>
    <case condition=\"$choice4.selected=true\">
      and it factors to <mathInput name=\"userInput1\" />
    </case>
    <else>.</else>
  </conditionalContent>
</choice>
```

Both patterns previously threw a circular dependency error. Both now work correctly.

## Root Cause

`indicesMatchedByBoundValue` in `ChoiceInput.js` always declared `choiceChildren.text` as a resolve-blocker dependency even when `bindValueTo` was absent (where the text is never actually used). This created a cycle:

```
allSelectedIndices → indicesMatchedByBoundValue → c1.text
  → composite expansion of $c1.selected → c1.selected
  → childIndicesSelected → selectedIndices → allSelectedIndices
```

## Fix

- Added a `hasBoundValue` boolean state variable (depends only on `bindValueTo` attribute presence)
- `indicesMatchedByBoundValue` now uses `stateVariablesDeterminingDependencies: [\"hasBoundValue\"]`
- `indicesMatchedByBoundValue` only declares its bound-value-specific dependencies when `bindValueTo` is actually set, so the unnecessary `choiceChildren.text` dependency no longer participates in the cycle

When `bindValueTo` is absent, the variable always returns `[]`, so removing those dependencies preserves existing behavior while breaking the resolver-blocker cycle.

## Tests

Two new tests added to `choiceinput.test.ts`:
- `$c1.selected inside c1 does not cause circular dependency`
- `conditionalContent depending on choice.selected inside choice does not cause circular dependency`

Closes #1399.

---
🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)