### PR TITLE
Add an activity coordinator for static hosts: lazy boot, park/restore, shared cores

### DIFF
--- a/.changeset/standalone-activity-coordinator.md
+++ b/.changeset/standalone-activity-coordinator.md
@@ -1,0 +1,15 @@
+---
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+New `coordinator.js`, published alongside the standalone bundle: a small
+script a static host page (e.g. a PreTeXt book) adds next to its same-origin
+DoenetML activity iframes. It lazy-loads activities with a page-wide
+boot-concurrency cap, keeps at most `maxLiveViewers` live (parking
+off-screen ones by flushing their state and detaching the iframe, and
+restoring them — reader's work intact — on scroll-back via a
+`SPLICE.getState` warehouse), and can serve all activities from a shared
+core-worker pool. The activity pages themselves need no changes: the
+coordinator marks each activity URL with a fragment token that the
+standalone bundle detects.

--- a/packages/standalone/COORDINATION.md
+++ b/packages/standalone/COORDINATION.md
@@ -1,0 +1,82 @@
+# Coordinating many DoenetML activities on one page
+
+Static host pages that embed many DoenetML activities as same-origin iframes
+— the model PreTeXt uses for its generated `…-if.html` interactive pages —
+historically paid for every activity at once: N parallel multi-MB bundle
+parses and N dedicated ~100 MB core workers at load, and all N stayed in
+memory forever (Active Calculus pages have been measured at 1.7–3.6 GB).
+
+`coordinator.js`, published alongside the bundle in `@doenet/standalone`,
+fixes this with **one script tag on the host page**:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@doenet/standalone@<version>/coordinator.js"></script>
+```
+
+The activity pages themselves need **no changes**: the coordinator marks
+each activity iframe's URL with a fragment token, and the standalone bundle
+the activity already loads detects that token and cooperates.
+
+## What it does
+
+- **Lazy boot with a concurrency cap.** Activity iframes are detached up
+  front and only load when they come near the viewport AND a boot slot is
+  free (default: 2 at a time, visible-first). An activity the reader never
+  scrolls to never boots at all.
+- **Park / restore.** At most `maxLiveViewers` (default 3) activities stay
+  live. When the reader scrolls on, off-screen activities beyond the budget
+  are *parked*: the coordinator flushes their state (`SPLICE.flushState`),
+  warehouses the final `SPLICE.reportScoreAndState`, and detaches the
+  iframe (`about:blank`) — the element, and therefore the page layout,
+  stays. Scrolling back restores the activity; the rebooting viewer asks
+  for its state (`SPLICE.getState`) and the coordinator answers from the
+  warehouse, so **the reader's work survives** with no interaction.
+- **Shared core workers** (opt-in, `data-shared-core-workers="true"`):
+  activities obtain their document cores from a coordinator-owned worker
+  pool instead of each booting a dedicated worker — the dominant per-
+  activity memory cost on multi-activity pages.
+
+## Configuration
+
+Options are read from the script tag's `data-` attributes:
+
+```html
+<script
+    src="…/coordinator.js"
+    data-max-live-viewers="3"
+    data-max-concurrent-boots="2"
+    data-visible-margin="1000px"
+    data-park-delay-ms="2000"
+    data-flush-timeout-ms="5000"
+    data-shared-core-workers="true"
+    data-iframe-selector="iframe[src$='-if.html']"
+></script>
+```
+
+For programmatic control, set `data-doenet-manual-init` on the script tag
+and call `window.initializeDoenetCoordinator({ maxLiveViewers: 3, … })`
+yourself (same option names, camelCase).
+
+`window.doenetCoordinatorStats()` returns live diagnostics
+(`{ activities, byState, booting, bootQueue, sharedCorePool }`).
+
+## Requirements and behavior notes
+
+- Activity iframes must be **same-origin** with the host page (the
+  activity *page*, not the CDN bundle it loads — PreTeXt's layout). The
+  default selector targets `…-if.html` URLs plus any iframe with a
+  `data-doenet-coordinate` attribute.
+- Activities should have an explicit `height` (PreTeXt sets one): the
+  iframe element stays in the layout while parked, so no reflow occurs.
+- Parked activities' state lives in the coordinator's in-page warehouse.
+  Navigating away from the host page discards it, exactly as it discards
+  live activities' state — pair with a persistence backend (Runestone,
+  etc.) if state must survive navigation; the coordinator's flushes ride
+  the normal `SPLICE.reportScoreAndState` channel such a backend already
+  consumes.
+- Activities running a standalone bundle older than the coordinator
+  protocol boot normally but are managed conservatively (a 90 s watchdog
+  stands in for their missing boot-complete signal, and their state cannot
+  be warehoused; they still lazy-load).
+- The coordinator manages iframes present at initialization
+  (DOMContentLoaded); dynamically inserted activities are not yet managed.

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -125,6 +125,16 @@ button: it flushes any pending edits to the viewer so the next
 no-op when nothing has changed, and warns when there is no viewer
 (`showViewer={false}`).
 
+## Coordinating many activities on one page
+
+Pages embedding many activities as same-origin iframes (the PreTeXt model)
+can add `coordinator.js` — published alongside this bundle — to lazy-load,
+cap, park, and restore activities so memory tracks what the reader can see
+instead of how many activities the page embeds, optionally serving all
+activities from a shared core-worker pool. One script tag on the host page;
+the activity pages need no changes. See
+[COORDINATION.md](https://github.com/Doenet/DoenetML/blob/main/packages/standalone/COORDINATION.md).
+
 ## Host message protocol (SPLICE)
 
 The viewer exchanges JSON messages with its host via `postMessage`.

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -30,6 +30,22 @@
     },
     "wireit": {
         "build": {
+            "command": "vite -c vite.config-coordinator.ts build",
+            "files": [
+                "src/coordinator.ts",
+                "../doenetml-iframe/src/shared-core-pool.ts",
+                "vite.config-coordinator.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/coordinator.js",
+                "dist/coordinator.js.map"
+            ],
+            "dependencies": [
+                "build:main"
+            ]
+        },
+        "build:main": {
             "command": "vite build",
             "files": [
                 "src/**/*.ts",
@@ -39,7 +55,9 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "!dist/coordinator.js",
                 "dist/**/*.map",
+                "!dist/coordinator.js.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json",
                 "dist/**/*.css",

--- a/packages/standalone/src/coordinated-mode.ts
+++ b/packages/standalone/src/coordinated-mode.ts
@@ -1,0 +1,123 @@
+/**
+ * Child-side support for the parent-page coordinator (`dist/coordinator.js`).
+ *
+ * The coordinator lives on a PARENT page that embeds DoenetML activities as
+ * real same-origin iframes (the PreTeXt `…-if.html` model). It gates,
+ * parks, and restores those iframes purely by controlling their `src` — and
+ * marks each activity URL with a fragment token before (re)loading it.
+ * Detecting that token here, inside the standalone bundle the child page
+ * loads, lets otherwise-unmodified child pages participate fully: adding the
+ * coordinator script to the parent page is the only host change.
+ *
+ * When the token is present the viewer entry:
+ *  - defaults `flags.messageParent`/`allowSaveState`/`allowLoadState` to
+ *    true, so state reports and the boot-time `SPLICE.getState` request
+ *    reach the coordinator (which acts as the state warehouse across
+ *    park/restore cycles);
+ *  - posts `bootComplete` to the parent once the document initializes (the
+ *    coordinator's boot-slot release signal);
+ *  - with the `sc` variant, routes core creation to the coordinator's
+ *    shared core-worker pool (#1466) instead of booting a dedicated ~100 MB
+ *    worker per iframe.
+ */
+
+export type CoordinatedMode = {
+    /** The coordinator owns a shared core-worker pool; route cores to it. */
+    sharedCores: boolean;
+};
+
+// The fragment token the coordinator appends to activity URLs. `v1` is the
+// protocol version; the `sc` suffix advertises the shared-core pool. The
+// token is only ever written by a coordinator running on the parent page in
+// this same page load, so a capability it advertises is guaranteed present.
+const MARKER = /(?:^#|&)doenetCoordinated=v1(sc)?(?:&|$)/;
+
+export function detectCoordinatedMode(): CoordinatedMode | null {
+    // Guard against the marked URL being opened directly as a top-level
+    // page (a shared link, say): without a coordinator on a parent page,
+    // coordinated behavior must stay off. Detect "framed" via
+    // `frameElement` rather than comparing `window.parent` to `window` —
+    // test proxies that defeat frame-busting (e.g. Cypress's
+    // modifyObstructiveCode) rewrite parent/top/self comparisons in served
+    // JS, which would silently disable coordination in exactly the
+    // environments that test it.
+    let framed: boolean;
+    try {
+        framed = window.frameElement !== null;
+    } catch {
+        // A cross-origin parent throws — definitely framed (though such a
+        // parent could not have run our coordinator; the token check below
+        // still governs).
+        framed = true;
+    }
+    if (!framed) {
+        return null;
+    }
+    const match = MARKER.exec(window.location.hash);
+    if (!match) {
+        return null;
+    }
+    return { sharedCores: Boolean(match[1]) };
+}
+
+/**
+ * Post a lifecycle message to the coordinator. Coordinated children are
+ * same-origin with their parent (the coordinator only marks same-origin
+ * activity iframes), so target the parent's origin explicitly.
+ */
+export function postToCoordinator(
+    data: Record<string, unknown>,
+    transfer?: Transferable[],
+) {
+    window.parent.postMessage(
+        { origin: "doenetCoordinatedChild", data },
+        window.location.origin,
+        transfer ?? [],
+    );
+}
+
+/**
+ * Route this realm's core creation to the coordinator's shared core-worker
+ * pool: install `doenetGlobalConfig.createExternalCoreWorkerPort` so the
+ * viewer obtains each core over a locally-minted `MessageChannel` whose far
+ * port the coordinator forwards to a shared host worker. Messages the
+ * viewer sends on its port buffer until the core is exposed, so core
+ * creation stays synchronous here. (Same design as the doenetml-iframe
+ * wrapper's port provider — one protocol, two transports.)
+ *
+ * Must run after the standalone bundle's doenetml module has evaluated
+ * (which creates `window.doenetGlobalConfig`) and before anything renders a
+ * viewer; the entry module's top level satisfies both.
+ */
+export function installCoordinatorSharedCorePortProvider() {
+    let coreCounter = 0;
+    const childId = Math.random().toString(36).slice(2);
+    (window as any).doenetGlobalConfig.createExternalCoreWorkerPort = () => {
+        const coreId = `coordinated-${childId}-${++coreCounter}`;
+        const channel = new MessageChannel();
+        window.parent.postMessage(
+            {
+                origin: "doenetCoordinatedChild",
+                data: {
+                    type: "createSharedCore",
+                    coreId,
+                    // The coordinator resolves the (version-matched) worker
+                    // co-served next to this bundle.
+                    standaloneUrl: import.meta.url,
+                },
+            },
+            window.location.origin,
+            [channel.port2],
+        );
+        return {
+            port: channel.port1,
+            destroy: (suspectWedge?: boolean) => {
+                postToCoordinator({
+                    type: "destroySharedCore",
+                    coreId,
+                    suspectWedge: Boolean(suspectWedge),
+                });
+            },
+        };
+    };
+}

--- a/packages/standalone/src/coordinator.ts
+++ b/packages/standalone/src/coordinator.ts
@@ -85,7 +85,10 @@ const DEFAULTS = {
     sharedCoreWorkers: false,
 };
 
-type ActivityState = "detached" | "booting" | "live" | "parking" | "parked";
+// "parked" is also the initial state: a discovered iframe is detached to
+// about:blank and awaits its first boot slot exactly as a re-parked one does
+// (so coming into view unparks it through the same path).
+type ActivityState = "booting" | "live" | "parking" | "parked";
 
 type ActivityRecord = {
     iframe: HTMLIFrameElement;
@@ -314,7 +317,7 @@ export function initializeDoenetCoordinator(
         const now = Date.now();
         let active = 0;
         for (const record of records.values()) {
-            if (record.state !== "parked" && record.state !== "detached") {
+            if (record.state !== "parked") {
                 active++;
             }
         }

--- a/packages/standalone/src/coordinator.ts
+++ b/packages/standalone/src/coordinator.ts
@@ -1,0 +1,559 @@
+/**
+ * DoenetML activity coordinator for static host pages (#1439, #1441 stream
+ * B, and the PreTeXt milestone of #1466).
+ *
+ * Built as `dist/coordinator.js` — a small dependency-free (no React)
+ * script a host page adds alongside its DoenetML activity iframes:
+ *
+ * ```html
+ * <script src="https://cdn.jsdelivr.net/npm/@doenet/standalone@<version>/coordinator.js"></script>
+ * ```
+ *
+ * The coordinator targets the PreTeXt embedding model: each activity is a
+ * real same-origin iframe (e.g. `…-if.html`) whose document loads
+ * `@doenet/standalone` and calls `renderDoenetViewerToContainer`. It
+ * manages those iframes purely by controlling their `src`, so the child
+ * pages need no changes — the standalone bundle they already load detects
+ * the coordinator's URL-fragment token (see `coordinated-mode.ts`) and
+ * cooperates:
+ *
+ * - **Lazy boot with a concurrency cap.** Activity iframes are detached
+ *   (src cleared) up front and only load when they come near the viewport
+ *   AND a boot slot is free (`maxConcurrentBoots`, visible-first), so a
+ *   chapter with 30 activities boots ~2 at a time instead of stampeding.
+ * - **Park / restore.** At most `maxLiveViewers` activities stay live.
+ *   Off-screen ones beyond the budget are parked: the coordinator flushes
+ *   their state (`SPLICE.flushState`), warehouses the resulting
+ *   `SPLICE.reportScoreAndState`, and detaches the iframe (the element —
+ *   and thus the layout — stays). Scrolling back restores the iframe; the
+ *   rebooting viewer requests its state back (`SPLICE.getState`) and the
+ *   coordinator answers from the warehouse, so typed work survives.
+ * - **Shared core workers** (`sharedCoreWorkers: true`): child viewers
+ *   route core creation to a coordinator-owned worker pool instead of each
+ *   booting a dedicated ~100 MB worker (one protocol with
+ *   `@doenet/doenetml-iframe`'s `useSharedCoreWorker`).
+ *
+ * The script auto-initializes at DOMContentLoaded with options read from
+ * its own `data-` attributes; call `window.initializeDoenetCoordinator()`
+ * for programmatic control instead (set `data-doenet-manual-init` on the
+ * script tag to suppress auto-init).
+ */
+
+// The shared core-worker pool implementation is maintained in
+// @doenet/doenetml-iframe (which pioneered the protocol in #1466). Import
+// it by source path so both consumers bundle one implementation; it is
+// self-contained (Comlink only).
+import {
+    handleCreateSharedCore,
+    handleDestroySharedCore,
+    destroySharedCoresForViewer,
+    getSharedCorePoolStats,
+} from "../../doenetml-iframe/src/shared-core-pool";
+
+export type DoenetCoordinatorOptions = {
+    /**
+     * CSS selector for the activity iframes to manage. Default targets
+     * PreTeXt's generated interactive pages plus an explicit opt-in
+     * attribute.
+     */
+    iframeSelector?: string;
+    /** Page-wide budget of simultaneously live activities. Default 3. */
+    maxLiveViewers?: number;
+    /** Page-wide cap on concurrently booting activities. Default 2. */
+    maxConcurrentBoots?: number;
+    /** How far outside the viewport still counts as visible. Default "1000px". */
+    visibleMargin?: string;
+    /** Off-screen debounce before an activity may be parked. Default 2000. */
+    parkDelayMs?: number;
+    /** How long to await the pre-park flush acknowledgement. Default 5000. */
+    flushTimeoutMs?: number;
+    /** A boot never reporting complete frees its slot after this long. Default 90000. */
+    bootWatchdogMs?: number;
+    /** Serve child viewers cores from a coordinator-owned shared worker pool. */
+    sharedCoreWorkers?: boolean;
+};
+
+const DEFAULTS = {
+    iframeSelector:
+        "iframe[data-doenet-coordinate], iframe[src$='-if.html'], iframe[src*='-if.html?']",
+    maxLiveViewers: 3,
+    maxConcurrentBoots: 2,
+    visibleMargin: "1000px",
+    parkDelayMs: 2000,
+    flushTimeoutMs: 5000,
+    bootWatchdogMs: 90_000,
+    sharedCoreWorkers: false,
+};
+
+type ActivityState = "detached" | "booting" | "live" | "parking" | "parked";
+
+type ActivityRecord = {
+    iframe: HTMLIFrameElement;
+    /** The activity URL with the coordinator's fragment token appended. */
+    markedSrc: string;
+    state: ActivityState;
+    visible: boolean;
+    lastVisibleOrder: number;
+    invisibleSince: number;
+    /** Latest SPLICE.reportScoreAndState from this activity (the warehouse). */
+    lastReport: any;
+    /** message_id of an in-flight pre-park flush. */
+    parkFlushId: string | null;
+    parkFlushCleanup: (() => void) | null;
+    bootWatchdogId: ReturnType<typeof setTimeout> | null;
+    /** Shared-core ids created by this activity's current realm. */
+    poolViewerId: string;
+};
+
+let initialized = false;
+
+export function initializeDoenetCoordinator(
+    options: DoenetCoordinatorOptions = {},
+) {
+    if (initialized) {
+        console.warn("Doenet coordinator: already initialized; ignoring.");
+        return;
+    }
+    initialized = true;
+
+    const opts = { ...DEFAULTS, ...options };
+    const marker = `doenetCoordinated=v1${opts.sharedCoreWorkers ? "sc" : ""}`;
+
+    const records = new Map<HTMLIFrameElement, ActivityRecord>();
+    let visibleOrderCounter = 0;
+    let flushIdCounter = 0;
+    const bootSlotHolders = new Set<ActivityRecord>();
+    const bootQueue: ActivityRecord[] = [];
+
+    /** The record whose (same-origin) iframe posted this message, if any. */
+    function recordForEvent(event: MessageEvent): ActivityRecord | undefined {
+        for (const record of records.values()) {
+            if (
+                record.iframe.isConnected &&
+                record.iframe.contentWindow === event.source
+            ) {
+                return record;
+            }
+        }
+        return undefined;
+    }
+
+    function markSrc(src: string): string {
+        return src + (src.includes("#") ? "&" : "#") + marker;
+    }
+
+    // ---- boot slots ----
+
+    function requestBootSlot(record: ActivityRecord) {
+        if (bootSlotHolders.has(record) || bootQueue.includes(record)) {
+            return;
+        }
+        bootQueue.push(record);
+        pumpBootQueue();
+    }
+
+    function cancelBootRequest(record: ActivityRecord) {
+        const idx = bootQueue.indexOf(record);
+        if (idx !== -1) {
+            bootQueue.splice(idx, 1);
+        }
+    }
+
+    function releaseBootSlot(record: ActivityRecord) {
+        if (record.bootWatchdogId !== null) {
+            clearTimeout(record.bootWatchdogId);
+            record.bootWatchdogId = null;
+        }
+        if (bootSlotHolders.delete(record)) {
+            pumpBootQueue();
+        }
+    }
+
+    function pumpBootQueue() {
+        while (
+            bootQueue.length > 0 &&
+            bootSlotHolders.size < opts.maxConcurrentBoots
+        ) {
+            // Visible-first, then queue order.
+            let best = 0;
+            for (let i = 1; i < bootQueue.length; i++) {
+                if (bootQueue[i].visible && !bootQueue[best].visible) {
+                    best = i;
+                }
+            }
+            const [record] = bootQueue.splice(best, 1);
+            if (!record.visible || record.state !== "parked") {
+                continue;
+            }
+            bootSlotHolders.add(record);
+            boot(record);
+        }
+    }
+
+    function boot(record: ActivityRecord) {
+        record.state = "booting";
+        navigateToMarkedSrc(record);
+        // A boot that never reports complete (wedged worker, ancient bundle
+        // that predates the coordinated-mode token) must not starve the
+        // queue; the boot itself continues, only the slot is freed.
+        record.bootWatchdogId = setTimeout(() => {
+            record.bootWatchdogId = null;
+            if (record.state === "booting") {
+                record.state = "live";
+            }
+            releaseBootSlot(record);
+            evaluateBudget();
+        }, opts.bootWatchdogMs);
+    }
+
+    /**
+     * Navigate the iframe to its marked URL via a guaranteed FULL load.
+     * The marked URL differs from the original only by its fragment, and
+     * the token must be present when the standalone bundle EVALUATES — but
+     * if the original document managed to commit before (or while) we
+     * detached it, assigning the marked URL directly would be treated as a
+     * same-document fragment navigation and nothing would re-evaluate.
+     * So: only assign the marked URL once an `about:blank` document has
+     * actually committed; otherwise (re)detach and wait for that commit.
+     */
+    function navigateToMarkedSrc(record: ActivityRecord) {
+        const iframe = record.iframe;
+        let committedHref: string | null = null;
+        try {
+            // Same-origin by construction (activities are filtered at
+            // discovery), so the child location is readable.
+            committedHref = iframe.contentWindow?.location.href ?? null;
+        } catch {
+            committedHref = null;
+        }
+        if (committedHref === "about:blank") {
+            iframe.src = record.markedSrc;
+            return;
+        }
+        const onDetached = () => {
+            iframe.removeEventListener("load", onDetached);
+            if (record.state === "booting") {
+                iframe.src = record.markedSrc;
+            }
+        };
+        iframe.addEventListener("load", onDetached);
+        iframe.src = "about:blank";
+    }
+
+    // ---- park / restore ----
+
+    function beginPark(record: ActivityRecord) {
+        if (record.state !== "live" || !record.iframe.contentWindow) {
+            return;
+        }
+        record.state = "parking";
+        const flushId = `__doenetCoordinatorFlush-${++flushIdCounter}`;
+        record.parkFlushId = flushId;
+        const post = () => {
+            record.iframe.contentWindow?.postMessage(
+                { subject: "SPLICE.flushState", message_id: flushId },
+                "*",
+            );
+        };
+        const retryTimer = setInterval(post, 500);
+        const timeoutTimer = setTimeout(() => {
+            // No acknowledgement. A persistence path exists (the token set
+            // allowSaveState), so what the warehouse holds is what a live
+            // wedged realm could offer anyway — park regardless.
+            finishPark(record);
+        }, opts.flushTimeoutMs);
+        record.parkFlushCleanup = () => {
+            clearInterval(retryTimer);
+            clearTimeout(timeoutTimer);
+            record.parkFlushCleanup = null;
+        };
+        post();
+    }
+
+    function finishPark(record: ActivityRecord) {
+        record.parkFlushCleanup?.();
+        record.parkFlushId = null;
+        if (record.state !== "parking") {
+            return;
+        }
+        if (record.visible) {
+            // Scrolled back mid-flush; nothing was torn down.
+            record.state = "live";
+            return;
+        }
+        // Detach the realm. The iframe element (and the page layout) stays;
+        // the browser discards the document, its worker(s), and its shared
+        // cores — release the latter from the pool.
+        destroySharedCoresForViewer(record.poolViewerId);
+        releaseBootSlot(record);
+        record.iframe.src = "about:blank";
+        record.state = "parked";
+    }
+
+    function unpark(record: ActivityRecord) {
+        if (record.state !== "parked") {
+            return;
+        }
+        requestBootSlot(record);
+    }
+
+    // ---- budget ----
+
+    let evaluateTimerId: ReturnType<typeof setTimeout> | null = null;
+    function scheduleEvaluate(delayMs: number) {
+        if (evaluateTimerId !== null) {
+            return;
+        }
+        evaluateTimerId = setTimeout(() => {
+            evaluateTimerId = null;
+            evaluateBudget();
+        }, delayMs);
+    }
+
+    function evaluateBudget() {
+        const now = Date.now();
+        let active = 0;
+        for (const record of records.values()) {
+            if (record.state !== "parked" && record.state !== "detached") {
+                active++;
+            }
+        }
+        let excess = active - opts.maxLiveViewers;
+        if (excess <= 0) {
+            return;
+        }
+        const candidates: ActivityRecord[] = [];
+        let nextExpiry = Infinity;
+        for (const record of records.values()) {
+            if (record.state !== "live" || record.visible) {
+                continue;
+            }
+            const eligibleAt = record.invisibleSince + opts.parkDelayMs;
+            if (eligibleAt > now) {
+                nextExpiry = Math.min(nextExpiry, eligibleAt);
+                continue;
+            }
+            candidates.push(record);
+        }
+        candidates.sort((a, b) => a.lastVisibleOrder - b.lastVisibleOrder);
+        for (const record of candidates) {
+            if (excess <= 0) {
+                break;
+            }
+            excess--;
+            beginPark(record);
+        }
+        if (excess > 0 && nextExpiry < Infinity) {
+            scheduleEvaluate(Math.max(0, nextExpiry - now));
+        }
+    }
+
+    // ---- messages from activities ----
+
+    window.addEventListener("message", (event: MessageEvent) => {
+        const data = event.data;
+        if (!data || typeof data !== "object") {
+            return;
+        }
+
+        // Shared core-worker pool protocol (same shapes as
+        // @doenet/doenetml-iframe's useSharedCoreWorker).
+        if (data.origin === "doenetCoordinatedChild" && data.data) {
+            const record = recordForEvent(event);
+            if (!record) {
+                return;
+            }
+            const inner = data.data;
+            if (inner.type === "bootComplete") {
+                if (record.state === "booting") {
+                    record.state = "live";
+                }
+                releaseBootSlot(record);
+                evaluateBudget();
+                return;
+            }
+            if (
+                opts.sharedCoreWorkers &&
+                inner.type === "createSharedCore" &&
+                event.ports[0]
+            ) {
+                handleCreateSharedCore({
+                    viewerId: record.poolViewerId,
+                    coreId: String(inner.coreId),
+                    standaloneUrl: String(inner.standaloneUrl),
+                    port: event.ports[0],
+                });
+                return;
+            }
+            if (opts.sharedCoreWorkers && inner.type === "destroySharedCore") {
+                handleDestroySharedCore({
+                    coreId: String(inner.coreId),
+                    suspectWedge: Boolean(inner.suspectWedge),
+                });
+                return;
+            }
+            return;
+        }
+
+        // SPLICE traffic from the child viewers (routed here by the
+        // coordinated-mode `messageParent` flag).
+        if (typeof data.subject !== "string") {
+            return;
+        }
+        const record = recordForEvent(event);
+        if (!record) {
+            return;
+        }
+        if (data.subject === "SPLICE.reportScoreAndState") {
+            // The warehouse: always keep the latest state.
+            record.lastReport = data;
+            return;
+        }
+        if (
+            data.subject === "SPLICE.flushState.response" &&
+            data.message_id === record.parkFlushId
+        ) {
+            finishPark(record);
+            return;
+        }
+        if (data.subject === "SPLICE.getState" && record.lastReport?.state) {
+            // A restored activity asking for its parked state back.
+            record.iframe.contentWindow?.postMessage(
+                {
+                    subject: "SPLICE.getState.response",
+                    message_id: data.message_id,
+                    state: record.lastReport.state,
+                },
+                "*",
+            );
+            return;
+        }
+    });
+
+    // ---- discovery + visibility ----
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            for (const entry of entries) {
+                const record = records.get(entry.target as HTMLIFrameElement);
+                if (!record || record.visible === entry.isIntersecting) {
+                    continue;
+                }
+                record.visible = entry.isIntersecting;
+                if (entry.isIntersecting) {
+                    record.lastVisibleOrder = ++visibleOrderCounter;
+                    if (record.state === "parked") {
+                        unpark(record);
+                    }
+                    scheduleEvaluate(0);
+                } else {
+                    record.invisibleSince = Date.now();
+                    if (record.state === "parked") {
+                        cancelBootRequest(record);
+                    }
+                    scheduleEvaluate(opts.parkDelayMs);
+                }
+            }
+        },
+        { rootMargin: opts.visibleMargin },
+    );
+
+    let poolViewerCounter = 0;
+    for (const element of document.querySelectorAll(opts.iframeSelector)) {
+        if (!(element instanceof HTMLIFrameElement)) {
+            continue;
+        }
+        const originalSrc = element.src;
+        if (!originalSrc) {
+            continue;
+        }
+        // Same-origin activities only (the child bundle must be able to
+        // post to us, and we manage its URL).
+        try {
+            if (new URL(originalSrc).origin !== window.location.origin) {
+                continue;
+            }
+        } catch {
+            continue;
+        }
+        const record: ActivityRecord = {
+            iframe: element,
+            markedSrc: markSrc(originalSrc),
+            state: "parked",
+            visible: false,
+            lastVisibleOrder: 0,
+            invisibleSince: Date.now(),
+            lastReport: null,
+            parkFlushId: null,
+            parkFlushCleanup: null,
+            bootWatchdogId: null,
+            poolViewerId: `coordinator-${++poolViewerCounter}`,
+        };
+        records.set(element, record);
+        // Detach immediately: activities load only via boot slots. (An
+        // iframe that already started loading is cancelled; it cannot have
+        // user state yet.)
+        element.src = "about:blank";
+        observer.observe(element);
+    }
+
+    // Diagnostics for tests and host dashboards.
+    (window as any).doenetCoordinatorStats = () => {
+        const byState: Record<string, number> = {};
+        for (const record of records.values()) {
+            byState[record.state] = (byState[record.state] ?? 0) + 1;
+        }
+        return {
+            activities: records.size,
+            byState,
+            booting: bootSlotHolders.size,
+            bootQueue: bootQueue.length,
+            sharedCorePool: getSharedCorePoolStats(),
+        };
+    };
+
+    console.log(
+        `Doenet coordinator: managing ${records.size} activit${records.size === 1 ? "y" : "ies"} (maxLiveViewers=${opts.maxLiveViewers}, maxConcurrentBoots=${opts.maxConcurrentBoots}, sharedCoreWorkers=${opts.sharedCoreWorkers})`,
+    );
+}
+
+// Expose for manual initialization and auto-init with options read from the
+// script tag's data attributes (kebab-case → camelCase handled by dataset).
+(window as any).initializeDoenetCoordinator = initializeDoenetCoordinator;
+
+const scriptElement = document.currentScript as HTMLScriptElement | null;
+if (!scriptElement?.dataset.doenetManualInit) {
+    const datasetOptions: DoenetCoordinatorOptions = {};
+    const dataset = scriptElement?.dataset ?? {};
+    if (dataset.iframeSelector) {
+        datasetOptions.iframeSelector = dataset.iframeSelector;
+    }
+    if (dataset.maxLiveViewers) {
+        datasetOptions.maxLiveViewers = parseInt(dataset.maxLiveViewers, 10);
+    }
+    if (dataset.maxConcurrentBoots) {
+        datasetOptions.maxConcurrentBoots = parseInt(
+            dataset.maxConcurrentBoots,
+            10,
+        );
+    }
+    if (dataset.visibleMargin) {
+        datasetOptions.visibleMargin = dataset.visibleMargin;
+    }
+    if (dataset.parkDelayMs) {
+        datasetOptions.parkDelayMs = parseInt(dataset.parkDelayMs, 10);
+    }
+    if (dataset.flushTimeoutMs) {
+        datasetOptions.flushTimeoutMs = parseInt(dataset.flushTimeoutMs, 10);
+    }
+    if (dataset.sharedCoreWorkers) {
+        datasetOptions.sharedCoreWorkers =
+            dataset.sharedCoreWorkers !== "false";
+    }
+    const start = () => initializeDoenetCoordinator(datasetOptions);
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start, { once: true });
+    } else {
+        start();
+    }
+}

--- a/packages/standalone/src/coordinator.ts
+++ b/packages/standalone/src/coordinator.ts
@@ -280,8 +280,11 @@ export function initializeDoenetCoordinator(
             return;
         }
         if (record.visible) {
-            // Scrolled back mid-flush; nothing was torn down.
+            // Scrolled back mid-flush; nothing was torn down. It rejoins the
+            // live budget (from which it was excluded while parking), so
+            // re-check whether some other off-screen viewer should now shed.
             record.state = "live";
+            scheduleEvaluate(0);
             return;
         }
         // Detach the realm. The iframe element (and the page layout) stays;
@@ -315,9 +318,13 @@ export function initializeDoenetCoordinator(
 
     function evaluateBudget() {
         const now = Date.now();
+        // Count only what still occupies the live budget: booting and live
+        // realms. A "parking" realm is already committed to being shed, so
+        // counting it would let a second evaluateBudget firing during its
+        // flush window shed an *additional* viewer the budget never needed.
         let active = 0;
         for (const record of records.values()) {
-            if (record.state !== "parked") {
+            if (record.state === "booting" || record.state === "live") {
                 active++;
             }
         }
@@ -359,8 +366,9 @@ export function initializeDoenetCoordinator(
             return;
         }
 
-        // Shared core-worker pool protocol (same shapes as
-        // @doenet/doenetml-iframe's useSharedCoreWorker).
+        // Messages from coordinated children: the boot-complete lifecycle
+        // signal plus the shared core-worker pool protocol (whose shapes
+        // match @doenet/doenetml-iframe's useSharedCoreWorker).
         if (data.origin === "doenetCoordinatedChild" && data.data) {
             const record = recordForEvent(event);
             if (!record) {

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -16,11 +16,25 @@ import type {
 import "@doenet/doenetml/style.css";
 import "./pretext-compat.css";
 import { ResizeWatcher } from "./resize-watcher";
+import {
+    detectCoordinatedMode,
+    installCoordinatorSharedCorePortProvider,
+    postToCoordinator,
+} from "./coordinated-mode";
 
 // Re-export React and friends in case a user really wants to use them
 export { React, ReactDOM, DoenetViewer, DoenetEditor };
 
 export const version: string = STANDALONE_VERSION;
+
+// Parent-page coordinator support (see coordinated-mode.ts): when this
+// page's URL carries the coordinator's fragment token, viewers rendered
+// here report their lifecycle to the parent and (with the `sc` variant)
+// obtain their cores from the coordinator's shared worker pool.
+const coordinatedMode = detectCoordinatedMode();
+if (coordinatedMode?.sharedCores) {
+    installCoordinatorSharedCorePortProvider();
+}
 
 // Cache React roots per container so repeat calls to
 // renderDoenet{Viewer,Editor}ToContainer re-render in place instead of
@@ -111,6 +125,24 @@ export function renderDoenetViewerToContainer(
         delete config.flags;
     }
 
+    // Under a parent-page coordinator, default the flags its park/restore
+    // machinery depends on: `messageParent` routes SPLICE messages to the
+    // coordinator's window, `allowSaveState` emits the state reports it
+    // warehouses, and `allowLoadState` makes a restored viewer request that
+    // state back at boot. Explicit attributes/config still win.
+    if (coordinatedMode) {
+        const coordinatedFlagDefaults: Record<string, boolean> = {
+            messageParent: true,
+            allowSaveState: true,
+            allowLoadState: true,
+        };
+        for (const [key, value] of Object.entries(coordinatedFlagDefaults)) {
+            if (!(key in flags)) {
+                flags[key] = value;
+            }
+        }
+    }
+
     // Compose the resize-readiness signal with any caller-supplied
     // `initializedCallback` so we don't clobber it via the `{...config}` spread.
     const {
@@ -142,6 +174,10 @@ export function renderDoenetViewerToContainer(
                 // iframe. See issue #1434.
                 if (sendResizeEvents) {
                     resizeWatcher.markReady();
+                }
+                // The coordinator's boot-slot release signal.
+                if (coordinatedMode) {
+                    postToCoordinator({ type: "bootComplete" });
                 }
                 configInitializedCallback?.(arg);
             }}

--- a/packages/standalone/tsconfig.json
+++ b/packages/standalone/tsconfig.json
@@ -2,11 +2,18 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist/",
-        "rootDir": "./src"
+        // rootDir spans `packages/` (not just `src`) and composite is off so
+        // the typecheck tolerates coordinator.ts importing
+        // `@doenet/doenetml-iframe`'s shared-core-pool source directly (it
+        // bundles that one implementation; the dist d.ts, rolled up from
+        // index.tsx by vite-plugin-dts, never reaches the coordinator entry).
+        "rootDir": "..",
+        "composite": false
     },
     "include": ["./**/*.ts", "./**/*.tsx", "./**/*.js", "./**/*.jsx"],
     "exclude": [
         "vite.config.ts",
+        "vite.config-coordinator.ts",
         "node_modules",
         "runner-results",
         ".wireit",

--- a/packages/standalone/vite.config-coordinator.ts
+++ b/packages/standalone/vite.config-coordinator.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vite";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
+
+// Builds the activity coordinator (dist/coordinator.js): a small classic
+// script — no React, no dependence on the main bundle — that a static host
+// page (e.g. a PreTeXt book) adds alongside its DoenetML activity iframes.
+// See src/coordinator.ts. Runs AFTER the main build (wireit dependency)
+// into the same dist/, so the file publishes next to doenet-standalone.js.
+export default defineConfig({
+    plugins: [suppressLogPlugin()],
+    build: {
+        minify: true,
+        sourcemap: true,
+        emptyOutDir: false,
+        lib: {
+            entry: { coordinator: "./src/coordinator.ts" },
+            formats: ["iife"],
+            name: "DoenetCoordinator",
+        },
+        rollupOptions: {
+            output: {
+                entryFileNames: "coordinator.js",
+            },
+        },
+    },
+    define: {
+        "process.env.NODE_ENV": '"production"',
+    },
+});

--- a/packages/test-cypress/cypress/e2e/standalone/coordinator.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/coordinator.cy.js
@@ -1,0 +1,99 @@
+// E2E for the standalone activity coordinator (dist/coordinator.js):
+// a static host page (public/coordination-page.html, the PreTeXt model)
+// embeds two same-origin `…-if.html` activity iframes under a coordinator
+// configured with maxLiveViewers=1, maxConcurrentBoots=1, and shared core
+// workers. The child pages know nothing about the coordinator — the
+// standalone bundle they load detects the coordinator's URL-fragment token.
+
+const BOOT_TIMEOUT = 60_000;
+
+/**
+ * Assert the activity iframe's document has RENDERED the given text (script
+ * tags — which hold the raw doenetml source — are excluded).
+ */
+function assertActivityRenders(selector, text) {
+    cy.get(selector)
+        .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+        .should((body) => {
+            const clone = body.cloneNode(true);
+            clone.querySelectorAll("script").forEach((s) => s.remove());
+            expect(
+                (clone.textContent ?? "").includes(text),
+                `${selector} rendered "${text}"`,
+            ).to.eq(true);
+        });
+}
+
+function assertParked(selector) {
+    cy.get(selector, { timeout: BOOT_TIMEOUT }).should(($iframe) => {
+        expect($iframe[0].src, `${selector} detached`).to.contain(
+            "about:blank",
+        );
+    });
+}
+
+describe("standalone activity coordinator", { retries: 1 }, () => {
+    it("gates boots, parks the off-screen activity, and restores typed state on scroll-back", () => {
+        cy.viewport(1000, 660);
+        cy.visit("/coordination-page.html");
+
+        // Activity 1 (visible) boots through its boot slot; activity 2 (far
+        // below the viewport) stays detached — it never loads at all.
+        assertActivityRenders("#act1", "One typed:");
+        cy.get("#act2").should(($iframe) => {
+            expect($iframe[0].src, "act2 never booted").to.contain(
+                "about:blank",
+            );
+        });
+
+        // The child obtained its core from the coordinator's shared pool.
+        cy.window().then((win) => {
+            cy.wrap(null, { timeout: 20_000 }).should(() => {
+                const stats = win.doenetCoordinatorStats();
+                expect(
+                    stats.sharedCorePool.liveCores,
+                    `shared cores: ${JSON.stringify(stats)}`,
+                ).to.be.gte(1);
+            });
+        });
+
+        // Type into activity 1 and commit with Enter.
+        cy.get("#act1")
+            .its("0.contentDocument.body")
+            .find("input:not([type=checkbox])", { timeout: BOOT_TIMEOUT })
+            .then(cy.wrap)
+            .type("carried across the park{enter}");
+        assertActivityRenders("#act1", "One typed: carried across the park");
+
+        // Scroll to activity 2: it boots on visibility; activity 1 leaves
+        // the viewport, gets flushed, and parks (its iframe detaches to
+        // about:blank — the element and layout stay).
+        cy.get("#act2").scrollIntoView();
+        assertActivityRenders("#act2", "Activity two body");
+        assertParked("#act1");
+
+        // Scroll back: activity 1 reboots, asks the coordinator for its
+        // state (SPLICE.getState), and the typed work is restored with no
+        // user interaction. Activity 2 parks in turn (budget 1).
+        cy.get("#act1").scrollIntoView();
+        assertActivityRenders("#act1", "One typed: carried across the park");
+        cy.get("#act1")
+            .its("0.contentDocument.body")
+            .find("input:not([type=checkbox])", { timeout: BOOT_TIMEOUT })
+            .should("have.value", "carried across the park");
+        assertParked("#act2");
+
+        // Steady state: one live activity, one parked, no held boot slots.
+        cy.window().then((win) => {
+            cy.wrap(null, { timeout: 20_000 }).should(() => {
+                const stats = win.doenetCoordinatorStats();
+                expect(
+                    stats,
+                    `settled: ${JSON.stringify(stats)}`,
+                ).to.deep.include({ booting: 0, bootQueue: 0 });
+                expect(stats.byState.live ?? 0, "live").to.eq(1);
+                expect(stats.byState.parked ?? 0, "parked").to.eq(1);
+            });
+        });
+    });
+});

--- a/packages/test-cypress/package.json
+++ b/packages/test-cypress/package.json
@@ -46,7 +46,8 @@
                 "../doenetml-prototype:build",
                 "../doenetml:build",
                 "../prefigure:build",
-                "../ui-components:build"
+                "../ui-components:build",
+                "../standalone:build"
             ]
         }
     },

--- a/packages/test-cypress/public/coordination-activity-1-if.html
+++ b/packages/test-cypress/public/coordination-activity-1-if.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<!-- Mimics a PreTeXt-generated DoenetML interactive page (…-if.html):
+     loads @doenet/standalone (same-origin here, CDN in production) and
+     renders the activity on script load. Deliberately knows NOTHING about
+     the coordinator on its parent page. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script
+            onload="onLoad()"
+            type="module"
+            src="/standalone/doenet-standalone.js"
+        ></script>
+        <script>
+            function onLoad() {
+                window.renderDoenetViewerToContainer(
+                    document.querySelector(".doenetml-applet"),
+                );
+            }
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>Activity one: <textInput name="ti" /></p>
+<p>One typed: $ti.value</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/public/coordination-activity-2-if.html
+++ b/packages/test-cypress/public/coordination-activity-2-if.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<!-- See coordination-activity-1-if.html. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script
+            onload="onLoad()"
+            type="module"
+            src="/standalone/doenet-standalone.js"
+        ></script>
+        <script>
+            function onLoad() {
+                window.renderDoenetViewerToContainer(
+                    document.querySelector(".doenetml-applet"),
+                );
+            }
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>Activity two body</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/public/coordination-page.html
+++ b/packages/test-cypress/public/coordination-page.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<!-- A static host page (the PreTeXt model): DoenetML activities embedded as
+     real same-origin iframes, coordinated by dist/coordinator.js from
+     @doenet/standalone. The tight limits (1 live viewer, 1 boot at a time,
+     short park delay) exercise gating, parking, and restore in the e2e
+     spec. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Coordinated DoenetML activities</title>
+        <script
+            src="/standalone/coordinator.js"
+            data-max-live-viewers="1"
+            data-max-concurrent-boots="1"
+            data-park-delay-ms="300"
+            data-visible-margin="100px"
+            data-flush-timeout-ms="15000"
+            data-shared-core-workers="true"
+        ></script>
+    </head>
+    <body>
+        <h1>Coordinated activities</h1>
+        <iframe
+            id="act1"
+            src="/coordination-activity-1-if.html"
+            width="800"
+            height="500"
+            style="border: 1px solid gray"
+        ></iframe>
+        <div style="height: 2500px">spacer</div>
+        <iframe
+            id="act2"
+            src="/coordination-activity-2-if.html"
+            width="800"
+            height="500"
+            style="border: 1px solid gray"
+        ></iframe>
+    </body>
+</html>

--- a/packages/test-cypress/vite.config.ts
+++ b/packages/test-cypress/vite.config.ts
@@ -2,8 +2,10 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -26,6 +28,34 @@ export default defineConfig({
                         "../fonts/*",
                     ),
                     dest: "fonts/",
+                    overwrite: false,
+                },
+                // Coordinator e2e (public/coordination-*.html): serve
+                // @doenet/standalone and its co-located worker same-origin,
+                // mimicking a PreTeXt site's layout. (Path-relative rather
+                // than require.resolve: the standalone package's exports map
+                // only declares the `import` condition.)
+                {
+                    src: [
+                        path.resolve(
+                            __dirname,
+                            "../standalone/dist/doenet-standalone.js",
+                        ),
+                        path.resolve(__dirname, "../standalone/dist/style.css"),
+                        path.resolve(
+                            __dirname,
+                            "../standalone/dist/coordinator.js",
+                        ),
+                    ],
+                    dest: "standalone/",
+                    overwrite: false,
+                },
+                {
+                    src: path.join(
+                        require.resolve("@doenet/doenetml-worker/index.js"),
+                        "../*",
+                    ),
+                    dest: "standalone/doenetml-worker/",
                     overwrite: false,
                 },
             ],


### PR DESCRIPTION
> **Previously stacked on #1475** (lazy boot / boot-concurrency cap), #1474, and #1473 — all now merged. This branch is rebased onto `main`, so the diff below contains only this PR's changes.

## Problem

PreTeXt-style hosts (the deployment behind #874's 1.7–3.6 GB Active Calculus pages) embed each DoenetML activity as a real same-origin iframe whose page loads `@doenet/standalone` from the CDN and renders on script load. They are static generated sites: no React wrapper, no host script to adopt `mountPolicy` — so the windowed-mounting series (#1474/#1475) couldn't reach them, and #1439's coordinator plus stream E's PreTeXt milestone (#1466) remained open.

## Change

A new **`coordinator.js`** published alongside the standalone bundle (11 KB minified, 4.5 KB gzip, no React). **One script tag on the host page is the entire adoption step:**

```html
<script src="https://cdn.jsdelivr.net/npm/@doenet/standalone@<version>/coordinator.js"></script>
```

The activity pages need **no changes**: the coordinator manages the iframes purely by controlling their `src`, and marks each activity URL with a fragment token (`#doenetCoordinated=v1[sc]`) that the standalone bundle those pages already load detects at evaluation.

