### PR TITLE
More memory reductions from Fable

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -569,6 +569,11 @@ export default class Core {
             );
         }
 
+        // The circular-check memos now hold one entry per state variable
+        // created during the load; drop them and let them regrow with the
+        // (typically few) components involved in later updates.
+        this.dependencies.clearCircularCheckMemos();
+
         const returnResult = {
             coreInfo: this.coreInfo,
         };

--- a/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
+++ b/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
@@ -428,6 +428,9 @@ export class StalenessPropagator {
                         if (!upDep.valuesChanged) {
                             upDep.valuesChanged = [];
                         }
+                        // the interned (frozen, shared) structures must be
+                        // replaced with mutable copies before recording
+                        upDep.thawValuesChangedRecord(componentInd);
                         if (!upDep.valuesChanged[componentInd]) {
                             upDep.valuesChanged[componentInd] = {};
                         }

--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -827,16 +827,6 @@ async function createReferenceShadowStateVariableDefinitions({
     });
 }
 
-/**
- * Rewrite each named state-variable definition in
- * `stateVariableDefinitions` so it reads from the corresponding variable
- * on `targetComponent` instead of computing its own value. Handles both
- * scalar and array variables; `differentStateVariablesInTarget[i]` (if
- * provided) overrides the target variable name for shadow `i`. When a
- * shadowed variable was used by an `additionalStateVariablesDefined`
- * group, the un-shadowed siblings get the variable scrubbed from their
- * definition output via `modifyStateDefToDeleteVariableReferences`.
- */
 /*
  * Shared shadow definition functions.
  *
@@ -1039,6 +1029,16 @@ function shadowInverseArrayDefinitionByKey(
     };
 }
 
+/**
+ * Rewrite each named state-variable definition in
+ * `stateVariableDefinitions` so it reads from the corresponding variable
+ * on `targetComponent` instead of computing its own value. Handles both
+ * scalar and array variables; `differentStateVariablesInTarget[i]` (if
+ * provided) overrides the target variable name for shadow `i`. When a
+ * shadowed variable was used by an `additionalStateVariablesDefined`
+ * group, the un-shadowed siblings get the variable scrubbed from their
+ * definition output via `modifyStateDefToDeleteVariableReferences`.
+ */
 function modifyStateDefsToBeShadows({
     stateVariablesToShadow,
     stateVariableDefinitions,

--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -837,6 +837,208 @@ async function createReferenceShadowStateVariableDefinitions({
  * group, the un-shadowed siblings get the variable scrubbed from their
  * definition output via `modifyStateDefToDeleteVariableReferences`.
  */
+/*
+ * Shared shadow definition functions.
+ *
+ * `modifyStateDefsToBeShadows` used to create 3 fresh closures (plus their
+ * shared context) per shadowed state variable per component instance — for
+ * copy/repeat-heavy documents this was the dominant remaining per-instance
+ * definition cost after the per-class definition cache (see
+ * https://github.com/Doenet/DoenetML/issues/1428). These module-level
+ * functions replace those closures; the per-variable parameters they need
+ * are stored as `shadow*` fields on the (per-instance) definition object.
+ *
+ * They read the parameters via `this`, which is safe because:
+ *  - shadow-path definitions ARE the state-variable objects (BaseComponent
+ *    uses the factory's per-instance clones directly), and
+ *  - every core call site invokes these as methods of the state-variable
+ *    object (`stateVarObj.definition(args)`, `stateVarObj.returnDependencies(...)`,
+ *    `stateVarObj.arrayDefinitionByKey(args)`, ...) or binds first
+ *    (`arrayStateVarObj.returnDependencies.bind(arrayStateVarObj)` in
+ *    `StateVariableInitializer`).
+ */
+function shadowReturnDependencies(this: any, args: any) {
+    // start from the original dependencies when they were kept for
+    // readyToExpandWhenResolved (see shadowOriginalReturnDependencies)
+    let dependencies: Record<string, any> = Object.assign(
+        {},
+        this.shadowOriginalReturnDependencies?.(args),
+    );
+
+    dependencies.targetVariable = {
+        dependencyType: "stateVariable",
+        componentIdx: this.shadowOfComponentIdx,
+        variableName: this.shadowVarNameInTarget,
+    };
+    if (this.shadowCopyComponentType) {
+        dependencies.targetVariableComponentType = {
+            dependencyType: "stateVariableComponentType",
+            componentIdx: this.shadowOfComponentIdx,
+            variableName: this.shadowVarNameInTarget,
+        };
+    }
+    return dependencies;
+}
+
+function shadowDefinition(
+    this: any,
+    { dependencyValues, usedDefault }: any,
+): Record<string, any> {
+    const varName = this.shadowVarName;
+    let result: Record<string, any> = {};
+
+    // TODO: how do we make it do this just once?
+    if ("targetVariableComponentType" in dependencyValues) {
+        result.setCreateComponentOfType = {
+            [varName]: dependencyValues.targetVariableComponentType,
+        };
+    }
+
+    if (
+        usedDefault.targetVariable &&
+        "defaultValue" in this &&
+        this.hasEssential
+    ) {
+        result.useEssentialOrDefaultValue = {
+            [varName]: {
+                defaultValue: dependencyValues.targetVariable,
+            },
+        };
+    } else {
+        result.setValue = {
+            [varName]: dependencyValues.targetVariable,
+        };
+    }
+
+    return result;
+}
+
+function shadowInverseDefinition(
+    this: any,
+    { desiredStateVariableValues }: any,
+) {
+    return {
+        success: true,
+        instructions: [
+            {
+                setDependency: "targetVariable",
+                desiredValue: desiredStateVariableValues[this.shadowVarName],
+                shadowedVariable: true,
+            },
+        ],
+    };
+}
+
+function shadowReturnArrayDependenciesByKey(this: any, { arrayKeys }: any) {
+    let dependenciesByKey: Record<string, any> = {};
+
+    for (let key of arrayKeys) {
+        dependenciesByKey[key] = {
+            targetVariable: {
+                dependencyType: "stateVariable",
+                componentIdx: this.shadowOfComponentIdx,
+                variableName:
+                    this.shadowOverrideVarName ||
+                    this.arrayVarNameFromArrayKey(key),
+            },
+        };
+    }
+
+    let globalDependencies: Record<string, any> = {};
+
+    if (this.shadowCopyComponentType) {
+        globalDependencies.targetVariableComponentType = {
+            dependencyType: "stateVariableComponentType",
+            componentIdx: this.shadowOfComponentIdx,
+            variableName: this.shadowVarName,
+        };
+    }
+
+    if (this.inverseShadowToSetEntireArray) {
+        globalDependencies.targetArray = {
+            dependencyType: "stateVariable",
+            componentIdx: this.shadowOfComponentIdx,
+            variableName: this.shadowVarName,
+        };
+    }
+
+    return { globalDependencies, dependenciesByKey };
+}
+
+function shadowArrayDefinitionByKey(
+    this: any,
+    { globalDependencyValues, dependencyValuesByKey, arrayKeys }: any,
+) {
+    const varName = this.shadowVarName;
+    let newEntries: Record<string, any> = {};
+
+    for (let arrayKey of arrayKeys) {
+        if ("targetVariable" in dependencyValuesByKey[arrayKey]) {
+            newEntries[arrayKey] =
+                dependencyValuesByKey[arrayKey].targetVariable;
+        } else {
+            // put in a placeholder value until this can be rerun
+            // with the updated dependencies
+            newEntries[arrayKey] = this.defaultValueByArrayKey?.(arrayKey);
+        }
+    }
+
+    let result: Record<string, any> = {
+        setValue: { [varName]: newEntries },
+    };
+
+    // TODO: how do we make it do this just once?
+    if ("targetVariableComponentType" in globalDependencyValues) {
+        result.setCreateComponentOfType = {
+            [varName]: globalDependencyValues.targetVariableComponentType,
+        };
+    }
+
+    return result;
+}
+
+function shadowInverseArrayDefinitionByKey(
+    this: any,
+    {
+        desiredStateVariableValues,
+        dependencyValuesByKey,
+        dependencyNamesByKey,
+        arraySize,
+        initialChange,
+    }: any,
+) {
+    const varName = this.shadowVarName;
+    if (this.inverseShadowToSetEntireArray) {
+        return {
+            success: true,
+            instructions: [
+                {
+                    setDependency: "targetArray",
+                    desiredValue: desiredStateVariableValues[varName],
+                    treatAsInitialChange: initialChange,
+                },
+            ],
+        };
+    }
+
+    let instructions = [];
+    for (let key in desiredStateVariableValues[varName]) {
+        if (!dependencyValuesByKey[key]) {
+            continue;
+        }
+
+        instructions.push({
+            setDependency: dependencyNamesByKey[key].targetVariable,
+            desiredValue: desiredStateVariableValues[varName][key],
+            shadowedVariable: true,
+        });
+    }
+    return {
+        success: true,
+        instructions,
+    };
+}
+
 function modifyStateDefsToBeShadows({
     stateVariablesToShadow,
     stateVariableDefinitions,
@@ -895,197 +1097,40 @@ function modifyStateDefsToBeShadows({
             stateDef.public &&
             stateDef.shadowingInstructions.hasVariableComponentType;
 
+        // Parameters for the shared shadow definition functions (see the
+        // module-level `shadow*` functions above), stored on the
+        // per-instance definition instead of captured in per-variable
+        // closures.
+        stateDef.shadowOfComponentIdx = targetComponent.componentIdx;
+        stateDef.shadowVarName = varName;
+        stateDef.shadowCopyComponentType = copyComponentType;
+
         if (stateDef.isArray) {
-            let overrideVarNameWith = differentStateVariablesInTarget[varInd];
+            stateDef.shadowOverrideVarName =
+                differentStateVariablesInTarget[varInd];
 
-            stateDef.returnArrayDependenciesByKey = function ({ arrayKeys }) {
-                let dependenciesByKey = {};
-
-                for (let key of arrayKeys) {
-                    dependenciesByKey[key] = {
-                        targetVariable: {
-                            dependencyType: "stateVariable",
-                            componentIdx: targetComponent.componentIdx,
-                            variableName:
-                                overrideVarNameWith ||
-                                this.arrayVarNameFromArrayKey(key),
-                        },
-                    };
-                }
-
-                let globalDependencies = {};
-
-                if (copyComponentType) {
-                    globalDependencies.targetVariableComponentType = {
-                        dependencyType: "stateVariableComponentType",
-                        componentIdx: targetComponent.componentIdx,
-                        variableName: varName,
-                    };
-                }
-
-                if (stateDef.inverseShadowToSetEntireArray) {
-                    globalDependencies.targetArray = {
-                        dependencyType: "stateVariable",
-                        componentIdx: targetComponent.componentIdx,
-                        variableName: varName,
-                    };
-                }
-
-                return { globalDependencies, dependenciesByKey };
-            };
-
-            stateDef.arrayDefinitionByKey = function ({
-                globalDependencyValues,
-                dependencyValuesByKey,
-                arrayKeys,
-            }) {
-                let newEntries = {};
-
-                for (let arrayKey of arrayKeys) {
-                    if ("targetVariable" in dependencyValuesByKey[arrayKey]) {
-                        newEntries[arrayKey] =
-                            dependencyValuesByKey[arrayKey].targetVariable;
-                    } else {
-                        // put in a placeholder value until this can be rerun
-                        // with the updated dependencies
-                        newEntries[arrayKey] =
-                            stateDef.defaultValueByArrayKey?.(arrayKey);
-                    }
-                }
-
-                let result = {
-                    setValue: { [varName]: newEntries },
-                };
-
-                // TODO: how do we make it do this just once?
-                if ("targetVariableComponentType" in globalDependencyValues) {
-                    result.setCreateComponentOfType = {
-                        [varName]:
-                            globalDependencyValues.targetVariableComponentType,
-                    };
-                }
-
-                return result;
-            };
-
-            stateDef.inverseArrayDefinitionByKey = function ({
-                desiredStateVariableValues,
-                dependencyValuesByKey,
-                dependencyNamesByKey,
-                arraySize,
-                initialChange,
-            }) {
-                if (stateDef.inverseShadowToSetEntireArray) {
-                    return {
-                        success: true,
-                        instructions: [
-                            {
-                                setDependency: "targetArray",
-                                desiredValue:
-                                    desiredStateVariableValues[varName],
-                                treatAsInitialChange: initialChange,
-                            },
-                        ],
-                    };
-                }
-
-                let instructions = [];
-                for (let key in desiredStateVariableValues[varName]) {
-                    if (!dependencyValuesByKey[key]) {
-                        continue;
-                    }
-
-                    instructions.push({
-                        setDependency: dependencyNamesByKey[key].targetVariable,
-                        desiredValue: desiredStateVariableValues[varName][key],
-                        shadowedVariable: true,
-                    });
-                }
-                return {
-                    success: true,
-                    instructions,
-                };
-            };
+            stateDef.returnArrayDependenciesByKey =
+                shadowReturnArrayDependenciesByKey;
+            stateDef.arrayDefinitionByKey = shadowArrayDefinitionByKey;
+            stateDef.inverseArrayDefinitionByKey =
+                shadowInverseArrayDefinitionByKey;
         } else {
-            let returnStartingDependencies = () => ({});
-
             if (foundReadyToExpandWhenResolved) {
                 // even though won't use original dependencies
                 // if found a readyToExpandWhenResolved
                 // keep original dependencies so that readyToExpandWhenResolved
                 // won't be resolved until all its dependent variables are resolved
-                returnStartingDependencies =
+                stateDef.shadowOriginalReturnDependencies =
                     stateDef.returnDependencies.bind(stateDef);
             }
 
-            let varNameInTarget = differentStateVariablesInTarget[varInd];
-            if (!varNameInTarget) {
-                varNameInTarget = varName;
-            }
+            stateDef.shadowVarNameInTarget =
+                differentStateVariablesInTarget[varInd] || varName;
 
-            stateDef.returnDependencies = function (args) {
-                let dependencies = Object.assign(
-                    {},
-                    returnStartingDependencies(args),
-                );
-
-                dependencies.targetVariable = {
-                    dependencyType: "stateVariable",
-                    componentIdx: targetComponent.componentIdx,
-                    variableName: varNameInTarget,
-                };
-                if (copyComponentType) {
-                    dependencies.targetVariableComponentType = {
-                        dependencyType: "stateVariableComponentType",
-                        componentIdx: targetComponent.componentIdx,
-                        variableName: varNameInTarget,
-                    };
-                }
-                return dependencies;
-            };
-            stateDef.definition = function ({ dependencyValues, usedDefault }) {
-                let result = {};
-
-                // TODO: how do we make it do this just once?
-                if ("targetVariableComponentType" in dependencyValues) {
-                    result.setCreateComponentOfType = {
-                        [varName]: dependencyValues.targetVariableComponentType,
-                    };
-                }
-
-                if (
-                    usedDefault.targetVariable &&
-                    "defaultValue" in stateDef &&
-                    stateDef.hasEssential
-                ) {
-                    result.useEssentialOrDefaultValue = {
-                        [varName]: {
-                            defaultValue: dependencyValues.targetVariable,
-                        },
-                    };
-                } else {
-                    result.setValue = {
-                        [varName]: dependencyValues.targetVariable,
-                    };
-                }
-
-                return result;
-            };
+            stateDef.returnDependencies = shadowReturnDependencies;
+            stateDef.definition = shadowDefinition;
             stateDef.excludeDependencyValuesInInverseDefinition = true;
-            stateDef.inverseDefinition = function ({
-                desiredStateVariableValues,
-            }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setDependency: "targetVariable",
-                            desiredValue: desiredStateVariableValues[varName],
-                            shadowedVariable: true,
-                        },
-                    ],
-                };
-            };
+            stateDef.inverseDefinition = shadowInverseDefinition;
         }
     }
     for (let varName in deleteStateVariablesFromDefinition) {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -213,6 +213,48 @@ export class Dependency {
                 index,
             });
         }
+
+        // The parallel downstream arrays repeat heavily across dependencies
+        // (mostly length 1, and all the dependencies of one component point
+        // at the same targets), so share one frozen array per distinct list.
+        // The mutators below thaw before changing the downstream set.
+        this.downstreamComponentIndices =
+            this.dependencyHandler.internComponentIndexList(
+                this.downstreamComponentIndices,
+            );
+        this.downstreamComponentTypes =
+            this.dependencyHandler.internComponentTypeList(
+                this.downstreamComponentTypes,
+            );
+        if (this.mappedDownstreamVariableNamesByComponent) {
+            this.mappedDownstreamVariableNamesByComponent =
+                this.dependencyHandler.internNameListArray(
+                    this.mappedDownstreamVariableNamesByComponent,
+                );
+        }
+    }
+
+    /**
+     * Replace the interned (frozen, shared) parallel downstream arrays with
+     * mutable copies before changing the downstream set.
+     */
+    thawDownstreamArrays() {
+        if (Object.isFrozen(this.downstreamComponentIndices)) {
+            this.downstreamComponentIndices = [
+                ...this.downstreamComponentIndices,
+            ];
+        }
+        if (Object.isFrozen(this.downstreamComponentTypes)) {
+            this.downstreamComponentTypes = [...this.downstreamComponentTypes];
+        }
+        if (
+            this.mappedDownstreamVariableNamesByComponent &&
+            Object.isFrozen(this.mappedDownstreamVariableNamesByComponent)
+        ) {
+            this.mappedDownstreamVariableNamesByComponent = [
+                ...this.mappedDownstreamVariableNamesByComponent,
+            ];
+        }
     }
 
     async addDownstreamComponent({
@@ -221,6 +263,8 @@ export class Dependency {
         index,
     }: any) {
         this.componentIdentitiesChanged = true;
+
+        this.thawDownstreamArrays();
 
         this.downstreamComponentIndices.splice(
             index,
@@ -469,6 +513,8 @@ export class Dependency {
             this.componentIdentitiesChanged = true;
         }
 
+        this.thawDownstreamArrays();
+
         let componentIdx = this.downstreamComponentIndices[indexToRemove];
 
         this.downstreamComponentIndices.splice(indexToRemove, 1);
@@ -562,6 +608,8 @@ export class Dependency {
 
     async swapDownstreamComponents(index1: number, index2: number) {
         this.componentIdentitiesChanged = true;
+
+        this.thawDownstreamArrays();
 
         [
             this.downstreamComponentIndices[index1],

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -36,7 +36,7 @@ export function cloneChangeMetadataIfNeeded({
  * One shared object instead of one `{ changed: true }` per
  * (dependency, downstream component, variable).
  */
-const INITIAL_CHANGE_RECORD = Object.freeze({ changed: true });
+export const INITIAL_CHANGE_RECORD = Object.freeze({ changed: true });
 
 export class Dependency {
     [key: string]: any;
@@ -170,6 +170,21 @@ export class Dependency {
             downComponents.downstreamComponentIndices;
         let downstreamComponentTypes = downComponents.downstreamComponentTypes;
 
+        // These two name lists repeat heavily across dependencies and often
+        // alias definition-owned arrays, so intern frozen copies (the
+        // originals stay mutable for their owners). After this point the
+        // fields are only replaced, never mutated in place; the one appender
+        // (`ShadowSourceDependency.determineDownstreamComponents`) thaws
+        // first.
+        this.upstreamVariableNames =
+            this.dependencyHandler.internVariableNameListByCopy(
+                this.upstreamVariableNames,
+            );
+        this.originalDownstreamVariableNames =
+            this.dependencyHandler.internVariableNameListByCopy(
+                this.originalDownstreamVariableNames,
+            );
+
         this.componentIdentitiesChanged = true;
 
         let upCompDownDeps =
@@ -232,6 +247,12 @@ export class Dependency {
                     this.mappedDownstreamVariableNamesByComponent,
                 );
         }
+        if (this.valuesChanged) {
+            this.valuesChanged =
+                this.dependencyHandler.internValuesChangedArray(
+                    this.valuesChanged,
+                );
+        }
     }
 
     /**
@@ -254,6 +275,80 @@ export class Dependency {
             this.mappedDownstreamVariableNamesByComponent = [
                 ...this.mappedDownstreamVariableNamesByComponent,
             ];
+        }
+        if (this.valuesChanged && Object.isFrozen(this.valuesChanged)) {
+            this.valuesChanged = [...this.valuesChanged];
+        }
+    }
+
+    /**
+     * Replace the interned (frozen, shared) `valuesChanged` outer array
+     * and/or the record at `componentInd` with mutable copies so a caller
+     * can record change metadata on them.
+     */
+    thawValuesChangedRecord(componentInd: number) {
+        if (!this.valuesChanged) {
+            return;
+        }
+        if (Object.isFrozen(this.valuesChanged)) {
+            this.valuesChanged = [...this.valuesChanged];
+        }
+        const record = this.valuesChanged[componentInd];
+        if (record && Object.isFrozen(record)) {
+            this.valuesChanged[componentInd] = { ...record };
+        }
+    }
+
+    /**
+     * Remove the change record for `varName` of the downstream component at
+     * `componentInd` after `getValue` consumed it (records are recreated on
+     * demand when marked changed again). Fully-consumed records converge to
+     * the shared frozen empty record, and outer arrays of shared records are
+     * re-interned, so an unchanging dependency retains no per-dependency
+     * change-tracking allocations at all.
+     */
+    consumeChangeRecord(componentInd: number, varName: string) {
+        const outer = this.valuesChanged;
+        if (!outer) {
+            return;
+        }
+        const record = outer[componentInd];
+        if (!record) {
+            return;
+        }
+        let replacement = record;
+        if (Object.isFrozen(record)) {
+            if (!(varName in record)) {
+                return;
+            }
+            const remaining = Object.keys(record).filter(
+                (name) => name !== varName,
+            );
+            if (remaining.length === 0) {
+                replacement = this.dependencyHandler.emptyValuesChangedRecord;
+            } else {
+                replacement = {};
+                for (const name of remaining) {
+                    replacement[name] = record[name];
+                }
+            }
+        } else {
+            delete record[varName];
+            if (Object.keys(record).length === 0) {
+                replacement = this.dependencyHandler.emptyValuesChangedRecord;
+            }
+        }
+        if (replacement !== record) {
+            if (Object.isFrozen(this.valuesChanged)) {
+                this.valuesChanged = [...this.valuesChanged];
+            }
+            this.valuesChanged[componentInd] = replacement;
+        }
+        if (!Object.isFrozen(this.valuesChanged)) {
+            this.valuesChanged =
+                this.dependencyHandler.internValuesChangedArray(
+                    this.valuesChanged,
+                );
         }
     }
 
@@ -388,11 +483,17 @@ export class Dependency {
                     mappedVarNames,
                 );
 
-                let valsChanged: Record<string, any> = {};
-                for (let downVar of mappedVarNames) {
-                    valsChanged[downVar] = INITIAL_CHANGE_RECORD;
-                }
-                this.valuesChanged.splice(index, 0, valsChanged);
+                // The initial change state is fully determined by the
+                // (interned) variable-name list, so share one frozen record
+                // per distinct list. Writers thaw/replace before mutating.
+                this.valuesChanged.splice(
+                    index,
+                    0,
+                    this.dependencyHandler.internInitialValuesChangedRecord(
+                        mappedVarNames,
+                        INITIAL_CHANGE_RECORD,
+                    ),
+                );
 
                 if (this.variablesOptional) {
                     // if variables are optional, then include variables in downVarNames
@@ -893,13 +994,10 @@ export class Dependency {
                                     });
                                 }
                                 if (consumeChanges) {
-                                    // delete rather than reset to `{}`:
-                                    // change records are recreated on demand,
-                                    // and empty leftovers were a major
-                                    // retained-memory cost
-                                    delete this.valuesChanged[componentInd][
-                                        mappedVarName
-                                    ];
+                                    this.consumeChangeRecord(
+                                        componentInd,
+                                        mappedVarName,
+                                    );
                                 }
 
                                 if (mappedStateVarObj.usedDefault) {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -564,10 +564,17 @@ export class Dependency {
             }
 
             for (let varName of downVarNames) {
-                if (downCompUpDeps[varName] === undefined) {
-                    downCompUpDeps[varName] = [];
+                // Exact-capacity growth: most variables keep a single
+                // upstream dependency, while a push-grown array reserves
+                // ≥16 element slots. `concat` allocates exactly the needed
+                // length; readers always re-fetch the list from the map, so
+                // replacing the array is safe.
+                const existingUpDeps = downCompUpDeps[varName];
+                if (existingUpDeps === undefined) {
+                    downCompUpDeps[varName] = [this];
+                } else {
+                    downCompUpDeps[varName] = existingUpDeps.concat(this);
                 }
-                downCompUpDeps[varName].push(this);
 
                 if (varName !== this.downstreamVariableNameIfNoVariables) {
                     for (let upstreamVarName of this.upstreamVariableNames) {
@@ -669,7 +676,13 @@ export class Dependency {
                                 componentIdx
                             ][vName];
                         } else {
-                            downCompUpDeps.splice(ind, 1);
+                            // exact-capacity rebuild — splice keeps the
+                            // over-allocated backing store
+                            this.dependencyHandler.upstreamDependencies[
+                                componentIdx
+                            ][vName] = downCompUpDeps
+                                .slice(0, ind)
+                                .concat(downCompUpDeps.slice(ind + 1));
                         }
                     }
                 }
@@ -830,7 +843,13 @@ export class Dependency {
                                 downCompIdx as number
                             ][vName as string];
                         } else {
-                            downCompUpDeps.splice(ind, 1);
+                            // exact-capacity rebuild — splice keeps the
+                            // over-allocated backing store
+                            this.dependencyHandler.upstreamDependencies[
+                                downCompIdx as number
+                            ][vName as string] = downCompUpDeps
+                                .slice(0, ind)
+                                .concat(downCompUpDeps.slice(ind + 1));
                         }
                     }
                 }

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -100,6 +100,25 @@ export class DependencyHandler {
      */
     _internedVariableNameLists: Map<string, readonly string[]>;
 
+    /**
+     * Interned lists for the per-dependency parallel arrays
+     * (`downstreamComponentIndices`, `downstreamComponentTypes`, and the
+     * outer array of `mappedDownstreamVariableNamesByComponent`). Most
+     * dependencies have exactly one downstream component, and all the
+     * dependencies of one component point at the same few targets, so these
+     * mostly-length-1 arrays repeat heavily across dependencies.
+     * `Dependency.initialize` interns them once the downstream set is built;
+     * the base-class mutators (`addDownstreamComponent` /
+     * `removeDownstreamComponent` / `swapDownstreamComponents`) thaw (copy)
+     * before mutating.
+     */
+    _internedComponentIndexLists: Map<string, readonly number[]>;
+    _internedComponentTypeLists: Map<string, readonly string[]>;
+    _internedNameListArrays: Map<string, readonly (readonly string[])[]>;
+    /** ids for interned inner name lists, used to key the outer arrays */
+    _internedListIds: WeakMap<object, number>;
+    _nextInternedListId: number;
+
     constructor({
         _components,
         componentInfoObjects,
@@ -141,6 +160,59 @@ export class DependencyHandler {
         this.attributeRefResolutionDependenciesByReferenced = {};
 
         this._internedVariableNameLists = new Map();
+        this._internedComponentIndexLists = new Map();
+        this._internedComponentTypeLists = new Map();
+        this._internedNameListArrays = new Map();
+        this._internedListIds = new WeakMap();
+        this._nextInternedListId = 1;
+    }
+
+    internComponentIndexList(indices: number[]): number[] {
+        const key = indices.join(",");
+        let interned = this._internedComponentIndexLists.get(key);
+        if (!interned) {
+            interned = Object.freeze(indices);
+            this._internedComponentIndexLists.set(key, interned);
+        }
+        return interned as number[];
+    }
+
+    internComponentTypeList(types: string[]): string[] {
+        // component types are identifiers, so "\n" cannot appear in one
+        const key = types.join("\n");
+        let interned = this._internedComponentTypeLists.get(key);
+        if (!interned) {
+            interned = Object.freeze(types);
+            this._internedComponentTypeLists.set(key, interned);
+        }
+        return interned as string[];
+    }
+
+    /**
+     * Intern an array whose elements are already-interned name lists
+     * (from `internVariableNameList`), keyed by the identity of those
+     * elements. Elements that are not interned lists (no assigned id) make
+     * the array non-internable; it is returned unchanged.
+     */
+    internNameListArray(outer: string[][]): string[][] {
+        const ids: number[] = [];
+        for (const inner of outer) {
+            const id =
+                typeof inner === "object" && inner !== null
+                    ? this._internedListIds.get(inner)
+                    : undefined;
+            if (id === undefined) {
+                return outer;
+            }
+            ids.push(id);
+        }
+        const key = ids.join(",");
+        let interned = this._internedNameListArrays.get(key);
+        if (!interned) {
+            interned = Object.freeze(outer);
+            this._internedNameListArrays.set(key, interned);
+        }
+        return interned as string[][];
     }
 
     internVariableNameList(names: string[]): string[] {
@@ -154,6 +226,8 @@ export class DependencyHandler {
         if (!interned) {
             interned = Object.freeze(names);
             this._internedVariableNameLists.set(key, interned);
+            this._internedListIds.set(interned, this._nextInternedListId);
+            this._nextInternedListId++;
         }
         return interned as string[];
     }

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -119,6 +119,25 @@ export class DependencyHandler {
     _internedListIds: WeakMap<object, number>;
     _nextInternedListId: number;
 
+    /**
+     * Interned initial `valuesChanged` records (every variable name mapped
+     * to the shared initial change record), keyed by the interned-list id of
+     * the variable-name list they cover. A new dependency's change state is
+     * fully determined by its (interned) variable-name list, so all such
+     * dependencies can share one frozen record until first written.
+     */
+    _internedValuesChangedRecords: Map<number, Record<string, any>>;
+    /**
+     * Interned `valuesChanged` outer arrays, keyed by the joined ids of
+     * their (interned) per-component records. Covers both the initial state
+     * and the fully-consumed state (`emptyValuesChangedRecord` entries), so
+     * dependencies whose changes were consumed converge back to shared
+     * structures instead of retaining a mutable array + empty record each.
+     */
+    _internedValuesChangedArrays: Map<string, Record<string, any>[]>;
+    /** Shared frozen record for a fully-consumed `valuesChanged` entry. */
+    emptyValuesChangedRecord: Record<string, any>;
+
     constructor({
         _components,
         componentInfoObjects,
@@ -165,6 +184,14 @@ export class DependencyHandler {
         this._internedNameListArrays = new Map();
         this._internedListIds = new WeakMap();
         this._nextInternedListId = 1;
+        this._internedValuesChangedRecords = new Map();
+        this._internedValuesChangedArrays = new Map();
+        this.emptyValuesChangedRecord = Object.freeze({});
+        this._internedListIds.set(
+            this.emptyValuesChangedRecord,
+            this._nextInternedListId,
+        );
+        this._nextInternedListId++;
     }
 
     internComponentIndexList(indices: number[]): number[] {
@@ -230,6 +257,85 @@ export class DependencyHandler {
             this._nextInternedListId++;
         }
         return interned as string[];
+    }
+
+    /**
+     * Like `internVariableNameList`, but never freezes the caller's array:
+     * on a cache miss the interned entry is a frozen copy. For dependency
+     * fields that alias arrays owned elsewhere (state-variable definitions,
+     * constructor arguments), which must stay mutable for their owners.
+     */
+    internVariableNameListByCopy(names: readonly string[]): string[] {
+        const key = names.join("\n");
+        const interned = this._internedVariableNameLists.get(key);
+        if (interned) {
+            return interned as string[];
+        }
+        return this.internVariableNameList([...names]);
+    }
+
+    /**
+     * Return the shared frozen initial `valuesChanged` record (every
+     * variable mapped to the shared initial change record) for the given
+     * interned variable-name list. Falls back to a fresh mutable record if
+     * `names` was not interned. Writers must thaw/replace before mutating;
+     * see `Dependency.thawValuesChangedRecord` and
+     * `Dependency.consumeChangeRecord`.
+     */
+    internInitialValuesChangedRecord(
+        names: readonly string[],
+        initialChangeRecord: Record<string, any>,
+    ): Record<string, any> {
+        const listId = this._internedListIds.get(names as string[]);
+        if (listId === undefined) {
+            const record: Record<string, any> = {};
+            for (const name of names) {
+                record[name] = initialChangeRecord;
+            }
+            return record;
+        }
+        let record = this._internedValuesChangedRecords.get(listId);
+        if (!record) {
+            record = {};
+            for (const name of names) {
+                record[name] = initialChangeRecord;
+            }
+            Object.freeze(record);
+            this._internedValuesChangedRecords.set(listId, record);
+            this._internedListIds.set(record, this._nextInternedListId);
+            this._nextInternedListId++;
+        }
+        return record;
+    }
+
+    /**
+     * Intern a `valuesChanged` outer array whose entries are all interned
+     * records (from `internInitialValuesChangedRecord` or
+     * `emptyValuesChangedRecord`), keyed by the identity of those entries.
+     * Any non-interned (hence mutable) entry makes the array non-internable;
+     * it is returned unchanged.
+     */
+    internValuesChangedArray(
+        outer: Record<string, any>[],
+    ): Record<string, any>[] {
+        const ids: number[] = [];
+        for (const record of outer) {
+            const id =
+                typeof record === "object" && record !== null
+                    ? this._internedListIds.get(record)
+                    : undefined;
+            if (id === undefined) {
+                return outer;
+            }
+            ids.push(id);
+        }
+        const key = ids.join(",");
+        let interned = this._internedValuesChangedArrays.get(key);
+        if (!interned) {
+            interned = Object.freeze(outer) as Record<string, any>[];
+            this._internedValuesChangedArrays.set(key, interned);
+        }
+        return interned;
     }
 
     async setUpComponentDependencies(component: ComponentInstance) {
@@ -818,6 +924,20 @@ export class DependencyHandler {
         }
     }
 
+    /**
+     * Drop the circular-check memo records. They are pure caches ("this
+     * state variable already passed the check"), so clearing costs only
+     * re-verification when a later dependency change re-triggers a check.
+     * Called once initial document construction finishes: at that point the
+     * memos cover every state variable created during the load (one record
+     * entry per state variable), but they regrow only for the typically few
+     * components involved in subsequent updates.
+     */
+    clearCircularCheckMemos() {
+        this.circularCheckPassed = {};
+        this.circularResolveBlockedCheckPassed = {};
+    }
+
     resetCircularCheckPassed(componentIdx: ComponentIdx, varName: string) {
         let stateVariableIdentifier = componentIdx + ":" + varName;
         if (this.circularCheckPassed[stateVariableIdentifier]) {
@@ -1247,6 +1367,9 @@ export class DependencyHandler {
                 if (upDep.valuesChanged) {
                     let ind =
                         upDep.downstreamComponentIndices.indexOf(componentIdx);
+                    // the interned (frozen, shared) structures must be
+                    // replaced with mutable copies before recording
+                    upDep.thawValuesChangedRecord(ind);
                     let upValuesChanged = upDep.valuesChanged[ind][varName];
 
                     if (!upValuesChanged) {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -115,7 +115,14 @@ export class DependencyHandler {
     _internedComponentIndexLists: Map<string, readonly number[]>;
     _internedComponentTypeLists: Map<string, readonly string[]>;
     _internedNameListArrays: Map<string, readonly (readonly string[])[]>;
-    /** ids for interned inner name lists, used to key the outer arrays */
+    /**
+     * Identity ids for the interned inner structures — name lists (from
+     * `internVariableNameList`) and `valuesChanged` records (from
+     * `internInitialValuesChangedRecord` and `emptyValuesChangedRecord`).
+     * Used to key the interned outer arrays that contain them
+     * (`internNameListArray` / `internValuesChangedArray`) and, for a name
+     * list, its interned initial change record.
+     */
     _internedListIds: WeakMap<object, number>;
     _nextInternedListId: number;
 

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -2119,15 +2119,15 @@ export class DependencyHandler {
 
         let neededToResolveBlocked = neededForBlocked[blockerType];
         if (!neededToResolveBlocked) {
-            neededToResolveBlocked = neededForBlocked[blockerType] = [];
-        }
-
-        // if blockers is already recorded, then nothing to do
-        if (neededToResolveBlocked.includes(blockerCode)) {
+            // exact capacity: three quarters of blocker lists only ever hold
+            // one code, while a push-grown array reserves ≥16 element slots
+            neededForBlocked[blockerType] = [blockerCode];
+        } else if (neededToResolveBlocked.includes(blockerCode)) {
+            // blocker is already recorded, so nothing to do
             return;
+        } else {
+            neededToResolveBlocked.push(blockerCode);
         }
-
-        neededToResolveBlocked.push(blockerCode);
 
         if (typeBlocked === "stateVariable") {
             let component = this._components[componentIdxBlocked];
@@ -2182,9 +2182,9 @@ export class DependencyHandler {
 
         let blockedByBlocker = resolvedBlockedByBlocker[typeBlocked];
         if (!blockedByBlocker) {
-            blockedByBlocker = resolvedBlockedByBlocker[typeBlocked] = [];
-        }
-        if (!blockedByBlocker.includes(codeBlocked)) {
+            // exact capacity, as for `neededToResolveBlocked` above
+            resolvedBlockedByBlocker[typeBlocked] = [codeBlocked];
+        } else if (!blockedByBlocker.includes(codeBlocked)) {
             blockedByBlocker.push(codeBlocked);
         }
 

--- a/packages/doenetml-worker-javascript/src/core/dependencies/shadowDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/shadowDependencies.ts
@@ -497,6 +497,13 @@ export class ShadowSourceDependency extends Dependency {
                         component.shadows.propVariable,
                     )
                 ) {
+                    // on re-determination the list is interned (frozen,
+                    // shared) — copy before appending
+                    if (Object.isFrozen(this.originalDownstreamVariableNames)) {
+                        this.originalDownstreamVariableNames = [
+                            ...this.originalDownstreamVariableNames,
+                        ];
+                    }
                     this.originalDownstreamVariableNames.push(
                         component.shadows.propVariable,
                     );

--- a/packages/doenetml-worker-javascript/src/core/dependencies/stateVariableDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/stateVariableDependencies.ts
@@ -439,9 +439,7 @@ export class StateVariableComponentTypeDependency extends StateVariableDependenc
                                 });
                         }
                         if (consumeChanges) {
-                            // delete rather than reset to `{}`; recreated on
-                            // demand when marked changed again
-                            delete this.valuesChanged[0][mappedVarName];
+                            this.consumeChangeRecord(0, mappedVarName);
                         }
 
                         let hasVariableComponentType =


### PR DESCRIPTION
Continue memory reduction work. Follow-ups to the memory pass in #1435
(items 1–3 there) and the single-downstream parallel-array fast path
tracked in #1444.

5. **Shared shadow definition functions** — the follow-up flagged in #1435
   item 1 ("make shadow definitions generic functions parameterized by
   fields on the state-variable object instead of per-instance closures").
   Status: **done (2026-07-10)**.

   `modifyStateDefsToBeShadows` (`core/StateVariableDefinitionFactory.ts`)
   used to build 3 fresh closures per shadowed state variable per component
   instance — `returnDependencies` / `definition` / `inverseDefinition` for
   scalars, or `returnArrayDependenciesByKey` / `arrayDefinitionByKey` /
   `inverseArrayDefinitionByKey` for arrays — plus their shared capture
   context. For copy/repeat-heavy documents (reference-shadow components are
   a large fraction of these) that was the dominant remaining per-instance
   definition cost after #1435's per-class definition cache.

   Those closures are replaced with module-level `shadow*` functions that
   read the per-variable parameters (`shadowOfComponentIdx`, `shadowVarName`,
   `shadowVarNameInTarget`, `shadowOverrideVarName`, `shadowCopyComponentType`,
   `shadowOriginalReturnDependencies`, and the existing
   `inverseShadowToSetEntireArray`) from `this` instead of from a closure.
   This is safe because the shadow-path definitions *are* the
   state-variable objects (`BaseComponent` uses the factory's per-instance
   clones directly) and every core call site invokes them as methods
   (`stateVarObj.definition(args)`, `…returnDependencies(…)`,
   `…arrayDefinitionByKey(args)`, …) or binds first
   (`StateVariableInitializer`). Net effect: the per-instance parameters
   move from three closures + context onto a few plain fields on the
   definition object.

6. **Intern the `downstreamComponentIndices` / `downstreamComponentTypes` /
   `mappedDownstreamVariableNamesByComponent` parallel arrays** — the
   single-downstream fast path of #1444. Status: **done (2026-07-10)**.

   Most dependencies have exactly one downstream component, and all the
   dependencies of one component point at the same few targets, so these
   mostly-length-1 arrays repeat heavily across dependencies. Once
   `Dependency.initialize` has built the downstream set it interns one
   shared frozen array per distinct list:
   `DependencyHandler.internComponentIndexList` (keyed on
   `indices.join(",")`), `internComponentTypeList` (keyed on
   `types.join("\n")`; component types are identifiers so `"\n"` cannot
   occur in one), and `internNameListArray` for the outer array of
   already-interned name lists (keyed on their interned-list ids, falling
   back to the caller's array when any element is not an interned list). The
   base-class mutators `addDownstreamComponent` / `removeDownstreamComponent`
   / `swapDownstreamComponents` call `thawDownstreamArrays()` to replace the
   frozen shared arrays with mutable copies before changing the downstream
   set, so the sharing is transparent. (`valuesChanged` — the fourth
   parallel array — is item 8.)

7. **Exact-capacity growth for the upstream-dependency and blocker lists.**
   Status: **done (2026-07-10)**.

   The per-`(component, variable)` upstream-dependency lists
   (`upstreamDependencies[cIdx][vName]`) and the resolve-blocker lists
   (`neededToResolve` / `resolveBlockedBy`) are built with `[x]` / `concat`
   and rebuilt on removal with `slice().concat()` instead of `push` /
   `splice`. A push-grown array reserves ≥16 element slots, while most of
   these lists only ever hold a single entry; `concat` allocates exactly the
   needed length, and the removal rebuild sheds the over-allocated backing
   store that `splice` would keep. Readers always re-fetch the list from the
   map, so replacing the array reference (rather than mutating in place) is
   safe.

8. **Intern `valuesChanged` change-tracking records** — the remaining
   un-shared parallel array from #1444. Status: **done (2026-07-10)**.

   A fresh post-interning snapshot of the repeat document (1010.3 MB)
   re-ranked the levers and showed `valuesChanged` summed to **~113 MB
   across all dependency classes** (67.5 SV + 13.2 Parent + 12.5
   SourceComposite + 7.4 DetermineDependencies + 5.7 Attribute + 3.7
   Ancestor + 2.9 ShadowSource), larger than the earlier SV-only figure.
   Two observations make it internable after all:
   - The *initial* state is fully determined by the (already interned)
     variable-name list: every record maps each name to the shared frozen
     initial change record. One frozen record per distinct name list
     (`DependencyHandler.internInitialValuesChangedRecord`), and the outer
     array — keyed by the identity ids of its records — is interned too
     (`internValuesChangedArray`).
   - The *consumed* state (after `getValue` deletes the entries) is even
     more uniform: an empty record. `Dependency.consumeChangeRecord`
     replaces fully-consumed records with a shared frozen
     `emptyValuesChangedRecord` and re-interns the outer array, so an
     unchanging dependency retains **zero** per-dependency change-tracking
     allocations in both its lazy and evaluated states.

   Writers thaw first: `thawValuesChangedRecord` (used by
   `StalenessPropagator.markUpstreamDependentsStale` and
   `DependencyHandler.recordActualChangeInUpstreamDependencies`) copies the
   frozen outer array/record before recording, and the existing
   frozen-leaf replace-on-write from item 1c is unchanged. The three
   base-class downstream mutators already funnel through
   `thawDownstreamArrays`, which now also thaws `valuesChanged`.

   Measured (node benchmark, this change alone): Venn **330.4 → 299.5 MB
   (−30.9 MB)**; repeat **1010.3 → 898.0 MB (−112.3 MB)** — essentially
   the entire attributed cost.

9. **Intern `upstreamVariableNames` and `originalDownstreamVariableNames`**
   — the two remaining per-dependency name-list fields (~13 MB + ~27 MB on
   the repeat profile). Status: **done (2026-07-10)**.

   Both fields reach their final values by the time
   `Dependency.initialize` has run `setUpParameters` +
   `determineDownstreamComponents`, and are read-only afterwards except
   for one appender (`ShadowSourceDependency.determineDownstreamComponents`
   adding a prop variable on re-determination, which now thaws first).
   They often *alias* arrays owned elsewhere — state-variable definitions
   (`this.definition.variableNames`) and the shared
   `allStateVariablesAffected` constructor argument — so freezing in place
   would corrupt the owners. A new `internVariableNameListByCopy` interns
   a frozen *copy* on cache miss and leaves the caller's array mutable.

   Measured together with item 10 (node benchmark): Venn **299.5 →
   265.7 MB (−33.8 MB)**; repeat **898.0 → 798.2 MB (−99.8 MB)**. Per the
   snapshot attribution ~24 MB of the repeat delta is item 10's memos, so
   the name lists account for roughly −76 MB — about double the ~40 MB
   attributed to the two fields alone, because the interned copies also
   deduplicate identical lists reached through other labels.

10. **Clear circular-check memos after initial document construction** —
    `circularCheckPassed` + `circularResolveBlockedCheckPassed`, 24 MB on
    the repeat profile (12 MB each, single Records with one entry per
    state variable). Status: **done (2026-07-10)**.

    The memos are pure caches ("this state variable already passed the
    check"); `resetCircularCheckPassed` only uses entry presence to prune
    its recursion, so clearing them wholesale is semantically a full reset
    and costs only re-verification if a later dependency change re-runs a
    check. `Core.generateDast` now calls
    `DependencyHandler.clearCircularCheckMemos()` once construction
    finishes; the memos regrow only for components involved in subsequent
    updates.

    Measured impact: included in item 9's combined numbers (~24 MB of the
    repeat-document delta per the snapshot attribution: the two memo
    Records were 12.0 MB each).

## Measured memory reduction (browser benchmark)

Whole-browser PSS via the checked-in `packages/memory-benchmark` harness
(Linux; default scenarios `--counts 1,4 --sizes 25,250`), same machine, one run
each. This complements the per-item node-heap figures above — it measures the
full renderer process, so the totals are larger in scope.

- **before** = the `main` commit this branch is merged onto (`68cb68097`)
- **after**  = this branch (`mem2`), merged with that same `main`

| scenario   | before (MB) | after (MB) | delta              |
| ---------- | ----------- | ---------- | ------------------ |
| blank      | 189         | 189        | 0                  |
| direct-1   | 558         | 558        | 0                  |
| iframe-1   | 558         | 557        | −1                 |
| direct-4   | 968         | 967        | −1                 |
| iframe-4   | 1180        | 1177       | −3                 |
| repeat-25  | 757         | 712        | **−45 (−5.9%)**    |
| repeat-250 | 1813        | 1378       | **−435 (−24.0%)**  |

Document-scaling cost (repeat-S total − direct-1 total):

| scenario   | components | before  | after  | delta            | per component       |
| ---------- | ---------- | ------- | ------ | ---------------- | ------------------- |
| repeat-25  | ~125       | 199 MB  | 154 MB | −45 MB (−22.6%)  | 1.59 → 1.23 MB/comp |
| repeat-250 | ~1250      | 1255 MB | 820 MB | −435 MB (−34.7%) | 1.00 → 0.66 MB/comp |

The reduction is entirely per-component core-worker memory, consistent with the
changes above: fixed and small-document/multi-instance costs are unchanged
within noise (`blank` and `direct-1` are bit-identical run to run), while the
repeat-250 PSS drop is isolated to the **renderer** process (1653 → 1217 MB,
−436 MB; browser/gpu/utility/zygote flat) — where the core worker lives. The
delta scales ~10× with component count (45 → 435 MB), i.e. roughly linear at
~0.34 MB saved per component.


Closes #1444.

