### PR TITLE
ci: publish VS Code extension pre-release on every merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,15 +102,18 @@ jobs:
     # main, mirroring the `dev-release` pattern for npm packages.
     #
     # Version scheme: the extension version uses an integer semver (required by
-    # the VS Code Marketplace), so we cannot use the `-dev.timestamp.hash`
-    # suffix that npm dev packages use.  Instead we derive a pre-release patch
-    # number from the CI run number, adding a large offset (10000) to keep it
-    # well above any stable patch (e.g. 0.7.20) while still being unique and
-    # monotonically increasing.  Example: CI run 42 → extension version 0.7.10042.
+    # the VS Code Marketplace), so we cannot use the `-dev.N` suffix that npm
+    # dev packages use.  Instead we add a large offset (10000) to the publish
+    # workflow run number to keep the patch well above any stable patch while
+    # remaining unique and monotonically increasing.  The two are correlatable:
+    #   npm 0.7.20-dev.150  ↔  VS Code 0.7.10150  (publish workflow run 150)
+    # A workflow rerun republishes the same code under the same version, which
+    # is correct — "version already published" on a rerun means the first
+    # attempt succeeded.
     #
     # Secret requirement: `VSCE_PAT` must be configured as a **repository-level**
     # secret (not only in the `production` environment) for this job to publish.
-    # If the secret is absent the publish step is skipped and a warning is emitted.
+    # If the secret is absent the publish step emits a warning and exits cleanly.
     dev-vscode-extension:
         name: Dev VS Code Extension Pre-release
         runs-on: ubuntu-latest
@@ -155,14 +158,13 @@ jobs:
                   CURRENT=$(node -p "require('./packages/vscode-extension/extension/package.json').version")
                   MAJOR=$(echo "$CURRENT" | cut -d. -f1)
                   MINOR=$(echo "$CURRENT" | cut -d. -f2)
-                  # Offset the CI run number by 10000 so pre-release patches are
-                  # always much larger than any stable patch (e.g. 0.7.20).
-                  # Correlates with the npm dev release: npm 0.7.20-dev.150
-                  # corresponds to VS Code 0.7.10150.
+                  # Add 10000 to the publish workflow run number to keep pre-release
+                  # patches well above any stable patch (e.g. 0.7.20).  Correlates
+                  # with the npm dev release: npm 0.7.20-dev.150 ↔ VS Code 0.7.10150.
                   PATCH=$(( ${{ github.run_number }} + 10000 ))
                   VERSION="${MAJOR}.${MINOR}.${PATCH}"
                   echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-                  echo "Pre-release version: ${VERSION} (npm dev suffix: ${{ github.run_number }})"
+                  echo "Pre-release version: ${VERSION} (publish run: ${{ github.run_number }})"
 
             - name: Set pre-release version in extension manifest
               run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,16 +182,19 @@ jobs:
                   WIREIT_CACHE: "local"
 
             - name: Publish VS Code extension pre-release
-              if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && secrets.VSCE_PAT != '' }}
-              run: npm run publish:prerelease -w @doenet/vscode-extension
+              if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+              run: |
+                  # secrets.* is not available in `if:` expressions (GitHub Actions
+                  # treats secrets as empty strings there), so we guard here in the
+                  # shell where the secret is actually populated via env:.
+                  if [ -z "${VSCE_PAT}" ]; then
+                      echo "::warning::VSCE_PAT repository secret is not set — VS Code extension pre-release was not published."
+                      echo "Add VSCE_PAT as a repository-level secret (Settings → Secrets → Actions) to enable pre-release publishing."
+                      exit 0
+                  fi
+                  npm run publish:prerelease -w @doenet/vscode-extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-            - name: Warn if VSCE_PAT is not configured
-              if: ${{ secrets.VSCE_PAT == '' }}
-              run: |
-                  echo "::warning::VSCE_PAT repository secret is not set — VS Code extension pre-release was not published."
-                  echo "Add VSCE_PAT as a repository-level secret (Settings → Secrets → Actions) to enable pre-release publishing."
 
     production-release:
         name: Production Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,9 +74,7 @@ jobs:
             - name: Update versions
               run: |
                   CURRENT_VERSION=$(node -p "require('./packages/doenetml/package.json').version")
