### PR TITLE
Memory: install class-invariant array defaults on shared class definitions

### DIFF
--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -5,6 +5,7 @@ import {
     validateListItemsAgainstValidValues,
 } from "../utils/attributes";
 import type { AttributeDefinition } from "../utils/dast/types";
+import { normalizeArrayStateVariableDefaults } from "./StateVariableInitializer";
 
 /**
  * Map from `attributeSpecification.createPrimitiveOfType` codes to the
@@ -82,6 +83,13 @@ function getClassStateVariableDefinitions(core: Core, componentClass: any) {
             );
         // class definitions win on a name collision, as before
         Object.assign(combined, normalized);
+        // Install the class-invariant array defaults (keyToIndex,
+        // getAllArrayKeys, entryPrefixes fallback, ...) once per class, so
+        // instances don't re-assign them as own properties. Covers the
+        // `normalized` map too: its values are the same objects.
+        for (const varName in combined) {
+            normalizeArrayStateVariableDefaults(combined[varName], varName);
+        }
         (combined as any)[SHARED_STATE_VARIABLE_DEFINITIONS] = true;
         entry = { combined, normalized };
         perCore.set(componentClass, entry);

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -992,6 +992,76 @@ const ARRAY_ARRAY_SIZE_DESCRIPTOR: PropertyDescriptor = Object.freeze({
     get: getArrayArraySize,
 });
 
+/**
+ * Populate the class-invariant array defaults directly on a (shared,
+ * per-class) state-variable definition, so component instances inherit
+ * them through their definition prototype (non-shadow path) or pick them
+ * up in their flat per-instance clone (adapter/shadow path) instead of
+ * each instance assigning the same values as own properties.
+ *
+ * Called by `StateVariableDefinitionFactory.getClassStateVariableDefinitions`
+ * while building the per-class definition cache. `initializeArrayStateVariable`
+ * keeps guarded fallbacks for array definitions created outside that cache.
+ *
+ * All defaults installed here must be receiver-free or read only fields
+ * present on both definitions and runtime state-variable objects
+ * (class-level description objects also invoke `getArrayKeysFromVarName`
+ * and `arrayVarNameFromPropIndex`).
+ */
+export function normalizeArrayStateVariableDefaults(def: any, varName: string) {
+    if (!def.isArray) {
+        return;
+    }
+
+    if (def.numDimensions === undefined) {
+        def.numDimensions = 1;
+    }
+    if (!def.entryPrefixes) {
+        def.entryPrefixes = [varName];
+    }
+
+    const multiDim = def.numDimensions > 1;
+
+    if (!def.keyToIndex) {
+        def.keyToIndex = multiDim ? multiDimKeyToIndex : oneDimKeyToIndex;
+    }
+    if (!def.indexToKey) {
+        def.indexToKey = arrayIndexToKey;
+    }
+    if (!def.getAllArrayKeys) {
+        def.getAllArrayKeys = multiDim
+            ? multiDimGetAllArrayKeys
+            : oneDimGetAllArrayKeys;
+    }
+    if (!def.getArrayKeysFromVarName) {
+        def.getArrayKeysFromVarName = returnDefaultGetArrayKeysFromVarName(
+            def.numDimensions,
+        );
+    }
+    if (!def.arrayVarNameFromArrayKey) {
+        def.arrayVarNameFromArrayKey = multiDim
+            ? defaultMultiDimArrayVarNameFromArrayKey
+            : defaultOneDimArrayVarNameFromArrayKey;
+    }
+    if (!def.arrayVarNameFromPropIndex) {
+        // one closure per (class, variable) — was one per component instance
+        def.arrayVarNameFromPropIndex = returnDefaultArrayVarNameFromPropIndex(
+            def.numDimensions,
+            def.entryPrefixes[0],
+        );
+    }
+    if (!def.returnEntryDimensions) {
+        def.returnEntryDimensions = defaultReturnEntryDimensions;
+    }
+    if (
+        def.shadowingInstructions &&
+        !def.shadowingInstructions.returnWrappingComponents
+    ) {
+        def.shadowingInstructions.returnWrappingComponents =
+            defaultReturnWrappingComponents;
+    }
+}
+
 // ─── Shared array-size state-variable machinery ─────────────────────────
 // `this` is the __array_size_* state-variable object. Its parameters are
 // stored as fields when `createArraySizeStateVariable` builds it:
