### PR TITLE
Mount windowed viewers lazily with a page-wide boot-concurrency cap

### DIFF
--- a/.changeset/iframe-lazy-mount-boot-cap.md
+++ b/.changeset/iframe-lazy-mount-boot-cap.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml-iframe": patch
+---
+
+Windowed viewers (`mountPolicy`) now mount lazily with a boot-concurrency
+cap: a windowed `<DoenetViewer>` starts as a fixed-height placeholder and
+only creates its iframe when it comes near the viewport AND a page-wide boot
+slot is free (`maxConcurrentBoots`, default 2, visible-first) — an
+off-screen viewer never boots at all, eliminating the initialization
+stampede when a page with many activities loads. Measured on the windowed
+benchmark: a 16-activity page settles at ~735 MB (vs ~1041 MB when
+everything booted before parking, and ~3 GB unwindowed), with no N-realm
+boot transient.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -139,7 +139,8 @@ typed work survives the round trip with no user interaction.
 either `flags.allowSaveState` (the wrapper snapshots the flushed
 `reportScoreAndState` and seeds `initialState` on restore) or
 `flags.allowLocalState` (IndexedDB restores on reboot). Windowed viewers
-with neither flag always stay live (a console warning points this out).
+with neither flag still mount lazily but, once booted, always stay live
+(a console warning points this out).
 
 Notes:
 

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -102,13 +102,15 @@ inner viewer.
 
 Pages that embed many viewers (assignment pages, textbook chapters) pay
 memory for every mounted iframe, whether or not the student can see it. The
