### PR TITLE
fix: add textEdit ranges to close-tag completions for VSCode compatibility

### DIFF
--- a/.changeset/vscode-close-tag-completion.md
+++ b/.changeset/vscode-close-tag-completion.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: Fix close-tag autocomplete in VS Code.
+
+When typing a closing tag in the editor (for example `</te|` inside `<text>`),
+the close-tag completion now stays in sync with the full partially typed prefix
+and accepting it replaces that whole prefix. This avoids VS Code/native-LSP
+flows that could previously duplicate the `/` or leave the already-typed suffix
+behind when completing a close tag.

--- a/.changeset/vscode-close-tag-completion.md
+++ b/.changeset/vscode-close-tag-completion.md
@@ -6,10 +6,14 @@
 "doenet-vscode-extension": patch
 ---
 
-Editor: Fix close-tag autocomplete in VS Code.
+Editor: Fix stale VS Code tag/snippet autocomplete ranges.
 
 When typing a closing tag in the editor (for example `</te|` inside `<text>`),
 the close-tag completion now stays in sync with the full partially typed prefix
 and accepting it replaces that whole prefix. This avoids VS Code/native-LSP
 flows that could previously duplicate the `/` or leave the already-typed suffix
 behind when completing a close tag.
+
+The same refresh logic now also keeps `<`-triggered snippet completions in sync
+with the typed prefix, including the prefigure `annotations-skeleton` snippet,
+so accepting those items no longer leaves stale typed characters behind either.

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -124,9 +124,6 @@ function createCloseTagCompletionItem(
         kind: CompletionItemKind.Property,
     };
     if (editOffsets) {
-        // Explicit completion can offer a close tag with no leading `<`
-        // already typed. In that case, replace the empty range with the full
-        // close tag rather than relying on the label-only insertion.
         item.textEdit = {
             range: createTextEditRange(
                 editOffsets.sourceObj,
@@ -135,6 +132,13 @@ function createCloseTagCompletionItem(
             ),
             newText: `</${elementName}>`,
         };
+        // VS Code uses `filterText` (falling back to `label`) to decide
+        // which items to show as the user types.  The textEdit range starts
+        // at the `<` character, so the "typed prefix" VS Code compares
+        // against is e.g. `<`, `</`, `</t` — none of which is a prefix of
+        // the label `"/text>"`.  Setting filterText to the full close tag
+        // ensures the item keeps appearing after each additional keystroke.
+        item.filterText = `</${elementName}>`;
     }
     return item;
 }
