### PR TITLE
fix: coexist with a host-provided MathJax instead of clobbering it

### DIFF
--- a/.changeset/bump-mathjax-4-1-3.md
+++ b/.changeset/bump-mathjax-4-1-3.md
@@ -1,0 +1,22 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Update the bundled MathJax from 4.1.0 to 4.1.3.
+
+Doenet now loads MathJax `4.1.3` (from 4.1.0) for the copy it injects when a
+page provides none, and the VS Code preview's Content-Security-Policy allowlist
+is bumped to match. The `4.1.x` line is bug-fix only: 4.1.3 notably fixes
+infinite-loop crashes in the semantic-enrichment/speech code, a Safari rendering
+bug for math in `overflow: auto` containers, and assorted TeX edge cases; 4.1.1
+and 4.1.2 improved dark-mode contrast and accessibility. This also aligns the
+version Doenet injects with what host pages that ship a floating `mathjax@4`
+tag (e.g. PreTeXt books) now load, so typesetting is consistent whether Doenet
+loads MathJax itself or reuses a host-provided engine.
+
+Note: MathJax 4.1.2 corrected the LaTeX size macros (`\large`, `\tiny`, etc.) to
+use standard LaTeX sizes.

--- a/.changeset/coexist-with-host-mathjax.md
+++ b/.changeset/coexist-with-host-mathjax.md
@@ -1,0 +1,37 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Viewer: coexist with a MathJax that the host page already provides.
+
+`DoenetViewer` / `DoenetEditor` previously wrapped content in
+`better-react-mathjax`'s `MathJaxContext`, which unconditionally assigned
+`window.MathJax = config` and appended its own MathJax `<script>` — with no
+check for a MathJax the host page had already loaded. When a Doenet activity was
+embedded in a page that loads its own MathJax (e.g. PreTeXt books), this clobbered
+the host's live engine with a plain config object and/or raced a second engine,
+causing intermittent, load-order-dependent failures to render.
+
+Doenet now loads MathJax through a coexisting loader: if a live MathJax engine
+is already present it is reused and `window.MathJax` is never overwritten; if a
+MathJax `<script>` is already on the page (including a deferred one) Doenet waits
+for it instead of injecting a second copy; only when no MathJax is present does
+Doenet load its own. This also removes the duplicate engine (and its extra
+worker) that was previously loaded per embedded activity.
+
+Two new controls are exposed on `DoenetViewer` / `DoenetEditor` (and, for the
+standalone build, as `data-doenet-mathjax-url` / `data-doenet-use-existing-mathjax`
+attributes and `renderDoenet*ToContainer` config keys):
+
+- `mathjaxUrl` — the MathJax script URL to load when the page provides none.
+- `useExistingMathjax` — force reuse of a host-provided MathJax even when it is
+  not yet detectable (e.g. the host loads it after Doenet mounts).
+
+Reusing a host engine means the host's MathJax version governs typesetting;
+MathJax 3.x–4.x are supported for reuse.
+
+Closes #1433.

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -8,7 +8,7 @@ import React, {
     useState,
 } from "react";
 import { DocViewer } from "./Viewer/DocViewer";
