### PR TITLE
Shared core-worker host: multiplex document cores onto shared workers

### DIFF
--- a/.changeset/shared-core-worker-host.md
+++ b/.changeset/shared-core-worker-host.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Opt-in shared core-worker host: multiplex document cores onto shared workers.
+
+Setting `doenetGlobalConfig.useSharedCoreWorker = true` makes viewers on a page share core workers (up to `sharedCoreWorkerMaxCores` cores per worker, default 12) instead of booting one ~100 MB dedicated worker per document. Each document's core runs independently on its own message channel with the same API as before; tearing down one document releases only its core. Measured on the memory benchmark: 8 viewers drop from ~1455 MB to ~584 MB total (marginal cost per additional viewer ~136 MB → ~12 MB).
+
+Default off. Trade-off when opted in: a worker-level hang or crash affects every document on that worker (per-core teardown is still individual); the recovery escalation ladder is tracked in #1466.

--- a/.changeset/shared-core-worker-host.md
+++ b/.changeset/shared-core-worker-host.md
@@ -8,4 +8,6 @@ Opt-in shared core-worker host: multiplex document cores onto shared workers.
 
 Setting `doenetGlobalConfig.useSharedCoreWorker = true` makes viewers on a page share core workers (up to `sharedCoreWorkerMaxCores` cores per worker, default 12) instead of booting one ~100 MB dedicated worker per document. Each document's core runs independently on its own message channel with the same API as before; tearing down one document releases only its core. Measured on the memory benchmark: 8 viewers drop from ~1455 MB to ~584 MB total (marginal cost per additional viewer ~136 MB → ~12 MB).
 
+For iframe embedding, `@doenet/doenetml-iframe`'s `DoenetViewer` gains a `useSharedCoreWorker` prop: the parent page owns the shared worker pool and forwards each iframe's core over a `MessagePort`, so the cores of many same-origin iframes — which cannot share workers on their own — multiplex onto parent-owned workers (pools are keyed per standalone version). This works with the default CDN-served bundle (the worker is loaded via a same-origin `importScripts` bootstrap when cross-origin).
+
 Default off. Trade-off when opted in: a worker-level hang or crash affects every document on that worker (per-core teardown is still individual); the recovery escalation ladder is tracked in #1466.

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -3,6 +3,10 @@
 declare const viewerId: string;
 declare const doenetViewerProps: Record<string, any>;
 declare const doenetViewerPropsSpecified: string[];
