### PR TITLE
fix: gate standalone viewer resize messages until first render

### DIFF
--- a/.changeset/standalone-gate-resize-until-rendered.md
+++ b/.changeset/standalone-gate-resize-until-rendered.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop the standalone viewer from collapsing its host iframe during boot.
+
+When embedded with `data-doenet-send-resize-events="true"`, the viewer used to start reporting its height to the parent page the moment the React element mounted — before the core had rendered anything. Hosts that honor these messages (e.g. PreTeXt) would shrink the iframe to a sliver while the activity was still loading, and leave it collapsed if the render never completed.
+
+The viewer now waits for the document's first render before reporting heights, and never reports collapse-level heights. Host iframes keep their placeholder size until real content appears, then resize to its true height.

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -29,6 +29,12 @@ export const version: string = STANDALONE_VERSION;
 const viewerRootsByContainer = new WeakMap<Element, ReactDOM.Root>();
 const editorRootsByContainer = new WeakMap<Element, ReactDOM.Root>();
 
+// Cache the ResizeWatcher per container alongside its React root. Repeat renders
+// reuse the same watcher so we don't leak a still-observing ResizeObserver from
+// a prior render (each would keep posting heights). `watch()` re-points the
+// observer at the current element, and `markReady()` is idempotent.
+const viewerResizeWatchersByContainer = new WeakMap<Element, ResizeWatcher>();
+
 type EditorHandleEntry = {
     mountedHandle: DoenetEditorHandle | null;
     pendingHandleActions: ((h: DoenetEditorHandle) => void)[];
@@ -85,7 +91,12 @@ export function renderDoenetViewerToContainer(
         attrs[name] = value;
     }
     const { addVirtualKeyboard, sendResizeEvents, ...flags } = attrs;
-    const resizeWatcher = new ResizeWatcher();
+
+    let resizeWatcher = viewerResizeWatchersByContainer.get(container);
+    if (!resizeWatcher) {
+        resizeWatcher = new ResizeWatcher();
+        viewerResizeWatchersByContainer.set(container, resizeWatcher);
+    }
 
     if (config && "flags" in config) {
         Object.assign(flags, config.flags);

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -92,6 +92,13 @@ export function renderDoenetViewerToContainer(
         delete config.flags;
     }
 
+    // Compose the resize-readiness signal with any caller-supplied
+    // `initializedCallback` so we don't clobber it via the `{...config}` spread.
+    const {
+        initializedCallback: configInitializedCallback,
+        ...restConfig
+    }: { initializedCallback?: (arg: unknown) => void } = config ?? {};
+
     let root = viewerRootsByContainer.get(container);
     if (!root) {
         root = ReactDOM.createRoot(container);
@@ -107,7 +114,17 @@ export function renderDoenetViewerToContainer(
                     resizeWatcher.watch(r);
                 }
             }}
-            {...config}
+            initializedCallback={(arg: unknown) => {
+                // Only start reporting heights to the host once the document has
+                // actually rendered — otherwise a not-yet-booted (or failed)
+                // container reports a near-zero height and collapses the host
+                // iframe. See issue #1434.
+                if (sendResizeEvents) {
+                    resizeWatcher.markReady();
+                }
+                configInitializedCallback?.(arg);
+            }}
+            {...restConfig}
         />,
     );
 }

