### PR TITLE
Memory: release initialization-only data (serialized document, coreInfo object, Rust dast_root/source)

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -159,7 +159,6 @@ export default class Core {
     cumulativeStateVariableChanges: any;
     canonicalGeneratedVariantString?: string;
     canonicalDocVariantStrings?: string[];
-    coreInfo?: CoreInfo;
     coreInfoString?: string;
     doenetMLNewlines?: any;
 
@@ -539,7 +538,10 @@ export default class Core {
         // Note: `coreInfo` is fixed even though `this.rendererTypesInDocument`
         // could change. Both the canonical variant strings and the original
         // `rendererTypesInDocument` could differ depending on the initial state.
-        this.coreInfo = {
+        // Only the JSON string is retained on the instance (for saved-state
+        // payloads); keeping the object as well would duplicate the initial
+        // renderer instructions for the life of the session.
+        const coreInfo: CoreInfo = {
             generatedVariantString: this.canonicalGeneratedVariantString!,
             allPossibleVariants: deepClone(
                 await this.document.sharedParameters!.allPossibleVariants,
@@ -549,7 +551,7 @@ export default class Core {
         };
 
         this.coreInfoString = JSON.stringify(
-            this.coreInfo,
+            coreInfo,
             serializedComponentsReplacer,
         );
 
@@ -580,7 +582,7 @@ export default class Core {
         this.dependencies.clearCircularCheckMemos();
 
         const returnResult = {
-            coreInfo: this.coreInfo,
+            coreInfo,
         };
 
         // Warn about any unmatched children.

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -393,6 +393,11 @@ export default class Core {
 
         let serializedComponents = [deepClone(this.serializedDocument)];
 
+        // The serialized document is consumed only by the clone above;
+        // release it so the worker does not retain a full serialized copy
+        // of the document for the life of the session.
+        this.serializedDocument = undefined;
+
         numberAnswers(serializedComponents, this.componentInfoObjects);
 
         this.documentIdx = serializedComponents[0].componentIdx;

--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -219,6 +219,13 @@ export class PublicDoenetMLCore {
         sendEvent: SendEvent,
         requestSolutionView: RequestSolutionView,
     ) {
+        if (this.initialized && !this.coreBaseArgs?.serializedDocument) {
+            return {
+                success: false as const,
+                errMsg: "Cannot create the core a second time from the same worker; the serialized document was released after the first core was created.",
+            };
+        }
+
         let coreArgs = {
             ...this.coreBaseArgs!,
             ...args,
@@ -239,6 +246,11 @@ export class PublicDoenetMLCore {
 
         if (this.initialized) {
             this.core = new Core(coreArgs);
+            // The core now owns the only needed reference to the serialized
+            // document (and releases it once consumed in `generateDast`);
+            // drop this alias so the worker does not retain a full
+            // serialized copy of the document for the life of the session.
+            this.coreBaseArgs!.serializedDocument = undefined;
             try {
                 const result = await this.core.generateDast();
                 return { success: true as const, ...result };

--- a/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
@@ -17,6 +17,12 @@ import { gatherVariantComponents } from "../utils/variants";
 import { unwrapSource } from "../utils/dast/convertNormalizedDast";
 import { extractCreateComponentIdxMapping } from "../utils/componentIndices";
 
+// Most components keep no children serialized (only classes with a static
+// `keepChildrenSerialized` do), so they all share one frozen empty array
+// instead of allocating one apiece. Frozen so an accidental in-place
+// mutation throws instead of corrupting every other component.
+const EMPTY_SERIALIZED_CHILDREN: any[] = Object.freeze([]) as any;
+
 /**
  * Builds component instances from serialized DAST. Handles the recursive
  * walk that creates a parent before its children, registers each new
@@ -662,7 +668,10 @@ export async function createChildrenThenComponent({
         ancestors,
         definingChildren,
         stateVariableDefinitions,
-        serializedChildren: childrenToRemainSerialized,
+        serializedChildren:
+            childrenToRemainSerialized.length > 0
+                ? childrenToRemainSerialized
+                : EMPTY_SERIALIZED_CHILDREN,
         serializedComponent,
         attributes,
         componentInfoObjects: core.componentInfoObjects,

--- a/packages/doenetml-worker-rust/lib-js-wasm-binding/src/lib.rs
+++ b/packages/doenetml-worker-rust/lib-js-wasm-binding/src/lib.rs
@@ -29,7 +29,6 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 pub struct PublicDoenetMLCore {
     core: Core,
     dast_root: Option<DastRoot>,
-    source: String,
     flags_json: Option<String>,
     initialized: bool,
 }
@@ -82,17 +81,26 @@ impl PublicDoenetMLCore {
         PublicDoenetMLCore {
             core: Core::new(),
             dast_root: None,
-            source: "".to_string(),
             flags_json: None,
             initialized: false,
         }
     }
 
-    pub fn set_source(&mut self, dast: DastRoot, source: &str) -> Result<(), String> {
+    // `source` is unused; the parameter is kept so the JS-side calling
+    // convention does not change.
+    pub fn set_source(&mut self, dast: DastRoot, _source: &str) -> Result<(), String> {
         self.dast_root = Some(dast);
-        self.source = source.to_string();
         self.initialized = false;
         Ok(())
+    }
+
+    /// Drop the data that is only needed while initializing a core
+    /// (currently the document's DAST, which for large documents holds
+    /// megabytes of WASM linear memory). Called by the worker once the
+    /// JavaScript core has consumed the normalized DAST; calling
+    /// `set_source` again repopulates the data.
+    pub fn release_initialization_data(&mut self) {
+        self.dast_root = None;
     }
 
     pub fn set_flags(&mut self, flags: &str) {

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -322,6 +322,11 @@ export class CoreWorker {
                     calculateRootNames,
                 });
             this.javascript_initialized = true;
+            // The JavaScript core has consumed the normalized DAST; free the
+            // Rust core's retained copy of the document DAST (the rust
+            // core-type path still needs it for later
+            // `returnNormalizedDastRoot` calls, so only release here).
+            this.doenetCore.release_initialization_data();
             return initializedResult;
         } catch (err) {
             console.error(err);
@@ -488,6 +493,11 @@ export class CoreWorker {
             calculateRootNames,
         });
         this.javascript_initialized = true;
+        // The JavaScript core has consumed the normalized DAST; free the
+        // Rust core's retained copy of the document DAST (the rust core-type
+        // path still needs it for later `returnNormalizedDastRoot` calls, so
+        // only release here).
+        this.doenetCore.release_initialization_data();
 
         const args = {
             coreId: "a",


### PR DESCRIPTION
Contained memory reductions from #1441's stream D (worker internals): four small, independent changes that release data retained for the whole session but consumed only during initialization. First PR of a short series; the follow-ups target the runtime state-variable objects (#1458).

11. **Release the serialized document after core creation.** The full serialized
    document was retained twice for the life of the worker session: as
    `Core.serializedDocument` — read exactly once, at the start of
    `generateDast`, where it is deep-cloned — and as its alias
    `coreBaseArgs.serializedDocument` in the worker wrapper
    (`doenetml-worker-javascript/src/CoreWorker.ts`). Both references are now
    released at their last use. A second `createCoreGenerateDast` on the same
    worker returns a descriptive error instead of silently reusing stale state;
    every caller (DocViewer, PreTeXt export, test harness) creates a fresh
    worker per core. Part of #1429's scope (the `Core.serializedDocument`
    retention half; per-component `serializedChildren` release remains open).

12. **Stop retaining the `coreInfo` object alongside its JSON string.**
    `generateDast` built `coreInfo` (including the full initial renderer
    instructions via `documentToRender`), stringified it into `coreInfoString`
    for saved-state payloads, and kept **both** on the `Core` instance for the
    session. Only the string is read after the return (`StatePersistence`);
    the object is now a local, returned to the caller and dropped. Part of
    #1430's scope (its remaining items — `essentialValuesSavedInDefinition`
    and `cumulativeStateVariableChanges` — need a deeper audit and stay open).

13. **Share one frozen empty array for components with no serialized
    children.** Only the 11 component classes with a static
    `keepChildrenSerialized` ever populate `childrenToRemainSerialized`; every
    other component allocated its own empty array and held it for its
    lifetime. They now share a single frozen module-level empty array
    (frozen so an accidental in-place mutation throws instead of corrupting
    every other component; nothing mutates it today). Part of #1429's scope.

14. **Free Rust initialization data.** The wasm binding
    (`lib-js-wasm-binding/src/lib.rs`) retained for the whole session:
    - `source` — the full DoenetML source string, **written but never read
      anywhere**; removed (the `set_source` signature is unchanged).
    - `dast_root` — the full document DAST, needed on the JavaScript core-type
      path only until the JS core has consumed the normalized root. The worker
      now calls a new `release_initialization_data()` at that point (both the
      `initializeJavascriptCore` and `returnFlatDastFromJS` paths). The rust
      core-type path is unchanged: the LSP calls `returnNormalizedDastRoot`
      after initialization, so it keeps its DAST; calling `set_source` again
      repopulates the data.

    Freeing does not shrink WASM linear memory (it only grows), but it returns
    the pages to the allocator so later resolver churn (composite
    expansion/deletion) reuses them instead of growing the memory further.
    Closes #1431.

Numbering continues #1435 (items 1–4) and #1451 (items 5–10).

## Verification

- Full `doenetml-worker-javascript` suite: test:group1–4, **3,071 passed / 0
  failed**. Typecheck unchanged from `main` (38 pre-existing errors on both).
- `doenetml-worker` (bundling worker) suite: 35 tests pass — exercises the new
  `release_initialization_data` call through the wasm binding.
- Rust: `cargo test -p doenetml-core --lib` unchanged from `main` (175 passed /
  16 pre-existing failures, identical before and after); `cargo test --workspace`
  does not compile on `main` either (stale integration-test utils, unrelated).
- Browser memory benchmark (`packages/memory-benchmark`, paired runs on the
  same machine, `main` = 742b70f39): all scenarios within noise except the
  document-scaling one, as expected for changes that release initialization
  data — the benchmark's small documents have small serialized trees.

  | scenario | main (MB) | this PR (MB) | delta |
  | --- | --- | --- | --- |
  | blank | 203 | 206 | +3 (noise) |
  | direct-1 | 574 | 575 | +1 |
  | iframe-1 | 575 | 576 | +1 |
  | direct-4 | 987 | 986 | −1 |
  | iframe-4 | 1199 | 1197 | −2 |
  | repeat-25 | 737 | 737 | 0 |
  | repeat-250 | 1476 | 1459 | **−17** |

  The wins scale with document size (the released structures are copies of the
  document), so real textbook-scale documents benefit more than the generated
  benchmark docs; the wasm-side release additionally avoids linear-memory
  growth over long interactive sessions, which a load-time snapshot cannot
  show.

No changeset: internal worker memory changes with no author-visible behavior
change (same rationale as #1435/#1451), so the improvement rides the next
release rather than cutting its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
