### PR TITLE
fix: render dynamic inline math without flashing raw LaTeX

### DIFF
--- a/.changeset/dynamic-math-no-raw-flash.md
+++ b/.changeset/dynamic-math-no-raw-flash.md
@@ -1,0 +1,29 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Viewer: stop flashing raw LaTeX while inline math updates (e.g. dragging a point).
+
+Inline math that references a changing value — like `$P` for a dragged point, or
+a `<number>`/`<line>` bound to it — is rendered with `better-react-mathjax`'s
+`<MathJax dynamic>`, which writes the new raw LaTeX into the DOM and typesets it
+asynchronously. When updates outpaced MathJax (e.g. a point referenced many
+times, dragged), the raw LaTeX (`\left( 3, 4 \right)`) stayed visible during the
+drag, and its update effect could drop the final typeset, leaving one copy stuck
+showing raw LaTeX until the next unrelated re-render.
+
+These value-display renderers (`<m>`/`<me>`/`<men>`, point, number, line, vector,
+angle, label, answer, and response/label helpers) now render through a new
+double-buffered `DynamicMath` component: it typesets the new LaTeX on an
+off-screen buffer and swaps the result in only once it is ready, keeping the
+previously rendered math on screen meanwhile. Rapid updates are coalesced to the
+latest value (so nothing is left un-typeset) and throttled. The math therefore
+stays rendered throughout a drag — momentarily stale during a fast drag, but
+never showing raw LaTeX and never blanking.
+
+Math inside inputs and some labels (e.g. `<mathInput>` previews) still uses the
+previous path and is unaffected by this change.

--- a/packages/doenetml/src/Viewer/renderers/angle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/angle.tsx
@@ -4,7 +4,7 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 import { JXGAngle, JXGPoint } from "./jsxgraph-distrib/types";
 import { textRendererStyle } from "@doenet/utils";
 import { DocContext } from "../DocViewer";
