### PR TITLE
ci: auto-publish prefigure when version bumps on main

### DIFF
--- a/.github/scripts/find-previous-ci-sha.mjs
+++ b/.github/scripts/find-previous-ci-sha.mjs
@@ -1,0 +1,56 @@
+/**
+ * Find the head SHA of the most recent successful CI run on main that
+ * predates the current run. Prints the SHA to stdout, or nothing if no
+ * prior run is found.
+ *
+ * Required environment variables:
+ *   GITHUB_TOKEN       - GitHub Actions token with `actions: read` permission
+ *   REPO               - Repository in "owner/name" format (e.g. "Doenet/DoenetML")
+ *   CI_RUN_ID          - Numeric ID of the current CI run (excluded from results)
+ *   CI_RUN_CREATED_AT  - ISO 8601 timestamp of the current CI run (used as upper bound)
+ *   TRIGGER_SHA        - Head SHA of the current CI run (excluded from results)
+ */
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.REPO;
+const currentRunId = Number(process.env.CI_RUN_ID);
+const currentCreatedAt = Date.parse(process.env.CI_RUN_CREATED_AT);
+const currentHeadSha = process.env.TRIGGER_SHA;
+
+if (!token || !repo || !currentRunId || !currentCreatedAt || !currentHeadSha) {
+    console.error("Missing required environment for find-previous-ci-sha");
+    process.exit(1);
+}
+
+const url = `https://api.github.com/repos/${repo}/actions/workflows/ci.yml/runs?branch=main&event=push&status=completed&per_page=100`;
+
+const response = await fetch(url, {
+    headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    },
+});
+
+if (!response.ok) {
+    console.error(
+        `Failed to query CI workflow runs: ${response.status} ${response.statusText}`,
+    );
+    console.error(await response.text());
+    process.exit(1);
+}
+
+const data = await response.json();
+const runs = data.workflow_runs ?? [];
+
+const previousRun = runs.find(
+    (run) =>
+        run.conclusion === "success" &&
+        run.id !== currentRunId &&
+        run.head_sha !== currentHeadSha &&
+        Date.parse(run.created_at) < currentCreatedAt,
+);
+
+if (previousRun) {
+    process.stdout.write(previousRun.head_sha);
+}

--- a/.github/scripts/purge-jsdelivr-prefigure.sh
+++ b/.github/scripts/purge-jsdelivr-prefigure.sh
@@ -18,7 +18,7 @@ sleep 15
 echo "Purging jsDelivr cache for @doenet/prefigure@${TAG} (package-level)..."
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}" || exit 1
 
-echo "Purging key prefigure assets for @${TAG} tag..."
+echo "Purging key prefigure assets for @doenet/prefigure@${TAG}..."
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}/prefigure.js" || exit 1
 
 echo "Successfully purged jsDelivr cache for @doenet/prefigure@${TAG}"

--- a/.github/scripts/purge-jsdelivr-prefigure.sh
+++ b/.github/scripts/purge-jsdelivr-prefigure.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Purge jsDelivr cache for @doenet/prefigure at a specific version tag.
+#
+# Usage: purge-jsdelivr-prefigure.sh <tag>
+# Example: purge-jsdelivr-prefigure.sh latest
+
+set -e
+
+TAG="${1}"
+if [[ -z "${TAG}" ]]; then
+    echo "Error: tag argument is required (e.g. 'latest')" >&2
+    exit 1
+fi
+
+echo "Waiting for npm package propagation before purging jsDelivr cache..."
+sleep 15
+
+echo "Purging jsDelivr cache for @doenet/prefigure@${TAG} (package-level)..."
+curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}" || exit 1
+
+echo "Purging key prefigure assets for @${TAG} tag..."
+curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}/prefigure.js" || exit 1
+
+echo "Successfully purged jsDelivr cache for @doenet/prefigure@${TAG}"

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -68,11 +68,15 @@ jobs:
     publish-prefigure:
         name: Publish Prefigure
         needs: [check-version-changed]