@@ -1454,7 +1524,9 @@ async function initializeArrayStateVariable({
         // (useful, for example, to set entire rows)
         // If it has more dimensinos than numDimensions, behavior isn't determined
         // (it should throw an error, assuming the array entries aren't arrays)
-        stateVarObj.keyToIndex = multiDimKeyToIndex;
+        if (!stateVarObj.keyToIndex) {
+            stateVarObj.keyToIndex = multiDimKeyToIndex;
+        }
         stateVarObj.setArrayValue = multiDimSetArrayValue;
         stateVarObj.getArrayValue = multiDimGetArrayValue;
 
@@ -1490,7 +1562,9 @@ async function initializeArrayStateVariable({
             multiDimAdjustArrayToNewArraySize;
     } else {
         // have just one dimension
-        stateVarObj.keyToIndex = oneDimKeyToIndex;
+        if (!stateVarObj.keyToIndex) {
+            stateVarObj.keyToIndex = oneDimKeyToIndex;
+        }
         stateVarObj.setArrayValue = oneDimSetArrayValue;
         stateVarObj.getArrayValue = oneDimGetArrayValue;
 
@@ -1527,7 +1601,9 @@ async function initializeArrayStateVariable({
             returnDefaultGetArrayKeysFromVarName(stateVarObj.numDimensions);
     }
 
-    stateVarObj.indexToKey = arrayIndexToKey;
+    if (!stateVarObj.indexToKey) {
+        stateVarObj.indexToKey = arrayIndexToKey;
+    }
 
     if (!stateVarObj.returnEntryDimensions) {
         stateVarObj.returnEntryDimensions = defaultReturnEntryDimensions;

--- a/packages/doenetml-worker-javascript/src/utils/stateVariables.js
+++ b/packages/doenetml-worker-javascript/src/utils/stateVariables.js
@@ -100,59 +100,70 @@ export function renameStateVariable({
     }
 }
 
-export function returnDefaultGetArrayKeysFromVarName(numDim) {
-    // the default function for getArrayKeysFromVarName ignores the
-    // array entry prefix, but is just based on the variable ending.
-    // A component class's function could use arrayEntryPrefix
+// The default functions for getArrayKeysFromVarName ignore the
+// array entry prefix, but are just based on the variable ending.
+// A component class's function could use arrayEntryPrefix.
+// They are shared module-level functions (rather than closures created
+// per call) so that every array state variable using the default holds
+// a reference to the same function.
 
-    if (numDim > 1) {
-        return function ({
-            arrayEntryPrefix,
-            varEnding,
-            arraySize,
-            numDimensions,
-        }) {
-            let indices = varEnding.split("_").map((x) => Number(x) - 1);
-            if (
-                indices.length === numDimensions &&
-                indices.every((x, i) => Number.isInteger(x) && x >= 0)
-            ) {
-                if (arraySize) {
-                    if (indices.every((x, i) => x < arraySize[i])) {
-                        return [String(indices)];
-                    } else {
-                        return [];
-                    }
-                } else {
-                    // If not given the array size,
-                    // then return the array keys assuming the array is large enough.
-                    // Must do this as it is used to determine potential array entries.
-                    return [String(indices)];
-                }
+function defaultGetArrayKeysFromVarNameMultiDim({
+    arrayEntryPrefix,
+    varEnding,
+    arraySize,
+    numDimensions,
+}) {
+    let indices = varEnding.split("_").map((x) => Number(x) - 1);
+    if (
+        indices.length === numDimensions &&
+        indices.every((x, i) => Number.isInteger(x) && x >= 0)
+    ) {
+        if (arraySize) {
+            if (indices.every((x, i) => x < arraySize[i])) {
+                return [String(indices)];
             } else {
                 return [];
             }
-        };
+        } else {
+            // If not given the array size,
+            // then return the array keys assuming the array is large enough.
+            // Must do this as it is used to determine potential array entries.
+            return [String(indices)];
+        }
     } else {
-        return function ({ arrayEntryPrefix, varEnding, arraySize }) {
-            let index = Number(varEnding) - 1;
-            if (Number.isInteger(index) && index >= 0) {
-                if (arraySize) {
-                    if (index < arraySize[0]) {
-                        return [String(index)];
-                    } else {
-                        return [];
-                    }
-                } else {
-                    // If not given the array size,
-                    // then return the array keys assuming the array is large enough.
-                    // Must do this as it is used to determine potential array entries.
-                    return [String(index)];
-                }
+        return [];
+    }
+}
+
+function defaultGetArrayKeysFromVarNameOneDim({
+    arrayEntryPrefix,
+    varEnding,
+    arraySize,
+}) {
+    let index = Number(varEnding) - 1;
+    if (Number.isInteger(index) && index >= 0) {
+        if (arraySize) {
+            if (index < arraySize[0]) {
+                return [String(index)];
             } else {
                 return [];
             }
-        };
+        } else {
+            // If not given the array size,
+            // then return the array keys assuming the array is large enough.
+            // Must do this as it is used to determine potential array entries.
+            return [String(index)];
+        }
+    } else {
+        return [];
+    }
+}
+
+export function returnDefaultGetArrayKeysFromVarName(numDim) {
+    if (numDim > 1) {
+        return defaultGetArrayKeysFromVarNameMultiDim;
+    } else {
+        return defaultGetArrayKeysFromVarNameOneDim;
     }
 }
 


### PR DESCRIPTION
Final PR of #1458's memory series. #1460 and #1461 have merged, and this branch is now rebased onto `main`, so its diff is just the single commit for item 20.

Second lever of #1458 ("slim runtime state-variable objects"), completing the issue: move the class-invariant per-state-variable default assignments from per-instance initialization time to per-class definition-normalization time.

20. **Class-invariant array defaults installed once per class.**
    `initializeArrayStateVariable` assigned ~10 defaults on every array state
    variable of every component instance — `numDimensions`, the
    `entryPrefixes` fallback, `keyToIndex`, `indexToKey`, `getAllArrayKeys`,
    `getArrayKeysFromVarName`, `arrayVarNameFromArrayKey`,
    `arrayVarNameFromPropIndex`, `returnEntryDimensions`, and
    `shadowingInstructions.returnWrappingComponents`. A new
    `normalizeArrayStateVariableDefaults` pass inside
    `getClassStateVariableDefinitions` now installs them **once per component
    class** when the per-class definition cache (from #1435) is built.

    - Non-shadow instances inherit the fields through the existing
      `Object.create` definition wrapper — the own-property slots disappear.
    - Adapter/reference-shadow clones pick them up by copy — shared function
      references on flat objects, exactly as before.
    - The initializer keeps guarded fallbacks (`if (!stateVarObj.X)`) so an
      array definition created outside the class cache still works; for
      cache-normalized definitions the guards never fire.
    - `returnDefaultGetArrayKeysFromVarName` now returns one of two shared
      module-level functions instead of building a fresh closure per call —
      this deduplicates every caller, including the description objects built
      by `BaseComponent.returnStateVariableInfo` (which must stay
      receiver-free, the reason these two defaults were not converted to
      `this`-based functions in #1461).
    - `returnDefaultArrayVarNameFromPropIndex` still builds a closure (it is
      parameterized by the entry prefix), but once per `(class, variable)`
      instead of once per component instance.

Numbering continues #1435 (1–4), #1451 (5–10), #1460 (11–14), #1461 (15–19).

**Explicit non-goal** (possible follow-up): hoisting the *runtime machinery*
references (`definition`, `markStale`, `setArrayValue`, …) onto class
definitions as well — feasible now that they are `this`-based, but it
interacts with the shadow-path `arrayDefinitionByKey` overrides, so this PR
stays mechanical.

Closes #1458.

## Measured — honest framing: this is a structural completion, not a big lever

Node worker heap vs the #1461 branch: `repeat-250` **1403.0 → 1402.7 MB** and
an array-heavy variant (repeat-150 of point/point/line in a graph, exercising
many array state variables) **969.2 → 968.4 MB** — i.e. **within noise**.
Browser PSS agrees: `repeat-250` 1259 → 1267 MB (+8, well inside the ±35 MB
run-to-run variance observed for the base branch itself), all other scenarios
±5 MB.

The reason: #1461 already eliminated the heavyweight per-array closures, and
its commit 3 already pointed the guarded defaults at shared functions. What
this PR removes per array state variable is small — one
`getArrayKeysFromVarName` closure, one `arrayVarNameFromPropIndex` closure,
and ~10 own-property slots (the slots only on directly-created components;
shadow clones copy the fields either way) — roughly 100–200 bytes per array
state variable, and the benchmark documents are dominated by scalar variables
and shadow clones.

The value is structural rather than measured: array defaults now live on the
class definitions where they belong (the initializer shrinks accordingly),
description objects share the same defaults, and a definition is now fully
self-contained per class — the shape #1459 (lazy materialization) needs, and
the prerequisite for the runtime-machinery hoist described below if it ever
becomes worth doing.

## Verification

- Full `doenetml-worker-javascript` suite per the 4 groups: **3,071 passed /
  0 failed**. Typecheck unchanged from the base branch (35 errors, all
  pre-existing).
- Shadow/copy-path smoke suites (unlinked copy, repeat, conditionalcontent)
  pass — the riskiest path, since shadow clones now copy the normalized
  defaults.

No changeset: internal worker memory changes with no author-visible behavior
change (same rationale as the rest of the series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

