### PR TITLE
feat: upgrade prefigure to 0.6.7 and add native fill-pattern support

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,5 +15,5 @@
     "access": "restricted",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": []
+    "ignore": ["@doenet/prefigure"]
 }

--- a/.changeset/graph-fill-style-patterns.md
+++ b/.changeset/graph-fill-style-patterns.md
@@ -4,7 +4,6 @@
 "@doenet/doenetml-iframe": patch
 "@doenet/vscode-extension": patch
 "doenet-vscode-extension": patch
-"@doenet/prefigure": patch
 ---
 
 Graph: revise closed-shape `fillStyle` patterns and add `fillPatternOpacity`.
@@ -25,8 +24,6 @@ The `dots` and `diamonds` patterns are drawn from the BANA (Braille Authority of
 
 The previous `crosshatch` and `diagonalCrosshatch` values are replaced by `dots` and `diamonds`, respectively.
 
-The JSXGraph interactive renderer supports all patterns. Filled circles and polygons also include the pattern wording in their text style descriptions (such as `styleDescription` and `fillStyleDescription`).
-
-`@doenet/prefigure` no longer injects SVG hatch definitions. Until native PreFigure pattern support lands, non-solid `fillStyle` values there warn and fall back to solid fills.
+The JSXGraph interactive renderer supports all patterns. The PreFigure renderer uses the native `fill-pattern` attribute (available from prefig 0.6.7). Filled circles and polygons also include the pattern wording in their text style descriptions (such as `styleDescription` and `fillStyleDescription`).
 
 Closes #1386.

--- a/.changeset/prefigure-fill-pattern-native.md
+++ b/.changeset/prefigure-fill-pattern-native.md
@@ -1,10 +1,9 @@
 ---
-"@doenet/prefigure": patch
 "@doenet/doenetml": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
 ---
 
-Upgrade PreFigure runtime to 0.6.7 and add native fill-pattern support.
+PreFigure renderer: use native `fill-pattern` attribute for patterned `fillStyle` values.
 
 The `@doenet/prefigure` package now vendors `prefig-0.6.7-py3-none-any.whl`, which added native `fill-pattern` support. The PreFigure renderer now uses the `fill-pattern` attribute for patterned `fillStyle` values (`horizontal`, `vertical`, `diagonal`, `backDiagonal`, `dots`, `diamonds`) instead of falling back to a solid fill with a warning. Pattern opacity is controlled by `fillPatternOpacity` (mapped to `fill-opacity` on the patterned element).

--- a/.changeset/prefigure-fill-pattern-native.md
+++ b/.changeset/prefigure-fill-pattern-native.md
@@ -1,0 +1,10 @@
+---
+"@doenet/prefigure": patch
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Upgrade PreFigure runtime to 0.6.7 and add native fill-pattern support.
+
+The `@doenet/prefigure` package now vendors `prefig-0.6.7-py3-none-any.whl`, which added native `fill-pattern` support. The PreFigure renderer now uses the `fill-pattern` attribute for patterned `fillStyle` values (`horizontal`, `vertical`, `diagonal`, `backDiagonal`, `dots`, `diamonds`) instead of falling back to a solid fill with a warning. Pattern opacity is controlled by `fillPatternOpacity` (mapped to `fill-opacity` on the patterned element).

--- a/.changeset/prefigure-fill-pattern-native.md
+++ b/.changeset/prefigure-fill-pattern-native.md
@@ -2,6 +2,8 @@
 "@doenet/doenetml": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
 ---
 
 PreFigure renderer: use native `fill-pattern` attribute for patterned `fillStyle` values.

--- a/.github/skills/changesets/SKILL.md
+++ b/.github/skills/changesets/SKILL.md
@@ -24,7 +24,12 @@ Bump any one of these and Changesets bumps all six. Listing or omitting a fixed-
 
 ## Independent Versioning
 
-- `@doenet/prefigure` versions independently.
+`@doenet/prefigure` is published but **never listed in any changeset**. Its npm
+version is manually pinned to match the bundled `prefig` Python wheel version
+(e.g. `0.6.7`) so consumers can see which upstream Python runtime they are
+running. It lives in the `ignore` list in `.changeset/config.json`. When
+bumping the prefig wheel, update `packages/prefigure/package.json` directly
+following the instructions in `packages/prefigure/README.md`.
 
 ## Never Versioned
 

--- a/packages/doenetml-print/src/ptx-compiler.ts
+++ b/packages/doenetml-print/src/ptx-compiler.ts
@@ -16,8 +16,8 @@ const rawPackaging = rawPackagingImport as Uint8Array;
 import rawLxmlImport from "./assets/lxml-5.2.1-cp312-cp312-pyodide_2024_0_wasm32.whl?uint8array&base64";
 const rawLxml = rawLxmlImport as Uint8Array;
 
-// @ts-ignore
 // Keep this wheel path in sync with PREFIG_VERSION in packages/prefigure/src/worker/compiler-metadata.ts
+// @ts-ignore
 import rawPrefigImport from "../../prefigure/pyodide_packages/prefig-0.6.7-py3-none-any.whl?uint8array&base64";
 const rawPrefig = rawPrefigImport as Uint8Array;
 

--- a/packages/doenetml-print/src/ptx-compiler.ts
+++ b/packages/doenetml-print/src/ptx-compiler.ts
@@ -17,7 +17,8 @@ import rawLxmlImport from "./assets/lxml-5.2.1-cp312-cp312-pyodide_2024_0_wasm32
 const rawLxml = rawLxmlImport as Uint8Array;
 
 // @ts-ignore
-import rawPrefigImport from "../../prefigure/pyodide_packages/prefig-0.5.15-py3-none-any.whl?uint8array&base64";
+// Keep this wheel path in sync with PREFIG_VERSION in packages/prefigure/src/worker/compiler-metadata.ts
+import rawPrefigImport from "../../prefigure/pyodide_packages/prefig-0.6.7-py3-none-any.whl?uint8array&base64";
 const rawPrefig = rawPrefigImport as Uint8Array;
 
 type PyodideAPI = Awaited<ReturnType<typeof loadPyodide>>;

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -270,15 +270,6 @@ describe("Graph prefigure renderer core @group4", () => {
         expect(prefigureXML).toContain(`fill-opacity="0.8"`);
         expect(prefigureXML).not.toContain(`fill-opacity="0.3"`);
         expect(prefigureXML).not.toContain(`url(#`);
-        expect(prefigureXML.indexOf(`fill-pattern="dot"`)).toBeLessThan(
-            prefigureXML.indexOf(`stroke-opacity="0.7"`),
-        );
-        expect(prefigureXML.indexOf(`fill="green"`)).toBeLessThan(
-            prefigureXML.indexOf(`stroke-opacity="0.7"`),
-        );
-        expect(prefigureXML.indexOf(`fill-opacity="0.8"`)).toBeGreaterThan(
-            prefigureXML.indexOf(`stroke-opacity="0.7"`),
-        );
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(diagnosticsByType.warnings).toHaveLength(0);

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -266,9 +266,19 @@ describe("Graph prefigure renderer core @group4", () => {
 
         expect(prefigureXML).toContain(`fill-pattern="dot"`);
         expect(prefigureXML).toContain(`fill="green"`);
+        expect(prefigureXML).toContain(`stroke-opacity="0.7"`);
         expect(prefigureXML).toContain(`fill-opacity="0.8"`);
         expect(prefigureXML).not.toContain(`fill-opacity="0.3"`);
         expect(prefigureXML).not.toContain(`url(#`);
+        expect(prefigureXML.indexOf(`fill-pattern="dot"`)).toBeLessThan(
+            prefigureXML.indexOf(`stroke-opacity="0.7"`),
+        );
+        expect(prefigureXML.indexOf(`fill="green"`)).toBeLessThan(
+            prefigureXML.indexOf(`stroke-opacity="0.7"`),
+        );
+        expect(prefigureXML.indexOf(`fill-opacity="0.8"`)).toBeGreaterThan(
+            prefigureXML.indexOf(`stroke-opacity="0.7"`),
+        );
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -281,11 +281,7 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         const diagnosticsByType = await getWarnings(doenetML);
-        expect(
-            diagnosticsByType.warnings.some((x) =>
-                x.message.includes("fill style"),
-            ),
-        ).eq(false);
+        expect(diagnosticsByType.warnings).toHaveLength(0);
     });
 
     it("renderer=prefigure maps endpoint and equilibriumPoint as points", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -255,7 +255,7 @@ describe("Graph prefigure renderer core @group4", () => {
         );
     });
 
-    it("renderer=prefigure warns and falls back to solid fills for patterned polygons", async () => {
+    it("renderer=prefigure uses fill-pattern for patterned polygon fills", async () => {
         const doenetML = withStyleDefinitions(
             '    <styleDefinition styleNumber="7" fillColor="green" fillStyle="dots" fillOpacity="0.3" fillPatternOpacity="0.8" />',
             prefigureGraph(
@@ -264,18 +264,18 @@ describe("Graph prefigure renderer core @group4", () => {
         );
         const prefigureXML = await getPrefigureXML(doenetML);
 
+        expect(prefigureXML).toContain(`fill-pattern="dot"`);
         expect(prefigureXML).toContain(`fill="green"`);
-        expect(prefigureXML).toContain(`fill-opacity="0.3"`);
+        expect(prefigureXML).toContain(`fill-opacity="0.8"`);
+        expect(prefigureXML).not.toContain(`fill-opacity="0.3"`);
         expect(prefigureXML).not.toContain(`url(#`);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(
             diagnosticsByType.warnings.some((x) =>
-                x.message.includes(
-                    "fill style 'dots' is unsupported by PreFigure; falling back to a solid fill.",
-                ),
+                x.message.includes("fill style"),
             ),
-        ).eq(true);
+        ).eq(false);
     });
 
     it("renderer=prefigure maps endpoint and equilibriumPoint as points", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -127,7 +127,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><line at="line_0" endpoints="((1,2),(3,4))" infinite="yes" stroke="#1f5dff" thickness="4" fill="#1f5dff" stroke-opacity="0.7" fill-opacity="0.3" label-location="0.95" alignment="s">A</line></coordinates><annotations></annotations></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><line at="line_0" endpoints="((1,2),(3,4))" infinite="yes" stroke="#1f5dff" thickness="4" fill="#1f5dff" fill-opacity="0.3" stroke-opacity="0.7" label-location="0.95" alignment="s">A</line></coordinates><annotations></annotations></diagram>"`,
         );
     });
 
@@ -1083,7 +1083,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><vector at="vector_0" tail="(0,0)" v="(3,3)" stroke="#1f5dff" thickness="4" fill="#1f5dff" stroke-opacity="0.7" fill-opacity="0.3" /><label p="(2.85,2.85)" alignment="north">V</label></coordinates><annotations></annotations></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><vector at="vector_0" tail="(0,0)" v="(3,3)" stroke="#1f5dff" thickness="4" fill="#1f5dff" fill-opacity="0.3" stroke-opacity="0.7" /><label p="(2.85,2.85)" alignment="north">V</label></coordinates><annotations></annotations></diagram>"`,
         );
     });
 
@@ -1194,9 +1194,10 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).toContain(
             `points="((3,0),(5,0),(4,1))" closed="yes" stroke="#1f5dff" thickness="4" fill="red"`,
         );
-        expect(prefigureXML).toContain(
-            `points="((3,0),(5,0),(4,1))" closed="yes" stroke="#1f5dff" thickness="4" fill="red" stroke-opacity="0.7" fill-opacity="0.4"`,
-        );
+        // Verify fill attrs are present on the filled polygon (order-independent)
+        expect(prefigureXML).toContain(`fill="red"`);
+        expect(prefigureXML).toContain(`stroke-opacity="0.7"`);
+        expect(prefigureXML).toContain(`fill-opacity="0.4"`);
     });
 
     it("renderer=prefigure maps triangle and rectangle directly to polygons", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
@@ -32,21 +32,6 @@ describe("PreFigure style attributes", () => {
             expect(attrs).toContain('fill-opacity="0.8"');
             expect(attrs).not.toContain('fill-opacity="0.3"');
             expect(attrs.join(" ")).not.toContain("url(#");
-            expect(
-                attrs.findIndex(
-                    (x) => x === `fill-pattern="${expectedPattern}"`,
-                ),
-            ).toBeLessThan(
-                attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
-            );
-            expect(attrs.findIndex((x) => x === 'fill="#abcd"')).toBeLessThan(
-                attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
-            );
-            expect(
-                attrs.findIndex((x) => x === 'fill-opacity="0.8"'),
-            ).toBeGreaterThan(
-                attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
-            );
             expect(diagnostics).toHaveLength(0);
         },
     );
@@ -92,12 +77,6 @@ describe("PreFigure style attributes", () => {
         expect(attrs).toContain('fill-opacity="0.3"');
         expect(attrs).not.toContain('fill-pattern="solid"');
         expect(attrs).not.toContain('fill-opacity="0.8"');
-        expect(attrs.findIndex((x) => x === 'fill="blue"')).toBeLessThan(
-            attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
-        );
-        expect(
-            attrs.findIndex((x) => x === 'fill-opacity="0.3"'),
-        ).toBeGreaterThan(attrs.findIndex((x) => x === 'stroke-opacity="0.7"'));
         expect(diagnostics).toHaveLength(0);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
@@ -18,6 +18,7 @@ describe("PreFigure style attributes", () => {
                 selectedStyle: {
                     fillColor: "#abcd",
                     fillStyle,
+                    lineOpacity: 0.7,
                     fillOpacity: 0.3,
                     fillPatternOpacity: 0.8,
                 },
@@ -27,9 +28,25 @@ describe("PreFigure style attributes", () => {
 
             expect(attrs).toContain(`fill-pattern="${expectedPattern}"`);
             expect(attrs).toContain('fill="#abcd"');
+            expect(attrs).toContain('stroke-opacity="0.7"');
             expect(attrs).toContain('fill-opacity="0.8"');
             expect(attrs).not.toContain('fill-opacity="0.3"');
             expect(attrs.join(" ")).not.toContain("url(#");
+            expect(
+                attrs.findIndex(
+                    (x) => x === `fill-pattern="${expectedPattern}"`,
+                ),
+            ).toBeLessThan(
+                attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
+            );
+            expect(attrs.findIndex((x) => x === 'fill="#abcd"')).toBeLessThan(
+                attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
+            );
+            expect(
+                attrs.findIndex((x) => x === 'fill-opacity="0.8"'),
+            ).toBeGreaterThan(
+                attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
+            );
             expect(diagnostics).toHaveLength(0);
         },
     );
@@ -62,14 +79,25 @@ describe("PreFigure style attributes", () => {
             selectedStyle: {
                 fillColorWord: "blue",
                 fillStyle: "solid",
+                lineOpacity: 0.7,
                 fillOpacity: 0.3,
+                fillPatternOpacity: 0.8,
             },
             diagnostics,
             warningPrefix: "test",
         });
 
         expect(attrs).toContain('fill="blue"');
+        expect(attrs).toContain('stroke-opacity="0.7"');
         expect(attrs).toContain('fill-opacity="0.3"');
+        expect(attrs).not.toContain('fill-pattern="solid"');
+        expect(attrs).not.toContain('fill-opacity="0.8"');
+        expect(attrs.findIndex((x) => x === 'fill="blue"')).toBeLessThan(
+            attrs.findIndex((x) => x === 'stroke-opacity="0.7"'),
+        );
+        expect(
+            attrs.findIndex((x) => x === 'fill-opacity="0.3"'),
+        ).toBeGreaterThan(attrs.findIndex((x) => x === 'stroke-opacity="0.7"'));
         expect(diagnostics).toHaveLength(0);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/style.test.ts
@@ -3,9 +3,16 @@ import { styleAttributes } from "../../utils/prefigure/style";
 import type { DiagnosticRecord } from "@doenet/utils";
 
 describe("PreFigure style attributes", () => {
-    it.each(["dots", "diagonal"])(
-        "falls back to solid fills for non-solid fillStyle value %s",
-        (fillStyle) => {
+    it.each([
+        ["horizontal", "horizontal"],
+        ["vertical", "vertical"],
+        ["diagonal", "diagonal"],
+        ["backdiagonal", "backdiagonal"],
+        ["dots", "dot"],
+        ["diamonds", "diamond"],
+    ])(
+        "emits fill-pattern for supported fillStyle value %s",
+        (fillStyle, expectedPattern) => {
             const diagnostics: DiagnosticRecord[] = [];
             const attrs = styleAttributes({
                 selectedStyle: {
@@ -18,16 +25,36 @@ describe("PreFigure style attributes", () => {
                 warningPrefix: "test",
             });
 
+            expect(attrs).toContain(`fill-pattern="${expectedPattern}"`);
             expect(attrs).toContain('fill="#abcd"');
-            expect(attrs).toContain('fill-opacity="0.3"');
+            expect(attrs).toContain('fill-opacity="0.8"');
+            expect(attrs).not.toContain('fill-opacity="0.3"');
             expect(attrs.join(" ")).not.toContain("url(#");
-            expect(diagnostics).toHaveLength(1);
-            expect(diagnostics[0].type).toBe("warning");
-            expect(diagnostics[0].message).toContain(
-                `fill style '${fillStyle}' is unsupported by PreFigure; falling back to a solid fill.`,
-            );
+            expect(diagnostics).toHaveLength(0);
         },
     );
+
+    it("warns and falls back to solid fill for unsupported fillStyle value", () => {
+        const diagnostics: DiagnosticRecord[] = [];
+        const attrs = styleAttributes({
+            selectedStyle: {
+                fillColor: "#abcd",
+                fillStyle: "crosshatch",
+                fillOpacity: 0.3,
+            },
+            diagnostics,
+            warningPrefix: "test",
+        });
+
+        expect(attrs).toContain('fill="#abcd"');
+        expect(attrs).toContain('fill-opacity="0.3"');
+        expect(attrs.join(" ")).not.toContain("fill-pattern");
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].type).toBe("warning");
+        expect(diagnostics[0].message).toContain(
+            `fill style 'crosshatch' is unsupported by PreFigure; falling back to a solid fill.`,
+        );
+    });
 
     it("keeps solid fills warning-free", () => {
         const diagnostics: DiagnosticRecord[] = [];

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
@@ -110,29 +110,14 @@ export function styleAttributes({
                 ? prefigureFillPatternByFillStyle[fillStyle]
                 : undefined;
 
-        if (prefigurePattern !== undefined) {
-            attrs.push(`fill-pattern="${escapeXml(prefigurePattern)}"`);
-        }
         const fill = selectedStyle?.fillColor ?? selectedStyle?.fillColorWord;
-        if (fill) {
-            attrs.push(`fill="${escapeXml(fill)}"`);
-        }
-    }
-
-    const lineOpacity = formatNumber(selectedStyle?.lineOpacity);
-    if (lineOpacity !== null) {
-        attrs.push(`stroke-opacity="${escapeXml(lineOpacity)}"`);
-    }
-
-    if (includeFill) {
-        const fillStyle = selectedStyle?.fillStyle;
-        const prefigurePattern =
-            fillStyle && fillStyle !== "solid"
-                ? prefigureFillPatternByFillStyle[fillStyle]
-                : undefined;
 
         if (prefigurePattern !== undefined) {
-            // Patterned fill: use fillPatternOpacity for opacity
+            // Patterned fill: emit fill-pattern, fill color, and fillPatternOpacity
+            attrs.push(`fill-pattern="${escapeXml(prefigurePattern)}"`);
+            if (fill) {
+                attrs.push(`fill="${escapeXml(fill)}"`);
+            }
             const fillPatternOpacity = formatNumber(
                 selectedStyle?.fillPatternOpacity,
             );
@@ -141,6 +126,9 @@ export function styleAttributes({
             }
         } else {
             // Solid fill (or unsupported pattern falling back to solid)
+            if (fill) {
+                attrs.push(`fill="${escapeXml(fill)}"`);
+            }
             const fillOpacity = formatNumber(selectedStyle?.fillOpacity);
             if (fillOpacity !== null) {
                 attrs.push(`fill-opacity="${escapeXml(fillOpacity)}"`);
@@ -153,6 +141,11 @@ export function styleAttributes({
                 });
             }
         }
+    }
+
+    const lineOpacity = formatNumber(selectedStyle?.lineOpacity);
+    if (lineOpacity !== null) {
+        attrs.push(`stroke-opacity="${escapeXml(lineOpacity)}"`);
     }
 
     const lineStyle = selectedStyle?.lineStyle;

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/style.ts
@@ -3,6 +3,19 @@ import { escapeXml, formatNumber, pushWarning } from "./common";
 import type { SelectedStyle } from "./types";
 import type { DiagnosticRecord } from "@doenet/utils";
 
+/**
+ * Maps DoenetML fillStyle values (stored lowercase) to prefigure fill-pattern values.
+ * DoenetML's "dots"/"diamonds" (plural) map to prefigure's "dot"/"diamond" (singular).
+ */
+const prefigureFillPatternByFillStyle: Record<string, string> = {
+    horizontal: "horizontal",
+    vertical: "vertical",
+    diagonal: "diagonal",
+    backdiagonal: "backdiagonal",
+    dots: "dot",
+    diamonds: "diamond",
+};
+
 const prefigureDashByLineStyle: Record<string, string | null> = {
     solid: null,
     dashed: "9 9",
@@ -91,6 +104,15 @@ export function styleAttributes({
     }
 
     if (includeFill) {
+        const fillStyle = selectedStyle?.fillStyle;
+        const prefigurePattern =
+            fillStyle && fillStyle !== "solid"
+                ? prefigureFillPatternByFillStyle[fillStyle]
+                : undefined;
+
+        if (prefigurePattern !== undefined) {
+            attrs.push(`fill-pattern="${escapeXml(prefigurePattern)}"`);
+        }
         const fill = selectedStyle?.fillColor ?? selectedStyle?.fillColorWord;
         if (fill) {
             attrs.push(`fill="${escapeXml(fill)}"`);
@@ -103,18 +125,33 @@ export function styleAttributes({
     }
 
     if (includeFill) {
-        const fillOpacity = formatNumber(selectedStyle?.fillOpacity);
-        if (fillOpacity !== null) {
-            attrs.push(`fill-opacity="${escapeXml(fillOpacity)}"`);
-        }
-
         const fillStyle = selectedStyle?.fillStyle;
-        if (fillStyle && fillStyle !== "solid") {
-            pushWarning({
-                diagnostics,
-                message: `${warningPrefix}: fill style '${fillStyle}' is unsupported by PreFigure; falling back to a solid fill.`,
-                position: warningPosition,
-            });
+        const prefigurePattern =
+            fillStyle && fillStyle !== "solid"
+                ? prefigureFillPatternByFillStyle[fillStyle]
+                : undefined;
+
+        if (prefigurePattern !== undefined) {
+            // Patterned fill: use fillPatternOpacity for opacity
+            const fillPatternOpacity = formatNumber(
+                selectedStyle?.fillPatternOpacity,
+            );
+            if (fillPatternOpacity !== null) {
+                attrs.push(`fill-opacity="${escapeXml(fillPatternOpacity)}"`);
+            }
+        } else {
+            // Solid fill (or unsupported pattern falling back to solid)
+            const fillOpacity = formatNumber(selectedStyle?.fillOpacity);
+            if (fillOpacity !== null) {
+                attrs.push(`fill-opacity="${escapeXml(fillOpacity)}"`);
+            }
+            if (fillStyle && fillStyle !== "solid") {
+                pushWarning({
+                    diagnostics,
+                    message: `${warningPrefix}: fill style '${fillStyle}' is unsupported by PreFigure; falling back to a solid fill.`,
+                    position: warningPosition,
+                });
+            }
         }
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
@@ -34,6 +34,7 @@ export interface SelectedStyle {
     fillColorWord?: string;
     lineOpacity?: number;
     fillOpacity?: number;
+    fillPatternOpacity?: number;
     lineStyle?: string;
     fillStyle?: string;
     markerStyle?: string;

--- a/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
@@ -5,7 +5,7 @@ const DEFAULT_PREFIGURE_DIAGCESS_SCRIPT_URL =
 // It is configured here (not auto-derived from prefigure package metadata),
 // but should still be manually kept aligned with runtime version bumps.
 const DEFAULT_PREFIGURE_MODULE_URL =
-    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.15/prefigure.js";
+    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.6.7/prefigure.js";
 
 const env = (
     import.meta as ImportMeta & {

--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -150,7 +150,11 @@ npm run verify-wheel-sync -w @doenet/prefigure
 
 ### Upgrade PreFigure runtime version
 
-1. Update `version` in `packages/prefigure/package.json`.
+`@doenet/prefigure` is **not** managed by Changesets. Its npm version is manually
+pinned to match the bundled `prefig` Python wheel so consumers can immediately
+see which upstream version they are running. Follow these steps when bumping:
+
+1. Update `version` in `packages/prefigure/package.json` to match the new wheel version.
 2. Update `PREFIG_VERSION` in `src/worker/compiler-metadata.ts`.
 3. Update the default CDN module URL in `packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts`.
 4. If the bundled accessibility runtime changed, update the default diagcess CDN URL there as well.

--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -159,9 +159,10 @@ see which upstream version they are running. Follow these steps when bumping:
 3. Update the default CDN module URL in `packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts`.
 4. If the bundled accessibility runtime changed, update the default diagcess CDN URL there as well.
 5. Update `prefigure.doenet.org` outside this repository so the fallback build-service path matches the new runtime behavior before local WASM compilation warms up.
-6. Run `npm run setup -w @doenet/prefigure` to fetch the matching `prefig-<version>-py3-none-any.whl`.
-7. Run `npm run verify-wheel-sync -w @doenet/prefigure`.
-8. Build and run the browser runtime check:
+6. Update the hardcoded wheel path in `packages/doenetml-print/src/ptx-compiler.ts` — the Vite `?uint8array&base64` asset import must be a static literal string, so it cannot reference `PREFIG_WHEEL_FILENAME` directly. Search for the old version string and replace it.
+7. Run `npm run setup -w @doenet/prefigure` to fetch the matching `prefig-<version>-py3-none-any.whl`.
+8. Run `npm run verify-wheel-sync -w @doenet/prefigure`.
+9. Build and run the browser runtime check:
 
 ```bash
 npm run build -w @doenet/prefigure

--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -29,7 +29,7 @@ Or load from CDN:
 
 ```html
 <script type="module">
-  import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.15/prefigure.js';
+  import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.6.7/prefigure.js';
   await prefigure.initPrefigure();
   const result = await prefigure.compilePrefigure(diagramXml, { mode: 'svg' });
 </script>

--- a/packages/prefigure/package.json
+++ b/packages/prefigure/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/prefigure",
     "type": "module",
     "description": "Standalone PreFigure WASM compiler for browser and CDN usage",
-    "version": "0.5.15",
+    "version": "0.6.7",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/prefigure/src/worker/compiler-metadata.ts
+++ b/packages/prefigure/src/worker/compiler-metadata.ts
@@ -13,5 +13,5 @@
  *
  * Keep this file free of imports so it tree-shakes to a tiny constant.
  */
-export const PREFIG_VERSION = "0.5.15";
+export const PREFIG_VERSION = "0.6.7";
 export const PREFIG_WHEEL_FILENAME = `prefig-${PREFIG_VERSION}-py3-none-any.whl`;


### PR DESCRIPTION
## Summary

Upgrades the bundled `prefig` Python wheel to 0.6.7 (which added native `@fill-pattern` support) and wires the PreFigure renderer to use it for patterned `fillStyle` values.

### PreFigure fill-pattern support

The PreFigure renderer now emits the native `fill-pattern` attribute instead of warning and falling back to solid fills. The mapping from DoenetML `fillStyle` to prefigure `fill-pattern`:

| DoenetML `fillStyle` | PreFigure `fill-pattern` |
|---|---|
| `horizontal` | `horizontal` |
| `vertical` | `vertical` |
| `diagonal` | `diagonal` |
| `backDiagonal` | `backdiagonal` |
| `dots` | `dot` |
| `diamonds` | `diamond` |

Pattern opacity is taken from `fillPatternOpacity`. Unsupported `fillStyle` values still warn and fall back to solid.

### prefig wheel upgrade (0.5.15 → 0.6.7)

- `compiler-metadata.ts`: `PREFIG_VERSION = "0.6.7"`
- `packages/prefigure/package.json`: `"version": "0.6.7"`
- Default CDN module URL updated to `@doenet/prefigure@0.6.7`
- Old wheel replaced with `prefig-0.6.7-py3-none-any.whl` via `npm run setup`

### Changeset housekeeping

`@doenet/prefigure`'s npm version is manually pinned to match the bundled `prefig` wheel version — added it to the changeset `ignore` list, updated the prefigure README and the changesets skill to make this explicit, removed the stale `@doenet/prefigure` entry from the `graph-fill-style-patterns` changeset (PR #1396), and kept the dedicated native-PreFigure changeset focused on the renderer-specific behavior across the viewer/editor bundles that surface it.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
