### PR TITLE
fix: suppress false-positive module attribute diagnostics in VSCode extension

### DIFF
--- a/.changeset/vscode-module-custom-attributes.md
+++ b/.changeset/vscode-module-custom-attributes.md
@@ -1,0 +1,10 @@
+---
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+VS Code extension: stop flagging custom `<module>` attributes as unknown when they are declared inside the copied module's `<moduleAttributes>` block.
+
+The extension now passes its bundled DoenetML worker to the language server so the Rust-backed resolver can inspect the referenced module definition before validating a `<module copy="$name" ... />` site.
+
+Closes #1375.

--- a/packages/doenetml-prototype/src/editor/editor-viewer.tsx
+++ b/packages/doenetml-prototype/src/editor/editor-viewer.tsx
@@ -17,6 +17,7 @@ import { ButtonGroup } from "./components/ui/button-group";
 import { Dropdown } from "./components/ui/dropdown";
 import type { CoreType } from "../state/redux-slices/core/slice";
 import { isSaveShortcutKeydown, isMacPlatform } from "@doenet/utils";
+import { doenetGlobalConfig } from "../global-config";
 
 // Injected by vite
 declare const DOENETML_VERSION: string;
@@ -157,6 +158,9 @@ export function EditorViewer({
                                 <div className="editor-panel-codemirror">
                                     <CodeMirror
                                         value={sourceInEditor}
+                                        doenetWorkerUrl={
+                                            doenetGlobalConfig.doenetWorkerUrl
+                                        }
                                         onChange={(source) => {
                                             if (source !== sourceInEditor) {
                                                 setSourceInEditor(source);

--- a/packages/doenetml-prototype/src/global-config.ts
+++ b/packages/doenetml-prototype/src/global-config.ts
@@ -26,6 +26,6 @@ function getWorkerUrl() {
     } catch (e) {
         // `window.location.href` may not be a valid URL. For example, in an iframe it
         // could be `about:srcdoc`.
-        return "https://doenet.org/doenetml-worker/CoreWorker.js";
+        return "https://doenet.org/doenetml-worker/index.js";
     }
 }

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -50,25 +50,34 @@ import {
 } from "./flatDastUpdateFromJS";
 import { resolvePathImmediatelyToNodeIdx } from "@doenet/debug-hooks";
 import { translateJsCoreActionName } from "./jsCoreActionNames";
-let wasmBlobUrl: string = WASM_BYTES_DATA_URL;
-try {
-    // If the URL starts with `data:*;base64,`, then it is a data URL and we want to get
-    // the base64 part
-    if (wasmBlobUrl.match(/^data:.*;base64,/)) {
-        const base64 = wasmBlobUrl.split(",")[1];
-        // Create a blob URL from the base64 data
+// The wasm-bindgen `init` function accepts a `BufferSource` (ArrayBuffer)
+// directly — passing the decoded bytes avoids any `fetch()` round-trip and
+// works in all environments including VS Code's web-worker extension host
+// where `fetch()` is blocked for blob/data URLs (issue #1375).
+// Previously, the data URL was converted to a blob URL first (to work around
+// CORS/Firefox issues with data URLs), but fetching that blob URL is also
+// blocked in VS Code.  Passing the ArrayBuffer directly uses
+// `WebAssembly.instantiate(buffer, imports)` inside wasm-bindgen, which
+// requires no network access at all.
+let wasmInitInput: string | ArrayBuffer = WASM_BYTES_DATA_URL;
+if (
+    typeof wasmInitInput === "string" &&
+    wasmInitInput.match(/^data:.*;base64,/)
+) {
+    try {
+        const base64 = wasmInitInput.split(",")[1];
         const byteCharacters = atob(base64);
-        const byteNumbers = new Uint8Array(byteCharacters.length);
+        const wasmBytes = new Uint8Array(byteCharacters.length);
         for (let i = 0; i < byteCharacters.length; i++) {
-            byteNumbers[i] = byteCharacters.charCodeAt(i);
+            wasmBytes[i] = byteCharacters.charCodeAt(i);
         }
-        const byteArray = new Uint8Array(byteNumbers);
-        wasmBlobUrl = URL.createObjectURL(
-            new Blob([byteArray], { type: "application/wasm" }),
+        wasmInitInput = wasmBytes.buffer;
+    } catch (e) {
+        console.warn(
+            "Error while decoding WASM data URL, falling back to URL (fetch may fail):",
+            e,
         );
     }
-} catch (e) {
-    console.warn("Error while creating blob URL for wasm bundle", e);
 }
 
 /**
@@ -161,7 +170,7 @@ export class CoreWorker {
 
         try {
             if (!this.wasm_initialized) {
-                await init({ module_or_path: wasmBlobUrl });
+                await init({ module_or_path: wasmInitInput });
                 this.wasm_initialized = true;
             }
 
@@ -205,7 +214,7 @@ export class CoreWorker {
 
         try {
             if (!this.wasm_initialized) {
-                await init({ module_or_path: wasmBlobUrl });
+                await init({ module_or_path: wasmInitInput });
                 this.wasm_initialized = true;
             }
 

--- a/packages/lsp-tools/test/module-instance-attributes.test.ts
+++ b/packages/lsp-tools/test/module-instance-attributes.test.ts
@@ -127,6 +127,22 @@ async function moduleAttrDiagnostics(source: string, attrName: string) {
                 );
             });
 
+            it('issue #1375: <math> attribute declared in <moduleAttributes> does not warn (ans="57")', async () => {
+                // Exact DoenetML from the bug report.  VSCode was flagging
+                // `ans` as an unknown attribute because the Rust resolver
+                // adapter was never initialized in the extension context.
+                const source = `<setup>
+  <module name="testModule">
+    <moduleAttributes>
+      <math name="ans" />
+    </moduleAttributes>
+  </module>
+</setup>
+
+<module copy="$testModule" ans="57" />`;
+                expect(await moduleAttrDiagnostics(source, "ans")).toEqual([]);
+            });
+
             it("undeclared attribute still warns", async () => {
                 const source = `<setup><module name="m"><moduleAttributes><text name="declared">x</text></moduleAttributes></module></setup>
 <module copy="$m" undeclared="x" />`;

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -65,9 +65,10 @@ connection.onInitialize((params: InitializeParams) => {
     } else if (
         initializationOptions &&
         typeof initializationOptions === "object" &&
-        "doenetWorkerUrl" in initializationOptions &&
-        initOptionsWorkerUrl != null
+        "doenetWorkerUrl" in initializationOptions
     ) {
+        // Warn when the key is present but the value is not a non-empty string
+        // (covers null, undefined, empty string, and wrong types).
         console.warn(
             "[DoenetML LSP] ignoring invalid initializationOptions.doenetWorkerUrl",
         );

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -56,14 +56,20 @@ connection.onInitialize((params: InitializeParams) => {
         capabilities.textDocument?.publishDiagnostics?.relatedInformation ||
         false;
 
+    const initializationOptions = params.initializationOptions;
     const initOptionsWorkerUrl = (
-        params.initializationOptions as { doenetWorkerUrl?: unknown } | null
+        initializationOptions as { doenetWorkerUrl?: unknown } | null
     )?.doenetWorkerUrl;
     if (typeof initOptionsWorkerUrl === "string" && initOptionsWorkerUrl) {
         config.doenetWorkerUrl = initOptionsWorkerUrl;
-    } else {
+    } else if (
+        initializationOptions &&
+        typeof initializationOptions === "object" &&
+        "doenetWorkerUrl" in initializationOptions &&
+        initOptionsWorkerUrl != null
+    ) {
         console.warn(
-            "[DoenetML LSP] no doenetWorkerUrl in initializationOptions — rust resolver disabled",
+            "[DoenetML LSP] ignoring invalid initializationOptions.doenetWorkerUrl",
         );
     }
 

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -61,6 +61,10 @@ connection.onInitialize((params: InitializeParams) => {
     )?.doenetWorkerUrl;
     if (typeof initOptionsWorkerUrl === "string" && initOptionsWorkerUrl) {
         config.doenetWorkerUrl = initOptionsWorkerUrl;
+    } else {
+        console.warn(
+            "[DoenetML LSP] no doenetWorkerUrl in initializationOptions — rust resolver disabled",
+        );
     }
 
     const result: InitializeResult = {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -80,7 +80,7 @@
             ]
         },
         "build:doenetml-worker": {
-            "command": "mkdir -p extension/build/doenetml-worker && cp ../doenetml-worker/dist/index.js extension/build/doenetml-worker/index.js",
+            "command": "node -e \"const {mkdirSync,copyFileSync}=require('fs');mkdirSync('extension/build/doenetml-worker',{recursive:true});copyFileSync('../doenetml-worker/dist/index.js','extension/build/doenetml-worker/index.js')\"",
             "files": [],
             "output": [
                 "extension/build/doenetml-worker/**/*"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -24,10 +24,11 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run build",
-        "build": "npm run build:preview-window && npm run build:extension && npm run build:language-server",
+        "build": "npm run build:preview-window && npm run build:extension && npm run build:language-server && npm run build:doenetml-worker",
         "build:language-server": "wireit",
         "build:extension": "wireit",
         "build:preview-window": "wireit",
+        "build:doenetml-worker": "wireit",
         "dev": "vite -c vite.preview-window.config.mts",
         "watch": "npm run build && vite -c vite.language-server.config.mts build --watch",
         "test": "vitest",
@@ -76,6 +77,16 @@
             ],
             "dependencies": [
                 "../doenetml:build"
+            ]
+        },
+        "build:doenetml-worker": {
+            "command": "mkdir -p extension/build/doenetml-worker && cp ../doenetml-worker/dist/index.js extension/build/doenetml-worker/index.js",
+            "files": [],
+            "output": [
+                "extension/build/doenetml-worker/**/*"
+            ],
+            "dependencies": [
+                "../doenetml-worker:build"
             ]
         }
     },

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -35,6 +35,40 @@ export function deactivate(): Thenable<void> | undefined {
  * Setup the language server.
  */
 async function setupLanguageServer(context: ExtensionContext) {
+    // Read the bundled doenetml-worker file and create a blob URL from it.
+    // The language server (running as a web worker) needs to spawn its own
+    // rust-backed core sub-worker for path resolution — that's how it
+    // suppresses false-positive "unknown attribute" diagnostics on
+    // `<module copy="$x" ans="57" />` (issue #1375).
+    //
+    // We pass the blob URL via `initializationOptions.doenetWorkerUrl`, which
+    // the LSP's `onInitialize` handler already reads and stores in `config`.
+    // Using a blob URL (rather than a vscode-file:// URL directly) ensures the
+    // language server worker can call `new Worker(url)` in any context.
+    let doenetWorkerBlobUrl: string | undefined;
+    try {
+        const workerUri = vscode.Uri.joinPath(
+            context.extensionUri,
+            "build/doenetml-worker/index.js",
+        );
+        const workerBytes = await vscode.workspace.fs.readFile(workerUri);
+        // Decode the bytes as a UTF-8 string so the Blob is created from the
+        // exact file content.  Using `workerBytes.buffer` directly is unsafe
+        // because VS Code's readFile may return a Uint8Array that is a
+        // sub-view of a larger ArrayBuffer (non-zero byteOffset), which would
+        // include garbage bytes before the actual file content and corrupt the
+        // JavaScript source.
+        const workerSource = new TextDecoder().decode(workerBytes);
+        doenetWorkerBlobUrl = URL.createObjectURL(
+            new Blob([workerSource], { type: "application/javascript" }),
+        );
+    } catch (e) {
+        console.warn(
+            "[DoenetML] Could not load doenetml-worker for LSP rust resolver:",
+            e,
+        );
+    }
+
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         // Register the server for plain text documents
@@ -42,6 +76,9 @@ async function setupLanguageServer(context: ExtensionContext) {
             { scheme: "file", language: "doenet" },
             { scheme: "untitled", language: "doenet" },
         ],
+        initializationOptions: doenetWorkerBlobUrl
+            ? { doenetWorkerUrl: doenetWorkerBlobUrl }
+            : undefined,
     };
 
     // Create a worker. The worker main file implements the language server.

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -84,7 +84,7 @@ async function setupLanguageServer(context: ExtensionContext) {
     );
 
     // Start the client. This will also launch the server
-    client.start();
+    await client.start();
 
     const formatAsDoenet = registerFormatCommand(
         "doenet.formatAsDoenetML",
@@ -113,7 +113,7 @@ function registerFormatCommand(commandName: string, requestName: string) {
             requestName,
             String(currentDocument.uri),
         );
-        activeTextEditor.edit((editBuilder) => {
+        await activeTextEditor.edit((editBuilder) => {
             for (const edit of edits) {
                 editBuilder.replace(
                     lspRangeToVscodeRange(edit.range),

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -18,17 +18,18 @@ import { DoenetPreviewPanel } from "./preview-panel/doenet-preview-panel";
 import { lspRangeToVscodeRange } from "./utils/lsp-range-to-vscode-range";
 
 let client: LanguageClient;
+let doenetWorkerBlobUrl: string | undefined;
 
-export function activate(context: ExtensionContext) {
-    setupLanguageServer(context);
+export async function activate(context: ExtensionContext) {
+    await setupLanguageServer(context);
     setupPreviewWindow(context);
 }
 
-export function deactivate(): Thenable<void> | undefined {
-    if (!client) {
-        return undefined;
+export async function deactivate(): Promise<void> {
+    if (client) {
+        await client.stop();
     }
-    return client.stop();
+    revokeDoenetWorkerBlobUrl();
 }
 
 /**
@@ -45,23 +46,9 @@ async function setupLanguageServer(context: ExtensionContext) {
     // the LSP's `onInitialize` handler already reads and stores in `config`.
     // Using a blob URL (rather than a vscode-file:// URL directly) ensures the
     // language server worker can call `new Worker(url)` in any context.
-    let doenetWorkerBlobUrl: string | undefined;
+    revokeDoenetWorkerBlobUrl();
     try {
-        const workerUri = vscode.Uri.joinPath(
-            context.extensionUri,
-            "build/doenetml-worker/index.js",
-        );
-        const workerBytes = await vscode.workspace.fs.readFile(workerUri);
-        // Decode the bytes as a UTF-8 string so the Blob is created from the
-        // exact file content.  Using `workerBytes.buffer` directly is unsafe
-        // because VS Code's readFile may return a Uint8Array that is a
-        // sub-view of a larger ArrayBuffer (non-zero byteOffset), which would
-        // include garbage bytes before the actual file content and corrupt the
-        // JavaScript source.
-        const workerSource = new TextDecoder().decode(workerBytes);
-        doenetWorkerBlobUrl = URL.createObjectURL(
-            new Blob([workerSource], { type: "application/javascript" }),
-        );
+        doenetWorkerBlobUrl = await createDoenetWorkerBlobUrl(context);
     } catch (e) {
         console.warn(
             "[DoenetML] Could not load doenetml-worker for LSP rust resolver:",
@@ -168,6 +155,32 @@ async function setupLanguageServer(context: ExtensionContext) {
     );
 
     context.subscriptions.push(formatAsDoenet, formatAsXML, formatAsMarkdown);
+}
+
+async function createDoenetWorkerBlobUrl(context: ExtensionContext) {
+    const workerUri = vscode.Uri.joinPath(
+        context.extensionUri,
+        "build/doenetml-worker/index.js",
+    );
+    const workerBytes = await vscode.workspace.fs.readFile(workerUri);
+    // Decode the bytes as a UTF-8 string so the Blob is created from the
+    // exact file content.  Using `workerBytes.buffer` directly is unsafe
+    // because VS Code's readFile may return a Uint8Array that is a
+    // sub-view of a larger ArrayBuffer (non-zero byteOffset), which would
+    // include garbage bytes before the actual file content and corrupt the
+    // JavaScript source.
+    const workerSource = new TextDecoder().decode(workerBytes);
+    return URL.createObjectURL(
+        new Blob([workerSource], { type: "application/javascript" }),
+    );
+}
+
+function revokeDoenetWorkerBlobUrl() {
+    if (!doenetWorkerBlobUrl) {
+        return;
+    }
+    URL.revokeObjectURL(doenetWorkerBlobUrl);
+    doenetWorkerBlobUrl = undefined;
 }
 
 /**

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -26,10 +26,13 @@ export async function activate(context: ExtensionContext) {
 }
 
 export async function deactivate(): Promise<void> {
-    if (client) {
-        await client.stop();
+    try {
+        if (client) {
+            await client.stop();
+        }
+    } finally {
+        revokeDoenetWorkerBlobUrl();
     }
-    revokeDoenetWorkerBlobUrl();
 }
 
 /**
@@ -139,15 +142,11 @@ async function createDoenetWorkerBlobUrl(context: ExtensionContext) {
         "build/doenetml-worker/index.js",
     );
     const workerBytes = await vscode.workspace.fs.readFile(workerUri);
-    // Decode the bytes as a UTF-8 string so the Blob is created from the
-    // exact file content.  Using `workerBytes.buffer` directly is unsafe
-    // because VS Code's readFile may return a Uint8Array that is a
-    // sub-view of a larger ArrayBuffer (non-zero byteOffset), which would
-    // include garbage bytes before the actual file content and corrupt the
-    // JavaScript source.
-    const workerSource = new TextDecoder().decode(workerBytes);
+    // Pass the Uint8Array directly — Blob respects the view's byteOffset and
+    // length, so there is no risk of including extra bytes from a larger
+    // backing ArrayBuffer that VS Code may return.
     return URL.createObjectURL(
-        new Blob([workerSource], { type: "application/javascript" }),
+        new Blob([workerBytes], { type: "application/javascript" }),
     );
 }
 

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -86,75 +86,42 @@ async function setupLanguageServer(context: ExtensionContext) {
     // Start the client. This will also launch the server
     client.start();
 
-    const formatAsDoenet = commands.registerCommand(
+    const formatAsDoenet = registerFormatCommand(
         "doenet.formatAsDoenetML",
-        async () => {
-            const activeTextEditor = vscode.window.activeTextEditor;
-            if (!activeTextEditor) {
-                return;
-            }
-            const currentDocument = vscode.window.activeTextEditor?.document;
-            const edits: TextEdit[] = await client.sendRequest(
-                "doenet.formatAsDoenetML",
-                String(currentDocument.uri),
-            );
-            activeTextEditor.edit((editBuilder) => {
-                for (const edit of edits) {
-                    editBuilder.replace(
-                        lspRangeToVscodeRange(edit.range),
-                        edit.newText,
-                    );
-                }
-            });
-        },
+        "doenet.formatAsDoenetML",
     );
-    const formatAsXML = commands.registerCommand(
+    const formatAsXML = registerFormatCommand(
         "doenet.formatAsXML",
-        async () => {
-            const activeTextEditor = vscode.window.activeTextEditor;
-            if (!activeTextEditor) {
-                return;
-            }
-            const currentDocument = vscode.window.activeTextEditor?.document;
-            const edits: TextEdit[] = await client.sendRequest(
-                "doenet.formatAsXML",
-                String(currentDocument.uri),
-            );
-            activeTextEditor.edit((editBuilder) => {
-                for (const edit of edits) {
-                    editBuilder.replace(
-                        lspRangeToVscodeRange(edit.range),
-                        edit.newText,
-                    );
-                }
-            });
-        },
+        "doenet.formatAsXML",
     );
-
-    const formatAsMarkdown = commands.registerCommand(
+    const formatAsMarkdown = registerFormatCommand(
         "doenet.formatAsMarkdown",
-        async () => {
-            const activeTextEditor = vscode.window.activeTextEditor;
-            if (!activeTextEditor) {
-                return;
-            }
-            const currentDocument = vscode.window.activeTextEditor?.document;
-            const edits: TextEdit[] = await client.sendRequest(
-                "doenet.formatAsMarkdown",
-                String(currentDocument.uri),
-            );
-            activeTextEditor.edit((editBuilder) => {
-                for (const edit of edits) {
-                    editBuilder.replace(
-                        lspRangeToVscodeRange(edit.range),
-                        edit.newText,
-                    );
-                }
-            });
-        },
+        "doenet.formatAsMarkdown",
     );
 
     context.subscriptions.push(formatAsDoenet, formatAsXML, formatAsMarkdown);
+}
+
+function registerFormatCommand(commandName: string, requestName: string) {
+    return commands.registerCommand(commandName, async () => {
+        const activeTextEditor = vscode.window.activeTextEditor;
+        if (!activeTextEditor) {
+            return;
+        }
+        const currentDocument = activeTextEditor.document;
+        const edits: TextEdit[] = await client.sendRequest(
+            requestName,
+            String(currentDocument.uri),
+        );
+        activeTextEditor.edit((editBuilder) => {
+            for (const edit of edits) {
+                editBuilder.replace(
+                    lspRangeToVscodeRange(edit.range),
+                    edit.newText,
+                );
+            }
+        });
+    });
 }
 
 async function createDoenetWorkerBlobUrl(context: ExtensionContext) {

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -83,23 +83,32 @@ async function setupLanguageServer(context: ExtensionContext) {
         worker,
     );
 
-    // Start the client. This will also launch the server
-    await client.start();
+    try {
+        // Start the client. This will also launch the server
+        await client.start();
 
-    const formatAsDoenet = registerFormatCommand(
-        "doenet.formatAsDoenetML",
-        "doenet.formatAsDoenetML",
-    );
-    const formatAsXML = registerFormatCommand(
-        "doenet.formatAsXML",
-        "doenet.formatAsXML",
-    );
-    const formatAsMarkdown = registerFormatCommand(
-        "doenet.formatAsMarkdown",
-        "doenet.formatAsMarkdown",
-    );
+        const formatAsDoenet = registerFormatCommand(
+            "doenet.formatAsDoenetML",
+            "doenet.formatAsDoenetML",
+        );
+        const formatAsXML = registerFormatCommand(
+            "doenet.formatAsXML",
+            "doenet.formatAsXML",
+        );
+        const formatAsMarkdown = registerFormatCommand(
+            "doenet.formatAsMarkdown",
+            "doenet.formatAsMarkdown",
+        );
 
-    context.subscriptions.push(formatAsDoenet, formatAsXML, formatAsMarkdown);
+        context.subscriptions.push(
+            formatAsDoenet,
+            formatAsXML,
+            formatAsMarkdown,
+        );
+    } catch (e) {
+        revokeDoenetWorkerBlobUrl();
+        throw e;
+    }
 }
 
 function registerFormatCommand(commandName: string, requestName: string) {

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -76,18 +76,20 @@ async function setupLanguageServer(context: ExtensionContext) {
         context.extensionUri,
         "build/language-server/index.js",
     );
-    const worker = new Worker(serverMain.toString(true));
 
-    // Create the language client and start the client.
-    client = new LanguageClient(
-        "DoenetLanguageServer",
-        "Doenet Language Server",
-        clientOptions,
-        worker,
-    );
-
+    // Wrap Worker construction, LanguageClient construction, and client.start()
+    // together so that any throw at any point revokes the blob URL.
     try {
-        // Start the client. This will also launch the server
+        const worker = new Worker(serverMain.toString(true));
+
+        client = new LanguageClient(
+            "DoenetLanguageServer",
+            "Doenet Language Server",
+            clientOptions,
+            worker,
+        );
+
+        // Start the client. This will also launch the server.
         await client.start();
 
         const formatAsDoenet = registerFormatCommand(

--- a/packages/vscode-extension/test/language-server.test.ts
+++ b/packages/vscode-extension/test/language-server.test.ts
@@ -1,13 +1,193 @@
-import { describe, expect, it } from "vitest";
-// Required to use a worker inside a test
-import "@vitest/web-worker";
-import util from "util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const origLog = console.log;
-console.log = (...args) => {
-    origLog(...args.map((x) => util.inspect(x, false, 10, true)));
-};
+const hoisted = vi.hoisted(() => ({
+    readFile: vi.fn(),
+    joinPath: vi.fn(),
+    registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidChangeTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
+    stop: vi.fn(async () => {}),
+    sendRequest: vi.fn(),
+    languageClientCalls: [] as {
+        options: unknown;
+        worker: unknown;
+    }[],
+}));
 
-describe("Doenet vscode extension", async () => {
-    it("empty test", async () => {});
+vi.mock("vscode", () => ({
+    workspace: {
+        fs: {
+            readFile: hoisted.readFile,
+        },
+        onDidChangeTextDocument: hoisted.onDidChangeTextDocument,
+        onDidSaveTextDocument: hoisted.onDidSaveTextDocument,
+    },
+    commands: {
+        registerCommand: hoisted.registerCommand,
+    },
+    Uri: {
+        joinPath: hoisted.joinPath,
+    },
+    window: {
+        activeTextEditor: undefined,
+        onDidChangeActiveTextEditor: hoisted.onDidChangeActiveTextEditor,
+    },
+}));
+
+vi.mock("vscode-languageclient/browser", () => {
+    class MockLanguageClient {
+        constructor(
+            _id: string,
+            _name: string,
+            options: unknown,
+            worker: unknown,
+        ) {
+            hoisted.languageClientCalls.push({ options, worker });
+        }
+
+        start = vi.fn();
+        stop = hoisted.stop;
+        sendRequest = hoisted.sendRequest;
+    }
+
+    return { LanguageClient: MockLanguageClient };
+});
+
+class FakeWorker {
+    static instances: FakeWorker[] = [];
+
+    constructor(public url: string) {
+        FakeWorker.instances.push(this);
+    }
+}
+
+function makeUri(path: string) {
+    return {
+        path,
+        toString(_skipEncoding?: boolean) {
+            return `vscode-file://${path}`;
+        },
+    };
+}
+
+function createContext() {
+    return {
+        extensionUri: makeUri("/extension"),
+        subscriptions: [] as unknown[],
+    };
+}
+
+function makeSubarrayBytes(text: string) {
+    const full = new Uint8Array(text.length + 4);
+    full.fill(33);
+    full.set(new TextEncoder().encode(text), 2);
+    return full.subarray(2, 2 + text.length);
+}
+
+function stubUrlStatics(
+    createObjectURL: (blob: Blob) => string,
+    revokeObjectURL: (url: string) => void,
+) {
+    const UrlWithBlobStatics = class extends URL {};
+    UrlWithBlobStatics.createObjectURL = createObjectURL;
+    UrlWithBlobStatics.revokeObjectURL = revokeObjectURL;
+    vi.stubGlobal("URL", UrlWithBlobStatics);
+}
+
+describe("Doenet vscode extension", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.resetModules();
+        FakeWorker.instances = [];
+        hoisted.readFile.mockReset();
+        hoisted.joinPath.mockReset();
+        hoisted.registerCommand.mockClear();
+        hoisted.onDidChangeTextDocument.mockClear();
+        hoisted.onDidSaveTextDocument.mockClear();
+        hoisted.onDidChangeActiveTextEditor.mockClear();
+        hoisted.stop.mockClear();
+        hoisted.sendRequest.mockClear();
+        hoisted.languageClientCalls.length = 0;
+        hoisted.joinPath.mockImplementation(
+            (...parts: Array<{ path?: string } | string>) =>
+                makeUri(
+                    parts
+                        .map((part) =>
+                            typeof part === "string"
+                                ? part
+                                : (part.path ?? String(part)),
+                        )
+                        .join("/"),
+                ),
+        );
+        vi.stubGlobal("Worker", FakeWorker);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it("passes the bundled worker to the language server and revokes the blob URL on deactivate", async () => {
+        const expectedSource = 'console.log("worker");';
+        hoisted.readFile.mockResolvedValue(makeSubarrayBytes(expectedSource));
+
+        const createObjectURL = vi.fn((blob: Blob) => {
+            expect(blob.type).toBe("application/javascript");
+            return "blob:doenet-worker";
+        });
+        const revokeObjectURL = vi.fn();
+        stubUrlStatics(createObjectURL, revokeObjectURL);
+
+        const { activate, deactivate } = await import("../src/extension/index");
+        const context = createContext();
+        await activate(context as any);
+
+        expect(hoisted.readFile).toHaveBeenCalledWith(
+            expect.objectContaining({
+                path: expect.stringContaining("build/doenetml-worker/index.js"),
+            }),
+        );
+        expect(await createObjectURL.mock.calls[0][0].text()).toBe(
+            expectedSource,
+        );
+        expect(hoisted.languageClientCalls).toHaveLength(1);
+        expect(hoisted.languageClientCalls[0]?.options).toMatchObject({
+            initializationOptions: {
+                doenetWorkerUrl: "blob:doenet-worker",
+            },
+        });
+        expect(FakeWorker.instances[0]?.url).toContain(
+            "build/language-server/index.js",
+        );
+
+        await deactivate();
+        expect(hoisted.stop).toHaveBeenCalledTimes(1);
+        expect(revokeObjectURL).toHaveBeenCalledWith("blob:doenet-worker");
+    });
+
+    it("starts the client without initializationOptions when the bundled worker cannot be read", async () => {
+        hoisted.readFile.mockRejectedValue(new Error("missing worker"));
+        const createObjectURL = vi.fn();
+        const revokeObjectURL = vi.fn();
+        stubUrlStatics(createObjectURL, revokeObjectURL);
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const { activate, deactivate } = await import("../src/extension/index");
+        await activate(createContext() as any);
+
+        expect(createObjectURL).not.toHaveBeenCalled();
+        expect(hoisted.languageClientCalls[0]?.options).toMatchObject({
+            initializationOptions: undefined,
+        });
+        expect(warn).toHaveBeenCalledWith(
+            "[DoenetML] Could not load doenetml-worker for LSP rust resolver:",
+            expect.any(Error),
+        );
+
+        await deactivate();
+        expect(revokeObjectURL).not.toHaveBeenCalled();
+    });
 });

--- a/packages/vscode-extension/test/language-server.test.ts
+++ b/packages/vscode-extension/test/language-server.test.ts
@@ -7,6 +7,7 @@ const hoisted = vi.hoisted(() => ({
     onDidChangeTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
     onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
     onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
+    start: vi.fn(async () => {}),
     stop: vi.fn(async () => {}),
     sendRequest: vi.fn(),
     languageClientCalls: [] as {
@@ -46,7 +47,7 @@ vi.mock("vscode-languageclient/browser", () => {
             hoisted.languageClientCalls.push({ options, worker });
         }
 
-        start = vi.fn();
+        start = hoisted.start;
         stop = hoisted.stop;
         sendRequest = hoisted.sendRequest;
     }
@@ -107,6 +108,7 @@ describe("Doenet vscode extension", () => {
         hoisted.onDidChangeTextDocument.mockClear();
         hoisted.onDidSaveTextDocument.mockClear();
         hoisted.onDidChangeActiveTextEditor.mockClear();
+        hoisted.start.mockReset();
         hoisted.stop.mockClear();
         hoisted.sendRequest.mockClear();
         hoisted.languageClientCalls.length = 0;
@@ -166,6 +168,36 @@ describe("Doenet vscode extension", () => {
         await deactivate();
         expect(hoisted.stop).toHaveBeenCalledTimes(1);
         expect(revokeObjectURL).toHaveBeenCalledWith("blob:doenet-worker");
+    });
+
+    it("waits for the language client to finish starting before activate resolves", async () => {
+        hoisted.readFile.mockResolvedValue(
+            makeSubarrayBytes('console.log("worker");'),
+        );
+        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+
+        let resolveStart: (() => void) | undefined;
+        hoisted.start.mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveStart = resolve;
+                }),
+        );
+
+        const { activate } = await import("../src/extension/index");
+        let activateResolved = false;
+        const activatePromise = activate(createContext() as any).then(() => {
+            activateResolved = true;
+        });
+
+        await vi.waitFor(() => {
+            expect(hoisted.start).toHaveBeenCalledTimes(1);
+        });
+        expect(activateResolved).toBe(false);
+
+        resolveStart?.();
+        await activatePromise;
+        expect(activateResolved).toBe(true);
     });
 
     it("starts the client without initializationOptions when the bundled worker cannot be read", async () => {

--- a/packages/vscode-extension/test/language-server.test.ts
+++ b/packages/vscode-extension/test/language-server.test.ts
@@ -200,6 +200,23 @@ describe("Doenet vscode extension", () => {
         expect(activateResolved).toBe(true);
     });
 
+    it("revokes the worker blob URL when activation fails after reading the worker", async () => {
+        hoisted.readFile.mockResolvedValue(
+            makeSubarrayBytes('console.log("worker");'),
+        );
+        const createObjectURL = vi.fn(() => "blob:doenet-worker");
+        const revokeObjectURL = vi.fn();
+        stubUrlStatics(createObjectURL, revokeObjectURL);
+        hoisted.start.mockRejectedValue(new Error("start failed"));
+
+        const { activate } = await import("../src/extension/index");
+
+        await expect(activate(createContext() as any)).rejects.toThrow(
+            "start failed",
+        );
+        expect(revokeObjectURL).toHaveBeenCalledWith("blob:doenet-worker");
+    });
+
     it("starts the client without initializationOptions when the bundled worker cannot be read", async () => {
         hoisted.readFile.mockRejectedValue(new Error("missing worker"));
         const createObjectURL = vi.fn();


### PR DESCRIPTION
Closes #1375.

## Problem

The VSCode extension never passed `doenetWorkerUrl` in `initializationOptions` when starting the language server. Without it, the Rust resolver adapter was never initialized, so `_refreshModuleInstanceAttributes()` always cleared the per-instance attribute allowlist — causing every author-declared attribute on `<module copy=\"$x\" ...>` to be flagged as unknown.

```xml
<setup>
  <module name=\"testModule\">
    <moduleAttributes>
      <math name=\"ans\" />
    </moduleAttributes>
  </module>
</setup>

<module copy=\"$testModule\" ans=\"57\" />
<!-- VSCode was reporting: Element <module> doesn't have an attribute called `ans` -->
```

## Root cause chain

1. VS Code extension → never sent `doenetWorkerUrl` in LSP `initializationOptions`
2. LSP `config.doenetWorkerUrl` stayed `undefined`
3. `getRustCore(undefined)` returned `null`
4. `RustResolverAdapter` never created → `_moduleInstanceAttributeAllowlist` always empty
5. Custom `<module>` attributes always flagged

## Fix

**`packages/vscode-extension/src/extension/index.ts`** — At activation, read the bundled doenetml-worker file, create a blob URL, and pass it as `initializationOptions.doenetWorkerUrl`. The extension now also revokes that blob URL on deactivate so reloads do not leak the bundled worker blob for the lifetime of the extension host, and it revokes the blob URL if activation fails after the worker has been loaded.

**`packages/vscode-extension/package.json`** — New `build:doenetml-worker` wireit task copies `@doenet/doenetml-worker/dist/index.js` into the VSIX as a separate file.

**`packages/doenetml-worker/src/CoreWorker.ts`** — Changed WASM loading to pass the decoded `ArrayBuffer` directly to wasm-bindgen's `init()` instead of converting to a blob URL then `fetch()`-ing it. `fetch()` is blocked in VS Code's web-worker extension host context (`vscode-file://` origin); `WebAssembly.instantiate(buffer, imports)` needs no network access and works everywhere. Tiny bundle size decrease as a side effect.

**`packages/lsp/src/index.ts`** — Accept `doenetWorkerUrl` when it is provided, and only warn for an invalid supplied value instead of warning on every initialization that omits the option.

**`packages/doenetml-prototype/src/editor/editor-viewer.tsx`** — Pass `doenetWorkerUrl` to `<CodeMirror>` (pre-existing gap that silently disabled module attribute resolution in the prototype editor).

**`packages/doenetml-prototype/src/global-config.ts`** — Update the prototype fallback worker URL from the removed `CoreWorker.js` entry to the current `index.js` bundle so `about:srcdoc` / invalid-URL embeddings still hand CodeMirror a valid worker URL.

**`packages/lsp-tools/test/module-instance-attributes.test.ts`** — Regression test pinning the exact DoenetML from the issue report.

**`packages/vscode-extension/test/language-server.test.ts`** — Unit tests cover the extension-side worker handoff, verify that blob creation uses the exact bytes returned by `workspace.fs.readFile()`, assert that the blob URL is revoked on deactivate, assert that activation waits for `client.start()`, and assert cleanup still happens if activation fails after the worker blob is created.

## Bundle size impact

| Bundle | Change |
|--------|--------|
| `@doenet/doenetml-worker` | −584 B (slightly smaller) |
| `@doenet/lsp` | no change |
| VSCode language-server | no change (2.2 MB) |
| VSCode VSIX | +11 MB (new `build/doenetml-worker/index.js`) |

Web-facing bundles are essentially unchanged.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)