### PR TITLE
fix: style disabled textInput correctly when inside a graph

### DIFF
--- a/.changeset/disabled-textinput-in-graph.md
+++ b/.changeset/disabled-textinput-in-graph.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Disabled `<textInput>` controls inside `<graph>` now use the same muted disabled styling as other text inputs instead of appearing enabled.
+
+Closes #1289.

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -202,6 +202,21 @@ export default function TextInput(props: UseDoenetRendererProps) {
         }
     }
 
+    function applyDisabledStyleJXG(
+        rendNodeInput: HTMLElement,
+        disabled: boolean,
+    ) {
+        if (disabled) {
+            rendNodeInput.style.background = "var(--revealButtonSurface)";
+            rendNodeInput.style.border = "2px solid var(--revealButtonSurface)";
+            rendNodeInput.style.cursor = "not-allowed";
+        } else {
+            rendNodeInput.style.background = "var(--canvas)";
+            rendNodeInput.style.border = "var(--mainBorder)";
+            rendNodeInput.style.cursor = "auto";
+        }
+    }
+
     function createInputJXG() {
         if (board === null) {
             return null;
@@ -280,8 +295,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
 
         newInputJXG.rendNodeInput.style.width = width!;
         newInputJXG.rendNodeInput.style.color = "var(--canvasText)";
-        newInputJXG.rendNodeInput.style.background = "var(--canvas)";
-        newInputJXG.rendNodeInput.style.borderColor = "var(--canvasText)";
+        applyDisabledStyleJXG(newInputJXG.rendNodeInput, SVs.disabled);
 
         newInputJXG.rendNodeLabel.style.marginRight = "2px";
 
@@ -549,6 +563,10 @@ export default function TextInput(props: UseDoenetRendererProps) {
             if (inputJXG.current.visProp.disabled !== SVs.disabled) {
                 inputJXG.current.visProp.disabled = SVs.disabled;
                 inputJXG.current.setAttribute({ disabled: SVs.disabled });
+                applyDisabledStyleJXG(
+                    inputJXG.current.rendNodeInput,
+                    SVs.disabled,
+                );
             }
 
             inputJXG.current.visProp.highlight = !fixLocation.current;

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -212,7 +212,8 @@ export default function TextInput(props: UseDoenetRendererProps) {
             rendNodeInput.style.cursor = "not-allowed";
         } else {
             rendNodeInput.style.background = "var(--canvas)";
-            rendNodeInput.style.border = "var(--mainBorder)";
+            rendNodeInput.style.border = "";
+            rendNodeInput.style.borderColor = "var(--canvasText)";
             rendNodeInput.style.cursor = "auto";
         }
     }

--- a/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
@@ -95,6 +95,24 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
     });
 
     it("styles disabled graph textInput like other disabled text inputs", () => {
+        function expectMatchingStyles() {
+            for (let property of [
+                "background-color",
+                "border-top-color",
+                "cursor",
+            ]) {
+                cy.get("@plainInput")
+                    .invoke("css", property)
+                    .then((plainValue) => {
+                        cy.get("@graphInput").should(
+                            "have.css",
+                            property,
+                            plainValue,
+                        );
+                    });
+            }
+        }
+
         cy.window().then(async (win) => {
             win.postMessage(
                 {
@@ -102,6 +120,7 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
     <booleanInput name="toggleDisabled" prefill="true">
       <label>Disable graph input</label>
     </booleanInput>
+    <textInput name="plain" disabled="$toggleDisabled" />
     <graph name="g">
       <textInput name="ti" disabled="$toggleDisabled" />
     </graph>
@@ -111,43 +130,24 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
             );
         });
 
+        cy.get("#plain_input").as("plainInput");
         cy.get("#g").find("input").should("have.length", 1).as("graphInput");
 
+        cy.get("@plainInput").should("be.disabled");
         cy.get("@graphInput").should("be.disabled");
-        cy.get("@graphInput").should(
-            "have.css",
-            "background-color",
-            "rgb(227, 227, 227)",
-        );
-        cy.get("@graphInput").should(
-            "have.css",
-            "border-top-color",
-            "rgb(227, 227, 227)",
-        );
-        cy.get("@graphInput").should("have.css", "cursor", "not-allowed");
+        expectMatchingStyles();
 
         cy.get("#toggleDisabled_input").click({ force: true });
 
+        cy.get("@plainInput").should("not.be.disabled");
         cy.get("@graphInput").should("not.be.disabled");
-        cy.get("@graphInput").should(
-            "have.css",
-            "background-color",
-            "rgb(255, 255, 255)",
-        );
-        cy.get("@graphInput").should(
-            "have.css",
-            "border-top-color",
-            "rgb(0, 0, 0)",
-        );
+        expectMatchingStyles();
 
         cy.get("#toggleDisabled_input").click({ force: true });
 
+        cy.get("@plainInput").should("be.disabled");
         cy.get("@graphInput").should("be.disabled");
-        cy.get("@graphInput").should(
-            "have.css",
-            "background-color",
-            "rgb(227, 227, 227)",
-        );
+        expectMatchingStyles();
     });
 
     it("focused state variable is not saved to database (doNotSave)", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/textinput.cy.js
@@ -94,6 +94,62 @@ describe("TextInput Tag Tests", { tags: ["@group2"] }, function () {
         cy.get("#piv").should("have.text", "immediate value: hello");
     });
 
+    it("styles disabled graph textInput like other disabled text inputs", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <booleanInput name="toggleDisabled" prefill="true">
+      <label>Disable graph input</label>
+    </booleanInput>
+    <graph name="g">
+      <textInput name="ti" disabled="$toggleDisabled" />
+    </graph>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#g").find("input").should("have.length", 1).as("graphInput");
+
+        cy.get("@graphInput").should("be.disabled");
+        cy.get("@graphInput").should(
+            "have.css",
+            "background-color",
+            "rgb(227, 227, 227)",
+        );
+        cy.get("@graphInput").should(
+            "have.css",
+            "border-top-color",
+            "rgb(227, 227, 227)",
+        );
+        cy.get("@graphInput").should("have.css", "cursor", "not-allowed");
+
+        cy.get("#toggleDisabled_input").click({ force: true });
+
+        cy.get("@graphInput").should("not.be.disabled");
+        cy.get("@graphInput").should(
+            "have.css",
+            "background-color",
+            "rgb(255, 255, 255)",
+        );
+        cy.get("@graphInput").should(
+            "have.css",
+            "border-top-color",
+            "rgb(0, 0, 0)",
+        );
+
+        cy.get("#toggleDisabled_input").click({ force: true });
+
+        cy.get("@graphInput").should("be.disabled");
+        cy.get("@graphInput").should(
+            "have.css",
+            "background-color",
+            "rgb(227, 227, 227)",
+        );
+    });
+
     it("focused state variable is not saved to database (doNotSave)", () => {
         let doenetML = `
     <p><textInput name="ti">


### PR DESCRIPTION
## Summary

When a `<textInput>` is placed inside a `<graph>` element, it is rendered via JSXGraph using inline styles on the underlying DOM input element — rather than the CSS classes used outside a graph. As a result, the `.text-input-disabled` CSS class was never applied to the JXG-rendered input, so a disabled text input inside a graph looked identical to an enabled one.

## Changes

Adds an `applyDisabledStyleJXG()` helper function inside the `TextInput` renderer that mirrors the `.text-input-disabled` CSS styles:
- Sets `background` to `var(--revealButtonSurface)`
- Sets `border` to `2px solid var(--revealButtonSurface)` (using the `border` shorthand rather than just `borderColor`, so `border-style` is forced to `solid` — preventing the browser-default inset bevel that would otherwise make top/left borders appear thicker and darker)
- Sets `cursor` to `not-allowed`

The helper is called both on initial JXG input creation and whenever the disabled state changes during updates.

Also adds a Cypress regression test for graph-hosted disabled text inputs and a changeset for the user-visible fix.

## Repro

```xml
<graph>
   <textInput disabled />
</graph>
```

Closes #1289.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)