+        # Allow reruns to retry post-publish steps without attempting a
+        # duplicate npm publish once the version is already on the registry.
         if: >-
             always() && (
               github.event_name == 'workflow_dispatch' ||
               (github.event.workflow_run.conclusion == 'success' &&
-               needs.check-version-changed.outputs.should_publish == 'true')
+               needs.check-version-changed.result == 'success' &&
+               (needs.check-version-changed.outputs.should_publish == 'true' ||
+                github.run_attempt > 1))
             )
         runs-on: ubuntu-latest
         environment: production
@@ -138,14 +142,21 @@ jobs:
               run: npm run verify-wheel-sync -w @doenet/prefigure
 
             - name: Publish prefigure package
-              if: steps.params.outputs.dry_run != 'true'
+              if: >-
+                  steps.params.outputs.dry_run != 'true' &&
+                  (github.event_name == 'workflow_dispatch' ||
+                   needs.check-version-changed.outputs.should_publish == 'true')
               env:
                   NPM_TAG: ${{ steps.params.outputs.npm_tag }}
               run: |
                   node .github/scripts/npm-publish-with-retry.mjs packages/prefigure/dist --tag "${NPM_TAG}"
 
             - name: Purge jsDelivr cache
-              if: steps.params.outputs.dry_run != 'true'
+              if: >-
+                  steps.params.outputs.dry_run != 'true' &&
+                  (github.event_name == 'workflow_dispatch' ||
+                   needs.check-version-changed.outputs.should_publish == 'true' ||
+                   github.run_attempt > 1)
               env:
                   NPM_TAG: ${{ steps.params.outputs.npm_tag }}
               run: |

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -13,14 +13,52 @@ on:
                 required: true
                 type: string
                 default: latest
+    workflow_run:
+        workflows: ["CI"]
+        types: [completed]
+        branches: [main]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
     cancel-in-progress: false
 
 jobs:
+    check-version-changed:
+        name: Check if prefigure version changed
+        runs-on: ubuntu-latest
+        if: github.event_name == 'workflow_run'
+        outputs:
+            should_publish: ${{ steps.check.outputs.should_publish }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 2
+                  ref: ${{ github.event.workflow_run.head_sha }}
+
+            - name: Check for version bump
+              id: check
+              run: |
+                  PREV=$(git show HEAD~1:packages/prefigure/package.json | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(JSON.parse(d).version))" 2>/dev/null || echo "none")
+                  CURR=$(node -e "console.log(require('./packages/prefigure/package.json').version)")
+                  echo "Previous version: $PREV"
+                  echo "Current version:  $CURR"
+                  if [ "$PREV" != "$CURR" ]; then
+                      echo "should_publish=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "Prefigure version unchanged ($CURR), skipping publish."
+                      echo "should_publish=false" >> "$GITHUB_OUTPUT"
+                  fi
+
     publish-prefigure:
         name: Publish Prefigure
+        needs: [check-version-changed]
+        if: >-
+            always() && (
+              github.event_name == 'workflow_dispatch' ||
+              (github.event.workflow_run.conclusion == 'success' &&
+               needs.check-version-changed.outputs.should_publish == 'true')
+            )
         runs-on: ubuntu-latest
         environment: production
         permissions:
@@ -28,10 +66,22 @@ jobs:
             contents: read
             id-token: write
         steps:
+            - name: Set publish parameters
+              id: params
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                      echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+                      echo "npm_tag=${{ inputs.npm_tag }}" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "dry_run=false" >> "$GITHUB_OUTPUT"
+                      echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+                  ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
             - name: Determine checked out commit SHA
               id: checked-sha
@@ -73,16 +123,16 @@ jobs:
               run: npm run verify-wheel-sync -w @doenet/prefigure
 
             - name: Publish prefigure package
-              if: ${{ !inputs.dry_run }}
+              if: steps.params.outputs.dry_run != 'true'
               env:
-                  NPM_TAG: ${{ inputs.npm_tag }}
+                  NPM_TAG: ${{ steps.params.outputs.npm_tag }}
               run: |
                   node .github/scripts/npm-publish-with-retry.mjs packages/prefigure/dist --tag "${NPM_TAG}"
 
             - name: Purge jsDelivr cache
-              if: ${{ !inputs.dry_run }}
+              if: steps.params.outputs.dry_run != 'true'
               env:
-                  NPM_TAG: ${{ inputs.npm_tag }}
+                  NPM_TAG: ${{ steps.params.outputs.npm_tag }}
               run: |
                   echo "Waiting for npm package propagation before purging jsDelivr cache..."
                   sleep 15

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -192,6 +192,14 @@ jobs:
                   fetch-depth: 0
                   ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
+            - name: Use Node.js 24
+              uses: actions/setup-node@v6
+              with:
+                  # See ci.yml for the rationale behind pinning to 24.15.0.
+                  node-version: 24.15.0
+                  registry-url: https://registry.npmjs.org
+                  cache: "npm"
+
             - name: Determine checked out commit SHA
               id: checked-sha
               run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -216,14 +224,6 @@ jobs:
                       echo "Error: checked-out commit is not reachable from origin/main. Only commits on main may be published." >&2
                       exit 1
                   fi
-
-            - name: Use Node.js 24
-              uses: actions/setup-node@v6
-              with:
-                  # See ci.yml for the rationale behind pinning to 24.15.0.
-                  node-version: 24.15.0
-                  registry-url: https://registry.npmjs.org
-                  cache: "npm"
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -29,10 +29,12 @@ jobs:
         if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
         outputs:
             should_publish: ${{ steps.check.outputs.should_publish }}
+            is_latest_main: ${{ steps.check.outputs.is_latest_main }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
+                  fetch-depth: 0
                   ref: ${{ github.event.workflow_run.head_sha }}
 
             - name: Use Node.js 24
@@ -45,6 +47,15 @@ jobs:
             - name: Check whether current version is already published
               id: check
               run: |
+                  git fetch origin main
+                  if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+                      echo "Triggered commit is not the current origin/main tip, skipping publish."
+                      echo "is_latest_main=false" >> "$GITHUB_OUTPUT"
+                      echo "should_publish=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
+                  echo "is_latest_main=true" >> "$GITHUB_OUTPUT"
                   # Compare against npm rather than HEAD~1 so reruns and
                   # multi-commit pushes on main make the right publish decision.
                   CURR=$(node -e "console.log(require('./packages/prefigure/package.json').version)")
@@ -75,6 +86,7 @@ jobs:
               github.event_name == 'workflow_dispatch' ||
               (github.event.workflow_run.conclusion == 'success' &&
                needs.check-version-changed.result == 'success' &&
+               needs.check-version-changed.outputs.is_latest_main == 'true' &&
                (needs.check-version-changed.outputs.should_publish == 'true' ||
                 github.run_attempt > 1))
             )
@@ -109,7 +121,12 @@ jobs:
             - name: Verify commit is on main
               run: |
                   git fetch origin main
-                  if ! git merge-base --is-ancestor HEAD origin/main; then
+                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
+                      if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+                          echo "Error: auto-publish only runs for the current origin/main tip." >&2
+                          exit 1
+                      fi
+                  elif ! git merge-base --is-ancestor HEAD origin/main; then
                       echo "Error: checked-out commit is not reachable from origin/main. Only commits on main may be published." >&2
                       exit 1
                   fi

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -24,30 +24,45 @@ concurrency:
 
 jobs:
     check-version-changed:
-        name: Check if prefigure version changed
+        name: Check if prefigure needs publishing
         runs-on: ubuntu-latest
-        if: github.event_name == 'workflow_run'
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
         outputs:
             should_publish: ${{ steps.check.outputs.should_publish }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
-                  fetch-depth: 2
                   ref: ${{ github.event.workflow_run.head_sha }}
 
-            - name: Check for version bump
+            - name: Use Node.js 24
+              uses: actions/setup-node@v6
+              with:
+                  # See ci.yml for the rationale behind pinning to 24.15.0.
+                  node-version: 24.15.0
+                  registry-url: https://registry.npmjs.org
+
+            - name: Check whether current version is already published
               id: check
               run: |
-                  PREV=$(git show HEAD~1:packages/prefigure/package.json | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>console.log(JSON.parse(d).version))" 2>/dev/null || echo "none")
+                  # Compare against npm rather than HEAD~1 so reruns and
+                  # multi-commit pushes on main make the right publish decision.
                   CURR=$(node -e "console.log(require('./packages/prefigure/package.json').version)")
-                  echo "Previous version: $PREV"
-                  echo "Current version:  $CURR"
-                  if [ "$PREV" != "$CURR" ]; then
+                  echo "Current version: $CURR"
+                  set +e
+                  VIEW_OUTPUT=$(npm view "@doenet/prefigure@${CURR}" version --json 2>&1)
+                  VIEW_STATUS=$?
+                  set -e
+                  if [ "$VIEW_STATUS" -eq 0 ]; then
+                      echo "Version ${CURR} is already published, skipping publish."
+                      echo "should_publish=false" >> "$GITHUB_OUTPUT"
+                  elif echo "$VIEW_OUTPUT" | grep -q "E404"; then
+                      echo "Version ${CURR} is not yet published."
                       echo "should_publish=true" >> "$GITHUB_OUTPUT"
                   else
-                      echo "Prefigure version unchanged ($CURR), skipping publish."
-                      echo "should_publish=false" >> "$GITHUB_OUTPUT"
+                      echo "$VIEW_OUTPUT" >&2
+                      echo "Failed to query npm for @doenet/prefigure@${CURR}." >&2
+                      exit 1
                   fi
 
     publish-prefigure:

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -27,9 +27,12 @@ jobs:
         name: Check if prefigure needs publishing
         runs-on: ubuntu-latest
         if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+        permissions:
+            actions: read
+            contents: read
         outputs:
             should_publish: ${{ steps.check.outputs.should_publish }}
-            is_latest_main: ${{ steps.check.outputs.is_latest_main }}
+            matches_main_version: ${{ steps.check.outputs.matches_main_version }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -46,20 +49,89 @@ jobs:
 
             - name: Check whether current version is already published
               id: check
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  CI_RUN_ID: ${{ github.event.workflow_run.id }}
+                  CI_RUN_CREATED_AT: ${{ github.event.workflow_run.created_at }}
+                  TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
               run: |
+                  json_version_from_stdin() {
+                      node -e 'const fs = require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(0, "utf8")).version);'
+                  }
+
                   git fetch origin main
-                  if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
-                      echo "Triggered commit is not the current origin/main tip, skipping publish."
-                      echo "is_latest_main=false" >> "$GITHUB_OUTPUT"
+                  CURR=$(node -e "console.log(require('./packages/prefigure/package.json').version)")
+                  # If main has moved on to a different prefigure version, let the
+                  # newer run own that publish instead of moving the registry back.
+                  MAIN=$(git show origin/main:packages/prefigure/package.json | json_version_from_stdin)
+                  echo "Triggering commit version: $CURR"
+                  echo "Current origin/main version: $MAIN"
+                  if [ "$CURR" != "$MAIN" ]; then
+                      echo "Triggered commit no longer matches the current origin/main prefigure version, skipping publish."
+                      echo "matches_main_version=false" >> "$GITHUB_OUTPUT"
                       echo "should_publish=false" >> "$GITHUB_OUTPUT"
                       exit 0
                   fi
 
-                  echo "is_latest_main=true" >> "$GITHUB_OUTPUT"
-                  # Compare against npm rather than HEAD~1 so reruns and
-                  # multi-commit pushes on main make the right publish decision.
-                  CURR=$(node -e "console.log(require('./packages/prefigure/package.json').version)")
-                  echo "Current version: $CURR"
+                  echo "matches_main_version=true" >> "$GITHUB_OUTPUT"
+
+                  # Compare against the previous distinct main CI head so a single
+                  # push containing multiple commits still counts as one version bump.
+                  PREV_SHA=$(node --input-type=module - <<'NODE'
+                  const token = process.env.GITHUB_TOKEN;
+                  const repo = process.env.REPO;
+                  const currentRunId = Number(process.env.CI_RUN_ID);
+                  const currentCreatedAt = Date.parse(
+                      process.env.CI_RUN_CREATED_AT,
+                  );
+                  const currentHeadSha = process.env.TRIGGER_SHA;
+                  const url = `https://api.github.com/repos/${repo}/actions/workflows/ci.yml/runs?branch=main&event=push&status=completed&per_page=100`;
+                  const response = await fetch(url, {
+                      headers: {
+                          Authorization: `Bearer ${token}`,
+                          Accept: "application/vnd.github+json",
+                          "X-GitHub-Api-Version": "2022-11-28",
+                      },
+                  });
+                  if (!response.ok) {
+                      console.error(
+                          `Failed to query CI workflow runs: ${response.status} ${response.statusText}`,
+                      );
+                      console.error(await response.text());
+                      process.exit(1);
+                  }
+                  const data = await response.json();
+                  const runs = data.workflow_runs ?? [];
+                  const previousRun = runs.find(
+                      (run) =>
+                          run.conclusion === "success" &&
+                          run.id !== currentRunId &&
+                          run.head_sha !== currentHeadSha &&
+                          Date.parse(run.created_at) < currentCreatedAt,
+                  );
+                  if (previousRun) {
+                      console.log(previousRun.head_sha);
+                  }
+                  NODE
+                  )
+                  if [ -n "$PREV_SHA" ]; then
+                      PREV=$(git show "${PREV_SHA}:packages/prefigure/package.json" | json_version_from_stdin)
+                      echo "Previous main CI version (${PREV_SHA}): $PREV"
+                  elif git rev-parse HEAD^ >/dev/null 2>&1; then
+                      PREV=$(git show HEAD^:packages/prefigure/package.json | json_version_from_stdin)
+                      echo "Previous main CI run not found; falling back to parent version: $PREV"
+                  else
+                      PREV=""
+                      echo "No previous main baseline found; treating current version as new."
+                  fi
+
+                  if [ -n "$PREV" ] && [ "$CURR" = "$PREV" ]; then
+                      echo "Prefigure version is unchanged since the previous main CI baseline, skipping publish."
+                      echo "should_publish=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
                   set +e
                   VIEW_OUTPUT=$(npm view "@doenet/prefigure@${CURR}" version --json 2>&1)
                   VIEW_STATUS=$?
@@ -86,7 +158,7 @@ jobs:
               github.event_name == 'workflow_dispatch' ||
               (github.event.workflow_run.conclusion == 'success' &&
                needs.check-version-changed.result == 'success' &&
-               needs.check-version-changed.outputs.is_latest_main == 'true' &&
+               needs.check-version-changed.outputs.matches_main_version == 'true' &&
                (needs.check-version-changed.outputs.should_publish == 'true' ||
                 github.run_attempt > 1))
             )
@@ -118,12 +190,20 @@ jobs:
               id: checked-sha
               run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-            - name: Verify commit is on main
+            - name: Verify target still matches main
               run: |
+                  json_version_from_stdin() {
+                      node -e 'const fs = require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(0, "utf8")).version);'
+                  }
+
                   git fetch origin main
                   if [ "${{ github.event_name }}" = "workflow_run" ]; then
-                      if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
-                          echo "Error: auto-publish only runs for the current origin/main tip." >&2
+                      HEAD_VERSION=$(node -e "console.log(require('./packages/prefigure/package.json').version)")
+                      # Allow later main commits with the same prefigure version,
+                      # but stop once main advances to a newer prefigure version.
+                      MAIN_VERSION=$(git show origin/main:packages/prefigure/package.json | json_version_from_stdin)
+                      if [ "$HEAD_VERSION" != "$MAIN_VERSION" ]; then
+                          echo "Error: auto-publish only runs while origin/main still carries prefigure version ${HEAD_VERSION} (current main version: ${MAIN_VERSION})." >&2
                           exit 1
                       fi
                   elif ! git merge-base --is-ancestor HEAD origin/main; then

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -33,6 +33,7 @@ jobs:
         outputs:
             should_publish: ${{ steps.check.outputs.should_publish }}
             matches_main_version: ${{ steps.check.outputs.matches_main_version }}
+            already_published: ${{ steps.check.outputs.already_published }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -70,6 +71,7 @@ jobs:
                   if [ "$CURR" != "$MAIN" ]; then
                       echo "Triggered commit no longer matches the current origin/main prefigure version, skipping publish."
                       echo "matches_main_version=false" >> "$GITHUB_OUTPUT"
+                      echo "already_published=false" >> "$GITHUB_OUTPUT"
                       echo "should_publish=false" >> "$GITHUB_OUTPUT"
                       exit 0
                   fi
@@ -128,6 +130,7 @@ jobs:
 
                   if [ -n "$PREV" ] && [ "$CURR" = "$PREV" ]; then
                       echo "Prefigure version is unchanged since the previous main CI baseline, skipping publish."
+                      echo "already_published=false" >> "$GITHUB_OUTPUT"
                       echo "should_publish=false" >> "$GITHUB_OUTPUT"
                       exit 0
                   fi
@@ -138,9 +141,11 @@ jobs:
                   set -e
                   if [ "$VIEW_STATUS" -eq 0 ]; then
                       echo "Version ${CURR} is already published, skipping publish."
+                      echo "already_published=true" >> "$GITHUB_OUTPUT"
                       echo "should_publish=false" >> "$GITHUB_OUTPUT"
                   elif echo "$VIEW_OUTPUT" | grep -q "E404"; then
                       echo "Version ${CURR} is not yet published."
+                      echo "already_published=false" >> "$GITHUB_OUTPUT"
                       echo "should_publish=true" >> "$GITHUB_OUTPUT"
                   else
                       echo "$VIEW_OUTPUT" >&2
@@ -160,7 +165,8 @@ jobs:
                needs.check-version-changed.result == 'success' &&
                needs.check-version-changed.outputs.matches_main_version == 'true' &&
                (needs.check-version-changed.outputs.should_publish == 'true' ||
-                github.run_attempt > 1))
+                (needs.check-version-changed.outputs.already_published == 'true' &&
+                 github.run_attempt > 1)))
             )
         runs-on: ubuntu-latest
         environment: production