**Coordinator (parent page):**
- Detaches activity iframes up front; loads them only near the viewport through a boot-slot semaphore (`maxConcurrentBoots`, default 2, visible-first). An activity the reader never scrolls to **never boots**.
- Keeps at most `maxLiveViewers` (default 3) live. LRU off-screen activities are parked: `SPLICE.flushState` (retry + timeout) → warehouse the resulting `reportScoreAndState` → detach to `about:blank`. The iframe element — and the page layout — stays.
- Restores on scroll-back and answers the rebooting viewer's `SPLICE.getState` from the warehouse: **the reader's typed work survives** with no interaction.
- `data-shared-core-workers="true"`: activities draw their cores from a coordinator-owned shared worker pool — bundling `@doenet/doenetml-iframe`'s pool implementation, so it is one protocol with `useSharedCoreWorker` (#1467). This completes stream E's PreTeXt milestone.
- Configured via script-tag `data-` attributes or `window.initializeDoenetCoordinator()`; `window.doenetCoordinatorStats()` for diagnostics. Documented in `COORDINATION.md` + a README section.

**Coordinated child mode (standalone entry):** under the token, default `flags.messageParent`/`allowSaveState`/`allowLoadState` (explicit values win), post `bootComplete` on initialization (the boot-slot release), and — `sc` variant — install the `createExternalCoreWorkerPort` seam routing cores to the coordinator's pool. Old bundles that predate the token still work: they lazy-load and a 90 s watchdog stands in for their missing boot signal.