@@ -283,9 +283,7 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
         : undefined;
     return (
         <span style={style} id={id}>
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {mathJaxify}
-            </MathJax>
+            <DynamicMath latex={mathJaxify} />
         </span>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -9,7 +9,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 import { DescriptionPopover } from "./utils/Description";
 
 interface AnswerSVs {
@@ -58,11 +58,7 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
 
     let label: React.ReactNode = SVs.label;
     if (SVs.labelHasLatex) {
-        label = (
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {label}
-            </MathJax>
-        );
+        label = <DynamicMath latex={SVs.label} />;
     }
 
     const inputChildrenToRender = SVs.inputChildIndices.map(

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -4,7 +4,7 @@ import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
@@ -316,11 +316,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
     let label: React.ReactNode = SVs.value;
 
     if (SVs.hasLatex) {
-        label = (
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {label}
-            </MathJax>
-        );
+        label = <DynamicMath latex={SVs.value} />;
     }
     if (SVs.forTargetRendererId) {
         if (SVs.forTargetIsGroup) {

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -4,7 +4,7 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 import { textRendererStyle } from "@doenet/utils";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
@@ -352,9 +352,7 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
         : undefined;
     return (
         <span style={style} id={id}>
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {mathJaxify}
-            </MathJax>
+            <DynamicMath latex={mathJaxify} />
         </span>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -4,7 +4,7 @@ import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
@@ -339,17 +339,11 @@ export default React.memo(function MathComponent(
         ? textRendererStyle(darkMode ?? "light", SVs.selectedStyle)
         : undefined;
 
-    const hideUntilTypeset = !choiceInputInlineContext.isHidden
-        ? "first"
-        : undefined;
-
     return (
         <>
             {anchors}
             <span style={style} id={id}>
-                <MathJax hideUntilTypeset={hideUntilTypeset} inline dynamic>
-                    {latexWithDelims}
-                </MathJax>
+                <DynamicMath latex={latexWithDelims} />
             </span>
         </>
     );

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -1,4 +1,4 @@
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 
 import React, { useContext, useRef } from "react";
 import JXG from "jsxgraph";
@@ -299,9 +299,7 @@ export default React.memo(function NumberComponent(
 
     return (
         <span style={style} id={id}>
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {number}
-            </MathJax>
+            <DynamicMath latex={number} />
         </span>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -4,7 +4,7 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { BoardContext, POINT_LAYER_OFFSET } from "./graph";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 import { textRendererStyle } from "@doenet/utils";
 import { characterizeOffGraphPoint } from "./utils/offGraphIndicators";
 import {
@@ -664,9 +664,7 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
         : undefined;
     return (
         <span style={style} id={id}>
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {mathJaxify}
-            </MathJax>
+            <DynamicMath latex={mathJaxify} />
         </span>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef } from "react";
+import { loadMathJax } from "@doenet/utils";
+
+/**
+ * Renders continuously-updating inline math (e.g. `$P` while a point is
+ * dragged) without the flash of raw LaTeX.
+ *
+ * `better-react-mathjax`'s `<MathJax dynamic>` writes the new raw LaTeX into the
+ * DOM and typesets it *asynchronously*. When updates outpace MathJax (dragging a
+ * point referenced many times), that leaves raw LaTeX on screen, and its update
+ * effect can drop the final typeset, leaving one element stuck showing raw
+ * LaTeX until the next unrelated re-render.
+ *
+ * This component double-buffers instead: it typesets the new LaTeX on an
+ * off-screen buffer and swaps the rendered result into place only once it is
+ * ready, keeping the previously rendered output visible in the meantime. Rapid
+ * updates are coalesced to the latest value (so nothing is ever left
+ * un-typeset) and throttled (so a fast drag doesn't flood MathJax). The visible
+ * math is therefore always rendered — momentarily stale during a fast drag,
+ * never raw and never blank.
+ *
+ * `latex` is the full inline string including delimiters, e.g. `\(x^2\)`.
+ */
+
+/** Minimum time between typesets of a single element (ms). Caps how often a
+ * fast drag re-typesets; the displayed value lags by at most this plus one
+ * typeset, which is imperceptible for coordinate read-outs. */
+const THROTTLE_MS = 100;
+
+/** The parts of a loaded MathJax 3/4 engine this component uses. */
+interface LoadedMathJax {
+    startup: { promise: Promise<unknown> };
+    typesetPromise: (nodes: HTMLElement[]) => Promise<unknown>;
+    typesetClear: (nodes: HTMLElement[]) => void;
+}
+
+export function DynamicMath({ latex }: { latex: string }) {
+    const visibleRef = useRef<HTMLSpanElement>(null);
+    const bufferRef = useRef<HTMLSpanElement | null>(null);
+    // Latest requested value, the one currently displayed, and a re-entrancy
+    // guard so only one typeset runs at a time per element.
+    const pending = useRef<string | null>(null);
+    const current = useRef<string | null>(null);
+    const busy = useRef(false);
+    const lastTypesetAt = useRef(0);
+
+    useEffect(() => {
+        pending.current = latex;
+        void pump();
+        // `pump` reads refs only; re-running it whenever `latex` changes is all
+        // that is needed.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [latex]);
+
+    useEffect(() => {
+        return () => {
+            bufferRef.current?.remove();
+            bufferRef.current = null;
+        };
+    }, []);
+
+    async function pump() {
+        if (busy.current) {
+            return;
+        }
+        const visible = visibleRef.current;
+        if (!visible) {
+            return;
+        }
+        busy.current = true;
+        try {
+            const MathJax = (await loadMathJax()) as unknown as LoadedMathJax;
+            await MathJax.startup.promise;
+            while (
+                pending.current !== null &&
+                pending.current !== current.current
+            ) {
+                const wait =
+                    THROTTLE_MS - (performance.now() - lastTypesetAt.current);
+                if (wait > 0) {
+                    await new Promise((resolve) => setTimeout(resolve, wait));
+                }
+                // Grab the newest requested value, skipping any intermediate
+                // ones that arrived while we were waiting or typesetting.
+                const next = pending.current;
+                if (next === null) {
+                    break;
+                }
+                pending.current = null;
+
+                const buffer = ensureBuffer(bufferRef);
+                buffer.innerHTML = next;
+                // Drop MathJax's record of the previous render so its internal
+                // list doesn't grow without bound under frequent updates.
+                MathJax.typesetClear([buffer]);
+                await MathJax.typesetPromise([buffer]);
+                // Swap the freshly rendered output in; the old output stayed
+                // visible until exactly now, so there is no raw/blank flash.
+                visible.replaceChildren(...Array.from(buffer.childNodes));
+
+                current.current = next;
+                lastTypesetAt.current = performance.now();
+            }
+        } catch (e) {
+            // On failure, keep the last good render rather than flashing raw
+            // LaTeX or going blank.
+            console.error("DynamicMath: MathJax typesetting failed", e);
+        } finally {
+            busy.current = false;
+        }
+    }
+
+    return <span ref={visibleRef} style={{ display: "inline" }} />;
+}
+
+/** Lazily create the off-screen, assistive-tech-hidden typeset buffer. */
+function ensureBuffer(
+    bufferRef: React.MutableRefObject<HTMLSpanElement | null>,
+): HTMLSpanElement {
+    let buffer = bufferRef.current;
+    if (!buffer) {
+        buffer = document.createElement("span");
+        buffer.setAttribute("aria-hidden", "true");
+        buffer.style.position = "absolute";
+        buffer.style.visibility = "hidden";
+        buffer.style.left = "-9999px";
+        buffer.style.top = "0";
+        document.body.appendChild(buffer);
+        bufferRef.current = buffer;
+    }
+    return buffer;
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -43,6 +43,9 @@ export function DynamicMath({ latex }: { latex: string }) {
     const current = useRef<string | null>(null);
     const busy = useRef(false);
     const lastTypesetAt = useRef(0);
+    // False once unmounted, so an in-flight `pump` stops before touching a
+    // detached node or re-creating the off-screen buffer after cleanup.
+    const mounted = useRef(true);
 
     useEffect(() => {
         pending.current = latex;
@@ -53,7 +56,11 @@ export function DynamicMath({ latex }: { latex: string }) {
     }, [latex]);
 
     useEffect(() => {
+        // Set on setup (not just at declaration) so a StrictMode remount, which
+        // reruns this effect after the cleanup below, re-arms the guard.
+        mounted.current = true;
         return () => {
+            mounted.current = false;
             bufferRef.current?.remove();
             bufferRef.current = null;
         };
@@ -72,6 +79,7 @@ export function DynamicMath({ latex }: { latex: string }) {
             const MathJax = (await loadMathJax()) as unknown as LoadedMathJax;
             await MathJax.startup.promise;
             while (
+                mounted.current &&
                 pending.current !== null &&
                 pending.current !== current.current
             ) {
@@ -79,6 +87,11 @@ export function DynamicMath({ latex }: { latex: string }) {
                     THROTTLE_MS - (performance.now() - lastTypesetAt.current);
                 if (wait > 0) {
                     await new Promise((resolve) => setTimeout(resolve, wait));
+                }
+                // Bail if we unmounted while waiting, before creating the
+                // buffer (which cleanup has already removed) or typesetting.
+                if (!mounted.current) {
+                    break;
                 }
                 // Grab the newest requested value, skipping any intermediate
                 // ones that arrived while we were waiting or typesetting.
@@ -94,6 +107,12 @@ export function DynamicMath({ latex }: { latex: string }) {
                 // list doesn't grow without bound under frequent updates.
                 MathJax.typesetClear([buffer]);
                 await MathJax.typesetPromise([buffer]);
+                // Bail if we unmounted during the typeset: the buffer was
+                // removed by cleanup and `visible` is detached, so there is
+                // nothing to swap into.
+                if (!mounted.current) {
+                    break;
+                }
                 // Swap the freshly rendered output in; the old output stayed
                 // visible until exactly now, so there is no raw/blank flash.
                 visible.replaceChildren(...Array.from(buffer.childNodes));

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -46,18 +46,9 @@ export function DynamicMath({ latex }: { latex: string }) {
     // detached node or re-creating the off-screen buffer after cleanup.
     const mounted = useRef(true);
 
-    useEffect(() => {
-        pending.current = latex;
-        // Fire the typeset loop. `renderPendingLatex` reads refs only and resets `busy` in its
-        // `finally`; re-running it whenever `latex` changes is all that is
-        // needed. On failure, keep the last good render rather than flashing raw
-        // LaTeX or going blank.
-        renderPendingLatex().catch((e) => {
-            console.error("DynamicMath: MathJax typesetting failed", e);
-        });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [latex]);
-
+    // Arm/re-arm the unmount guard and clean up the off-screen buffer. Runs
+    // before the [latex] effect below on every (re)mount, so the loop there
+    // always starts with `mounted.current === true`.
     useEffect(() => {
         // Set on setup (not just at declaration) so a StrictMode remount, which
         // reruns this effect after the cleanup below, re-arms the guard.
@@ -69,87 +60,105 @@ export function DynamicMath({ latex }: { latex: string }) {
         };
     }, []);
 
-    /**
-     * The typeset-and-swap loop, (re)invoked on every `latex` change. It runs
-     * at most one instance at a time (guarded by `busy`), so overlapping
-     * invocations return immediately and the already-running loop picks up the
-     * newer value. It waits for MathJax, then repeatedly: throttles, takes the
-     * latest `pending` value (skipping any intermediate ones), typesets it on
-     * the off-screen buffer, drops MathJax's record of that render, and swaps
-     * the rendered nodes into the visible span. It exits once `pending` has
-     * caught up to what is displayed (or the component unmounts), leaving the
-     * newest value on screen.
-     */
-    async function renderPendingLatex() {
-        if (busy.current) {
-            return;
-        }
-        const visible = visibleRef.current;
-        if (!visible) {
-            return;
-        }
-        busy.current = true;
-        try {
-            const MathJax = (await loadMathJax()) as unknown as LoadedMathJax;
-            await MathJax.startup.promise;
-            while (
-                mounted.current &&
-                pending.current !== null &&
-                pending.current !== current.current
-            ) {
-                const wait =
-                    THROTTLE_MS - (performance.now() - lastTypesetAt.current);
-                if (wait > 0) {
-                    await new Promise((resolve) => setTimeout(resolve, wait));
-                }
-                // Bail if we unmounted while waiting, before creating the
-                // buffer (which cleanup has already removed) or typesetting.
-                if (!mounted.current) {
-                    break;
-                }
-                // Grab the newest requested value, skipping any intermediate
-                // ones that arrived while we were waiting or typesetting.
-                const next = pending.current;
-                if (next === null) {
-                    break;
-                }
-                pending.current = null;
+    useEffect(() => {
+        pending.current = latex;
+        // On failure, keep the last good render rather than flashing raw LaTeX
+        // or going blank.
+        renderPendingLatex().catch((e) => {
+            console.error("DynamicMath: MathJax typesetting failed", e);
+        });
 
-                const buffer = ensureBuffer(bufferRef);
-                buffer.innerHTML = next;
-                await MathJax.typesetPromise([buffer]);
-                // Drop MathJax's record of this render as soon as the typeset
-                // finishes — before the unmount check below and before moving
-                // the rendered nodes out of the buffer. `typesetClear` prunes
-                // math items whose nodes are still inside the buffer (matched
-                // via `buffer.contains(...)`, which holds even once cleanup has
-                // detached the buffer from the document), so clearing here —
-                // while the fresh output is still in the buffer — is what keeps
-                // MathJax's internal math list (and the detached DOM it would
-                // otherwise retain across every swap) from growing without
-                // bound under frequent updates. Clearing before the unmount
-                // check is deliberate: if we bailed first, an unmount mid-drag
-                // would re-leak exactly this item. Clearing only forgets the
-                // item; the rendered DOM stays fully functional.
-                MathJax.typesetClear([buffer]);
-                // Bail if we unmounted during the typeset: the buffer was
-                // removed by cleanup and `visible` is detached, so there is
-                // nothing to swap into. MathJax's record was already cleared
-                // above, so bailing here leaks nothing.
-                if (!mounted.current) {
-                    break;
-                }
-                // Swap the freshly rendered output in; the old output stayed
-                // visible until exactly now, so there is no raw/blank flash.
-                visible.replaceChildren(...Array.from(buffer.childNodes));
-
-                current.current = next;
-                lastTypesetAt.current = performance.now();
+        /**
+         * The typeset-and-swap loop, (re)invoked on every `latex` change. It
+         * runs at most one instance at a time (guarded by `busy`), so
+         * overlapping invocations return immediately and the already-running
+         * loop picks up the newer value. It waits for MathJax, then repeatedly:
+         * throttles, takes the latest `pending` value (skipping any intermediate
+         * ones), typesets it on the off-screen buffer, drops MathJax's record of
+         * that render, and swaps the rendered nodes into the visible span. It
+         * exits once `pending` has caught up to what is displayed (or the
+         * component unmounts), leaving the newest value on screen.
+         *
+         * Defined inside the effect (its only caller) so it isn't an effect
+         * dependency: it reads refs only, so re-running it on each `latex`
+         * change is exactly right.
+         */
+        async function renderPendingLatex() {
+            if (busy.current) {
+                return;
             }
-        } finally {
-            busy.current = false;
+            const visible = visibleRef.current;
+            if (!visible) {
+                return;
+            }
+            busy.current = true;
+            try {
+                const MathJax =
+                    (await loadMathJax()) as unknown as LoadedMathJax;
+                await MathJax.startup.promise;
+                while (
+                    mounted.current &&
+                    pending.current !== null &&
+                    pending.current !== current.current
+                ) {
+                    const wait =
+                        THROTTLE_MS -
+                        (performance.now() - lastTypesetAt.current);
+                    if (wait > 0) {
+                        await new Promise((resolve) =>
+                            setTimeout(resolve, wait),
+                        );
+                    }
+                    // Bail if we unmounted while waiting, before creating the
+                    // buffer (which cleanup has already removed) or typesetting.
+                    if (!mounted.current) {
+                        break;
+                    }
+                    // Grab the newest requested value, skipping any intermediate
+                    // ones that arrived while we were waiting or typesetting.
+                    const next = pending.current;
+                    if (next === null) {
+                        break;
+                    }
+                    pending.current = null;
+
+                    const buffer = ensureBuffer(bufferRef);
+                    buffer.innerHTML = next;
+                    await MathJax.typesetPromise([buffer]);
+                    // Drop MathJax's record of this render as soon as the
+                    // typeset finishes — before the unmount check below and
+                    // before moving the rendered nodes out of the buffer.
+                    // `typesetClear` prunes math items whose nodes are still
+                    // inside the buffer (matched via `buffer.contains(...)`,
+                    // which holds even once cleanup has detached the buffer from
+                    // the document), so clearing here — while the fresh output
+                    // is still in the buffer — is what keeps MathJax's internal
+                    // math list (and the detached DOM it would otherwise retain
+                    // across every swap) from growing without bound under
+                    // frequent updates. Clearing before the unmount check is
+                    // deliberate: if we bailed first, an unmount mid-drag would
+                    // re-leak exactly this item. Clearing only forgets the item;
+                    // the rendered DOM stays fully functional.
+                    MathJax.typesetClear([buffer]);
+                    // Bail if we unmounted during the typeset: the buffer was
+                    // removed by cleanup and `visible` is detached, so there is
+                    // nothing to swap into. MathJax's record was already cleared
+                    // above, so bailing here leaks nothing.
+                    if (!mounted.current) {
+                        break;
+                    }
+                    // Swap the freshly rendered output in; the old output stayed
+                    // visible until exactly now, so there is no raw/blank flash.
+                    visible.replaceChildren(...Array.from(buffer.childNodes));
+
+                    current.current = next;
+                    lastTypesetAt.current = performance.now();
+                }
+            } finally {
+                busy.current = false;
+            }
         }
-    }
+    }, [latex]);
 
     return <span ref={visibleRef} style={{ display: "inline" }} />;
 }

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -42,15 +42,19 @@ export function DynamicMath({ latex }: { latex: string }) {
     const current = useRef<string | null>(null);
     const busy = useRef(false);
     const lastTypesetAt = useRef(0);
-    // False once unmounted, so an in-flight `pump` stops before touching a
+    // False once unmounted, so an in-flight `renderPendingLatex` stops before touching a
     // detached node or re-creating the off-screen buffer after cleanup.
     const mounted = useRef(true);
 
     useEffect(() => {
         pending.current = latex;
-        void pump();
-        // `pump` reads refs only; re-running it whenever `latex` changes is all
-        // that is needed.
+        // Fire the typeset loop. `renderPendingLatex` reads refs only and resets `busy` in its
+        // `finally`; re-running it whenever `latex` changes is all that is
+        // needed. On failure, keep the last good render rather than flashing raw
+        // LaTeX or going blank.
+        renderPendingLatex().catch((e) => {
+            console.error("DynamicMath: MathJax typesetting failed", e);
+        });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [latex]);
 
@@ -65,7 +69,18 @@ export function DynamicMath({ latex }: { latex: string }) {
         };
     }, []);
 
-    async function pump() {
+    /**
+     * The typeset-and-swap loop, (re)invoked on every `latex` change. It runs
+     * at most one instance at a time (guarded by `busy`), so overlapping
+     * invocations return immediately and the already-running loop picks up the
+     * newer value. It waits for MathJax, then repeatedly: throttles, takes the
+     * latest `pending` value (skipping any intermediate ones), typesets it on
+     * the off-screen buffer, drops MathJax's record of that render, and swaps
+     * the rendered nodes into the visible span. It exits once `pending` has
+     * caught up to what is displayed (or the component unmounts), leaving the
+     * newest value on screen.
+     */
+    async function renderPendingLatex() {
         if (busy.current) {
             return;
         }
@@ -131,10 +146,6 @@ export function DynamicMath({ latex }: { latex: string }) {
                 current.current = next;
                 lastTypesetAt.current = performance.now();
             }
-        } catch (e) {
-            // On failure, keep the last good render rather than flashing raw
-            // LaTeX or going blank.
-            console.error("DynamicMath: MathJax typesetting failed", e);
         } finally {
             busy.current = false;
         }

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -103,9 +103,6 @@ export function DynamicMath({ latex }: { latex: string }) {
 
                 const buffer = ensureBuffer(bufferRef);
                 buffer.innerHTML = next;
-                // Drop MathJax's record of the previous render so its internal
-                // list doesn't grow without bound under frequent updates.
-                MathJax.typesetClear([buffer]);
                 await MathJax.typesetPromise([buffer]);
                 // Bail if we unmounted during the typeset: the buffer was
                 // removed by cleanup and `visible` is detached, so there is
@@ -113,6 +110,15 @@ export function DynamicMath({ latex }: { latex: string }) {
                 if (!mounted.current) {
                     break;
                 }
+                // Drop MathJax's record of this render *before* moving the
+                // rendered nodes out of the buffer. `typesetClear` only prunes
+                // math items whose nodes are still inside the buffer, so
+                // clearing here — while the fresh output is still in the buffer
+                // — is what actually keeps MathJax's internal math list (and the
+                // detached DOM it would otherwise retain across every swap) from
+                // growing without bound under frequent updates. Clearing only
+                // forgets the item; the rendered DOM stays fully functional.
+                MathJax.typesetClear([buffer]);
                 // Swap the freshly rendered output in; the old output stayed
                 // visible until exactly now, so there is no raw/blank flash.
                 visible.replaceChildren(...Array.from(buffer.childNodes));

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -1,6 +1,18 @@
 import React, { useEffect, useRef } from "react";
 import { loadMathJax } from "@doenet/utils";
 
+/** Minimum time between typesets of a single element (ms). Caps how often a
+ * fast drag re-typesets; the displayed value lags by at most this plus one
+ * typeset, which is imperceptible for coordinate read-outs. */
+const THROTTLE_MS = 100;
+
+/** The parts of a loaded MathJax 3/4 engine this component uses. */
+interface LoadedMathJax {
+    startup: { promise: Promise<unknown> };
+    typesetPromise: (nodes: HTMLElement[]) => Promise<unknown>;
+    typesetClear: (nodes: HTMLElement[]) => void;
+}
+
 /**
  * Renders continuously-updating inline math (e.g. `$P` while a point is
  * dragged) without the flash of raw LaTeX.
@@ -21,19 +33,6 @@ import { loadMathJax } from "@doenet/utils";
  *
  * `latex` is the full inline string including delimiters, e.g. `\(x^2\)`.
  */
-
-/** Minimum time between typesets of a single element (ms). Caps how often a
- * fast drag re-typesets; the displayed value lags by at most this plus one
- * typeset, which is imperceptible for coordinate read-outs. */
-const THROTTLE_MS = 100;
-
-/** The parts of a loaded MathJax 3/4 engine this component uses. */
-interface LoadedMathJax {
-    startup: { promise: Promise<unknown> };
-    typesetPromise: (nodes: HTMLElement[]) => Promise<unknown>;
-    typesetClear: (nodes: HTMLElement[]) => void;
-}
-
 export function DynamicMath({ latex }: { latex: string }) {
     const visibleRef = useRef<HTMLSpanElement>(null);
     const bufferRef = useRef<HTMLSpanElement | null>(null);

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -104,21 +104,27 @@ export function DynamicMath({ latex }: { latex: string }) {
                 const buffer = ensureBuffer(bufferRef);
                 buffer.innerHTML = next;
                 await MathJax.typesetPromise([buffer]);
+                // Drop MathJax's record of this render as soon as the typeset
+                // finishes — before the unmount check below and before moving
+                // the rendered nodes out of the buffer. `typesetClear` prunes
+                // math items whose nodes are still inside the buffer (matched
+                // via `buffer.contains(...)`, which holds even once cleanup has
+                // detached the buffer from the document), so clearing here —
+                // while the fresh output is still in the buffer — is what keeps
+                // MathJax's internal math list (and the detached DOM it would
+                // otherwise retain across every swap) from growing without
+                // bound under frequent updates. Clearing before the unmount
+                // check is deliberate: if we bailed first, an unmount mid-drag
+                // would re-leak exactly this item. Clearing only forgets the
+                // item; the rendered DOM stays fully functional.
+                MathJax.typesetClear([buffer]);
                 // Bail if we unmounted during the typeset: the buffer was
                 // removed by cleanup and `visible` is detached, so there is
-                // nothing to swap into.
+                // nothing to swap into. MathJax's record was already cleared
+                // above, so bailing here leaks nothing.
                 if (!mounted.current) {
                     break;
                 }
-                // Drop MathJax's record of this render *before* moving the
-                // rendered nodes out of the buffer. `typesetClear` only prunes
-                // math items whose nodes are still inside the buffer, so
-                // clearing here — while the fresh output is still in the buffer
-                // — is what actually keeps MathJax's internal math list (and the
-                // detached DOM it would otherwise retain across every swap) from
-                // growing without bound under frequent updates. Clearing only
-                // forgets the item; the rendered DOM stays fully functional.
-                MathJax.typesetClear([buffer]);
                 // Swap the freshly rendered output in; the old output stayed
                 // visible until exactly now, so there is no raw/blank flash.
                 visible.replaceChildren(...Array.from(buffer.childNodes));

--- a/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/DynamicMath.tsx
@@ -78,10 +78,6 @@ export function DynamicMath({ latex }: { latex: string }) {
          * that render, and swaps the rendered nodes into the visible span. It
          * exits once `pending` has caught up to what is displayed (or the
          * component unmounts), leaving the newest value on screen.
-         *
-         * Defined inside the effect (its only caller) so it isn't an effect
-         * dependency: it reads refs only, so re-running it on each `latex`
-         * change is exactly right.
          */
         async function renderPendingLatex() {
             if (busy.current) {

--- a/packages/doenetml/src/Viewer/renderers/utils/labelWithLatex.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/labelWithLatex.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./DynamicMath";
 
 /**
  * Render a label as plain text or as inline MathJax, depending on whether the
@@ -13,11 +13,7 @@ export function renderLabelWithLatex({
     labelHasLatex: boolean;
 }): React.ReactNode {
     if (labelHasLatex) {
-        return (
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {label}
-            </MathJax>
-        );
+        return <DynamicMath latex={label} />;
     }
 
     return label;

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -4,7 +4,7 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET, VERTEX_LAYER_OFFSET } from "./graph";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "./utils/DynamicMath";
 import { textRendererStyle } from "@doenet/utils";
 import { DocContext } from "../DocViewer";
 import { JXGLine, JXGPoint } from "./jsxgraph-distrib/types";
@@ -537,9 +537,7 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
         : undefined;
     return (
         <span style={style} id={id}>
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {mathJaxify}
-            </MathJax>
+            <DynamicMath latex={mathJaxify} />
         </span>
     );
 });

--- a/packages/doenetml/src/utils/responses.tsx
+++ b/packages/doenetml/src/utils/responses.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import me from "math-expressions";
-import { MathJax } from "better-react-mathjax";
+import { DynamicMath } from "../Viewer/renderers/utils/DynamicMath";
 
 /**
  * Format responses from submitted events into react elements
@@ -24,12 +24,12 @@ export function formatResponse(
                         .round_numbers_to_precision_plus_decimals(6, 2);
                     return (
                         <div key={i}>
-                            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                                {
+                            <DynamicMath
+                                latex={
                                     //@ts-ignore
                                     "\\(" + expr.toLatex() + "\\)"
                                 }
-                            </MathJax>
+                            />
                         </div>
                     );
                 } else {


### PR DESCRIPTION
## Problem

Inline math that references a continuously-changing value flashes **raw LaTeX** while it updates. Dragging a point `P` that is referenced many times as `$P`:

- during the drag, the `$P` copies show raw `\left( 3, 4 \right)` instead of rendered coordinates;
- when you stop (but keep holding), all but one settle to rendered math and **one stays stuck as raw LaTeX** indefinitely;
- releasing finally renders it.

The same affects other value displays bound to a dragged/animated value (`<number>`, `<line>`, etc.).

## Root cause

These renderers use `better-react-mathjax`'s `<MathJax dynamic>`, which writes the new raw LaTeX into the DOM and typesets it **asynchronously**. When updates outpace MathJax (many references × a fast drag, made worse by MathJax 4's worker-based typesetting), the raw LaTeX is visible in the gap before typesetting completes; and its update effect skips issuing the trailing typeset while a prior one is in flight, so one element is left un-typeset until an unrelated re-render (the release) nudges it. (Independent of the coexistence work in #1446 — it reproduces on a clean `main`.)

## Fix

A small **double-buffered** `DynamicMath` component (plain MathJax via the existing `loadMathJax` singleton): it typesets the new LaTeX on an off-screen buffer and swaps the rendered result into place only once ready, keeping the previously rendered math visible in the meantime. Rapid updates are **coalesced** to the latest value (so nothing is ever left un-typeset) and **throttled** (so a fast drag doesn't flood MathJax); it calls `typesetClear` for MathJax memory hygiene. The visible math therefore stays rendered throughout a drag — momentarily stale during a fast drag, but **never raw and never blank**.

Applied to the value-display renderers: `<m>`/`<me>`/`<men>` (math), point, number, line, vector, angle, label, answer, and the label/response helpers. Math inside inputs and some labels (`<mathInput>` previews, choice/text/fraction/matrix/boolean inputs, button labels) keeps the previous path for now — those are typing-driven, a different UX to validate — and are a natural follow-up.

## Verification (real browser, Playwright/Chromium)

Screenshotted a real point-drag of the reporter's DoenetML — not just DOM metrics (a couple of metric-only checks misled me mid-investigation: `has mjx-container` counts MathJax *error boxes* as "rendered", and a raw-cell count misses *blank* cells):

- **Before**: during drag all 14 `$P` show raw LaTeX; held-pause leaves 1 stuck raw; release renders all.
- **After**: 14 rendered / 0 raw / 0 blank / 0 error at every step — during drag, held-pause, and release. Verified again with point + number + line together, and confirmed `<m>`/`<me>` (display) / `<men>` (numbered) still render with correct layout.

Builds on the MathJax context from #1446 (already in `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)