-                  TIMESTAMP=$(date +%Y%m%d%H%M%S)
-                  COMMIT_HASH=$(git rev-parse --short HEAD)
-                  VERSION="${CURRENT_VERSION}-dev.${TIMESTAMP}.${COMMIT_HASH}"
+                  VERSION="${CURRENT_VERSION}-dev.${{ github.run_number }}"
                   npm run version -- ${VERSION} --no-git-tag-version
 
             - name: Build workspaces
@@ -158,12 +156,13 @@ jobs:
                   MAJOR=$(echo "$CURRENT" | cut -d. -f1)
                   MINOR=$(echo "$CURRENT" | cut -d. -f2)
                   # Offset the CI run number by 10000 so pre-release patches are
-                  # always much larger than any stable patch (e.g. 0.7.20) and
-                  # the number is clearly a CI artefact, not a hand-crafted bump.
+                  # always much larger than any stable patch (e.g. 0.7.20).
+                  # Correlates with the npm dev release: npm 0.7.20-dev.150
+                  # corresponds to VS Code 0.7.10150.
                   PATCH=$(( ${{ github.run_number }} + 10000 ))
                   VERSION="${MAJOR}.${MINOR}.${PATCH}"
                   echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-                  echo "Pre-release version: ${VERSION}"
+                  echo "Pre-release version: ${VERSION} (npm dev suffix: ${{ github.run_number }})"
 
             - name: Set pre-release version in extension manifest
               run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,10 +170,15 @@ jobs:
               run: |
                   node -e "
                     const fs = require('fs');
-                    const p = 'packages/vscode-extension/extension/package.json';
-                    const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
-                    pkg.version = '${{ steps.prerelease-version.outputs.version }}';
-                    fs.writeFileSync(p, JSON.stringify(pkg, null, 4) + '\n');
+                    const version = '${{ steps.prerelease-version.outputs.version }}';
+                    for (const p of [
+                      'packages/vscode-extension/package.json',
+                      'packages/vscode-extension/extension/package.json',
+                    ]) {
+                      const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+                      pkg.version = version;
+                      fs.writeFileSync(p, JSON.stringify(pkg, null, 4) + '\n');
+                    }
                   "
 
             - name: Build VS Code extension

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,6 +100,100 @@ jobs:
               if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
               run: bash .github/scripts/purge-jsdelivr.sh dev
 