-opt-in `mountPolicy` prop bounds this: at most `maxLiveViewers` viewers stay
-live page-wide, and off-screen viewers beyond the budget are **parked** —
-their state is flushed (via the `SPLICE.flushState` machinery) and their
-iframe is replaced by a placeholder of the same height, so the page layout
-doesn't shift. Scrolling a parked viewer back near the viewport restores it,
-seeded with the flushed state: typed work survives the round trip with no
-user interaction.
+opt-in `mountPolicy` prop bounds this: windowed viewers **start as
+placeholders and only create their iframe when they come near the viewport**
+(an off-screen viewer never boots at all), simultaneous boots are capped
+page-wide, and at most `maxLiveViewers` viewers stay live. Off-screen
+viewers beyond the budget are **parked** — their state is flushed (via the
+`SPLICE.flushState` machinery) and their iframe is replaced by a placeholder
+of the same height, so the page layout doesn't shift. Scrolling a parked
+viewer back near the viewport restores it, seeded with the flushed state:
+typed work survives the round trip with no user interaction.
 
 ```tsx
 <DoenetViewer
@@ -127,6 +129,11 @@ user interaction.
   before it may be parked (debounce against scroll flicker).
 - `flushTimeoutMs` (default 5000) — how long to wait for the pre-park state
   flush to be acknowledged before parking anyway.
+- `maxConcurrentBoots` (default 2) — page-wide cap on how many windowed
+  viewers may be booting their iframe realm at once (each boot parses the
+  multi-MB standalone bundle and starts a core worker). Additional viewers
+  wait for a slot, visible-first — this removes the initialization stampede
+  when a page with many activities loads.
 
 **Parking requires a persistence path** so no student work can be lost:
 either `flags.allowSaveState` (the wrapper snapshots the flushed

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -32,10 +32,15 @@ import {
     registerWindowedViewer,
     setViewerVisibility,
     notifyViewerState,
+    requestBootSlot,
+    cancelBootRequest,
+    releaseBootSlot,
     DEFAULT_MAX_LIVE_VIEWERS,
     DEFAULT_VISIBLE_MARGIN,
     DEFAULT_FLUSH_TIMEOUT_MS,
     DEFAULT_PARK_DELAY_MS,
+    DEFAULT_MAX_CONCURRENT_BOOTS,
+    BOOT_SLOT_WATCHDOG_MS,
     type MountPolicy,
 } from "./viewer-lifecycle-manager";
 
@@ -133,16 +138,20 @@ export type DoenetViewerIframeProps = DoenetViewerProps & {
     useSharedCoreWorker?: boolean;
     /**
      * Opt-in windowed mounting (#1441, stream B): keep at most
-     * `maxLiveViewers` viewers live on the page. Off-screen viewers beyond
-     * the budget are *parked* — their state is flushed (`SPLICE.flushState`)
-     * and their iframe is replaced by a fixed-height placeholder — and
-     * restored when scrolled back near the viewport. Parking requires a
-     * persistence path: it only activates for viewers with
-     * `flags.allowSaveState` (the wrapper snapshots the flushed
-     * `reportScoreAndState` and seeds `initialState` on restore) or
+     * `maxLiveViewers` viewers live on the page. Windowed viewers start as
+     * fixed-height placeholders and only create their iframe when they come
+     * near the viewport AND a boot slot is free (`maxConcurrentBoots` caps
+     * simultaneous realm boots page-wide — an off-screen viewer never boots
+     * at all). Off-screen viewers beyond the budget are *parked* — their
+     * state is flushed (`SPLICE.flushState`) and their iframe is replaced
+     * by the placeholder again — and restored when scrolled back near the
+     * viewport. Parking requires a persistence path: it only activates for
+     * viewers with `flags.allowSaveState` (the wrapper snapshots the
+     * flushed `reportScoreAndState` and seeds `initialState` on restore) or
      * `flags.allowLocalState` (IndexedDB restores on reboot); otherwise the
-     * viewer always stays live. The policy is read at mount; changing it
-     * afterwards is not supported. Default off (no prop = today's behavior).
+     * viewer boots on visibility but then always stays live. The policy is
+     * read at mount; changing it afterwards is not supported. Default off
+     * (no prop = today's behavior).
      */
     mountPolicy?: MountPolicy;
 };
@@ -278,12 +287,15 @@ export function DoenetViewer({
 
     // ---- Windowed mounting (mountPolicy) state ----
     // The policy is read at mount and treated as immutable afterwards.
+    // Windowed viewers START parked: the iframe is only created once the
+    // viewer is near the viewport AND a boot slot is free (#1439) — an
+    // off-screen viewer never boots at all.
     const windowed = mountPolicy?.mode === "windowed";
-    const [parked, setParked] = React.useState(false);
+    const [parked, setParked] = React.useState(windowed);
     // Bumped on unpark so the srcDoc memo rebuilds (baking the restored
     // state) even though none of its other inputs changed.
     const [parkGeneration, setParkGeneration] = React.useState(0);
-    const parkedRef = React.useRef(false);
+    const parkedRef = React.useRef(windowed);
     const parkingRef = React.useRef(false);
     const visibleRef = React.useRef(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -311,6 +323,36 @@ export function DoenetViewer({
         pinnedVariantIndexRef.current =
             doenetViewerProps.requestedVariantIndex ??
             Math.floor(Math.random() * 1000000) + 1;
+    }
+    // Watchdog freeing a held boot slot if the realm never reports
+    // initialized (the boot itself continues; only the slot is reclaimed).
+    const bootWatchdogRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+        null,
+    );
+    // Stable composed initializedCallback: releases this viewer's boot slot,
+    // then forwards to the host's latest callback. Registered with the
+    // iframe instead of the host's own callback when windowed (the iframe
+    // side sees one stable identity; the host's identity is still what the
+    // function-prop change detection compares).
+    const composedInitializedCallbackRef = React.useRef<
+        ((arg: unknown) => void) | null
+    >(null);
+    if (composedInitializedCallbackRef.current === null) {
+        composedInitializedCallbackRef.current = (arg: unknown) => {
+            if (bootWatchdogRef.current !== null) {
+                clearTimeout(bootWatchdogRef.current);
+                bootWatchdogRef.current = null;
+            }
+            releaseBootSlot(id);
+            (doenetViewerPropsRef.current as any).initializedCallback?.(arg);
+        };
+    }
+    /** Proxy the composed callback for windowed viewers, the raw one otherwise. */
+    function functionPropToProxy(key: string, prop: Function): Function {
+        if (windowed && key === "initializedCallback") {
+            return composedInitializedCallbackRef.current!;
+        }
+        return prop;
     }
 
     const [height, setHeight] = React.useState("500px");
@@ -591,6 +633,14 @@ export function DoenetViewer({
             }
 
             if (data.error) {
+                // A failed boot must not hold its boot slot.
+                if (windowed) {
+                    if (bootWatchdogRef.current !== null) {
+                        clearTimeout(bootWatchdogRef.current);
+                        bootWatchdogRef.current = null;
+                    }
+                    releaseBootSlot(id);
+                }
                 //@ts-ignore
                 return setInErrorState(data.error);
             } else if (data.iframeReady) {
@@ -616,8 +666,24 @@ export function DoenetViewer({
                         if (typeof prop === "function") {
                             registeredFunctions[key] = prop;
                             proxiedFunctions.push(key);
-                            proxiedFunctions.push(Comlink.proxy(prop));
+                            proxiedFunctions.push(
+                                Comlink.proxy(functionPropToProxy(key, prop)),
+                            );
                         }
+                    }
+                    // Windowed viewers always register the composed
+                    // initializedCallback (it releases the boot slot), even
+                    // when the host passed none.
+                    if (
+                        windowed &&
+                        !("initializedCallback" in registeredFunctions)
+                    ) {
+                        proxiedFunctions.push("initializedCallback");
+                        proxiedFunctions.push(
+                            Comlink.proxy(
+                                composedInitializedCallbackRef.current!,
+                            ),
+                        );
                     }
                     viewerIframe
                         .renderViewerWithFunctionProps(...proxiedFunctions)
@@ -643,9 +709,11 @@ export function DoenetViewer({
                 }
             }
         };
-        if (ref.current) {
-            window.addEventListener("message", listener);
-        }
+        // Attach unconditionally: a windowed viewer renders NO iframe at
+        // first commit (it starts as a parked placeholder), but this
+        // listener must already be in place when the lazily-created iframe
+        // signals iframeReady later.
+        window.addEventListener("message", listener);
 
         return () => {
             window.removeEventListener("message", listener);
@@ -733,7 +801,13 @@ export function DoenetViewer({
         const proxiedFunctions: (string | Function)[] = [];
         for (const [key, val] of Object.entries(current)) {
             proxiedFunctions.push(key);
-            proxiedFunctions.push(Comlink.proxy(val));
+            proxiedFunctions.push(Comlink.proxy(functionPropToProxy(key, val)));
+        }
+        if (windowed && !("initializedCallback" in current)) {
+            proxiedFunctions.push("initializedCallback");
+            proxiedFunctions.push(
+                Comlink.proxy(composedInitializedCallbackRef.current!),
+            );
         }
         const action = (remote: ViewerIframeRemote) => {
             remote
@@ -869,22 +943,49 @@ export function DoenetViewer({
         // realm's iframeReady.
         viewerIframeRef.current = null;
         destroySharedCoresForViewer(id);
+        // A parked viewer no longer boots; free its slot for the queue.
+        if (bootWatchdogRef.current !== null) {
+            clearTimeout(bootWatchdogRef.current);
+            bootWatchdogRef.current = null;
+        }
+        releaseBootSlot(id);
         parkedRef.current = true;
         setParked(true);
         notifyViewerState(id, "parked");
     }
 
-    /** Restore a parked viewer (on scrolling back into view). */
+    /**
+     * Restore a parked viewer (on scrolling back into view) once a boot
+     * slot is free (#1439): at most `maxConcurrentBoots` windowed viewers
+     * evaluate the multi-MB bundle at once, visible-first. The request is
+     * deduplicated by the manager and withdrawn if the viewer scrolls away
+     * before a slot frees up.
+     */
     function unpark() {
         if (!parkedRef.current) {
             return;
         }
-        parkedRef.current = false;
-        setParked(false);
-        // Rebuild the srcdoc so the restored realm boots seeded with the
-        // parked snapshot (see the srcDoc memo).
-        setParkGeneration((generation) => generation + 1);
-        notifyViewerState(id, "live");
+        requestBootSlot(id, () => {
+            // Granted — possibly synchronously, possibly much later. Only
+            // boot if this viewer still wants to be live.
+            if (!parkedRef.current || !visibleRef.current) {
+                releaseBootSlot(id);
+                return;
+            }
+            parkedRef.current = false;
+            setParked(false);
+            // Rebuild the srcdoc so the restored realm boots seeded with the
+            // parked snapshot (see the srcDoc memo).
+            setParkGeneration((generation) => generation + 1);
+            notifyViewerState(id, "live");
+            if (bootWatchdogRef.current !== null) {
+                clearTimeout(bootWatchdogRef.current);
+            }
+            bootWatchdogRef.current = setTimeout(() => {
+                bootWatchdogRef.current = null;
+                releaseBootSlot(id);
+            }, BOOT_SLOT_WATCHDOG_MS);
+        });
     }
 
     // Observe visibility of the wrapper div (which stays mounted across
@@ -900,6 +1001,11 @@ export function DoenetViewer({
                     setViewerVisibility(id, entry.isIntersecting);
                     if (entry.isIntersecting && parkedRef.current) {
                         unpark();
+                    } else if (!entry.isIntersecting) {
+                        // No longer worth booting; withdraw a queued boot
+                        // request (a granted/booting viewer is left alone —
+                        // the park policy handles it).
+                        cancelBootRequest(id);
                     }
                 }
             },
@@ -928,12 +1034,23 @@ export function DoenetViewer({
             id,
             maxLiveViewers:
                 mountPolicy?.maxLiveViewers ?? DEFAULT_MAX_LIVE_VIEWERS,
+            maxConcurrentBoots:
+                mountPolicy?.maxConcurrentBoots ?? DEFAULT_MAX_CONCURRENT_BOOTS,
             parkDelayMs: mountPolicy?.parkDelayMs ?? DEFAULT_PARK_DELAY_MS,
             canPark,
             requestPark: beginPark,
         });
+        // Windowed viewers start parked (no iframe until visible + a boot
+        // slot); tell the manager so the budget starts correct.
+        if (parkedRef.current) {
+            notifyViewerState(id, "parked");
+        }
         return () => {
             parkFlushCleanupRef.current?.();
+            if (bootWatchdogRef.current !== null) {
+                clearTimeout(bootWatchdogRef.current);
+                bootWatchdogRef.current = null;
+            }
             unregister();
         };
     }, [windowed]);

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -336,6 +336,14 @@ export function DoenetViewer({
             bootWatchdogRef.current = null;
         }
     }
+    /**
+     * Give up this viewer's boot slot and stop the watchdog guarding it —
+     * used whenever the boot concludes (initialized, errored, or parked).
+     */
+    function relinquishBootSlot() {
+        clearBootWatchdog();
+        releaseBootSlot(id);
+    }
     // Stable composed initializedCallback: releases this viewer's boot slot,
     // then forwards to the host's latest callback. Registered with the
     // iframe instead of the host's own callback when windowed (the iframe
@@ -346,8 +354,7 @@ export function DoenetViewer({
     >(null);
     if (composedInitializedCallbackRef.current === null) {
         composedInitializedCallbackRef.current = (arg: unknown) => {
-            clearBootWatchdog();
-            releaseBootSlot(id);
+            relinquishBootSlot();
             (doenetViewerPropsRef.current as any).initializedCallback?.(arg);
         };
     }
@@ -357,6 +364,24 @@ export function DoenetViewer({
             return composedInitializedCallbackRef.current!;
         }
         return prop;
+    }
+    /**
+     * Append the composed `initializedCallback` proxy to a Comlink
+     * function-prop argument list when windowed and the host supplied no
+     * `initializedCallback` of its own, so the boot-slot release still
+     * reaches the iframe. `hostFunctions` is the set of function props the
+     * host actually passed (keyed by name).
+     */
+    function appendComposedInitializedCallback(
+        proxiedFunctions: (string | Function)[],
+        hostFunctions: Record<string, Function>,
+    ) {
+        if (windowed && !("initializedCallback" in hostFunctions)) {
+            proxiedFunctions.push("initializedCallback");
+            proxiedFunctions.push(
+                Comlink.proxy(composedInitializedCallbackRef.current!),
+            );
+        }
     }
 
     const [height, setHeight] = React.useState("500px");
@@ -639,8 +664,7 @@ export function DoenetViewer({
             if (data.error) {
                 // A failed boot must not hold its boot slot.
                 if (windowed) {
-                    clearBootWatchdog();
-                    releaseBootSlot(id);
+                    relinquishBootSlot();
                 }
                 //@ts-ignore
                 return setInErrorState(data.error);
@@ -675,17 +699,10 @@ export function DoenetViewer({
                     // Windowed viewers always register the composed
                     // initializedCallback (it releases the boot slot), even
                     // when the host passed none.
-                    if (
-                        windowed &&
-                        !("initializedCallback" in registeredFunctions)
-                    ) {
-                        proxiedFunctions.push("initializedCallback");
-                        proxiedFunctions.push(
-                            Comlink.proxy(
-                                composedInitializedCallbackRef.current!,
-                            ),
-                        );
-                    }
+                    appendComposedInitializedCallback(
+                        proxiedFunctions,
+                        registeredFunctions,
+                    );
                     viewerIframe
                         .renderViewerWithFunctionProps(...proxiedFunctions)
                         .catch(
@@ -804,12 +821,7 @@ export function DoenetViewer({
             proxiedFunctions.push(key);
             proxiedFunctions.push(Comlink.proxy(functionPropToProxy(key, val)));
         }
-        if (windowed && !("initializedCallback" in current)) {
-            proxiedFunctions.push("initializedCallback");
-            proxiedFunctions.push(
-                Comlink.proxy(composedInitializedCallbackRef.current!),
-            );
-        }
+        appendComposedInitializedCallback(proxiedFunctions, current);
         const action = (remote: ViewerIframeRemote) => {
             remote
                 .updateViewerFunctionProps(...proxiedFunctions)
@@ -945,8 +957,7 @@ export function DoenetViewer({
         viewerIframeRef.current = null;
         destroySharedCoresForViewer(id);
         // A parked viewer no longer boots; free its slot for the queue.
-        clearBootWatchdog();
-        releaseBootSlot(id);
+        relinquishBootSlot();
         parkedRef.current = true;
         setParked(true);
         notifyViewerState(id, "parked");

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -329,6 +329,13 @@ export function DoenetViewer({
     const bootWatchdogRef = React.useRef<ReturnType<typeof setTimeout> | null>(
         null,
     );
+    /** Cancel the boot-slot watchdog timer if one is pending. */
+    function clearBootWatchdog() {
+        if (bootWatchdogRef.current !== null) {
+            clearTimeout(bootWatchdogRef.current);
+            bootWatchdogRef.current = null;
+        }
+    }
     // Stable composed initializedCallback: releases this viewer's boot slot,
     // then forwards to the host's latest callback. Registered with the
     // iframe instead of the host's own callback when windowed (the iframe
@@ -339,10 +346,7 @@ export function DoenetViewer({
     >(null);
     if (composedInitializedCallbackRef.current === null) {
         composedInitializedCallbackRef.current = (arg: unknown) => {
-            if (bootWatchdogRef.current !== null) {
-                clearTimeout(bootWatchdogRef.current);
-                bootWatchdogRef.current = null;
-            }
+            clearBootWatchdog();
             releaseBootSlot(id);
             (doenetViewerPropsRef.current as any).initializedCallback?.(arg);
         };
@@ -635,10 +639,7 @@ export function DoenetViewer({
             if (data.error) {
                 // A failed boot must not hold its boot slot.
                 if (windowed) {
-                    if (bootWatchdogRef.current !== null) {
-                        clearTimeout(bootWatchdogRef.current);
-                        bootWatchdogRef.current = null;
-                    }
+                    clearBootWatchdog();
                     releaseBootSlot(id);
                 }
                 //@ts-ignore
@@ -944,10 +945,7 @@ export function DoenetViewer({
         viewerIframeRef.current = null;
         destroySharedCoresForViewer(id);
         // A parked viewer no longer boots; free its slot for the queue.
-        if (bootWatchdogRef.current !== null) {
-            clearTimeout(bootWatchdogRef.current);
-            bootWatchdogRef.current = null;
-        }
+        clearBootWatchdog();
         releaseBootSlot(id);
         parkedRef.current = true;
         setParked(true);
@@ -978,9 +976,7 @@ export function DoenetViewer({
             // parked snapshot (see the srcDoc memo).
             setParkGeneration((generation) => generation + 1);
             notifyViewerState(id, "live");
-            if (bootWatchdogRef.current !== null) {
-                clearTimeout(bootWatchdogRef.current);
-            }
+            clearBootWatchdog();
             bootWatchdogRef.current = setTimeout(() => {
                 bootWatchdogRef.current = null;
                 releaseBootSlot(id);
@@ -1047,10 +1043,7 @@ export function DoenetViewer({
         }
         return () => {
             parkFlushCleanupRef.current?.();
-            if (bootWatchdogRef.current !== null) {
-                clearTimeout(bootWatchdogRef.current);
-                bootWatchdogRef.current = null;
-            }
+            clearBootWatchdog();
             unregister();
         };
     }, [windowed]);

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -92,6 +92,12 @@ export function createHtmlForDoenetViewer(
     // Since for some callbacks, we have different behavior whether or not it was specified,
     // we pass an extra variable of the props that were specified.
     const doenetViewerPropsSpecified: string[] = Object.keys(doenetViewerProps);
+    // The wrapper may supply its own composed `initializedCallback` (the
+    // windowed-mounting boot-slot release) even when the host didn't specify
+    // one; list it so the in-iframe entry adopts the proxy when sent.
+    if (!doenetViewerPropsSpecified.includes("initializedCallback")) {
+        doenetViewerPropsSpecified.push("initializedCallback");
+    }
 
     // XXX: rather than serving Comlink from the cdn, below, serve it directly
     // TODO: rather than load the Doenet logo from doenet.org, serve it directly

--- a/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
+++ b/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
@@ -49,12 +49,27 @@ export type MountPolicy = {
      * parked. Default 2000.
      */
     parkDelayMs?: number;
+    /**
+     * Page-wide cap on how many windowed viewers may be *booting* their
+     * iframe realm at once (each boot parses the multi-MB standalone bundle
+     * and starts a core worker — the initialization stampede #1439
+     * targets). Additional viewers wait for a slot, visible-first. As with
+     * `maxLiveViewers`, the smallest value across viewers wins. Default 2.
+     */
+    maxConcurrentBoots?: number;
 };
 
 export const DEFAULT_MAX_LIVE_VIEWERS = 3;
 export const DEFAULT_VISIBLE_MARGIN = "1000px";
 export const DEFAULT_FLUSH_TIMEOUT_MS = 5000;
 export const DEFAULT_PARK_DELAY_MS = 2000;
+export const DEFAULT_MAX_CONCURRENT_BOOTS = 2;
+/**
+ * A boot that never reports initialized (wedged worker, huge document on a
+ * slow machine) must not starve the queue forever; its slot is reclaimed
+ * after this long. The boot itself continues — only the slot is freed.
+ */
+export const BOOT_SLOT_WATCHDOG_MS = 90_000;
 
 export type ViewerLifecycleState = "live" | "parking" | "parked";
 
@@ -79,6 +94,14 @@ let warnedMixedBudgets = false;
 let evaluateTimerId: ReturnType<typeof setTimeout> | null = null;
 let evaluateTimerAt = Infinity;
 
+// ---- Boot-slot semaphore (#1439) ----
+// Caps how many windowed viewers boot their iframe realm simultaneously.
+let effectiveMaxBoots: number | null = null;
+const bootSlotHolders = new Set<string>();
+type BootRequest = { id: string; requestOrder: number; grant: () => void };
+let bootRequestCounter = 0;
+const bootQueue: BootRequest[] = [];
+
 /**
  * Register a windowed viewer. Returns an unregister function for the
  * component's unmount cleanup.
@@ -86,16 +109,22 @@ let evaluateTimerAt = Infinity;
 export function registerWindowedViewer({
     id,
     maxLiveViewers,
+    maxConcurrentBoots,
     parkDelayMs,
     canPark,
     requestPark,
 }: {
     id: string;
     maxLiveViewers: number;
+    maxConcurrentBoots: number;
     parkDelayMs: number;
     canPark: () => boolean;
     requestPark: () => void;
 }): () => void {
+    effectiveMaxBoots =
+        effectiveMaxBoots === null
+            ? maxConcurrentBoots
+            : Math.min(effectiveMaxBoots, maxConcurrentBoots);
     if (
         effectiveMaxLive !== null &&
         effectiveMaxLive !== maxLiveViewers &&
@@ -125,8 +154,66 @@ export function registerWindowedViewer({
 
     return () => {
         records.delete(id);
+        cancelBootRequest(id);
+        releaseBootSlot(id);
         scheduleEvaluate(0);
     };
+}
+
+/**
+ * Request a boot slot; `grant` is called (synchronously when a slot is
+ * free) once this viewer may create its iframe. Visible viewers are served
+ * before off-screen ones, then request order. A duplicate request for an id
+ * already queued or already holding a slot is ignored.
+ */
+export function requestBootSlot(id: string, grant: () => void) {
+    if (bootSlotHolders.has(id) || bootQueue.some((r) => r.id === id)) {
+        return;
+    }
+    bootQueue.push({ id, requestOrder: ++bootRequestCounter, grant });
+    pumpBootQueue();
+}
+
+/** Withdraw a queued boot request (e.g. the viewer scrolled away again). */
+export function cancelBootRequest(id: string) {
+    const idx = bootQueue.findIndex((r) => r.id === id);
+    if (idx !== -1) {
+        bootQueue.splice(idx, 1);
+    }
+}
+
+/**
+ * Release a held boot slot (the boot finished, failed, was watchdogged, or
+ * the viewer parked/unmounted). Idempotent.
+ */
+export function releaseBootSlot(id: string) {
+    if (bootSlotHolders.delete(id)) {
+        pumpBootQueue();
+    }
+}
+
+function pumpBootQueue() {
+    const max = effectiveMaxBoots ?? Infinity;
+    while (bootQueue.length > 0 && bootSlotHolders.size < max) {
+        // Visible-first, then request order.
+        let best = 0;
+        for (let i = 1; i < bootQueue.length; i++) {
+            const bestVisible = Boolean(
+                records.get(bootQueue[best].id)?.visible,
+            );
+            const thisVisible = Boolean(records.get(bootQueue[i].id)?.visible);
+            if (
+                (thisVisible && !bestVisible) ||
+                (thisVisible === bestVisible &&
+                    bootQueue[i].requestOrder < bootQueue[best].requestOrder)
+            ) {
+                best = i;
+            }
+        }
+        const [request] = bootQueue.splice(best, 1);
+        bootSlotHolders.add(request.id);
+        request.grant();
+    }
 }
 
 /**
@@ -176,7 +263,14 @@ export function getViewerLifecycleStats() {
             parked++;
         }
     }
-    return { registered: records.size, live, parking, parked };
+    return {
+        registered: records.size,
+        live,
+        parking,
+        parked,
+        booting: bootSlotHolders.size,
+        bootQueue: bootQueue.length,
+    };
 }
 
 /** Test-only: forget every registration and reset module state. */
@@ -190,6 +284,10 @@ export function __resetViewerLifecycleManagerForTests() {
         evaluateTimerId = null;
     }
     evaluateTimerAt = Infinity;
+    effectiveMaxBoots = null;
+    bootSlotHolders.clear();
+    bootQueue.length = 0;
+    bootRequestCounter = 0;
 }
 
 /**

--- a/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
+++ b/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
@@ -9,8 +9,13 @@
  * a placeholder), so idle memory tracks what the user can see rather than
  * how many documents the page embeds.
  *
- * This module is pure policy: *when* to park. The mechanics of parking
- * (flushing state, swapping the iframe for a placeholder, restoring) live in
+ * It also gates *when* a lazily-mounted viewer may boot its iframe realm: a
+ * page-wide boot-slot semaphore (`maxConcurrentBoots`) caps how many viewers
+ * evaluate the multi-MB standalone bundle at once, serving visible viewers
+ * first (see `requestBootSlot`).
+ *
+ * This module is pure policy: *when* to park and *when* to boot. The
+ * mechanics (flushing state, creating/swapping the iframe, restoring) live in
  * the `DoenetViewer` wrapper, which registers callbacks here. Module-level
  * state is intentional — the budget is shared by every windowed viewer on
  * the page (same pattern as `shared-core-pool.ts`).

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.lazyMount.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.lazyMount.cy.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/index";
+import {
+    __resetViewerLifecycleManagerForTests,
+    getViewerLifecycleStats,
+} from "../../../src/viewer-lifecycle-manager";
+import { STANDALONE_BLOB_URL, STANDALONE_CSS_BLOB_URL } from "./helpers";
+
+// #1439 (native half): windowed viewers start as placeholders and only
+// create their iframe when near the viewport and granted a boot slot — an
+// off-screen viewer never boots at all, so mounting N viewers costs the
+// boot of only the visible few (no initialization stampede).
+
+const CONTENT_TIMEOUT = 40_000;
+
+const MOUNT_POLICY = {
+    mode: "windowed" as const,
+    maxLiveViewers: 3,
+    maxConcurrentBoots: 1,
+    parkDelayMs: 300,
+    visibleMargin: "100px",
+};
+
+function Harness() {
+    const viewers = [];
+    for (let i = 0; i < 4; i++) {
+        viewers.push(
+            // Fixed-height containers so booted viewers (whose iframes
+            // shrink to their content height) don't collapse the page and
+            // pull the far-away viewers into the viewport. 500px (less than
+            // the 600px viewport) so viewer-1 genuinely OVERLAPS the
+            // viewport: cypress mounts components inside an iframe, where
+            // rootMargin on an implicit-root IntersectionObserver is
+            // ignored, so `visibleMargin` cannot be relied on here.
+            <div
+                key={i}
+                data-test={`viewer-${i}`}
+                style={{ height: "500px", overflow: "hidden" }}
+            >
+                <DoenetViewer
+                    doenetML={`<p>Viewer number ${i}</p>`}
+                    activityId={`lazy-act-${i}`}
+                    docId={`lazy-doc-${i}`}
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
+    }
+    return <div>{viewers}</div>;
+}
+
+/**
+ * Assert the viewer's document RENDERED the given text. A plain
+ * `contain.text` on the body would also match the raw doenetML source
+ * inside the srcdoc's <script> tag before anything renders, so strip
+ * script tags before checking. (The DoenetML `<p>` component renders as a
+ * `<div>`, so element-based selectors are no help here.)
+ */
+function assertRenders(which: string, text: string) {
+    cy.get(`[data-test=${which}] iframe`, { timeout: CONTENT_TIMEOUT })
+        .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+        .should((body: any) => {
+            // `.its(...)` yields the raw body element (not a jQuery wrap).
+            const clone = (body as HTMLElement).cloneNode(true) as HTMLElement;
+            clone.querySelectorAll("script").forEach((s) => s.remove());
+            expect(
+                (clone.textContent ?? "").includes(text),
+                `${which} rendered "${text}"`,
+            ).to.eq(true);
+        });
+}
+
+describe("DoenetViewer (iframe wrapper) — lazy windowed mounting with a boot cap", () => {
+    beforeEach(() => {
+        __resetViewerLifecycleManagerForTests();
+    });
+
+    it("only near-viewport viewers ever create an iframe; the rest stay parked placeholders", () => {
+        cy.viewport(900, 600);
+        cy.mount(<Harness />);
+
+        // Containers are 500px tall in a 600px viewport: viewer-0 fills
+        // most of it and viewer-1's top 100px overlap; viewers 2 and 3 are
+        // fully below. The overlapping ones boot (one at a time under the
+        // cap of 1)...
+        assertRenders("viewer-0", "Viewer number 0");
+        assertRenders("viewer-1", "Viewer number 1");
+
+        // ...while the off-screen ones never got an iframe at all.
+        cy.get("[data-test=viewer-2] iframe").should("not.exist");
+        cy.get("[data-test=viewer-3] iframe").should("not.exist");
+        cy.get("[data-test=viewer-2] [data-doenet-parked-viewer]").should(
+            "exist",
+        );
+        cy.get("[data-test=viewer-3] [data-doenet-parked-viewer]").should(
+            "exist",
+        );
+
+        // The manager settles with no held slots and no queue.
+        cy.wrap(null, { timeout: 20_000 }).should(() => {
+            const stats = getViewerLifecycleStats();
+            expect(
+                stats,
+                `settled state: ${JSON.stringify(stats)}`,
+            ).to.deep.include({
+                booting: 0,
+                bootQueue: 0,
+                live: 2,
+                parked: 2,
+            });
+        });
+
+        // Scrolling to the bottom boots viewer 3 on demand.
+        cy.get("[data-test=viewer-3]").scrollIntoView();
+        assertRenders("viewer-3", "Viewer number 3");
+    });
+});

--- a/packages/doenetml-iframe/test/cypress/component/viewerLifecycleManager.cy.ts
+++ b/packages/doenetml-iframe/test/cypress/component/viewerLifecycleManager.cy.ts
@@ -3,6 +3,9 @@ import {
     setViewerVisibility,
     notifyViewerState,
     getViewerLifecycleStats,
+    requestBootSlot,
+    cancelBootRequest,
+    releaseBootSlot,
     __resetViewerLifecycleManagerForTests,
 } from "../../../src/viewer-lifecycle-manager";
 
@@ -21,6 +24,7 @@ function addViewer(
     id: string,
     {
         maxLiveViewers = 2,
+        maxConcurrentBoots = 99,
         parkDelayMs = 100,
         canPark = true,
         parkImmediately = true,
@@ -30,6 +34,7 @@ function addViewer(
     viewer.unregister = registerWindowedViewer({
         id,
         maxLiveViewers,
+        maxConcurrentBoots,
         parkDelayMs,
         canPark: () => canPark,
         requestPark: () => {
@@ -138,6 +143,7 @@ describe("viewer-lifecycle-manager — windowed mounting policy", () => {
         a.unregister = registerWindowedViewer({
             id: "a",
             maxLiveViewers: 1,
+            maxConcurrentBoots: 99,
             parkDelayMs: 100,
             canPark: () => true,
             requestPark: () => {
@@ -213,6 +219,63 @@ describe("viewer-lifecycle-manager — windowed mounting policy", () => {
                 parking: 1, // c
                 parked: 1, // b
             });
+        });
+    });
+
+    describe("boot-slot semaphore (#1439)", () => {
+        function addQueued(id: string, granted: string[], opts = {}) {
+            addViewer(id, { maxConcurrentBoots: 1, ...opts });
+            requestBootSlot(id, () => granted.push(id));
+        }
+
+        it("caps concurrent boots and serves the queue on release", () => {
+            const granted: string[] = [];
+            addQueued("a", granted);
+            addQueued("b", granted);
+            addQueued("c", granted);
+            expect(granted, "only one slot").to.deep.eq(["a"]);
+            expect(getViewerLifecycleStats()).to.deep.include({
+                booting: 1,
+                bootQueue: 2,
+            });
+            releaseBootSlot("a");
+            expect(granted, "release grants the next").to.deep.eq(["a", "b"]);
+            releaseBootSlot("b");
+            releaseBootSlot("c");
+            expect(granted).to.deep.eq(["a", "b", "c"]);
+            expect(getViewerLifecycleStats()).to.deep.include({
+                booting: 0,
+                bootQueue: 0,
+            });
+        });
+
+        it("serves visible viewers before earlier-queued off-screen ones", () => {
+            const granted: string[] = [];
+            addQueued("a", granted);
+            addQueued("b", granted);
+            addQueued("c", granted);
+            setViewerVisibility("c", true);
+            releaseBootSlot("a");
+            expect(granted, "visible c jumps the queue").to.deep.eq(["a", "c"]);
+        });
+
+        it("cancelling a queued request removes it; duplicates are ignored", () => {
+            const granted: string[] = [];
+            addQueued("a", granted);
+            addQueued("b", granted);
+            requestBootSlot("b", () => granted.push("b-duplicate"));
+            cancelBootRequest("b");
+            releaseBootSlot("a");
+            expect(granted, "cancelled b never granted").to.deep.eq(["a"]);
+        });
+
+        it("unregistering releases a held slot and withdraws a queued request", () => {
+            const granted: string[] = [];
+            const a = addViewer("a", { maxConcurrentBoots: 1 });
+            requestBootSlot("a", () => granted.push("a"));
+            addQueued("b", granted);
+            a.unregister();
+            expect(granted, "a's slot passed to b").to.deep.eq(["a", "b"]);
         });
     });
 

--- a/packages/memory-benchmark/pages-src/windowed.jsx
+++ b/packages/memory-benchmark/pages-src/windowed.jsx
@@ -30,10 +30,10 @@ const MOUNT_POLICY = {
     mode: "windowed",
     maxLiveViewers: keep,
     parkDelayMs: 500,
-    visibleMargin: "500px",
-    // Generous: N realms boot concurrently, and an acknowledged flush-park
-    // is the realistic steady state we want to measure (timeout-parking
-    // reaches the same memory state but would hide a broken flush path).
+    // Small margin so the number of live (near-viewport) viewers is
+    // deterministic (~2 at the default placeholder height) and independent
+    // of N.
+    visibleMargin: "200px",
     flushTimeoutMs: 60_000,
 };
 
@@ -70,15 +70,20 @@ function App() {
 
 createRoot(document.getElementById("root")).render(<App />);
 
-// Done once the page settles at the budget: everything beyond `keep` parked,
-// no park in flight, and at least one visible viewer fully booted.
+// Done once the page settles: nothing mid-park or mid-boot, every viewer
+// accounted for as live or parked, and every live viewer fully booted.
+// (Off-screen viewers start parked and never boot; only the ~2 viewers
+// within the margin boot, staggered by the boot-slot cap.)
 const settleTimer = setInterval(() => {
     const stats = getViewerLifecycleStats();
     window.__parkedCount = stats.parked;
     if (
-        stats.parked >= n - keep &&
         stats.parking === 0 &&
-        window.__initializedCount >= 1
+        stats.booting === 0 &&
+        stats.bootQueue === 0 &&
+        stats.live + stats.parked === n &&
+        stats.live >= 1 &&
+        window.__initializedCount >= stats.live
     ) {
         clearInterval(settleTimer);
         window.__done = true;


### PR DESCRIPTION
> **Previously stacked on #1474** (windowed mounting) and #1473, both now merged. This branch is rebased onto `main`, so the diff below contains only this PR's changes.

## Problem

#1439's core complaint: when a page with many DoenetML activities loads, every embedded viewer boots at once — N parallel parses of the multi-MB standalone bundle plus N core-worker boots (the memory/CPU spike behind #874). Windowed mounting (#1474) bounded the *steady state*, but still paid the stampede: all N realms booted, then N−K of them parked. Booting 13 realms just to throw 11 away is exactly the waste #1439 targets.

## Change (native React-host half of #1439)

Windowed viewers now **mount lazily**: a windowed `<DoenetViewer>` starts as its fixed-height placeholder and creates its iframe only when it comes near the viewport **and** a page-wide boot slot is free. An off-screen viewer never boots at all.

- The lifecycle manager gains a **boot-slot semaphore**: `mountPolicy.maxConcurrentBoots` (default 2, smallest value across viewers wins). Grants are **visible-first**, then request order; a queued request is withdrawn if the viewer scrolls away before a slot frees.
- Slots release on viewer initialized, in-iframe error, park, unmount — plus a 90 s watchdog so a wedged boot can't starve the queue (the boot itself continues; only the slot is reclaimed).
- The release signal rides a **wrapper-composed `initializedCallback`** registered with the iframe even when the host passed none (the srcdoc's specified-props list now always includes it). The host's callback identity still drives function-prop change detection, so identity churn semantics are unchanged.
- **Bug fix this surfaced:** the wrapper's message listener was only attached when an iframe existed at first commit — fatal for any lazily-created iframe (its `iframeReady` would be missed, wedging the boot and, transitively, the whole boot queue). It now attaches unconditionally.

## Measurements

Windowed benchmark, same machine, lazy (this PR) vs boot-all-then-park (#1474):

| scenario | #1474 | this PR | live realms booted |
| --- | --- | --- | --- |
| windowed-8-3 | 1085 MB | **718 MB** | 2 (only near-viewport) |
| windowed-16-3 | 1041 MB | **735 MB** | 2 |

Marginal cost per parked instance stays ~0 MB (2 MB, noise). For scale: 16 activities unwindowed ≈ 16 × 196 MB ≈ 3.1 GB + fixed. There is also no longer any N-realm boot transient — peak ≈ steady state.

## Tests

- 4 new manager unit tests (semaphore cap + queue, visible-first priority, cancel/dedupe, unregister-releases) alongside the existing 7 policy tests.
- New `DoenetViewer.lazyMount.cy.tsx` end-to-end: 4 windowed viewers, cap 1 — the two near-viewport viewers boot one at a time, the two off-screen ones **never create an iframe**, the manager settles with no held slots, and scrolling down boots the last viewer on demand.
- Full `doenetml-iframe` suite: 16 specs / 34 tests passing locally (parking, flushState, shared-core, prop-update suites unchanged).

Advances #1439 (native half) and #1441 (stream B). The remaining #1439 half — a tiny coordinator script for non-React static hosts (PreTeXt's `-if.html` pages), including park/restore and shared-core port distribution — lands as the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

