### PR TITLE
Apply iframe DoenetViewer prop changes without reloading the iframe

### DIFF
--- a/.changeset/iframe-viewer-live-prop-updates.md
+++ b/.changeset/iframe-viewer-live-prop-updates.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml-iframe": patch
+---
+
+`<DoenetViewer>` prop changes no longer reload the iframe. The wrapper now
+pushes serializable prop changes into the already-loaded iframe as messages
+(the pattern `<DoenetEditor>` already used), and the inner viewer applies
+them with in-process semantics: `render`/`darkMode`/`flags`/callbacks apply
+live, and a `doenetML` (or `activityId`/`docId`/`attemptNumber`/
+`requestedVariantIndex`) change re-initializes the document's core inside
+the same realm instead of re-parsing the multi-MB standalone bundle. Only a
+change of the bundle itself (`standaloneUrl`/`cssUrl`/`doenetmlVersion`, a
+version change detected in `doenetML`, or `useSharedCoreWorker`) reloads the
+iframe; to force a full remount, change the component's React `key`.
+Function props follow the latest identity passed, including identities
+passed after mount. Bundles older than 0.7.18 (which cannot re-render in
+place) keep the historical reload-on-change behavior.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -71,6 +71,33 @@ latest editor buffer:
 
 ## DoenetViewer
 
+### Prop changes and iframe reloads
+
+Changing props on a mounted `<DoenetViewer>` does **not** reload the iframe:
+the wrapper pushes changes into the already-loaded iframe as messages, and
+the inner viewer applies them with the same semantics as the in-process
+`<DoenetViewer>` from `@doenet/doenetml`. In particular:
+
+| Prop change                                                                | Effect                                                                                                      |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `render`, `darkMode`, `flags`, `answerResponseCounts`, callbacks, …         | applied live, no reload (flipping `render` false→true starts the document in the already-loaded realm)       |
+| `doenetML`, `activityId`, `docId`, `attemptNumber`, `requestedVariantIndex` | the document's core re-initializes **inside the same iframe realm** — the multi-MB bundle is not re-parsed   |
+| `initialState`, `forceDisable` and the other `force*` props, `userId`       | read at (re-)initialization only, exactly like the in-process viewer — change `docId`/`attemptNumber` or remount via `key=` to apply |
+| `standaloneUrl`, `cssUrl`, `doenetmlVersion` (or a version change detected in `doenetML`), `useSharedCoreWorker` | a different bundle/realm is required, so the iframe reloads                                                   |
+
+To force a full remount (fresh realm and worker), change the component's
+React `key`.
+
+Function props (callbacks) are forwarded across the iframe boundary via
+Comlink proxies and always follow the latest identity passed — parents may
+pass inline arrow functions freely; identity churn does not re-render the
+inner viewer.
+
+> **Note:** in-place updates require a standalone bundle ≥ 0.7.18. When an
+> older version is pinned (via `doenetmlVersion` or detected from the
+> document's `xmlns`), the wrapper falls back to its historical behavior of
+> reloading the iframe on any prop change.
+
 ### Host message protocol (SPLICE)
 
 The viewer exchanges JSON messages with the host page via `postMessage`.

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -297,14 +297,6 @@ function renderWithLastAugmentedProps() {
     );
 }
 