+// Baked into the srcdoc when the parent component opts into the shared
+// core-worker host (#1466). Guarded with `typeof` at the use site so this
+// script also works in srcdocs generated without the const.
+declare const doenetSharedCoreWorker: boolean | undefined;
 declare const ComlinkViewer: { expose: Function; windowEndpoint: Function };
 interface Window {
     renderDoenetViewerToContainer: (
@@ -10,6 +14,7 @@ interface Window {
         doenetMLSource?: string,
         config?: object,
     ) => void;
+    doenetGlobalConfig: Record<string, any>;
 }
 
 // Wait for the @doenet/standalone bundle to finish evaluating and
@@ -91,8 +96,49 @@ function renderViewerWithFunctionProps(...args: (string | Function)[]) {
 // rationale — nothing inside is expected to throw, but an unhandled
 // rejection inside the iframe is hard to diagnose, so log locally and
 // try to surface an error to the parent.
+/**
+ * Route this realm's core creation to the PARENT page's shared worker pool
+ * (#1466): install `doenetGlobalConfig.createExternalCoreWorkerPort` so the
+ * viewer obtains each core over a locally-minted `MessageChannel` whose far
+ * port the parent forwards to a shared host worker's `createCore`. Messages
+ * the viewer sends on its port buffer until the core is exposed, so core
+ * creation stays synchronous here. `destroy` notifies the parent to release
+ * the core (forwarding wedge suspicion for host quarantine).
+ *
+ * Must run after the standalone bundle has evaluated — the bundle replaces
+ * `window.doenetGlobalConfig` — and before anything renders a viewer.
+ */
+function installSharedCorePortProvider() {
+    let coreCounter = 0;
+    window.doenetGlobalConfig.createExternalCoreWorkerPort = () => {
+        const coreId = `${viewerId}-core-${++coreCounter}`;
+        const channel = new MessageChannel();
+        window.parent.postMessage(
+            { origin: viewerId, data: { type: "createSharedCore", coreId } },
+            window.parent.origin,
+            [channel.port2],
+        );
+        return {
+            port: channel.port1,
+            destroy: (suspectWedge?: boolean) => {
+                messageParentFromViewer({
+                    type: "destroySharedCore",
+                    coreId,
+                    suspectWedge: Boolean(suspectWedge),
+                });
+            },
+        };
+    };
+}
+
 (async () => {
     if (await waitForStandaloneBundle(60_000)) {
+        if (
+            typeof doenetSharedCoreWorker !== "undefined" &&
+            doenetSharedCoreWorker
+        ) {
+            installSharedCorePortProvider();
+        }
         messageParentFromViewer({ iframeReady: true });
     } else {
         messageParentFromViewer({

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -23,6 +23,11 @@ import {
     createHtmlForDoenetEditor,
     setIframeBodyBackground,
 } from "./utils";
+import {
+    handleCreateSharedCore,
+    handleDestroySharedCore,
+    destroySharedCoresForViewer,
+} from "./shared-core-pool";
 
 export const version: string = IFRAME_VERSION;
 const latestDoenetmlVersion: string = version;
@@ -98,6 +103,17 @@ export type DoenetViewerIframeProps = DoenetViewerProps & {
      * overwriting any doenetmlVersion or urls provided
      */
     autodetectVersion?: boolean;
+    /**
+     * Opt-in (#1466): multiplex this viewer's core onto a shared core worker
+     * owned by this (parent) page, instead of the iframe booting its own
+     * ~100 MB dedicated worker. Viewers on the same page with the same
+     * standalone version share workers (up to a pool cap per worker), which
+     * is the dominant memory saving on pages embedding many documents.
+     * Trade-off: a worker-level hang or crash affects every document on that
+     * worker (per-core teardown stays individual; suspect workers are
+     * quarantined so retries boot fresh ones). Default off.
+     */
+    useSharedCoreWorker?: boolean;
 };
 
 export type DoenetEditorIframeProps = DoenetEditorProps & {
@@ -148,6 +164,7 @@ export function DoenetViewer({
     cssUrl: specifiedCssUrl,
     doenetmlVersion: specifiedDoenetmlVersion,
     autodetectVersion = true,
+    useSharedCoreWorker = false,
     ...doenetViewerProps
 }: DoenetViewerIframeProps) {
     const [id, _] = React.useState(() => Math.random().toString(36).slice(2));
@@ -188,6 +205,24 @@ export function DoenetViewer({
         cssUrl = `https://cdn.jsdelivr.net/npm/@doenet/standalone@${selectedDoenetmlVersion}/style.css`;
     }
 
+    // Latest standaloneUrl for the (deps-empty) message listener below — it
+    // can change after mount via the autodetect-version fallback, and the
+    // shared-core pool keys its workers by the URL the iframe actually loads.
+    const standaloneUrlRef = React.useRef(standaloneUrl);
+    standaloneUrlRef.current = standaloneUrl;
+
+    // Shared-core cleanup (#1466): an unmounted iframe realm never runs its
+    // own core teardown, so release any cores this viewer created on the
+    // parent-owned pool.
+    React.useEffect(() => {
+        if (!useSharedCoreWorker) {
+            return;
+        }
+        return () => {
+            destroySharedCoresForViewer(id);
+        };
+    }, []);
+
     React.useEffect(() => {
         const listener = (event: MessageEvent<IframeMessage>) => {
             if (event.origin !== window.location.origin) {
@@ -219,6 +254,26 @@ export function DoenetViewer({
             }
 
             const data = event.data.data;
+
+            // Shared core-worker protocol (#1466): the iframe's viewer mints
+            // a MessageChannel, keeps one port, and sends the other here to
+            // be forwarded to a parent-owned shared host worker.
+            if (data.type === "createSharedCore" && event.ports[0]) {
+                handleCreateSharedCore({
+                    viewerId: id,
+                    coreId: String(data.coreId),
+                    standaloneUrl: standaloneUrlRef.current,
+                    port: event.ports[0],
+                });
+                return;
+            }
+            if (data.type === "destroySharedCore") {
+                handleDestroySharedCore({
+                    coreId: String(data.coreId),
+                    suspectWedge: Boolean(data.suspectWedge),
+                });
+                return;
+            }
 
             // If receive a scrollTo event from the iframe,
             // that means that a scroll-only link (i.e. with target of the form "#anchor")
@@ -335,6 +390,7 @@ export function DoenetViewer({
                     doenetViewerProps,
                     standaloneUrl,
                     cssUrl,
+                    useSharedCoreWorker,
                 )}
                 style={{
                     width: "100%",

--- a/packages/doenetml-iframe/src/shared-core-pool.ts
+++ b/packages/doenetml-iframe/src/shared-core-pool.ts
@@ -1,0 +1,221 @@
+import * as Comlink from "comlink";
+
+// Parent-side shared core-worker pool (#1466, milestone 3).
+//
+// Each srcdoc iframe is its own realm and cannot share workers with its
+// siblings, so the PARENT page (where this React component runs) owns the
+// worker pool. An iframe that opts in mints a `MessageChannel` locally, keeps
+// one port for its viewer, and posts the other port here
+// (`createSharedCore`); we forward that port to a shared host worker's
+// `createCore`, so the core lives beside the other iframes' cores in the same
+// worker instead of costing its own ~100 MB dedicated worker.
+//
+// Pools are keyed by the RESOLVED worker URL, so components pinned to
+// different standalone versions get separate (matching-version) workers.
+
+/** Mirrors the pool cap in @doenet/doenetml's docUtils. */
+const MAX_CORES_PER_WORKER = 12;
+
+type SharedHost = {
+    worker: Worker;
+    remote: {
+        createCore: (port: MessagePort) => Promise<number>;
+        destroyCore: (id: number) => Promise<void>;
+    };
+    liveCores: number;
+    quarantined: boolean;
+};
+
+const hostsByWorkerUrl = new Map<string, SharedHost[]>();
+
+type CoreRecord = {
+    viewerId: string;
+    host: SharedHost;
+    /** Pool key of `host`, needed for quarantine bookkeeping at destroy time. */
+    workerUrl: string;
+    idPromise: Promise<number>;
+    destroyed: boolean;
+};
+
+const coreRecords = new Map<string, CoreRecord>();
+
+/**
+ * Resolve the worker URL for a standalone bundle URL: the worker directory is
+ * co-served next to the bundle (`doenetml-worker/index.js`, both on npm/CDN
+ * and in a dist deploy). For a blob/data `standaloneUrl` (no "next to the
+ * bundle"), fall back to `<origin>/doenetml-worker/index.js` on this page —
+ * the same chain the standalone bundle itself uses.
+ */
+function resolveWorkerUrl(standaloneUrl: string): string | null {
+    try {
+        return new URL("./doenetml-worker/index.js", standaloneUrl).href;
+    } catch {
+        // opaque base (blob:/data:) — fall through
+    }
+    try {
+        return new URL("/doenetml-worker/index.js", document.baseURI).href;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * A dedicated `new Worker(url)` requires a same-origin URL. When the worker
+ * resolves cross-origin (the CDN case), wrap it in a tiny same-origin
+ * classic-worker bootstrap that `importScripts()` the real (CORS-served)
+ * worker — the same technique as @doenet/doenetml's external-worker entry.
+ */
+function workerCreationUrl(workerUrl: string): string {
+    try {
+        if (new URL(workerUrl).origin === window.location.origin) {
+            return workerUrl;
+        }
+    } catch {
+        // fall through to the bootstrap
+    }
+    const bootstrap = `importScripts(${JSON.stringify(workerUrl)});`;
+    return URL.createObjectURL(
+        new Blob([bootstrap], { type: "text/javascript" }),
+    );
+}
+
+function quarantineHost(workerUrl: string, host: SharedHost) {
+    host.quarantined = true;
+    if (host.liveCores <= 0) {
+        try {
+            host.worker.terminate();
+        } catch {
+            // best-effort
+        }
+        const pool = hostsByWorkerUrl.get(workerUrl);
+        const index = pool?.indexOf(host) ?? -1;
+        if (pool && index !== -1) {
+            pool.splice(index, 1);
+        }
+    }
+}
+
+function getHost(workerUrl: string): SharedHost {
+    let pool = hostsByWorkerUrl.get(workerUrl);
+    if (!pool) {
+        pool = [];
+        hostsByWorkerUrl.set(workerUrl, pool);
+    }
+    let host = pool.find(
+        (h) => !h.quarantined && h.liveCores < MAX_CORES_PER_WORKER,
+    );
+    if (!host) {
+        const worker = new Worker(workerCreationUrl(workerUrl), {
+            type: "classic",
+        });
+        const newHost: SharedHost = {
+            worker,
+            remote: Comlink.wrap(worker) as unknown as SharedHost["remote"],
+            liveCores: 0,
+            quarantined: false,
+        };
+        worker.addEventListener("error", () => {
+            quarantineHost(workerUrl, newHost);
+        });
+        pool.push(newHost);
+        host = newHost;
+    }
+    return host;
+}
+
+/**
+ * Handle a `createSharedCore` request from an iframe: forward its transferred
+ * port to a (possibly new) shared host worker's `createCore`. The iframe's
+ * viewer is already sending on its end of the channel; those messages buffer
+ * until the core is exposed.
+ */
+export function handleCreateSharedCore({
+    viewerId,
+    coreId,
+    standaloneUrl,
+    port,
+}: {
+    viewerId: string;
+    coreId: string;
+    standaloneUrl: string;
+    port: MessagePort;
+}) {
+    const workerUrl = resolveWorkerUrl(standaloneUrl);
+    if (workerUrl === null) {
+        // Nothing we can do — the viewer's handshake watchdog will surface
+        // the failure (and DocViewer will retry / error out).
+        console.warn(
+            "doenetml-iframe: could not resolve a shared core worker URL for",
+            standaloneUrl,
+        );
+        return;
+    }
+    const host = getHost(workerUrl);
+    host.liveCores++;
+    const idPromise = host.remote.createCore(Comlink.transfer(port, [port]));
+    idPromise.catch(() => {
+        // Failure surfaces through the viewer's own watchdogged calls; this
+        // handler only prevents an unhandled rejection.
+    });
+    coreRecords.set(coreId, {
+        viewerId,
+        host,
+        workerUrl,
+        idPromise,
+        destroyed: false,
+    });
+}
+
+/**
+ * Handle a `destroySharedCore` request (or component-unmount cleanup):
+ * release the core on its host, and quarantine the host when the teardown
+ * carried wedge suspicion (see CoreWorkerHandle.kill in @doenet/doenetml).
+ */
+export function handleDestroySharedCore({
+    coreId,
+    suspectWedge,
+}: {
+    coreId: string;
+    suspectWedge: boolean;
+}) {
+    const record = coreRecords.get(coreId);
+    if (!record || record.destroyed) {
+        return;
+    }
+    record.destroyed = true;
+    coreRecords.delete(coreId);
+    record.host.liveCores--;
+    // Best-effort: works whenever the host's event loop is alive.
+    record.idPromise
+        .then((id) => record.host.remote.destroyCore(id))
+        .catch(() => {});
+    if (suspectWedge || record.host.quarantined) {
+        quarantineHost(record.workerUrl, record.host);
+    }
+}
+
+/**
+ * Release every core created for a viewer (component unmount / iframe
+ * teardown): an abruptly-removed iframe realm never runs its own destroy
+ * path, so without this the cores would leak on the shared host.
+ */
+export function destroySharedCoresForViewer(viewerId: string) {
+    for (const [coreId, record] of [...coreRecords]) {
+        if (record.viewerId === viewerId) {
+            handleDestroySharedCore({ coreId, suspectWedge: false });
+        }
+    }
+}
+
+/** Pool observability for tests and debugging. */
+export function getSharedCorePoolStats() {
+    let hosts = 0;
+    let liveCores = 0;
+    for (const pool of hostsByWorkerUrl.values()) {
+        hosts += pool.length;
+        for (const host of pool) {
+            liveCores += host.liveCores;
+        }
+    }
+    return { hosts, liveCores };
+}

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -84,6 +84,7 @@ export function createHtmlForDoenetViewer(
     doenetViewerProps: DoenetViewerProps,
     standaloneUrl: string,
     cssUrl: string,
+    useSharedCoreWorker = false,
 ) {
     // Since function props disappear when stringifying
     // and we'll have access to them only via proxying with ComLink,
@@ -102,6 +103,7 @@ export function createHtmlForDoenetViewer(
             const viewerId = "${id}";
             const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
             const doenetViewerPropsSpecified = ${JSON.stringify(doenetViewerPropsSpecified)};
+            const doenetSharedCoreWorker = ${JSON.stringify(!!useSharedCoreWorker)};
             import * as ComlinkViewer from "https://unpkg.com/comlink/dist/esm/comlink.mjs";
 
             // This source code has been compiled by vite and should be directly included.

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import { DoenetViewer } from "../../../src/index";
+import { getSharedCorePoolStats } from "../../../src/shared-core-pool";
+import {
+    STANDALONE_BLOB_URL,
+    STANDALONE_CSS_BLOB_URL,
+    IFRAME_READY_TIMEOUT,
+} from "./helpers";
+
+// Cross-iframe shared core-worker host (#1466, milestone 3): with
+// `useSharedCoreWorker`, each iframe's viewer obtains its core over a
+// MessagePort that the PARENT page forwards to a shared host worker — the
+// iframes' cores multiplex onto parent-owned workers instead of each iframe
+// booting its own ~100 MB dedicated worker.
+//
+// These specs load the standalone bundle from a Blob URL, so the pool
+// resolves the worker via its origin-root fallback
+// (`/doenetml-worker/index.js`, served by the dev-server middleware in
+// cypress.config.ts).
+//
+// Because Cypress component specs share the parent realm (and module graph)
+// with the mounted component, `getSharedCorePoolStats` observes the very pool
+// the component uses.
+
+const VIEWER_BOOT_TIMEOUT = 60_000;
+
+function assertIframeContains(index: number, text: string) {
+    cy.get("iframe")
+        .eq(index)
+        .its("0.contentDocument.body", { timeout: VIEWER_BOOT_TIMEOUT })
+        .should("contain.text", text);
+}
+
+describe("DoenetViewer (iframe wrapper) — shared core-worker host (#1466)", () => {
+    it("two iframes' cores share one parent-owned host worker", () => {
+        cy.mount(
+            <div>
+                <DoenetViewer
+                    doenetML="<p>first shared iframe viewer</p>"
+                    useSharedCoreWorker
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+                <DoenetViewer
+                    doenetML="<p>second shared iframe viewer</p>"
+                    useSharedCoreWorker
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
+
+        assertIframeContains(0, "first shared iframe viewer");
+        assertIframeContains(1, "second shared iframe viewer");
+
+        // Both cores landed on ONE parent-owned host worker.
+        cy.wrap(null).should(() => {
+            const stats = getSharedCorePoolStats();
+            expect(stats.liveCores, "live cores").to.eq(2);
+            expect(stats.hosts, "host workers").to.eq(1);
+        });
+    });
+
+    it("unmounting a viewer releases its core from the pool", () => {
+        function Harness() {
+            const [showSecond, setShowSecond] = useState(true);
+            return (
+                <div>
+                    <button
+                        data-test="remove-second"
+                        onClick={() => setShowSecond(false)}
+                    >
+                        remove second
+                    </button>
+                    <DoenetViewer
+                        doenetML="<p>persistent viewer</p>"
+                        useSharedCoreWorker
+                        standaloneUrl={STANDALONE_BLOB_URL}
+                        cssUrl={STANDALONE_CSS_BLOB_URL}
+                        addVirtualKeyboard={false}
+                    />
+                    {showSecond ? (
+                        <DoenetViewer
+                            doenetML="<p>ephemeral viewer</p>"
+                            useSharedCoreWorker
+                            standaloneUrl={STANDALONE_BLOB_URL}
+                            cssUrl={STANDALONE_CSS_BLOB_URL}
+                            addVirtualKeyboard={false}
+                        />
+                    ) : null}
+                </div>
+            );
+        }
+
+        cy.mount(<Harness />);
+
+        assertIframeContains(0, "persistent viewer");
+        assertIframeContains(1, "ephemeral viewer");
+
+        // Both cores live (the pool may still hold cores from the previous
+        // test's realm-independent state — component specs get a fresh module
+        // graph per spec file, not per test — so compare relative counts).
+        let coresBefore = 0;
+        cy.wrap(null)
+            .should(() => {
+                coresBefore = getSharedCorePoolStats().liveCores;
+                expect(coresBefore, "cores before unmount").to.be.gte(2);
+            })
+            .then(() => {
+                cy.get("[data-test=remove-second]").click();
+                // The unmount cleanup releases exactly the removed viewer's core.
+                cy.wrap(null, { timeout: IFRAME_READY_TIMEOUT }).should(() => {
+                    expect(
+                        getSharedCorePoolStats().liveCores,
+                        "cores after unmount",
+                    ).to.eq(coresBefore - 1);
+                });
+                // The surviving viewer is unaffected.
+                assertIframeContains(0, "persistent viewer");
+            });
+    });
+});

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -111,6 +111,22 @@ if (typeof globalThis !== "undefined" && !globalThis.document) {
         baseURI: baseUrl,
     };
 }
+/**
+ * Initialize the WASM module exactly once per worker realm. wasm-bindgen's
+ * `init` only guards *completed* initializations (`if (wasm !== undefined)`),
+ * so concurrent in-flight calls — which happen when several hosted cores
+ * (#1466) boot at once on one worker — would race and instantiate the module
+ * multiple times, corrupting the module-level instance the glue points at.
+ * Gate every caller behind one shared promise.
+ */
+let wasmInitPromise: Promise<unknown> | null = null;
+function ensureWasmInitialized(): Promise<unknown> {
+    if (!wasmInitPromise) {
+        wasmInitPromise = init({ module_or_path: wasmInitInput });
+    }
+    return wasmInitPromise;
+}
+
 export class CoreWorker {
     doenetCore?: PublicDoenetMLCore;
     javascriptCore?: PublicDoenetMLCoreJavascript;
@@ -157,6 +173,55 @@ export class CoreWorker {
 
     isProcessingPromise = Promise.resolve();
 
+    // --- Multi-core host support (#1466, stream E of #1441) ---------------
+    //
+    // One worker process can host several independent cores, collapsing the
+    // ~104 MB per-worker fixed floor (script eval + WASM) to one copy per
+    // page. The worker's default exposed instance doubles as the host: the
+    // main thread calls `createCore` with a transferred `MessagePort` and
+    // drives the new core over that port with the same Comlink API a
+    // dedicated worker would offer. All cores share this worker's WASM
+    // instance (wasm-bindgen `init` is idempotent per module scope); each
+    // core is a separate `PublicDoenetMLCore` / JS core with its own state.
+
+    /** Cores created via `createCore`, so `destroyCore` can release them. */
+    _hostedCores: Map<number, { core: CoreWorker; port: MessagePort }> =
+        new Map();
+    _nextHostedCoreId = 1;
+
+    /**
+     * Create an additional, independent core in this worker and expose it on
+     * `port` via Comlink. Returns an id for a later `destroyCore` call.
+     */
+    async createCore(port: MessagePort): Promise<number> {
+        const core = new CoreWorker();
+        Comlink.expose(core, port);
+        const id = this._nextHostedCoreId++;
+        this._hostedCores.set(id, { core, port });
+        return id;
+    }
+
+    /**
+     * Release a core created by `createCore`: give it a graceful
+     * `terminate()` (frees the Rust core and JS core), then close its port
+     * and drop the reference. Best-effort — a torn-down document must never
+     * take its sibling cores with it.
+     */
+    async destroyCore(id: number) {
+        const entry = this._hostedCores.get(id);
+        if (!entry) {
+            return;
+        }
+        this._hostedCores.delete(id);
+        try {
+            await entry.core.terminate();
+        } catch (err) {
+            console.error("Error terminating hosted core", err);
+        } finally {
+            entry.port.close();
+        }
+    }
+
     setCoreType(core_type: "rust" | "javascript") {
         this.core_type = core_type;
     }
@@ -170,7 +235,7 @@ export class CoreWorker {
 
         try {
             if (!this.wasm_initialized) {
-                await init({ module_or_path: wasmInitInput });
+                await ensureWasmInitialized();
                 this.wasm_initialized = true;
             }
 
@@ -214,7 +279,7 @@ export class CoreWorker {
 
         try {
             if (!this.wasm_initialized) {
-                await init({ module_or_path: wasmInitInput });
+                await ensureWasmInitialized();
                 this.wasm_initialized = true;
             }
 

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -122,7 +122,14 @@ if (typeof globalThis !== "undefined" && !globalThis.document) {
 let wasmInitPromise: Promise<unknown> | null = null;
 function ensureWasmInitialized(): Promise<unknown> {
     if (!wasmInitPromise) {
-        wasmInitPromise = init({ module_or_path: wasmInitInput });
+        // Clear the cached promise on failure so a later core can retry the
+        // init rather than every future caller inheriting one rejected
+        // promise forever. Concurrent in-flight callers still share (and all
+        // observe the rejection of) the single attempt.
+        wasmInitPromise = init({ module_or_path: wasmInitInput }).catch((e) => {
+            wasmInitPromise = null;
+            throw e;
+        });
     }
     return wasmInitPromise;
 }
@@ -188,6 +195,14 @@ export class CoreWorker {
     _hostedCores: Map<number, { core: CoreWorker; port: MessagePort }> =
         new Map();
     _nextHostedCoreId = 1;
+    /**
+     * Whether this instance is a hosted core (created via `createCore`) rather
+     * than the worker's default (host) instance. A hosted core shares the
+     * worker thread with its siblings, so its `terminate()` must free only its
+     * own Rust/JS cores and NOT `close()` the worker — that would take every
+     * sibling core down with it.
+     */
+    _isHostedCore = false;
 
     /**
      * Create an additional, independent core in this worker and expose it on
@@ -195,6 +210,7 @@ export class CoreWorker {
      */
     async createCore(port: MessagePort): Promise<number> {
         const core = new CoreWorker();
+        core._isHostedCore = true;
         Comlink.expose(core, port);
         const id = this._nextHostedCoreId++;
         this._hostedCores.set(id, { core, port });
@@ -938,8 +954,15 @@ export class CoreWorker {
             resolve();
         }
 
-        // Terminate the worker itself
-        close();
+        // Terminate the worker itself — but only for the worker's default
+        // (host) instance. A hosted core (#1466) shares the thread with its
+        // sibling cores, so closing here would take them all down; its
+        // teardown ends after freeing the Rust and JS cores above. The host
+        // worker is instead force-terminated natively (or destroyed
+        // per-core via `destroyCore`) from the main thread.
+        if (!this._isHostedCore) {
+            close();
+        }
     }
 
     async returnAllStateVariables(consoleLogComponents = false) {

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -220,33 +220,34 @@ export function DocViewer({
     const [ignoreRendererError, setIgnoreRendererError] = useState(false);
 
     const coreWorker = useRef<Remote<CoreWorker> | null>(null);
-    // Native handle for the same worker `coreWorker` wraps, kept so a wedged
-    // worker can be force-terminated even when its Comlink `terminate()` would
-    // itself hang on the stuck queue (Doenet/DoenetApps#2957). Set and
-    // cleared in lockstep with `coreWorker` (always via
-    // `attachNewCoreWorker`/`teardownCurrentCoreWorker`).
-    const nativeCoreWorker = useRef<Worker | null>(null);
+    // Kill switch for the same core `coreWorker` wraps, kept so a wedged
+    // core can be force-released even when its Comlink `terminate()` would
+    // itself hang on the stuck queue (Doenet/DoenetApps#2957). Natively
+    // terminates a dedicated worker; on a shared host worker (#1466) it
+    // destroys just this core. Set and cleared in lockstep with `coreWorker`
+    // (always via `attachNewCoreWorker`/`teardownCurrentCoreWorker`).
+    const coreWorkerKill = useRef<(() => void) | null>(null);
 
-    // Spin up a fresh core worker and store its Comlink remote and native
-    // handle in lockstep. Returns the remote for the caller to drive.
+    // Spin up a fresh core worker and store its Comlink remote and kill
+    // switch in lockstep. Returns the remote for the caller to drive.
     function attachNewCoreWorker(): Remote<CoreWorker> {
-        const { remote, worker } = createCoreWorker();
+        const { remote, kill } = createCoreWorker();
         coreWorker.current = remote;
-        nativeCoreWorker.current = worker;
+        coreWorkerKill.current = kill;
         return remote;
     }
 
-    // Tear down whatever worker the refs currently point at and clear them
+    // Tear down whatever core the refs currently point at and clear them
     // (keeping the two refs in lockstep). Refs are cleared up front so a
-    // worker that's being terminated is never reachable mid-teardown; the
+    // core that's being terminated is never reachable mid-teardown; the
     // returned promise settles once `disposeCoreWorker` has finished, for
     // callers that need to await the teardown before swapping in a replacement.
     function teardownCurrentCoreWorker({ graceful }: { graceful: boolean }) {
         const remote = coreWorker.current;
-        const native = nativeCoreWorker.current;
+        const kill = coreWorkerKill.current;
         coreWorker.current = null;
-        nativeCoreWorker.current = null;
-        return disposeCoreWorker(remote, native, { graceful });
+        coreWorkerKill.current = null;
+        return disposeCoreWorker(remote, kill, { graceful });
     }
 
     function clearDeferredCoreActions() {

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -226,7 +226,9 @@ export function DocViewer({
     // terminates a dedicated worker; on a shared host worker (#1466) it
     // destroys just this core. Set and cleared in lockstep with `coreWorker`
     // (always via `attachNewCoreWorker`/`teardownCurrentCoreWorker`).
-    const coreWorkerKill = useRef<(() => void) | null>(null);
+    const coreWorkerKill = useRef<((suspectWedge?: boolean) => void) | null>(
+        null,
+    );
 
     // Spin up a fresh core worker and store its Comlink remote and kill
     // switch in lockstep. Returns the remote for the caller to drive.

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -101,9 +101,15 @@ export function withTimeout<T>(
  */
 export async function disposeCoreWorker(
     remote: Remote<CoreWorker> | null,
-    kill: (() => void) | null,
+    kill: ((suspectWedge?: boolean) => void) | null,
     { graceful }: { graceful: boolean },
 ) {
+    // A non-graceful teardown means the caller already believes the core is
+    // wedged (watchdogged handshake timeout); a graceful terminate that times
+    // out is the same signal discovered late. Either way, pass the suspicion
+    // to `kill` so a shared host (#1466) can quarantine the worker and route
+    // retries to a fresh one.
+    let suspectWedge = !graceful;
     if (graceful && remote) {
         try {
             await withTimeout(
@@ -113,10 +119,11 @@ export async function disposeCoreWorker(
             );
         } catch {
             // fall through to the guaranteed kill below
+            suspectWedge = true;
         }
     }
     try {
-        kill?.();
+        kill?.(suspectWedge);
     } catch {
         // best-effort; nothing more we can do
     }

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -93,13 +93,15 @@ export function withTimeout<T>(
 /**
  * Tear down a core worker. When `graceful`, first give the Comlink
  * `terminate()` a bounded chance to run its cleanup (it frees the Rust core
- * and the JS core); regardless, always follow with a native
- * `worker.terminate()` so a wedged worker — whose Comlink terminate would
- * itself hang on the stuck queue — is still guaranteed to die.
+ * and the JS core); regardless, always follow with the handle's `kill`
+ * switch — so a wedged core, whose Comlink terminate would itself hang on
+ * the stuck queue, is still guaranteed to be released. (`kill` natively
+ * terminates a dedicated worker; on a shared host worker it closes the
+ * core's port and destroys just that core — see `CoreWorkerHandle`.)
  */
 export async function disposeCoreWorker(
     remote: Remote<CoreWorker> | null,
-    nativeWorker: Worker | null,
+    kill: (() => void) | null,
     { graceful }: { graceful: boolean },
 ) {
     if (graceful && remote) {
@@ -110,11 +112,11 @@ export async function disposeCoreWorker(
                 "core worker graceful terminate",
             );
         } catch {
-            // fall through to the guaranteed native kill below
+            // fall through to the guaranteed kill below
         }
     }
     try {
-        nativeWorker?.terminate();
+        kill?.();
     } catch {
         // best-effort; nothing more we can do
     }

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -9,6 +9,22 @@ if (typeof window === "undefined") {
 export const doenetGlobalConfig: {
     doenetWorkerUrl: string;
     /**
+     * Opt-in (#1466): host multiple document cores in a shared core worker
+     * instead of one dedicated worker per document. Collapses the ~104 MB
+     * per-worker fixed floor (script eval + WASM compile) to one copy per
+     * worker, at the cost of coarser failure isolation: a worker-level hang
+     * or crash affects every document on that worker (per-core teardown is
+     * still individual). Default off.
+     */
+    useSharedCoreWorker?: boolean;
+    /**
+     * Pool cap for `useSharedCoreWorker`: maximum live cores per shared
+     * worker before a new worker is spun up. Bounds both the blast radius of
+     * a worker-level failure and single-isolate heap pressure. Falls back to
+     * a built-in default when unset.
+     */
+    sharedCoreWorkerMaxCores?: number;
+    /**
      * Maximum number of times `DocViewer` will retry the core-worker
      * *handshake* before giving up and surfacing an error. Each handshake
      * that fails to complete within `coreHandshakeWatchdogMs` is abandoned

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -25,6 +25,22 @@ export const doenetGlobalConfig: {
      */
     sharedCoreWorkerMaxCores?: number;
     /**
+     * Host-provided core factory (#1466): when set, `createCoreWorker`
+     * obtains each core over a `MessagePort` minted by this function instead
+     * of creating (or sharing) a worker in this realm. Used by
+     * `@doenet/doenetml-iframe` to multiplex the cores of many same-origin
+     * iframes onto worker(s) owned by the PARENT page — an iframe realm
+     * cannot share workers with its siblings on its own. The returned `port`
+     * must speak the per-core `CoreWorker` Comlink protocol (the far end is
+     * typically handed to a host worker's `createCore`); `destroy` releases
+     * the core, forwarding wedge suspicion (see `CoreWorkerHandle.kill`).
+     * Returning `null` falls back to this realm's own workers.
+     */
+    createExternalCoreWorkerPort?: () => {
+        port: MessagePort;
+        destroy: (suspectWedge?: boolean) => void;
+    } | null;
+    /**
      * Maximum number of times `DocViewer` will retry the core-worker
      * *handshake* before giving up and surfacing an error. Each handshake
      * that fails to complete within `coreHandshakeWatchdogMs` is abandoned

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -20,12 +20,18 @@ export type CoreWorkerHandle = {
      *
      * Dedicated-worker mode: natively terminates the worker. Shared-worker
      * mode (#1466): closes this core's port and asks the host to destroy the
-     * core — sibling cores are unaffected, but note this cannot recover from
-     * a wedge that blocks the whole worker thread (only killing the shared
-     * worker would, which would take the siblings with it; the escalation
-     * ladder is follow-up work on #1466).
+     * core — sibling cores are unaffected.
+     *
+     * `suspectWedge` marks teardowns where the core stopped responding (a
+     * watchdogged handshake timeout, or a graceful terminate that timed out)
+     * rather than an ordinary unmount. In shared mode this quarantines the
+     * core's host worker: no new cores are assigned to it (a retry therefore
+     * lands on a fresh worker), and it is natively terminated once its last
+     * core is gone. Existing sibling cores keep running — the suspicion may
+     * be a false positive (e.g. CPU contention), and a sibling that is truly
+     * affected will trip its own watchdog.
      */
-    kill: () => void;
+    kill: (suspectWedge?: boolean) => void;
 };
 
 /** Default pool cap for shared core workers (see `sharedCoreWorkerMaxCores`). */
@@ -38,11 +44,42 @@ const DEFAULT_SHARED_CORE_WORKER_MAX_CORES = 12;
  * once created — assignment-style pages mount/unmount documents repeatedly,
  * and re-paying the ~100 MB boot on each remount would defeat the purpose.
  */
-const sharedHosts: {
+type SharedHost = {
     worker: Worker;
     remote: Comlink.Remote<CoreWorker>;
     liveCores: number;
-}[] = [];
+    /**
+     * A quarantined host receives no new cores (retries land on a fresh
+     * worker) and is natively terminated once its last core is gone. Set when
+     * a core on this host stops responding (`kill(suspectWedge)`) or the
+     * worker itself fires an `error` event.
+     */
+    quarantined: boolean;
+};
+
+const sharedHosts: SharedHost[] = [];
+
+/**
+ * Quarantine a shared host: stop assigning new cores to it, and once no live
+ * cores remain, natively terminate it and drop it from the pool. Live sibling
+ * cores are left running — the suspicion may be a false positive (CPU
+ * contention), and a truly affected sibling will trip its own watchdog, whose
+ * `kill(suspectWedge)` lands back here until the host empties out.
+ */
+function quarantineSharedHost(host: SharedHost) {
+    host.quarantined = true;
+    if (host.liveCores <= 0) {
+        try {
+            host.worker.terminate();
+        } catch {
+            // best-effort; nothing more we can do
+        }
+        const index = sharedHosts.indexOf(host);
+        if (index !== -1) {
+            sharedHosts.splice(index, 1);
+        }
+    }
+}
 
 /**
  * Create a core on a shared host worker (#1466): the host worker's default
@@ -53,17 +90,26 @@ function createSharedWorkerCore(): CoreWorkerHandle {
     const maxCores =
         doenetGlobalConfig.sharedCoreWorkerMaxCores ??
         DEFAULT_SHARED_CORE_WORKER_MAX_CORES;
-    let host = sharedHosts.find((h) => h.liveCores < maxCores);
+    let host = sharedHosts.find(
+        (h) => !h.quarantined && h.liveCores < maxCores,
+    );
     if (!host) {
         const worker = new Worker(doenetGlobalConfig.doenetWorkerUrl, {
             type: "classic",
         });
-        host = {
+        const newHost: SharedHost = {
             worker,
             remote: Comlink.wrap(worker) as Comlink.Remote<CoreWorker>,
             liveCores: 0,
+            quarantined: false,
         };
-        sharedHosts.push(host);
+        // A worker-level error (e.g. the script failed to load) poisons every
+        // core on it; make sure no future cores land there.
+        worker.addEventListener("error", () => {
+            quarantineSharedHost(newHost);
+        });
+        sharedHosts.push(newHost);
+        host = newHost;
     }
     const channel = new MessageChannel();
     // Not awaited: messages the caller sends on port1 in the meantime are
@@ -81,7 +127,7 @@ function createSharedWorkerCore(): CoreWorkerHandle {
     const remote = Comlink.wrap(channel.port1) as Comlink.Remote<CoreWorker>;
     host.liveCores++;
     let killed = false;
-    const kill = () => {
+    const kill = (suspectWedge?: boolean) => {
         if (killed) {
             return;
         }
@@ -92,6 +138,14 @@ function createSharedWorkerCore(): CoreWorkerHandle {
         // core does not block it — cores share the thread, so this only fails
         // on a thread-blocking wedge), release the core's memory.
         coreIdPromise.then((id) => host.remote.destroyCore(id)).catch(() => {});
+        if (suspectWedge || host.quarantined) {
+            // Unresponsive core (or already-suspect host): stop assigning new
+            // cores here, and terminate the worker once it holds none. A
+            // subsequent retry by the caller then boots on a fresh worker —
+            // this is what lets DocViewer's handshake watchdog + retry ladder
+            // recover in shared mode even from a thread-blocking wedge.
+            quarantineSharedHost(host);
+        }
     };
     return { remote, kill };
 }

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -161,6 +161,46 @@ function createSharedWorkerCore(): CoreWorkerHandle {
  * multiplexed onto shared host workers instead of one worker per document.
  */
 export function createCoreWorker(): CoreWorkerHandle {
+    // A host-provided core factory takes precedence (#1466): the embedding
+    // page (e.g. @doenet/doenetml-iframe's parent component) owns the shared
+    // worker pool and hands this realm a per-core MessagePort, so cores from
+    // MANY same-origin iframes multiplex onto the same workers — something
+    // this realm cannot arrange on its own.
+    const externalPortProvider =
+        doenetGlobalConfig.createExternalCoreWorkerPort;
+    if (externalPortProvider) {
+        try {
+            const external = externalPortProvider();
+            if (external) {
+                const remote = Comlink.wrap(
+                    external.port,
+                ) as Comlink.Remote<CoreWorker>;
+                let killed = false;
+                const kill = (suspectWedge?: boolean) => {
+                    if (killed) {
+                        return;
+                    }
+                    killed = true;
+                    try {
+                        external.port.close();
+                    } catch {
+                        // best-effort
+                    }
+                    try {
+                        external.destroy(suspectWedge);
+                    } catch {
+                        // best-effort
+                    }
+                };
+                return { remote, kill };
+            }
+        } catch (e) {
+            console.warn(
+                "External core worker port unavailable, falling back:",
+                e,
+            );
+        }
+    }
     if (doenetGlobalConfig.useSharedCoreWorker) {
         try {
             return createSharedWorkerCore();

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -12,29 +12,116 @@ export type CoreWorkerHandle = {
     /** The Comlink-wrapped async API for the core worker. */
     remote: Comlink.Remote<CoreWorker>;
     /**
-     * The underlying native `Worker`. Retained so a *wedged* worker can be
-     * force-killed with `worker.terminate()`. The Comlink `remote.terminate()`
-     * call routes through the worker's own serialization queue, so if that
-     * queue is stuck (e.g. a hung WASM init), the Comlink terminate hangs too
-     * — leaving no way to recover. See Doenet/DoenetApps#2957.
+     * Force-kill switch, used when the core has stopped responding. The
+     * Comlink `remote.terminate()` call routes through the core's own
+     * serialization queue, so if that queue is stuck (e.g. a hung WASM init),
+     * the Comlink terminate hangs too — this is the escape hatch. See
+     * Doenet/DoenetApps#2957.
+     *
+     * Dedicated-worker mode: natively terminates the worker. Shared-worker
+     * mode (#1466): closes this core's port and asks the host to destroy the
+     * core — sibling cores are unaffected, but note this cannot recover from
+     * a wedge that blocks the whole worker thread (only killing the shared
+     * worker would, which would take the siblings with it; the escalation
+     * ladder is follow-up work on #1466).
      */
-    worker: Worker;
+    kill: () => void;
 };
+
+/** Default pool cap for shared core workers (see `sharedCoreWorkerMaxCores`). */
+const DEFAULT_SHARED_CORE_WORKER_MAX_CORES = 12;
+
+/**
+ * Live shared host workers for this realm (only used when
+ * `doenetGlobalConfig.useSharedCoreWorker` is set). Each hosts up to the pool
+ * cap of cores; when all are full, a new one is spun up. Hosts are kept warm
+ * once created — assignment-style pages mount/unmount documents repeatedly,
+ * and re-paying the ~100 MB boot on each remount would defeat the purpose.
+ */
+const sharedHosts: {
+    worker: Worker;
+    remote: Comlink.Remote<CoreWorker>;
+    liveCores: number;
+}[] = [];
+
+/**
+ * Create a core on a shared host worker (#1466): the host worker's default
+ * instance doubles as a core factory, and each core is driven over its own
+ * `MessagePort` with the same Comlink API a dedicated worker would offer.
+ */
+function createSharedWorkerCore(): CoreWorkerHandle {
+    const maxCores =
+        doenetGlobalConfig.sharedCoreWorkerMaxCores ??
+        DEFAULT_SHARED_CORE_WORKER_MAX_CORES;
+    let host = sharedHosts.find((h) => h.liveCores < maxCores);
+    if (!host) {
+        const worker = new Worker(doenetGlobalConfig.doenetWorkerUrl, {
+            type: "classic",
+        });
+        host = {
+            worker,
+            remote: Comlink.wrap(worker) as Comlink.Remote<CoreWorker>,
+            liveCores: 0,
+        };
+        sharedHosts.push(host);
+    }
+    const channel = new MessageChannel();
+    // Not awaited: messages the caller sends on port1 in the meantime are
+    // buffered by the channel until the host exposes the core on port2, so
+    // the returned remote is usable immediately (the caller's handshake
+    // watchdog covers the failure case, as it does for a dedicated worker
+    // that never boots).
+    const coreIdPromise = host.remote.createCore(
+        Comlink.transfer(channel.port2, [channel.port2]),
+    );
+    coreIdPromise.catch(() => {
+        // Failure surfaces to the caller through its own (watchdogged) calls
+        // on `remote`; this handler only prevents an unhandled rejection.
+    });
+    const remote = Comlink.wrap(channel.port1) as Comlink.Remote<CoreWorker>;
+    host.liveCores++;
+    let killed = false;
+    const kill = () => {
+        if (killed) {
+            return;
+        }
+        killed = true;
+        host.liveCores--;
+        channel.port1.close();
+        // Best-effort: if the host's event loop is alive (a wedged sibling
+        // core does not block it — cores share the thread, so this only fails
+        // on a thread-blocking wedge), release the core's memory.
+        coreIdPromise.then((id) => host.remote.destroyCore(id)).catch(() => {});
+    };
+    return { remote, kill };
+}
 
 /**
  * Create a DoenetCoreWorker that is wrapped in Comlink for a nice async API.
  *
- * Returns both the Comlink `remote` (the normal async API) and the native
- * `worker` handle. Callers should drive the worker through `remote`; the
- * native `worker` is only for `terminate()` as a guaranteed kill switch when
- * the worker has stopped responding.
+ * Returns the Comlink `remote` (the normal async API) and a `kill` switch.
+ * Callers should drive the core through `remote`; `kill` is only for
+ * guaranteed teardown when the core has stopped responding.
+ *
+ * With `doenetGlobalConfig.useSharedCoreWorker` set (#1466), cores are
+ * multiplexed onto shared host workers instead of one worker per document.
  */
 export function createCoreWorker(): CoreWorkerHandle {
+    if (doenetGlobalConfig.useSharedCoreWorker) {
+        try {
+            return createSharedWorkerCore();
+        } catch (e) {
+            console.warn(
+                "Shared core worker unavailable, falling back to a dedicated worker:",
+                e,
+            );
+        }
+    }
     const worker = new Worker(doenetGlobalConfig.doenetWorkerUrl, {
         type: "classic",
     });
     const remote = Comlink.wrap(worker) as Comlink.Remote<CoreWorker>;
-    return { remote, worker };
+    return { remote, kill: () => worker.terminate() };
 }
 
 export async function initializeCoreWorker({

--- a/packages/doenetml/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
@@ -14,6 +14,40 @@ import { doenetGlobalConfig } from "../../../src/global-config";
 // assigned to it and it is terminated once empty — so the retry boots on a
 // fresh worker rather than landing back on a possibly-wedged host.
 
+// Harness for the sibling-teardown regression test: a removable sibling
+// viewer and a survivor viewer whose core we drive after the sibling is gone.
+// The survivor's `updateValue` button increments `$c`, so a working core turns
+// "survivor is 0" into "survivor is 1"; a dead core leaves it stuck at 0.
+function SiblingTeardownHarness() {
+    const [showSibling, setShowSibling] = React.useState(true);
+    return (
+        <div>
+            <button
+                data-test="remove-sibling"
+                onClick={() => setShowSibling(false)}
+            >
+                remove sibling
+            </button>
+            {showSibling ? (
+                <DoenetViewer
+                    doenetML="<p>sibling to remove</p>"
+                    addVirtualKeyboard={false}
+                />
+            ) : null}
+            <DoenetViewer
+                doenetML={`
+                    <number name="c">0</number>
+                    <updateValue name="bump" target="$c" newValue="$c+1">
+                        <label>bump survivor</label>
+                    </updateValue>
+                    <p>survivor is $c</p>
+                `}
+                addVirtualKeyboard={false}
+            />
+        </div>
+    );
+}
+
 describe("DoenetViewer shared core-worker host (#1466)", () => {
     afterEach(() => {
         delete doenetGlobalConfig.useSharedCoreWorker;
@@ -40,6 +74,33 @@ describe("DoenetViewer shared core-worker host (#1466)", () => {
 
         cy.contains("first shared viewer", { timeout: 20000 }).should("exist");
         cy.contains("second shared viewer", { timeout: 20000 }).should("exist");
+    });
+
+    it("a surviving core keeps responding after a sibling on the same host is torn down", () => {
+        // Regression for the cycle-1 bug (#1467): a hosted core's terminate()
+        // must not call the worker-global close(). Two cores share one host
+        // worker; tearing the sibling's core down (unmount -> destroyCore)
+        // must leave the survivor's core fully live. If close() ran, the whole
+        // host — and the survivor with it — would die, and the survivor could
+        // retain its stale DOM while no longer RESPONDING to interaction.
+        doenetGlobalConfig.useSharedCoreWorker = true;
+
+        cy.mount(<SiblingTeardownHarness />);
+
+        // Both cores boot on the same shared host (pool cap >> 2).
+        cy.contains("sibling to remove", { timeout: 20000 }).should("exist");
+        cy.contains("survivor is 0", { timeout: 20000 }).should("exist");
+
+        // Unmount the sibling viewer -> its core is torn down on the shared
+        // host. The survivor viewer stays mounted.
+        cy.get('[data-test="remove-sibling"]').click();
+        cy.contains("sibling to remove").should("not.exist");
+
+        // Drive the survivor's core: the click must round-trip through the
+        // still-alive host worker and update the rendered value. (The cycle-1
+        // bug would leave it stuck at "survivor is 0".)
+        cy.contains("button", "bump survivor").click();
+        cy.contains("survivor is 1", { timeout: 20000 }).should("exist");
     });
 
     it("recovers from a hung handshake: quarantine + retry on a fresh host", () => {

--- a/packages/doenetml/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+import { doenetGlobalConfig } from "../../../src/global-config";
+
+// Component coverage for the shared core-worker host (#1466): with
+// `doenetGlobalConfig.useSharedCoreWorker` set, viewers on a page multiplex
+// their cores onto shared workers (one core per MessagePort) instead of
+// booting one dedicated worker each.
+//
+// The recovery test drives the same handshake watchdog + retry ladder as
+// DoenetEditor.viewerRenderStall.cy.tsx (Doenet/DoenetApps#2957), via the
+// `__doenetTestCoreInitHook` seam. In shared mode a watchdogged (non-graceful)
+// teardown additionally QUARANTINES the core's host worker — no new cores are
+// assigned to it and it is terminated once empty — so the retry boots on a
+// fresh worker rather than landing back on a possibly-wedged host.
+
+describe("DoenetViewer shared core-worker host (#1466)", () => {
+    afterEach(() => {
+        delete doenetGlobalConfig.useSharedCoreWorker;
+        delete doenetGlobalConfig.__doenetTestCoreInitHook;
+        delete doenetGlobalConfig.coreHandshakeWatchdogMs;
+        delete doenetGlobalConfig.coreBootMaxAttempts;
+    });
+
+    it("renders two viewers whose cores share a host worker", () => {
+        doenetGlobalConfig.useSharedCoreWorker = true;
+
+        cy.mount(
+            <div>
+                <DoenetViewer
+                    doenetML="<p>first shared viewer</p>"
+                    addVirtualKeyboard={false}
+                />
+                <DoenetViewer
+                    doenetML="<p>second shared viewer</p>"
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
+
+        cy.contains("first shared viewer", { timeout: 20000 }).should("exist");
+        cy.contains("second shared viewer", { timeout: 20000 }).should("exist");
+    });
+
+    it("recovers from a hung handshake: quarantine + retry on a fresh host", () => {
+        doenetGlobalConfig.useSharedCoreWorker = true;
+
+        let handshakeAttempts = 0;
+        // Hang forever on the first handshake attempt. The watchdog fires, the
+        // non-graceful teardown quarantines the (empty) host worker, and the
+        // retry must boot a fresh host — pre-quarantine, the retry would be
+        // assigned to the same possibly-wedged worker.
+        doenetGlobalConfig.__doenetTestCoreInitHook = (phase, attempt) => {
+            if (phase === "handshake") {
+                handshakeAttempts = Math.max(handshakeAttempts, attempt + 1);
+                if (attempt === 0) {
+                    return new Promise<void>(() => {
+                        /* never resolves */
+                    });
+                }
+            }
+        };
+        // Generous enough that a healthy handshake completes well within it,
+        // so the watchdog fires on the injected hang, not on slow boot.
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 4000;
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>recovered shared viewer</p>"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.contains("recovered shared viewer", { timeout: 20000 }).should(
+            "exist",
+        );
+
+        cy.then(() => {
+            expect(
+                handshakeAttempts,
+                "handshake was retried after the hung first attempt",
+            ).to.be.greaterThan(1);
+        });
+    });
+});

--- a/packages/memory-benchmark/README.md
+++ b/packages/memory-benchmark/README.md
@@ -34,6 +34,7 @@ Playwright's Chromium must be installed once: `npx playwright install chromium`.
 | `iframe-N`         | N viewers in one iframe each, the way `@doenet/doenetml-iframe` and PreTeXt embed documents                     |
 | `iframe-xorigin-N` | Like `iframe-N`, but the standalone bundle (and its co-located worker) is served from a second, CORS-enabled origin — the cross-origin CDN situation PreTeXt and doenet.org are actually in |
 | `shared-N`         | Like `direct-N`, but with the shared core-worker host (#1466) opted in (`doenetGlobalConfig.useSharedCoreWorker`) — cores multiplex onto shared workers instead of one dedicated worker per viewer |
+| `iframe-shared-N`  | The full #1466 deployment model: cross-origin CDN bundle AND a parent-owned shared host worker the iframes' cores multiplex onto (as `doenetml-iframe`'s `useSharedCoreWorker` arranges) |
 | `workers-parse-N`  | N raw core workers, script evaluated only, no document — isolates the per-worker script parse/eval floor       |
 | `workers-init-N`   | `workers-parse-N` + WASM compile/instantiate + the document-independent core handshake on an empty document — the per-instance share a shared/multiplexed worker (#1441 stream E) would eliminate |
 | `repeat-S`         | One viewer with a generated `<repeatForSequence>` document of S iterations (≈5S components) — document scaling |

--- a/packages/memory-benchmark/README.md
+++ b/packages/memory-benchmark/README.md
@@ -33,6 +33,7 @@ Playwright's Chromium must be installed once: `npx playwright install chromium`.
 | `direct-N`         | N viewers sharing one realm (`renderDoenetViewerToContainer` on one page)                                       |
 | `iframe-N`         | N viewers in one iframe each, the way `@doenet/doenetml-iframe` and PreTeXt embed documents                     |
 | `iframe-xorigin-N` | Like `iframe-N`, but the standalone bundle (and its co-located worker) is served from a second, CORS-enabled origin — the cross-origin CDN situation PreTeXt and doenet.org are actually in |
+| `shared-N`         | Like `direct-N`, but with the shared core-worker host (#1466) opted in (`doenetGlobalConfig.useSharedCoreWorker`) — cores multiplex onto shared workers instead of one dedicated worker per viewer |
 | `workers-parse-N`  | N raw core workers, script evaluated only, no document — isolates the per-worker script parse/eval floor       |
 | `workers-init-N`   | `workers-parse-N` + WASM compile/instantiate + the document-independent core handshake on an empty document — the per-instance share a shared/multiplexed worker (#1441 stream E) would eliminate |
 | `repeat-S`         | One viewer with a generated `<repeatForSequence>` document of S iterations (≈5S components) — document scaling |

--- a/packages/memory-benchmark/pages/direct.html
+++ b/packages/memory-benchmark/pages/direct.html
@@ -10,9 +10,13 @@
         <script>
             // N viewers sharing one realm, via the standalone global API.
             // ?doc= selects the document served by /doenetml-source.
+            // ?shared=1 opts into the shared core-worker host (#1466): all
+            // viewers' cores multiplex onto shared workers instead of one
+            // dedicated worker each.
             const params = new URLSearchParams(location.search);
             const n = parseInt(params.get("n") ?? "1", 10);
             const doc = params.get("doc") ?? "default";
+            const shared = params.get("shared") === "1";
             window.__done = false;
             window.__initializedCount = 0;
             (async () => {
@@ -22,6 +26,12 @@
                 const waitForApi = setInterval(() => {
                     if (!window.renderDoenetViewerToContainer) return;
                     clearInterval(waitForApi);
+                    if (shared) {
+                        // The bundle has loaded (it defines the render API),
+                        // so window.doenetGlobalConfig exists; set the opt-in
+                        // before any viewer creates its core worker.
+                        window.doenetGlobalConfig.useSharedCoreWorker = true;
+                    }
                     for (let i = 0; i < n; i++) {
                         const div = document.createElement("div");
                         div.id = "viewer" + i;

--- a/packages/memory-benchmark/pages/iframes.html
+++ b/packages/memory-benchmark/pages/iframes.html
@@ -5,10 +5,11 @@
         <title>iframe embed</title>
     </head>
     <body>
-        <script>
+        <script type="module">
             // Mimic @doenet/doenetml-iframe (and PreTeXt): each instance is an
             // iframe whose document loads the full standalone bundle and
             // renders one viewer. ?doc= selects the document.
+            import * as Comlink from "/comlink.mjs";
             const params = new URLSearchParams(location.search);
             const n = parseInt(params.get("n") ?? "1", 10);
             const doc = params.get("doc") ?? "default";
@@ -18,11 +19,60 @@
             // pass ?cdn=<other-origin> to model a CDN-hosted bundle whose
             // worker is cross-origin to this (inherited-origin) srcdoc realm.
             const assetOrigin = params.get("cdn") || origin;
+            // ?shared=1 models the cross-iframe shared core-worker host
+            // (#1466, as @doenet/doenetml-iframe's useSharedCoreWorker does):
+            // this PARENT page owns one host worker, and each iframe's viewer
+            // gets its core over a MessagePort forwarded to that host.
+            const shared = params.get("shared") === "1";
             window.__done = false;
             window.__initializedCount = 0;
+
+            // Parent-owned shared host worker (created on first request).
+            let hostRemote = null;
+            function getHostRemote() {
+                if (!hostRemote) {
+                    const workerUrl = new URL(
+                        "./doenetml-worker/index.js",
+                        assetOrigin + "/standalone/doenet-standalone.js",
+                    ).href;
+                    // Cross-origin worker URLs need the same-origin
+                    // importScripts bootstrap (same technique as the
+                    // standalone external-worker entry).
+                    const creationUrl =
+                        new URL(workerUrl).origin === origin
+                            ? workerUrl
+                            : URL.createObjectURL(
+                                  new Blob(
+                                      [
+                                          `importScripts(${JSON.stringify(workerUrl)});`,
+                                      ],
+                                      { type: "text/javascript" },
+                                  ),
+                              );
+                    const worker = new Worker(creationUrl, {
+                        type: "classic",
+                    });
+                    hostRemote = Comlink.wrap(worker);
+                }
+                return hostRemote;
+            }
+
             window.addEventListener("message", (e) => {
                 if (e.data === "viewer-initialized") {
                     window.__initializedCount++;
+                    return;
+                }
+                if (
+                    e.data &&
+                    e.data.type === "createSharedCore" &&
+                    e.ports[0]
+                ) {
+                    const port = e.ports[0];
+                    getHostRemote()
+                        .createCore(Comlink.transfer(port, [port]))
+                        .catch((err) =>
+                            console.error("createCore failed", err),
+                        );
                 }
             });
             (async () => {
@@ -35,9 +85,22 @@
 </head><body><div id="root"></div>
 <script>
 const SOURCE = ${JSON.stringify(source)};
+const SHARED = ${JSON.stringify(shared)};
 const waitForApi = setInterval(() => {
   if (!window.renderDoenetViewerToContainer) return;
   clearInterval(waitForApi);
+  if (SHARED) {
+    // Obtain cores from the parent-owned shared host: mint a channel, keep
+    // one port for this realm's viewer, send the other to the parent to be
+    // forwarded to the host worker's createCore (messages buffer meanwhile).
+    window.doenetGlobalConfig.createExternalCoreWorkerPort = () => {
+      const channel = new MessageChannel();
+      window.parent.postMessage({ type: "createSharedCore" }, "*", [
+        channel.port2,
+      ]);
+      return { port: channel.port1, destroy: () => {} };
+    };
+  }
   window.renderDoenetViewerToContainer(
     document.getElementById("root"),
     SOURCE,

--- a/packages/memory-benchmark/src/measure.mjs
+++ b/packages/memory-benchmark/src/measure.mjs
@@ -381,6 +381,15 @@ const scenarios = [
             url: `${base}/direct.html?n=${n}&shared=1`,
             expectInitialized: n,
         },
+        {
+            // The full deployment model (#1466 milestone 3): cross-origin CDN
+            // bundle AND the parent-owned shared host worker, so the iframes'
+            // cores multiplex onto one worker (as doenetml-iframe's
+            // useSharedCoreWorker arranges).
+            name: `iframe-shared-${n}`,
+            url: `${base}/iframes.html?n=${n}&cdn=${encodeURIComponent(cdnBase)}&shared=1`,
+            expectInitialized: n,
+        },
     ]),
     // Per-worker fixed floor: N raw core workers, no viewers/documents.
     // `parse` = worker script evaluated only; `init` = + WASM compile and the
@@ -441,6 +450,7 @@ if (hi > lo) {
         "iframe",
         "iframe-xorigin",
         "shared",
+        "iframe-shared",
         "workers-parse",
         "workers-init",
     ]) {

--- a/packages/memory-benchmark/src/measure.mjs
+++ b/packages/memory-benchmark/src/measure.mjs
@@ -373,6 +373,14 @@ const scenarios = [
             url: `${base}/iframes.html?n=${n}&cdn=${encodeURIComponent(cdnBase)}`,
             expectInitialized: n,
         },
+        {
+            // Same as direct-N, but with the shared core-worker host (#1466)
+            // opted in: cores multiplex onto shared workers instead of one
+            // dedicated worker per viewer.
+            name: `shared-${n}`,
+            url: `${base}/direct.html?n=${n}&shared=1`,
+            expectInitialized: n,
+        },
     ]),
     // Per-worker fixed floor: N raw core workers, no viewers/documents.
     // `parse` = worker script evaluated only; `init` = + WASM compile and the
@@ -432,6 +440,7 @@ if (hi > lo) {
         "direct",
         "iframe",
         "iframe-xorigin",
+        "shared",
         "workers-parse",
         "workers-init",
     ]) {


### PR DESCRIPTION
_#1465 has merged; this branch is rebased directly onto `main`, so the whole diff belongs to this PR._

First milestone of #1466 (stream E of #1441): host multiple document cores in **one shared worker per page** instead of one dedicated ~100 MB worker per document. Opt-in, default off.

## What it does

- **Worker side** (`packages/doenetml-worker/src/CoreWorker.ts`): the worker's default exposed instance doubles as a host. `createCore(port)` creates an independent core exposed on a transferred `MessagePort` — the per-core Comlink API is unchanged, so `DocViewer` drives it exactly as it drives a dedicated worker. `destroyCore(id)` gives that core a graceful `terminate()` (frees the Rust + JS cores) and closes its port without touching siblings.
- **WASM init race fix**: wasm-bindgen's `init` guard only covers *completed* initializations, so several cores booting at once on one worker raced and instantiated the module multiple times (this hung an 8-viewer shared boot). Init is now gated behind a single module-level promise. (Unreachable in dedicated mode — one core per worker inits once — so no behavior change with the flag off.)
- **Main-thread side** (`docUtils.ts`, `coreWorkerBoot.ts`, `DocViewer.tsx`): `doenetGlobalConfig.useSharedCoreWorker` routes `createCoreWorker()` through shared hosts, with a pool cap (`sharedCoreWorkerMaxCores`, default 12) that spills over to a new worker — bounding both failure blast radius and single-isolate heap pressure. `CoreWorkerHandle`'s native-worker field becomes a `kill()` switch: dedicated mode natively terminates the worker exactly as before; shared mode closes the core's port and asks the host to destroy just that core.

## Measured (`packages/memory-benchmark`, new `shared-N` scenario, paired same-session runs)

| scenario | dedicated (direct-N) | shared (this PR) |
|---|---|---|
| 1 viewer | 500 MB | 501 MB |
| 8 viewers | **1455 MB** | **584 MB** |
| marginal / additional viewer | ~136 MB | **~12 MB** |
| workers at N=8 | 9 | 2 (1 host + 1 MathJax) |

This collapses the ~104 MB/instance worker floor measured in [the #1441 sizing comment](https://github.com/Doenet/DoenetML/issues/1441#issuecomment-4942631708) — and a bit more: real (non-idle) workers cost more than the idle-floor lower bound.

## Correctness

- Core independence verified by driving one of two shared-mode viewers (Playwright, headless Chrome): answer submission marked correct and `$mi^2` recomputed live in the driven viewer; the sibling viewer stayed untouched (empty inputs, unsubmitted button, `__²` placeholder). Structural check: 2 workers total (1 shared host + 1 MathJax) where dedicated mode has 3.
- `doenetml-worker` vitest suite 35/35; `doenetml` Cypress 32/32; `doenetml-iframe` Cypress 14/14 (all with the flag defaulting off; the flag-off path is byte-for-byte the old behavior apart from the `kill()` indirection).
- Typecheck: no new errors (17 pre-existing renderer errors on the base branch, unchanged).

## Failure recovery (second commit)

DocViewer's handshake watchdog + retry ladder is shared-mode-aware: the handle's `kill` switch carries a `suspectWedge` signal (set on any non-graceful teardown and on graceful-terminate timeout), and a suspect kill **quarantines** the core's host worker — no new cores are assigned to it (the retry boots a fresh worker) and it is natively terminated once its last core is gone. Live siblings keep running (suspicion can be a false positive; a truly affected sibling trips its own watchdog into the same quarantine). Worker-level `error` events also quarantine. Component spec (`DoenetViewer.sharedCoreWorker.cy.tsx`): shared rendering of two viewers; hung-handshake recovery via quarantine + fresh host; and (regression guard for the teardown fix below) a surviving core that still **responds** to an `updateValue` interaction after a sibling core on the same host is torn down — not merely retaining stale DOM.

## Hosted-core teardown fix (top commit)

A hosted core's `terminate()` frees only its own Rust + JS cores; the worker-global `close()` now runs **only** for the worker's default (host) instance, gated on a `_isHostedCore` flag. Previously a hosted core's teardown called `close()`, which would take down the shared host worker — and every sibling core on it — when any one document unmounted. Dedicated (flag-off) mode is unchanged: the default instance still `close()`s exactly as before. The double `terminate()` that shared graceful teardown can produce (once over the core's port, once via `destroyCore`) is safe: the Rust free is guarded and the JS core's `terminate()` is idempotent.

## Cross-iframe sharing for the real deployment (third commit)

`@doenet/doenetml-iframe`'s `DoenetViewer` gains a **`useSharedCoreWorker` prop**: the PARENT page owns the worker pool (`shared-core-pool.ts` — worker resolved next to `standaloneUrl` with the `importScripts` bootstrap when the CDN-served worker is cross-origin; 12-core cap with spillover; suspect quarantine; pools keyed per standalone version) and forwards each iframe's core over a `MessagePort`. The iframe's viewer obtains cores through a new `doenetGlobalConfig.createExternalCoreWorkerPort` seam — the channel is minted locally so core creation stays synchronous (messages buffer until the host exposes the core). Component unmount releases the viewer's cores (an abruptly-removed iframe realm never runs its own teardown). Editors unchanged.

Measured on the **full deployment model** (new `iframe-shared-N` scenario: cross-origin CDN bundle + parent-owned host):

| real deployment | dedicated | shared (this PR) |
|---|---|---|
| 1 iframe | 502 MB | 501 MB |
| 8 iframes | **1876 MB** | **1002 MB** |
| marginal / additional iframe | ~196 MB | **~72 MB** |
| workers at N=8 | 16 | 9 (1 host + 8 MathJax) |

The residual ~72 MB/instance is ~60 MB iframe-realm cost + ~12 MB core — realm cost is now the dominant per-instance term (stream B / #1437-remainder territory). New component spec (`DoenetViewer.sharedCoreWorker.cy.tsx`): two iframes' cores share one parent-owned host worker; unmounting a viewer releases exactly its core. Full doenetml-iframe suite 16/16.

## Known limitations (follow-up on #1466)

- An **already-running** document on a thread-blocked worker still freezes (same as dedicated mode, wider blast radius); lossless mid-session re-init needs #1440 flush-state.
- PreTeXt adoption needs a parent-side coordinator on its `…-if.html` pages (it doesn't use `doenetml-iframe`); the `createExternalCoreWorkerPort` seam + message protocol shipped here is what such a coordinator drives.
- Observed while auditing: the worker's `navigateToTarget`/`navigateToHash` global `postMessage` calls (`NavigationHandler.ts`) have no consumer anywhere in the repo — already dead letters in dedicated mode, so not a shared-mode regression; flagging for a separate cleanup.

Part of #1466 / #1441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