-import { MathJaxContext } from "better-react-mathjax";
+import { MathJaxContext } from "@doenet/utils/mathjax";
 import { mathjaxConfig, isErrorRecord, isWarningRecord } from "@doenet/utils";
 import type { DiagnosticsSummary } from "./EditorViewer/diagnostics";
 import type {
@@ -101,6 +101,8 @@ export function DoenetViewer({
     initializeCounters = {},
     fetchExternalDoenetML,
     requestScrollTo,
+    mathjaxUrl,
+    useExistingMathjax = false,
     onInit = () => {},
 }: {
     doenetML: string;
@@ -154,6 +156,21 @@ export function DoenetViewer({
     initializeCounters?: Record<string, number>;
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     requestScrollTo?: (offset: number) => void;
+    /**
+     * URL of the MathJax script to load when the page does not already provide
+     * MathJax. Defaults to the version Doenet is tested against. Ignored when a
+     * host-provided MathJax engine or script is detected. Because a page shares
+     * a single MathJax, only the first-mounted viewer's value takes effect.
+     */
+    mathjaxUrl?: string;
+    /**
+     * Force Doenet to reuse a MathJax provided by the host page instead of ever
+     * loading its own — wait for `window.MathJax` rather than injecting a
+     * script. Use when the host loads MathJax after Doenet mounts (so no script
+     * is detectable yet). Existing/loading MathJax is reused automatically even
+     * without this flag; it only matters when detection cannot see it in time.
+     */
+    useExistingMathjax?: boolean;
     /**
      * Called when React has initialized and passed the DOM node that is a parent of
      * the DoenetML UI.
@@ -299,7 +316,12 @@ export function DoenetViewer({
 
     return (
         <ReduxProvider store={store}>
-            <MathJaxContext config={mathjaxConfig} version={4}>
+            <MathJaxContext
+                config={mathjaxConfig}
+                version={4}
+                src={mathjaxUrl}
+                useExistingMathJax={useExistingMathjax}
+            >
                 <div
                     data-theme={resolvedTheme}
                     ref={(r) => {
@@ -367,6 +389,17 @@ type DoenetEditorProps = {
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     docsURL?: string;
     /**
+     * URL of the MathJax script to load when the page does not already provide
+     * MathJax. Defaults to the version Doenet is tested against. Ignored when a
+     * host-provided MathJax engine or script is detected. See `DoenetViewer`.
+     */
+    mathjaxUrl?: string;
+    /**
+     * Force reuse of a host-provided MathJax instead of ever loading Doenet's
+     * own copy. See `DoenetViewer` for details.
+     */
+    useExistingMathjax?: boolean;
+    /**
      * Controls which tab the diagnostics/responses/help panel opens to at
      * mount. Three forms:
      *  - prop omitted (`undefined`): default — panel opens on the help tab
@@ -418,6 +451,8 @@ export const DoenetEditor = React.forwardRef<
         fetchExternalDoenetML,
         docsURL,
         initialOpenTab,
+        mathjaxUrl,
+        useExistingMathjax = false,
     },
     ref,
 ) {
@@ -496,7 +531,12 @@ export const DoenetEditor = React.forwardRef<
 
     return (
         <ReduxProvider store={store}>
-            <MathJaxContext config={mathjaxConfig} version={4}>
+            <MathJaxContext
+                config={mathjaxConfig}
+                version={4}
+                src={mathjaxUrl}
+                useExistingMathJax={useExistingMathjax}
+            >
                 <div data-theme={resolvedTheme} style={{ display: "contents" }}>
                     <WrapWithKeyboard
                         addVirtualKeyboard={addVirtualKeyboard}

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -49,6 +49,48 @@ For example,
 </div>
 ```
 
+## MathJax
+
+The renderer uses MathJax to typeset math. It **coexists** with a MathJax that
+the host page already provides:
+
+- If the page already has a live MathJax engine, the renderer reuses it and
+  never overwrites `window.MathJax`.
+- If a MathJax `<script>` is already on the page (including a deferred one that
+  has not executed yet), the renderer waits for it instead of loading a second
+  copy.
+- Only when the page provides no MathJax does the renderer load its own.
+
+This avoids the double-loaded / clobbered MathJax that could otherwise break
+embeds in pages that ship their own MathJax (e.g. PreTeXt books).
+
+Two `data-doenet` attributes (or `renderDoenet{Viewer,Editor}ToContainer`
+config keys / React props) control this:
+
+| Attribute                             | Prop                 | Meaning                                                                                       |
+| ------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------- |
+| `data-doenet-mathjax-url`             | `mathjaxUrl`         | URL of the MathJax script to load when the page provides none.                               |
+| `data-doenet-use-existing-mathjax`    | `useExistingMathjax` | Force reuse of a host MathJax even when it is not yet detectable (host loads it after Doenet). |
+
+```html
+<div class="doenetml-applet">
+    <script
+        type="text/doenetml"
+        data-doenet-use-existing-mathjax="true"
+    >
+        <p>$x^2 + y^2$</p>
+    </script>
+</div>
+```
+
+Because a page shares a single MathJax, when several activities are embedded
+only the first one to mount decides which MathJax is loaded.
+
+**Supported versions:** Doenet renders with MathJax 4 and loads that version
+when injecting its own copy. When reusing a host-provided engine, the host's
+version governs typesetting; MathJax 3.x–4.x are supported for reuse (they
+share the typesetting API Doenet relies on). MathJax 2 is not supported.
+
 ## Editor control handle
 
 `renderDoenetEditorToContainer` (also exposed as a global) returns a small

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -84,7 +84,15 @@ export function renderDoenetViewerToContainer(
         const value = normalizeBooleanAttr(attr.value);
         attrs[name] = value;
     }
-    const { addVirtualKeyboard, sendResizeEvents, ...flags } = attrs;
+    // `mathjaxUrl` / `useExistingMathjax` are viewer props, not flags — pull
+    // them out so they reach `DoenetViewer` directly instead of `flags`.
+    const {
+        addVirtualKeyboard,
+        sendResizeEvents,
+        mathjaxUrl,
+        useExistingMathjax,
+        ...flags
+    } = attrs;
     const resizeWatcher = new ResizeWatcher();
 
     if (config && "flags" in config) {
@@ -102,6 +110,8 @@ export function renderDoenetViewerToContainer(
             doenetML={doenetMLSource}
             addVirtualKeyboard={addVirtualKeyboard}
             flags={flags}
+            mathjaxUrl={mathjaxUrl}
+            useExistingMathjax={useExistingMathjax}
             onInit={(r) => {
                 if (sendResizeEvents) {
                     resizeWatcher.watch(r);
@@ -159,8 +169,9 @@ export function renderDoenetEditorToContainer(
         attrs[name] = value;
     }
 
-    // DoenetEditor doesn't accept flags, so only attribute using is addVirtualKeyboard
-    const { addVirtualKeyboard } = attrs;
+    // DoenetEditor doesn't accept flags, so the only attributes used are
+    // addVirtualKeyboard and the MathJax loading controls.
+    const { addVirtualKeyboard, mathjaxUrl, useExistingMathjax } = attrs;
 
     // Hold pending control actions until the inner DoenetEditor commits
     // (callback ref fires). React commits asynchronously after `createRoot.render`,
@@ -229,6 +240,8 @@ export function renderDoenetEditorToContainer(
             ref={refCallback}
             doenetML={doenetMLSource}
             addVirtualKeyboard={addVirtualKeyboard}
+            mathjaxUrl={mathjaxUrl}
+            useExistingMathjax={useExistingMathjax}
             {...config}
         />,
     );

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,6 +22,9 @@
         },
         "./style": {
             "import": "./dist/style.js"
+        },
+        "./mathjax": {
+            "import": "./dist/mathjax.js"
         }
     },
     "scripts": {
@@ -35,6 +38,7 @@
             "command": "vite build",
             "files": [
                 "src/**/*.ts",
+                "src/**/*.tsx",
                 "src/**/*.js",
                 "vite.config.ts",
                 "tsconfig.json"

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,6 +14,7 @@ export * from "./components/sequence";
 export * from "./components/size";
 export * from "./math/array";
 export * from "./math/math";
+export * from "./math/mathjax-loader";
 export * from "./math/mathexpressions";
 export * from "./math/rounding";
 export * from "./math/subset-of-reals-operations";

--- a/packages/utils/src/math/MathJaxContext.tsx
+++ b/packages/utils/src/math/MathJaxContext.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from "react";
+import { MathJaxBaseContext } from "better-react-mathjax";
+import type { MathJaxSubscriberProps } from "better-react-mathjax";
+import { loadMathJax } from "./mathjax-loader";
+import type { LoadMathJaxOptions } from "./mathjax-loader";
+
+export type { LoadMathJaxOptions } from "./mathjax-loader";
+export { loadMathJax, DEFAULT_MATHJAX_SRC } from "./mathjax-loader";
+
+export interface MathJaxContextProps extends LoadMathJaxOptions {
+    /**
+     * Which MathJax major version the consuming `<MathJax>` components should
+     * assume. Only 3 and 4 share the API Doenet relies on and they take the
+     * same code path, so this defaults to 4 and rarely needs changing.
+     */
+    version?: 3 | 4;
+    children?: React.ReactNode;
+}
+
+/**
+ * Drop-in replacement for `better-react-mathjax`'s `MathJaxContext` that
+ * coexists with a MathJax the host page may already provide.
+ *
+ * It provides the same `MathJaxBaseContext` that `better-react-mathjax`'s
+ * `<MathJax>` render components consume, but its `promise` comes from
+ * {@link loadMathJax}, which reuses an existing/loading host engine instead of
+ * unconditionally injecting a second copy and clobbering `window.MathJax`.
+ *
+ * See {@link loadMathJax} for the detection/coexistence rules and the range of
+ * supported MathJax versions.
+ */
+export function MathJaxContext({
+    config,
+    src,
+    useExistingMathJax,
+    timeoutMs,
+    version = 4,
+    children,
+}: MathJaxContextProps) {
+    const value = useMemo<MathJaxSubscriberProps>(() => {
+        const promise = loadMathJax({
+            config,
+            src,
+            useExistingMathJax,
+            timeoutMs,
+        });
+        // `loadMathJax` resolves the live engine. `better-react-mathjax` keys
+        // its subscriber type on a literal version discriminant, which our
+        // `3 | 4` prop does not narrow to, so build the value untyped and cast.
+        return { version, promise } as unknown as MathJaxSubscriberProps;
+    }, [config, src, useExistingMathJax, timeoutMs, version]);
+
+    return (
+        <MathJaxBaseContext.Provider value={value}>
+            {children}
+        </MathJaxBaseContext.Provider>
+    );
+}
+
+export default MathJaxContext;

--- a/packages/utils/src/math/mathjax-loader.test.ts
+++ b/packages/utils/src/math/mathjax-loader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     DEFAULT_MATHJAX_SRC,
     isMathJaxEngine,
@@ -196,5 +196,39 @@ describe("loadMathJax", () => {
         const engine = makeEngine();
         win.MathJax = engine;
         await expect(promise).resolves.toBe(engine);
+    });
+
+    it("rejects when the injected script fails to load", async () => {
+        const promise = loadMathJax({ config: { tex: {} } });
+        expect(appendedScripts).toHaveLength(1);
+
+        // The browser fires an `error` event when the script URL fails to load.
+        appendedScripts[0]._fire("error");
+
+        await expect(promise).rejects.toThrow(/failed to load MathJax/);
+    });
+
+    it("rejects after the timeout when a promised host MathJax never appears", async () => {
+        vi.useFakeTimers();
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const promise = loadMathJax({
+                useExistingMathJax: true,
+                timeoutMs: 1000,
+            });
+            // Attach the rejection handler before advancing so the rejection is
+            // never observed as unhandled.
+            const assertion = expect(promise).rejects.toThrow(/timed out/);
+
+            // Drive the poll loop past the deadline; MathJax never shows up.
+            await vi.advanceTimersByTimeAsync(1100);
+
+            await assertion;
+            expect(appendedScripts).toHaveLength(0); // never injected our own
+            expect(warnSpy).toHaveBeenCalled();
+        } finally {
+            warnSpy.mockRestore();
+            vi.useRealTimers();
+        }
     });
 });

--- a/packages/utils/src/math/mathjax-loader.test.ts
+++ b/packages/utils/src/math/mathjax-loader.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    DEFAULT_MATHJAX_SRC,
+    isMathJaxEngine,
+    loadMathJax,
+} from "./mathjax-loader";
+
+/**
+ * These tests exercise the coexistence decisions of `loadMathJax` against a
+ * minimal stub of the tiny DOM surface the loader touches, so they run in the
+ * default (node) Vitest environment without jsdom.
+ */
+
+type FakeScript = {
+    type: string;
+    src: string;
+    async: boolean;
+    setAttribute: (name: string, value: string) => void;
+    hasAttribute: (name: string) => boolean;
+    addEventListener: (name: string, cb: (event?: unknown) => void) => void;
+    _attrs: Record<string, string>;
+    _fire: (name: string) => void;
+};
+
+function makeScript(src = ""): FakeScript {
+    const attrs: Record<string, string> = {};
+    const listeners: Record<string, (event?: unknown) => void> = {};
+    return {
+        type: "",
+        src,
+        async: false,
+        setAttribute(name, value) {
+            attrs[name] = value;
+        },
+        hasAttribute(name) {
+            return name in attrs;
+        },
+        addEventListener(name, cb) {
+            listeners[name] = cb;
+        },
+        _attrs: attrs,
+        _fire(name) {
+            listeners[name]?.();
+        },
+    };
+}
+
+let appendedScripts: FakeScript[];
+let domScripts: FakeScript[];
+
+function installFakeDom() {
+    appendedScripts = [];
+    domScripts = [];
+    const fakeDocument = {
+        createElement: (_tag: string) => makeScript(),
+        head: {
+            appendChild: (script: FakeScript) => {
+                appendedScripts.push(script);
+                domScripts.push(script);
+            },
+        },
+        querySelectorAll: (_selector: string) =>
+            domScripts.filter((script) => script.src),
+    };
+    const fakeWindow: Record<string, unknown> = {
+        setTimeout: (fn: () => void, ms?: number) =>
+            globalThis.setTimeout(fn, ms),
+    };
+    (globalThis as any).window = fakeWindow;
+    (globalThis as any).document = fakeDocument;
+    return { fakeWindow, fakeDocument };
+}
+
+/** A stand-in for a fully loaded MathJax engine. */
+function makeEngine() {
+    return {
+        version: "4.1.3",
+        startup: { promise: Promise.resolve() },
+        typesetPromise: () => Promise.resolve(),
+        typesetClear: () => {},
+    };
+}
+
+afterEach(() => {
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+});
+
+describe("isMathJaxEngine", () => {
+    it("recognizes a loaded engine but not a plain config object", () => {
+        expect(isMathJaxEngine(makeEngine())).toBe(true);
+        expect(isMathJaxEngine(undefined)).toBe(false);
+        expect(isMathJaxEngine({ tex: { tags: "ams" } })).toBe(false);
+        // A config may carry a `startup` option, but no `startup.promise`.
+        expect(isMathJaxEngine({ startup: { typeset: false } })).toBe(false);
+    });
+});
+
+describe("loadMathJax", () => {
+    beforeEach(() => {
+        installFakeDom();
+    });
+
+    it("reuses an existing live engine without injecting a script or touching window.MathJax", async () => {
+        const engine = makeEngine();
+        const win = (globalThis as any).window;
+        win.MathJax = engine;
+
+        const result = await loadMathJax({ config: { tex: {} } });
+
+        expect(result).toBe(engine);
+        expect(win.MathJax).toBe(engine); // never overwritten
+        expect(appendedScripts).toHaveLength(0); // no second copy loaded
+    });
+
+    it("waits for an already-present (deferred) MathJax script instead of injecting its own", async () => {
+        const win = (globalThis as any).window;
+        // A deferred host script is in the DOM but has not executed yet.
+        domScripts.push(
+            makeScript("https://cdn.jsdelivr.net/npm/mathjax@4/tex-svg.js"),
+        );
+
+        const promise = loadMathJax({ config: { tex: {} } });
+
+        // Synchronously, the loader must not inject its own script nor stage a
+        // config onto window.MathJax — the host owns MathJax.
+        expect(appendedScripts).toHaveLength(0);
+        expect(win.MathJax).toBeUndefined();
+
+        // The host script eventually executes and installs the engine.
+        const engine = makeEngine();
+        win.MathJax = engine;
+
+        await expect(promise).resolves.toBe(engine);
+    });
+
+    it("injects its own script and stages config when no MathJax is present", async () => {
+        const win = (globalThis as any).window;
+
+        const promise = loadMathJax({ config: { tex: { tags: "ams" } } });
+
+        expect(appendedScripts).toHaveLength(1);
+        const injected = appendedScripts[0];
+        expect(injected.src).toBe(DEFAULT_MATHJAX_SRC);
+        expect(injected._attrs["data-doenet-mathjax"]).toBe("true");
+        // Config staged because window.MathJax was unclaimed.
+        expect(win.MathJax).toEqual({ tex: { tags: "ams" } });
+
+        // Simulate the script loading and replacing window.MathJax with the engine.
+        const engine = makeEngine();
+        win.MathJax = engine;
+        injected._fire("load");
+
+        await expect(promise).resolves.toBe(engine);
+    });
+
+    it("honors a custom src and does not clobber a host-staged config", async () => {
+        const win = (globalThis as any).window;
+        const hostConfig = { tex: { macros: {} } };
+        win.MathJax = hostConfig; // host staged a config but no script yet
+
+        const customSrc = "https://example.test/mathjax@4/tex-chtml.js";
+        const promise = loadMathJax({ config: { tex: {} }, src: customSrc });
+
+        expect(appendedScripts).toHaveLength(1);
+        expect(appendedScripts[0].src).toBe(customSrc);
+        expect(win.MathJax).toBe(hostConfig); // not overwritten
+
+        const engine = makeEngine();
+        win.MathJax = engine;
+        appendedScripts[0]._fire("load");
+        await expect(promise).resolves.toBe(engine);
+    });
+
+    it("memoizes a single promise across calls (one MathJax per realm)", async () => {
+        const first = loadMathJax();
+        const second = loadMathJax();
+        expect(second).toBe(first);
+        // Only one script injected despite two calls.
+        expect(appendedScripts).toHaveLength(1);
+
+        const engine = makeEngine();
+        (globalThis as any).window.MathJax = engine;
+        appendedScripts[0]._fire("load");
+        await expect(first).resolves.toBe(engine);
+    });
+
+    it("waits when useExistingMathjax is set even with no script present", async () => {
+        const win = (globalThis as any).window;
+
+        const promise = loadMathJax({ useExistingMathJax: true });
+
+        // No script injected — we are waiting for the host to provide MathJax.
+        expect(appendedScripts).toHaveLength(0);
+
+        const engine = makeEngine();
+        win.MathJax = engine;
+        await expect(promise).resolves.toBe(engine);
+    });
+});

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -38,7 +38,7 @@
  * Pinned to match the version Doenet is tested against.
  */
 export const DEFAULT_MATHJAX_SRC =
-    "https://cdn.jsdelivr.net/npm/mathjax@4.1.0/tex-mml-chtml.js";
+    "https://cdn.jsdelivr.net/npm/mathjax@4.1.3/tex-mml-chtml.js";
 
 /**
  * Minimal shape of a loaded MathJax 3/4 engine that the renderers rely on.

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -1,0 +1,259 @@
+/**
+ * Coexisting MathJax loader.
+ *
+ * The rendering layer uses `better-react-mathjax`, whose `MathJaxContext`
+ * unconditionally (1) assigns `window.MathJax = config` and (2) appends a
+ * MathJax `<script>` to the page — with no check for a MathJax that the host
+ * page already loaded. When a Doenet activity is embedded in a page that loads
+ * its own MathJax (e.g. PreTeXt books), that clobbers the host's live engine
+ * with a plain config object and/or races a second engine, producing
+ * intermittent, load-order-dependent failures.
+ *
+ * This module replaces that loader with one that *coexists* with a
+ * host-provided MathJax:
+ *
+ *  - If a live MathJax engine is already present, reuse it and never touch
+ *    `window.MathJax`.
+ *  - If a MathJax `<script>` is already on the page (possibly deferred and not
+ *    yet executed), wait for it instead of injecting a second copy.
+ *  - Otherwise, inject our own copy — and only stage `window.MathJax = config`
+ *    when nothing else has claimed that global.
+ *
+ * The resulting promise is memoized on `window` so that every viewer, editor,
+ * and virtual-keyboard tray in the realm shares a single MathJax, regardless of
+ * how many (possibly separately-bundled) copies of this module are loaded.
+ *
+ * ## Supported MathJax versions
+ *
+ * Doenet renders with MathJax 4 and pins {@link DEFAULT_MATHJAX_SRC} for the
+ * copy it injects. When reusing a host-provided engine, the host's version
+ * governs typesetting. MathJax 3 and 4 share the component-tex/typeset API this
+ * code relies on (`startup.promise`, `typesetPromise`, `typesetClear`), so a
+ * host engine in the 3.x–4.x range works; MathJax 2 (which exposes `Hub`
+ * instead) is not supported for reuse.
+ */
+
+/**
+ * The MathJax script Doenet injects when no MathJax is present on the page.
+ * Pinned to match the version Doenet is tested against.
+ */
+export const DEFAULT_MATHJAX_SRC =
+    "https://cdn.jsdelivr.net/npm/mathjax@4.1.0/tex-mml-chtml.js";
+
+/**
+ * Minimal shape of a loaded MathJax 3/4 engine that the renderers rely on.
+ * Intentionally loose — the full types live in `better-react-mathjax`.
+ */
+export interface MathJaxEngine {
+    startup?: { promise?: Promise<unknown> } & Record<string, unknown>;
+    typesetPromise?: (...args: unknown[]) => Promise<unknown>;
+    typesetClear?: (...args: unknown[]) => unknown;
+    version?: string;
+    [key: string]: unknown;
+}
+
+declare global {
+    interface Window {
+        // Before MathJax's engine script runs, `window.MathJax` holds a plain
+        // config object; afterwards it is the live engine. It may also be
+        // provided by the host page rather than by Doenet.
+        MathJax?: MathJaxEngine | object;
+    }
+}
+
+export interface LoadMathJaxOptions {
+    /**
+     * MathJax configuration object. Staged as `window.MathJax` before our own
+     * script loads. Ignored when a host MathJax engine or script is detected,
+     * so a host's configuration is never overwritten.
+     */
+    config?: object;
+    /**
+     * URL of the MathJax script to inject when no MathJax is present on the
+     * page. Defaults to {@link DEFAULT_MATHJAX_SRC}.
+     */
+    src?: string;
+    /**
+     * When `true`, always reuse a host-provided MathJax: wait for `window.MathJax`
+     * to become a live engine instead of ever injecting our own copy. Use this
+     * when the host loads MathJax but does so after Doenet mounts (so no script
+     * is detectable yet).
+     */
+    useExistingMathJax?: boolean;
+    /**
+     * How long, in milliseconds, to wait for a host-provided MathJax before
+     * rejecting. Only applies when we are waiting on someone else's MathJax
+     * (an existing script or `useExistingMathJax`). Defaults to 30000.
+     */
+    timeoutMs?: number;
+}
+
+/**
+ * Key under which the shared MathJax promise is memoized on `window`. Using a
+ * global (rather than a module-level variable) makes the singleton robust even
+ * when this module is bundled into several packages on the same page.
+ */
+const GLOBAL_PROMISE_KEY = "__doenetMathJaxPromise";
+
+/**
+ * Attribute placed on the `<script>` we inject, so it is not mistaken for a
+ * host-provided MathJax script by {@link findMathJaxScript}.
+ */
+const DOENET_MATHJAX_SCRIPT_ATTR = "data-doenet-mathjax";
+
+/**
+ * Matches the `src` of a MathJax `<script>`. Covers CDN URLs (which contain
+ * `mathjax` in the path) as well as the common component entry-point filenames.
+ */
+const MATHJAX_SRC_PATTERN = /mathjax|tex-(chtml|mml|svg)|mml-chtml/i;
+
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * Distinguishes a live, loaded MathJax engine from a plain config object (which
+ * is what `window.MathJax` holds after configuration but before the engine
+ * script runs). Only a loaded engine exposes `startup.promise`.
+ */
+export function isMathJaxEngine(
+    candidate: unknown,
+): candidate is MathJaxEngine {
+    if (!candidate || typeof candidate !== "object") {
+        return false;
+    }
+    const startup = (candidate as MathJaxEngine).startup;
+    return (
+        !!startup &&
+        typeof startup === "object" &&
+        typeof (startup.promise as Promise<unknown> | undefined)?.then ===
+            "function"
+    );
+}
+
+/**
+ * Finds a MathJax `<script>` already present on the page, excluding the one we
+ * inject ourselves. A deferred host script counts: it is in the DOM from
+ * initial parse even though it has not executed yet.
+ */
+function findMathJaxScript(): HTMLScriptElement | null {
+    const scripts = document.querySelectorAll<HTMLScriptElement>("script[src]");
+    for (const script of scripts) {
+        if (script.hasAttribute(DOENET_MATHJAX_SCRIPT_ATTR)) {
+            continue;
+        }
+        if (MATHJAX_SRC_PATTERN.test(script.src)) {
+            return script;
+        }
+    }
+    return null;
+}
+
+/**
+ * Polls until `window.MathJax` becomes a live engine, then resolves. Rejects if
+ * the engine has not appeared within `timeoutMs`. Used when we are waiting on a
+ * host-provided MathJax rather than loading our own.
+ */
+function waitForExistingMathJax(timeoutMs: number): Promise<MathJaxEngine> {
+    return new Promise((resolve, reject) => {
+        const deadline = Date.now() + timeoutMs;
+        function poll() {
+            const mathJax = window.MathJax;
+            if (isMathJaxEngine(mathJax)) {
+                resolve(mathJax);
+                return;
+            }
+            if (Date.now() > deadline) {
+                const message =
+                    "DoenetViewer: timed out waiting for a host-provided MathJax. " +
+                    "Ensure the page loads MathJax, or unset `useExistingMathJax`.";
+                console.warn(message);
+                reject(new Error(message));
+                return;
+            }
+            window.setTimeout(poll, 50);
+        }
+        poll();
+    });
+}
+
+/**
+ * Injects our own MathJax `<script>` and resolves once it has loaded. Only
+ * stages `window.MathJax = config` when nothing else has already claimed that
+ * global, so a host configuration is never clobbered.
+ */
+function injectMathJax(
+    src: string,
+    config: object | undefined,
+): Promise<MathJaxEngine> {
+    return new Promise((resolve, reject) => {
+        if (config && window.MathJax == null) {
+            window.MathJax = config;
+        }
+        const script = document.createElement("script");
+        script.type = "text/javascript";
+        script.src = src;
+        script.async = true;
+        script.setAttribute(DOENET_MATHJAX_SCRIPT_ATTR, "true");
+        script.addEventListener("load", () => {
+            resolve(window.MathJax as MathJaxEngine);
+        });
+        script.addEventListener("error", () => {
+            reject(
+                new Error(`DoenetViewer: failed to load MathJax from ${src}`),
+            );
+        });
+        document.head.appendChild(script);
+    });
+}
+
+function createMathJaxPromise(
+    options: LoadMathJaxOptions,
+): Promise<MathJaxEngine> {
+    const {
+        config,
+        src = DEFAULT_MATHJAX_SRC,
+        useExistingMathJax = false,
+        timeoutMs = DEFAULT_TIMEOUT_MS,
+    } = options;
+
+    // A live engine is already present — reuse it and never touch window.MathJax.
+    if (isMathJaxEngine(window.MathJax)) {
+        return Promise.resolve(window.MathJax);
+    }
+
+    // A MathJax script is already on the page (possibly deferred), or the host
+    // told us to reuse theirs — wait for it rather than injecting a second copy.
+    if (useExistingMathJax || findMathJaxScript()) {
+        return waitForExistingMathJax(timeoutMs);
+    }
+
+    // Nothing else provides MathJax — load our own copy.
+    return injectMathJax(src, config);
+}
+
+/**
+ * Loads MathJax, coexisting with any MathJax the host page provides, and
+ * returns a promise for the live engine. The promise is memoized on `window`,
+ * so repeated calls (from multiple viewers/editors/keyboard trays) share a
+ * single MathJax and the first caller's options win.
+ */
+export function loadMathJax(
+    options: LoadMathJaxOptions = {},
+): Promise<MathJaxEngine> {
+    if (typeof window === "undefined") {
+        return Promise.reject(
+            new Error("MathJax can only be loaded in a browser environment"),
+        );
+    }
+
+    const cached = (window as unknown as Record<string, unknown>)[
+        GLOBAL_PROMISE_KEY
+    ] as Promise<MathJaxEngine> | undefined;
+    if (cached) {
+        return cached;
+    }
+
+    const promise = createMathJaxPromise(options);
+    (window as unknown as Record<string, unknown>)[GLOBAL_PROMISE_KEY] =
+        promise;
+    return promise;
+}

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
                     "./src/diagnostics/renderDiagnosticMarkdownHtml.ts",
                 parseInlineMarkdown: "./src/markdown/parseInlineMarkdown.ts",
                 style: "./src/style/index.ts",
+                mathjax: "./src/math/MathJaxContext.tsx",
             },
             formats: ["es"],
         },

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { OnClick } from "./keyboard";
 import { KeyboardTray } from "./keyboard-tray";