**Two environment-hardening details worth reviewer attention:**
- Boot navigations wait for the `about:blank` commit before assigning the marked URL — otherwise a marked URL that differs only by fragment can degrade to a *same-document fragment navigation*, and the bundle never re-evaluates with the token present.
- The child's framed-check reads `frameElement` instead of comparing `window.parent === window`: anti-frame-busting rewriters (Cypress's `modifyObstructiveCode`, some ad-network sanitizers) rewrite parent/top comparisons in served JS, which would silently disable coordination exactly where it's tested.

## Tests

New e2e in `packages/test-cypress` (real same-origin `…-if.html` child pages that know nothing about the coordinator, served exactly like a PreTeXt site): under `maxLiveViewers=1`, `maxConcurrentBoots=1`, shared cores on —
- the visible activity boots and takes its core from the pool (1 host / 1 live core);
- the off-screen activity **never loads**;
- typing, scrolling on → the first activity flushes and parks (`about:blank`), the second boots;
- scrolling back → the first restores **with the typed text intact** (getState warehouse round trip), the second parks;
- settled stats: 1 live / 1 parked, no held slots, no queue.

Full `doenetml-iframe` suite re-run against the rebuilt standalone: 16 specs / 34 tests passing.

Closes #1439. Completes the stream-E PreTeXt milestone from #1466 (which remains open for the rest of stream E); part of #1441 (stream B). With this, every deployment model has an instance-bounding path: React hosts via `mountPolicy` (#1474/#1475), static hosts via `coordinator.js` — plus shared core workers on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



