### PR TITLE
Preserve preview window scroll position across source refreshes (VS Code extension)

### DIFF
--- a/.changeset/preview-scroll-restore.md
+++ b/.changeset/preview-scroll-restore.md
@@ -1,0 +1,14 @@
+---
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+VS Code extension: Keep the preview window's scroll position when the source is refreshed.
+
+Previously, every refresh of the preview (saving the document, pressing Force
+Refresh, or switching editors) rebuilt the rendered activity and reset the
+preview's scroll position to the top. The preview now records its scroll
+position when new source arrives and re-applies it while the viewer re-renders,
+clamped to the content height (so a shorter document lands at its bottom rather
+than jumping to the top). Restoration stops as soon as the user scrolls or
+interacts with the preview, or after a few seconds.

--- a/packages/vscode-extension/src/preview-window/App.tsx
+++ b/packages/vscode-extension/src/preview-window/App.tsx
@@ -7,18 +7,86 @@ import "./App.css";
 import "@doenet/doenetml/style.css";
 import { onClassChange, setColorStyle } from "./utilities/dark-mode-monitor";
 
+/**
+ * How long (ms) to keep re-applying the saved scroll position while the
+ * viewer re-renders after a source change. The viewer rebuilds its DOM
+ * asynchronously (worker boot + progressive render), so the content
+ * collapses and grows back over an unknown time span.
+ */
+const SCROLL_RESTORE_WINDOW_MS = 4000;
+
+/**
+ * Keep `container`'s scroll position at (as close as possible to) its
+ * current value while the content inside it is torn down and rebuilt.
+ *
+ * Every animation frame, scroll to the saved position, clamped to the
+ * current content height. Stops after `SCROLL_RESTORE_WINDOW_MS`, or as soon
+ * as the user scrolls or interacts with the container themselves.
+ *
+ * Returns a function that cancels the restoration.
+ */
+function keepScrollPosition(container: HTMLElement): () => void {
+    const target = container.scrollTop;
+    let rafId = 0;
+
+    const userEvents = ["wheel", "touchstart", "mousedown", "keydown"] as const;
+    const cancel = () => {
+        cancelAnimationFrame(rafId);
+        for (const eventName of userEvents) {
+            container.removeEventListener(eventName, cancel);
+        }
+    };
+
+    if (target <= 0) {
+        return cancel;
+    }
+    for (const eventName of userEvents) {
+        container.addEventListener(eventName, cancel, { passive: true });
+    }
+
+    const deadline = Date.now() + SCROLL_RESTORE_WINDOW_MS;
+    const tick = () => {
+        const maxScroll = Math.max(
+            0,
+            container.scrollHeight - container.clientHeight,
+        );
+        const desired = Math.min(target, maxScroll);
+        if (Math.abs(container.scrollTop - desired) > 1) {
+            container.scrollTop = desired;
+        }
+        if (Date.now() >= deadline) {
+            cancel();
+        } else {
+            rafId = requestAnimationFrame(tick);
+        }
+    };
+    rafId = requestAnimationFrame(tick);
+
+    return cancel;
+}
+
 function App() {
     const [source, setSource] = React.useState(
         "Sample Source\n<graph><line /></graph>",
     );
     const [dirty, setDirty] = React.useState(false);
     const [darkMode, setDarkMode] = React.useState(false);
+    const previewContainerRef = React.useRef<HTMLDivElement>(null);
+    const cancelScrollRestoreRef = React.useRef<(() => void) | null>(null);
 
     React.useEffect(() => {
         const callback = (event: MessageEvent) => {
             const message = event.data; // The JSON data our extension sent
             switch (message.command) {
                 case "setSource":
+                    // Changing the source rebuilds the viewer's DOM, which
+                    // would otherwise reset the scroll position to the top.
+                    if (previewContainerRef.current) {
+                        cancelScrollRestoreRef.current?.();
+                        cancelScrollRestoreRef.current = keepScrollPosition(
+                            previewContainerRef.current,
+                        );
+                    }
                     setSource(message.text);
                     setDirty(false);
                     break;
@@ -76,7 +144,7 @@ function App() {
                     Force Refresh{dirty ? " *" : ""}
                 </VSCodeButton>
             </div>
-            <div className="doenet-preview">
+            <div className="doenet-preview" ref={previewContainerRef}>
                 <DoenetViewer
                     doenetML={source}
                     darkMode={darkMode ? "dark" : "light"}


### PR DESCRIPTION
## Problem

In the VS Code extension, every refresh of the Doenet Preview panel — saving the document, pressing **Force Refresh**, or switching to another Doenet editor — rebuilds the rendered activity and resets the preview's scroll position to the very top. When authoring a long activity, you lose your place on every save.

## Fix

When the webview receives a `setSource` message, it records the preview container's scroll position and re-applies it on each animation frame while the viewer tears down and re-renders, clamped to the current content height (the viewer rebuilds asynchronously, so content collapses and grows back over an unknown time span). Restoration stops as soon as:

- the position sticks and the window elapses (4 s), or
- the user scrolls or interacts with the preview (wheel / touch / mouse / keyboard), so it never fights the user.

If the new document is shorter than the old scroll position, the view lands clamped at the bottom instead of jumping to the top.

All changes are confined to the preview webview (`src/preview-window/App.tsx`); no extension-host or viewer changes.

## Verification

Tested headlessly by driving the **built** preview-window bundle in Chromium (Playwright), posting `setSource` messages exactly as the extension host does:

| Scenario | Unpatched | Patched |
|---|---|---|
| Refresh after scrolling to 3023 px | resets to 0 | restored to 3023 |
| User wheel-scrolls during the restore window | — | user position wins; restore cancelled |
| New document much shorter than scroll position | — | clamps to bottom (no jump to top) |

Also verified: `tsc --noEmit` clean, Prettier clean.

## Notes

This is the first step of preview/editor position sync; scrolling the preview to the *edited element* (via `lsp-tools`' `elementAtOffset`) and click-to-navigate in both directions could build on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)