--- a/packages/standalone/src/resize-watcher.ts
+++ b/packages/standalone/src/resize-watcher.ts
@@ -13,7 +13,7 @@ export class ResizeWatcher {
     resizeObserver: ResizeObserver | null = null;
 
     /**
-     * Heights (in px, before the padding fudge below) at or under this floor are
+     * Heights (in px, before the padding fudge below) under this floor are
      * treated as "not really rendered" and are never reported, even after
      * {@link markReady}. This keeps a failed or empty render from collapsing the
      * host iframe: the host keeps its placeholder size rather than shrinking to

--- a/packages/standalone/src/resize-watcher.ts
+++ b/packages/standalone/src/resize-watcher.ts
@@ -1,10 +1,28 @@
 /**
- * Watch the DOM element for resize events and message them to the parent window.
- * This function assume we are in an iframe
+ * Watch the DOM element for resize events and message its height to the parent
+ * window. This class assumes we are in an iframe.
+ *
+ * Height reports are gated until the document has completed its first render
+ * (see {@link markReady}). Before then — while the core worker is still booting,
+ * or if it never boots at all — the watched container has a near-zero height,
+ * and reporting it would collapse a host iframe that honors the resize protocol
+ * (e.g. PreTeXt). See issue #1434.
  */
 export class ResizeWatcher {
     elm: HTMLElement | null = null;
     resizeObserver: ResizeObserver | null = null;
+
+    /**
+     * Heights (in px, before the padding fudge below) at or under this floor are
+     * treated as "not really rendered" and are never reported, even after
+     * {@link markReady}. This keeps a failed or empty render from collapsing the
+     * host iframe: the host keeps its placeholder size rather than shrinking to
+     * a sliver.
+     */
+    static MIN_CONTENT_HEIGHT = 40;
+
+    private ready = false;
+    private lastObservedHeight = 0;
 
     /**
      * Set the element to watch. This will unwatch any previously watched element.
@@ -17,18 +35,39 @@ export class ResizeWatcher {
         this.elm = elm;
         this.resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                const { width, height } = entry.contentRect;
-                // SPLICE protocol messages to the parent window
-                window.parent.postMessage(
-                    {
-                        subject: "lti.frameResize",
-                        // There is extra padding in the iframe, so we add some extra pixels to compensate
-                        height: height + 50,
-                    },
-                    "*",
-                );
+                this.lastObservedHeight = entry.contentRect.height;
+                this.maybePost();
             }
         });
         this.resizeObserver.observe(elm);
+    }
+
+    /**
+     * Signal that the document has completed its first render, so real content
+     * heights may now be reported to the host. Also posts the current height
+     * immediately, in case the resize that revealed the content already fired
+     * before this signal arrived.
+     */
+    markReady() {
+        this.ready = true;
+        this.maybePost();
+    }
+
+    private maybePost() {
+        if (
+            !this.ready ||
+            this.lastObservedHeight < ResizeWatcher.MIN_CONTENT_HEIGHT
+        ) {
+            return;
+        }
+        // SPLICE protocol message to the parent window
+        window.parent.postMessage(
+            {
+                subject: "lti.frameResize",
+                // There is extra padding in the iframe, so we add some extra pixels to compensate
+                height: this.lastObservedHeight + 50,
+            },
+            "*",
+        );
     }
 }

--- a/packages/standalone/src/resize-watcher.ts
+++ b/packages/standalone/src/resize-watcher.ts
@@ -21,8 +21,8 @@ export class ResizeWatcher {
      */
     static MIN_CONTENT_HEIGHT = 40;
 
-    private ready = false;
-    private lastObservedHeight = 0;
+    _ready = false;
+    _lastObservedHeight = 0;
 
     /**
      * Set the element to watch. This will unwatch any previously watched element.
@@ -35,8 +35,8 @@ export class ResizeWatcher {
         this.elm = elm;
         this.resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                this.lastObservedHeight = entry.contentRect.height;
-                this.maybePost();
+                this._lastObservedHeight = entry.contentRect.height;
+                this._maybePost();
             }
         });
         this.resizeObserver.observe(elm);
@@ -49,14 +49,14 @@ export class ResizeWatcher {
      * before this signal arrived.
      */
     markReady() {
-        this.ready = true;
-        this.maybePost();
+        this._ready = true;
+        this._maybePost();
     }
 
-    private maybePost() {
+    _maybePost() {
         if (
-            !this.ready ||
-            this.lastObservedHeight < ResizeWatcher.MIN_CONTENT_HEIGHT
+            !this._ready ||
+            this._lastObservedHeight < ResizeWatcher.MIN_CONTENT_HEIGHT
         ) {
             return;
         }
@@ -65,7 +65,7 @@ export class ResizeWatcher {
             {
                 subject: "lti.frameResize",
                 // There is extra padding in the iframe, so we add some extra pixels to compensate
-                height: this.lastObservedHeight + 50,
+                height: this._lastObservedHeight + 50,
             },
             "*",
         );


### PR DESCRIPTION
## Problem

Reported by PreTeXt users ([thread](https://groups.google.com/g/pretext-dev/c/JAmt-9qhXuI)): an embedded Doenet activity shows its loading logo, then the iframe "resizes to nothing" / becomes a narrow white box — until the activity finally renders (~15 s on slow loads), or permanently when the render fails.

The standalone viewer started reporting its content height to the parent window **as soon as the React element mounted** (`onInit`), long before the core worker booted or rendered anything. `ResizeWatcher` posted `{subject: "lti.frameResize"}` on **every** `ResizeObserver` entry, unconditionally — including the near-zero heights of a not-yet-rendered (or failed) container. Hosts like PreTeXt honor these messages, so the aspect-ratio placeholder iframe collapsed to ~50 px during boot.

## Fix

- **`packages/standalone/src/resize-watcher.ts`** — the watcher no longer posts unconditionally:
  - Height reports are **gated on a readiness signal** (`markReady()`). Nothing is posted while the core is still booting; if the worker never boots (the failure mode), the signal never fires and the host keeps its placeholder.
  - A **`MIN_CONTENT_HEIGHT` floor (40 px)** is enforced even after readiness, so an empty or failed render can never report a collapse-level height.
  - `markReady()` posts the current height immediately, covering the race where the resize that revealed the content fired just before the signal.
- **`packages/standalone/src/index.tsx`**:
  - `markReady()` is wired to the viewer's `initializedCallback` (which fires at `setStage("coreCreated")`, the true first-render signal), composed with any caller-supplied `initializedCallback` so the `{...config}` spread doesn't clobber it.
  - The `ResizeWatcher` is now **cached per container** (like the React root already is). Repeat `renderDoenetViewerToContainer` calls reuse the same watcher instead of leaving a prior render's still-observing `ResizeObserver` connected and posting stale heights.

This also improves the internal `@doenet/doenetml-iframe` (which sets `data-doenet-send-resize-events="true"`): it now keeps its 500 px default until real content appears instead of collapsing during boot.

## Deliberately deferred

The issue's optional suggestion (#3) of an explicit `doenet.ready` protocol message plus embedder documentation requires host-side changes; the collapse itself is fully resolved by the gating above, so it is left out to keep the fix focused.

## Validation

The issue's validation is manual (embed with `data-doenet-send-resize-events="true"` in an aspect-ratio iframe, throttle network/CPU so boot takes seconds — the iframe must keep its placeholder until content appears; then block the worker URL — the iframe should keep the placeholder rather than collapse). The `@doenet/standalone` package has no test harness (`"test": "echo No tests"`) and no matching Cypress spec, so this was verified via `tsc --noEmit` and a production `vite build`.

Closes #1434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