@@ -253,7 +259,8 @@ jobs:
                   steps.params.outputs.dry_run != 'true' &&
                   (github.event_name == 'workflow_dispatch' ||
                    needs.check-version-changed.outputs.should_publish == 'true' ||
-                   github.run_attempt > 1)
+                   (needs.check-version-changed.outputs.already_published == 'true' &&
+                    github.run_attempt > 1))
               env:
                   NPM_TAG: ${{ steps.params.outputs.npm_tag }}
               run: |

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -57,7 +57,7 @@ jobs:
                   CI_RUN_CREATED_AT: ${{ github.event.workflow_run.created_at }}
                   TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
               run: |
-                  json_version_from_stdin() {
+                  json_version() {
                       node -e 'const fs = require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(0, "utf8")).version);'
                   }
 
@@ -65,7 +65,7 @@ jobs:
                   CURR=$(node -e "console.log(require('./packages/prefigure/package.json').version)")
                   # If main has moved on to a different prefigure version, let the
                   # newer run own that publish instead of moving the registry back.
-                  MAIN=$(git show origin/main:packages/prefigure/package.json | json_version_from_stdin)
+                  MAIN=$(git show origin/main:packages/prefigure/package.json | json_version)
                   echo "Triggering commit version: $CURR"
                   echo "Current origin/main version: $MAIN"
                   if [ "$CURR" != "$MAIN" ]; then
@@ -80,48 +80,12 @@ jobs:
 
                   # Compare against the previous distinct main CI head so a single
                   # push containing multiple commits still counts as one version bump.
-                  PREV_SHA=$(node --input-type=module - <<'NODE'
-                  const token = process.env.GITHUB_TOKEN;
-                  const repo = process.env.REPO;
-                  const currentRunId = Number(process.env.CI_RUN_ID);
-                  const currentCreatedAt = Date.parse(
-                      process.env.CI_RUN_CREATED_AT,
-                  );
-                  const currentHeadSha = process.env.TRIGGER_SHA;
-                  const url = `https://api.github.com/repos/${repo}/actions/workflows/ci.yml/runs?branch=main&event=push&status=completed&per_page=100`;
-                  const response = await fetch(url, {
-                      headers: {
-                          Authorization: `Bearer ${token}`,
-                          Accept: "application/vnd.github+json",
-                          "X-GitHub-Api-Version": "2022-11-28",
-                      },
-                  });
-                  if (!response.ok) {
-                      console.error(
-                          `Failed to query CI workflow runs: ${response.status} ${response.statusText}`,
-                      );
-                      console.error(await response.text());
-                      process.exit(1);
-                  }
-                  const data = await response.json();
-                  const runs = data.workflow_runs ?? [];
-                  const previousRun = runs.find(
-                      (run) =>
-                          run.conclusion === "success" &&
-                          run.id !== currentRunId &&
-                          run.head_sha !== currentHeadSha &&
-                          Date.parse(run.created_at) < currentCreatedAt,
-                  );
-                  if (previousRun) {
-                      console.log(previousRun.head_sha);
-                  }
-                  NODE
-                  )
+                  PREV_SHA=$(node .github/scripts/find-previous-ci-sha.mjs)
                   if [ -n "$PREV_SHA" ]; then
-                      PREV=$(git show "${PREV_SHA}:packages/prefigure/package.json" | json_version_from_stdin)
+                      PREV=$(git show "${PREV_SHA}:packages/prefigure/package.json" | json_version)
                       echo "Previous main CI version (${PREV_SHA}): $PREV"
                   elif git rev-parse HEAD^ >/dev/null 2>&1; then
-                      PREV=$(git show HEAD^:packages/prefigure/package.json | json_version_from_stdin)
+                      PREV=$(git show HEAD^:packages/prefigure/package.json | json_version)
                       echo "Previous main CI run not found; falling back to parent version: $PREV"
                   else
                       PREV=""
@@ -263,8 +227,4 @@ jobs:
                     github.run_attempt > 1))
               env:
                   NPM_TAG: ${{ steps.params.outputs.npm_tag }}
