### PR TITLE
Windowed mounting: support report-callback hosts, add keepLive, gate parking on bundle version

### DIFF
--- a/.changeset/iframe-windowed-callback-hosts-keep-live.md
+++ b/.changeset/iframe-windowed-callback-hosts-keep-live.md
@@ -1,0 +1,23 @@
+---
+"@doenet/doenetml-iframe": patch
+---
+
+Windowed mounting (`mountPolicy`) improvements for embedding hosts:
+
+- Hosts that consume state reports through the `reportScoreAndStateCallback`
+  prop (which suppresses the `SPLICE.reportScoreAndState` message the park
+  snapshot was captured from) are now fully supported — the wrapper captures
+  the flushed report before forwarding it to the callback, so parking stays
+  lossless.
+- New dynamic `keepLive` prop: treat a windowed viewer as visible — boot it
+  eagerly (still subject to the page-wide boot cap) and never park it while
+  set. For hosts that know a hidden viewer is about to be shown, e.g. a
+  paginator prefetching the pages adjacent to the current one.
+- Parking is now gated on the selected standalone bundle being new enough to
+  acknowledge `SPLICE.flushState` (v0.7.21+; custom `standaloneUrl`s are
+  assumed modern). Previously, parking a viewer pinned to an older
+  `doenetmlVersion` timed out the flush and could lose up to a
+  report-throttle interval of work; such viewers now stay live (they still
+  mount lazily and obey the boot cap).
+- The windowed-without-persistence console warning fires once per page
+  instead of once per viewer.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -140,7 +140,38 @@ either `flags.allowSaveState` (the wrapper snapshots the flushed
 `reportScoreAndState` and seeds `initialState` on restore) or
 `flags.allowLocalState` (IndexedDB restores on reboot). Windowed viewers
 with neither flag still mount lazily but, once booted, always stay live
-(a console warning points this out).
+(a console warning — once per page — points this out). Hosts that consume
+reports through the `reportScoreAndStateCallback` prop are fully supported:
+the wrapper captures the flushed report for its park snapshot before
+forwarding it to the callback.
+
+Parking also requires a standalone bundle new enough to acknowledge the
+flush (v0.7.21+). A viewer pinned to an older `doenetmlVersion` mounts
+lazily and obeys the boot cap, but is never parked. A host-specified
+`standaloneUrl` is assumed modern (hosts shipping a custom URL control both
+sides — note a `-dev.N` prerelease *version string* compares as its base
+release, so dev-channel hosts should pin `standaloneUrl` rather than
+`doenetmlVersion`).
+
+#### `keepLive`: prefetching hosts
+
+A windowed viewer inside a hidden (`display:none`) or far-off-screen
+container never intersects the viewport, so it would stay parked forever.
+A host that knows the viewer is about to be shown — e.g. a paginator
+prefetching the pages adjacent to the current one — sets the dynamic
+`keepLive` prop to treat it as visible: it boots eagerly (still subject to
+`maxConcurrentBoots`, visible-first) and is never parked while the hint is
+set. Clear the hint and the viewer becomes an ordinary windowed citizen
+again (parked when off-screen and over budget).
+
+```tsx
+<DoenetViewer
+    doenetML={doenetML}
+    flags={{ allowSaveState: true }}
+    mountPolicy={{ mode: "windowed", maxLiveViewers: 3 }}
+    keepLive={Math.abs(itemIndex - currentIndex) <= 1}
+/>
+```
 
 Notes:
 

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -7,6 +7,9 @@ declare const doenetViewerPropsSpecified: string[];
 // core-worker host (#1466). Guarded with `typeof` at the use site so this
 // script also works in srcdocs generated without the const.
 declare const doenetSharedCoreWorker: boolean | undefined;
