### PR TITLE
Memory: share state-variable runtime functions across instances

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -159,7 +159,6 @@ export default class Core {
     cumulativeStateVariableChanges: any;
     canonicalGeneratedVariantString?: string;
     canonicalDocVariantStrings?: string[];
-    coreInfo?: CoreInfo;
     coreInfoString?: string;
     doenetMLNewlines?: any;
 
@@ -539,7 +538,10 @@ export default class Core {
         // Note: `coreInfo` is fixed even though `this.rendererTypesInDocument`
         // could change. Both the canonical variant strings and the original
         // `rendererTypesInDocument` could differ depending on the initial state.
-        this.coreInfo = {
+        // Only the JSON string is retained on the instance (for saved-state
+        // payloads); keeping the object as well would duplicate the initial
+        // renderer instructions for the life of the session.
+        const coreInfo: CoreInfo = {
             generatedVariantString: this.canonicalGeneratedVariantString!,
             allPossibleVariants: deepClone(
                 await this.document.sharedParameters!.allPossibleVariants,
@@ -549,7 +551,7 @@ export default class Core {
         };
 
         this.coreInfoString = JSON.stringify(
-            this.coreInfo,
+            coreInfo,
             serializedComponentsReplacer,
         );
 
@@ -580,7 +582,7 @@ export default class Core {
         this.dependencies.clearCircularCheckMemos();
 
         const returnResult = {
-            coreInfo: this.coreInfo,
+            coreInfo,
         };
 
         // Warn about any unmatched children.

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -310,6 +310,11 @@ export default class Core {
             copyToClipboard: this.copyToClipboard.bind(this),
             navigateToTarget: (args: any) =>
                 navigateToTarget({ core: this, args }),
+            // State-variable runtime plumbing, not component-facing API:
+            // the shared state-variable functions in StateVariableInitializer
+            // reach core through `svComponent.coreFunctions`.
+            getStateVariableValue: this.getStateVariableValue, // bound above
+            addDiagnostic: this.addDiagnostic.bind(this),
         };
 
         this.updateInfo = {

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -393,6 +393,11 @@ export default class Core {
 
         let serializedComponents = [deepClone(this.serializedDocument)];
 
+        // The serialized document is consumed only by the clone above;
+        // release it so the worker does not retain a full serialized copy
+        // of the document for the life of the session.
+        this.serializedDocument = undefined;
+
         numberAnswers(serializedComponents, this.componentInfoObjects);
 
         this.documentIdx = serializedComponents[0].componentIdx;

--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -219,6 +219,13 @@ export class PublicDoenetMLCore {
         sendEvent: SendEvent,
         requestSolutionView: RequestSolutionView,
     ) {
+        if (this.initialized && !this.coreBaseArgs?.serializedDocument) {
+            return {
+                success: false as const,
+                errMsg: "Cannot create the core a second time from the same worker; the serialized document was released after the first core was created.",
+            };
+        }
+
         let coreArgs = {
             ...this.coreBaseArgs!,
             ...args,
@@ -239,6 +246,11 @@ export class PublicDoenetMLCore {
 
         if (this.initialized) {
             this.core = new Core(coreArgs);
+            // The core now owns the only needed reference to the serialized
+            // document (and releases it once consumed in `generateDast`);
+            // drop this alias so the worker does not retain a full
+            // serialized copy of the document for the life of the session.
+            this.coreBaseArgs!.serializedDocument = undefined;
             try {
                 const result = await this.core.generateDast();
                 return { success: true as const, ...result };

--- a/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
@@ -17,6 +17,12 @@ import { gatherVariantComponents } from "../utils/variants";
 import { unwrapSource } from "../utils/dast/convertNormalizedDast";
 import { extractCreateComponentIdxMapping } from "../utils/componentIndices";
 
+// Most components keep no children serialized (only classes with a static
+// `keepChildrenSerialized` do), so they all share one frozen empty array
+// instead of allocating one apiece. Frozen so an accidental in-place
+// mutation throws instead of corrupting every other component.
+const EMPTY_SERIALIZED_CHILDREN: any[] = Object.freeze([]) as any;
+
 /**
  * Builds component instances from serialized DAST. Handles the recursive
  * walk that creates a parent before its children, registers each new
@@ -662,7 +668,10 @@ export async function createChildrenThenComponent({
         ancestors,
         definingChildren,
         stateVariableDefinitions,
-        serializedChildren: childrenToRemainSerialized,
+        serializedChildren:
+            childrenToRemainSerialized.length > 0
+                ? childrenToRemainSerialized
+                : EMPTY_SERIALIZED_CHILDREN,
         serializedComponent,
         attributes,
         componentInfoObjects: core.componentInfoObjects,

--- a/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
+++ b/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
@@ -1,7 +1,10 @@
 import type Core from "../Core";
 import type { ComponentInstance } from "../types/componentInstance";
 import { returnActiveChildrenIndicesToRender } from "./ChildMatcher";
-import { initializeStateVariable } from "./StateVariableInitializer";
+import {
+    initializeStateVariable,
+    installStaleValueGetter,
+} from "./StateVariableInitializer";
 /**
  * Walks the dependency graph to invalidate state-variable values and
  * propagate freshness changes:
@@ -612,11 +615,7 @@ export class StalenessPropagator {
      * as stale: the next `await stateVarObj.value` will recompute, while
      * `_previousValue` is preserved for change-detection.
      */
-    async _replaceWithStaleGetter(
-        stateVarObj: any,
-        component: any,
-        vName: string,
-    ) {
+    async _replaceWithStaleGetter(stateVarObj: any) {
         // save old value
         stateVarObj._previousValue = await stateVarObj.value;
         if (Array.isArray(stateVarObj._previousValue)) {
@@ -624,12 +623,7 @@ export class StalenessPropagator {
         }
         // mark stale by putting the getter back in place to compute a new
         // value next time it is requested
-        delete stateVarObj.value;
-        const getStateVar = this.core.getStateVariableValue;
-        Object.defineProperty(stateVarObj, "value", {
-            get: () => getStateVar({ component, stateVariable: vName }),
-            configurable: true,
-        });
+        installStaleValueGetter(stateVarObj);
     }
 
     /**
@@ -808,11 +802,7 @@ export class StalenessPropagator {
             delete stateVarObj.recursiveDependencyValues;
 
             if (previouslyFreshVars.includes(vName)) {
-                await this._replaceWithStaleGetter(
-                    stateVarObj,
-                    component,
-                    vName,
-                );
+                await this._replaceWithStaleGetter(stateVarObj);
             }
         }
 

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -149,6 +149,306 @@ const ENTRY_ARRAY_ENTRY_SIZE_DESCRIPTOR: PropertyDescriptor = Object.freeze({
     get: getEntryArrayEntrySize,
 });
 
+// ─── Shared array machinery ─────────────────────────────────────────────
+// Module-level equivalents of what used to be per-array closures in
+// `initializeArrayStateVariable`. `this` is the array state-variable
+// object; per-variable parameters (arrayValues, numDimensions,
+// entryPrefixes, svComponent, svVarName) are fields on it.
+
+function multiDimKeyToIndex(key: string) {
+    return key.split(",").map((x) => Number(x));
+}
+
+function oneDimKeyToIndex(key: string) {
+    return Number(key);
+}
+
+// converting from index to key is the same for single and multiple
+// dimensions, as we just want the string representation
+function arrayIndexToKey(index: any) {
+    return String(index);
+}
+
+function defaultReturnEntryDimensions() {
+    return 0;
+}
+
+function multiDimSetArrayValue(
+    this: any,
+    { value, arrayKey, arraySize, arrayValues = this.arrayValues }: any,
+) {
+    const component = this.svComponent;
+    const addDiagnostic = component.coreFunctions.addDiagnostic;
+    const numDimensions = this.numDimensions;
+
+    let index = this.keyToIndex(arrayKey);
+    let numDimensionsInArrayKey = index.length;
+    // Pre-existing typo fixed per CORE_REFACTOR_DEFERRED.md
+    // §"Pre-existing unreachable diagnostic": the original
+    // `!numDimensionsInArrayKey > stateVarObj.numDimensions`
+    // evaluates to `false > number === false` for any positive
+    // integer, so the diagnostic was unreachable.
+    if (numDimensionsInArrayKey > numDimensions) {
+        addDiagnostic({
+            type: "info",
+            message:
+                "Cannot set array value.  Number of dimensions is too large.",
+            position: component.position,
+            sourceDoc: component.sourceDoc,
+        });
+        return { nFailures: 1 };
+    }
+    let arrayValuesDrillDown = arrayValues;
+    let arraySizeDrillDown = arraySize;
+    for (let indComponent of index.slice(0, index.length - 1)) {
+        if (indComponent >= 0 && indComponent < arraySizeDrillDown[0]) {
+            if (!arrayValuesDrillDown[indComponent]) {
+                arrayValuesDrillDown[indComponent] = [];
+            }
+            arrayValuesDrillDown = arrayValuesDrillDown[indComponent];
+            arraySizeDrillDown = arraySizeDrillDown.slice(1);
+        } else {
+            addDiagnostic({
+                type: "info",
+                message: "ignore setting array value out of bounds",
+                position: component.position,
+                sourceDoc: component.sourceDoc,
+            });
+            return { nFailures: 1 };
+        }
+    }
+
+    let nFailures = 0;
+
+    if (numDimensionsInArrayKey < numDimensions) {
+        // if dimensions from arrayKey is less than number of dimensions
+        // then attempt to get additional dimensions from
+        // array indices of value
+
+        let setArrayValuesPiece = function (
+            desiredValue: any,
+            arrayValuesPiece: any,
+            arraySizePiece: any,
+        ): { nFailures: number } {
+            // try to set value of entries of arrayValuePiece to entries of desiredValue
+            // given that size of arrayValuesPieces is arraySizePiece
+
+            if (!Array.isArray(desiredValue)) {
+                addDiagnostic({
+                    type: "info",
+                    message:
+                        "ignoring array values with insufficient dimensions",
+                    position: component.position,
+                    sourceDoc: component.sourceDoc,
+                });
+                return { nFailures: 1 };
+            }
+
+            let nFailuresSub = 0;
+
+            let currentSize = arraySizePiece[0];
+            if (desiredValue.length > currentSize) {
+                addDiagnostic({
+                    type: "info",
+                    message: "ignoring array values out of bounds",
+                    position: component.position,
+                    sourceDoc: component.sourceDoc,
+                });
+                nFailuresSub += desiredValue.length - currentSize;
+                desiredValue = desiredValue.slice(0, currentSize);
+            }
+
+            if (arraySizePiece.length === 1) {
+                // down to last dimension
+                for (let [ind, val] of desiredValue.entries() as Iterable<
+                    [number, any]
+                >) {
+                    arrayValuesPiece[ind] = val;
+                }
+            } else {
+                for (let [ind, val] of desiredValue.entries() as Iterable<
+                    [number, any]
+                >) {
+                    if (!arrayValuesPiece[ind]) {
+                        arrayValuesPiece[ind] = [];
+                    }
+                    let result = setArrayValuesPiece(
+                        val,
+                        arrayValuesPiece[ind],
+                        arraySizePiece.slice(1),
+                    );
+                    nFailuresSub += result.nFailures;
+                }
+            }
+
+            return { nFailures: nFailuresSub };
+        };
+
+        let result = setArrayValuesPiece(
+            value,
+            arrayValuesDrillDown,
+            arraySizeDrillDown,
+        );
+        nFailures += result.nFailures;
+    } else {
+        arrayValuesDrillDown[index[index.length - 1]] = value;
+    }
+
+    return { nFailures };
+}
+
+function oneDimSetArrayValue(
+    this: any,
+    { value, arrayKey, arraySize, arrayValues = this.arrayValues }: any,
+) {
+    let ind = this.keyToIndex(arrayKey);
+    if (ind >= 0 && ind < arraySize[0]) {
+        arrayValues[ind] = value;
+        return { nFailures: 0 };
+    } else {
+        const component = this.svComponent;
+        component.coreFunctions.addDiagnostic({
+            type: "info",
+            message: `Ignoring setting array values out of bounds: ${arrayKey} of ${this.svVarName}`,
+            position: component.position,
+            sourceDoc: component.sourceDoc,
+        });
+        return { nFailures: 1 };
+    }
+}
+
+function multiDimGetArrayValue(
+    this: any,
+    { arrayKey, arrayValues = this.arrayValues }: any,
+) {
+    let index = this.keyToIndex(arrayKey);
+    let aVals = arrayValues;
+    for (let indComponent of index.slice(0, index.length - 1)) {
+        aVals = aVals[indComponent];
+        if (!aVals) {
+            return undefined;
+        }
+    }
+    return aVals[index[index.length - 1]];
+}
+
+function oneDimGetArrayValue(
+    this: any,
+    { arrayKey, arrayValues = this.arrayValues }: any,
+) {
+    return arrayValues[arrayKey];
+}
+
+function multiDimGetAllArrayKeys(
+    arraySize: any,
+    flatten = true,
+    desiredSize?: any,
+) {
+    function prependToAllKeys(keys: any[], newStuff: any) {
+        for (let [ind, key] of keys.entries() as Iterable<[number, any]>) {
+            if (Array.isArray(key)) {
+                prependToAllKeys(key, newStuff);
+            } else {
+                keys[ind] = newStuff + "," + key;
+            }
+        }
+    }
+
+    function getAllArrayKeysSub(subArraySize: any): any[] {
+        if (subArraySize.length === 1) {
+            // array of numbers from 0 to subArraySize[0], cast to strings
+            return Array.from(Array(subArraySize[0]), (_, i) => String(i));
+        } else {
+            let currentSize = subArraySize[0];
+            let subSubKeys = getAllArrayKeysSub(subArraySize.slice(1));
+            let subKeys: any[] = [];
+            for (let ind = 0; ind < currentSize; ind++) {
+                if (flatten) {
+                    subKeys.push(...subSubKeys.map((x: any) => ind + "," + x));
+                } else {
+                    let newSubSubKeys = deepClone(subSubKeys);
+                    prependToAllKeys(newSubSubKeys, ind);
+                    subKeys.push(newSubSubKeys);
+                }
+            }
+            return subKeys;
+        }
+    }
+
+    if (desiredSize) {
+        if (desiredSize.length === 0) {
+            return [];
+        } else {
+            return getAllArrayKeysSub(desiredSize);
+        }
+    } else if (!arraySize || arraySize.length === 0) {
+        return [];
+    } else {
+        return getAllArrayKeysSub(arraySize);
+    }
+}
+
+function oneDimGetAllArrayKeys(
+    arraySize: any,
+    flatten?: any,
+    desiredSize?: any,
+) {
+    if (desiredSize) {
+        if (desiredSize.length === 0) {
+            return [];
+        } else {
+            // array of numbers from 0 to desiredSize[0], cast to strings
+            return Array.from(Array(desiredSize[0]), (_, i) => String(i));
+        }
+    } else if (!arraySize || arraySize.length === 0) {
+        return [];
+    } else {
+        // array of numbers from 0 to arraySize[0], cast to strings
+        return Array.from(Array(arraySize[0]), (_, i) => String(i));
+    }
+}
+
+function defaultMultiDimArrayVarNameFromArrayKey(this: any, arrayKey: string) {
+    return (
+        this.entryPrefixes[0] +
+        arrayKey
+            .split(",")
+            .map((x: string) => Number(x) + 1)
+            .join("_")
+    );
+}
+
+function defaultOneDimArrayVarNameFromArrayKey(this: any, arrayKey: string) {
+    return this.entryPrefixes[0] + String(Number(arrayKey) + 1);
+}
+
+async function multiDimAdjustArrayToNewArraySize(this: any) {
+    function resizeSubArray(subArray: any[], subArraySize: any) {
+        subArray.length = subArraySize[0];
+
+        if (subArraySize.length > 1) {
+            let subSubArraySize = subArraySize.slice(1);
+            for (let [ind, subSubArray] of subArray.entries() as Iterable<
+                [number, any]
+            >) {
+                if (!subSubArray) {
+                    // add in any empty entries
+                    subSubArray = subArray[ind] = [];
+                }
+                resizeSubArray(subSubArray, subSubArraySize);
+            }
+        }
+    }
+
+    let arraySize = await this.arraySize;
+    resizeSubArray(this.arrayValues, arraySize);
+}
+
+async function oneDimAdjustArrayToNewArraySize(this: any) {
+    let arraySize = await this.arraySize;
+    this.arrayValues.length = arraySize[0];
+}
+
 // returnDependencies for an array entry delegates to the array's
 // returnDependencies, adding this entry's arraySize/arrayKeys to the
 // arguments.
@@ -549,221 +849,17 @@ async function initializeArrayStateVariable({
         // (useful, for example, to set entire rows)
         // If it has more dimensinos than numDimensions, behavior isn't determined
         // (it should throw an error, assuming the array entries aren't arrays)
-        stateVarObj.keyToIndex = (key: string) =>
-            key.split(",").map((x) => Number(x));
-        stateVarObj.setArrayValue = function ({
-            value,
-            arrayKey,
-            arraySize,
-            arrayValues = stateVarObj.arrayValues,
-        }: any) {
-            let index = stateVarObj.keyToIndex(arrayKey);
-            let numDimensionsInArrayKey = index.length;
-            // Pre-existing typo fixed per CORE_REFACTOR_DEFERRED.md
-            // §"Pre-existing unreachable diagnostic": the original
-            // `!numDimensionsInArrayKey > stateVarObj.numDimensions`
-            // evaluates to `false > number === false` for any positive
-            // integer, so the diagnostic was unreachable.
-            if (numDimensionsInArrayKey > stateVarObj.numDimensions) {
-                core.addDiagnostic({
-                    type: "info",
-                    message:
-                        "Cannot set array value.  Number of dimensions is too large.",
-                    position: component.position,
-                    sourceDoc: component.sourceDoc,
-                });
-                return { nFailures: 1 };
-            }
-            let arrayValuesDrillDown = arrayValues;
-            let arraySizeDrillDown = arraySize;
-            for (let indComponent of index.slice(0, index.length - 1)) {
-                if (indComponent >= 0 && indComponent < arraySizeDrillDown[0]) {
-                    if (!arrayValuesDrillDown[indComponent]) {
-                        arrayValuesDrillDown[indComponent] = [];
-                    }
-                    arrayValuesDrillDown = arrayValuesDrillDown[indComponent];
-                    arraySizeDrillDown = arraySizeDrillDown.slice(1);
-                } else {
-                    core.addDiagnostic({
-                        type: "info",
-                        message: "ignore setting array value out of bounds",
-                        position: component.position,
-                        sourceDoc: component.sourceDoc,
-                    });
-                    return { nFailures: 1 };
-                }
-            }
-
-            let nFailures = 0;
-
-            if (numDimensionsInArrayKey < stateVarObj.numDimensions) {
-                // if dimensions from arrayKey is less than number of dimensions
-                // then attempt to get additional dimensions from
-                // array indices of value
-
-                let setArrayValuesPiece = function (
-                    desiredValue: any,
-                    arrayValuesPiece: any,
-                    arraySizePiece: any,
-                ): { nFailures: number } {
-                    // try to set value of entries of arrayValuePiece to entries of desiredValue
-                    // given that size of arrayValuesPieces is arraySizePiece
-
-                    if (!Array.isArray(desiredValue)) {
-                        core.addDiagnostic({
-                            type: "info",
-                            message:
-                                "ignoring array values with insufficient dimensions",
-                            position: component.position,
-                            sourceDoc: component.sourceDoc,
-                        });
-                        return { nFailures: 1 };
-                    }
-
-                    let nFailuresSub = 0;
-
-                    let currentSize = arraySizePiece[0];
-                    if (desiredValue.length > currentSize) {
-                        core.addDiagnostic({
-                            type: "info",
-                            message: "ignoring array values out of bounds",
-                            position: component.position,
-                            sourceDoc: component.sourceDoc,
-                        });
-                        nFailuresSub += desiredValue.length - currentSize;
-                        desiredValue = desiredValue.slice(0, currentSize);
-                    }
-
-                    if (arraySizePiece.length === 1) {
-                        // down to last dimension
-                        for (let [
-                            ind,
-                            val,
-                        ] of desiredValue.entries() as Iterable<
-                            [number, any]
-                        >) {
-                            arrayValuesPiece[ind] = val;
-                        }
-                    } else {
-                        for (let [
-                            ind,
-                            val,
-                        ] of desiredValue.entries() as Iterable<
-                            [number, any]
-                        >) {
-                            if (!arrayValuesPiece[ind]) {
-                                arrayValuesPiece[ind] = [];
-                            }
-                            let result = setArrayValuesPiece(
-                                val,
-                                arrayValuesPiece[ind],
-                                arraySizePiece.slice(1),
-                            );
-                            nFailuresSub += result.nFailures;
-                        }
-                    }
-
-                    return { nFailures: nFailuresSub };
-                };
-
-                let result = setArrayValuesPiece(
-                    value,
-                    arrayValuesDrillDown,
-                    arraySizeDrillDown,
-                );
-                nFailures += result.nFailures;
-            } else {
-                arrayValuesDrillDown[index[index.length - 1]] = value;
-            }
-
-            return { nFailures };
-        };
-        stateVarObj.getArrayValue = function ({
-            arrayKey,
-            arrayValues = stateVarObj.arrayValues,
-        }: any) {
-            let index = stateVarObj.keyToIndex(arrayKey);
-            let aVals = arrayValues;
-            for (let indComponent of index.slice(0, index.length - 1)) {
-                aVals = aVals[indComponent];
-                if (!aVals) {
-                    return undefined;
-                }
-            }
-            return aVals[index[index.length - 1]];
-        };
+        stateVarObj.keyToIndex = multiDimKeyToIndex;
+        stateVarObj.setArrayValue = multiDimSetArrayValue;
+        stateVarObj.getArrayValue = multiDimGetArrayValue;
 
         if (!stateVarObj.getAllArrayKeys) {
-            stateVarObj.getAllArrayKeys = function (
-                arraySize: any,
-                flatten = true,
-                desiredSize?: any,
-            ) {
-                function prependToAllKeys(keys: any[], newStuff: any) {
-                    for (let [ind, key] of keys.entries() as Iterable<
-                        [number, any]
-                    >) {
-                        if (Array.isArray(key)) {
-                            prependToAllKeys(key, newStuff);
-                        } else {
-                            keys[ind] = newStuff + "," + key;
-                        }
-                    }
-                }
-
-                function getAllArrayKeysSub(subArraySize: any): any[] {
-                    if (subArraySize.length === 1) {
-                        // array of numbers from 0 to subArraySize[0], cast to strings
-                        return Array.from(Array(subArraySize[0]), (_, i) =>
-                            String(i),
-                        );
-                    } else {
-                        let currentSize = subArraySize[0];
-                        let subSubKeys = getAllArrayKeysSub(
-                            subArraySize.slice(1),
-                        );
-                        let subKeys: any[] = [];
-                        for (let ind = 0; ind < currentSize; ind++) {
-                            if (flatten) {
-                                subKeys.push(
-                                    ...subSubKeys.map(
-                                        (x: any) => ind + "," + x,
-                                    ),
-                                );
-                            } else {
-                                let newSubSubKeys = deepClone(subSubKeys);
-                                prependToAllKeys(newSubSubKeys, ind);
-                                subKeys.push(newSubSubKeys);
-                            }
-                        }
-                        return subKeys;
-                    }
-                }
-
-                if (desiredSize) {
-                    if (desiredSize.length === 0) {
-                        return [];
-                    } else {
-                        return getAllArrayKeysSub(desiredSize);
-                    }
-                } else if (!arraySize || arraySize.length === 0) {
-                    return [];
-                } else {
-                    return getAllArrayKeysSub(arraySize);
-                }
-            };
+            stateVarObj.getAllArrayKeys = multiDimGetAllArrayKeys;
         }
 
         if (!stateVarObj.arrayVarNameFromArrayKey) {
-            stateVarObj.arrayVarNameFromArrayKey = function (arrayKey: string) {
-                return (
-                    entryPrefixes[0] +
-                    arrayKey
-                        .split(",")
-                        .map((x) => Number(x) + 1)
-                        .join("_")
-                );
-            };
+            stateVarObj.arrayVarNameFromArrayKey =
+                defaultMultiDimArrayVarNameFromArrayKey;
         }
 
         // arrayVarNameFromPropIndex is a function that calculates the name
@@ -785,86 +881,21 @@ async function initializeArrayStateVariable({
                 );
         }
 
-        stateVarObj.adjustArrayToNewArraySize = async function () {
-            function resizeSubArray(subArray: any[], subArraySize: any) {
-                subArray.length = subArraySize[0];
-
-                if (subArraySize.length > 1) {
-                    let subSubArraySize = subArraySize.slice(1);
-                    for (let [
-                        ind,
-                        subSubArray,
-                    ] of subArray.entries() as Iterable<[number, any]>) {
-                        if (!subSubArray) {
-                            // add in any empty entries
-                            subSubArray = subArray[ind] = [];
-                        }
-                        resizeSubArray(subSubArray, subSubArraySize);
-                    }
-                }
-            }
-
-            let arraySize = await stateVarObj.arraySize;
-            resizeSubArray(stateVarObj.arrayValues, arraySize);
-        };
+        stateVarObj.adjustArrayToNewArraySize =
+            multiDimAdjustArrayToNewArraySize;
     } else {
         // have just one dimension
-        stateVarObj.keyToIndex = (key: string) => Number(key);
-        stateVarObj.setArrayValue = function ({
-            value,
-            arrayKey,
-            arraySize,
-            arrayValues = stateVarObj.arrayValues,
-        }: any) {
-            let ind = stateVarObj.keyToIndex(arrayKey);
-            if (ind >= 0 && ind < arraySize[0]) {
-                arrayValues[ind] = value;
-                return { nFailures: 0 };
-            } else {
-                core.addDiagnostic({
-                    type: "info",
-                    message: `Ignoring setting array values out of bounds: ${arrayKey} of ${stateVariable}`,
-                    position: component.position,
-                    sourceDoc: component.sourceDoc,
-                });
-                return { nFailures: 1 };
-            }
-        };
-        stateVarObj.getArrayValue = function ({
-            arrayKey,
-            arrayValues = stateVarObj.arrayValues,
-        }: any) {
-            return arrayValues[arrayKey];
-        };
+        stateVarObj.keyToIndex = oneDimKeyToIndex;
+        stateVarObj.setArrayValue = oneDimSetArrayValue;
+        stateVarObj.getArrayValue = oneDimGetArrayValue;
 
         if (!stateVarObj.getAllArrayKeys) {
-            stateVarObj.getAllArrayKeys = function (
-                arraySize: any,
-                flatten?: any,
-                desiredSize?: any,
-            ) {
-                if (desiredSize) {
-                    if (desiredSize.length === 0) {
-                        return [];
-                    } else {
-                        // array of numbers from 0 to desiredSize[0], cast to strings
-                        return Array.from(Array(desiredSize[0]), (_, i) =>
-                            String(i),
-                        );
-                    }
-                } else if (!arraySize || arraySize.length === 0) {
-                    return [];
-                } else {
-                    // array of numbers from 0 to arraySize[0], cast to strings
-                    return Array.from(Array(arraySize[0]), (_, i) => String(i));
-                }
-            };
+            stateVarObj.getAllArrayKeys = oneDimGetAllArrayKeys;
         }
 
         if (!stateVarObj.arrayVarNameFromArrayKey) {
-            stateVarObj.arrayVarNameFromArrayKey = function (arrayKey: string) {
-                return entryPrefixes[0] + String(Number(arrayKey) + 1);
-            };
+            stateVarObj.arrayVarNameFromArrayKey =
+                defaultOneDimArrayVarNameFromArrayKey;
         }
 
         // arrayVarNameFromPropIndex is a function that calculates the name
@@ -883,11 +914,7 @@ async function initializeArrayStateVariable({
                 returnDefaultArrayVarNameFromPropIndex(1, entryPrefixes[0]);
         }
 
-        stateVarObj.adjustArrayToNewArraySize = async function () {
-            // console.log(`adjust array ${stateVariable} of ${component.componentIdx} to new array size: ${stateVarObj.arraySize[0]}`);
-            let arraySize = await stateVarObj.arraySize;
-            stateVarObj.arrayValues.length = arraySize[0];
-        };
+        stateVarObj.adjustArrayToNewArraySize = oneDimAdjustArrayToNewArraySize;
     }
 
     if (!stateVarObj.getArrayKeysFromVarName) {
@@ -895,12 +922,10 @@ async function initializeArrayStateVariable({
             returnDefaultGetArrayKeysFromVarName(stateVarObj.numDimensions);
     }
 
-    // converting from index to key is the same for single and multiple
-    // dimensions, as we just want the string representation
-    stateVarObj.indexToKey = (index: any) => String(index);
+    stateVarObj.indexToKey = arrayIndexToKey;
 
     if (!stateVarObj.returnEntryDimensions) {
-        stateVarObj.returnEntryDimensions = () => 0;
+        stateVarObj.returnEntryDimensions = defaultReturnEntryDimensions;
     }
 
     if (stateVarObj.shadowingInstructions) {

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -449,6 +449,581 @@ async function oneDimAdjustArrayToNewArraySize(this: any) {
     this.arrayValues.length = arraySize[0];
 }
 
+/**
+ * Resolve the array state-variable object from a receiver that may be
+ * either the array itself or one of its array ENTRIES: entries receive
+ * field copies of the array's `definition` / `inverseDefinition` /
+ * `markStale` (see `initializeArrayEntryStateVariable`), so those shared
+ * functions are invoked with the entry as `this`. All bookkeeping —
+ * dependencyNames, freshness keys, setValue keys — must use the ARRAY's
+ * object and variable name (`_remapArrayEntryFreshness` in
+ * StalenessPropagator relies on the array's name in fresh/partiallyFresh
+ * keys), exactly as the old per-array closures did by capture.
+ */
+function resolveArrayStateVarObj(svObj: any) {
+    return svObj.isArrayEntry
+        ? svObj.svComponent.state[svObj.arrayStateVariable]
+        : svObj;
+}
+
+function defaultReturnWrappingComponents(prefix?: any) {
+    return [];
+}
+
+// create returnDependencies function from returnArrayDependenciesByKey
+async function arrayReturnDependencies(this: any, args: any) {
+    const arrayStateVarObj = resolveArrayStateVarObj(this);
+    const component = arrayStateVarObj.svComponent;
+    const arrayVarName = arrayStateVarObj.svVarName;
+
+    args.arraySize = await arrayStateVarObj.arraySize;
+
+    // delete the internally added dependencies from args.stateValues
+    for (let key in args.stateValues) {
+        if (key.slice(0, 8) === "__array_") {
+            delete args.stateValues[key];
+        }
+    }
+
+    if (args.arrayKeys === undefined) {
+        args.arrayKeys = arrayStateVarObj.getAllArrayKeys(args.arraySize);
+    }
+
+    // link all dependencyNames of additionalStateVariablesDefined
+    // to the same object, as they will share the same freshnessinfo
+    // TODO: a better idea?  This seems like it could lead to confusion.
+    if (!arrayStateVarObj.dependencyNames) {
+        arrayStateVarObj.dependencyNames = {
+            namesByKey: {},
+            keysByName: {},
+            global: [],
+        };
+        if (arrayStateVarObj.additionalStateVariablesDefined) {
+            for (let vName of arrayStateVarObj.additionalStateVariablesDefined) {
+                component.state[vName].dependencyNames =
+                    arrayStateVarObj.dependencyNames;
+            }
+        }
+    }
+
+    let dependencies: Record<string, any> = {};
+
+    if (
+        arrayStateVarObj.basedOnArrayKeyStateVariables &&
+        args.arrayKeys.length > 1
+    ) {
+        const allStateVariablesAffected = [
+            arrayVarName,
+            ...(arrayStateVarObj.additionalStateVariablesDefined ?? []),
+        ];
+        for (let arrayKey of args.arrayKeys) {
+            for (let vName of allStateVariablesAffected) {
+                let sObj = component.state[vName];
+                dependencies[vName + "_" + arrayKey] = {
+                    dependencyType: "stateVariable",
+                    variableName: sObj.arrayVarNameFromArrayKey(arrayKey),
+                };
+            }
+        }
+    } else {
+        let arrayDependencies =
+            arrayStateVarObj.returnArrayDependenciesByKey(args);
+
+        if (arrayDependencies.globalDependencies) {
+            arrayStateVarObj.dependencyNames.global = Object.keys(
+                arrayDependencies.globalDependencies,
+            );
+            Object.assign(dependencies, arrayDependencies.globalDependencies);
+        }
+
+        if (!arrayDependencies.dependenciesByKey) {
+            arrayDependencies.dependenciesByKey = {};
+        }
+
+        for (let arrayKey of args.arrayKeys) {
+            // namesByKey also functions to indicate that dependencies
+            // have been returned for that arrayKey
+
+            // If had additional nameByKey, it should be treated as dependencies changing
+            // so that we recalculate the value of the array variable
+            // TODO: we are communicating this to updateDependencies by adding
+            // an attribute to the arguments?  Is there a better way of doing it.
+            // Didn't want to add to the return value, as that would add complexity
+            // to how we normally define returnDependencies
+            // We could change returnDependencies to output an object.
+            // That would probably be cleaner.
+            if (!(arrayKey in arrayStateVarObj.dependencyNames.namesByKey)) {
+                args.changedDependency = true;
+            }
+            arrayStateVarObj.dependencyNames.namesByKey[arrayKey] = {};
+            for (let depName in arrayDependencies.dependenciesByKey[arrayKey]) {
+                let extendedDepName = "__" + arrayKey + "_" + depName;
+                dependencies[extendedDepName] =
+                    arrayDependencies.dependenciesByKey[arrayKey][depName];
+                arrayStateVarObj.dependencyNames.namesByKey[arrayKey][depName] =
+                    extendedDepName;
+                if (
+                    !arrayStateVarObj.dependencyNames.keysByName[
+                        extendedDepName
+                    ]
+                ) {
+                    arrayStateVarObj.dependencyNames.keysByName[
+                        extendedDepName
+                    ] = [];
+                }
+                if (
+                    !arrayStateVarObj.dependencyNames.keysByName[
+                        extendedDepName
+                    ].includes(arrayKey)
+                ) {
+                    arrayStateVarObj.dependencyNames.keysByName[
+                        extendedDepName
+                    ].push(arrayKey);
+                }
+            }
+        }
+
+        // to tie into making sure array size is a dependency, below
+        arrayStateVarObj.dependencyNames.global.push("__array_size");
+    }
+
+    // make sure array size is a dependency
+    dependencies.__array_size = {
+        dependencyType: "stateVariable",
+        variableName: arrayStateVarObj.arraySizeStateVariable,
+    };
+
+    return dependencies;
+}
+
+function arrayGetCurrentFreshness(
+    this: any,
+    { freshnessInfo, arrayKeys, arraySize }: any,
+) {
+    const arrayStateVarObj = resolveArrayStateVarObj(this);
+    const arrayVarName = arrayStateVarObj.svVarName;
+
+    if (arrayKeys === undefined) {
+        arrayKeys = arrayStateVarObj.getAllArrayKeys(arraySize);
+    }
+
+    let freshByKey = freshnessInfo.freshByKey;
+
+    let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
+    for (let arrayKey of arrayKeys) {
+        if (freshByKey[arrayKey]) {
+            numberFresh += 1;
+        }
+    }
+
+    if (numberFresh > 0) {
+        if (numberFresh === arrayKeys.length + 1) {
+            return { fresh: { [arrayVarName]: true } };
+        } else {
+            return { partiallyFresh: { [arrayVarName]: numberFresh } };
+        }
+    } else {
+        return { fresh: { [arrayVarName]: false } };
+    }
+}
+
+function arrayMarkStale(
+    this: any,
+    { freshnessInfo, changes, arrayKeys, arraySize }: any,
+) {
+    const arrayStateVarObj = resolveArrayStateVarObj(this);
+    const arrayVarName = arrayStateVarObj.svVarName;
+
+    let result: any = {};
+
+    if (arrayKeys === undefined) {
+        arrayKeys = arrayStateVarObj.getAllArrayKeys(arraySize);
+    }
+
+    if (arrayStateVarObj.markStaleByKey) {
+        result = arrayStateVarObj.markStaleByKey({ arrayKeys, changes });
+    }
+
+    let freshByKey = freshnessInfo.freshByKey;
+
+    if (changes.__array_size) {
+        freshnessInfo.freshArraySize = false;
+        // everything is stale
+        freshnessInfo.freshByKey = {};
+        result.fresh = { [arrayVarName]: false };
+        return result;
+    }
+
+    if (Object.keys(freshByKey).length === 0) {
+        // everything is stale, except possibly array size
+        // (check for nothing fresh as a shortcut, as mark stale could
+        // be called repeated if size doesn't change, given that it's partially fresh)
+        freshnessInfo.freshByKey = {};
+        if (freshnessInfo.freshArraySize) {
+            result.partiallyFresh = { [arrayVarName]: 1 };
+            return result;
+        } else {
+            result.fresh = { [arrayVarName]: false };
+            return result;
+        }
+    }
+
+    for (let changeName in changes) {
+        if (arrayStateVarObj.dependencyNames.global.includes(changeName)) {
+            // everything is stale, except possible array size
+            freshnessInfo.freshByKey = {};
+            if (freshnessInfo.freshArraySize) {
+                result.partiallyFresh = { [arrayVarName]: 1 };
+                return result;
+            } else {
+                result.fresh = { [arrayVarName]: false };
+                return result;
+            }
+        }
+
+        if (
+            arrayStateVarObj.basedOnArrayKeyStateVariables &&
+            arrayKeys.length > 1
+        ) {
+            delete freshByKey[changeName];
+        } else {
+            for (let key of arrayStateVarObj.dependencyNames.keysByName[
+                changeName
+            ]) {
+                delete freshByKey[key];
+            }
+        }
+    }
+
+    // check if the array keys requested are fresh
+    let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
+    for (let arrayKey of arrayKeys) {
+        if (freshByKey[arrayKey]) {
+            numberFresh += 1;
+        }
+    }
+
+    if (numberFresh > 0) {
+        if (numberFresh === arrayKeys.length + 1) {
+            result.fresh = { [arrayVarName]: true };
+            return result;
+        } else {
+            result.partiallyFresh = { [arrayVarName]: numberFresh };
+            return result;
+        }
+    } else {
+        result.fresh = { [arrayVarName]: false };
+        return result;
+    }
+}
+
+function arrayFreshenOnNoChanges(
+    this: any,
+    { arrayKeys, freshnessInfo, arraySize }: any,
+) {
+    const arrayStateVarObj = resolveArrayStateVarObj(this);
+    let freshByKey = freshnessInfo.freshByKey;
+
+    if (arrayKeys === undefined) {
+        arrayKeys = arrayStateVarObj.getAllArrayKeys(arraySize);
+    }
+
+    for (let arrayKey of arrayKeys) {
+        freshByKey[arrayKey] = true;
+    }
+}
+
+function extractArrayDependencies(
+    arrayStateVarObj: any,
+    dependencyValues: any,
+    arrayKeys: any[],
+    usedDefault: any,
+) {
+    let globalDependencyValues: Record<string, any> = {};
+    let globalUsedDefault: Record<string, any> = {};
+    for (let dependencyName of arrayStateVarObj.dependencyNames.global) {
+        globalDependencyValues[dependencyName] =
+            dependencyValues[dependencyName];
+        globalUsedDefault[dependencyName] = usedDefault[dependencyName];
+    }
+
+    let dependencyValuesByKey: Record<string, any> = {};
+    let usedDefaultByKey: Record<string, any> = {};
+    let foundAllDependencyValuesForKey: Record<string, any> = {};
+    for (let arrayKey of arrayKeys) {
+        dependencyValuesByKey[arrayKey] = {};
+        usedDefaultByKey[arrayKey] = {};
+        if (arrayKey in arrayStateVarObj.dependencyNames.namesByKey) {
+            foundAllDependencyValuesForKey[arrayKey] = true;
+            for (let dependencyName in arrayStateVarObj.dependencyNames
+                .namesByKey[arrayKey]) {
+                let extendedDepName =
+                    arrayStateVarObj.dependencyNames.namesByKey[arrayKey][
+                        dependencyName
+                    ];
+                if (extendedDepName in dependencyValues) {
+                    dependencyValuesByKey[arrayKey][dependencyName] =
+                        dependencyValues[extendedDepName];
+                    usedDefaultByKey[arrayKey][dependencyName] =
+                        usedDefault[extendedDepName];
+                } else {
+                    foundAllDependencyValuesForKey[arrayKey] = false;
+                }
+            }
+        }
+    }
+
+    return {
+        globalDependencyValues,
+        globalUsedDefault,
+        dependencyValuesByKey,
+        usedDefaultByKey,
+        foundAllDependencyValuesForKey,
+    };
+}
+
+function arrayDefinition(this: any, args: any) {
+    const arrayStateVarObj = resolveArrayStateVarObj(this);
+    const arrayVarName = arrayStateVarObj.svVarName;
+    const component = arrayStateVarObj.svComponent;
+
+    if (args.arrayKeys === undefined) {
+        args.arrayKeys = arrayStateVarObj.getAllArrayKeys(args.arraySize);
+    }
+
+    if (
+        arrayStateVarObj.basedOnArrayKeyStateVariables &&
+        args.arrayKeys.length > 1
+    ) {
+        // if based on array key state variables and have more than one array key
+        // then must have calculated all the relevant array keys
+        // when retrieving the dependency values
+        // Hence there is nothing to do, as arrayValues has been populated
+        // with all the requisite values
+
+        return {};
+    } else {
+        let extractedDeps = extractArrayDependencies(
+            arrayStateVarObj,
+            args.dependencyValues,
+            args.arrayKeys,
+            args.usedDefault,
+        );
+        let globalDependencyValues = extractedDeps.globalDependencyValues;
+        let globalUsedDefault = extractedDeps.globalUsedDefault;
+        let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
+        let usedDefaultByKey = extractedDeps.usedDefaultByKey;
+        let foundAllDependencyValuesForKey =
+            extractedDeps.foundAllDependencyValuesForKey;
+
+        delete args.dependencyValues;
+        args.globalDependencyValues = globalDependencyValues;
+        args.globalUsedDefault = globalUsedDefault;
+        args.dependencyValuesByKey = dependencyValuesByKey;
+        args.usedDefaultByKey = usedDefaultByKey;
+
+        let arrayKeysToRecalculate = [];
+        let freshByKey = args.freshnessInfo.freshByKey;
+        for (let arrayKey of args.arrayKeys) {
+            // only recalculate if
+            // - arrayKey isn't fresh, and
+            // - found all dependency values for array key (i.e., have calculated dependencies for arrayKey)
+            if (
+                !freshByKey[arrayKey] &&
+                foundAllDependencyValuesForKey[arrayKey]
+            ) {
+                freshByKey[arrayKey] = true;
+                arrayKeysToRecalculate.push(arrayKey);
+            }
+        }
+
+        let result;
+        if (arrayKeysToRecalculate.length === 0) {
+            result = {};
+        } else {
+            args.arrayKeys = arrayKeysToRecalculate;
+
+            if (!arrayStateVarObj.arrayDefinitionByKey) {
+                throw Error(
+                    `For ${arrayVarName} of ${component.componentType}, arrayDefinitionByKey must be a function`,
+                );
+            }
+
+            result = arrayStateVarObj.arrayDefinitionByKey(args);
+
+            // in case definition returns additional array entries,
+            // mark all array keys received as fresh as well
+            if (result.setValue && result.setValue[arrayVarName]) {
+                for (let arrayKey in result.setValue[arrayVarName]) {
+                    freshByKey[arrayKey] = true;
+                }
+            }
+            if (
+                result.useEssentialOrDefaultValue &&
+                result.useEssentialOrDefaultValue[arrayVarName]
+            ) {
+                for (let arrayKey in result.useEssentialOrDefaultValue[
+                    arrayVarName
+                ]) {
+                    freshByKey[arrayKey] = true;
+                }
+            }
+        }
+
+        if (!args.freshnessInfo.freshArraySize) {
+            if (args.changes.__array_size) {
+                result.arraySizeChanged = [arrayVarName];
+                if (arrayStateVarObj.additionalStateVariablesDefined) {
+                    for (let varName of arrayStateVarObj.additionalStateVariablesDefined) {
+                        // do we have to check if it is array?
+                        if (component.state[varName].isArray) {
+                            result.arraySizeChanged.push(varName);
+                        }
+                    }
+                }
+            }
+            args.freshnessInfo.freshArraySize = true;
+        }
+
+        return result;
+    }
+}
+
+function arrayInverseDefinition(this: any, args: any) {
+    const arrayStateVarObj = resolveArrayStateVarObj(this);
+    const arrayVarName = arrayStateVarObj.svVarName;
+
+    if (!arrayStateVarObj.inverseArrayDefinitionByKey) {
+        return { success: false };
+    }
+
+    if (args.arrayKeys === undefined) {
+        args.arrayKeys = arrayStateVarObj.getAllArrayKeys(args.arraySize);
+    }
+
+    if (
+        arrayStateVarObj.basedOnArrayKeyStateVariables &&
+        args.arrayKeys.length > 1
+    ) {
+        const allStateVariablesAffected = [
+            arrayVarName,
+            ...(arrayStateVarObj.additionalStateVariablesDefined ?? []),
+        ];
+        let instructions = [];
+
+        for (let vName of allStateVariablesAffected) {
+            for (let key in args.desiredStateVariableValues[vName]) {
+                let depName = vName + "_" + key;
+                if (depName in args.dependencyValues) {
+                    instructions.push({
+                        setDependency: depName,
+                        desiredValue:
+                            args.desiredStateVariableValues[vName][key],
+                        treatAsInitialChange: args.initialChange,
+                    });
+                }
+            }
+        }
+
+        return {
+            success: true,
+            instructions,
+        };
+    } else {
+        let extractedDeps = extractArrayDependencies(
+            arrayStateVarObj,
+            args.dependencyValues,
+            args.arrayKeys,
+            args.usedDefault,
+        );
+        let globalDependencyValues = extractedDeps.globalDependencyValues;
+        let globalUsedDefault = extractedDeps.globalUsedDefault;
+        let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
+        let usedDefaultByKey = extractedDeps.usedDefaultByKey;
+
+        delete args.dependencyValues;
+        args.globalDependencyValues = globalDependencyValues;
+        args.globalUsedDefault = globalUsedDefault;
+        args.dependencyValuesByKey = dependencyValuesByKey;
+        args.usedDefaultByKey = usedDefaultByKey;
+
+        args.dependencyNamesByKey = arrayStateVarObj.dependencyNames.namesByKey;
+
+        if (!arrayStateVarObj.allowExtraArrayKeysInInverse) {
+            // by default, inverseArrayDefinitionByKey does not need to be
+            // programmed defensively against arrayKeys that don't exist
+            // as they are filtered out here.
+            // However, if allowExtraArrayKeysInInverse, then we skip this
+            // filtering to allow the possibility that the array size
+            // could be changed.
+            let newDesiredStateVariableValues: Record<string, any> = {};
+            for (let vName in args.desiredStateVariableValues) {
+                newDesiredStateVariableValues[vName] = {};
+                for (let key in args.desiredStateVariableValues[vName]) {
+                    if (args.arrayKeys.includes(key)) {
+                        newDesiredStateVariableValues[vName][key] =
+                            args.desiredStateVariableValues[vName][key];
+                    }
+                }
+            }
+            args.desiredStateVariableValues = newDesiredStateVariableValues;
+        }
+
+        let result = arrayStateVarObj.inverseArrayDefinitionByKey(args);
+        return result;
+    }
+}
+
+function getArrayArraySize(this: any) {
+    return (async () => {
+        if (
+            !this.svComponent.state[this.arraySizeStateVariable]
+                .initiallyResolved
+        ) {
+            return [];
+        }
+        if (this.arraySizeStale) {
+            await this.recalculateArraySizeDependentQuantities();
+        }
+        return await this.svComponent.stateValues[this.arraySizeStateVariable];
+    })();
+}
+const ARRAY_ARRAY_SIZE_DESCRIPTOR: PropertyDescriptor = Object.freeze({
+    get: getArrayArraySize,
+});
+
+async function arrayRecalculateArraySizeDependentQuantities(this: any) {
+    const component = this.svComponent;
+    let newArraySize = await component.stateValues[this.arraySizeStateVariable];
+    if (
+        this.previousArraySize.length !== newArraySize.length ||
+        this.previousArraySize.some((v: any, i: number) => v != newArraySize[i])
+    ) {
+        this.previousArraySize = [...newArraySize];
+        let varNamesIncluding = (this.varNamesIncludingArrayKeys = {} as any);
+        for (let entryName of this.arrayEntryNames) {
+            let entryStateVarObj = component.state[entryName];
+            let arrayKeys = this.getArrayKeysFromVarName({
+                arrayEntryPrefix: entryStateVarObj.entryPrefix,
+                varEnding: entryStateVarObj.varEnding,
+                arraySize: newArraySize,
+                numDimensions: this.numDimensions,
+            });
+            entryStateVarObj._unflattenedArrayKeys = arrayKeys;
+            entryStateVarObj._arrayKeys = flattenDeep(arrayKeys);
+
+            // for each arrayKey, add this entry name to the array's list variables
+            for (let arrayKey of entryStateVarObj._arrayKeys) {
+                if (!varNamesIncluding[arrayKey]) {
+                    varNamesIncluding[arrayKey] = [];
+                }
+                varNamesIncluding[arrayKey].push(entryName);
+            }
+        }
+    }
+    this.arraySizeStale = false;
+}
+
 // returnDependencies for an array entry delegates to the array's
 // returnDependencies, adding this entry's arraySize/arrayKeys to the
 // arguments.
@@ -961,9 +1536,8 @@ async function initializeArrayStateVariable({
         // to make array indexing (maybe even including slices) be the basis.
 
         if (!stateVarObj.shadowingInstructions.returnWrappingComponents) {
-            stateVarObj.shadowingInstructions.returnWrappingComponents = (
-                prefix: any,
-            ) => [];
+            stateVarObj.shadowingInstructions.returnWrappingComponents =
+                defaultReturnWrappingComponents;
         }
         stateVarObj.wrappingComponents =
             stateVarObj.shadowingInstructions.returnWrappingComponents();
@@ -974,524 +1548,22 @@ async function initializeArrayStateVariable({
     stateVarObj.arrayEntryNames = [];
     stateVarObj.varNamesIncludingArrayKeys = {};
 
-    let allStateVariablesAffected = [stateVariable];
-    if (stateVarObj.additionalStateVariablesDefined) {
-        allStateVariablesAffected.push(
-            ...stateVarObj.additionalStateVariablesDefined,
-        );
-    }
-
     // create the definition, etc., functions for the array state variable
+    // (module-level functions shared across all array state variables;
+    // entries invoke some of them with the ENTRY as receiver, so they
+    // resolve the array object via resolveArrayStateVarObj)
 
-    // create returnDependencies function from returnArrayDependenciesByKey
-    stateVarObj.returnDependencies = async function (args: any) {
-        // console.log(`return dependencies for array ${stateVariable} of ${component.componentIdx}`)
-        // console.log(JSON.parse(JSON.stringify(args)));
+    stateVarObj.returnDependencies = arrayReturnDependencies;
 
-        args.arraySize = await stateVarObj.arraySize;
+    stateVarObj.getCurrentFreshness = arrayGetCurrentFreshness;
 
-        // delete the internally added dependencies from args.stateValues
-        for (let key in args.stateValues) {
-            if (key.slice(0, 8) === "__array_") {
-                delete args.stateValues[key];
-            }
-        }
+    stateVarObj.markStale = arrayMarkStale;
 
-        if (args.arrayKeys === undefined) {
-            args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
-        }
+    stateVarObj.freshenOnNoChanges = arrayFreshenOnNoChanges;
 
-        // link all dependencyNames of additionalStateVariablesDefined
-        // to the same object, as they will share the same freshnessinfo
-        // TODO: a better idea?  This seems like it could lead to confusion.
-        if (!stateVarObj.dependencyNames) {
-            stateVarObj.dependencyNames = {
-                namesByKey: {},
-                keysByName: {},
-                global: [],
-            };
-            if (stateVarObj.additionalStateVariablesDefined) {
-                for (let vName of stateVarObj.additionalStateVariablesDefined) {
-                    component.state[vName].dependencyNames =
-                        stateVarObj.dependencyNames;
-                }
-            }
-        }
+    stateVarObj.definition = arrayDefinition;
 
-        let dependencies: Record<string, any> = {};
-
-        if (
-            stateVarObj.basedOnArrayKeyStateVariables &&
-            args.arrayKeys.length > 1
-        ) {
-            for (let arrayKey of args.arrayKeys) {
-                for (let vName of allStateVariablesAffected) {
-                    let sObj = component.state[vName];
-                    dependencies[vName + "_" + arrayKey] = {
-                        dependencyType: "stateVariable",
-                        variableName: sObj.arrayVarNameFromArrayKey(arrayKey),
-                    };
-                }
-            }
-        } else {
-            let arrayDependencies =
-                stateVarObj.returnArrayDependenciesByKey(args);
-
-            if (arrayDependencies.globalDependencies) {
-                stateVarObj.dependencyNames.global = Object.keys(
-                    arrayDependencies.globalDependencies,
-                );
-                Object.assign(
-                    dependencies,
-                    arrayDependencies.globalDependencies,
-                );
-            }
-
-            if (!arrayDependencies.dependenciesByKey) {
-                arrayDependencies.dependenciesByKey = {};
-            }
-
-            for (let arrayKey of args.arrayKeys) {
-                // namesByKey also functions to indicate that dependencies
-                // have been returned for that arrayKey
-
-                // If had additional nameByKey, it should be treated as dependencies changing
-                // so that we recalculate the value of the array variable
-                // TODO: we are communicating this to updateDependencies by adding
-                // an attribute to the arguments?  Is there a better way of doing it.
-                // Didn't want to add to the return value, as that would add complexity
-                // to how we normally define returnDependencies
-                // We could change returnDependencies to output an object.
-                // That would probably be cleaner.
-                if (!(arrayKey in stateVarObj.dependencyNames.namesByKey)) {
-                    args.changedDependency = true;
-                }
-                stateVarObj.dependencyNames.namesByKey[arrayKey] = {};
-                for (let depName in arrayDependencies.dependenciesByKey[
-                    arrayKey
-                ]) {
-                    let extendedDepName = "__" + arrayKey + "_" + depName;
-                    dependencies[extendedDepName] =
-                        arrayDependencies.dependenciesByKey[arrayKey][depName];
-                    stateVarObj.dependencyNames.namesByKey[arrayKey][depName] =
-                        extendedDepName;
-                    if (
-                        !stateVarObj.dependencyNames.keysByName[extendedDepName]
-                    ) {
-                        stateVarObj.dependencyNames.keysByName[
-                            extendedDepName
-                        ] = [];
-                    }
-                    if (
-                        !stateVarObj.dependencyNames.keysByName[
-                            extendedDepName
-                        ].includes(arrayKey)
-                    ) {
-                        stateVarObj.dependencyNames.keysByName[
-                            extendedDepName
-                        ].push(arrayKey);
-                    }
-                }
-            }
-
-            // to tie into making sure array size is a dependency, below
-            stateVarObj.dependencyNames.global.push("__array_size");
-        }
-
-        // make sure array size is a dependency
-        dependencies.__array_size = {
-            dependencyType: "stateVariable",
-            variableName: stateVarObj.arraySizeStateVariable,
-        };
-
-        // console.log(`resulting dependencies for ${stateVariable} of ${component.componentIdx}`)
-        // console.log(dependencies)
-        return dependencies;
-    };
-
-    stateVarObj.getCurrentFreshness = function ({
-        freshnessInfo,
-        arrayKeys,
-        arraySize,
-    }: any) {
-        // console.log(`getCurrentFreshness for array ${stateVariable} of ${component.componentIdx}`)
-        // console.log(arrayKeys, arraySize);
-        // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
-
-        if (arrayKeys === undefined) {
-            arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
-        }
-
-        let freshByKey = freshnessInfo.freshByKey;
-
-        let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
-        for (let arrayKey of arrayKeys) {
-            if (freshByKey[arrayKey]) {
-                numberFresh += 1;
-            }
-        }
-
-        if (numberFresh > 0) {
-            if (numberFresh === arrayKeys.length + 1) {
-                return { fresh: { [stateVariable]: true } };
-            } else {
-                return { partiallyFresh: { [stateVariable]: numberFresh } };
-            }
-        } else {
-            return { fresh: { [stateVariable]: false } };
-        }
-    };
-
-    stateVarObj.markStale = function ({
-        freshnessInfo,
-        changes,
-        arrayKeys,
-        arraySize,
-    }: any) {
-        // console.log(`markStale for array ${stateVariable} of ${component.componentIdx}`)
-        // console.log(changes, arrayKeys, arraySize);
-        // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
-
-        let result: any = {};
-
-        if (arrayKeys === undefined) {
-            arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
-        }
-
-        if (stateVarObj.markStaleByKey) {
-            result = stateVarObj.markStaleByKey({ arrayKeys, changes });
-        }
-
-        let freshByKey = freshnessInfo.freshByKey;
-
-        if (changes.__array_size) {
-            freshnessInfo.freshArraySize = false;
-            // everything is stale
-            freshnessInfo.freshByKey = {};
-            result.fresh = { [stateVariable]: false };
-            return result;
-        }
-
-        if (Object.keys(freshByKey).length === 0) {
-            // everything is stale, except possibly array size
-            // (check for nothing fresh as a shortcut, as mark stale could
-            // be called repeated if size doesn't change, given that it's partially fresh)
-            freshnessInfo.freshByKey = {};
-            if (freshnessInfo.freshArraySize) {
-                result.partiallyFresh = { [stateVariable]: 1 };
-                return result;
-            } else {
-                result.fresh = { [stateVariable]: false };
-                return result;
-            }
-        }
-
-        for (let changeName in changes) {
-            if (stateVarObj.dependencyNames.global.includes(changeName)) {
-                // everything is stale, except possible array size
-                freshnessInfo.freshByKey = {};
-                if (freshnessInfo.freshArraySize) {
-                    result.partiallyFresh = { [stateVariable]: 1 };
-                    return result;
-                } else {
-                    result.fresh = { [stateVariable]: false };
-                    return result;
-                }
-            }
-
-            if (
-                stateVarObj.basedOnArrayKeyStateVariables &&
-                arrayKeys.length > 1
-            ) {
-                delete freshByKey[changeName];
-            } else {
-                for (let key of stateVarObj.dependencyNames.keysByName[
-                    changeName
-                ]) {
-                    delete freshByKey[key];
-                }
-            }
-        }
-
-        // check if the array keys requested are fresh
-        let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
-        for (let arrayKey of arrayKeys) {
-            if (freshByKey[arrayKey]) {
-                numberFresh += 1;
-            }
-        }
-
-        // console.log(`ending freshness`)
-        // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
-
-        if (numberFresh > 0) {
-            if (numberFresh === arrayKeys.length + 1) {
-                result.fresh = { [stateVariable]: true };
-                return result;
-            } else {
-                result.partiallyFresh = { [stateVariable]: numberFresh };
-                return result;
-            }
-        } else {
-            result.fresh = { [stateVariable]: false };
-            return result;
-        }
-    };
-
-    stateVarObj.freshenOnNoChanges = function ({
-        arrayKeys,
-        freshnessInfo,
-        arraySize,
-    }: any) {
-        // console.log(`freshenOnNoChanges for ${stateVariable} of ${component.componentIdx}`)
-        let freshByKey = freshnessInfo.freshByKey;
-
-        if (arrayKeys === undefined) {
-            arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
-        }
-
-        for (let arrayKey of arrayKeys) {
-            freshByKey[arrayKey] = true;
-        }
-    };
-
-    function extractArrayDependencies(
-        dependencyValues: any,
-        arrayKeys: any[],
-        usedDefault: any,
-    ) {
-        // console.log(`extract array dependencies`, dependencyValues, arrayKeys, usedDefault)
-        // console.log(JSON.parse(JSON.stringify(arrayKeys)))
-
-        let globalDependencyValues: Record<string, any> = {};
-        let globalUsedDefault: Record<string, any> = {};
-        for (let dependencyName of stateVarObj.dependencyNames.global) {
-            globalDependencyValues[dependencyName] =
-                dependencyValues[dependencyName];
-            globalUsedDefault[dependencyName] = usedDefault[dependencyName];
-        }
-
-        let dependencyValuesByKey: Record<string, any> = {};
-        let usedDefaultByKey: Record<string, any> = {};
-        let foundAllDependencyValuesForKey: Record<string, any> = {};
-        for (let arrayKey of arrayKeys) {
-            dependencyValuesByKey[arrayKey] = {};
-            usedDefaultByKey[arrayKey] = {};
-            if (arrayKey in stateVarObj.dependencyNames.namesByKey) {
-                foundAllDependencyValuesForKey[arrayKey] = true;
-                for (let dependencyName in stateVarObj.dependencyNames
-                    .namesByKey[arrayKey]) {
-                    let extendedDepName =
-                        stateVarObj.dependencyNames.namesByKey[arrayKey][
-                            dependencyName
-                        ];
-                    if (extendedDepName in dependencyValues) {
-                        dependencyValuesByKey[arrayKey][dependencyName] =
-                            dependencyValues[extendedDepName];
-                        usedDefaultByKey[arrayKey][dependencyName] =
-                            usedDefault[extendedDepName];
-                    } else {
-                        foundAllDependencyValuesForKey[arrayKey] = false;
-                    }
-                }
-            }
-        }
-
-        return {
-            globalDependencyValues,
-            globalUsedDefault,
-            dependencyValuesByKey,
-            usedDefaultByKey,
-            foundAllDependencyValuesForKey,
-        };
-    }
-
-    stateVarObj.definition = function (args: any) {
-        // console.log(`definition in array ${stateVariable} of ${component.componentIdx}`)
-        // console.log(JSON.parse(JSON.stringify(args)));
-        // console.log(args.arrayKeys)
-        // console.log(args.dependencyValues)
-
-        if (args.arrayKeys === undefined) {
-            args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
-        }
-
-        if (
-            stateVarObj.basedOnArrayKeyStateVariables &&
-            args.arrayKeys.length > 1
-        ) {
-            // if based on array key state variables and have more than one array key
-            // then must have calculated all the relevant array keys
-            // when retrieving the dependency values
-            // Hence there is nothing to do, as arrayValues has been populated
-            // with all the requisite values
-
-            return {};
-        } else {
-            let extractedDeps = extractArrayDependencies(
-                args.dependencyValues,
-                args.arrayKeys,
-                args.usedDefault,
-            );
-            let globalDependencyValues = extractedDeps.globalDependencyValues;
-            let globalUsedDefault = extractedDeps.globalUsedDefault;
-            let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
-            let usedDefaultByKey = extractedDeps.usedDefaultByKey;
-            let foundAllDependencyValuesForKey =
-                extractedDeps.foundAllDependencyValuesForKey;
-
-            delete args.dependencyValues;
-            args.globalDependencyValues = globalDependencyValues;
-            args.globalUsedDefault = globalUsedDefault;
-            args.dependencyValuesByKey = dependencyValuesByKey;
-            args.usedDefaultByKey = usedDefaultByKey;
-
-            let arrayKeysToRecalculate = [];
-            let freshByKey = args.freshnessInfo.freshByKey;
-            for (let arrayKey of args.arrayKeys) {
-                // only recalculate if
-                // - arrayKey isn't fresh, and
-                // - found all dependency values for array key (i.e., have calculated dependencies for arrayKey)
-                if (
-                    !freshByKey[arrayKey] &&
-                    foundAllDependencyValuesForKey[arrayKey]
-                ) {
-                    freshByKey[arrayKey] = true;
-                    arrayKeysToRecalculate.push(arrayKey);
-                }
-            }
-
-            let result;
-            if (arrayKeysToRecalculate.length === 0) {
-                result = {};
-            } else {
-                args.arrayKeys = arrayKeysToRecalculate;
-
-                if (!stateVarObj.arrayDefinitionByKey) {
-                    throw Error(
-                        `For ${stateVariable} of ${component.componentType}, arrayDefinitionByKey must be a function`,
-                    );
-                }
-
-                result = stateVarObj.arrayDefinitionByKey(args);
-
-                // in case definition returns additional array entries,
-                // mark all array keys received as fresh as well
-                if (result.setValue && result.setValue[stateVariable]) {
-                    for (let arrayKey in result.setValue[stateVariable]) {
-                        freshByKey[arrayKey] = true;
-                    }
-                }
-                if (
-                    result.useEssentialOrDefaultValue &&
-                    result.useEssentialOrDefaultValue[stateVariable]
-                ) {
-                    for (let arrayKey in result.useEssentialOrDefaultValue[
-                        stateVariable
-                    ]) {
-                        freshByKey[arrayKey] = true;
-                    }
-                }
-            }
-
-            if (!args.freshnessInfo.freshArraySize) {
-                if (args.changes.__array_size) {
-                    result.arraySizeChanged = [stateVariable];
-                    if (stateVarObj.additionalStateVariablesDefined) {
-                        for (let varName of stateVarObj.additionalStateVariablesDefined) {
-                            // do we have to check if it is array?
-                            if (component.state[varName].isArray) {
-                                result.arraySizeChanged.push(varName);
-                            }
-                        }
-                    }
-                }
-                args.freshnessInfo.freshArraySize = true;
-            }
-
-            return result;
-        }
-    };
-
-    stateVarObj.inverseDefinition = function (args: any) {
-        // console.log(`inverse definition args for ${stateVariable}`)
-        // console.log(args)
-
-        if (!stateVarObj.inverseArrayDefinitionByKey) {
-            return { success: false };
-        }
-
-        if (args.arrayKeys === undefined) {
-            args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
-        }
-
-        if (
-            stateVarObj.basedOnArrayKeyStateVariables &&
-            args.arrayKeys.length > 1
-        ) {
-            let instructions = [];
-
-            for (let vName of allStateVariablesAffected) {
-                for (let key in args.desiredStateVariableValues[vName]) {
-                    let depName = vName + "_" + key;
-                    if (depName in args.dependencyValues) {
-                        instructions.push({
-                            setDependency: depName,
-                            desiredValue:
-                                args.desiredStateVariableValues[vName][key],
-                            treatAsInitialChange: args.initialChange,
-                        });
-                    }
-                }
-            }
-
-            return {
-                success: true,
-                instructions,
-            };
-        } else {
-            let extractedDeps = extractArrayDependencies(
-                args.dependencyValues,
-                args.arrayKeys,
-                args.usedDefault,
-            );
-            let globalDependencyValues = extractedDeps.globalDependencyValues;
-            let globalUsedDefault = extractedDeps.globalUsedDefault;
-            let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
-            let usedDefaultByKey = extractedDeps.usedDefaultByKey;
-
-            delete args.dependencyValues;
-            args.globalDependencyValues = globalDependencyValues;
-            args.globalUsedDefault = globalUsedDefault;
-            args.dependencyValuesByKey = dependencyValuesByKey;
-            args.usedDefaultByKey = usedDefaultByKey;
-
-            args.dependencyNamesByKey = stateVarObj.dependencyNames.namesByKey;
-
-            if (!stateVarObj.allowExtraArrayKeysInInverse) {
-                // by default, inverseArrayDefinitionByKey does not need to be
-                // programmed defensively against arrayKeys that don't exist
-                // as they are filtered out here.
-                // However, if allowExtraArrayKeysInInverse, then we skip this
-                // filtering to allow the possibility that the array size
-                // could be changed.
-                let newDesiredStateVariableValues: Record<string, any> = {};
-                for (let vName in args.desiredStateVariableValues) {
-                    newDesiredStateVariableValues[vName] = {};
-                    for (let key in args.desiredStateVariableValues[vName]) {
-                        if (args.arrayKeys.includes(key)) {
-                            newDesiredStateVariableValues[vName][key] =
-                                args.desiredStateVariableValues[vName][key];
-                        }
-                    }
-                }
-                args.desiredStateVariableValues = newDesiredStateVariableValues;
-            }
-
-            let result = stateVarObj.inverseArrayDefinitionByKey(args);
-            return result;
-        }
-    };
+    stateVarObj.inverseDefinition = arrayInverseDefinition;
 
     await createArraySizeStateVariable({
         core,
@@ -1503,59 +1575,14 @@ async function initializeArrayStateVariable({
     stateVarObj.arraySizeStale = true;
     stateVarObj.previousArraySize = [];
 
-    Object.defineProperty(stateVarObj, "arraySize", {
-        get: function () {
-            return (async () => {
-                if (
-                    !component.state[stateVarObj.arraySizeStateVariable]
-                        .initiallyResolved
-                ) {
-                    return [];
-                }
-                if (stateVarObj.arraySizeStale) {
-                    await stateVarObj.recalculateArraySizeDependentQuantities();
-                }
-                return await component.stateValues[
-                    stateVarObj.arraySizeStateVariable
-                ];
-            })();
-        },
-    });
+    Object.defineProperty(
+        stateVarObj,
+        "arraySize",
+        ARRAY_ARRAY_SIZE_DESCRIPTOR,
+    );
 
-    stateVarObj.recalculateArraySizeDependentQuantities = async function () {
-        let newArraySize =
-            await component.stateValues[stateVarObj.arraySizeStateVariable];
-        if (
-            stateVarObj.previousArraySize.length !== newArraySize.length ||
-            stateVarObj.previousArraySize.some(
-                (v: any, i: number) => v != newArraySize[i],
-            )
-        ) {
-            stateVarObj.previousArraySize = [...newArraySize];
-            let varNamesIncluding = (stateVarObj.varNamesIncludingArrayKeys =
-                {});
-            for (let entryName of stateVarObj.arrayEntryNames) {
-                let entryStateVarObj = component.state[entryName];
-                let arrayKeys = stateVarObj.getArrayKeysFromVarName({
-                    arrayEntryPrefix: entryStateVarObj.entryPrefix,
-                    varEnding: entryStateVarObj.varEnding,
-                    arraySize: newArraySize,
-                    numDimensions: stateVarObj.numDimensions,
-                });
-                entryStateVarObj._unflattenedArrayKeys = arrayKeys;
-                entryStateVarObj._arrayKeys = flattenDeep(arrayKeys);
-
-                // for each arrayKey, add this entry name to the array's list variables
-                for (let arrayKey of entryStateVarObj._arrayKeys) {
-                    if (!varNamesIncluding[arrayKey]) {
-                        varNamesIncluding[arrayKey] = [];
-                    }
-                    varNamesIncluding[arrayKey].push(entryName);
-                }
-            }
-        }
-        stateVarObj.arraySizeStale = false;
-    };
+    stateVarObj.recalculateArraySizeDependentQuantities =
+        arrayRecalculateArraySizeDependentQuantities;
 
     // link all freshnessInfo of additionalStateVariablesDefined
     // to the same object, as they will share the same freshnessinfo

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -65,6 +65,121 @@ export function installStaleValueGetter(stateVarObj: any) {
     Object.defineProperty(stateVarObj, "value", STALE_VALUE_DESCRIPTOR);
 }
 
+// ─── Shared array-entry machinery ───────────────────────────────────────
+// Module-level equivalents of what used to be per-entry closures in
+// `initializeArrayEntryStateVariable`. `this` is the array-ENTRY
+// state-variable object; the array it belongs to is reached via
+// `this.svComponent.state[this.arrayStateVariable]` (a state-variable
+// object's identity never changes once created, so the indirection is
+// stable).
+
+// Variant used when the class overrides `getEntryValues`.
+async function entryGetValueViaGetEntryValues(this: any) {
+    const arrayStateVarObj = this.svComponent.state[this.arrayStateVariable];
+    return await arrayStateVarObj.getEntryValues({
+        varName: this.svVarName,
+    });
+}
+
+// Default variant: returns the values corresponding to this entry's
+// arrayKeys (a scalar if there is just a single value), read from the
+// array's arrayValues via its getArrayValue.
+async function entryGetValueFromArrayValues(this: any) {
+    const arrayStateVarObj = this.svComponent.state[this.arrayStateVariable];
+    const arrayKeys = await this.arrayKeys;
+    if (arrayKeys.length === 0) {
+        return;
+    }
+    const value = [];
+    for (const arrayKey of arrayKeys) {
+        value.push(arrayStateVarObj.getArrayValue({ arrayKey }));
+    }
+    if (value.length === 1) {
+        return value[0];
+    } else {
+        return value;
+    }
+}
+
+function getEntryArrayKeys(this: any) {
+    return (async () => {
+        // first evaluate arraySize so _arrayKeys is recalculated
+        // in case arraySize change
+        await this.svComponent.state[this.arrayStateVariable].arraySize;
+        return this._arrayKeys;
+    })();
+}
+const ENTRY_ARRAY_KEYS_DESCRIPTOR: PropertyDescriptor = Object.freeze({
+    get: getEntryArrayKeys,
+});
+
+function getEntryUnflattenedArrayKeys(this: any) {
+    return (async () => {
+        // first evaluate arraySize so _unflattenedArrayKeys is recalculated
+        // in case arraySize change
+        await this.svComponent.state[this.arrayStateVariable].arraySize;
+        return this._unflattenedArrayKeys;
+    })();
+}
+const ENTRY_UNFLATTENED_ARRAY_KEYS_DESCRIPTOR: PropertyDescriptor =
+    Object.freeze({ get: getEntryUnflattenedArrayKeys });
+
+function getEntryArraySize(this: any) {
+    return this.svComponent.state[this.arrayStateVariable].arraySize;
+}
+const ENTRY_ARRAY_SIZE_DESCRIPTOR: PropertyDescriptor = Object.freeze({
+    get: getEntryArraySize,
+});
+
+function getEntryArrayEntrySize(this: any) {
+    return (async () => {
+        // assume array is rectangular, so just look at first subarray of each dimension
+        let unflattenedArrayKeys = await this.unflattenedArrayKeys;
+        let arrayEntrySize: number[] = [];
+        let subArray = [unflattenedArrayKeys];
+        for (let i = 0; i < this.numDimensions; i++) {
+            subArray = subArray[0];
+            arrayEntrySize.push(subArray.length);
+        }
+        arrayEntrySize.reverse(); // so starts with inner dimension
+        return arrayEntrySize;
+    })();
+}
+const ENTRY_ARRAY_ENTRY_SIZE_DESCRIPTOR: PropertyDescriptor = Object.freeze({
+    get: getEntryArrayEntrySize,
+});
+
+// returnDependencies for an array entry delegates to the array's
+// returnDependencies, adding this entry's arraySize/arrayKeys to the
+// arguments.
+async function entryReturnDependencies(this: any, args: any) {
+    const arrayStateVarObj = this.svComponent.state[this.arrayStateVariable];
+
+    // add array size to argument of return dependencies
+    args.arraySize = await this.arraySize;
+    args.arrayKeys = await this.arrayKeys;
+    let dependencies = await arrayStateVarObj.returnDependencies(args);
+
+    // We keep track of how many names were defined when we calculate dependencies
+    // If this number changes, it should be treated as dependencies changing
+    // so that we recalculate the value of the arrayEntry variable
+    // TODO: we are communicating this to updateDependencies by adding
+    // an attribute to the arguments?  Is there a better way of doing it.
+    // Didn't want to add to the return value, as that would add complexity
+    // to how we normally define returnDependencies
+    // We could change returnDependencies to output an object.
+    // That would probably be cleaner.
+    let numNames = Object.keys(
+        arrayStateVarObj.dependencyNames.namesByKey,
+    ).length;
+    if (this.numberNamesInPreviousReturnDep !== numNames) {
+        args.changedDependency = true;
+    }
+    this.numberNamesInPreviousReturnDep = numNames;
+
+    return dependencies;
+}
+
 export async function initializeComponentStateVariables({
     core,
     component,
@@ -270,32 +385,14 @@ async function initializeArrayEntryStateVariable({
     if (arrayStateVarObj.getEntryValues) {
         // the function getEntryValues must have been overwritten by the class
         // so use this function instead
-        stateVarObj.getValueFromArrayValues = async function () {
-            return await arrayStateVarObj.getEntryValues({
-                varName: stateVariable,
-            });
-        };
+        stateVarObj.getValueFromArrayValues = entryGetValueViaGetEntryValues;
     } else {
         // getValueFromArrayValues returns an array of the values
         // that correspond to the arrayKeys of this entry state variable
         // (returning a scalar instead if it is just a single value)
         // It uses the function getArrayValue, which gets the values
         // from arrayValues of the corresponding array state variable
-        stateVarObj.getValueFromArrayValues = async function () {
-            let arrayKeys = await stateVarObj.arrayKeys;
-            if (arrayKeys.length === 0) {
-                return;
-            }
-            let value = [];
-            for (let arrayKey of arrayKeys) {
-                value.push(arrayStateVarObj.getArrayValue({ arrayKey }));
-            }
-            if (value.length === 1) {
-                return value[0];
-            } else {
-                return value;
-            }
-        };
+        stateVarObj.getValueFromArrayValues = entryGetValueFromArrayValues;
     }
 
     stateVarObj.arraySizeStateVariable =
@@ -304,27 +401,17 @@ async function initializeArrayEntryStateVariable({
     stateVarObj._arrayKeys = [];
     stateVarObj._unflattenedArrayKeys = [];
 
-    Object.defineProperty(stateVarObj, "arrayKeys", {
-        get: function () {
-            return (async () => {
-                // first evaluate arraySize so _arrayKeys is recalculated
-                // in case arraySize change
-                await arrayStateVarObj.arraySize;
-                return stateVarObj._arrayKeys;
-            })();
-        },
-    });
+    Object.defineProperty(
+        stateVarObj,
+        "arrayKeys",
+        ENTRY_ARRAY_KEYS_DESCRIPTOR,
+    );
 
-    Object.defineProperty(stateVarObj, "unflattenedArrayKeys", {
-        get: function () {
-            return (async () => {
-                // first evaluate arraySize so _unflattenedArrayKeys is recalculated
-                // in case arraySize change
-                await arrayStateVarObj.arraySize;
-                return stateVarObj._unflattenedArrayKeys;
-            })();
-        },
-    });
+    Object.defineProperty(
+        stateVarObj,
+        "unflattenedArrayKeys",
+        ENTRY_UNFLATTENED_ARRAY_KEYS_DESCRIPTOR,
+    );
 
     if (component.state[stateVarObj.arraySizeStateVariable].initiallyResolved) {
         let arraySize = await arrayStateVarObj.arraySize;
@@ -350,28 +437,18 @@ async function initializeArrayEntryStateVariable({
 
     arrayStateVarObj.arrayEntryNames.push(stateVariable);
 
-    Object.defineProperty(stateVarObj, "arraySize", {
-        get: () => arrayStateVarObj.arraySize,
-    });
+    Object.defineProperty(
+        stateVarObj,
+        "arraySize",
+        ENTRY_ARRAY_SIZE_DESCRIPTOR,
+    );
 
     // TODO: delete since arrayEntrySize isn't currently used?
-    Object.defineProperty(stateVarObj, "arrayEntrySize", {
-        get: function () {
-            return (async () => {
-                // assume array is rectangular, so just look at first subarray of each dimension
-                let unflattenedArrayKeys =
-                    await stateVarObj.unflattenedArrayKeys;
-                let arrayEntrySize: number[] = [];
-                let subArray = [unflattenedArrayKeys];
-                for (let i = 0; i < stateVarObj.numDimensions; i++) {
-                    subArray = subArray[0];
-                    arrayEntrySize.push(subArray.length);
-                }
-                arrayEntrySize.reverse(); // so starts with inner dimension
-                return arrayEntrySize;
-            })();
-        },
-    });
+    Object.defineProperty(
+        stateVarObj,
+        "arrayEntrySize",
+        ENTRY_ARRAY_ENTRY_SIZE_DESCRIPTOR,
+    );
 
     if (arrayStateVarObj.stateVariablesDeterminingDependencies) {
         if (!stateVarObj.stateVariablesDeterminingDependencies) {
@@ -390,33 +467,7 @@ async function initializeArrayEntryStateVariable({
     }
 
     // add a returnDependencies function based on the array returnDependencies
-    let arrayReturnDependencies =
-        arrayStateVarObj.returnDependencies.bind(arrayStateVarObj);
-    stateVarObj.returnDependencies = async function (args: any) {
-        // add array size to argument of return dependencies
-        args.arraySize = await stateVarObj.arraySize;
-        args.arrayKeys = await stateVarObj.arrayKeys;
-        let dependencies = await arrayReturnDependencies(args);
-
-        // We keep track of how many names were defined when we calculate dependencies
-        // If this number changes, it should be treated as dependencies changing
-        // so that we recalculate the value of the arrayEntry variable
-        // TODO: we are communicating this to updateDependencies by adding
-        // an attribute to the arguments?  Is there a better way of doing it.
-        // Didn't want to add to the return value, as that would add complexity
-        // to how we normally define returnDependencies
-        // We could change returnDependencies to output an object.
-        // That would probably be cleaner.
-        let numNames = Object.keys(
-            arrayStateVarObj.dependencyNames.namesByKey,
-        ).length;
-        if (stateVarObj.numberNamesInPreviousReturnDep !== numNames) {
-            args.changedDependency = true;
-        }
-        stateVarObj.numberNamesInPreviousReturnDep = numNames;
-
-        return dependencies;
-    };
+    stateVarObj.returnDependencies = entryReturnDependencies;
 }
 
 async function initializeArrayStateVariable({

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -14,12 +14,14 @@ import {
  * materialization, size-tracking variables for arrays, and prop-index-to-
  * array-key resolution.
  *
- * The per-state-variable getter captures `core.getStateVariableValue` once
- * inside `initializeStateVariable`. This works today because Core's
- * constructor eagerly binds that method, so the captured reference stays
- * valid for the lifetime of the component. If a future phase moves
- * `getStateVariableValue` onto a separate manager, this capture must
- * become a lazy lookup so the binding source stays live.
+ * To avoid one closure (plus captured context) per state variable per
+ * component instance, the runtime behavior is provided by module-level
+ * functions shared across all state variables (the same approach as the
+ * `shadow*` functions in `StateVariableDefinitionFactory`). They read
+ * their per-variable parameters from fields on the state-variable object
+ * itself: `initializeStateVariable` stores the owning component as
+ * `svComponent` and the variable's own name as `svVarName`, and the
+ * shared functions reach core through `svComponent.coreFunctions`.
  *
  * Stateless — exported functions take a back-reference to Core to read
  * `stateVariableChangeTriggers` and to invoke `getStateVariableValue`,
@@ -27,6 +29,41 @@ import {
  * private helper `initializeArrayEntryStateVariable` needs none of these
  * and so does not take `core`.
  */
+
+/**
+ * The shared getter installed for `value` on every unresolved-or-stale
+ * state variable. `this` is the state-variable object the property is
+ * read from; evaluating the variable replaces the getter with a plain
+ * data property (see `installStaleValueGetter`).
+ */
+function getStaleStateVariableValue(this: any) {
+    return this.svComponent.coreFunctions.getStateVariableValue({
+        component: this.svComponent,
+        stateVariable: this.svVarName,
+    });
+}
+
+// One shared descriptor: `Object.defineProperty` copies the attributes out
+// of it, so reusing the object is safe.
+const STALE_VALUE_DESCRIPTOR: PropertyDescriptor = Object.freeze({
+    get: getStaleStateVariableValue,
+    configurable: true,
+});
+
+/**
+ * (Re-)install the lazy `value` getter on `stateVarObj`.
+ *
+ * Contract relied on elsewhere: `value` must remain an OWN accessor
+ * property while unresolved/stale (StateVariableEvaluator and
+ * StalenessPropagator detect staleness via
+ * `Object.getOwnPropertyDescriptor(stateVarObj, "value")?.get`), and
+ * evaluation replaces it with an own data property via
+ * `delete stateVarObj.value` + plain assignment.
+ */
+export function installStaleValueGetter(stateVarObj: any) {
+    delete stateVarObj.value;
+    Object.defineProperty(stateVarObj, "value", STALE_VALUE_DESCRIPTOR);
+}
 
 export async function initializeComponentStateVariables({
     core,
@@ -68,16 +105,18 @@ export async function initializeStateVariable({
     arrayStateVariable?: string;
     arrayEntryPrefix?: string;
 }) {
-    let getStateVar = core.getStateVariableValue;
     if (!component.state[stateVariable]) {
         component.state[stateVariable] = {};
     }
     let stateVarObj = component.state[stateVariable];
+    // Back-pointers read by the shared runtime functions (via `this`).
+    // Note: state-variable objects must never be JSON-serialized or
+    // deep-cloned wholesale — `svComponent` makes them cyclic. (Nothing
+    // does so today; persistence extracts individual values.)
+    stateVarObj.svComponent = component;
+    stateVarObj.svVarName = stateVariable;
     stateVarObj.isResolved = false;
-    Object.defineProperty(stateVarObj, "value", {
-        get: () => getStateVar({ component, stateVariable }),
-        configurable: true,
-    });
+    installStaleValueGetter(stateVarObj);
 
     if (arrayEntryPrefix !== undefined) {
         // Callers always pair `arrayEntryPrefix` with `arrayStateVariable`;

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -184,8 +184,7 @@ function multiDimSetArrayValue(
 
     let index = this.keyToIndex(arrayKey);
     let numDimensionsInArrayKey = index.length;
-    // Pre-existing typo fixed per CORE_REFACTOR_DEFERRED.md
-    // §"Pre-existing unreachable diagnostic": the original
+    // Pre-existing typo fix: the original
     // `!numDimensionsInArrayKey > stateVarObj.numDimensions`
     // evaluates to `false > number === false` for any positive
     // integer, so the diagnostic was unreachable.

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -24,8 +24,9 @@ import {
  * shared functions reach core through `svComponent.coreFunctions`.
  *
  * Stateless — exported functions take a back-reference to Core to read
- * `stateVariableChangeTriggers` and to invoke `getStateVariableValue`,
- * `checkIfArrayEntry`, `addDiagnostic`, and `createFromArrayEntry`. The
+ * `stateVariableChangeTriggers` and to invoke `checkIfArrayEntry`,
+ * `addDiagnostic`, and `createFromArrayEntry` (the shared runtime functions
+ * instead reach core through `svComponent.coreFunctions`, as above). The
  * private helper `initializeArrayEntryStateVariable` needs none of these
  * and so does not take `core`.
  */

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -992,6 +992,36 @@ const ARRAY_ARRAY_SIZE_DESCRIPTOR: PropertyDescriptor = Object.freeze({
     get: getArrayArraySize,
 });
 
+// ─── Shared array-size state-variable machinery ─────────────────────────
+// `this` is the __array_size_* state-variable object. Its parameters are
+// stored as fields when `createArraySizeStateVariable` builds it:
+// - arraySizeVarNamesAffected: the (sorted) array variables whose
+//   arraySizeStale is set on markStale
+// - arraySizeSourceVarName: the array variable whose returnArraySize
+//   computes the size (the first array of the group to create the size
+//   variable, matching the closure it replaces)
+
+function arraySizeDefinition(this: any, { dependencyValues }: any) {
+    let arraySize = this.svComponent.state[
+        this.arraySizeSourceVarName
+    ].returnArraySize({
+        dependencyValues,
+    });
+    for (let [ind, value] of arraySize.entries() as Iterable<[number, any]>) {
+        if (!(Number.isInteger(value) && value >= 0)) {
+            arraySize[ind] = 0;
+        }
+    }
+    return { setValue: { [this.svVarName]: arraySize } };
+}
+
+function arraySizeMarkStale(this: any) {
+    for (let varName of this.arraySizeVarNamesAffected) {
+        this.svComponent.state[varName].arraySizeStale = true;
+    }
+    return {};
+}
+
 async function arrayRecalculateArraySizeDependentQuantities(this: any) {
     const component = this.svComponent;
     let newArraySize = await component.stateValues[this.arraySizeStateVariable];
@@ -1641,37 +1671,19 @@ async function createArraySizeStateVariable({
     if (component.state[arraySizeStateVar]) {
         if (component.state[arraySizeStateVar].isShadow) {
             let arraySizeStateVarObj = component.state[arraySizeStateVar];
-            arraySizeStateVarObj.markStale = function () {
-                for (let varName of allStateVariablesAffected) {
-                    component.state[varName].arraySizeStale = true;
-                }
-                return {};
-            };
+            arraySizeStateVarObj.arraySizeVarNamesAffected =
+                allStateVariablesAffected;
+            arraySizeStateVarObj.markStale = arraySizeMarkStale;
         }
         return;
     }
 
     component.state[arraySizeStateVar] = {
         returnDependencies: stateVarObj.returnArraySizeDependencies,
-        definition({ dependencyValues }: any) {
-            let arraySize = stateVarObj.returnArraySize({
-                dependencyValues,
-            });
-            for (let [ind, value] of arraySize.entries() as Iterable<
-                [number, any]
-            >) {
-                if (!(Number.isInteger(value) && value >= 0)) {
-                    arraySize[ind] = 0;
-                }
-            }
-            return { setValue: { [arraySizeStateVar]: arraySize } };
-        },
-        markStale() {
-            for (let varName of allStateVariablesAffected) {
-                component.state[varName].arraySizeStale = true;
-            }
-            return {};
-        },
+        definition: arraySizeDefinition,
+        markStale: arraySizeMarkStale,
+        arraySizeVarNamesAffected: allStateVariablesAffected,
+        arraySizeSourceVarName: stateVariable,
     };
 
     if (stateVarObj.stateVariablesDeterminingArraySizeDependencies) {

--- a/packages/doenetml-worker-rust/lib-js-wasm-binding/src/lib.rs
+++ b/packages/doenetml-worker-rust/lib-js-wasm-binding/src/lib.rs
@@ -29,7 +29,6 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 pub struct PublicDoenetMLCore {
     core: Core,
     dast_root: Option<DastRoot>,
-    source: String,
     flags_json: Option<String>,
     initialized: bool,
 }
@@ -82,17 +81,26 @@ impl PublicDoenetMLCore {
         PublicDoenetMLCore {
             core: Core::new(),
             dast_root: None,
-            source: "".to_string(),
             flags_json: None,
             initialized: false,
         }
     }
 
-    pub fn set_source(&mut self, dast: DastRoot, source: &str) -> Result<(), String> {
+    // `source` is unused; the parameter is kept so the JS-side calling
+    // convention does not change.
+    pub fn set_source(&mut self, dast: DastRoot, _source: &str) -> Result<(), String> {
         self.dast_root = Some(dast);
-        self.source = source.to_string();
         self.initialized = false;
         Ok(())
+    }
+
+    /// Drop the data that is only needed while initializing a core
+    /// (currently the document's DAST, which for large documents holds
+    /// megabytes of WASM linear memory). Called by the worker once the
+    /// JavaScript core has consumed the normalized DAST; calling
+    /// `set_source` again repopulates the data.
+    pub fn release_initialization_data(&mut self) {
+        self.dast_root = None;
     }
 
     pub fn set_flags(&mut self, flags: &str) {

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -322,6 +322,11 @@ export class CoreWorker {
                     calculateRootNames,
                 });
             this.javascript_initialized = true;
+            // The JavaScript core has consumed the normalized DAST; free the
+            // Rust core's retained copy of the document DAST (the rust
+            // core-type path still needs it for later
+            // `returnNormalizedDastRoot` calls, so only release here).
+            this.doenetCore.release_initialization_data();
             return initializedResult;
         } catch (err) {
             console.error(err);
@@ -488,6 +493,11 @@ export class CoreWorker {
             calculateRootNames,
         });
         this.javascript_initialized = true;
+        // The JavaScript core has consumed the normalized DAST; free the
+        // Rust core's retained copy of the document DAST (the rust core-type
+        // path still needs it for later `returnNormalizedDastRoot` calls, so
+        // only release here).
+        this.doenetCore.release_initialization_data();
 
         const args = {
             coreId: "a",

--- a/packages/doenetml/dev/testCode.doenet
+++ b/packages/doenetml/dev/testCode.doenet
@@ -1,17 +1,14 @@
-<booleanInput name="bi" />
+<setup>
+    <module name="testModule">
+        <moduleAttributes>
+            <math name="ans" />
+        </moduleAttributes>
+        Hi $ans.
+    </module>
+</setup>
 
-<conditionalContent>
-     <case condition="$bi">A</case>
+<module copy="$testModule" ans="57" ba="23" />
 
-    <else>
-        <p>
-            <updateValue
-                name="addPoint1"
-                target="$bi"
-                newValue="true"
-                type="boolean"
-            />
-        </p>
-    </else>
-
-</conditionalContent>
+<graph>
+    <point>(3,5)</point>
+</graph>

--- a/packages/doenetml/dev/testCode.doenet
+++ b/packages/doenetml/dev/testCode.doenet
@@ -1,14 +1,17 @@
-<setup>
-    <module name="testModule">
-        <moduleAttributes>
-            <math name="ans" />
-        </moduleAttributes>
-        Hi $ans.
-    </module>
-</setup>
+<booleanInput name="bi" />
 
-<module copy="$testModule" ans="57" ba="23" />
+<conditionalContent>
+     <case condition="$bi">A</case>
 
-<graph>
-    <point>(3,5)</point>
-</graph>
+    <else>
+        <p>
+            <updateValue
+                name="addPoint1"
+                target="$bi"
+                newValue="true"
+                type="boolean"
+            />
+        </p>
+    </else>
+
+</conditionalContent>


### PR DESCRIPTION
**Stacked on #1460** — the first 4 commits here are that PR; review the commits on top of it (items 15–19 below). Will rebase onto `main` once #1460 merges.

First of #1458's two levers ("slim runtime state-variable objects"): replace the per-state-variable closures built by `StateVariableInitializer` with **module-level functions shared across all state variables**, parameterized by `this` — the same approach #1451 applied to the shadow-definition functions, now applied to the ~10× larger runtime population (~400k state-variable objects on a large repeat document vs ~40k shadow definitions). Builds on #1460 (benchmark baselines below are measured against it).

15. **Back-pointers + one shared `value` getter.** Every state variable
    installed a fresh arrow-function getter capturing
    `{getStateVar, component, stateVariable}` — once at initialization and
    again on **every stale-mark** (`StalenessPropagator` rebuilt the closure on
    each invalidation, so this was interaction-time churn too, not just load
    cost). A post-#1451 heap analysis attributed **~27.7 MB** of closure
    contexts to these getters alone.

    `initializeStateVariable` now stores two back-pointer fields on each
    state-variable object (`svComponent`, `svVarName`), and one module-level
    getter reads its parameters from `this`, reaching core through the
    per-core `coreFunctions` bag (extended with `getStateVariableValue` and
    `addDiagnostic`, marked as runtime plumbing rather than component-facing
    API). Both install sites converge on a single exported
    `installStaleValueGetter` helper; `value` remains an **own** accessor
    (delete/redefine lifecycle and the two
    `Object.getOwnPropertyDescriptor(..., "value")?.get` staleness checks are
    unchanged), and the property descriptor object itself is shared and
    frozen.

16. **Shared array-entry machinery.** The 6 per-entry closures
    (`getValueFromArrayValues`, the `arrayKeys` / `unflattenedArrayKeys` /
    `arraySize` / `arrayEntrySize` getters, and the entry
    `returnDependencies`) become shared functions; the entry's array object is
    reached via `this.svComponent.state[this.arrayStateVariable]` (safe:
    state-variable-object identity never changes after creation — the only
    assignment sites are the `BaseComponent` constructor and
    `initializeStateVariable` itself). The per-entry
    `.bind(arrayStateVarObj)` on the array's `returnDependencies` disappears —
    the shared function calls it method-style.

17. **Shared simple array machinery.** ~8 more closures per array variable
    (`keyToIndex`, `setArrayValue`, `getArrayValue`, `getAllArrayKeys` /
    `arrayVarNameFromArrayKey` / `returnEntryDimensions` defaults,
    `adjustArrayToNewArraySize`, `indexToKey`) become shared functions (one
    per dimensionality where implementations differ); diagnostics go through
    `svComponent.coreFunctions.addDiagnostic`. The `getArrayKeysFromVarName` /
    `arrayVarNameFromPropIndex` defaults are deliberately left per-instance
    for now: they must stay receiver-free (class-level description objects
    also invoke them), so they move to the per-class definition normalization
    in the follow-up PR instead.

18. **Shared heavyweight array closures.** `returnDependencies` (from
    `returnArrayDependenciesByKey`), `getCurrentFreshness`, `markStale`,
    `freshenOnNoChanges`, `definition` (from `arrayDefinitionByKey`),
    `inverseDefinition`, the `arraySize` getter,
    `recalculateArraySizeDependentQuantities`, and the
    `extractArrayDependencies` helper. The subtle part: array **entries**
    receive field copies of the array's `definition` / `inverseDefinition` /
    `markStale` and invoke them with the *entry* as receiver, while all
    bookkeeping (dependencyNames, freshness keys, setValue keys) must use the
    **array's** object and variable name — the old closures guaranteed this by
    capture, and `_remapArrayEntryFreshness` depends on it. Every
    entry-invocable shared function therefore starts with a
    `resolveArrayStateVarObj(this)` prologue and keys freshness by the array's
    `svVarName`. This commit also removed 3 pre-existing TypeScript errors
    that lived inside the replaced closures (baseline 38 → 35).

19. **Shared array-size machinery.** The `__array_size_*` state variable's
    `definition` / `markStale` (and the shadow-path `markStale` override)
    become shared functions parameterized by two fields
    (`arraySizeVarNamesAffected`, `arraySizeSourceVarName` — the first array
    of the group to create the size variable, matching the closure it
    replaces).

Numbering continues #1435 (1–4), #1451 (5–10), and #1460 (11–14).

Net effect on a state-variable object: behavior moved from per-instance
closures to a few plain data fields + shared function references. Besides the
memory, this removes the per-stale-mark closure/context/descriptor allocation
on every invalidation, and it is a prerequisite-shaped step toward #1459 (lazy
materialization): a state variable's runtime behavior is now fully determined
by data on the object.

## Measured

**Node worker heap** (ad-hoc script constructing one core on the generated
`repeat-250` document, `--expose-gc`, heapUsed after GC; same methodology as
#1435/#1451): **1735 → 1403 MB (−332 MB, −19.1%)** vs the #1460 branch.

**Browser PSS** (`packages/memory-benchmark`, paired same-machine runs, base =
the #1460 branch):

| scenario | base (MB) | this PR (MB) | delta |
| --- | --- | --- | --- |
| blank | 203 | 203 | 0 |
| direct-1 | 573 | 573 | 0 |
| iframe-1 | 572 | 573 | +1 |
| direct-4 | 983 | 984 | +1 |
| iframe-4 | 1193 | 1193 | 0 |
| repeat-25 | 729 | 710 | **−19** |
| repeat-250 | 1388 | 1294 | **−94** |

Document-scaling cost over the small document: repeat-25 **156 → 137 MB
(−12.2%)**, repeat-250 **815 → 721 MB (−11.5%)** — i.e. ~0.65 → ~0.58 MB per
component, with fixed and per-instance costs unchanged (as expected: the
change is purely per-state-variable). The delta grows ~5× from repeat-25 to
repeat-250 (−19 → −94 MB), consistent with a per-component effect.

## Verification

- Full `doenetml-worker-javascript` suite per the 4 groups: **3,071 passed /
  0 failed**. Typecheck: 35 errors vs 38 on the base branch (3 pre-existing
  errors lived in replaced closures; none new).
- Browser memory benchmark: table above (paired same-machine runs vs #1460's
  branch).

No changeset: internal worker memory changes with no author-visible behavior
change (same rationale as #1435/#1451/#1460).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

