### PR TITLE
Add opt-in windowed mounting: park off-screen iframe viewers losslessly

### DIFF
--- a/.changeset/iframe-windowed-mounting.md
+++ b/.changeset/iframe-windowed-mounting.md
@@ -1,0 +1,14 @@
+---
+"@doenet/doenetml-iframe": patch
+---
+
+New opt-in `mountPolicy` prop on `<DoenetViewer>`: windowed mounting. With
+`mountPolicy={{ mode: "windowed", maxLiveViewers: K }}`, at most K viewers
+stay live page-wide; off-screen viewers beyond the budget are parked — their
+state is flushed via `SPLICE.flushState` and their iframe is replaced by a
+fixed-height placeholder — and restored (typed work intact) when scrolled
+back near the viewport. Parking requires a persistence path
+(`flags.allowSaveState` or `flags.allowLocalState`); viewers without one
+always stay live. Idle memory then tracks what the user can see instead of
+how many documents the page embeds: a parked instance measures ~0 MB versus
+~200 MB for a live iframe viewer.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -98,6 +98,56 @@ inner viewer.
 > document's `xmlns`), the wrapper falls back to its historical behavior of
 > reloading the iframe on any prop change.
 
+### Windowed mounting (`mountPolicy`)
+
+Pages that embed many viewers (assignment pages, textbook chapters) pay
+memory for every mounted iframe, whether or not the student can see it. The
+opt-in `mountPolicy` prop bounds this: at most `maxLiveViewers` viewers stay
+live page-wide, and off-screen viewers beyond the budget are **parked** —
+their state is flushed (via the `SPLICE.flushState` machinery) and their
+iframe is replaced by a placeholder of the same height, so the page layout
+doesn't shift. Scrolling a parked viewer back near the viewport restores it,
+seeded with the flushed state: typed work survives the round trip with no
+user interaction.
+
+```tsx
+<DoenetViewer
+    doenetML={doenetML}
+    flags={{ allowSaveState: true }}
+    mountPolicy={{ mode: "windowed", maxLiveViewers: 3 }}
+/>
+```
+
+- `maxLiveViewers` (default 3) — page-wide budget, shared by every windowed
+  viewer (the smallest value wins when viewers disagree). The budget is
+  soft: currently-visible viewers are never parked, even over budget.
+- `visibleMargin` (default `"1000px"`) — how far outside the viewport a
+  viewer still counts as visible (the `IntersectionObserver` rootMargin).
+- `parkDelayMs` (default 2000) — how long a viewer must stay off-screen
+  before it may be parked (debounce against scroll flicker).
+- `flushTimeoutMs` (default 5000) — how long to wait for the pre-park state
+  flush to be acknowledged before parking anyway.
+
+**Parking requires a persistence path** so no student work can be lost:
+either `flags.allowSaveState` (the wrapper snapshots the flushed
+`reportScoreAndState` and seeds `initialState` on restore) or
+`flags.allowLocalState` (IndexedDB restores on reboot). Windowed viewers
+with neither flag always stay live (a console warning points this out).
+
+Notes:
+
+- Eviction is least-recently-visible first.
+- While parked, a viewer emits no reports (its state was flushed at park
+  time). A host `SPLICE.flushState` broadcast is answered by the wrapper on
+  the parked viewer's behalf, so pre-navigation flush round-trips don't
+  hang.
+- When `requestedVariantIndex` is not specified, windowed viewers pin a
+  random variant once per mount so a restore cannot reroll the document.
+- Restoring pays a fresh iframe boot (bundle evaluation + core boot, ~1–2 s
+  warm). Pair with `useSharedCoreWorker` to make both live and restored
+  viewers cheaper.
+- `mountPolicy` is read at mount; changing it afterwards is not supported.
+
 ### Host message protocol (SPLICE)
 
 The viewer exchanges JSON messages with the host page via `postMessage`.

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -766,6 +766,17 @@ export function DoenetViewer({
     }
 
     /**
+     * Whether this viewer may be parked *right now*. Requires a persistence
+     * path (else parking loses work) AND a live iframe realm to flush: an
+     * errored or already-torn-down viewer has no `contentWindow`, so parking
+     * it is a no-op — and leaving it eligible would spin the manager, which
+     * re-asks (via `scheduleEvaluate(0)`) after every failed `beginPark`.
+     */
+    function canPark() {
+        return hasPersistencePath() && Boolean(ref.current?.contentWindow);
+    }
+
+    /**
      * Begin parking (called by the lifecycle manager): flush the viewer's
      * state, then swap the iframe for a placeholder once acknowledged.
      * Re-posts the flush every 500 ms (the viewer's listener registers on
@@ -805,25 +816,37 @@ export function DoenetViewer({
         post();
     }
 
-    /** The park flush acknowledged — finish parking (or abort if visible). */
-    function completeParkFlush(ack: any) {
+    /**
+     * Tear down the in-flight park flush (its retry/timeout timers) when it
+     * resolves — whether by acknowledgement or timeout. Returns whether the
+     * park should proceed: `false` if no flush was in flight, or the viewer
+     * scrolled back into view while the flush was in flight (nothing has been
+     * torn down, so it just stays live).
+     */
+    function endParkFlush(): boolean {
         if (!parkingRef.current) {
-            return;
+            return false;
         }
         parkFlushCleanupRef.current?.();
         parkFlushIdRef.current = null;
         parkingRef.current = false;
         if (visibleRef.current) {
-            // The viewer scrolled back into view while the flush was in
-            // flight. Nothing has been torn down — just stay live.
             notifyViewerState(id, "live");
+            return false;
+        }
+        return true;
+    }
+
+    /** The park flush acknowledged — finish parking (or abort if visible). */
+    function completeParkFlush(ack: any) {
+        if (!endParkFlush()) {
             return;
         }
         if (ack.hadState) {
             everHadStateRef.current = true;
-        }
-        if (ack.hadState && lastCapturedReportRef.current?.state) {
-            parkedSnapshotRef.current = lastCapturedReportRef.current.state;
+            if (lastCapturedReportRef.current?.state) {
+                parkedSnapshotRef.current = lastCapturedReportRef.current.state;
+            }
         }
         // else: keep any previous snapshot. `hadState: false` with a prior
         // snapshot means the core never booted this generation, so the prior
@@ -834,14 +857,7 @@ export function DoenetViewer({
 
     /** No acknowledgement within flushTimeoutMs — park anyway (see above). */
     function onParkFlushTimeout() {
-        if (!parkingRef.current) {
-            return;
-        }
-        parkFlushCleanupRef.current?.();
-        parkFlushIdRef.current = null;
-        parkingRef.current = false;
-        if (visibleRef.current) {
-            notifyViewerState(id, "live");
+        if (!endParkFlush()) {
             return;
         }
         finishPark();
@@ -913,7 +929,7 @@ export function DoenetViewer({
             maxLiveViewers:
                 mountPolicy?.maxLiveViewers ?? DEFAULT_MAX_LIVE_VIEWERS,
             parkDelayMs: mountPolicy?.parkDelayMs ?? DEFAULT_PARK_DELAY_MS,
-            canPark: hasPersistencePath,
+            canPark,
             requestPark: beginPark,
         });
         return () => {

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -28,6 +28,21 @@ import {
     handleDestroySharedCore,
     destroySharedCoresForViewer,
 } from "./shared-core-pool";
+import {
+    registerWindowedViewer,
+    setViewerVisibility,
+    notifyViewerState,
+    DEFAULT_MAX_LIVE_VIEWERS,
+    DEFAULT_VISIBLE_MARGIN,
+    DEFAULT_FLUSH_TIMEOUT_MS,
+    DEFAULT_PARK_DELAY_MS,
+    type MountPolicy,
+} from "./viewer-lifecycle-manager";
+
+export type { MountPolicy };
+// Page-wide windowed-mounting diagnostics (how many viewers are live vs
+// parked) — useful for host dashboards, tests, and benchmarks.
+export { getViewerLifecycleStats } from "./viewer-lifecycle-manager";
 
 export const version: string = IFRAME_VERSION;
 const latestDoenetmlVersion: string = version;
@@ -78,6 +93,8 @@ type IframeMessage = {
     data: Record<string, unknown>;
     subject?: string;
     height?: number;
+    /** Correlation id on SPLICE requests/responses. */
+    message_id?: string;
 };
 
 export type DoenetViewerIframeProps = DoenetViewerProps & {
@@ -114,6 +131,20 @@ export type DoenetViewerIframeProps = DoenetViewerProps & {
      * quarantined so retries boot fresh ones). Default off.
      */
     useSharedCoreWorker?: boolean;
+    /**
+     * Opt-in windowed mounting (#1441, stream B): keep at most
+     * `maxLiveViewers` viewers live on the page. Off-screen viewers beyond
+     * the budget are *parked* — their state is flushed (`SPLICE.flushState`)
+     * and their iframe is replaced by a fixed-height placeholder — and
+     * restored when scrolled back near the viewport. Parking requires a
+     * persistence path: it only activates for viewers with
+     * `flags.allowSaveState` (the wrapper snapshots the flushed
+     * `reportScoreAndState` and seeds `initialState` on restore) or
+     * `flags.allowLocalState` (IndexedDB restores on reboot); otherwise the
+     * viewer always stays live. The policy is read at mount; changing it
+     * afterwards is not supported. Default off (no prop = today's behavior).
+     */
+    mountPolicy?: MountPolicy;
 };
 
 export type DoenetEditorIframeProps = DoenetEditorProps & {
@@ -216,6 +247,7 @@ export function DoenetViewer({
     doenetmlVersion: specifiedDoenetmlVersion,
     autodetectVersion = true,
     useSharedCoreWorker = false,
+    mountPolicy,
     ...doenetViewerProps
 }: DoenetViewerIframeProps) {
     const [id, _] = React.useState(() => Math.random().toString(36).slice(2));
@@ -243,6 +275,44 @@ export function DoenetViewer({
     doenetViewerPropsRef.current = doenetViewerProps;
     const doenetMLRef = React.useRef(doenetML);
     doenetMLRef.current = doenetML;
+
+    // ---- Windowed mounting (mountPolicy) state ----
+    // The policy is read at mount and treated as immutable afterwards.
+    const windowed = mountPolicy?.mode === "windowed";
+    const [parked, setParked] = React.useState(false);
+    // Bumped on unpark so the srcDoc memo rebuilds (baking the restored
+    // state) even though none of its other inputs changed.
+    const [parkGeneration, setParkGeneration] = React.useState(0);
+    const parkedRef = React.useRef(false);
+    const parkingRef = React.useRef(false);
+    const visibleRef = React.useRef(false);
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const parkFlushCounterRef = React.useRef(0);
+    const parkFlushIdRef = React.useRef<string | null>(null);
+    const parkFlushCleanupRef = React.useRef<(() => void) | null>(null);
+    // Latest SPLICE.reportScoreAndState from OUR iframe (matched by
+    // event.source) — the state snapshot a park uses to seed `initialState`
+    // on restore.
+    const lastCapturedReportRef = React.useRef<any>(null);
+    // State baked into the next unpark's srcdoc. `undefined` = no snapshot:
+    // restore falls back to the host's own `initialState`/IndexedDB/getState.
+    const parkedSnapshotRef = React.useRef<Record<string, any> | undefined>(
+        undefined,
+    );
+    // Whether any park flush ever acknowledged holding state — used to
+    // answer host flushes while parked.
+    const everHadStateRef = React.useRef(false);
+    // Pin the variant for the component's lifetime when windowed: an
+    // undefined `requestedVariantIndex` makes the inner viewer pick a random
+    // variant per boot, and an unpark must not reroll the document.
+    // (Mirrors the in-process viewer's random-variant range.)
+    const pinnedVariantIndexRef = React.useRef<number | null>(null);
+    if (windowed && pinnedVariantIndexRef.current === null) {
+        pinnedVariantIndexRef.current =
+            doenetViewerProps.requestedVariantIndex ??
+            Math.floor(Math.random() * 1000000) + 1;
+    }
+
     const [height, setHeight] = React.useState("500px");
     const [inErrorState, setInErrorState] = React.useState<string | null>(null);
     const [ignoreDetectedVersion, setIgnoreDetectedVersion] =
@@ -326,18 +396,42 @@ export function DoenetViewer({
     // current values via refs: a rebuild bakes the *latest* doenetML/props,
     // and the layout effect below re-anchors the sent-snapshot baseline to
     // those same values.
-    const srcDoc = React.useMemo(
-        () =>
-            createHtmlForDoenetViewer(
-                id,
-                doenetMLRef.current,
-                doenetViewerPropsRef.current,
-                standaloneUrl,
-                cssUrl,
-                useSharedCoreWorker,
-            ),
-        [id, standaloneUrl, cssUrl, useSharedCoreWorker, legacyReloadKey],
-    );
+    const srcDoc = React.useMemo(() => {
+        let bakedProps = doenetViewerPropsRef.current;
+        if (windowed) {
+            // Windowed overrides: pin the variant so an unpark cannot reroll
+            // the document, and seed a parked snapshot (captured from the
+            // park flush) as `initialState` — which requires
+            // `allowLoadState` to be honored.
+            bakedProps = { ...bakedProps };
+            if (bakedProps.requestedVariantIndex === undefined) {
+                bakedProps.requestedVariantIndex =
+                    pinnedVariantIndexRef.current!;
+            }
+            if (parkedSnapshotRef.current !== undefined) {
+                bakedProps.initialState = parkedSnapshotRef.current;
+                bakedProps.flags = {
+                    ...(bakedProps.flags ?? {}),
+                    allowLoadState: true,
+                };
+            }
+        }
+        return createHtmlForDoenetViewer(
+            id,
+            doenetMLRef.current,
+            bakedProps,
+            standaloneUrl,
+            cssUrl,
+            useSharedCoreWorker,
+        );
+    }, [
+        id,
+        standaloneUrl,
+        cssUrl,
+        useSharedCoreWorker,
+        legacyReloadKey,
+        parkGeneration,
+    ]);
 
     // Shared-core cleanup on unmount (#1466): an unmounted iframe realm never
     // runs its own core teardown, so release any cores this viewer created on
@@ -383,6 +477,27 @@ export function DoenetViewer({
                 return;
             }
 
+            // A parked viewer has no realm to forward a host flush into, but
+            // the flush that parked it already pushed every pending save out
+            // — answer on its behalf so a host's pre-navigation flush
+            // round-trip doesn't hang on parked viewers (#1468 contract).
+            if (
+                windowed &&
+                parkedRef.current &&
+                event.data.subject === "SPLICE.flushState"
+            ) {
+                const currentProps = doenetViewerPropsRef.current;
+                window.postMessage({
+                    subject: "SPLICE.flushState.response",
+                    activity_id: currentProps.activityId ?? "a",
+                    doc_id: currentProps.docId ?? "1",
+                    message_id: event.data.message_id,
+                    success: true,
+                    hadState: everHadStateRef.current,
+                });
+                return;
+            }
+
             // forward host requests/responses (SPLICE getState response,
             // requestSolutionView response, submitAllAnswers, flushState) to
             // the iframe; the viewer's replies reach the host directly (the
@@ -404,6 +519,27 @@ export function DoenetViewer({
             if (event.data.subject === "lti.frameResize") {
                 if (event.data.height !== undefined) {
                     setHeight(event.data.height + "px");
+                }
+            }
+
+            // Windowed mounting: track the latest state report from OUR
+            // iframe (the park-snapshot source; reports reach this window
+            // because the in-iframe viewer posts to window.parent), and
+            // complete an in-flight park when its flush acknowledgement
+            // arrives. Reports are delivered before the acknowledgement
+            // (same-realm postMessage ordering), so the snapshot is current
+            // when the park completes.
+            if (windowed) {
+                if (event.data.subject === "SPLICE.reportScoreAndState") {
+                    lastCapturedReportRef.current = event.data;
+                    return;
+                }
+                if (
+                    event.data.subject === "SPLICE.flushState.response" &&
+                    event.data.message_id === parkFlushIdRef.current
+                ) {
+                    completeParkFlush(event.data);
+                    return;
                 }
             }
 
@@ -616,6 +752,176 @@ export function DoenetViewer({
         }
     });
 
+    // ---- Windowed mounting: park / unpark mechanics ----
+    // (Policy — when to park — lives in viewer-lifecycle-manager.ts; these
+    // functions are the mechanics the manager drives via `requestPark`.)
+    // All of them read refs rather than render-scope values so the
+    // mount-time closures registered with the manager and the (deps-empty)
+    // message listener stay correct across renders.
+
+    /** Whether parking can lose no work: some persistence path must exist. */
+    function hasPersistencePath() {
+        const flags: any = doenetViewerPropsRef.current.flags;
+        return Boolean(flags?.allowSaveState || flags?.allowLocalState);
+    }
+
+    /**
+     * Begin parking (called by the lifecycle manager): flush the viewer's
+     * state, then swap the iframe for a placeholder once acknowledged.
+     * Re-posts the flush every 500 ms (the viewer's listener registers on
+     * mount and flushing is idempotent) and parks anyway on timeout — by
+     * then a persistence path is guaranteed by `canPark`, and a realm that
+     * cannot acknowledge (still booting, or wedged) holds no recoverable
+     * work that staying live would preserve.
+     */
+    function beginPark() {
+        if (parkedRef.current || parkingRef.current) {
+            return;
+        }
+        if (!ref.current?.contentWindow) {
+            // No iframe to park (e.g. error state); correct the manager's
+            // optimistic "parking" mark.
+            notifyViewerState(id, "live");
+            return;
+        }
+        parkingRef.current = true;
+        const flushId = `__doenetParkFlush-${id}-${++parkFlushCounterRef.current}`;
+        parkFlushIdRef.current = flushId;
+        const post = () => {
+            ref.current?.contentWindow?.postMessage({
+                subject: "SPLICE.flushState",
+                message_id: flushId,
+            });
+        };
+        const retryTimer = setInterval(post, 500);
+        const timeoutTimer = setTimeout(() => {
+            onParkFlushTimeout();
+        }, mountPolicy?.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS);
+        parkFlushCleanupRef.current = () => {
+            clearInterval(retryTimer);
+            clearTimeout(timeoutTimer);
+            parkFlushCleanupRef.current = null;
+        };
+        post();
+    }
+
+    /** The park flush acknowledged — finish parking (or abort if visible). */
+    function completeParkFlush(ack: any) {
+        if (!parkingRef.current) {
+            return;
+        }
+        parkFlushCleanupRef.current?.();
+        parkFlushIdRef.current = null;
+        parkingRef.current = false;
+        if (visibleRef.current) {
+            // The viewer scrolled back into view while the flush was in
+            // flight. Nothing has been torn down — just stay live.
+            notifyViewerState(id, "live");
+            return;
+        }
+        if (ack.hadState) {
+            everHadStateRef.current = true;
+        }
+        if (ack.hadState && lastCapturedReportRef.current?.state) {
+            parkedSnapshotRef.current = lastCapturedReportRef.current.state;
+        }
+        // else: keep any previous snapshot. `hadState: false` with a prior
+        // snapshot means the core never booted this generation, so the prior
+        // snapshot is still the latest truth; with no snapshot at all the
+        // unpark falls back to the host's initialState/IndexedDB/getState.
+        finishPark();
+    }
+
+    /** No acknowledgement within flushTimeoutMs — park anyway (see above). */
+    function onParkFlushTimeout() {
+        if (!parkingRef.current) {
+            return;
+        }
+        parkFlushCleanupRef.current?.();
+        parkFlushIdRef.current = null;
+        parkingRef.current = false;
+        if (visibleRef.current) {
+            notifyViewerState(id, "live");
+            return;
+        }
+        finishPark();
+    }
+
+    function finishPark() {
+        // The dead realm's remote must not receive further updates; clear it
+        // so prop changes while parked queue and replay against the restored
+        // realm's iframeReady.
+        viewerIframeRef.current = null;
+        destroySharedCoresForViewer(id);
+        parkedRef.current = true;
+        setParked(true);
+        notifyViewerState(id, "parked");
+    }
+
+    /** Restore a parked viewer (on scrolling back into view). */
+    function unpark() {
+        if (!parkedRef.current) {
+            return;
+        }
+        parkedRef.current = false;
+        setParked(false);
+        // Rebuild the srcdoc so the restored realm boots seeded with the
+        // parked snapshot (see the srcDoc memo).
+        setParkGeneration((generation) => generation + 1);
+        notifyViewerState(id, "live");
+    }
+
+    // Observe visibility of the wrapper div (which stays mounted across
+    // park/unpark). Entering the margin unparks; the manager decides parking.
+    React.useEffect(() => {
+        if (!windowed || !containerRef.current) {
+            return;
+        }
+        const observer = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    visibleRef.current = entry.isIntersecting;
+                    setViewerVisibility(id, entry.isIntersecting);
+                    if (entry.isIntersecting && parkedRef.current) {
+                        unpark();
+                    }
+                }
+            },
+            {
+                rootMargin:
+                    mountPolicy?.visibleMargin ?? DEFAULT_VISIBLE_MARGIN,
+            },
+        );
+        observer.observe(containerRef.current);
+        return () => {
+            observer.disconnect();
+        };
+    }, [windowed]);
+
+    // Register with the page-wide lifecycle manager.
+    React.useEffect(() => {
+        if (!windowed) {
+            return;
+        }
+        if (!hasPersistencePath()) {
+            console.warn(
+                "DoenetViewer mountPolicy: windowed mounting is enabled but neither flags.allowSaveState nor flags.allowLocalState is set, so parking would lose student work. This viewer will always stay live.",
+            );
+        }
+        const unregister = registerWindowedViewer({
+            id,
+            maxLiveViewers:
+                mountPolicy?.maxLiveViewers ?? DEFAULT_MAX_LIVE_VIEWERS,
+            parkDelayMs: mountPolicy?.parkDelayMs ?? DEFAULT_PARK_DELAY_MS,
+            canPark: hasPersistencePath,
+            requestPark: beginPark,
+        });
+        return () => {
+            parkFlushCleanupRef.current?.();
+            unregister();
+        };
+    }, [windowed]);
+
     if (inErrorState) {
         if (foundAutoVersion) {
             setIgnoreDetectedVersion(true);
@@ -652,7 +958,20 @@ export function DoenetViewer({
         );
     }
 
-    return (
+    const viewerContent = parked ? (
+        // Fixed-height placeholder holding a parked viewer's place in the
+        // layout (the last height the iframe reported survives in state, so
+        // parking does not shift the page).
+        <div
+            data-doenet-parked-viewer="true"
+            style={{
+                width: "100%",
+                boxSizing: "border-box",
+                height,
+                minHeight: 50,
+            }}
+        />
+    ) : (
         <React.Fragment>
             {addVirtualKeyboard ? (
                 <ExternalVirtualKeyboard ownerRef={ref} theme={resolvedTheme} />
@@ -671,6 +990,20 @@ export function DoenetViewer({
                 height={height}
             />
         </React.Fragment>
+    );
+
+    if (!windowed) {
+        // Without a mountPolicy the rendered DOM is exactly the historical
+        // shape (no wrapper element).
+        return viewerContent;
+    }
+
+    // The wrapper div is the IntersectionObserver target; it stays mounted
+    // across park/unpark so visibility keeps being observed.
+    return (
+        <div ref={containerRef} style={{ width: "100%" }}>
+            {viewerContent}
+        </div>
     );
 }
 

--- a/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
+++ b/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
@@ -213,10 +213,19 @@ function scheduleEvaluate(delayMs: number) {
 }
 
 /**
- * Enforce the budget: if more viewers are live (or mid-park) than
- * `maxLiveViewers`, ask the least-recently-visible eligible off-screen
- * viewers to park. If some over-budget viewers are only ineligible because
- * their park-delay debounce hasn't elapsed, re-evaluate when it does.
+ * Enforce the budget: if more viewers are live than `maxLiveViewers`, ask the
+ * least-recently-visible eligible off-screen viewers to park. If some
+ * over-budget viewers are only ineligible because their park-delay debounce
+ * hasn't elapsed, re-evaluate when it does.
+ *
+ * Only genuinely `live` viewers count against the budget here. Viewers
+ * mid-park (`parking`) are already committed to freeing their slot, so
+ * counting them would over-park: a re-evaluation while one park is in flight
+ * (e.g. another park completing, which schedules an evaluate) would shed an
+ * additional live viewer to make room the in-flight park is already making,
+ * driving the page below `maxLiveViewers`. (A park that aborts flips the
+ * viewer back to `live`/visible and re-schedules an evaluate, so nothing is
+ * under-counted.)
  */
 function evaluate() {
     if (effectiveMaxLive === null) {
@@ -224,13 +233,13 @@ function evaluate() {
     }
     const now = Date.now();
 
-    let active = 0;
+    let live = 0;
     for (const record of records.values()) {
-        if (record.state !== "parked") {
-            active++;
+        if (record.state === "live") {
+            live++;
         }
     }
-    let excess = active - effectiveMaxLive;
+    let excess = live - effectiveMaxLive;
     if (excess <= 0) {
         return;
     }

--- a/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
+++ b/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
@@ -1,0 +1,272 @@
+/**
+ * Page-wide lifecycle manager for windowed `<DoenetViewer>` mounting
+ * (#1441, stream B).
+ *
+ * Viewers that opt in via the `mountPolicy` prop register here. The manager
+ * enforces a page-wide budget of live viewers: when more than
+ * `maxLiveViewers` are live at once, the least-recently-visible off-screen
+ * viewers are asked to park (flush their state and replace their iframe with
+ * a placeholder), so idle memory tracks what the user can see rather than
+ * how many documents the page embeds.
+ *
+ * This module is pure policy: *when* to park. The mechanics of parking
+ * (flushing state, swapping the iframe for a placeholder, restoring) live in
+ * the `DoenetViewer` wrapper, which registers callbacks here. Module-level
+ * state is intentional — the budget is shared by every windowed viewer on
+ * the page (same pattern as `shared-core-pool.ts`).
+ *
+ * Rules:
+ * - A currently-visible viewer is never parked (the budget is soft: if more
+ *   than `maxLiveViewers` are visible at once, all of them stay live).
+ * - A viewer only becomes eligible to park after it has been off-screen for
+ *   its `parkDelayMs` (debounce against scroll flicker).
+ * - Viewers whose `canPark` returns false (no persistence path — parking
+ *   would lose student work) are never parked.
+ * - Eviction order is least-recently-visible first.
+ */
+
+export type MountPolicy = {
+    /** The only mode currently defined. */
+    mode: "windowed";
+    /**
+     * Page-wide budget of simultaneously live (iframe-mounted) viewers.
+     * When viewers on the same page specify different values, the smallest
+     * wins. Default 3.
+     */
+    maxLiveViewers?: number;
+    /**
+     * `rootMargin` for the visibility observer — how far outside the
+     * viewport a viewer still counts as "visible". Default "1000px".
+     */
+    visibleMargin?: string;
+    /**
+     * How long to wait for the viewer to acknowledge the pre-park state
+     * flush before parking anyway. Default 5000.
+     */
+    flushTimeoutMs?: number;
+    /**
+     * How long a viewer must be continuously off-screen before it may be
+     * parked. Default 2000.
+     */
+    parkDelayMs?: number;
+};
+
+export const DEFAULT_MAX_LIVE_VIEWERS = 3;
+export const DEFAULT_VISIBLE_MARGIN = "1000px";
+export const DEFAULT_FLUSH_TIMEOUT_MS = 5000;
+export const DEFAULT_PARK_DELAY_MS = 2000;
+
+export type ViewerLifecycleState = "live" | "parking" | "parked";
+
+type ViewerRecord = {
+    id: string;
+    state: ViewerLifecycleState;
+    visible: boolean;
+    /** Monotonic counter value from when this viewer was last visible. */
+    lastVisibleOrder: number;
+    /** Timestamp when this viewer last became invisible. */
+    invisibleSince: number;
+    parkDelayMs: number;
+    canPark: () => boolean;
+    requestPark: () => void;
+};
+
+const records = new Map<string, ViewerRecord>();
+let visibleOrderCounter = 0;
+let effectiveMaxLive: number | null = null;
+let warnedMixedBudgets = false;
+
+let evaluateTimerId: ReturnType<typeof setTimeout> | null = null;
+let evaluateTimerAt = Infinity;
+
+/**
+ * Register a windowed viewer. Returns an unregister function for the
+ * component's unmount cleanup.
+ */
+export function registerWindowedViewer({
+    id,
+    maxLiveViewers,
+    parkDelayMs,
+    canPark,
+    requestPark,
+}: {
+    id: string;
+    maxLiveViewers: number;
+    parkDelayMs: number;
+    canPark: () => boolean;
+    requestPark: () => void;
+}): () => void {
+    if (
+        effectiveMaxLive !== null &&
+        effectiveMaxLive !== maxLiveViewers &&
+        !warnedMixedBudgets
+    ) {
+        warnedMixedBudgets = true;
+        console.warn(
+            `DoenetViewer mountPolicy: viewers on this page specify different maxLiveViewers (${effectiveMaxLive} and ${maxLiveViewers}); using the smaller value.`,
+        );
+    }
+    effectiveMaxLive =
+        effectiveMaxLive === null
+            ? maxLiveViewers
+            : Math.min(effectiveMaxLive, maxLiveViewers);
+
+    records.set(id, {
+        id,
+        state: "live",
+        visible: false,
+        lastVisibleOrder: 0,
+        invisibleSince: Date.now(),
+        parkDelayMs,
+        canPark,
+        requestPark,
+    });
+    scheduleEvaluate(parkDelayMs);
+
+    return () => {
+        records.delete(id);
+        scheduleEvaluate(0);
+    };
+}
+
+/**
+ * Report a visibility change from the component's IntersectionObserver.
+ */
+export function setViewerVisibility(id: string, visible: boolean) {
+    const record = records.get(id);
+    if (!record || record.visible === visible) {
+        return;
+    }
+    record.visible = visible;
+    if (visible) {
+        record.lastVisibleOrder = ++visibleOrderCounter;
+        // Another viewer may need to park to make room once this one is
+        // live again (the component unparks itself on visibility).
+        scheduleEvaluate(0);
+    } else {
+        record.invisibleSince = Date.now();
+        scheduleEvaluate(record.parkDelayMs);
+    }
+}
+
+/**
+ * Report a lifecycle-state change from the component (the component owns the
+ * actual park/unpark mechanics and reports the outcome here).
+ */
+export function notifyViewerState(id: string, state: ViewerLifecycleState) {
+    const record = records.get(id);
+    if (!record || record.state === state) {
+        return;
+    }
+    record.state = state;
+    scheduleEvaluate(0);
+}
+
+/** Snapshot for tests and diagnostics. */
+export function getViewerLifecycleStats() {
+    let live = 0,
+        parking = 0,
+        parked = 0;
+    for (const record of records.values()) {
+        if (record.state === "live") {
+            live++;
+        } else if (record.state === "parking") {
+            parking++;
+        } else {
+            parked++;
+        }
+    }
+    return { registered: records.size, live, parking, parked };
+}
+
+/** Test-only: forget every registration and reset module state. */
+export function __resetViewerLifecycleManagerForTests() {
+    records.clear();
+    visibleOrderCounter = 0;
+    effectiveMaxLive = null;
+    warnedMixedBudgets = false;
+    if (evaluateTimerId !== null) {
+        clearTimeout(evaluateTimerId);
+        evaluateTimerId = null;
+    }
+    evaluateTimerAt = Infinity;
+}
+
+/**
+ * Schedule an `evaluate()` after `delayMs`, coalescing with any
+ * already-scheduled evaluation (the earlier of the two wins).
+ */
+function scheduleEvaluate(delayMs: number) {
+    const at = Date.now() + delayMs;
+    if (evaluateTimerId !== null) {
+        if (at >= evaluateTimerAt) {
+            return;
+        }
+        clearTimeout(evaluateTimerId);
+    }
+    evaluateTimerAt = at;
+    evaluateTimerId = setTimeout(() => {
+        evaluateTimerId = null;
+        evaluateTimerAt = Infinity;
+        evaluate();
+    }, delayMs);
+}
+
+/**
+ * Enforce the budget: if more viewers are live (or mid-park) than
+ * `maxLiveViewers`, ask the least-recently-visible eligible off-screen
+ * viewers to park. If some over-budget viewers are only ineligible because
+ * their park-delay debounce hasn't elapsed, re-evaluate when it does.
+ */
+function evaluate() {
+    if (effectiveMaxLive === null) {
+        return;
+    }
+    const now = Date.now();
+
+    let active = 0;
+    for (const record of records.values()) {
+        if (record.state !== "parked") {
+            active++;
+        }
+    }
+    let excess = active - effectiveMaxLive;
+    if (excess <= 0) {
+        return;
+    }
+
+    const candidates: ViewerRecord[] = [];
+    let nextDebounceExpiry = Infinity;
+    for (const record of records.values()) {
+        if (record.state !== "live" || record.visible) {
+            continue;
+        }
+        const eligibleAt = record.invisibleSince + record.parkDelayMs;
+        if (eligibleAt > now) {
+            nextDebounceExpiry = Math.min(nextDebounceExpiry, eligibleAt);
+            continue;
+        }
+        if (!record.canPark()) {
+            continue;
+        }
+        candidates.push(record);
+    }
+
+    candidates.sort((a, b) => a.lastVisibleOrder - b.lastVisibleOrder);
+
+    for (const record of candidates) {
+        if (excess <= 0) {
+            break;
+        }
+        // Mark optimistically so a single evaluation pass doesn't ask the
+        // same viewer twice; the component corrects the state via
+        // `notifyViewerState` if the park aborts.
+        record.state = "parking";
+        excess--;
+        record.requestPark();
+    }
+
+    if (excess > 0 && nextDebounceExpiry < Infinity) {
+        scheduleEvaluate(Math.max(0, nextDebounceExpiry - now));
+    }
+}

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.parking.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.parking.cy.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/index";
+import { __resetViewerLifecycleManagerForTests } from "../../../src/viewer-lifecycle-manager";
+import { STANDALONE_BLOB_URL, STANDALONE_CSS_BLOB_URL } from "./helpers";
+
+// Windowed mounting (#1441, stream B) end-to-end: with
+// `mountPolicy={{mode:"windowed", maxLiveViewers:1}}`, the off-screen viewer
+// parks (its state is flushed and its iframe is replaced by a fixed-height
+// placeholder) and is restored — typed work intact — when scrolled back.
+
+const DOC_A = `<p>Viewer A: <textInput name="ti" /></p>
+<p>A typed: $ti.value</p>`;
+const DOC_B = `<p>Viewer B content</p>`;
+
+const CONTENT_TIMEOUT = 40_000;
+// Parking of the off-screen viewer waits for its realm to boot far enough to
+// acknowledge the flush (or the flush timeout), so give it real time.
+const PARK_TIMEOUT = 40_000;
+
+const MOUNT_POLICY = {
+    mode: "windowed" as const,
+    maxLiveViewers: 1,
+    parkDelayMs: 300,
+    visibleMargin: "100px",
+    flushTimeoutMs: 15_000,
+};
+
+function Harness() {
+    return (
+        <div>
+            <div data-test="viewer-a">
+                <DoenetViewer
+                    doenetML={DOC_A}
+                    activityId="act-A"
+                    docId="doc-A"
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>
+            <div style={{ height: "3000px" }} data-test="spacer" />
+            <div data-test="viewer-b">
+                <DoenetViewer
+                    doenetML={DOC_B}
+                    activityId="act-B"
+                    docId="doc-B"
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>
+        </div>
+    );
+}
+
+function viewerIframe(which: "viewer-a" | "viewer-b") {
+    return cy.get(`[data-test=${which}] iframe`);
+}
+
+function assertParked(which: "viewer-a" | "viewer-b") {
+    cy.get(`[data-test=${which}] [data-doenet-parked-viewer]`, {
+        timeout: PARK_TIMEOUT,
+    }).should("exist");
+    cy.get(`[data-test=${which}] iframe`).should("not.exist");
+}
+
+describe("DoenetViewer (iframe wrapper) — windowed mounting parks off-screen viewers", () => {
+    beforeEach(() => {
+        __resetViewerLifecycleManagerForTests();
+    });
+
+    it("parks beyond the budget, restores typed work on scroll-back, and answers host flushes while parked", () => {
+        cy.viewport(900, 600);
+        cy.mount(<Harness />);
+
+        // Viewer A (visible) boots; viewer B (far below the viewport) is
+        // over the budget of 1 and parks once its realm can acknowledge the
+        // flush. The placeholder holds its layout slot.
+        viewerIframe("viewer-a")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "A typed:");
+        assertParked("viewer-b");
+
+        // Type into A and commit with Enter (cannot .blur() across the
+        // iframe boundary).
+        viewerIframe("viewer-a")
+            .its("0.contentDocument.body")
+            .find("input:not([type=checkbox])")
+            .then(cy.wrap)
+            .type("survives the park{enter}");
+        viewerIframe("viewer-a")
+            .its("0.contentDocument.body")
+            .should("contain.text", "A typed: survives the park");
+
+        // Scroll to B: it unparks and boots; A leaves the margin and parks,
+        // flushing the typed state into the wrapper's snapshot.
+        cy.get("[data-test=viewer-b]").scrollIntoView();
+        viewerIframe("viewer-b")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Viewer B content");
+        assertParked("viewer-a");
+
+        // A host flush broadcast while A is parked: the wrapper answers for
+        // it (success, hadState) so pre-navigation flush round-trips don't
+        // hang on parked viewers.
+        cy.window().then((win) => {
+            const responses: any[] = [];
+            win.addEventListener("message", (e: MessageEvent) => {
+                if (
+                    e.data?.subject === "SPLICE.flushState.response" &&
+                    e.data?.message_id === "host-flush-while-parked"
+                ) {
+                    responses.push(e.data);
+                }
+            });
+            win.postMessage(
+                {
+                    subject: "SPLICE.flushState",
+                    message_id: "host-flush-while-parked",
+                },
+                "*",
+            );
+            cy.wrap(null, { timeout: 10_000 }).should(() => {
+                const fromA = responses.find((r) => r.activity_id === "act-A");
+                expect(fromA, "parked viewer A answered").to.exist;
+                expect(fromA.success, "success").to.eq(true);
+                expect(fromA.hadState, "hadState").to.eq(true);
+            });
+        });
+
+        // Scroll back to A: it unparks seeded with the flushed state — the
+        // typed work survives the park/unpark round trip with no user
+        // interaction; B parks again (budget 1).
+        cy.get("[data-test=viewer-a]").scrollIntoView();
+        viewerIframe("viewer-a")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "A typed: survives the park");
+        viewerIframe("viewer-a")
+            .its("0.contentDocument.body")
+            .find("input:not([type=checkbox])")
+            .should("have.value", "survives the park");
+        assertParked("viewer-b");
+    });
+});

--- a/packages/doenetml-iframe/test/cypress/component/viewerLifecycleManager.cy.ts
+++ b/packages/doenetml-iframe/test/cypress/component/viewerLifecycleManager.cy.ts
@@ -1,0 +1,177 @@
+import {
+    registerWindowedViewer,
+    setViewerVisibility,
+    notifyViewerState,
+    getViewerLifecycleStats,
+    __resetViewerLifecycleManagerForTests,
+} from "../../../src/viewer-lifecycle-manager";
+
+// Pure-logic tests for the windowed-mounting policy. `cy.clock` controls
+// both `Date.now` and `setTimeout`, so debounce windows advance
+// deterministically via `cy.tick`.
+
+type FakeViewer = {
+    id: string;
+    parkRequests: number;
+    unregister: () => void;
+};
+
+/** Register a fake viewer that parks instantly when asked. */
+function addViewer(
+    id: string,
+    {
+        maxLiveViewers = 2,
+        parkDelayMs = 100,
+        canPark = true,
+        parkImmediately = true,
+    } = {},
+): FakeViewer {
+    const viewer: FakeViewer = { id, parkRequests: 0, unregister: () => {} };
+    viewer.unregister = registerWindowedViewer({
+        id,
+        maxLiveViewers,
+        parkDelayMs,
+        canPark: () => canPark,
+        requestPark: () => {
+            viewer.parkRequests++;
+            if (parkImmediately) {
+                notifyViewerState(id, "parked");
+            }
+        },
+    });
+    return viewer;
+}
+
+describe("viewer-lifecycle-manager — windowed mounting policy", () => {
+    beforeEach(() => {
+        __resetViewerLifecycleManagerForTests();
+        cy.clock();
+    });
+
+    afterEach(() => {
+        __resetViewerLifecycleManagerForTests();
+    });
+
+    it("parks the least-recently-visible off-screen viewer when over budget", () => {
+        const a = addViewer("a");
+        const b = addViewer("b");
+        const c = addViewer("c");
+
+        // Visibility history: a seen first, then b, then c (c stays visible).
+        setViewerVisibility("a", true);
+        setViewerVisibility("a", false);
+        setViewerVisibility("b", true);
+        setViewerVisibility("b", false);
+        setViewerVisibility("c", true);
+
+        // 3 live, budget 2, both a and b past their debounce → the LRU (a)
+        // parks; one park brings the page back to budget, so b stays live.
+        cy.tick(200).then(() => {
+            expect(a.parkRequests, "a (LRU) parked").to.eq(1);
+            expect(b.parkRequests, "b stays live").to.eq(0);
+            expect(c.parkRequests, "c stays live").to.eq(0);
+            expect(getViewerLifecycleStats()).to.deep.include({
+                live: 2,
+                parked: 1,
+            });
+        });
+    });
+
+    it("never parks a visible viewer, even over budget", () => {
+        const a = addViewer("a", { maxLiveViewers: 1 });
+        const b = addViewer("b", { maxLiveViewers: 1 });
+        setViewerVisibility("a", true);
+        setViewerVisibility("b", true);
+
+        cy.tick(500).then(() => {
+            expect(a.parkRequests).to.eq(0);
+            expect(b.parkRequests).to.eq(0);
+            expect(getViewerLifecycleStats().live, "soft budget").to.eq(2);
+        });
+    });
+
+    it("waits out the park-delay debounce before parking", () => {
+        const a = addViewer("a", { maxLiveViewers: 1, parkDelayMs: 100 });
+        addViewer("b", { maxLiveViewers: 1, parkDelayMs: 100 });
+        setViewerVisibility("b", true);
+
+        // a has been invisible since registration; not yet past debounce.
+        cy.tick(50).then(() => {
+            expect(a.parkRequests, "debounce not yet elapsed").to.eq(0);
+        });
+        cy.tick(100).then(() => {
+            expect(a.parkRequests, "debounce elapsed").to.eq(1);
+        });
+    });
+
+    it("skips viewers that cannot park losslessly", () => {
+        const a = addViewer("a", { maxLiveViewers: 1, canPark: false });
+        addViewer("b", { maxLiveViewers: 1 });
+        setViewerVisibility("b", true);
+
+        cy.tick(500).then(() => {
+            expect(a.parkRequests, "no persistence path → never parked").to.eq(
+                0,
+            );
+            expect(getViewerLifecycleStats().live).to.eq(2);
+        });
+    });
+
+    it("uses the smallest budget when viewers disagree", () => {
+        const a = addViewer("a", { maxLiveViewers: 3 });
+        addViewer("b", { maxLiveViewers: 1 });
+        setViewerVisibility("b", true);
+
+        cy.tick(500).then(() => {
+            expect(a.parkRequests, "budget min(3, 1) = 1 applies").to.eq(1);
+        });
+    });
+
+    it("an aborted park (viewer reports live) is retried on the next evaluation", () => {
+        // Viewer that refuses the first park request (e.g. flush raced a
+        // scroll-back) and reports itself live again.
+        const a: FakeViewer = {
+            id: "a",
+            parkRequests: 0,
+            unregister: () => {},
+        };
+        a.unregister = registerWindowedViewer({
+            id: "a",
+            maxLiveViewers: 1,
+            parkDelayMs: 100,
+            canPark: () => true,
+            requestPark: () => {
+                a.parkRequests++;
+                if (a.parkRequests === 1) {
+                    notifyViewerState("a", "live");
+                } else {
+                    notifyViewerState("a", "parked");
+                }
+            },
+        });
+        addViewer("b", { maxLiveViewers: 1 });
+        setViewerVisibility("b", true);
+
+        // The "live" notification re-schedules evaluation; the viewer is
+        // still over budget, so it is asked again (the retry fires in the
+        // same timer batch, so only the final state is observable).
+        cy.tick(500).then(() => {
+            expect(a.parkRequests, "asked again after abort").to.eq(2);
+            expect(getViewerLifecycleStats().parked).to.eq(1);
+        });
+    });
+
+    it("unregistering frees the budget", () => {
+        const a = addViewer("a", { maxLiveViewers: 1, parkDelayMs: 100 });
+        const b = addViewer("b", { maxLiveViewers: 1 });
+        setViewerVisibility("b", true);
+
+        // Unregister b (unmounted) before a's debounce elapses: only one
+        // viewer remains, so nothing parks.
+        b.unregister();
+        cy.tick(500).then(() => {
+            expect(a.parkRequests).to.eq(0);
+            expect(getViewerLifecycleStats().registered).to.eq(1);
+        });
+    });
+});

--- a/packages/doenetml-iframe/test/cypress/component/viewerLifecycleManager.cy.ts
+++ b/packages/doenetml-iframe/test/cypress/component/viewerLifecycleManager.cy.ts
@@ -161,6 +161,61 @@ describe("viewer-lifecycle-manager — windowed mounting policy", () => {
         });
     });
 
+    it("does not over-park while a park is still in flight", () => {
+        // Budget 2, one visible (a) plus three off-screen viewers whose LRU
+        // order is b < c < d. b and c are asked to park but complete lazily
+        // (parkImmediately: false), so they sit in the "parking" state.
+        const a = addViewer("a", {
+            maxLiveViewers: 2,
+            parkImmediately: false,
+        });
+        const b = addViewer("b", {
+            maxLiveViewers: 2,
+            parkImmediately: false,
+        });
+        const c = addViewer("c", {
+            maxLiveViewers: 2,
+            parkImmediately: false,
+        });
+        const d = addViewer("d", {
+            maxLiveViewers: 2,
+            parkImmediately: false,
+        });
+
+        // Establish least-recently-visible order b < c < d; a stays visible.
+        setViewerVisibility("b", true);
+        setViewerVisibility("b", false);
+        setViewerVisibility("c", true);
+        setViewerVisibility("c", false);
+        setViewerVisibility("d", true);
+        setViewerVisibility("d", false);
+        setViewerVisibility("a", true);
+
+        // Over budget by 2 → the two LRU off-screen viewers (b, c) are asked
+        // to park; d stays live (budget 2 = a visible + d).
+        cy.tick(200).then(() => {
+            expect(b.parkRequests, "b (LRU) asked to park").to.eq(1);
+            expect(c.parkRequests, "c asked to park").to.eq(1);
+            expect(d.parkRequests, "d fills the budget, not parked").to.eq(0);
+        });
+
+        // b finishes parking while c is still in flight. The re-evaluation
+        // this triggers must NOT ask d to park: only one live viewer (a) is
+        // visible and d fills the budget of 2, while the in-flight c is
+        // committed to freeing its own slot.
+        cy.then(() => {
+            notifyViewerState("b", "parked");
+        });
+        cy.tick(200).then(() => {
+            expect(d.parkRequests, "d must not be over-parked").to.eq(0);
+            expect(getViewerLifecycleStats()).to.deep.include({
+                live: 2, // a, d
+                parking: 1, // c
+                parked: 1, // b
+            });
+        });
+    });
+
     it("unregistering frees the budget", () => {
         const a = addViewer("a", { maxLiveViewers: 1, parkDelayMs: 100 });
         const b = addViewer("b", { maxLiveViewers: 1 });

--- a/packages/memory-benchmark/package.json
+++ b/packages/memory-benchmark/package.json
@@ -15,7 +15,8 @@
         "benchmark": {
             "command": "node src/measure.mjs",
             "dependencies": [
-                "../standalone:build"
+                "../standalone:build",
+                "../doenetml-iframe:build"
             ]
         }
     },

--- a/packages/memory-benchmark/pages-src/windowed.jsx
+++ b/packages/memory-benchmark/pages-src/windowed.jsx
@@ -1,0 +1,86 @@
+/**
+ * Windowed-mounting scenario page (#1441 stream B): N REAL
+ * `@doenet/doenetml-iframe` `<DoenetViewer>`s with
+ * `mountPolicy={{mode:"windowed", maxLiveViewers:K}}`, viewport pinned at
+ * the top of the page. Off-screen viewers beyond the budget park (state
+ * flushed, iframe replaced by a placeholder), so the page should settle at
+ * ~K live realms regardless of N — the headline is that a parked instance
+ * costs ~0 MB.
+ *
+ * Unlike the other scenario pages (hand-rolled iframes that mimic the
+ * wrapper), this one must bundle the actual React component, because the
+ * parking logic lives in the wrapper itself; measure.mjs builds this file
+ * with esbuild at startup and serves it as /windowed.js.
+ *
+ * Query params: ?n=<total viewers> &keep=<maxLiveViewers>
+ */
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { DoenetViewer, getViewerLifecycleStats } from "@doenet/doenetml-iframe";
+
+const params = new URLSearchParams(location.search);
+const n = parseInt(params.get("n") ?? "8", 10);
+const keep = parseInt(params.get("keep") ?? "3", 10);
+
+window.__done = false;
+window.__initializedCount = 0;
+window.__lifecycleStats = () => getViewerLifecycleStats();
+
+const MOUNT_POLICY = {
+    mode: "windowed",
+    maxLiveViewers: keep,
+    parkDelayMs: 500,
+    visibleMargin: "500px",
+    // Generous: N realms boot concurrently, and an acknowledged flush-park
+    // is the realistic steady state we want to measure (timeout-parking
+    // reaches the same memory state but would hide a broken flush path).
+    flushTimeoutMs: 60_000,
+};
+
+const doenetML = await fetch("/doenetml-source?doc=default").then((res) =>
+    res.text(),
+);
+
+const standaloneUrl = `${location.origin}/standalone/doenet-standalone.js`;
+const cssUrl = `${location.origin}/standalone/style.css`;
+
+function App() {
+    const viewers = [];
+    for (let i = 0; i < n; i++) {
+        viewers.push(
+            <div key={i} style={{ margin: "20px 0" }}>
+                <DoenetViewer
+                    doenetML={doenetML}
+                    activityId={`bench-activity-${i}`}
+                    docId={`bench-doc-${i}`}
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    standaloneUrl={standaloneUrl}
+                    cssUrl={cssUrl}
+                    addVirtualKeyboard={false}
+                    initializedCallback={() => {
+                        window.__initializedCount++;
+                    }}
+                />
+            </div>,
+        );
+    }
+    return <div>{viewers}</div>;
+}
+
+createRoot(document.getElementById("root")).render(<App />);
+
+// Done once the page settles at the budget: everything beyond `keep` parked,
+// no park in flight, and at least one visible viewer fully booted.
+const settleTimer = setInterval(() => {
+    const stats = getViewerLifecycleStats();
+    window.__parkedCount = stats.parked;
+    if (
+        stats.parked >= n - keep &&
+        stats.parking === 0 &&
+        window.__initializedCount >= 1
+    ) {
+        clearInterval(settleTimer);
+        window.__done = true;
+    }
+}, 500);

--- a/packages/memory-benchmark/pages/windowed.html
+++ b/packages/memory-benchmark/pages/windowed.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>windowed mounting</title>
+        <link rel="stylesheet" href="/standalone/style.css" />
+    </head>
+    <body>
+        <div id="root"></div>
+        <!-- Built by measure.mjs (esbuild) from pages-src/windowed.jsx:
+             the real @doenet/doenetml-iframe component with mountPolicy. -->
+        <script type="module" src="/windowed.js"></script>
+    </body>
+</html>

--- a/packages/memory-benchmark/src/measure.mjs
+++ b/packages/memory-benchmark/src/measure.mjs
@@ -47,6 +47,29 @@ const WORKER_DIST = path.dirname(
 // Comlink (the worker's RPC layer), served to the workers-* page.
 const COMLINK_ESM = require.resolve("comlink/dist/esm/comlink.mjs");
 
+/**
+ * Bundle the windowed-mounting page (pages-src/windowed.jsx) with esbuild
+ * (hoisted at the repo root as a vite dependency) and return its source.
+ * Unlike the other scenario pages, this one uses the REAL
+ * `@doenet/doenetml-iframe` component — the parking logic under measurement
+ * lives in that wrapper, so a hand-rolled mimic would measure the browser,
+ * not the feature. Resolves to the package's built `dist/` via its exports
+ * map (the wireit dependency builds it first).
+ */
+async function buildWindowedPageScript() {
+    const esbuild = require("esbuild");
+    const result = await esbuild.build({
+        entryPoints: [path.resolve(HERE, "../pages-src/windowed.jsx")],
+        bundle: true,
+        write: false,
+        format: "esm",
+        target: "es2022",
+        define: { "process.env.NODE_ENV": '"production"' },
+        logLevel: "silent",
+    });
+    return result.outputFiles[0].text;
+}
+
 const DEFAULT_DOENETML = `
 <p>What is <m>1+1</m>? <answer name="ans"><mathInput/>2</answer></p>
 <graph size="small"><point name="P">(1,2)</point></graph>
@@ -113,7 +136,7 @@ function parseArgs() {
  * an iframe whose realm origin is the *main* server — modelling how PreTeXt and
  * doenet.org load `@doenet/standalone` cross-origin from a CDN.
  */
-function startServer(docs, { cors = false, json = {} } = {}) {
+function startServer(docs, { cors = false, json = {}, extra = {} } = {}) {
     const MIME = {
         ".js": "text/javascript",
         ".mjs": "text/javascript",
@@ -132,6 +155,14 @@ function startServer(docs, { cors = false, json = {} } = {}) {
                 ...corsHeaders,
             });
             res.end(JSON.stringify(json[url.pathname]));
+            return;
+        }
+        if (url.pathname in extra) {
+            // In-memory generated assets (e.g. the esbuild-built windowed
+            // page script).
+            const { content, type } = extra[url.pathname];
+            res.writeHead(200, { "content-type": type, ...corsHeaders });
+            res.end(content);
             return;
         }
         if (url.pathname === "/doenetml-source") {
@@ -342,6 +373,12 @@ const emptyDast = parser.normalizeDocumentDast(parser.lezerToDast(""), true);
 
 const { server, port } = await startServer(docs, {
     json: { "/empty-dast.json": emptyDast },
+    extra: {
+        "/windowed.js": {
+            content: await buildWindowedPageScript(),
+            type: "text/javascript",
+        },
+    },
 });
 const base = `http://127.0.0.1:${port}`;
 // Second, CORS-enabled server on a different port = a different origin. It
@@ -408,6 +445,17 @@ const scenarios = [
             expectInitialized: n,
         },
     ]),
+    // Windowed mounting (#1441 stream B): N real `@doenet/doenetml-iframe`
+    // viewers with mountPolicy {mode:"windowed", maxLiveViewers:3}; the page
+    // settles at ~3 live realms with the rest parked (state flushed, iframe
+    // replaced by a placeholder). Fixed counts rather than opts.counts: the
+    // headline is the marginal cost per additional PARKED instance
+    // ((windowed-16-3 − windowed-8-3)/8), which should be ≈ 0 MB.
+    ...[8, 16].map((count) => ({
+        name: `windowed-${count}-3`,
+        url: `${base}/windowed.html?n=${count}&keep=3`,
+        expectInitialized: 1,
+    })),
     // Document-scaling: one viewer, generated large document.
     ...opts.sizes.map((size) => ({
         name: `repeat-${size}`,
@@ -465,6 +513,15 @@ if (hi > lo) {
             );
         }
     }
+}
+const windowedLo = byName["windowed-8-3"];
+const windowedHi = byName["windowed-16-3"];
+if (windowedLo?.totalPssMB != null && windowedHi?.totalPssMB != null) {
+    console.error(
+        `marginal cost per additional PARKED instance (windowed@3): ~${Math.round(
+            (windowedHi.totalPssMB - windowedLo.totalPssMB) / 8,
+        )} MB`,
+    );
 }
 const small = byName["direct-1"];
 for (const size of opts.sizes) {


### PR DESCRIPTION
> **Previously stacked on #1473** (message-based prop updates), now merged. This branch is rebased onto `main`, so the diff below contains only this PR's changes.

## Problem

Stream B of #1441: pages embedding many DoenetML activities (assignment pages, PreTeXt/Active Calculus chapters — #874 reports 1.7–3.6 GB) pay ~200 MB for **every** mounted iframe viewer, visible or not. The stated goal in #1441 is *idle memory proportional to visible content, not document count*. The enabler, `SPLICE.flushState` (#1468), just merged — unmounting an in-progress viewer is now lossless.

## Change

New opt-in `mountPolicy` prop on the iframe `<DoenetViewer>`:

```tsx
<DoenetViewer
    doenetML={doenetML}
    flags={{ allowSaveState: true }}
    mountPolicy={{ mode: "windowed", maxLiveViewers: 3 }}
/>
```

At most `maxLiveViewers` viewers stay live page-wide. Off-screen viewers beyond the budget **park**: the wrapper flushes their state (`SPLICE.flushState` round-trip with retry + timeout), snapshots the flushed `reportScoreAndState`, and swaps the iframe for a fixed-height placeholder (no layout shift). Scrolling back restores the viewer seeded with the snapshot — **typed work survives with no user interaction**.

Design highlights:

- **Policy vs mechanics.** A new page-wide `viewer-lifecycle-manager` module owns *when* to park: least-recently-visible eviction; visible viewers are never parked (the budget is soft); a `parkDelayMs` debounce absorbs scroll flicker; viewers without a persistence path (`flags.allowSaveState` / `flags.allowLocalState`) are **never** parked — parking must be lossless. The wrapper owns the mechanics.
- **Restore paths.** `allowSaveState` → the wrapper seeds `initialState` from the captured report (force-merging `allowLoadState`); `allowLocalState` → IndexedDB restores on reboot with no wrapper snapshot needed.
- **Variant pinning.** With no `requestedVariantIndex`, windowed viewers pin a random variant once per mount so a restore cannot reroll the document.
- **Host contract preserved.** While parked, the wrapper answers host `SPLICE.flushState` broadcasts on the viewer's behalf (`success`, `hadState`) so pre-navigation flush round-trips never hang; the park flush already pushed every pending save out. Shared-core pool records (#1467) are released at park.
- Builds on #1473: the restored realm re-registers through the same iframeReady/queue/replay machinery, and prop changes while parked queue and replay against the restored realm.

## Measurements

New benchmark scenarios mount the **real React component** (esbuild-bundled at benchmark startup — the parking logic lives in the wrapper, so a hand-rolled mimic would measure the browser, not the feature):

| scenario | totalPSS (MB) | live realms |
| --- | --- | --- |
| windowed-8-3 | 1085 | 3 |
| windowed-16-3 | 1041 | 3 |

**Marginal cost per additional parked instance: ~0 MB** (−5 MB, within run noise), versus ~196 MB per live iframe viewer. Doubling the number of embedded documents costs nothing once past the budget. A 30-activity page at the previous ~196 MB/instance would sit around 6 GB; windowed at 3 it stays near ~1 GB.

## Tests

- `viewerLifecycleManager.cy.ts` — 8 deterministic policy tests under `cy.clock`: LRU order, never-park-visible, debounce, no-persistence-never-parks, min-of-budgets, abort-retry, no-over-park-while-a-park-is-in-flight, unregister.
- `DoenetViewer.parking.cy.tsx` — end-to-end with the built standalone bundle: over-budget viewer parks to a placeholder; typed work survives park → unpark; host flush answered while parked; LRU swaps on scroll.
- Full `doenetml-iframe` suite: 15 specs / 30 tests passing locally.

Part of #1441 (stream B). Follow-up (#1439): a boot-concurrency cap so the initial mount of N viewers doesn't stampede before parking settles, plus the coordinator for non-React (PreTeXt-style) hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

