### PR TITLE
fix: let clicks on a button's math label activate the button

### DIFF
--- a/.changeset/button-math-click-passthrough.md
+++ b/.changeset/button-math-click-passthrough.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Clicking the math in a button's label now activates the button. Previously, when a button's label contained math (e.g. a `<callAction>` with a `<label>` holding an `<m>`), MathJax intercepted clicks on the math and the button did nothing.

--- a/packages/ui-components/src/components/Button.tsx
+++ b/packages/ui-components/src/components/Button.tsx
@@ -28,10 +28,14 @@ export function Button(
     }
     let value = props.value ?? props.children;
     if (value && props.valueHasLatex) {
+        // Wrap the math in a container with pointer events disabled so that
+        // MathJax doesn't steal clicks intended for the button.
         value = (
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {value}
-            </MathJax>
+            <span style={{ pointerEvents: "none" }}>
+                <MathJax hideUntilTypeset={"first"} inline dynamic>
+                    {value}
+                </MathJax>
+            </span>
         );
     }
 


### PR DESCRIPTION
## Problem

Clicking the math in a button's label steals the click and the button is not activated. For example:

```xml
<callAction actionName="addChildren" target="$g">
    <curve>sqrt(x)</curve>
    <label> Plot <m>f(x)=\sqrt{x}</m> </label>
</callAction>
<graph name="g" size="medium"><shortDescription>graph of the parent function</shortDescription></graph>
```

Clicking the word "Plot" activates the button, but clicking the math does nothing.

## Cause

`<callAction>` renders as a `button`. When the `callAction` is outside a `<graph>`, it renders via the `<Button>` component in `@doenet/ui-components`, which wraps a LaTeX label in a bare `<MathJax>` element. MathJax's rendered DOM captures pointer events, so a click on the math never reaches the underlying `<button>`.

## Fix

Wrap the MathJax label content in a container with `pointer-events: none`, so clicks pass through to the button. This mirrors the technique already used for inline `choiceInput` options (which the issue referenced). `pointer-events: none` affects only mouse/touch — keyboard activation and screen-reader access to the button are unchanged.

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)