### PR TITLE
chore: lift Node 24.15.0 pins now that nodejs/node#63487 is fixed in 24.18.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
     "features": {
         "ghcr.io/devcontainers/features/node:1": {
-            "version": "24.15.0"
+            "version": "lts"
         },
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"

--- a/.github/workflows/changesets-version-pr.yml
+++ b/.github/workflows/changesets-version-pr.yml
@@ -25,8 +25,7 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  # See ci.yml for the rationale behind pinning to 24.15.0.
-                  node-version: 24.15.0
+                  node-version: 24.x
                   cache: "npm"
 
             - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,7 @@ jobs:
 
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -79,11 +75,7 @@ jobs:
         needs: build
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         steps:
             - uses: actions/checkout@v6
@@ -120,11 +112,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
                 test-group: [group1, group2, group3, group4]
         steps:
@@ -162,11 +150,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
                 test-group:
                     [
@@ -261,11 +245,7 @@ jobs:
         if: needs.changes.outputs.prefigure == 'true'
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
         steps:
             - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
@@ -360,11 +340,7 @@ jobs:
 
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -416,11 +392,7 @@ jobs:
         needs: build-docs
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
         steps:
             - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
@@ -461,11 +433,7 @@ jobs:
 
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
 
         steps:
             - name: Checkout sources
@@ -517,11 +485,7 @@ jobs:
 
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
 
         steps:
             - uses: actions/checkout@v6
@@ -577,11 +541,7 @@ jobs:
 
         strategy:
             matrix:
-                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
-                # (https://github.com/nodejs/node/issues/63487) that hangs
-                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
-                # Revisit once a fixed 24.x release is available in setup-node.
-                node-version: [24.15.0]
+                node-version: [24.x]
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/gh-pages-docs.yml
+++ b/.github/workflows/gh-pages-docs.yml
@@ -27,8 +27,7 @@ jobs:
 
         strategy:
             matrix:
-                # See ci.yml for the rationale behind pinning to 24.15.0.
-                node-version: [24.15.0]
+                node-version: [24.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -44,8 +44,7 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  # See ci.yml for the rationale behind pinning to 24.15.0.
-                  node-version: 24.15.0
+                  node-version: 24.x
                   registry-url: https://registry.npmjs.org
 
             - name: Check whether current version is already published
@@ -159,8 +158,7 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  # See ci.yml for the rationale behind pinning to 24.15.0.
-                  node-version: 24.15.0
+                  node-version: 24.x
                   registry-url: https://registry.npmjs.org
                   cache: "npm"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,7 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  # See ci.yml for the rationale behind pinning to 24.15.0.
-                  node-version: 24.15.0
+                  node-version: 24.x
                   registry-url: https://registry.npmjs.org
                   cache: "npm"
 
@@ -138,7 +137,7 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.15.0
+                  node-version: 24.x
                   cache: "npm"
 
             - name: Install dependencies
@@ -228,8 +227,7 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  # See ci.yml for the rationale behind pinning to 24.15.0.
-                  node-version: 24.15.0
+                  node-version: 24.x
                   registry-url: https://registry.npmjs.org
                   cache: "npm"
 


### PR DESCRIPTION
The extract-zip hang regression introduced in Node 24.16.0 was fixed in Node 24.18.0 (confirmed in nodejs/node#63487).

Restores the original floating versions:
- `.devcontainer/devcontainer.json`: node feature version back to `"lts"`
- All GitHub Actions workflows: `node-version` back to `24.x`

Closes #1166.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)