@@ -792,13 +796,17 @@ export async function getCompletionItems(
     const showElementMenu = hasLeadingLt || explicit;
     const elementMenuStart = hasLeadingLt ? offset - 1 : offset;
     const insertLeadingBracket = !hasLeadingLt;
-    const closeTagEditOffsets = insertLeadingBracket
-        ? {
-              sourceObj: this.sourceObj,
-              startOffset: elementMenuStart,
-              endOffset: offset,
-          }
-        : undefined;
+    // Always provide a textEdit range for close-tag completions so that
+    // VS Code (which re-triggers completion on `/`) inserts the correct
+    // text.  When `hasLeadingLt`, the range covers the `<` (offset-1 →
+    // offset), and `newText` starts with `</`, replacing the whole thing.
+    // When there is no leading `<` (explicit Ctrl+Space invoke), the range
+    // is empty (cursor → cursor) so `</tag>` is inserted verbatim.
+    const closeTagEditOffsets: CompletionTextEditOffsets = {
+        sourceObj: this.sourceObj,
+        startOffset: elementMenuStart,
+        endOffset: offset,
+    };
     let prevNonWhitespaceCharOffset = offset - 1;
     while (
         this.sourceObj.source
@@ -1175,8 +1183,27 @@ export async function getCompletionItems(
     }
 
     if (cursorPosition === "closeTagName") {
-        // We're in the close tag name. Suggest the close tag name.
-        return [createCloseTagCompletionItem(element.name)];
+        // Cursor is inside a partially-typed closing tag name (e.g. `</te|`).
+        // Scan backward from cursor to find the `<` so the textEdit can
+        // replace the entire `</...` prefix, not just what was typed after `/`.
+        // Without a textEdit, VS Code inserts at the cursor and duplicates
+        // the already-typed characters.
+        const src = this.sourceObj.source;
+        let ltPos = offset - 1;
+        while (ltPos >= 0 && src.charAt(ltPos) !== "<") {
+            ltPos--;
+        }
+        const closeTagNameEditOffsets: CompletionTextEditOffsets | undefined =
+            ltPos >= 0
+                ? {
+                      sourceObj: this.sourceObj,
+                      startOffset: ltPos,
+                      endOffset: offset,
+                  }
+                : undefined;
+        return [
+            createCloseTagCompletionItem(element.name, closeTagNameEditOffsets),
+        ];
     }
 
     const { tagComplete, closed } = this.sourceObj.isCompleteElement(element);
@@ -1225,7 +1252,15 @@ export async function getCompletionItems(
             (cursorPosition === "unknown" &&
                 this.sourceObj.source.charAt(offset).match(/(\s|\n)/)))
     ) {
-        return [createCloseTagCompletionItem(element.name)];
+        // Provide a textEdit so VS Code replaces the `</` prefix instead of
+        // appending after the `/` (which would produce `<//text>`).
+        return [
+            createCloseTagCompletionItem(element.name, {
+                sourceObj: this.sourceObj,
+                startOffset: offset - 2,
+                endOffset: offset,
+            }),
+        ];
     }
 
     if (cursorPosition === "openTagName") {

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -800,14 +800,6 @@ export async function getCompletionItems(
         offset = this.sourceObj.rowColToOffset(offset);
     }
 
-    // Ensure the per-instance `<module>` attribute allowlist is up to date
-    // for the current source revision before the attribute-name branch
-    // consults it.  Coalesces with the matching call in `getSchemaViolations`
-    // (validation typically runs first), so back-to-back validation +
-    // completion between edits costs at most one resolver round-trip per
-    // `<module copy=…>` site total.
-    await this._refreshModuleInstanceAttributes();
-
     const prevChar = this.sourceObj.source.charAt(offset - 1);
     const prevPrevChar = this.sourceObj.source.charAt(offset - 2);
 
@@ -1352,6 +1344,14 @@ export async function getCompletionItems(
         !isBareValueAfterEquals &&
         prevNonWhitespaceChar !== "="
     ) {
+        // Only attribute-name completions consult the per-instance
+        // `<module copy|extend=...>` allowlist, so defer the refresh until
+        // we know we are in that branch. This keeps unrelated completion
+        // triggers (notably close-tag flows in VS Code) off the resolver path.
+        // Coalesces with the matching call in `getSchemaViolations`, so
+        // back-to-back validation + completion between edits still costs at
+        // most one resolver round-trip per `<module copy=…>` site total.
+        await this._refreshModuleInstanceAttributes();
         const elmName = this.normalizeElementName(element.name);
         const ownEntry = this.schemaElementsByName[elmName];
         const helpEntry = this.resolveEffectiveSchemaElement(

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -338,6 +338,7 @@ function createDynamicSnippetCompletionItems(
     startOffset: number,
     endOffset: number,
     typedPrefix = "",
+    filterTextPrefix = "",
 ): CompletionItem[] {
     if (!allowedElementNames.includes("annotations")) {
         return [];
@@ -364,6 +365,7 @@ function createDynamicSnippetCompletionItems(
         [dynamicSnippet],
         startOffset,
         endOffset,
+        filterTextPrefix,
     );
 }
 
@@ -495,6 +497,7 @@ function createElementAndSnippetCompletionItems(
         startOffset,
         endOffset,
         typedPrefix,
+        snippetFilterTextPrefix,
     );
 
     return [...schemaItems, ...snippetItems, ...dynamicSnippetItems];

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -257,6 +257,24 @@ function createSnippetCompletionItems(
     }>,
     startOffset: number,
     endOffset: number,
+    /**
+     * Prefix prepended to `snippet.key` when building `filterText`.
+     *
+     * When the textEdit range starts at `<` (i.e. the user typed `<`), VS Code
+     * computes the filter prefix as the text in the range — e.g. `<ans` after
+     * typing `<ans`.  Without the `<` prefix, `filterText = "answer-labeled"`
+     * would not match the filter prefix `<ans` and the snippet would disappear
+     * from the list.  Passing `"<"` here makes `filterText = "<answer-labeled"`,
+     * which starts with `<ans` and keeps the item visible.
+     *
+     * CodemirrorLSP plugin strips the leading `<` before applying its own
+     * substring filter, so `"<answer-labeled".includes("ans")` still matches.
+     *
+     * Default `""` (no prefix) is correct for explicit Ctrl+Space invocations
+     * where the textEdit range is empty (starts at cursor) and the filter prefix
+     * is the bare typed word without a leading `<`.
+     */
+    filterTextPrefix: string = "",
 ): CompletionItem[] {
     return snippets.map((snippet) => {
         const { formattedSnippet, indentSize } = formatSnippetWithIndent(
@@ -282,7 +300,7 @@ function createSnippetCompletionItems(
                 range: createTextEditRange(sourceObj, startOffset, endOffset),
                 newText: formattedSnippet,
             },
-            filterText: snippet.key,
+            filterText: filterTextPrefix + snippet.key,
             ...(completionData
                 ? {
                       data: completionData,
@@ -441,11 +459,17 @@ function createElementAndSnippetCompletionItems(
         new Set(allowedElementNames),
         typedPrefix,
     );
+    // When the textEdit range starts at `<` (insertLeadingBracket=false, meaning
+    // the user typed `<`), VS Code computes the filter prefix from the range text
+    // (e.g. `<ans`). Prepend `<` to filterText so items match that prefix while
+    // still matching the bare typed word in codemirror (which uses substring).
+    const snippetFilterTextPrefix = insertLeadingBracket ? "" : "<";
     const snippetItems = createSnippetCompletionItems(
         autoCompleter.sourceObj,
         snippets,
         startOffset,
         endOffset,
+        snippetFilterTextPrefix,
     );
     for (const item of snippetItems) {
         // Snippet labels are unique snippet keys; look up sortText by the

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -2170,6 +2170,22 @@ describe("AutoCompleter", () => {
                 "<aa>\n  <bb></bb>\n  </aa>",
             );
         });
+
+        it("Adds the `<` filterText prefix to dynamic annotations snippets in prefigure graphs", async () => {
+            const source = `<graph renderer="prefigure">\n  <point name="P" />\n  <ann\n</graph>`;
+            const autoCompleter = new AutoCompleter(
+                source,
+                doenetSchema.elements,
+            );
+            const offset = source.indexOf("<ann") + 4;
+            const items = await autoCompleter.getCompletionItems(offset);
+
+            const snippetItem = items.find(
+                (item) => item.label === "annotations-skeleton",
+            );
+            expect(snippetItem).toBeDefined();
+            expect(snippetItem?.filterText).toBe("<annotations-skeleton");
+        });
     });
 
     describe("Offset-to-node-index mapping", () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -2135,7 +2135,7 @@ describe("AutoCompleter", () => {
             expect(
                 snippetItem?.textEdit && "range" in snippetItem.textEdit,
             ).toBe(true);
-            expect(snippetItem?.filterText).toBe("test-snippet");
+            expect(snippetItem?.filterText).toBe("<test-snippet");
         });
 
         it("Snippet items indent multiline text", async () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -346,12 +346,15 @@ describe("AutoCompleter", () => {
         // Same recovered empty-placeholder shape as the previous test, but the
         // surrounding <aa> is still open. Match the normal body completion
         // behavior by keeping the close-tag option before allowed children.
+        // The close-tag item must now include a textEdit (to replace the `<`
+        // with `</aa>`) so VS Code does not duplicate the `<` on acceptance.
         const source = `<aa><<c></c>`;
         const autoCompleter = new AutoCompleter(source, schema.elements);
         const offset = source.indexOf("<aa>") + 5; // right after the first inner `<`
         const items = await autoCompleter.getCompletionItems(offset);
         expect(items.map((i) => i.label)).toEqual(["/aa>", "b", "c", "d"]);
-        expect(items[0].textEdit).toBeUndefined();
+        expect(items[0].textEdit?.newText).toBe("</aa>");
+        expect(items[0].filterText).toBe("</aa>");
     });
 
     it("inserts a full close tag when explicit completion is invoked before another tag in an unclosed parent (#1328)", async () => {
@@ -680,8 +683,22 @@ describe("AutoCompleter", () => {
             expect(elm).toMatchInlineSnapshot(`
               [
                 {
+                  "filterText": "</a>",
                   "kind": 10,
                   "label": "/a>",
+                  "textEdit": {
+                    "newText": "</a>",
+                    "range": {
+                      "end": {
+                        "character": 5,
+                        "line": 0,
+                      },
+                      "start": {
+                        "character": 4,
+                        "line": 0,
+                      },
+                    },
+                  },
                 },
               ]
             `);
@@ -694,8 +711,22 @@ describe("AutoCompleter", () => {
             expect(elm).toMatchInlineSnapshot(`
               [
                 {
+                  "filterText": "</a>",
                   "kind": 10,
                   "label": "/a>",
+                  "textEdit": {
+                    "newText": "</a>",
+                    "range": {
+                      "end": {
+                        "character": 6,
+                        "line": 0,
+                      },
+                      "start": {
+                        "character": 4,
+                        "line": 0,
+                      },
+                    },
+                  },
                 },
               ]
             `);
@@ -713,8 +744,22 @@ describe("AutoCompleter", () => {
             expect(elm).toMatchInlineSnapshot(`
               [
                 {
+                  "filterText": "</a>",
                   "kind": 10,
                   "label": "/a>",
+                  "textEdit": {
+                    "newText": "</a>",
+                    "range": {
+                      "end": {
+                        "character": 5,
+                        "line": 0,
+                      },
+                      "start": {
+                        "character": 4,
+                        "line": 0,
+                      },
+                    },
+                  },
                 },
               ]
             `);
@@ -727,8 +772,22 @@ describe("AutoCompleter", () => {
             expect(elm).toMatchInlineSnapshot(`
               [
                 {
+                  "filterText": "</a>",
                   "kind": 10,
                   "label": "/a>",
+                  "textEdit": {
+                    "newText": "</a>",
+                    "range": {
+                      "end": {
+                        "character": 6,
+                        "line": 0,
+                      },
+                      "start": {
+                        "character": 4,
+                        "line": 0,
+                      },
+                    },
+                  },
                 },
               ]
             `);
@@ -845,8 +904,22 @@ describe("AutoCompleter", () => {
             expect(elm).toMatchInlineSnapshot(`
               [
                 {
+                  "filterText": "</aa>",
                   "kind": 10,
                   "label": "/aa>",
+                  "textEdit": {
+                    "newText": "</aa>",
+                    "range": {
+                      "end": {
+                        "character": 6,
+                        "line": 0,
+                      },
+                      "start": {
+                        "character": 5,
+                        "line": 0,
+                      },
+                    },
+                  },
                 },
                 {
                   "kind": 10,
@@ -879,8 +952,22 @@ describe("AutoCompleter", () => {
             expect(elm).toMatchInlineSnapshot(`
               [
                 {
+                  "filterText": "</aa>",
                   "kind": 10,
                   "label": "/aa>",
+                  "textEdit": {
+                    "newText": "</aa>",
+                    "range": {
+                      "end": {
+                        "character": 7,
+                        "line": 0,
+                      },
+                      "start": {
+                        "character": 5,
+                        "line": 0,
+                      },
+                    },
+                  },
                 },
               ]
             `);

--- a/packages/lsp/src/features/completions.ts
+++ b/packages/lsp/src/features/completions.ts
@@ -1,62 +1,93 @@
-import { Connection, CompletionItem } from "vscode-languageserver/browser";
+import {
+    CompletionItem,
+    CompletionList,
+    Connection,
+} from "vscode-languageserver/browser";
 import { DocumentInfo } from "../globals";
 import {
     awaitRustBootIfInitializing,
     isRefCompletionContext,
 } from "./_rust-ready";
 
+function shouldKeepCompletionListIncomplete(
+    completions: CompletionItem[],
+): boolean {
+    return completions.some((item) => {
+        return (
+            typeof item.label === "string" &&
+            item.label.startsWith("/") &&
+            item.label.endsWith(">") &&
+            typeof item.filterText === "string" &&
+            item.filterText.startsWith("</")
+        );
+    });
+}
+
 export function addDocumentCompletionSupport(
     connection: Connection,
     documentInfo: DocumentInfo,
 ) {
     // This handler provides the initial list of the completion items.
-    connection.onCompletion(async (params): Promise<CompletionItem[]> => {
-        const info = documentInfo.get(params.textDocument.uri);
-        if (!info) {
-            return [];
-        }
+    connection.onCompletion(
+        async (params): Promise<CompletionItem[] | CompletionList> => {
+            const info = documentInfo.get(params.textDocument.uri);
+            if (!info) {
+                return [];
+            }
 
-        let completionContext = info.autoCompleter.getCompletionContext(
-            params.position,
-        );
-
-        // A rust-dependent completion can land in the window between the
-        // document opening and the rust-core sub-worker finishing its boot.
-        // Returning `[]` then would close the editor's autocomplete session,
-        // so wait for the boot to settle (bounded by `RUST_BOOT_WAIT_MS`,
-        // see `_rust-ready.ts`) and answer with real results.
-        if (isRefCompletionContext(completionContext)) {
-            await awaitRustBootIfInitializing(info);
-            // The document may have changed while waiting — recompute.
-            completionContext = info.autoCompleter.getCompletionContext(
+            let completionContext = info.autoCompleter.getCompletionContext(
                 params.position,
             );
-        }
 
-        if (
-            isRefCompletionContext(completionContext) &&
-            (info.rustState !== "ready" || !info.rustAdapter)
-        ) {
-            return [];
-        }
+            // A rust-dependent completion can land in the window between the
+            // document opening and the rust-core sub-worker finishing its boot.
+            // Returning `[]` then would close the editor's autocomplete session,
+            // so wait for the boot to settle (bounded by `RUST_BOOT_WAIT_MS`,
+            // see `_rust-ready.ts`) and answer with real results.
+            if (isRefCompletionContext(completionContext)) {
+                await awaitRustBootIfInitializing(info);
+                // The document may have changed while waiting — recompute.
+                completionContext = info.autoCompleter.getCompletionContext(
+                    params.position,
+                );
+            }
 
-        // The client (CodeMirror plugin) sets `explicit` when the user
-        // invoked completion via Ctrl+Space, as opposed to the popup opening
-        // from typing. It rides on the completion context as a non-standard
-        // field; read it defensively. Explicit invocation opens the element
-        // menu even with no preceding `<` (e.g. between tags) — see
-        // `getCompletionItems`.
-        const explicit =
-            (params.context as { explicit?: boolean } | undefined)?.explicit ??
-            false;
+            if (
+                isRefCompletionContext(completionContext) &&
+                (info.rustState !== "ready" || !info.rustAdapter)
+            ) {
+                return [];
+            }
 
-        const completions = await info.autoCompleter.getCompletionItems(
-            params.position,
-            completionContext,
-            explicit,
-        );
-        return completions;
-    });
+            // The client (CodeMirror plugin) sets `explicit` when the user
+            // invoked completion via Ctrl+Space, as opposed to the popup opening
+            // from typing. It rides on the completion context as a non-standard
+            // field; read it defensively. Explicit invocation opens the element
+            // menu even with no preceding `<` (e.g. between tags) — see
+            // `getCompletionItems`.
+            const explicit =
+                (params.context as { explicit?: boolean } | undefined)
+                    ?.explicit ?? false;
+
+            const completions = await info.autoCompleter.getCompletionItems(
+                params.position,
+                completionContext,
+                explicit,
+            );
+            // VS Code only asks the server for refreshed completion items while a
+            // completion session is active if the prior list was marked
+            // `isIncomplete`. Close-tag completions need that refresh because the
+            // replacement range must expand as the user types `</te...`; otherwise
+            // accepting the stale item can leave the typed suffix behind.
+            if (shouldKeepCompletionListIncomplete(completions)) {
+                return {
+                    isIncomplete: true,
+                    items: completions,
+                };
+            }
+            return completions;
+        },
+    );
 
     // XXX Give more meaningful information when we have more advanced documentation
     connection.onCompletionResolve((item: CompletionItem): CompletionItem => {

--- a/packages/lsp/src/features/completions.ts
+++ b/packages/lsp/src/features/completions.ts
@@ -16,7 +16,8 @@ function completionItemNeedsRefresh(item: CompletionItem): boolean {
         item.label.startsWith("/") &&
         item.label.endsWith(">") &&
         typeof item.filterText === "string" &&
-        item.filterText.startsWith("</")
+        item.filterText.startsWith("</") &&
+        item.textEdit != null
     ) {
         return true;
     }

--- a/packages/lsp/src/features/completions.ts
+++ b/packages/lsp/src/features/completions.ts
@@ -10,6 +10,10 @@ import {
     isRefCompletionContext,
 } from "./_rust-ready";
 
+/**
+ * Identify completion items whose `textEdit` range must stay aligned with the
+ * user's typed prefix across repeated completion requests.
+ */
 function completionItemNeedsRefresh(item: CompletionItem): boolean {
     if (
         typeof item.label === "string" &&
@@ -33,9 +37,7 @@ function completionItemNeedsRefresh(item: CompletionItem): boolean {
 function shouldKeepCompletionListIncomplete(
     completions: CompletionItem[],
 ): boolean {
-    return completions.some((item) => {
-        return completionItemNeedsRefresh(item);
-    });
+    return completions.some(completionItemNeedsRefresh);
 }
 
 export function addDocumentCompletionSupport(

--- a/packages/lsp/src/features/completions.ts
+++ b/packages/lsp/src/features/completions.ts
@@ -1,5 +1,6 @@
 import {
     CompletionItem,
+    CompletionItemKind,
     CompletionList,
     Connection,
 } from "vscode-languageserver/browser";
@@ -9,17 +10,30 @@ import {
     isRefCompletionContext,
 } from "./_rust-ready";
 
+function completionItemNeedsRefresh(item: CompletionItem): boolean {
+    if (
+        typeof item.label === "string" &&
+        item.label.startsWith("/") &&
+        item.label.endsWith(">") &&
+        typeof item.filterText === "string" &&
+        item.filterText.startsWith("</")
+    ) {
+        return true;
+    }
+
+    return (
+        item.kind === CompletionItemKind.Snippet &&
+        typeof item.filterText === "string" &&
+        item.filterText.startsWith("<") &&
+        item.textEdit != null
+    );
+}
+
 function shouldKeepCompletionListIncomplete(
     completions: CompletionItem[],
 ): boolean {
     return completions.some((item) => {
-        return (
-            typeof item.label === "string" &&
-            item.label.startsWith("/") &&
-            item.label.endsWith(">") &&
-            typeof item.filterText === "string" &&
-            item.filterText.startsWith("</")
-        );
+        return completionItemNeedsRefresh(item);
     });
 }
 
@@ -76,9 +90,10 @@ export function addDocumentCompletionSupport(
             );
             // VS Code only asks the server for refreshed completion items while a
             // completion session is active if the prior list was marked
-            // `isIncomplete`. Close-tag completions need that refresh because the
-            // replacement range must expand as the user types `</te...`; otherwise
-            // accepting the stale item can leave the typed suffix behind.
+            // `isIncomplete`. Close-tag and `<`-prefixed snippet completions need
+            // that refresh because their replacement ranges must expand as the
+            // user keeps typing; otherwise accepting a stale item can leave the
+            // typed suffix behind.
             if (shouldKeepCompletionListIncomplete(completions)) {
                 return {
                     isIncomplete: true,

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -71,7 +71,7 @@ connection.onInitialize((params: InitializeParams) => {
             },
             // Tell the client that this server supports code completion.
             completionProvider: {
-                triggerCharacters: ["<", ".", "$", "/", '"', "'", "="],
+                triggerCharacters: ["<", ".", "$", "/", '"', "'", "=", " "],
                 resolveProvider: true,
             },
             documentFormattingProvider: true,

--- a/packages/lsp/src/index.ts
+++ b/packages/lsp/src/index.ts
@@ -82,7 +82,7 @@ connection.onInitialize((params: InitializeParams) => {
             },
             // Tell the client that this server supports code completion.
             completionProvider: {
-                triggerCharacters: ["<", ".", "$", "/", '"', "'", "=", " "],
+                triggerCharacters: ["<", ".", "$", "/", '"', "'", "="],
                 resolveProvider: true,
             },
             documentFormattingProvider: true,

--- a/packages/lsp/test/completions-feature.test.ts
+++ b/packages/lsp/test/completions-feature.test.ts
@@ -11,10 +11,37 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { addDocumentCompletionSupport } from "../src/features/completions";
-import type {
-    CompletionItem,
-    CompletionList,
+import {
+    CompletionItemKind,
+    type CompletionItem,
+    type CompletionList,
 } from "vscode-languageserver-protocol";
+
+function createDocumentEntry(
+    getCompletionContext: () => unknown,
+    getCompletionItems: () => CompletionItem[],
+    rustState: "ready" | "initializing" | "unavailable" = "unavailable",
+    rustAdapter?: unknown,
+    rustReady?: Promise<void>,
+) {
+    return {
+        autoCompleter: {
+            getCompletionContext,
+            getCompletionItems,
+        },
+        additionalDiagnostics: [],
+        rustState,
+        rustAdapter,
+        ...(rustReady ? { rustReady } : {}),
+    };
+}
+
+function createDocumentInfo(
+    uri: string,
+    documentEntry: ReturnType<typeof createDocumentEntry>,
+) {
+    return new Map([[uri, documentEntry]]);
+}
 
 /** Register the completion handler against `documentInfo` and return it. */
 function getCompletionHandler(documentInfo: Map<string, unknown>) {
@@ -37,76 +64,44 @@ describe("addDocumentCompletionSupport", () => {
     });
     it("allows non-ref completions when Rust is unavailable", async () => {
         const uri = "file:///test.doenet";
-        const getCompletionItems = vi.fn(() => [{ label: "graph", kind: 10 }]);
-
-        const documentInfo = new Map([
-            [
-                uri,
-                {
-                    autoCompleter: {
-                        getCompletionContext: () => ({ cursorPos: "body" }),
-                        getCompletionItems,
-                    },
-                    additionalDiagnostics: [],
-                    rustState: "unavailable",
-                    rustAdapter: undefined,
-                },
-            ],
+        const getCompletionItems = vi.fn(() => [
+            { label: "graph", kind: CompletionItemKind.Property },
         ]);
-
-        let completionHandler:
-            | ((params: any) => Promise<CompletionItem[] | CompletionList>)
-            | undefined;
-        const connection = {
-            onCompletion: (handler: any) => {
-                completionHandler = handler;
-            },
-            onCompletionResolve: () => {},
-        };
-
-        addDocumentCompletionSupport(connection as any, documentInfo as any);
+        const completionHandler = getCompletionHandler(
+            createDocumentInfo(
+                uri,
+                createDocumentEntry(
+                    () => ({ cursorPos: "body" }),
+                    getCompletionItems,
+                ),
+            ),
+        );
 
         const items = await completionHandler!({
             textDocument: { uri },
             position: { line: 0, character: 1 },
         });
 
-        expect(items).toEqual([{ label: "graph", kind: 10 }]);
+        expect(items).toEqual([
+            { label: "graph", kind: CompletionItemKind.Property },
+        ]);
         expect(getCompletionItems).toHaveBeenCalledOnce();
     });
 
     it("gates ref completions when Rust is unavailable", async () => {
         const uri = "file:///test.doenet";
-        const getCompletionItems = vi.fn(() => [{ label: "x", kind: 18 }]);
-
-        const documentInfo = new Map([
-            [
-                uri,
-                {
-                    autoCompleter: {
-                        getCompletionContext: () => ({
-                            cursorPos: "refMember",
-                        }),
-                        getCompletionItems,
-                    },
-                    additionalDiagnostics: [],
-                    rustState: "unavailable",
-                    rustAdapter: undefined,
-                },
-            ],
+        const getCompletionItems = vi.fn(() => [
+            { label: "x", kind: CompletionItemKind.Reference },
         ]);
-
-        let completionHandler:
-            | ((params: any) => Promise<CompletionItem[] | CompletionList>)
-            | undefined;
-        const connection = {
-            onCompletion: (handler: any) => {
-                completionHandler = handler;
-            },
-            onCompletionResolve: () => {},
-        };
-
-        addDocumentCompletionSupport(connection as any, documentInfo as any);
+        const completionHandler = getCompletionHandler(
+            createDocumentInfo(
+                uri,
+                createDocumentEntry(
+                    () => ({ cursorPos: "refMember" }),
+                    getCompletionItems,
+                ),
+            ),
+        );
 
         const items = await completionHandler!({
             textDocument: { uri },
@@ -119,25 +114,24 @@ describe("addDocumentCompletionSupport", () => {
 
     it("waits for the rust boot before answering a ref completion", async () => {
         const uri = "file:///test.doenet";
-        const getCompletionItems = vi.fn(() => [{ label: "coords", kind: 18 }]);
+        const getCompletionItems = vi.fn(() => [
+            { label: "coords", kind: CompletionItemKind.Reference },
+        ]);
 
         let resolveRustReady!: () => void;
         const rustReady = new Promise<void>((resolve) => {
             resolveRustReady = resolve;
         });
 
-        const docEntry = {
-            autoCompleter: {
-                getCompletionContext: () => ({ cursorPos: "refMember" }),
-                getCompletionItems,
-            },
-            additionalDiagnostics: [],
-            rustState: "initializing",
-            rustAdapter: undefined as unknown,
+        const docEntry = createDocumentEntry(
+            () => ({ cursorPos: "refMember" }),
+            getCompletionItems,
+            "initializing",
+            undefined,
             rustReady,
-        };
+        );
         const completionHandler = getCompletionHandler(
-            new Map([[uri, docEntry]]),
+            createDocumentInfo(uri, docEntry),
         );
 
         // Handler is invoked while Rust is still initializing — it must not
@@ -153,28 +147,29 @@ describe("addDocumentCompletionSupport", () => {
         docEntry.rustAdapter = {};
         resolveRustReady();
 
-        expect(await pending).toEqual([{ label: "coords", kind: 18 }]);
+        expect(await pending).toEqual([
+            { label: "coords", kind: CompletionItemKind.Reference },
+        ]);
         expect(getCompletionItems).toHaveBeenCalledOnce();
     });
 
     it("falls back to [] if the rust boot exceeds the wait cap", async () => {
         vi.useFakeTimers();
         const uri = "file:///test.doenet";
-        const getCompletionItems = vi.fn(() => [{ label: "coords", kind: 18 }]);
+        const getCompletionItems = vi.fn(() => [
+            { label: "coords", kind: CompletionItemKind.Reference },
+        ]);
 
-        const docEntry = {
-            autoCompleter: {
-                getCompletionContext: () => ({ cursorPos: "refMember" }),
-                getCompletionItems,
-            },
-            additionalDiagnostics: [],
-            rustState: "initializing",
-            rustAdapter: undefined,
+        const docEntry = createDocumentEntry(
+            () => ({ cursorPos: "refMember" }),
+            getCompletionItems,
+            "initializing",
+            undefined,
             // A broken worker never settles `rustReady`.
-            rustReady: new Promise<void>(() => {}),
-        };
+            new Promise<void>(() => {}),
+        );
         const completionHandler = getCompletionHandler(
-            new Map([[uri, docEntry]]),
+            createDocumentInfo(uri, docEntry),
         );
 
         const pending = completionHandler({
@@ -192,7 +187,7 @@ describe("addDocumentCompletionSupport", () => {
         const getCompletionItems = vi.fn(() => [
             {
                 label: "/text>",
-                kind: 10,
+                kind: CompletionItemKind.Property,
                 filterText: "</text>",
                 textEdit: {
                     newText: "</text>",
@@ -205,20 +200,13 @@ describe("addDocumentCompletionSupport", () => {
         ]);
 
         const completionHandler = getCompletionHandler(
-            new Map([
-                [
-                    uri,
-                    {
-                        autoCompleter: {
-                            getCompletionContext: () => ({ cursorPos: "body" }),
-                            getCompletionItems,
-                        },
-                        additionalDiagnostics: [],
-                        rustState: "unavailable",
-                        rustAdapter: undefined,
-                    },
-                ],
-            ]),
+            createDocumentInfo(
+                uri,
+                createDocumentEntry(
+                    () => ({ cursorPos: "body" }),
+                    getCompletionItems,
+                ),
+            ),
         );
 
         const items = await completionHandler({
@@ -231,7 +219,7 @@ describe("addDocumentCompletionSupport", () => {
             items: [
                 {
                     label: "/text>",
-                    kind: 10,
+                    kind: CompletionItemKind.Property,
                     filterText: "</text>",
                     textEdit: {
                         newText: "</text>",
@@ -250,26 +238,19 @@ describe("addDocumentCompletionSupport", () => {
         const getCompletionItems = vi.fn(() => [
             {
                 label: "/text>",
-                kind: 10,
+                kind: CompletionItemKind.Property,
                 filterText: "</text>",
             },
         ]);
 
         const completionHandler = getCompletionHandler(
-            new Map([
-                [
-                    uri,
-                    {
-                        autoCompleter: {
-                            getCompletionContext: () => ({ cursorPos: "body" }),
-                            getCompletionItems,
-                        },
-                        additionalDiagnostics: [],
-                        rustState: "unavailable",
-                        rustAdapter: undefined,
-                    },
-                ],
-            ]),
+            createDocumentInfo(
+                uri,
+                createDocumentEntry(
+                    () => ({ cursorPos: "body" }),
+                    getCompletionItems,
+                ),
+            ),
         );
 
         const items = await completionHandler({
@@ -280,7 +261,7 @@ describe("addDocumentCompletionSupport", () => {
         expect(items).toEqual([
             {
                 label: "/text>",
-                kind: 10,
+                kind: CompletionItemKind.Property,
                 filterText: "</text>",
             },
         ]);
@@ -291,7 +272,7 @@ describe("addDocumentCompletionSupport", () => {
         const getCompletionItems = vi.fn(() => [
             {
                 label: "answer-skeleton",
-                kind: 15,
+                kind: CompletionItemKind.Snippet,
                 filterText: "<answer-skeleton",
                 textEdit: {
                     newText: '<answer name="ans" />',
@@ -304,22 +285,13 @@ describe("addDocumentCompletionSupport", () => {
         ]);
 
         const completionHandler = getCompletionHandler(
-            new Map([
-                [
-                    uri,
-                    {
-                        autoCompleter: {
-                            getCompletionContext: () => ({
-                                cursorPos: "openTagName",
-                            }),
-                            getCompletionItems,
-                        },
-                        additionalDiagnostics: [],
-                        rustState: "unavailable",
-                        rustAdapter: undefined,
-                    },
-                ],
-            ]),
+            createDocumentInfo(
+                uri,
+                createDocumentEntry(
+                    () => ({ cursorPos: "openTagName" }),
+                    getCompletionItems,
+                ),
+            ),
         );
 
         const items = await completionHandler({
@@ -332,7 +304,7 @@ describe("addDocumentCompletionSupport", () => {
             items: [
                 {
                     label: "answer-skeleton",
-                    kind: 15,
+                    kind: CompletionItemKind.Snippet,
                     filterText: "<answer-skeleton",
                     textEdit: {
                         newText: '<answer name="ans" />',

--- a/packages/lsp/test/completions-feature.test.ts
+++ b/packages/lsp/test/completions-feature.test.ts
@@ -11,11 +11,15 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { addDocumentCompletionSupport } from "../src/features/completions";
+import type {
+    CompletionItem,
+    CompletionList,
+} from "vscode-languageserver-protocol";
 
 /** Register the completion handler against `documentInfo` and return it. */
 function getCompletionHandler(documentInfo: Map<string, unknown>) {
     let completionHandler:
-        | ((params: any) => Promise<Array<{ label: string; kind: number }>>)
+        | ((params: any) => Promise<CompletionItem[] | CompletionList>)
         | undefined;
     const connection = {
         onCompletion: (handler: any) => {
@@ -51,7 +55,7 @@ describe("addDocumentCompletionSupport", () => {
         ]);
 
         let completionHandler:
-            | ((params: any) => Promise<Array<{ label: string; kind: number }>>)
+            | ((params: any) => Promise<CompletionItem[] | CompletionList>)
             | undefined;
         const connection = {
             onCompletion: (handler: any) => {
@@ -93,7 +97,7 @@ describe("addDocumentCompletionSupport", () => {
         ]);
 
         let completionHandler:
-            | ((params: any) => Promise<Array<{ label: string; kind: number }>>)
+            | ((params: any) => Promise<CompletionItem[] | CompletionList>)
             | undefined;
         const connection = {
             onCompletion: (handler: any) => {
@@ -181,5 +185,63 @@ describe("addDocumentCompletionSupport", () => {
 
         expect(await pending).toEqual([]);
         expect(getCompletionItems).not.toHaveBeenCalled();
+    });
+
+    it("marks close-tag completions incomplete so VS Code re-requests them", async () => {
+        const uri = "file:///test.doenet";
+        const getCompletionItems = vi.fn(() => [
+            {
+                label: "/text>",
+                kind: 10,
+                filterText: "</text>",
+                textEdit: {
+                    newText: "</text>",
+                    range: {
+                        start: { line: 0, character: 5 },
+                        end: { line: 0, character: 7 },
+                    },
+                },
+            },
+        ]);
+
+        const completionHandler = getCompletionHandler(
+            new Map([
+                [
+                    uri,
+                    {
+                        autoCompleter: {
+                            getCompletionContext: () => ({ cursorPos: "body" }),
+                            getCompletionItems,
+                        },
+                        additionalDiagnostics: [],
+                        rustState: "unavailable",
+                        rustAdapter: undefined,
+                    },
+                ],
+            ]),
+        );
+
+        const items = await completionHandler({
+            textDocument: { uri },
+            position: { line: 0, character: 7 },
+        });
+
+        expect(items).toEqual({
+            isIncomplete: true,
+            items: [
+                {
+                    label: "/text>",
+                    kind: 10,
+                    filterText: "</text>",
+                    textEdit: {
+                        newText: "</text>",
+                        range: {
+                            start: { line: 0, character: 5 },
+                            end: { line: 0, character: 7 },
+                        },
+                    },
+                },
+            ],
+        });
     });
 });

--- a/packages/lsp/test/completions-feature.test.ts
+++ b/packages/lsp/test/completions-feature.test.ts
@@ -245,6 +245,47 @@ describe("addDocumentCompletionSupport", () => {
         });
     });
 
+    it("does not mark close-tag-shaped items incomplete when they lack a textEdit", async () => {
+        const uri = "file:///test.doenet";
+        const getCompletionItems = vi.fn(() => [
+            {
+                label: "/text>",
+                kind: 10,
+                filterText: "</text>",
+            },
+        ]);
+
+        const completionHandler = getCompletionHandler(
+            new Map([
+                [
+                    uri,
+                    {
+                        autoCompleter: {
+                            getCompletionContext: () => ({ cursorPos: "body" }),
+                            getCompletionItems,
+                        },
+                        additionalDiagnostics: [],
+                        rustState: "unavailable",
+                        rustAdapter: undefined,
+                    },
+                ],
+            ]),
+        );
+
+        const items = await completionHandler({
+            textDocument: { uri },
+            position: { line: 0, character: 7 },
+        });
+
+        expect(items).toEqual([
+            {
+                label: "/text>",
+                kind: 10,
+                filterText: "</text>",
+            },
+        ]);
+    });
+
     it("marks `<`-prefixed snippet completions incomplete so VS Code refreshes their textEdit range", async () => {
         const uri = "file:///test.doenet";
         const getCompletionItems = vi.fn(() => [

--- a/packages/lsp/test/completions-feature.test.ts
+++ b/packages/lsp/test/completions-feature.test.ts
@@ -244,4 +244,64 @@ describe("addDocumentCompletionSupport", () => {
             ],
         });
     });
+
+    it("marks `<`-prefixed snippet completions incomplete so VS Code refreshes their textEdit range", async () => {
+        const uri = "file:///test.doenet";
+        const getCompletionItems = vi.fn(() => [
+            {
+                label: "answer-skeleton",
+                kind: 15,
+                filterText: "<answer-skeleton",
+                textEdit: {
+                    newText: '<answer name="ans" />',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 1 },
+                    },
+                },
+            },
+        ]);
+
+        const completionHandler = getCompletionHandler(
+            new Map([
+                [
+                    uri,
+                    {
+                        autoCompleter: {
+                            getCompletionContext: () => ({
+                                cursorPos: "openTagName",
+                            }),
+                            getCompletionItems,
+                        },
+                        additionalDiagnostics: [],
+                        rustState: "unavailable",
+                        rustAdapter: undefined,
+                    },
+                ],
+            ]),
+        );
+
+        const items = await completionHandler({
+            textDocument: { uri },
+            position: { line: 0, character: 1 },
+        });
+
+        expect(items).toEqual({
+            isIncomplete: true,
+            items: [
+                {
+                    label: "answer-skeleton",
+                    kind: 15,
+                    filterText: "<answer-skeleton",
+                    textEdit: {
+                        newText: '<answer name="ans" />',
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 1 },
+                        },
+                    },
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
Without explicit `textEdit` ranges, VS Code duplicates typed characters when accepting close-tag completions. Typing `</` inside `<text>` and accepting the completion `/text>` produced broken results such as `<text><//text>`, and after typing farther into the tag name (`</te|`) VS Code could keep using a stale replacement range and leave the already-typed suffix behind. The same stale-range behavior could also affect `<`-triggered snippet completions that stay visible while the user keeps typing.

## Root cause

The CodeMirror LSP plugin keeps track of the trigger start across keystrokes, but VS Code's native LSP client only asks the server for updated items while a completion list is marked incomplete. The close-tag item therefore needed both an explicit `textEdit`/`filterText` and a way to force the server to refresh the item as the user keeps typing. Snippet completions that replace the whole `<...` prefix need the same refresh behavior for their replacement ranges.

## Fix

**`packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts`**

1. Close-tag completions now always carry explicit `textEdit` ranges in the relevant flows, including partially typed close tags, so accepting the item replaces the whole `</...` prefix.
2. Close-tag items set `filterText = "</tag>"` so they remain visible in VS Code as the typed prefix grows from `<` to `</` to `</te`.
3. Regular `<`-triggered snippets keep their `<`-prefixed `filterText`, and the dynamic prefigure `annotations-skeleton` snippet now uses the same filtering path so it stays visible as the tag name is typed.
4. The per-instance `<module copy|extend>` attribute refresh now runs only in the attribute-name completion branch, avoiding unrelated resolver work during close-tag completion requests.

**`packages/lsp/src/features/completions.ts`**

5. Completion responses that include a close-tag item or a `<`-triggered snippet item are now returned as `CompletionList { isIncomplete: true }`, so VS Code re-requests completions on subsequent keystrokes and gets an updated replacement range.

## Tests

- Updated `packages/lsp-tools/test/doenet-auto-complete.test.ts` assertions and snapshots for the explicit close-tag `textEdit`/`filterText` behavior.
- Added a focused dynamic-snippet regression in `packages/lsp-tools/test/doenet-auto-complete.test.ts` covering the prefigure `annotations-skeleton` filter behavior while typing `<ann`.
- Added focused `packages/lsp/test/completions-feature.test.ts` regressions covering the `isIncomplete` responses used by VS Code for both close-tag and `<`-triggered snippet completion refresh.
- Added a changeset describing the user-visible editor fix.