+// Baked into the srcdoc for windowed (mountPolicy) viewers. Guarded with
+// `typeof` at the use site like doenetSharedCoreWorker.
+declare const doenetWindowedViewer: boolean | undefined;
 declare const ComlinkViewer: {
     expose: Function;
     windowEndpoint: Function;
@@ -56,8 +59,28 @@ const functionPropDispatchers: Record<string, Function> = {};
 function getFunctionPropDispatcher(key: string): Function {
     let dispatcher = functionPropDispatchers[key];
     if (!dispatcher) {
-        dispatcher = (...callArgs: any[]) =>
-            currentFunctionProps[key]?.(...callArgs);
+        if (
+            key === "reportScoreAndStateCallback" &&
+            typeof doenetWindowedViewer !== "undefined" &&
+            doenetWindowedViewer
+        ) {
+            // Windowed viewers: deliver state reports over the same
+            // window.postMessage channel the `SPLICE.flushState`
+            // acknowledgement uses, instead of calling the host's Comlink
+            // proxy. The parent wrapper snapshots the report at park time
+            // and must see it BEFORE the flush acknowledgement; the window
+            // channel is FIFO, while a Comlink proxy rides its own
+            // MessagePort with no cross-channel ordering guarantee. The
+            // wrapper forwards the report to the host's callback.
+            dispatcher = (report: any) =>
+                messageParentFromViewer({
+                    type: "reportScoreAndState",
+                    report,
+                });
+        } else {
+            dispatcher = (...callArgs: any[]) =>
+                currentFunctionProps[key]?.(...callArgs);
+        }
         functionPropDispatchers[key] = dispatcher;
     }
     return dispatcher;

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -41,6 +41,7 @@ import {
     DEFAULT_PARK_DELAY_MS,
     DEFAULT_MAX_CONCURRENT_BOOTS,
     BOOT_SLOT_WATCHDOG_MS,
+    shouldWarnWindowedWithoutPersistence,
     type MountPolicy,
 } from "./viewer-lifecycle-manager";
 
@@ -48,6 +49,10 @@ export type { MountPolicy };
 // Page-wide windowed-mounting diagnostics (how many viewers are live vs
 // parked) — useful for host dashboards, tests, and benchmarks.
 export { getViewerLifecycleStats } from "./viewer-lifecycle-manager";
+import {
+    versionSupportsLiveUpdates,
+    versionSupportsParking,
+} from "./version-gates";
 
 export const version: string = IFRAME_VERSION;
 const latestDoenetmlVersion: string = version;
@@ -148,12 +153,27 @@ export type DoenetViewerIframeProps = DoenetViewerProps & {
      * viewport. Parking requires a persistence path: it only activates for
      * viewers with `flags.allowSaveState` (the wrapper snapshots the
      * flushed `reportScoreAndState` and seeds `initialState` on restore) or
-     * `flags.allowLocalState` (IndexedDB restores on reboot); otherwise the
-     * viewer boots on visibility but then always stays live. The policy is
-     * read at mount; changing it afterwards is not supported. Default off
-     * (no prop = today's behavior).
+     * `flags.allowLocalState` (IndexedDB restores on reboot), and only when
+     * the selected bundle is new enough to acknowledge the flush (v0.7.21+,
+     * or a host-specified `standaloneUrl`); otherwise the viewer boots on
+     * visibility but then always stays live. The policy is read at mount;
+     * changing it afterwards is not supported. Default off (no prop =
+     * today's behavior).
      */
     mountPolicy?: MountPolicy;
+    /**
+     * Windowed-mounting hint: treat this viewer as visible regardless of
+     * viewport intersection — boot it eagerly (still subject to the
+     * page-wide `maxConcurrentBoots` slot queue) and never park it while
+     * set. For hosts that know an off-screen or `display:none` viewer is
+     * about to be shown, e.g. a paginator prefetching the pages adjacent to
+     * the current one. Dynamic, unlike `mountPolicy`; no effect without a
+     * windowed `mountPolicy`. The hint counts as visibility for boot
+     * ordering and the least-recently-visible eviction order, so keep it on
+     * a few viewers at a time (a page-wide `keepLive` would defeat the
+     * budget).
+     */
+    keepLive?: boolean;
 };
 
 export type DoenetEditorIframeProps = DoenetEditorProps & {
@@ -195,40 +215,6 @@ type ViewerIframeRemote = Comlink.Remote<{
     updateViewerFunctionProps: (...args: (string | Function)[]) => void;
 }>;
 
-// In-place prop updates require a standalone bundle whose
-// `renderDoenetViewerToContainer` re-renders against a cached React root
-// (v0.7.18+, PR #1131). Calling it repeatedly against an older bundle mounts
-// competing React roots on the same container.
-const LIVE_UPDATE_MIN_VERSION = [0, 7, 18];
-
-/**
- * Whether the standalone bundle selected by `version` supports live
- * (in-place) prop updates. Missing version parts are npm ranges that
- * jsdelivr resolves to the newest matching release (e.g. "0.7" serves the
- * latest 0.7.x, which is ≥ 0.7.18), so they compare as the range's upper
- * bound. Unparseable versions are assumed modern.
- */
-function versionSupportsLiveUpdates(version: string): boolean {
-    const match = version
-        .replace(/^v/, "")
-        .match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
-    if (!match) {
-        return true;
-    }
-    const parts = [match[1], match[2], match[3]].map((p) =>
-        p === undefined ? Infinity : parseInt(p, 10),
-    );
-    for (let i = 0; i < 3; i++) {
-        if (parts[i] > LIVE_UPDATE_MIN_VERSION[i]) {
-            return true;
-        }
-        if (parts[i] < LIVE_UPDATE_MIN_VERSION[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
 /**
  * Render Doenet viewer constrained to an iframe. A URL pointing to a version of DoenetML
  * standalone must be provided (along with a URL to the corresponding CSS file).
@@ -257,6 +243,7 @@ export function DoenetViewer({
     autodetectVersion = true,
     useSharedCoreWorker = false,
     mountPolicy,
+    keepLive = false,
     ...doenetViewerProps
 }: DoenetViewerIframeProps) {
     const [id, _] = React.useState(() => Math.random().toString(36).slice(2));
@@ -297,15 +284,26 @@ export function DoenetViewer({
     const [parkGeneration, setParkGeneration] = React.useState(0);
     const parkedRef = React.useRef(windowed);
     const parkingRef = React.useRef(false);
-    const visibleRef = React.useRef(false);
+    // Raw viewport intersection, as last reported by the observer. Combined
+    // with the host's `keepLive` hint into `effectivelyVisible()`, which is
+    // what park abort and the unpark grant read; the manager learns the
+    // combined value via `setViewerVisibility` (see
+    // `updateEffectiveVisibility`). `keepLiveRef` is written by the
+    // `[keepLive]` effect (not during render, which a discarded concurrent
+    // render could pollute).
+    const intersectingRef = React.useRef(false);
+    const keepLiveRef = React.useRef(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
     const parkFlushCounterRef = React.useRef(0);
     const parkFlushIdRef = React.useRef<string | null>(null);
     const parkFlushCleanupRef = React.useRef<(() => void) | null>(null);
-    // Latest SPLICE.reportScoreAndState from OUR iframe (matched by
-    // event.source) — the state snapshot a park uses to seed `initialState`
-    // on restore.
-    const lastCapturedReportRef = React.useRef<any>(null);
+    // Latest state-bearing report from OUR iframe — the snapshot a park uses
+    // to seed `initialState` on restore. Normalized to `{ state }`: fed by
+    // the `SPLICE.reportScoreAndState` message (matched by event.source) or,
+    // when the host consumes reports via `reportScoreAndStateCallback`, by
+    // the iframe entry's window-channel report routing (which the wrapper
+    // then forwards to the host's callback — see the message listener).
+    const lastCapturedReportRef = React.useRef<{ state: unknown } | null>(null);
     // State baked into the next unpark's srcdoc. `undefined` = no snapshot:
     // restore falls back to the host's own `initialState`/IndexedDB/getState.
     const parkedSnapshotRef = React.useRef<Record<string, any> | undefined>(
@@ -440,6 +438,16 @@ export function DoenetViewer({
         usingCustomStandaloneUrl ||
         versionSupportsLiveUpdates(selectedDoenetmlVersion);
 
+    // Whether the selected bundle can acknowledge `SPLICE.flushState` —
+    // required for parking (see `versionSupportsParking`). Kept in a ref for
+    // the mount-time `canPark` closure; the selected version can change
+    // after mount (autodetect fallback, edited doenetML).
+    const parkingSupported =
+        usingCustomStandaloneUrl ||
+        versionSupportsParking(selectedDoenetmlVersion);
+    const parkingSupportedRef = React.useRef(parkingSupported);
+    parkingSupportedRef.current = parkingSupported;
+
     // Latest standaloneUrl for the (deps-empty) message listener below — it
     // can change after mount via the autodetect-version fallback, and the
     // shared-core pool keys its workers by the URL the iframe actually loads.
@@ -494,6 +502,7 @@ export function DoenetViewer({
             standaloneUrl,
             cssUrl,
             useSharedCoreWorker,
+            windowed,
         );
     }, [
         id,
@@ -597,12 +606,18 @@ export function DoenetViewer({
             // iframe (the park-snapshot source; reports reach this window
             // because the in-iframe viewer posts to window.parent), and
             // complete an in-flight park when its flush acknowledgement
-            // arrives. Reports are delivered before the acknowledgement
-            // (same-realm postMessage ordering), so the snapshot is current
-            // when the park completes.
+            // arrives. Reports are delivered before the acknowledgement:
+            // both ride this same window channel (a host that consumes
+            // reports via `reportScoreAndStateCallback` gets them via the
+            // iframe entry's window-channel routing below — a Comlink proxy
+            // would ride a separate MessagePort with no cross-channel
+            // ordering guarantee), so the snapshot is current when the park
+            // completes.
             if (windowed) {
                 if (event.data.subject === "SPLICE.reportScoreAndState") {
-                    lastCapturedReportRef.current = event.data;
+                    lastCapturedReportRef.current = {
+                        state: (event.data as any).state,
+                    };
                     return;
                 }
                 if (
@@ -619,6 +634,33 @@ export function DoenetViewer({
             }
 
             const data = event.data.data;
+
+            // A state report routed over the window channel by the iframe
+            // entry (windowed viewers whose host passed
+            // `reportScoreAndStateCallback` — the callback's presence makes
+            // the inner viewer call it INSTEAD of posting the SPLICE
+            // message). Capture the snapshot, then forward to the host's
+            // latest callback identity; if the host has since removed its
+            // callback, fall back to the message contract it now expects.
+            if (windowed && data.type === "reportScoreAndState") {
+                const report = (data.report ?? {}) as Record<string, any>;
+                lastCapturedReportRef.current = { state: report.state };
+                const hostCallback = (doenetViewerPropsRef.current as any)
+                    .reportScoreAndStateCallback;
+                if (typeof hostCallback === "function") {
+                    hostCallback(report);
+                } else {
+                    window.postMessage({
+                        subject: "SPLICE.reportScoreAndState",
+                        state: report.state,
+                        score: report.score,
+                        activity_id: report.activityId,
+                        doc_id: report.docId,
+                        message_id: Math.random().toString(36).slice(2),
+                    });
+                }
+                return;
+            }
 
             // Shared core-worker protocol (#1466): the iframe's viewer mints
             // a MessageChannel, keeps one port, and sends the other here to
@@ -854,13 +896,19 @@ export function DoenetViewer({
 
     /**
      * Whether this viewer may be parked *right now*. Requires a persistence
-     * path (else parking loses work) AND a live iframe realm to flush: an
+     * path (else parking loses work), a bundle new enough to acknowledge
+     * the park flush (else the flush times out and up to a throttle
+     * interval of work is lost), AND a live iframe realm to flush: an
      * errored or already-torn-down viewer has no `contentWindow`, so parking
      * it is a no-op — and leaving it eligible would spin the manager, which
      * re-asks (via `scheduleEvaluate(0)`) after every failed `beginPark`.
      */
     function canPark() {
-        return hasPersistencePath() && Boolean(ref.current?.contentWindow);
+        return (
+            hasPersistencePath() &&
+            parkingSupportedRef.current &&
+            Boolean(ref.current?.contentWindow)
+        );
     }
 
     /**
@@ -917,11 +965,24 @@ export function DoenetViewer({
         parkFlushCleanupRef.current?.();
         parkFlushIdRef.current = null;
         parkingRef.current = false;
-        if (visibleRef.current) {
+        if (effectivelyVisible()) {
             notifyViewerState(id, "live");
             return false;
         }
         return true;
+    }
+
+    /**
+     * Seed the unpark snapshot from the latest captured report, if any.
+     * Never downgrades: with no captured report, any previous snapshot is
+     * kept (it is still the latest truth), and with none at all the unpark
+     * falls back to the host's initialState/IndexedDB/getState.
+     */
+    function seedSnapshotFromCapturedReport() {
+        if (lastCapturedReportRef.current?.state) {
+            parkedSnapshotRef.current = lastCapturedReportRef.current
+                .state as Record<string, any>;
+        }
     }
 
     /** The park flush acknowledged — finish parking (or abort if visible). */
@@ -931,22 +992,22 @@ export function DoenetViewer({
         }
         if (ack.hadState) {
             everHadStateRef.current = true;
-            if (lastCapturedReportRef.current?.state) {
-                parkedSnapshotRef.current = lastCapturedReportRef.current.state;
-            }
         }
-        // else: keep any previous snapshot. `hadState: false` with a prior
-        // snapshot means the core never booted this generation, so the prior
-        // snapshot is still the latest truth; with no snapshot at all the
-        // unpark falls back to the host's initialState/IndexedDB/getState.
+        seedSnapshotFromCapturedReport();
         finishPark();
     }
 
-    /** No acknowledgement within flushTimeoutMs — park anyway (see above). */
+    /**
+     * No acknowledgement within flushTimeoutMs — park anyway (see above),
+     * but best-effort: a wedged realm cannot flush its pending changes, yet
+     * the latest report already captured is still the newest state in hand —
+     * restoring from it beats discarding it.
+     */
     function onParkFlushTimeout() {
         if (!endParkFlush()) {
             return;
         }
+        seedSnapshotFromCapturedReport();
         finishPark();
     }
 
@@ -977,7 +1038,7 @@ export function DoenetViewer({
         requestBootSlot(id, () => {
             // Granted — possibly synchronously, possibly much later. Only
             // boot if this viewer still wants to be live.
-            if (!parkedRef.current || !visibleRef.current) {
+            if (!parkedRef.current || !effectivelyVisible()) {
                 releaseBootSlot(id);
                 return;
             }
@@ -995,6 +1056,33 @@ export function DoenetViewer({
         });
     }
 
+    /**
+     * Effective visibility: viewport intersection OR the host's `keepLive`
+     * hint. A keepLive viewer behaves exactly like a visible one — it boots,
+     * aborts in-flight parks, and is never parked while the hint is set.
+     */
+    function effectivelyVisible() {
+        return intersectingRef.current || keepLiveRef.current;
+    }
+
+    /**
+     * Act on the current effective visibility: propagate it to the manager
+     * (whose never-park-visible rule and visible-first boot queue key off
+     * it), unpark when a parked viewer becomes effectively visible, and
+     * withdraw a queued boot request when it stops being — no longer worth
+     * booting (a granted/booting viewer is left alone; the park policy
+     * handles it).
+     */
+    function updateEffectiveVisibility() {
+        const effective = effectivelyVisible();
+        setViewerVisibility(id, effective);
+        if (effective) {
+            unpark();
+        } else {
+            cancelBootRequest(id);
+        }
+    }
+
     // Observe visibility of the wrapper div (which stays mounted across
     // park/unpark). Entering the margin unparks; the manager decides parking.
     React.useEffect(() => {
@@ -1004,16 +1092,8 @@ export function DoenetViewer({
         const observer = new IntersectionObserver(
             (entries) => {
                 for (const entry of entries) {
-                    visibleRef.current = entry.isIntersecting;
-                    setViewerVisibility(id, entry.isIntersecting);
-                    if (entry.isIntersecting && parkedRef.current) {
-                        unpark();
-                    } else if (!entry.isIntersecting) {
-                        // No longer worth booting; withdraw a queued boot
-                        // request (a granted/booting viewer is left alone —
-                        // the park policy handles it).
-                        cancelBootRequest(id);
-                    }
+                    intersectingRef.current = entry.isIntersecting;
+                    updateEffectiveVisibility();
                 }
             },
             {
@@ -1032,9 +1112,9 @@ export function DoenetViewer({
         if (!windowed) {
             return;
         }
-        if (!hasPersistencePath()) {
+        if (!hasPersistencePath() && shouldWarnWindowedWithoutPersistence()) {
             console.warn(
-                "DoenetViewer mountPolicy: windowed mounting is enabled but neither flags.allowSaveState nor flags.allowLocalState is set, so parking would lose student work. This viewer will always stay live.",
+                "DoenetViewer mountPolicy: windowed mounting is enabled but neither flags.allowSaveState nor flags.allowLocalState is set, so parking would lose student work. Such viewers will always stay live. (Warned once per page.)",
             );
         }
         const unregister = registerWindowedViewer({
@@ -1058,6 +1138,22 @@ export function DoenetViewer({
             unregister();
         };
     }, [windowed]);
+
+    // React to `keepLive` changes (a paginating host marking hidden pages
+    // adjacent to the current one; `display:none` never intersects, so the
+    // observer alone would leave them parked forever). The ref is written
+    // here — at commit — rather than during render, so a discarded
+    // concurrent render can't leak an uncommitted value to the observer.
+    // Placed after the registration effect so the first run — including an
+    // initial `keepLive` on mount — finds the viewer registered with the
+    // manager.
+    React.useEffect(() => {
+        if (!windowed) {
+            return;
+        }
+        keepLiveRef.current = keepLive;
+        updateEffectiveVisibility();
+    }, [windowed, keepLive]);
 
     if (inErrorState) {
         if (foundAutoVersion) {

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -85,6 +85,7 @@ export function createHtmlForDoenetViewer(
     standaloneUrl: string,
     cssUrl: string,
     useSharedCoreWorker = false,
+    windowed = false,
 ) {
     // Since function props disappear when stringifying
     // and we'll have access to them only via proxying with ComLink,
@@ -110,6 +111,7 @@ export function createHtmlForDoenetViewer(
             const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
             const doenetViewerPropsSpecified = ${JSON.stringify(doenetViewerPropsSpecified)};
             const doenetSharedCoreWorker = ${JSON.stringify(!!useSharedCoreWorker)};
+            const doenetWindowedViewer = ${JSON.stringify(!!windowed)};
             import * as ComlinkViewer from "https://unpkg.com/comlink/dist/esm/comlink.mjs";
 
             // This source code has been compiled by vite and should be directly included.

--- a/packages/doenetml-iframe/src/version-gates.ts
+++ b/packages/doenetml-iframe/src/version-gates.ts
@@ -1,0 +1,70 @@
+/**
+ * Feature gates keyed on the standalone-bundle version a viewer selects.
+ * The wrapper (this package) and the bundle inside the iframe ship
+ * separately — a host may pin `doenetmlVersion` to an old bundle — so
+ * wrapper features that need bundle cooperation must check the selected
+ * version. (A host-specified `standaloneUrl` carries no version
+ * information; callers treat it as modern — hosts shipping a custom URL
+ * control both sides.)
+ */
+
+// In-place prop updates require a standalone bundle whose
+// `renderDoenetViewerToContainer` re-renders against a cached React root
+// (v0.7.18+, PR #1131). Calling it repeatedly against an older bundle mounts
+// competing React roots on the same container.
+const LIVE_UPDATE_MIN_VERSION = [0, 7, 18];
+
+// First release whose standalone bundle acknowledges `SPLICE.flushState`
+// (#1468) — required for lossless parking.
+const PARK_MIN_VERSION = [0, 7, 21];
+
+/**
+ * Whether the standalone version string `version` selects a bundle at least
+ * as new as `min`. Missing version parts are npm ranges that jsdelivr
+ * resolves to the newest matching release (e.g. "0.7" serves the latest
+ * 0.7.x), so they compare as the range's upper bound. Unparseable versions
+ * are assumed modern.
+ */
+function versionAtLeast(version: string, min: number[]): boolean {
+    const match = version
+        .replace(/^v/, "")
+        .match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+    if (!match) {
+        return true;
+    }
+    const parts = [match[1], match[2], match[3]].map((p) =>
+        p === undefined ? Infinity : parseInt(p, 10),
+    );
+    for (let i = 0; i < 3; i++) {
+        if (parts[i] > min[i]) {
+            return true;
+        }
+        if (parts[i] < min[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Whether the standalone bundle selected by `version` supports live
+ * (in-place) prop updates (v0.7.18+, PR #1131's cached React root).
+ */
+export function versionSupportsLiveUpdates(version: string): boolean {
+    return versionAtLeast(version, LIVE_UPDATE_MIN_VERSION);
+}
+
+/**
+ * Whether the bundle selected by `version` can acknowledge
+ * `SPLICE.flushState` (v0.7.21+, #1468). Parking an older bundle would hit
+ * the flush timeout and park anyway, losing up to a report-throttle
+ * interval (60 s) of work — so such viewers are never parked (they still
+ * lazy-mount and obey the boot cap under a windowed `mountPolicy`). Caveat:
+ * a dev prerelease published before the feature's first release (e.g.
+ * `0.7.20-dev.N` built from a main that already carries it) parses as its
+ * `0.7.20` base and compares as too old — pin `standaloneUrl` in that case
+ * (custom URLs are assumed modern).
+ */
+export function versionSupportsParking(version: string): boolean {
+    return versionAtLeast(version, PARK_MIN_VERSION);
+}

--- a/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
+++ b/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
@@ -95,6 +95,21 @@ const records = new Map<string, ViewerRecord>();
 let visibleOrderCounter = 0;
 let effectiveMaxLive: number | null = null;
 let warnedMixedBudgets = false;
+let warnedWindowedWithoutPersistence = false;
+
+/**
+ * Once-per-page latch for the windowed-without-persistence warning: hosts
+ * that window by default mount many viewers with the same flags, and N
+ * copies of the warning is noise. Flips the latch on first call. Owned here
+ * so the test reset clears it alongside the rest of the module state.
+ */
+export function shouldWarnWindowedWithoutPersistence(): boolean {
+    if (warnedWindowedWithoutPersistence) {
+        return false;
+    }
+    warnedWindowedWithoutPersistence = true;
+    return true;
+}
 
 let evaluateTimerId: ReturnType<typeof setTimeout> | null = null;
 let evaluateTimerAt = Infinity;
@@ -284,6 +299,7 @@ export function __resetViewerLifecycleManagerForTests() {
     visibleOrderCounter = 0;
     effectiveMaxLive = null;
     warnedMixedBudgets = false;
+    warnedWindowedWithoutPersistence = false;
     if (evaluateTimerId !== null) {
         clearTimeout(evaluateTimerId);
         evaluateTimerId = null;

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.callbackHostParking.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.callbackHostParking.cy.tsx
@@ -10,14 +10,20 @@ import {
     assertParked,
 } from "./helpers";
 
-// Windowed mounting (#1441, stream B) end-to-end: with
-// `mountPolicy={{mode:"windowed", maxLiveViewers:1}}`, the off-screen viewer
-// parks (its state is flushed and its iframe is replaced by a fixed-height
-// placeholder) and is restored — typed work intact — when scrolled back.
+// Windowed mounting for callback hosts: a host that passes
+// `reportScoreAndStateCallback` suppresses the `SPLICE.reportScoreAndState`
+// message (the inner viewer calls the callback INSTEAD of posting), which is
+// what the park snapshot used to be captured from. The wrapper substitutes a
+// composed callback that captures the report before forwarding — so parking
+// stays lossless for hosts like the assignment viewer that consume reports
+// via the callback prop.
 
 const DOC_A = `<p>Viewer A: <textInput name="ti" /></p>
 <p>A typed: $ti.value</p>`;
 const DOC_B = `<p>Viewer B content</p>`;
+
+/** Reports viewer A's host callback received, exposed for assertions. */
+const hostReports: any[] = [];
 
 function Harness() {
     return (
@@ -29,6 +35,9 @@ function Harness() {
                     docId="doc-A"
                     flags={{ allowSaveState: true }}
                     mountPolicy={MOUNT_POLICY}
+                    reportScoreAndStateCallback={(data: unknown) => {
+                        hostReports.push(data);
+                    }}
                     standaloneUrl={STANDALONE_BLOB_URL}
                     cssUrl={STANDALONE_CSS_BLOB_URL}
                     addVirtualKeyboard={false}
@@ -51,81 +60,77 @@ function Harness() {
     );
 }
 
-describe("DoenetViewer (iframe wrapper) — windowed mounting parks off-screen viewers", () => {
+describe("DoenetViewer (iframe wrapper) — windowed mounting with a report callback host", () => {
     beforeEach(() => {
         __resetViewerLifecycleManagerForTests();
+        hostReports.length = 0;
     });
 
-    it("parks beyond the budget, restores typed work on scroll-back, and answers host flushes while parked", () => {
+    it("captures the park snapshot from the composed callback and still forwards reports to the host", () => {
         cy.viewport(900, 600);
         cy.mount(<Harness />);
 
-        // Viewer A (visible) boots; viewer B (far below the viewport) is
-        // over the budget of 1 and parks once its realm can acknowledge the
-        // flush. The placeholder holds its layout slot.
         viewerIframe("viewer-a")
             .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
             .should("contain.text", "A typed:");
         assertParked("viewer-b");
 
-        // Type into A and commit with Enter (cannot .blur() across the
-        // iframe boundary).
+        // Type into A and commit with Enter.
         viewerIframe("viewer-a")
             .its("0.contentDocument.body")
             .find("input:not([type=checkbox])")
             .then(cy.wrap)
-            .type("survives the park{enter}");
+            .type("callback snapshot{enter}");
         viewerIframe("viewer-a")
             .its("0.contentDocument.body")
-            .should("contain.text", "A typed: survives the park");
+            .should("contain.text", "A typed: callback snapshot");
 
-        // Scroll to B: it unparks and boots; A leaves the margin and parks,
-        // flushing the typed state into the wrapper's snapshot.
+        // A decoy report posted on the host window (e.g. an assignment-level
+        // report from the host's own reducer) must NOT pollute A's snapshot:
+        // the wrapper only captures from its own iframe / composed callback.
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    subject: "SPLICE.reportScoreAndState",
+                    activity_id: "act-A",
+                    doc_id: "doc-A",
+                    state: { decoy: "not a real doc state" },
+                    score: 0,
+                },
+                "*",
+            );
+        });
+
+        // Scroll to B: A leaves the margin and parks. The park flush pushes
+        // the pending save through the composed callback — the host receives
+        // it (forwarding) and the wrapper snapshots it (capture).
         cy.get("[data-test=viewer-b]").scrollIntoView();
         viewerIframe("viewer-b")
             .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
             .should("contain.text", "Viewer B content");
         assertParked("viewer-a");
 
-        // A host flush broadcast while A is parked: the wrapper answers for
-        // it (success, hadState) so pre-navigation flush round-trips don't
-        // hang on parked viewers.
-        cy.window().then((win) => {
-            const responses: any[] = [];
-            win.addEventListener("message", (e: MessageEvent) => {
-                if (
-                    e.data?.subject === "SPLICE.flushState.response" &&
-                    e.data?.message_id === "host-flush-while-parked"
-                ) {
-                    responses.push(e.data);
-                }
-            });
-            win.postMessage(
-                {
-                    subject: "SPLICE.flushState",
-                    message_id: "host-flush-while-parked",
-                },
-                "*",
+        cy.wrap(null).should(() => {
+            const withState = hostReports.filter(
+                (r) => r && typeof r === "object" && "state" in r,
             );
-            cy.wrap(null, { timeout: 10_000 }).should(() => {
-                const fromA = responses.find((r) => r.activity_id === "act-A");
-                expect(fromA, "parked viewer A answered").to.exist;
-                expect(fromA.success, "success").to.eq(true);
-                expect(fromA.hadState, "hadState").to.eq(true);
-            });
+            expect(
+                withState.length,
+                "host callback received the flushed report",
+            ).to.be.greaterThan(0);
         });
 
-        // Scroll back to A: it unparks seeded with the flushed state — the
-        // typed work survives the park/unpark round trip with no user
-        // interaction; B parks again (budget 1).
+        // Scroll back: A restores from the captured snapshot — the typed
+        // work survives even though no SPLICE.reportScoreAndState message
+        // ever reached the host window (and the decoy was ignored).
         cy.get("[data-test=viewer-a]").scrollIntoView();
         viewerIframe("viewer-a")
             .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
-            .should("contain.text", "A typed: survives the park");
+            .should("contain.text", "A typed: callback snapshot");
         viewerIframe("viewer-a")
             .its("0.contentDocument.body")
             .find("input:not([type=checkbox])")
-            .should("have.value", "survives the park");
+            .should("have.value", "callback snapshot");
         assertParked("viewer-b");
     });
 });

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.keepLive.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.keepLive.cy.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/index";
+import { __resetViewerLifecycleManagerForTests } from "../../../src/viewer-lifecycle-manager";
+import {
+    STANDALONE_BLOB_URL,
+    STANDALONE_CSS_BLOB_URL,
+    WINDOWED_MOUNT_POLICY as MOUNT_POLICY,
+    CONTENT_TIMEOUT,
+    PARK_TIMEOUT,
+    viewerIframe,
+} from "./helpers";
+
+// The `keepLive` hint: a windowed viewer inside a `display:none` container
+// never intersects the viewport, so visibility alone would leave it parked
+// forever. A host that knows the viewer is about to be shown (a paginator
+// prefetching the pages adjacent to the current one) sets `keepLive`, which
+// makes the wrapper treat it as visible: it boots eagerly and is never
+// parked while the hint is set — and parks normally once the hint is
+// removed.
+
+const DOC_V = `<p>Visible viewer content</p>`;
+const DOC_K = `<p>Hidden keepLive viewer content</p>`;
+
+function Harness() {
+    const [keepLive, setKeepLive] = React.useState(true);
+    return (
+        <div>
+            <button
+                data-test="toggle-keep-live"
+                onClick={() => setKeepLive((was) => !was)}
+            >
+                keepLive: {String(keepLive)}
+            </button>
+            <div data-test="viewer-v">
+                <DoenetViewer
+                    doenetML={DOC_V}
+                    activityId="act-V"
+                    docId="doc-V"
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>
+            {/* display:none — never intersects, like a paginator's hidden
+                next/previous page. */}
+            <div data-test="viewer-k" hidden>
+                <DoenetViewer
+                    doenetML={DOC_K}
+                    activityId="act-K"
+                    docId="doc-K"
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    keepLive={keepLive}
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>
+        </div>
+    );
+}
+
+describe("DoenetViewer (iframe wrapper) — keepLive treats a viewer as visible", () => {
+    beforeEach(() => {
+        __resetViewerLifecycleManagerForTests();
+    });
+
+    it("boots a display:none viewer, exempts it from parking, and parks it once the hint is removed", () => {
+        cy.viewport(900, 600);
+        cy.mount(<Harness />);
+
+        // Both boot: V is visible, K is keepLive — despite a budget of 1
+        // live viewer (the soft budget never parks effectively-visible
+        // viewers). The hidden iframe still renders its document.
+        viewerIframe("viewer-v")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Visible viewer content");
+        cy.get("[data-test=viewer-k] iframe", {
+            timeout: CONTENT_TIMEOUT,
+        }).should("exist");
+        viewerIframe("viewer-k")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Hidden keepLive viewer content");
+
+        // Outlast the park debounce: K must stay live while keepLive is set.
+        cy.wait(1500);
+        cy.get("[data-test=viewer-k] iframe").should("exist");
+
+        // Remove the hint: K is now invisible and over budget — it parks
+        // (flush acknowledged by the modern blob-URL bundle).
+        cy.get("[data-test=toggle-keep-live]").click();
+        cy.get("[data-test=viewer-k] [data-doenet-parked-viewer]", {
+            timeout: PARK_TIMEOUT,
+        }).should("exist");
+        cy.get("[data-test=viewer-k] iframe").should("not.exist");
+        // The visible viewer is untouched.
+        cy.get("[data-test=viewer-v] iframe").should("exist");
+
+        // Restore the hint: K unparks and boots again, still display:none.
+        cy.get("[data-test=toggle-keep-live]").click();
+        viewerIframe("viewer-k")
+            .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "Hidden keepLive viewer content");
+    });
+});

--- a/packages/doenetml-iframe/test/cypress/component/helpers.ts
+++ b/packages/doenetml-iframe/test/cypress/component/helpers.ts
@@ -23,6 +23,36 @@ export const STANDALONE_CSS_BLOB_URL = URL.createObjectURL(
 // whole timeout, so keep it tight.
 export const IFRAME_READY_TIMEOUT = 15_000;
 
+// ---- Windowed-mounting (mountPolicy) spec helpers ----
+
+// One shared policy for the windowed specs: a budget of one live viewer with
+// a short park debounce, so parking is observable quickly.
+export const WINDOWED_MOUNT_POLICY = {
+    mode: "windowed" as const,
+    maxLiveViewers: 1,
+    parkDelayMs: 300,
+    visibleMargin: "100px",
+    flushTimeoutMs: 15_000,
+};
+
+// Booting a viewer renders real content; parking additionally waits for the
+// realm to boot far enough to acknowledge the flush. Both need real time.
+export const CONTENT_TIMEOUT = 40_000;
+export const PARK_TIMEOUT = 40_000;
+
+/** The iframe of the viewer inside the `[data-test=<which>]` container. */
+export function viewerIframe(which: string) {
+    return cy.get(`[data-test=${which}] iframe`);
+}
+
+/** Assert the viewer parked: placeholder present, iframe detached. */
+export function assertParked(which: string) {
+    cy.get(`[data-test=${which}] [data-doenet-parked-viewer]`, {
+        timeout: PARK_TIMEOUT,
+    }).should("exist");
+    cy.get(`[data-test=${which}] iframe`).should("not.exist");
+}
+
 // A symbol we stash on the iframe's `contentDocument` to detect whether the
 // iframe was reloaded (a full reload replaces `contentDocument`, so any
 // property we added to the previous one is gone).

--- a/packages/doenetml-iframe/test/cypress/component/versionGates.cy.ts
+++ b/packages/doenetml-iframe/test/cypress/component/versionGates.cy.ts
@@ -1,0 +1,47 @@
+import {
+    versionSupportsLiveUpdates,
+    versionSupportsParking,
+} from "../../../src/version-gates";
+
+// Version-string gates for wrapper features that need bundle cooperation.
+// Missing parts are npm ranges jsdelivr resolves to the newest match, so
+// they compare as the range's upper bound; unparseable strings are assumed
+// modern.
+
+describe("version gates", () => {
+    it("gates live updates at 0.7.18", () => {
+        expect(versionSupportsLiveUpdates("0.7.17")).to.eq(false);
+        expect(versionSupportsLiveUpdates("0.7.18")).to.eq(true);
+        expect(versionSupportsLiveUpdates("0.7.19")).to.eq(true);
+        expect(versionSupportsLiveUpdates("0.6.99")).to.eq(false);
+        expect(versionSupportsLiveUpdates("1.0.0")).to.eq(true);
+    });
+
+    it("gates parking at 0.7.21 (first SPLICE.flushState release)", () => {
+        expect(versionSupportsParking("0.7.20")).to.eq(false);
+        expect(versionSupportsParking("0.7.21")).to.eq(true);
+        expect(versionSupportsParking("0.7.22")).to.eq(true);
+        expect(versionSupportsParking("0.8.0")).to.eq(true);
+        expect(versionSupportsParking("1.0.0")).to.eq(true);
+        expect(versionSupportsParking("0.6")).to.eq(false);
+    });
+
+    it("treats missing parts as the range's upper bound", () => {
+        // "0.7" pins ^0.7 on jsdelivr — resolves to the newest 0.7.x.
+        expect(versionSupportsParking("0.7")).to.eq(true);
+        expect(versionSupportsParking("0")).to.eq(true);
+        expect(versionSupportsLiveUpdates("0.7")).to.eq(true);
+    });
+
+    it("handles v-prefixes, prereleases, and unparseable strings", () => {
+        expect(versionSupportsParking("v0.7.21")).to.eq(true);
+        expect(versionSupportsParking("v0.7.20")).to.eq(false);
+        // A dev prerelease parses as its base triple: 0.7.20-dev.N compares
+        // as 0.7.20 even when built from a main that carries the feature —
+        // hosts on dev builds pin `standaloneUrl` instead (assumed modern).
+        expect(versionSupportsParking("0.7.20-dev.328")).to.eq(false);
+        expect(versionSupportsParking("0.7.21-dev.1")).to.eq(true);
+        // Unparseable ⇒ assumed modern.
+        expect(versionSupportsParking("latest")).to.eq(true);
+    });
+});


### PR DESCRIPTION
Closes three integration gaps in windowed mounting (`mountPolicy`, #1474/#1475) that block embedding hosts — concretely, the assignment viewer's adoption of stream B (Doenet/assignment-viewer#35–#37, tracked under #1441):

## Report-callback hosts can now park losslessly

A host that consumes state reports through the `reportScoreAndStateCallback` prop suppresses the `SPLICE.reportScoreAndState` message (the inner viewer calls the callback *instead* of posting) — but that message was the park snapshot's only source, so parking such a viewer restored stale or no state.

For windowed viewers, the iframe entry now routes reports over the **same `window.postMessage` channel as the `SPLICE.flushState` acknowledgement**; same-channel FIFO guarantees the wrapper captures the flushed report before the park completes. (Routing the host's Comlink proxy instead would ride a dedicated MessagePort, and cross-channel ordering between a port and a window message is unspecified — an unfixable race.) The wrapper forwards each report to the host's latest callback identity, falling back to the message contract if the host has since removed its callback.

## New `keepLive` prop (dynamic)

Treat a windowed viewer as visible: boot it eagerly (still subject to the page-wide `maxConcurrentBoots` queue) and never park it while set. A `display:none` container never intersects the viewport, so a paginator prefetching the pages adjacent to the current one needs this hint to keep instant page flips while pages beyond the window still park.

## Parking version gate

Parking now requires the selected standalone bundle to be new enough to acknowledge `SPLICE.flushState` (v0.7.21+; a host-specified `standaloneUrl` is assumed modern). Previously, parking a viewer pinned to an older `doenetmlVersion` hit the flush timeout and parked anyway — losing up to a report-throttle interval (60 s) of work. Such viewers now stay live; they still lazy-mount and obey the boot cap.

## Also, from review

- A timed-out park flush now seeds the restore snapshot from the latest captured report (best effort) instead of discarding it — a wedged realm no longer throws away state that was already in hand.
- The windowed-without-persistence warning fires once per page instead of once per viewer (the latch lives in the lifecycle manager so the test reset clears it).
- Version predicates moved to a small `version-gates` module; the windowed cypress specs share their harness helpers.

## Tests

- `DoenetViewer.callbackHostParking.cy.tsx`: typed work survives park/restore when the host passes `reportScoreAndStateCallback` and feeds nothing back; the host callback receives the flushed report; a decoy host-window report doesn't pollute the snapshot.
- `DoenetViewer.keepLive.cy.tsx`: a `display:none` viewer boots under `keepLive`, is exempt from parking while set, parks once cleared, and unparks when re-set.
- `versionGates.cy.ts`: predicate unit tests (thresholds, npm ranges, prereleases).
- Full package suite: 41/41 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)