-// Defer `iframeReady` until the standalone bundle has defined
-// `renderDoenetViewerToContainer`. See `waitForStandaloneBundle` above.
-//
-// The trailing `.catch(...)` is required by repo convention (AGENTS.md:
-// no fire-and-forget Promises). See the editor counterpart for the full
-// rationale — nothing inside is expected to throw, but an unhandled
-// rejection inside the iframe is hard to diagnose, so log locally and
-// try to surface an error to the parent.
 /**
  * Route this realm's core creation to the PARENT page's shared worker pool
  * (#1466): install `doenetGlobalConfig.createExternalCoreWorkerPort` so the
@@ -340,6 +332,14 @@ function installSharedCorePortProvider() {
     };
 }
 
+// Defer `iframeReady` until the standalone bundle has defined
+// `renderDoenetViewerToContainer`. See `waitForStandaloneBundle` above.
+//
+// The trailing `.catch(...)` is required by repo convention (AGENTS.md:
+// no fire-and-forget Promises). See the editor counterpart for the full
+// rationale — nothing inside is expected to throw, but an unhandled
+// rejection inside the iframe is hard to diagnose, so log locally and
+// try to surface an error to the parent.
 (async () => {
     if (await waitForStandaloneBundle(60_000)) {
         if (

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -7,7 +7,11 @@ declare const doenetViewerPropsSpecified: string[];
 // core-worker host (#1466). Guarded with `typeof` at the use site so this
 // script also works in srcdocs generated without the const.
 declare const doenetSharedCoreWorker: boolean | undefined;
-declare const ComlinkViewer: { expose: Function; windowEndpoint: Function };
+declare const ComlinkViewer: {
+    expose: Function;
+    windowEndpoint: Function;
+    releaseProxy: symbol;
+};
 interface Window {
     renderDoenetViewerToContainer: (
         container: Element,
@@ -15,6 +19,140 @@ interface Window {
         config?: object,
     ) => void;
     doenetGlobalConfig: Record<string, any>;
+}
+
+// Module-scope state below is per-iframe-document: each `<DoenetViewer>` lives
+// in its own iframe with its own copy of this module, so there's no risk of
+// two wrappers competing over the same singletons. Don't try to host multiple
+// viewers inside a single iframe document — they'd alias these mutables.
+
+// Holds the most recent full props bag (serializable props + stable function
+// dispatchers — see `currentFunctionProps`) so that `updateViewerProps` can
+// produce a new merged bag and re-render without re-sending the function
+// proxies from the parent.
+let lastAugmentedProps: Record<string, any> | null = null;
+
+// Live registry of the parent's proxied callbacks, keyed by prop name. The
+// mounted viewer is never handed these proxies directly; it gets a *stable
+// dispatcher* per key (see `getFunctionPropDispatcher`) that reads from this
+// registry at call time.
+//
+// This indirection is what keeps callback-identity churn from re-rendering
+// the viewer. A React parent that passes inline arrow callbacks hands the
+// wrapper a brand-new closure identity on every render; an identity-only
+// change just swaps the entry here — the viewer keeps calling the same stable
+// dispatcher, which dereferences the new closure — so no re-render happens
+// and a core boot in progress is left undisturbed. (This is the same design
+// as the editor entry; see iframe-editor-index.ts for the incident that
+// motivated it.)
+let currentFunctionProps: Record<string, Function> = {};
+
+// Stable dispatcher per function-prop key. Created lazily and never replaced,
+// so the viewer sees a single unchanging callback identity for the life of
+// the iframe document even as the underlying proxied closure is swapped
+// underneath.
+const functionPropDispatchers: Record<string, Function> = {};
+
+function getFunctionPropDispatcher(key: string): Function {
+    let dispatcher = functionPropDispatchers[key];
+    if (!dispatcher) {
+        dispatcher = (...callArgs: any[]) =>
+            currentFunctionProps[key]?.(...callArgs);
+        functionPropDispatchers[key] = dispatcher;
+    }
+    return dispatcher;
+}
+
+// Parse the `key, proxy, key, proxy, …` argument list the wrapper sends
+// (Comlink can't pass proxied functions as object values, only as direct
+// args) into a map.
+function functionPropArgsToMap(
+    args: (string | Function)[],
+): Record<string, Function> {
+    const map: Record<string, Function> = {};
+    for (let i = 0; i < args.length; i += 2) {
+        const key = args[i];
+        const fn = args[i + 1];
+        if (typeof key === "string" && typeof fn === "function") {
+            map[key] = fn;
+        }
+    }
+    return map;
+}
+
+function releaseFunctionProxy(fn: Function) {
+    try {
+        (fn as any)?.[ComlinkViewer.releaseProxy]?.();
+    } catch (e) {
+        console.warn(
+            "iframe DoenetViewer: failed to release stale Comlink proxy",
+            e,
+        );
+    }
+}
+
+// Adopt `incoming` as the live callback set, releasing the Comlink port of
+// every previous proxy that is being replaced or dropped (so the parent-side
+// MessageChannel closes — Comlink also has a FinalizationRegistry fallback,
+// but explicit release avoids depending on GC timing).
+function setCurrentFunctionProps(incoming: Record<string, Function>) {
+    for (const [key, fn] of Object.entries(currentFunctionProps)) {
+        if (incoming[key] !== fn) {
+            releaseFunctionProxy(fn);
+        }
+    }
+    currentFunctionProps = incoming;
+}
+
+// If the parent DoenetViewer was not given a requestScrollTo prop, the viewer
+// gets this default, which messages the parent so it can scroll the host page
+// when scroll-only links (with target of the form #anchor) are clicked.
+function defaultRequestScrollTo(offset: number) {
+    messageParentFromViewer({ type: "scrollTo", offset });
+}
+
+// Rebuild `lastAugmentedProps` so its function-typed entries exactly match the
+// dispatchers for the current callback set. Used when the *set of keys* changes
+// (a callback added or removed) — the one case that needs a re-render so the
+// viewer can react to a callback's presence/absence. All function-typed entries
+// in `lastAugmentedProps` are dispatchers (or the default requestScrollTo), so
+// dropping them and re-adding only the current keys correctly removes a
+// vanished callback and adds a new one.
+function syncAugmentedFunctionProps() {
+    if (!lastAugmentedProps) {
+        return;
+    }
+    const next: Record<string, any> = {};
+    for (const [key, val] of Object.entries(lastAugmentedProps)) {
+        if (typeof val !== "function") {
+            next[key] = val;
+        }
+    }
+    for (const key of Object.keys(currentFunctionProps)) {
+        next[key] = getFunctionPropDispatcher(key);
+    }
+    if (!("requestScrollTo" in next)) {
+        next.requestScrollTo = defaultRequestScrollTo;
+    }
+    lastAugmentedProps = next;
+}
+
+// The initial DoenetML lives in a `<script type="text/doenetml">` child of
+// `#root`. React replaces those children as soon as
+// `renderDoenetViewerToContainer` mounts the viewer, so we read it once up
+// front and pass it explicitly on every subsequent call. Unlike the editor
+// (where post-mount `doenetML` changes are ignored to protect the user's
+// in-progress edits), the viewer treats `doenetML` as live: the wrapper sends
+// changes through `updateViewerProps` and this variable is updated, letting
+// the inner DocViewer re-initialize its core in the same realm.
+let currentDoenetMLSource: string | null = null;
+function resolveDoenetMLSource(root: Element): string {
+    if (currentDoenetMLSource !== null) {
+        return currentDoenetMLSource;
+    }
+    const scriptTag = root.querySelector('script[type="text/doenetml"]');
+    currentDoenetMLSource = scriptTag?.innerHTML ?? "";
+    return currentDoenetMLSource;
 }
 
 // Wait for the @doenet/standalone bundle to finish evaluating and
@@ -43,17 +181,78 @@ async function waitForStandaloneBundle(timeoutMs: number): Promise<boolean> {
 }
 
 ComlinkViewer.expose(
-    { renderViewerWithFunctionProps },
+    {
+        renderViewerWithFunctionProps,
+        updateViewerProps(updatedSerializableProps: Record<string, any>) {
+            if (!lastAugmentedProps) {
+                console.warn(
+                    "iframe DoenetViewer: updateViewerProps arrived before renderViewerWithFunctionProps completed — likely a bug in the iframe wrapper's queue/replay sequencing.",
+                );
+                return;
+            }
+            // `doenetML` travels in the same snapshot as the other
+            // serializable props but is passed to
+            // `renderDoenetViewerToContainer` as the source argument, not
+            // inside the config bag.
+            const { doenetML, ...rest } = updatedSerializableProps;
+            if (typeof doenetML === "string") {
+                currentDoenetMLSource = doenetML;
+            }
+            lastAugmentedProps = {
+                ...lastAugmentedProps,
+                ...rest,
+            };
+            renderWithLastAugmentedProps();
+        },
+        updateViewerFunctionProps(...args: (string | Function)[]) {
+            // The wrapper sends key/proxy pairs the same way
+            // renderViewerWithFunctionProps does (Comlink can't pass proxies
+            // as values inside an object, only as direct arguments). Treat the
+            // args as a *full replacement* of the live callback set.
+            if (!lastAugmentedProps) {
+                console.warn(
+                    "iframe DoenetViewer: updateViewerFunctionProps arrived before renderViewerWithFunctionProps completed — likely a bug in the iframe wrapper's queue/replay sequencing.",
+                );
+                return;
+            }
+            const incoming = functionPropArgsToMap(args);
+            // Compare key sets *before* swapping — `setCurrentFunctionProps`
+            // below overwrites `currentFunctionProps`, so reading `prevKeys`
+            // from it must happen first.
+            const prevKeys = Object.keys(currentFunctionProps).sort();
+            const nextKeys = Object.keys(incoming).sort();
+            const keysChanged =
+                prevKeys.length !== nextKeys.length ||
+                prevKeys.some((key, i) => key !== nextKeys[i]);
+
+            // Swap the live callbacks (releasing replaced/removed proxies).
+            setCurrentFunctionProps(incoming);
+
+            // Identity-only change (same keys, new closures) — the common case
+            // when a parent passes inline arrow callbacks: the viewer holds
+            // stable dispatchers that read `currentFunctionProps` at call time,
+            // so the swap above is sufficient. We deliberately do NOT re-render
+            // here; re-rendering on every parent render could disturb a core
+            // boot in progress (see iframe-editor-index.ts).
+            if (keysChanged) {
+                // A callback was added or removed: re-render so the viewer can
+                // react to which callbacks are present. Rare and not part of
+                // the per-render identity churn.
+                syncAugmentedFunctionProps();
+                renderWithLastAugmentedProps();
+            }
+        },
+    },
     ComlinkViewer.windowEndpoint(globalThis.parent),
 );
 
 /**
- * Render the DoenetEditor to the container after reconstructing the props.
+ * Render the DoenetViewer to the container after reconstructing the props.
  *
- * Reconstruct the props from the serialized `doenetEditorProps` (from which functions have disappeared)
+ * Reconstruct the props from the serialized `doenetViewerProps` (from which functions have disappeared)
  * and the ComLink proxied functions specified in `args`.
  * Only include the ComLink proxies if the prop was actually specified,
- * so that the DoenetEditor can customize behavior based on the presence of callback
+ * so that the DoenetViewer can customize behavior based on the presence of callback
  *
  * Note that Comlink is unable to send proxied functions as an values of an object,
  * but must be direct arguments of the function.
@@ -61,14 +260,20 @@ ComlinkViewer.expose(
  * followed by the proxied function with that name.
  */
 function renderViewerWithFunctionProps(...args: (string | Function)[]) {
+    setCurrentFunctionProps(functionPropArgsToMap(args));
+
     const augmentedDoenetViewerProps = { ...doenetViewerProps };
     augmentedDoenetViewerProps.externalVirtualKeyboardProvided = true;
     for (const propName of doenetViewerPropsSpecified) {
-        if (!(propName in doenetViewerProps)) {
-            const idx = args.indexOf(propName);
-            if (idx !== -1) {
-                augmentedDoenetViewerProps[propName] = args[idx + 1];
-            }
+        if (
+            !(propName in doenetViewerProps) &&
+            propName in currentFunctionProps
+        ) {
+            // Hand the viewer a *stable dispatcher*, not the raw proxy, so a
+            // later callback-identity swap (via updateViewerFunctionProps)
+            // updates `currentFunctionProps` without forcing a re-render.
+            augmentedDoenetViewerProps[propName] =
+                getFunctionPropDispatcher(propName);
         }
     }
 
@@ -76,15 +281,19 @@ function renderViewerWithFunctionProps(...args: (string | Function)[]) {
     // then create a requestScrollTo prop that will message the parent
     // when scroll-only links (with target of the form #anchor) are clicked
     if (!doenetViewerPropsSpecified.includes("requestScrollTo")) {
-        augmentedDoenetViewerProps.requestScrollTo = (offset: number) => {
-            messageParentFromViewer({ type: "scrollTo", offset });
-        };
+        augmentedDoenetViewerProps.requestScrollTo = defaultRequestScrollTo;
     }
 
+    lastAugmentedProps = augmentedDoenetViewerProps;
+    renderWithLastAugmentedProps();
+}
+
+function renderWithLastAugmentedProps() {
+    const root = document.getElementById("root")!;
     window.renderDoenetViewerToContainer(
-        document.getElementById("root")!,
-        undefined,
-        augmentedDoenetViewerProps,
+        root,
+        resolveDoenetMLSource(root),
+        lastAugmentedProps!,
     );
 }
 

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -307,21 +307,11 @@ export function DoenetViewer({
 
     // Serializable snapshot of the live-updatable inputs (doenetML + all
     // non-function props), used for change detection against what the iframe
-    // last received.
-    //
-    // Change detection uses `JSON.stringify`, which assumes supported props
-    // are JSON-safe (scalars, plain arrays/objects). `undefined` values are
-    // dropped, `Date`/`Map`/`Set` are normalized to strings/empty objects,
-    // and key reordering produces spurious diffs. If a new prop with an
-    // exotic value type is added later, prefer a structural comparator over
-    // expanding what this serializer handles.
-    const propsForUpdate: Record<string, any> = { doenetML };
-    for (const [key, val] of Object.entries(doenetViewerProps)) {
-        if (typeof val !== "function") {
-            propsForUpdate[key] = val;
-        }
-    }
-    const propsSnapshotStr = JSON.stringify(propsForUpdate);
+    // last received. See `serializePropsSnapshot` for the JSON-safety caveats.
+    const propsSnapshotStr = serializePropsSnapshot(
+        { doenetML },
+        doenetViewerProps,
+    );
 
     // Legacy bundles (< 0.7.18) can't re-render in place, so fall back to
     // the historical behavior: bake current props into the srcdoc and reload
@@ -377,15 +367,10 @@ export function DoenetViewer({
     React.useLayoutEffect(() => {
         viewerIframeRef.current = null;
         destroySharedCoresForViewer(id);
-        const baselineProps: Record<string, any> = {
-            doenetML: doenetMLRef.current,
-        };
-        for (const [key, val] of Object.entries(doenetViewerPropsRef.current)) {
-            if (typeof val !== "function") {
-                baselineProps[key] = val;
-            }
-        }
-        lastSentPropsSnapshotRef.current = JSON.stringify(baselineProps);
+        lastSentPropsSnapshotRef.current = serializePropsSnapshot(
+            { doenetML: doenetMLRef.current },
+            doenetViewerPropsRef.current,
+        );
         // Function props re-register when the new iframe emits iframeReady
         // (the listener calls renderViewerWithFunctionProps with the latest
         // identities and re-populates this ref), so just clear it here.
@@ -572,7 +557,7 @@ export function DoenetViewer({
     // Push function-prop identity changes into the iframe, matching the
     // in-process `<DoenetViewer>` (where parents routinely pass a fresh
     // closure each render). Same strategy and caveats as the editor's
-    // function-prop effect above — see that comment block for the full
+    // function-prop effect below — see that comment block for the full
     // rationale (full-set resend, dispatchers on the iframe side, Comlink
     // port lifetime).
     //
@@ -706,6 +691,32 @@ type EditorIframeRemote = Comlink.Remote<{
     closeDiagnosticsPanel: () => void;
     updateRenderedView: () => void;
 }>;
+
+// Serialize the live-updatable props into the JSON string used both for
+// change detection (against what the iframe last received) and as the
+// payload pushed through `updateViewerProps`/`updateEditorProps`. The `seed`
+// entries (the viewer's source `doenetML`, or the editor's `width`) come
+// first, then every non-function entry of `props`; function props travel
+// separately as Comlink proxies.
+//
+// Change detection uses `JSON.stringify`, which assumes supported props are
+// JSON-safe (scalars, plain arrays/objects). `undefined` values are dropped,
+// `Date`/`Map`/`Set` are normalized to strings/empty objects, and key
+// reordering produces spurious diffs. If a new prop with an exotic value type
+// is added later, prefer a structural comparator over expanding what this
+// serializer handles.
+function serializePropsSnapshot(
+    seed: Record<string, any>,
+    props: Record<string, any>,
+): string {
+    const snapshot: Record<string, any> = { ...seed };
+    for (const [key, val] of Object.entries(props)) {
+        if (typeof val !== "function") {
+            snapshot[key] = val;
+        }
+    }
+    return JSON.stringify(snapshot);
+}
 
 // ComLink RPC calls return Promises, but the wrapper APIs built on them are
 // `void` (matching the in-process components so consumers can use one type
@@ -982,23 +993,14 @@ export const DoenetEditor = React.forwardRef<
 
     // Build the serializable prop snapshot used both for change detection
     // (vs. last sent) and as the baseline of "what the iframe currently
-    // believes." Drop function-typed entries (sent separately via
-    // updateEditorFunctionProps) and drop `doenetML` (initial-only — see
-    // initialIframePropsRef above).
-    //
-    // Change detection uses `JSON.stringify`, which assumes supported props
-    // are JSON-safe (scalars, plain arrays/objects). `undefined` values are
-    // dropped, `Date`/`Map`/`Set` are normalized to strings/empty objects,
-    // and key reordering produces spurious diffs. If a new prop with an
-    // exotic value type is added later, prefer a structural comparator over
-    // expanding what this serializer handles.
-    const propsForUpdate: Record<string, any> = { width };
-    for (const [key, val] of Object.entries(doenetEditorProps)) {
-        if (typeof val !== "function") {
-            propsForUpdate[key] = val;
-        }
-    }
-    const propsSnapshotStr = JSON.stringify(propsForUpdate);
+    // believes." Function-typed entries are sent separately (via
+    // updateEditorFunctionProps) and `doenetML` is excluded entirely
+    // (initial-only — see initialIframePropsRef above). See
+    // `serializePropsSnapshot` for the JSON-safety caveats.
+    const propsSnapshotStr = serializePropsSnapshot(
+        { width },
+        doenetEditorProps,
+    );
 
     // When `srcDoc` changes (autodetect-version fallback path), React updates
     // the iframe attribute and the browser reloads the iframe document. The
@@ -1013,17 +1015,10 @@ export const DoenetEditor = React.forwardRef<
     // is stable, so this effect is a no-op after the first commit.
     React.useLayoutEffect(() => {
         editorIframeRef.current = null;
-        const baselineProps: Record<string, any> = {
-            width: initialIframePropsRef.current!.width,
-        };
-        for (const [key, val] of Object.entries(
+        lastSentPropsSnapshotRef.current = serializePropsSnapshot(
+            { width: initialIframePropsRef.current!.width },
             initialIframePropsRef.current!.doenetEditorProps,
-        )) {
-            if (typeof val !== "function") {
-                baselineProps[key] = val;
-            }
-        }
-        lastSentPropsSnapshotRef.current = JSON.stringify(baselineProps);
+        );
         // Function props re-register when the new iframe emits iframeReady
         // (the listener calls renderEditorWithFunctionProps with the latest
         // identities and re-populates this ref), so just clear it here.

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -149,14 +149,65 @@ export type DoenetEditorIframeProps = DoenetEditorProps & {
     height?: string;
 };
 
+type ViewerIframeRemote = Comlink.Remote<{
+    renderViewerWithFunctionProps: (...args: (string | Function)[]) => void;
+    updateViewerProps: (props: Record<string, any>) => void;
+    updateViewerFunctionProps: (...args: (string | Function)[]) => void;
+}>;
+
+// In-place prop updates require a standalone bundle whose
+// `renderDoenetViewerToContainer` re-renders against a cached React root
+// (v0.7.18+, PR #1131). Calling it repeatedly against an older bundle mounts
+// competing React roots on the same container.
+const LIVE_UPDATE_MIN_VERSION = [0, 7, 18];
+
+/**
+ * Whether the standalone bundle selected by `version` supports live
+ * (in-place) prop updates. Missing version parts are npm ranges that
+ * jsdelivr resolves to the newest matching release (e.g. "0.7" serves the
+ * latest 0.7.x, which is ≥ 0.7.18), so they compare as the range's upper
+ * bound. Unparseable versions are assumed modern.
+ */
+function versionSupportsLiveUpdates(version: string): boolean {
+    const match = version
+        .replace(/^v/, "")
+        .match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+    if (!match) {
+        return true;
+    }
+    const parts = [match[1], match[2], match[3]].map((p) =>
+        p === undefined ? Infinity : parseInt(p, 10),
+    );
+    for (let i = 0; i < 3; i++) {
+        if (parts[i] > LIVE_UPDATE_MIN_VERSION[i]) {
+            return true;
+        }
+        if (parts[i] < LIVE_UPDATE_MIN_VERSION[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /**
  * Render Doenet viewer constrained to an iframe. A URL pointing to a version of DoenetML
  * standalone must be provided (along with a URL to the corresponding CSS file).
  *
- * Parameters being passed to the underlying DoenetML component are passed via the `DoenetViewerProps` prop.
- * However, only serializable parameters may be passed. E.g., callbacks **cannot** be passed to the underlying
- * DoenetML component. Instead you must use the message passing interface of `DoenetViewer` to communicate
- * with the underlying DoenetML component.
+ * Parameters for the underlying `DoenetViewer` component are passed via props.
+ * Serializable prop changes after mount are pushed into the iframe as
+ * messages and applied in place with the same semantics as the in-process
+ * `<DoenetViewer>`: e.g. flipping `render` starts the document without a
+ * reload, and changing `doenetML` (or `activityId`/`docId`/`attemptNumber`/
+ * `requestedVariantIndex`) re-initializes the document's core inside the
+ * same iframe realm — the multi-MB standalone bundle is not re-parsed. Only
+ * a change of the bundle itself (`standaloneUrl`/`cssUrl`/`doenetmlVersion`,
+ * a version change detected in `doenetML`, or `useSharedCoreWorker`) reloads
+ * the iframe. To force a full remount instead, change the component's `key`.
+ *
+ * Function props are forwarded across the iframe boundary via Comlink
+ * proxies and follow the latest identity passed. (Bundles older than
+ * v0.7.18 cannot re-render in place; for those the wrapper falls back to
+ * reloading the iframe on any prop change, its historical behavior.)
  */
 export function DoenetViewer({
     doenetML,
@@ -169,6 +220,29 @@ export function DoenetViewer({
 }: DoenetViewerIframeProps) {
     const [id, _] = React.useState(() => Math.random().toString(36).slice(2));
     const ref = React.useRef<HTMLIFrameElement>(null);
+    const viewerIframeRef = React.useRef<ViewerIframeRemote | null>(null);
+    const pendingActions = React.useRef<
+        ((remote: ViewerIframeRemote) => void)[]
+    >([]);
+    // Snapshot of the serializable props last pushed to the iframe via
+    // Comlink. Re-anchored when `srcDoc` rebuilds (see the layout effect
+    // below) so the live-update effect replays any drift against the
+    // freshly-loaded iframe.
+    const lastSentPropsSnapshotRef = React.useRef<string | null>(null);
+    // Snapshot of the function-typed props registered with the iframe via
+    // Comlink.proxy. Used to detect when the parent passes a new callback
+    // identity so the iframe can be re-pointed at the fresh closure.
+    const lastSentFunctionPropsRef = React.useRef<Record<
+        string,
+        Function
+    > | null>(null);
+    // Latest doenetML/props so the (deps-empty) message listener, the srcDoc
+    // memo, and re-entrant effects read current values rather than a stale
+    // closure's.
+    const doenetViewerPropsRef = React.useRef(doenetViewerProps);
+    doenetViewerPropsRef.current = doenetViewerProps;
+    const doenetMLRef = React.useRef(doenetML);
+    doenetMLRef.current = doenetML;
     const [height, setHeight] = React.useState("500px");
     const [inErrorState, setInErrorState] = React.useState<string | null>(null);
     const [ignoreDetectedVersion, setIgnoreDetectedVersion] =
@@ -176,6 +250,16 @@ export function DoenetViewer({
     const resolvedTheme = useResolvedTheme(
         doenetViewerProps.darkMode ?? "system",
     );
+
+    function syncIframeBodyBackground() {
+        const body = ref.current?.contentDocument?.body;
+        if (body) {
+            setIframeBodyBackground(
+                body,
+                doenetViewerPropsRef.current.darkMode,
+            );
+        }
+    }
 
     let standaloneUrl: string, cssUrl: string;
     let foundAutoVersion = false;
@@ -205,23 +289,108 @@ export function DoenetViewer({
         cssUrl = `https://cdn.jsdelivr.net/npm/@doenet/standalone@${selectedDoenetmlVersion}/style.css`;
     }
 
+    // Whether the bundle in the iframe can apply prop changes in place. A
+    // host-specified standaloneUrl carries no version information; assume it
+    // is a current bundle (hosts shipping a custom URL control both sides).
+    const usingCustomStandaloneUrl = Boolean(
+        specifiedStandaloneUrl && !foundAutoVersion,
+    );
+    const liveUpdatesSupported =
+        usingCustomStandaloneUrl ||
+        versionSupportsLiveUpdates(selectedDoenetmlVersion);
+
     // Latest standaloneUrl for the (deps-empty) message listener below — it
     // can change after mount via the autodetect-version fallback, and the
     // shared-core pool keys its workers by the URL the iframe actually loads.
     const standaloneUrlRef = React.useRef(standaloneUrl);
     standaloneUrlRef.current = standaloneUrl;
 
-    // Shared-core cleanup (#1466): an unmounted iframe realm never runs its
-    // own core teardown, so release any cores this viewer created on the
-    // parent-owned pool.
-    React.useEffect(() => {
-        if (!useSharedCoreWorker) {
-            return;
+    // Serializable snapshot of the live-updatable inputs (doenetML + all
+    // non-function props), used for change detection against what the iframe
+    // last received.
+    //
+    // Change detection uses `JSON.stringify`, which assumes supported props
+    // are JSON-safe (scalars, plain arrays/objects). `undefined` values are
+    // dropped, `Date`/`Map`/`Set` are normalized to strings/empty objects,
+    // and key reordering produces spurious diffs. If a new prop with an
+    // exotic value type is added later, prefer a structural comparator over
+    // expanding what this serializer handles.
+    const propsForUpdate: Record<string, any> = { doenetML };
+    for (const [key, val] of Object.entries(doenetViewerProps)) {
+        if (typeof val !== "function") {
+            propsForUpdate[key] = val;
         }
+    }
+    const propsSnapshotStr = JSON.stringify(propsForUpdate);
+
+    // Legacy bundles (< 0.7.18) can't re-render in place, so fall back to
+    // the historical behavior: bake current props into the srcdoc and reload
+    // the iframe on any change.
+    const legacyReloadKey = liveUpdatesSupported ? "" : propsSnapshotStr;
+
+    // Only recompute `srcDoc` when something that genuinely requires a
+    // reload changes: a new standalone bundle (autodetect-version fallback,
+    // or a version change detected in edited doenetML) or the
+    // shared-core-worker mode (baked as a const into the srcdoc). Other prop
+    // changes flow live through `updateViewerProps` below. The memo reads
+    // current values via refs: a rebuild bakes the *latest* doenetML/props,
+    // and the layout effect below re-anchors the sent-snapshot baseline to
+    // those same values.
+    const srcDoc = React.useMemo(
+        () =>
+            createHtmlForDoenetViewer(
+                id,
+                doenetMLRef.current,
+                doenetViewerPropsRef.current,
+                standaloneUrl,
+                cssUrl,
+                useSharedCoreWorker,
+            ),
+        [id, standaloneUrl, cssUrl, useSharedCoreWorker, legacyReloadKey],
+    );
+
+    // Shared-core cleanup on unmount (#1466): an unmounted iframe realm never
+    // runs its own core teardown, so release any cores this viewer created on
+    // the parent-owned pool. Unconditional (not gated on the current
+    // `useSharedCoreWorker` value): `destroySharedCoresForViewer` is a no-op
+    // when the viewer has no cores, and gating could miss cores created
+    // before a prop change.
+    React.useEffect(() => {
         return () => {
             destroySharedCoresForViewer(id);
         };
     }, []);
+
+    // When `srcDoc` changes (bundle swap via the autodetect-version fallback
+    // or a detected version change), React updates the iframe attribute and
+    // the browser reloads the iframe document. The previous Comlink remote
+    // becomes bound to a torn-down `contentWindow` until the new iframe sends
+    // `iframeReady`. Clear the remote synchronously at commit so updates
+    // dispatched between commit and the next `iframeReady` queue and replay
+    // against the new remote instead of dispatching into a dead one. The old
+    // realm also never ran its own teardown, so release any shared cores it
+    // created (#1466) before the new realm re-creates cores under the same
+    // viewer id. Finally, re-anchor the live-update snapshot refs to the
+    // values the memo above just baked into the new srcdoc, so the
+    // live-update effect can detect (and replay) any later drift. In the
+    // steady state `srcDoc` is stable, so this effect runs once at mount.
+    React.useLayoutEffect(() => {
+        viewerIframeRef.current = null;
+        destroySharedCoresForViewer(id);
+        const baselineProps: Record<string, any> = {
+            doenetML: doenetMLRef.current,
+        };
+        for (const [key, val] of Object.entries(doenetViewerPropsRef.current)) {
+            if (typeof val !== "function") {
+                baselineProps[key] = val;
+            }
+        }
+        lastSentPropsSnapshotRef.current = JSON.stringify(baselineProps);
+        // Function props re-register when the new iframe emits iframeReady
+        // (the listener calls renderViewerWithFunctionProps with the latest
+        // identities and re-populates this ref), so just clear it here.
+        lastSentFunctionPropsRef.current = null;
+    }, [srcDoc]);
 
     React.useEffect(() => {
         const listener = (event: MessageEvent<IframeMessage>) => {
@@ -308,11 +477,7 @@ export function DoenetViewer({
                 // and we can call `renderViewerWithFunctionProps`
 
                 if (ref.current) {
-                    const viewerIframe: Comlink.Remote<{
-                        renderViewerWithFunctionProps: (
-                            ...args: (string | Function)[]
-                        ) => void;
-                    }> = Comlink.wrap(
+                    const viewerIframe: ViewerIframeRemote = Comlink.wrap(
                         Comlink.windowEndpoint(ref.current.contentWindow!),
                     );
 
@@ -320,18 +485,40 @@ export function DoenetViewer({
                     // but must be direct arguments of the function.
                     // To indicate the functions names, the arguments are a series of string key names
                     // followed by the proxied function with that name.
+                    // Read from the ref so that if the parent passed a new
+                    // callback identity between mount and iframeReady, the
+                    // freshest closure is what gets registered.
+                    const latestProps = doenetViewerPropsRef.current;
                     const proxiedFunctions: (string | Function)[] = [];
-                    for (const [key, prop] of Object.entries(
-                        doenetViewerProps,
-                    )) {
+                    const registeredFunctions: Record<string, Function> = {};
+                    for (const [key, prop] of Object.entries(latestProps)) {
                         if (typeof prop === "function") {
+                            registeredFunctions[key] = prop;
                             proxiedFunctions.push(key);
                             proxiedFunctions.push(Comlink.proxy(prop));
                         }
                     }
-                    viewerIframe?.renderViewerWithFunctionProps(
-                        ...proxiedFunctions,
-                    );
+                    viewerIframe
+                        .renderViewerWithFunctionProps(...proxiedFunctions)
+                        .catch(
+                            logComlinkError(
+                                "DoenetViewer",
+                                "renderViewerWithFunctionProps",
+                            ),
+                        );
+                    // Record what we registered so the function-prop change
+                    // effect below can detect later identity changes.
+                    lastSentFunctionPropsRef.current = registeredFunctions;
+
+                    // Make the remote available to the live-update effects
+                    // and replay any updates queued before the iframe was
+                    // ready.
+                    viewerIframeRef.current = viewerIframe;
+                    const queued = pendingActions.current.splice(0);
+                    for (const action of queued) {
+                        action(viewerIframe);
+                    }
+                    syncIframeBodyBackground();
                 }
             }
         };
@@ -343,6 +530,106 @@ export function DoenetViewer({
             window.removeEventListener("message", listener);
         };
     }, []);
+
+    // Push serializable prop changes (including `doenetML`) into the iframe
+    // without reloading it. Compares against the ref re-anchored by the
+    // layoutEffect above (initial mount: baseline equal to current → no push;
+    // later renders: ref reflects last-sent state). `srcDoc` is in the dep
+    // list so a rebuild fires this effect even when no prop changed,
+    // replaying any drift. The inner DocViewer applies its in-process
+    // semantics to the update — e.g. a `doenetML` change re-initializes the
+    // core in the same realm. Skipped for legacy (< 0.7.18) bundles, which
+    // reload via `legacyReloadKey` instead.
+    React.useEffect(() => {
+        if (!liveUpdatesSupported) {
+            return;
+        }
+        if (lastSentPropsSnapshotRef.current === propsSnapshotStr) {
+            return;
+        }
+        lastSentPropsSnapshotRef.current = propsSnapshotStr;
+        const snapshot = JSON.parse(propsSnapshotStr);
+        const action = (remote: ViewerIframeRemote) => {
+            remote
+                .updateViewerProps(snapshot)
+                .catch(logComlinkError("DoenetViewer", "updateViewerProps"));
+        };
+        if (viewerIframeRef.current) {
+            action(viewerIframeRef.current);
+        } else {
+            pendingActions.current.push(action);
+        }
+    }, [propsSnapshotStr, srcDoc, liveUpdatesSupported]);
+
+    // Keep the iframe body's empty margin area aligned with live dark-mode
+    // changes without reloading the document. iframeReady also re-syncs the
+    // body after any srcDoc rebuild so mount-time darkMode doesn't leak back
+    // in.
+    React.useEffect(() => {
+        syncIframeBodyBackground();
+    }, [doenetViewerProps.darkMode]);
+
+    // Push function-prop identity changes into the iframe, matching the
+    // in-process `<DoenetViewer>` (where parents routinely pass a fresh
+    // closure each render). Same strategy and caveats as the editor's
+    // function-prop effect above — see that comment block for the full
+    // rationale (full-set resend, dispatchers on the iframe side, Comlink
+    // port lifetime).
+    //
+    // No deps array on purpose: change detection is by-hand identity
+    // comparison against `lastSentFunctionPropsRef`, not React's shallow
+    // dep diff. The effect fires every render and short-circuits when the
+    // function set is unchanged.
+    React.useEffect(() => {
+        if (!liveUpdatesSupported) {
+            return;
+        }
+        const prev = lastSentFunctionPropsRef.current;
+        if (prev === null) {
+            return;
+        }
+        const current: Record<string, Function> = {};
+        for (const [key, val] of Object.entries(doenetViewerPropsRef.current)) {
+            if (typeof val === "function") {
+                current[key] = val;
+            }
+        }
+        const prevKeys = Object.keys(prev);
+        const currKeys = Object.keys(current);
+        let changed = prevKeys.length !== currKeys.length;
+        if (!changed) {
+            for (const k of currKeys) {
+                if (prev[k] !== current[k]) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        if (!changed) {
+            return;
+        }
+        lastSentFunctionPropsRef.current = current;
+        const proxiedFunctions: (string | Function)[] = [];
+        for (const [key, val] of Object.entries(current)) {
+            proxiedFunctions.push(key);
+            proxiedFunctions.push(Comlink.proxy(val));
+        }
+        const action = (remote: ViewerIframeRemote) => {
+            remote
+                .updateViewerFunctionProps(...proxiedFunctions)
+                .catch(
+                    logComlinkError(
+                        "DoenetViewer",
+                        "updateViewerFunctionProps",
+                    ),
+                );
+        };
+        if (viewerIframeRef.current) {
+            action(viewerIframeRef.current);
+        } else {
+            pendingActions.current.push(action);
+        }
+    });
 
     if (inErrorState) {
         if (foundAutoVersion) {
@@ -388,14 +675,7 @@ export function DoenetViewer({
             <iframe
                 title="Doenet document"
                 ref={ref}
-                srcDoc={createHtmlForDoenetViewer(
-                    id,
-                    doenetML,
-                    doenetViewerProps,
-                    standaloneUrl,
-                    cssUrl,
-                    useSharedCoreWorker,
-                )}
+                srcDoc={srcDoc}
                 style={{
                     width: "100%",
                     boxSizing: "border-box",
@@ -427,13 +707,13 @@ type EditorIframeRemote = Comlink.Remote<{
     updateRenderedView: () => void;
 }>;
 
-// ComLink RPC calls return Promises, but the imperative handle methods are
-// `void` (matching the in-process handle so consumers can use one type for
-// both). Attach an explicit catch handler so we don't leave the Promise
+// ComLink RPC calls return Promises, but the wrapper APIs built on them are
+// `void` (matching the in-process components so consumers can use one type
+// for both). Attach an explicit catch handler so we don't leave the Promise
 // unhandled — surface errors via console rather than swallowing them.
-function logComlinkError(method: string) {
+function logComlinkError(component: string, method: string) {
     return (err: unknown) => {
-        console.warn(`iframe DoenetEditor: ${method} failed`, err);
+        console.warn(`iframe ${component}: ${method} failed`, err);
     };
 }
 
@@ -502,7 +782,12 @@ export const DoenetEditor = React.forwardRef<
                 const action = (remote: EditorIframeRemote) => {
                     remote
                         .openDiagnosticsTab(tabId)
-                        .catch(logComlinkError("openDiagnosticsTab"));
+                        .catch(
+                            logComlinkError(
+                                "DoenetEditor",
+                                "openDiagnosticsTab",
+                            ),
+                        );
                 };
                 if (editorIframeRef.current) {
                     action(editorIframeRef.current);
@@ -514,7 +799,12 @@ export const DoenetEditor = React.forwardRef<
                 const action = (remote: EditorIframeRemote) => {
                     remote
                         .closeDiagnosticsPanel()
-                        .catch(logComlinkError("closeDiagnosticsPanel"));
+                        .catch(
+                            logComlinkError(
+                                "DoenetEditor",
+                                "closeDiagnosticsPanel",
+                            ),
+                        );
                 };
                 if (editorIframeRef.current) {
                     action(editorIframeRef.current);
@@ -526,7 +816,12 @@ export const DoenetEditor = React.forwardRef<
                 const action = (remote: EditorIframeRemote) => {
                     remote
                         .updateRenderedView()
-                        .catch(logComlinkError("updateRenderedView"));
+                        .catch(
+                            logComlinkError(
+                                "DoenetEditor",
+                                "updateRenderedView",
+                            ),
+                        );
                 };
                 if (editorIframeRef.current) {
                     action(editorIframeRef.current);
@@ -630,7 +925,10 @@ export const DoenetEditor = React.forwardRef<
                     editorIframe
                         ?.renderEditorWithFunctionProps(...proxiedFunctions)
                         .catch(
-                            logComlinkError("renderEditorWithFunctionProps"),
+                            logComlinkError(
+                                "DoenetEditor",
+                                "renderEditorWithFunctionProps",
+                            ),
                         );
                     // Record what we registered so the function-prop change
                     // effect below can detect later identity changes.
@@ -746,7 +1044,7 @@ export const DoenetEditor = React.forwardRef<
         const action = (remote: EditorIframeRemote) => {
             remote
                 .updateEditorProps(snapshot)
-                .catch(logComlinkError("updateEditorProps"));
+                .catch(logComlinkError("DoenetEditor", "updateEditorProps"));
         };
         if (editorIframeRef.current) {
             action(editorIframeRef.current);
@@ -819,7 +1117,12 @@ export const DoenetEditor = React.forwardRef<
         const action = (remote: EditorIframeRemote) => {
             remote
                 .updateEditorFunctionProps(...proxiedFunctions)
-                .catch(logComlinkError("updateEditorFunctionProps"));
+                .catch(
+                    logComlinkError(
+                        "DoenetEditor",
+                        "updateEditorFunctionProps",
+                    ),
+                );
         };
         if (editorIframeRef.current) {
             action(editorIframeRef.current);

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.doenetMLLiveUpdate.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.doenetMLLiveUpdate.cy.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from "react";
+import { DoenetViewer } from "../../../src/index";
+import {
+    STANDALONE_BLOB_URL,
+    STANDALONE_CSS_BLOB_URL,
+    IFRAME_READY_TIMEOUT,
+    RELOAD_MARKER_KEY,
+} from "./helpers";
+
+// Rendering the document requires a full core-worker boot on top of the
+// bundle evaluation; budget more than IFRAME_READY_TIMEOUT for it.
+const CONTENT_TIMEOUT = 30_000;
+
+// Records every `initializedCallback` invocation along with the closure
+// version that received it, so we can verify (a) the core re-initializes on
+// a doenetML change and (b) the *latest* callback identity is the one
+// invoked (function-prop identity changes propagate live).
+declare global {
+    interface Window {
+        __initCalls: { version: number }[];
+    }
+}
+
+const FIRST_DOENETML = "<p>First version text</p>";
+const SECOND_DOENETML = "<p>Second version text</p>";
+
+function Harness() {
+    const [doenetML, setDoenetML] = useState(FIRST_DOENETML);
+    const [version, setVersion] = useState(1);
+    return (
+        <div>
+            <button
+                data-test="bump-version"
+                onClick={() => setVersion((v) => v + 1)}
+            >
+                Bump callback version
+            </button>
+            <button
+                data-test="change-doenetml"
+                onClick={() => setDoenetML(SECOND_DOENETML)}
+            >
+                Change DoenetML
+            </button>
+            <span data-test="version">{version}</span>
+            <DoenetViewer
+                doenetML={doenetML}
+                standaloneUrl={STANDALONE_BLOB_URL}
+                cssUrl={STANDALONE_CSS_BLOB_URL}
+                addVirtualKeyboard={false}
+                initializedCallback={() => {
+                    window.__initCalls.push({ version });
+                }}
+            />
+        </div>
+    );
+}
+
+describe("DoenetViewer (iframe wrapper) — doenetML changes re-initialize the core in the same realm", () => {
+    beforeEach(() => {
+        cy.window().then((win) => {
+            win.__initCalls = [];
+        });
+    });
+
+    it("re-renders the new document without reloading the iframe, invoking the latest callback identity", () => {
+        cy.mount(<Harness />);
+
+        // First document boots and reports initialized via the version-1
+        // closure.
+        cy.get("iframe", { timeout: IFRAME_READY_TIMEOUT })
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "First version text");
+        cy.window()
+            .its("__initCalls", { timeout: 4000 })
+            .should("have.length.at.least", 1);
+        cy.window().then((win) => {
+            expect(
+                win.__initCalls[0].version,
+                "initial boot uses the initial closure",
+            ).to.equal(1);
+        });
+
+        // Stamp the iframe document — if the iframe reloads, this property
+        // disappears.
+        cy.get("iframe").then(($iframe) => {
+            const doc = ($iframe[0] as HTMLIFrameElement).contentDocument!;
+            (doc as unknown as Record<string, string>)[RELOAD_MARKER_KEY] =
+                "INITIAL";
+        });
+
+        // Bump the callback identity (an identity-only change: no reload, no
+        // re-render inside the iframe), then change the doenetML. The core
+        // must re-initialize inside the same realm and report through the
+        // *new* closure.
+        cy.get("[data-test=bump-version]").click();
+        cy.get("[data-test=version]").should("have.text", "2");
+        cy.window().then((win) => {
+            win.__initCalls = [];
+        });
+
+        cy.get("[data-test=change-doenetml]").click();
+
+        cy.get("iframe")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Second version text");
+        cy.get("iframe")
+            .its("0.contentDocument.body")
+            .should("not.contain.text", "First version text");
+
+        // Same iframe document — the multi-MB bundle was not re-parsed.
+        cy.get("iframe").then(($iframe) => {
+            const doc = ($iframe[0] as HTMLIFrameElement).contentDocument!;
+            expect(
+                (doc as unknown as Record<string, string>)[RELOAD_MARKER_KEY],
+                "iframe must not have reloaded",
+            ).to.equal("INITIAL");
+        });
+
+        // The re-initialization invoked the bumped closure, not the
+        // mount-time one.
+        cy.window()
+            .its("__initCalls", { timeout: 4000 })
+            .should("have.length.at.least", 1);
+        cy.window().then((win) => {
+            const last = win.__initCalls[win.__initCalls.length - 1];
+            expect(
+                last.version,
+                "re-init reports through the latest callback identity",
+            ).to.equal(2);
+        });
+    });
+});

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.propUpdatesLive.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.propUpdatesLive.cy.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import { DoenetViewer } from "../../../src/index";
+import {
+    STANDALONE_BLOB_URL,
+    STANDALONE_CSS_BLOB_URL,
+    IFRAME_READY_TIMEOUT,
+    RELOAD_MARKER_KEY,
+} from "./helpers";
+
+// Rendering the document requires a full core-worker boot on top of the
+// bundle evaluation; budget more than IFRAME_READY_TIMEOUT for it.
+const CONTENT_TIMEOUT = 30_000;
+
+const DARK_BG = "rgb(18, 18, 18)"; // #121212
+const LIGHT_BG = "rgb(255, 255, 255)"; // white
+
+function stampReloadMarker() {
+    cy.get("iframe").then(($iframe) => {
+        const doc = ($iframe[0] as HTMLIFrameElement).contentDocument!;
+        (doc as unknown as Record<string, string>)[RELOAD_MARKER_KEY] =
+            "INITIAL";
+    });
+}
+
+function assertNotReloaded() {
+    cy.get("iframe").then(($iframe) => {
+        const doc = ($iframe[0] as HTMLIFrameElement).contentDocument!;
+        expect(
+            (doc as unknown as Record<string, string>)[RELOAD_MARKER_KEY],
+            "iframe must not have reloaded",
+        ).to.equal("INITIAL");
+    });
+}
+
+describe("DoenetViewer (iframe wrapper) — serializable prop changes apply without reloading the iframe", () => {
+    it("darkMode toggle updates the document in place (no reload)", () => {
+        function Harness() {
+            const [darkMode, setDarkMode] = useState<"light" | "dark">("light");
+            return (
+                <div>
+                    <button
+                        data-test="toggle"
+                        onClick={() =>
+                            setDarkMode((m) =>
+                                m === "light" ? "dark" : "light",
+                            )
+                        }
+                    >
+                        Toggle
+                    </button>
+                    <DoenetViewer
+                        doenetML="<p>Hello prop updates</p>"
+                        darkMode={darkMode}
+                        standaloneUrl={STANDALONE_BLOB_URL}
+                        cssUrl={STANDALONE_CSS_BLOB_URL}
+                        addVirtualKeyboard={false}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Harness />);
+
+        // Wait for the document itself to render (core booted), so the
+        // toggle below exercises a live update against a running viewer.
+        cy.get("iframe", { timeout: IFRAME_READY_TIMEOUT })
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Hello prop updates");
+
+        stampReloadMarker();
+
+        cy.get("[data-test=toggle]").click();
+        cy.get("iframe")
+            .its("0.contentDocument.body", { timeout: 10_000 })
+            .should("have.css", "background-color", DARK_BG);
+
+        assertNotReloaded();
+
+        cy.get("[data-test=toggle]").click();
+        cy.get("iframe")
+            .its("0.contentDocument.body", { timeout: 10_000 })
+            .should("have.css", "background-color", LIGHT_BG);
+
+        assertNotReloaded();
+
+        // The document survived both toggles in the same realm.
+        cy.get("iframe")
+            .its("0.contentDocument.body")
+            .should("contain.text", "Hello prop updates");
+    });
+
+    it("render flip false→true starts the document in the same realm (no reload)", () => {
+        function Harness() {
+            const [render, setRender] = useState(false);
+            return (
+                <div>
+                    <button data-test="show" onClick={() => setRender(true)}>
+                        Show
+                    </button>
+                    <DoenetViewer
+                        doenetML="<p>Deferred document</p>"
+                        render={render}
+                        standaloneUrl={STANDALONE_BLOB_URL}
+                        cssUrl={STANDALONE_CSS_BLOB_URL}
+                        addVirtualKeyboard={false}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Harness />);
+
+        // The viewer mounts with render=false: the srcdoc's loading
+        // placeholder is replaced by the (empty) React render, and no
+        // document content appears.
+        cy.get("iframe", { timeout: IFRAME_READY_TIMEOUT })
+            .its("0.contentDocument.body", { timeout: IFRAME_READY_TIMEOUT })
+            .find(".doenet-loading", { timeout: CONTENT_TIMEOUT })
+            .should("not.exist");
+        cy.get("iframe")
+            .its("0.contentDocument.body")
+            .should("not.contain.text", "Deferred document");
+
+        stampReloadMarker();
+
+        // Flip render: historically this regenerated the srcdoc and reloaded
+        // the iframe (a second full bundle parse); now it must start the
+        // document inside the already-loaded realm.
+        cy.get("[data-test=show]").click();
+
+        cy.get("iframe")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Deferred document");
+
+        assertNotReloaded();
+    });
+
+    it("a prop change during boot queues and applies once the iframe is ready", () => {
+        function Harness() {
+            const [darkMode, setDarkMode] = useState<"light" | "dark">("light");
+            return (
+                <div>
+                    <button
+                        data-test="go-dark"
+                        onClick={() => setDarkMode("dark")}
+                    >
+                        Go dark
+                    </button>
+                    <DoenetViewer
+                        doenetML="<p>Boot-window update</p>"
+                        darkMode={darkMode}
+                        standaloneUrl={STANDALONE_BLOB_URL}
+                        cssUrl={STANDALONE_CSS_BLOB_URL}
+                        addVirtualKeyboard={false}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Harness />);
+
+        // Change the prop immediately, long before the bundle finishes
+        // evaluating — the update must be queued and replayed at iframeReady,
+        // not lost (and not trigger a reload).
+        cy.get("[data-test=go-dark]").click();
+
+        cy.get("iframe", { timeout: IFRAME_READY_TIMEOUT })
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Boot-window update");
+        cy.get("iframe")
+            .its("0.contentDocument.body", { timeout: 10_000 })
+            .should("have.css", "background-color", DARK_BG);
+    });
+});


### PR DESCRIPTION
## Problem

`@doenet/doenetml-iframe`'s `DoenetViewer` bakes every prop into the iframe's `srcDoc`, computed inline on each render — so **any** serializable prop change reloads the iframe from scratch: a fresh parse of the multi-MB standalone bundle plus a full core-worker reboot. Consumers contort around this (assignment-viewer freezes props and pays a **double** bundle parse when `render` flips false→true on page navigation; DoenetApps passes callback identities through refs; the response-review page rebuilds the realm per selection). Function props were also registered once with the mount-time closures, so identities passed after mount were silently ignored.

The editor component in the same file solved all of this in #1131; the viewer never got the same treatment.

## Change

Mirror the editor's live-update pattern onto the viewer, with one viewer-specific difference — **`doenetML` is live** (there are no in-iframe user edits to protect):

- `srcDoc` is memoized on what genuinely requires a reload: `standaloneUrl`/`cssUrl` (including autodetect-version changes) and `useSharedCoreWorker`.
- All other serializable prop changes stream into the iframe via a new Comlink `updateViewerProps`; the baked entry script merges them and re-calls `renderDoenetViewerToContainer` against the cached React root. **The inner DocViewer's in-process semantics decide the effect** — one code path, exact parity with the in-process component:

| Prop change | Effect |
| --- | --- |
| `render`, `darkMode`, `flags`, `answerResponseCounts`, callbacks, … | live, no reload (a `render` flip starts the document in the already-loaded realm) |
| `doenetML`, `activityId`, `docId`, `attemptNumber`, `requestedVariantIndex` | core re-init **in the same realm** (DocViewer's `changedState` path) |
| `initialState`, `force*`, `userId` | read at (re-)initialization only — same as in-process; remount via `key=` to apply |
| `standaloneUrl`, `cssUrl`, `doenetmlVersion`, detected version change, `useSharedCoreWorker` | full iframe reload (correct escalation) |

- Function props get the editor's stable-dispatcher treatment: identity churn swaps the live closure without re-rendering (protecting the core-boot window), and the mount-time-stale-closure bug in the viewer's one-shot registration is fixed.
- **Version gate:** bundles older than 0.7.18 (before `renderDoenetViewerToContainer` cached its React root, #1131) can't re-render in place; for those the wrapper keeps the historical reload-on-any-change behavior. Host-specified `standaloneUrl`s are assumed current.
- Rider fix: shared-core pool records (#1466) are now released when the srcdoc rebuilds — previously a reload leaked the old realm's pool cores (cleanup only ran on unmount).

Behavior note for hosts: code that changed a prop specifically to force a fresh document now gets in-process semantics instead of a reload — change the component's `key` to force a remount. Documented in the README ("Prop changes and iframe reloads") and the changeset.

## Why (memory-reduction context)

Stream B of #1441: cheap remounts/updates are the enabler for windowed mounting (bounded live viewers) in follow-up work, and this removes assignment-viewer's double bundle parse per paginated item today. Also unblocks DoenetApps' review page switching student/item/attempt by core re-init (~1–2 s) instead of realm rebuild (Doenet/DoenetApps#2992).

## Tests

New cypress component specs (all use a reload marker on `contentDocument` to prove the realm survives):

- `DoenetViewer.propUpdatesLive.cy.tsx` — darkMode toggles apply in place; `render` false→true starts the document with zero reloads; a prop change posted during boot queues and applies at `iframeReady`.
- `DoenetViewer.doenetMLLiveUpdate.cy.tsx` — a `doenetML` change renders the new document in the same realm (completes in ~2 s, itself evidence the bundle wasn't re-parsed), and the re-init reports through the **latest** `initializedCallback` identity after an identity bump.

Full `doenetml-iframe` suite: 13 specs / 21 tests passing locally (including the #1467 shared-core and #1468 flushState full-chain specs).

Closes #1436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)