+    # Publishes a VS Code extension pre-release on every successful CI run on
+    # main, mirroring the `dev-release` pattern for npm packages.
+    #
+    # Version scheme: the extension version uses an integer semver (required by
+    # the VS Code Marketplace), so we cannot use the `-dev.timestamp.hash`
+    # suffix that npm dev packages use.  Instead we derive a pre-release patch
+    # number from the CI run number, adding a large offset (10000) to keep it
+    # well above any stable patch (e.g. 0.7.20) while still being unique and
+    # monotonically increasing.  Example: CI run 42 → extension version 0.7.10042.
+    #
+    # Secret requirement: `VSCE_PAT` must be configured as a **repository-level**
+    # secret (not only in the `production` environment) for this job to publish.
+    # If the secret is absent the publish step is skipped and a warning is emitted.
+    dev-vscode-extension:
+        name: Dev VS Code Extension Pre-release
+        runs-on: ubuntu-latest
+        if: >-
+            (github.event_name == 'workflow_run' &&
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.head_branch == 'main') ||
+            (github.event_name == 'workflow_dispatch' && inputs.channel == 'dev')
+        permissions:
+            actions: read
+            contents: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+            - name: Determine checked out commit SHA
+              id: checked-sha
+              run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+            - name: Use Node.js 24
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24.15.0
+                  cache: "npm"
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Verify CI succeeded for target commit
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  TARGET_SHA: ${{ steps.checked-sha.outputs.sha }}
+              run: node .github/scripts/verify-ci.mjs
+
+            - name: Compute pre-release version
+              id: prerelease-version
+              run: |
+                  # Read the current stable version from the extension manifest.
+                  CURRENT=$(node -p "require('./packages/vscode-extension/extension/package.json').version")
+                  MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+                  MINOR=$(echo "$CURRENT" | cut -d. -f2)
+                  # Offset the CI run number by 10000 so pre-release patches are
+                  # always much larger than any stable patch (e.g. 0.7.20) and
+                  # the number is clearly a CI artefact, not a hand-crafted bump.
+                  PATCH=$(( ${{ github.run_number }} + 10000 ))
+                  VERSION="${MAJOR}.${MINOR}.${PATCH}"
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "Pre-release version: ${VERSION}"
+
+            - name: Set pre-release version in extension manifest
+              run: |
+                  node -e "
+                    const fs = require('fs');
+                    const p = 'packages/vscode-extension/extension/package.json';
+                    const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+                    pkg.version = '${{ steps.prerelease-version.outputs.version }}';
+                    fs.writeFileSync(p, JSON.stringify(pkg, null, 4) + '\n');
+                  "
+
+            - name: Build VS Code extension
+              run: |
+                  export NODE_OPTIONS="--max_old_space_size=6114"
+                  npm run build -w @doenet/vscode-extension
+              env:
+                  WIREIT_CACHE: "local"
+
+            - name: Publish VS Code extension pre-release
+              if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && secrets.VSCE_PAT != '' }}
+              run: npm run publish:prerelease -w @doenet/vscode-extension
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+            - name: Warn if VSCE_PAT is not configured
+              if: ${{ secrets.VSCE_PAT == '' }}
+              run: |
+                  echo "::warning::VSCE_PAT repository secret is not set — VS Code extension pre-release was not published."
+                  echo "Add VSCE_PAT as a repository-level secret (Settings → Secrets → Actions) to enable pre-release publishing."
+
     production-release:
         name: Production Release
         runs-on: ubuntu-latest

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -33,6 +33,7 @@
         "test": "vitest",
         "package": "cd ./extension && vsce package --no-dependencies --out ../",
         "publish": "cd ./extension && vsce publish --no-dependencies",
+        "publish:prerelease": "cd ./extension && vsce publish --pre-release --no-dependencies",
         "run-in-browser:firefox": "vscode-test-web --browserType=firefox --extensionDevelopmentPath=./extension .",
         "run-in-browser:chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=./extension .",
         "run-in-browser": "npm run run-in-browser:firefox"


### PR DESCRIPTION
Adds a new `dev-vscode-extension` job to `publish.yml` that mirrors the existing dev npm release pattern for the VS Code extension.

## What it does

On every successful CI run on `main` (or manual `workflow_dispatch` with `channel=dev`), the job:
1. Verifies CI passed for the target commit
2. Computes a pre-release version: `major.minor.(runNumber + 10000)` — e.g. CI run 42 → `0.7.10042`, always greater than any stable patch
3. Builds the full extension (language server + preview window)
4. Publishes with `--pre-release` to the VS Code Marketplace

## User experience

VS Code Marketplace treats pre-release separately from the stable track. Users see the stable version (`0.7.20`) by default. Opting in via **"Switch to Pre-Release Version"** in the Extensions panel gives them the latest CI build. This makes it easy to share in-progress fixes with users before an official release (e.g. for the module custom-attribute diagnostics bug in #1375).

## Version scheme

The VS Code Marketplace requires integer semver — no `-dev.timestamp.hash` suffix like npm packages use. Pre-release builds use `major.minor.(runNumber + 10000)` to keep them clearly above any hand-crafted stable patch and monotonically increasing. When the stable version bumps (e.g. `0.8.0`), pre-releases automatically become `0.8.10NNN` with no workflow changes needed.

## Setup required

`VSCE_PAT` must be added as a **repository-level** secret (Settings → Secrets → Actions → New repository secret), not only in the `production` environment. The job emits a workflow warning if the secret is absent rather than failing, so the CI remains green even before the secret is configured.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)