-import { MathJaxContext } from "better-react-mathjax";
+import { MathJaxContext } from "@doenet/utils/mathjax";
 import { mathjaxConfig } from "@doenet/utils";
 
 type VirtualKeyboardState = {

--- a/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
+++ b/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
@@ -139,10 +139,10 @@ export class DoenetPreviewPanel {
                 `default-src 'none';`,
                 `style-src ${webview.cspSource} 'unsafe-inline' 'self';`,
                 // Note: If there is a path-name, it must end with a slash to include subfolders (e.g., https://example.com/foo will not match https://example.com/foo/bar)
-                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4.1.0/ https://doenet.vscode-unpkg.net;`,
-                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4.1.0/ https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
+                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4.1.3/ https://doenet.vscode-unpkg.net;`,
+                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4.1.3/ https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
                 `worker-src blob:;`,
-                `connect-src blob: data: https://cdn.jsdelivr.net/npm/mathjax@4.1.0/;`,
+                `connect-src blob: data: https://cdn.jsdelivr.net/npm/mathjax@4.1.3/;`,
                 `img-src 'self';`,
                 `font-src data: https://cdn.jsdelivr.net/npm/@mathjax/ https://*.vscode-resource.vscode-cdn.net https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
             ].join(" ")}"


### PR DESCRIPTION
## Problem

`DoenetViewer` / `DoenetEditor` wrapped content in `better-react-mathjax`'s `<MathJaxContext>`, whose loader **unconditionally**:

1. assigns `window.MathJax = config` (a plain config object), then
2. appends its own `<script src="…mathjax@4.1.0/tex-mml-chtml.js">`.

It never checks whether the host page already loaded MathJax. So when a Doenet activity is embedded in a page that loads its own MathJax (e.g. PreTeXt books, whose generated `-if.html` pages load a **deferred** `mathjax@4`):

- if the host engine initializes first, step 1 overwrites the live engine object with a config object, breaking it;
- if Doenet's copy wins, the host's deferred script runs into an already-defined `MathJax` global;
- either way two engines (each spawning its own worker in v4) race, and the interleaving depends on network/cache timing — hence the intermittent, per-navigation failures reported.

Closes #1433.

## Fix

Replace that loader with one that **coexists** with a host-provided MathJax:

- **Reuse a live engine** if `window.MathJax` is already loaded — and never overwrite `window.MathJax`.
- **Wait for an existing/deferred MathJax `<script>`** instead of injecting a second copy.
- **Only inject our own** when the page provides no MathJax, staging `window.MathJax = config` **only** when that global is unclaimed.

The promise is memoized on `window`, so every viewer/editor/keyboard-tray in the realm shares a single MathJax (this also removes the previously double-loaded engine + extra worker per embedded activity).

New knobs, exposed on `DoenetViewer` / `DoenetEditor` props, the standalone `renderDoenet*ToContainer` config, and `data-doenet-*` attributes:

| Attribute | Prop | Meaning |
| --- | --- | --- |
| `data-doenet-mathjax-url` | `mathjaxUrl` | MathJax script URL to load when the page provides none |
| `data-doenet-use-existing-mathjax` | `useExistingMathjax` | Force reuse of a host MathJax even when it is not yet detectable |

Supported versions documented (MathJax 3.x–4.x for reuse; injects 4).

### Implementation

- `packages/utils/src/math/mathjax-loader.ts` — framework-agnostic singleton `loadMathJax()` with the coexistence logic.
- `packages/utils/src/math/MathJaxContext.tsx` (new `@doenet/utils/mathjax` subpath) — drop-in provider feeding the same `MathJaxBaseContext` the `<MathJax>` renderers consume.
- `doenetml.tsx` and `unique-keyboard-tray.tsx` use it in place of `better-react-mathjax`'s context. (Non-production harnesses — docs site, `test-main` files, `doenetml-prototype` — are intentionally left as-is; they don't ship in the standalone/iframe bundles.)

## MathJax version bump

A second commit bumps the bundled MathJax **4.1.0 → 4.1.3** — both the URL Doenet injects when a page provides none (`DEFAULT_MATHJAX_SRC`) and the VS Code preview's Content-Security-Policy allowlist. The `4.1.x` line is bug-fix only (4.1.3 fixes semantic-enrichment/speech infinite-loop crashes and a Safari `overflow: auto` rendering bug; 4.1.1/4.1.2 improved dark-mode contrast and accessibility; 4.1.2 corrected the LaTeX size macros). This also aligns the injected version with the floating `mathjax@4` tag that PreTeXt books load, so typesetting is consistent whether Doenet loads MathJax itself or reuses a host engine.

## Validation

- **9 unit tests** (`mathjax-loader.test.ts`) covering every branch: reuse-no-clobber, wait-for-deferred-script, self-inject, host-config-not-clobbered, single-promise memoization, `useExistingMathjax`, script-load-error rejection, and timeout rejection when a promised host MathJax never appears.
- **Real-browser (Playwright/Chromium)** reproduction of the issue's scenario: with a deferred host MathJax, Doenet reused the host engine, `window.MathJax` stayed the host's, exactly one engine loaded, and Doenet injected no script; with no host MathJax, it injected exactly one.
- Full `@doenet/standalone` build passes; bundle inspection confirms the shipped loader and that the old clobbering path is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