-              run: |
-                  echo "Waiting for npm package propagation before purging jsDelivr cache..."
-                  sleep 15
-                  curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${NPM_TAG}" || exit 1
-                  curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${NPM_TAG}/prefigure.js" || exit 1
+              run: bash .github/scripts/purge-jsdelivr-prefigure.sh "${NPM_TAG}"


### PR DESCRIPTION
## Summary

Adds a `workflow_run` trigger to `publish-prefigure.yml` so the publish workflow fires automatically after CI passes on `main`, while preserving the existing manual dispatch behavior.

## How it works

A new `check-version-changed` job runs only for successful `workflow_run` events. It checks out the triggering commit, confirms that `origin/main` still carries the same `@doenet/prefigure` version, pins Node to the same version as the publish job, compares that version against the previous successful `main` CI baseline to detect an actual version bump, and asks npm whether that exact `@doenet/prefigure` version is already published. If `main` has advanced to a different prefigure version, the version is unchanged since the previous successful `main` CI baseline, or the version is already published, it outputs `should_publish=false`.

The `publish-prefigure` job checks out that same triggering commit and runs if:
- triggered manually (`workflow_dispatch`), OR  
- CI succeeded on `main` AND the version check succeeded AND `origin/main` still carries the same prefigure version AND either the checked version is not already published or the workflow is being rerun after that version has already reached npm

For auto-triggered runs, `dry_run`/`npm_tag` default to `false`/`latest`. On reruns after a successful publish, the workflow skips the duplicate npm publish but still retries the post-publish jsDelivr purge; unchanged-version auto-publish runs stay skipped even when rerun. If `main` advances to a newer prefigure version before an older auto-publish run reaches the publish job, the older run now skips so the newer version can own the publish.

## Changeset

No changeset is needed because this PR only changes CI workflow behavior.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
