### PR TITLE
Build state-variable dependencies on demand at first resolution attempt

### DIFF
--- a/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
@@ -762,7 +762,9 @@ export async function createChildrenThenComponent({
 
     await initializeComponentStateVariables({ core, component: newComponent });
 
-    await core.dependencies.setUpComponentDependencies(newComponent);
+    // Per-state-variable dependencies are built on demand at first
+    // resolution attempt; only the per-component map slots are created here.
+    core.dependencies.createComponentDependencySlots(newComponent);
 
     const variablesChanged =
         await core.dependencies.checkForDependenciesOnNewComponent(
@@ -781,8 +783,13 @@ export async function createChildrenThenComponent({
         componentIdx,
     });
 
-    await core.dependencies.resolveStateVariablesIfReady({
-        component: newComponent,
+    // Other components' dependencies may be blocked on this component's
+    // identity, so that resolution stays eager. The former per-state-variable
+    // resolve pass is gone: state variables now resolve on first demand.
+    await core.dependencies.resolveIfReady({
+        componentIdx,
+        type: "componentIdentity",
+        expandComposites: false,
     });
 
     core.recordStateVariablesMustEvaluate(componentIdx);

--- a/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
+++ b/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
@@ -108,12 +108,12 @@ export class StalenessPropagator {
                         }
                     }
 
-                    await this.core.dependencies.setUpStateVariableDependencies(
-                        {
-                            component,
-                            stateVariable,
-                            allStateVariablesAffected,
-                        },
+                    // Route through the idempotent wrapper so a re-entrant
+                    // demand for one of these just-created entries cannot
+                    // set up the group's dependencies twice.
+                    await this.core.dependencies.ensureStateVariableDependenciesSetUp(
+                        component.componentIdx,
+                        stateVariable,
                     );
 
                     let newStateVariablesToResolve = [];

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -145,6 +145,12 @@ export class DependencyHandler {
     /** Shared frozen record for a fully-consumed `valuesChanged` entry. */
     emptyValuesChangedRecord: Record<string, any>;
 
+    /**
+     * Number of state-variable groups whose dependencies have been built
+     * (on demand). Diagnostic counter for the lazy-materialization work.
+     */
+    numDependencySetups: number;
+
     constructor({
         _components,
         componentInfoObjects,
@@ -182,6 +188,8 @@ export class DependencyHandler {
             neededToResolve: {},
             resolveBlockedBy: {},
         };
+
+        this.numDependencySetups = 0;
 
         this.attributeRefResolutionDependenciesByReferenced = {};
 
@@ -345,60 +353,93 @@ export class DependencyHandler {
         return interned;
     }
 
-    async setUpComponentDependencies(component: ComponentInstance) {
+    /**
+     * Create the per-component entries in the two dependency maps.
+     *
+     * The maps are indexed unconditionally by component elsewhere
+     * (e.g. `markUpstreamDependentsStale`, `resetCircularCheckPassed`),
+     * so every component needs its slots at construction even though the
+     * per-state-variable dependencies are now built on demand by
+     * `ensureStateVariableDependenciesSetUp`.
+     */
+    createComponentDependencySlots(component: ComponentInstance) {
         // if component already has downstream dependencies
         // delete them, and the corresponding upstream dependencies
         if (this.downstreamDependencies[component.componentIdx]) {
             this.deleteAllDownstreamDependencies({ component });
         }
 
-        // console.log(`set up component dependencies of ${component.componentIdx}`)
         this.downstreamDependencies[component.componentIdx] = {};
         if (!this.upstreamDependencies[component.componentIdx]) {
             this.upstreamDependencies[component.componentIdx] = {};
         }
+    }
 
-        let stateVariablesToProccess: string[] = [];
-        let additionalStateVariablesThatWillBeProcessed: string[] = [];
-        for (let stateVariable in component.state) {
-            if (!(
-                component.state[stateVariable].isArrayEntry ||
-                component.state[stateVariable].isAlias ||
-                additionalStateVariablesThatWillBeProcessed.includes(
-                    stateVariable,
-                )
-            )) {
-                // TODO: if do indeed keep aliases deleted from state, then don't need second check, above
-                stateVariablesToProccess.push(stateVariable);
-                if (
-                    component.state[stateVariable]
-                        .additionalStateVariablesDefined
-                ) {
-                    additionalStateVariablesThatWillBeProcessed.push(
-                        ...component.state[stateVariable]
-                            .additionalStateVariablesDefined,
-                    );
-                }
+    /**
+     * Build the dependencies of `stateVariable` (and the rest of its
+     * `additionalStateVariablesDefined` group) if they have not been built
+     * yet. Dependencies are created on demand at the first resolution
+     * attempt (`resolveItem`/`resolveIfReady`) rather than at component
+     * construction, so state variables that are never demanded never pay
+     * for their dependency structures.
+     *
+     * The marker for "already set up" is the existence of the variable's
+     * slot in `downstreamDependencies` — slots are deleted only by
+     * whole-component teardown.
+     */
+    async ensureStateVariableDependenciesSetUp(
+        componentIdx: ComponentIdx,
+        stateVariable: string,
+    ) {
+        const component = this._components[componentIdx];
+        if (!component) {
+            return;
+        }
+        const stateVarObj = component.state[stateVariable];
+        if (!stateVarObj) {
+            // array entries that don't exist yet are created through
+            // `createFromArrayEntry`, which sets up dependencies itself
+            return;
+        }
+
+        const downDepsForComponent =
+            this.downstreamDependencies[component.componentIdx];
+        if (
+            !downDepsForComponent ||
+            downDepsForComponent[stateVariable] !== undefined
+        ) {
+            return;
+        }
+
+        // Every member of an `additionalStateVariablesDefined` group lists
+        // its siblings (see `returnNormalizedStateVariableDefinitions`),
+        // so the full group is recoverable from whichever member is
+        // demanded first.
+        const allStateVariablesAffected = [stateVariable];
+        if (stateVarObj.additionalStateVariablesDefined) {
+            allStateVariablesAffected.push(
+                ...stateVarObj.additionalStateVariablesDefined,
+            );
+        }
+
+        // Pre-create empty slots for the whole group before the async
+        // setup: variables whose `returnDependencies` yields no
+        // dependencies still need the slot to record they were set up, and
+        // `returnDependencies` can await other state variables, re-entering
+        // resolution for this same group.
+        for (const varName of allStateVariablesAffected) {
+            if (!downDepsForComponent[varName]) {
+                downDepsForComponent[varName] = {};
             }
         }
 
-        for (let stateVariable of stateVariablesToProccess) {
-            let allStateVariablesAffected = [stateVariable];
-            if (
-                component.state[stateVariable].additionalStateVariablesDefined
-            ) {
-                allStateVariablesAffected.push(
-                    ...component.state[stateVariable]
-                        .additionalStateVariablesDefined,
-                );
-            }
+        this.numDependencySetups++;
 
-            await this.setUpStateVariableDependencies({
-                component,
-                stateVariable,
-                allStateVariablesAffected,
-            });
-        }
+        await this.setUpStateVariableDependencies({
+            component,
+            stateVariable,
+            allStateVariablesAffected,
+        });
     }
 
     async setUpStateVariableDependencies({
@@ -2488,17 +2529,6 @@ export class DependencyHandler {
 
         let componentIdx = component.componentIdx;
 
-        if (!stateVariables) {
-            await this.resolveIfReady({
-                componentIdx,
-                type: "componentIdentity",
-                expandComposites: false,
-                // recurseUpstream: true
-            });
-
-            stateVariables = Object.keys(component.state);
-        }
-
         for (let varName of stateVariables) {
             // TODO: remove this commented out code if it turns out we don't need `determineDependenciesImmediately`
 
@@ -2558,6 +2588,18 @@ export class DependencyHandler {
     }: any) {
         // console.log(`resolve if ready ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
 
+        if (type === "stateVariable") {
+            // Dependencies are set up lazily, so an empty blocker ledger
+            // alone doesn't mean the variable is resolvable: its
+            // dependencies (whose creation records the blockers) must have
+            // been built first. This gate is what makes
+            // `processNewlyResolved` (reached only through here) safe.
+            await this.ensureStateVariableDependenciesSetUp(
+                componentIdx,
+                stateVariable,
+            );
+        }
+
         let haveNeededToResolve = this.checkIfHaveNeededToResolve({
             componentIdx,
             type,
@@ -2614,6 +2656,17 @@ export class DependencyHandler {
         // as resolving a determineDependency will call updateDependencies
         // and updateDependencies calls the getters on
         // the state variables determining dependencies
+
+        if (type === "stateVariable") {
+            // Set up this variable's dependencies now (if not yet built) so
+            // the peek below sees the real blockers — including the
+            // `__determine_dependencies` blocker consumed by the pre-pass —
+            // instead of discovering them through the retry loop.
+            await this.ensureStateVariableDependenciesSetUp(
+                componentIdx,
+                stateVariable,
+            );
+        }
 
         let neededForItem = this.peekNeededToResolve({
             componentIdx,

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/lazyStateVariables.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/lazyStateVariables.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+import { updateValue } from "../utils/actions";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+/**
+ * Tests for lazy state-variable materialization (issue #1459):
+ * dependency structures are built on demand at the first resolution
+ * attempt instead of eagerly at component construction.
+ */
+describe("Lazy state variable tests @group4", async () => {
+    it("undemanded state variables have no dependency structures until first read", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <function name="f">sin(x)</function>
+    <function name="g" maxima="(1,2) (4,3)" />
+    `,
+        });
+
+        const fIdx = await resolvePathToNodeIdx("f");
+        const gIdx = await resolvePathToNodeIdx("g");
+        const components = core.core!.components!;
+        const dependencies = core.core!.dependencies;
+
+        // `formula` is demanded by the renderer, so its dependencies exist
+        expect(dependencies.downstreamDependencies[fIdx].formula).toBeTypeOf(
+            "object",
+        );
+        expect(components[fIdx].state.formula.isResolved).eq(true);
+
+        // extrema were never demanded: no dependency slot, no blocker-ledger
+        // entries, not resolved
+        expect(dependencies.downstreamDependencies[fIdx].allMaxima).eq(
+            undefined,
+        );
+        expect(components[fIdx].state.allMaxima.isResolved).eq(false);
+        expect(
+            JSON.stringify(
+                dependencies.resolveBlockers.neededToResolve[fIdx] ?? {},
+            ),
+        ).not.contain("allMaxima");
+
+        // first read materializes the dependencies and produces the correct
+        // value
+        expect(await components[gIdx].state.numMaxima.value).eq(2);
+        expect(components[gIdx].state.numMaxima.isResolved).eq(true);
+        expect(dependencies.downstreamDependencies[gIdx].numMaxima).toBeTypeOf(
+            "object",
+        );
+    });
+
+    it("inverse-setting a never-read variable of a never-rendered component works", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <setup><number name="n">5</number></setup>
+    <updateValue name="uv" target="$n" newValue="8" />
+    `,
+        });
+
+        const nIdx = await resolvePathToNodeIdx("n");
+
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uv"),
+            core,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[nIdx].stateValues.value).eq(8);
+    });
+
+    it("saved state restores into variables of a never-rendered component", async () => {
+        const doenetML = `
+    <setup><number name="n">5</number></setup>
+    <updateValue name="uv" target="$n" newValue="8" />
+    <p name="p">count: $n</p>
+    `;
+
+        let { core, resolvePathToNodeIdx, scoreState } = await createTestCore({
+            doenetML,
+        });
+
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uv"),
+            core,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p")].stateValues.text,
+        ).eq("count: 8");
+
+        // non-submission updates only schedule a debounced save, so flush
+        // before grabbing the reported state
+        await core.saveImmediately();
+        const endingState = scoreState.state;
+
+        // reload with saved state; the essential value must land on the
+        // not-yet-resolved variable and be reflected at first read
+        ({ core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+            initialState: endingState,
+        }));
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p")].stateValues.text,
+        ).eq("count: 8");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("n")].stateValues.value,
+        ).eq(8);
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
@@ -240,23 +240,25 @@ describe("Warning Tests @group4", async () => {
         expect(diagnosticsByType.warnings.length).eq(0);
         expect(diagnosticsByType.infos.length).eq(5);
 
+        // Infos surface in evaluation order, which under on-demand
+        // dependency setup follows document order.
         expect(diagnosticsByType.infos[0].message).contain(
-            "Invalid value `new1` for attribute `format`",
-        );
-        expect(diagnosticsByType.infos[0].type).eq("info");
-        expect(diagnosticsByType.infos[0].position.start.line).eq(5);
-        expect(diagnosticsByType.infos[0].position.start.column).eq(3);
-        expect(diagnosticsByType.infos[0].position.end.line).eq(5);
-        expect(diagnosticsByType.infos[0].position.end.column).eq(46);
-
-        expect(diagnosticsByType.infos[1].message).contain(
             "Invalid value `bad` for attribute `type`",
         );
+        expect(diagnosticsByType.infos[0].type).eq("info");
+        expect(diagnosticsByType.infos[0].position.start.line).eq(2);
+        expect(diagnosticsByType.infos[0].position.start.column).eq(3);
+        expect(diagnosticsByType.infos[0].position.end.line).eq(2);
+        expect(diagnosticsByType.infos[0].position.end.column).eq(26);
+
+        expect(diagnosticsByType.infos[1].message).contain(
+            "Invalid value `new1` for attribute `format`",
+        );
         expect(diagnosticsByType.infos[1].type).eq("info");
-        expect(diagnosticsByType.infos[1].position.start.line).eq(2);
+        expect(diagnosticsByType.infos[1].position.start.line).eq(5);
         expect(diagnosticsByType.infos[1].position.start.column).eq(3);
-        expect(diagnosticsByType.infos[1].position.end.line).eq(2);
-        expect(diagnosticsByType.infos[1].position.end.column).eq(26);
+        expect(diagnosticsByType.infos[1].position.end.line).eq(5);
+        expect(diagnosticsByType.infos[1].position.end.column).eq(46);
 
         expect(diagnosticsByType.infos[2].message).contain(
             "Invalid value `new2` for attribute `format`",

--- a/packages/doenetml-worker-javascript/src/test/dynamicalsystem/odesystem.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/dynamicalsystem/odesystem.test.ts
@@ -939,21 +939,23 @@ describe("odeSystem Tag Tests @group4", async () => {
         expect(diagnosticsByType.errors.length).eq(0);
         expect(diagnosticsByType.warnings.length).eq(4);
 
+        // Warnings surface in evaluation order, which under on-demand
+        // dependency setup follows document order.
         expect(diagnosticsByType.warnings[0].message).contain(
-            `Invalid value of a variable: \`sin(x)\``,
-        );
-        expect(diagnosticsByType.warnings[0].position.start.line).eq(6);
-        expect(diagnosticsByType.warnings[0].position.start.column).eq(26);
-        expect(diagnosticsByType.warnings[0].position.end.line).eq(6);
-        expect(diagnosticsByType.warnings[0].position.end.column).eq(54);
-
-        expect(diagnosticsByType.warnings[1].message).contain(
             `Variables of \`<odeSystem>\` must be different than independent variable`,
         );
-        expect(diagnosticsByType.warnings[1].position.start.line).eq(2);
-        expect(diagnosticsByType.warnings[1].position.start.column).eq(12);
-        expect(diagnosticsByType.warnings[1].position.end.line).eq(2);
-        expect(diagnosticsByType.warnings[1].position.end.column).eq(25);
+        expect(diagnosticsByType.warnings[0].position.start.line).eq(2);
+        expect(diagnosticsByType.warnings[0].position.start.column).eq(12);
+        expect(diagnosticsByType.warnings[0].position.end.line).eq(2);
+        expect(diagnosticsByType.warnings[0].position.end.column).eq(25);
+
+        expect(diagnosticsByType.warnings[1].message).contain(
+            `Invalid value of a variable: \`sin(x)\``,
+        );
+        expect(diagnosticsByType.warnings[1].position.start.line).eq(6);
+        expect(diagnosticsByType.warnings[1].position.start.column).eq(26);
+        expect(diagnosticsByType.warnings[1].position.end.line).eq(6);
+        expect(diagnosticsByType.warnings[1].position.end.column).eq(54);
 
         expect(diagnosticsByType.warnings[2].message).contain(
             `Invalid value of a variable: \`sin(y)\``,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functionTag.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functionTag.test.ts
@@ -1831,21 +1831,23 @@ describe("Function tag tests @group4", async () => {
         expect(diagnosticsByType.errors.length).eq(0);
         expect(diagnosticsByType.warnings.length).eq(2);
 
+        // Warnings surface in evaluation order, which under on-demand
+        // dependency setup follows document order.
         expect(diagnosticsByType.warnings[0].message).contain(
-            `Invalid value of a variable: \`cos(x)\``,
-        );
-        expect(diagnosticsByType.warnings[0].position.start.line).eq(3);
-        expect(diagnosticsByType.warnings[0].position.start.column).eq(15);
-        expect(diagnosticsByType.warnings[0].position.end.line).eq(3);
-        expect(diagnosticsByType.warnings[0].position.end.column).eq(32);
-
-        expect(diagnosticsByType.warnings[1].message).contain(
             `Invalid value of a variable: \`sin(x)\``,
         );
-        expect(diagnosticsByType.warnings[1].position.start.line).eq(2);
+        expect(diagnosticsByType.warnings[0].position.start.line).eq(2);
+        expect(diagnosticsByType.warnings[0].position.start.column).eq(15);
+        expect(diagnosticsByType.warnings[0].position.end.line).eq(2);
+        expect(diagnosticsByType.warnings[0].position.end.column).eq(33);
+
+        expect(diagnosticsByType.warnings[1].message).contain(
+            `Invalid value of a variable: \`cos(x)\``,
+        );
+        expect(diagnosticsByType.warnings[1].position.start.line).eq(3);
         expect(diagnosticsByType.warnings[1].position.start.column).eq(15);
-        expect(diagnosticsByType.warnings[1].position.end.line).eq(2);
-        expect(diagnosticsByType.warnings[1].position.end.column).eq(33);
+        expect(diagnosticsByType.warnings[1].position.end.line).eq(3);
+        expect(diagnosticsByType.warnings[1].position.end.column).eq(32);
     });
 
     it("point constrained to function in different variable", async () => {


### PR DESCRIPTION
First stage of the lazy state-variable materialization project (issue #1459, part of #1441 stream D). A second PR with the placeholder-materialization stages is stacked on this branch.

## What changes

Component construction no longer builds dependency structures for every state variable of every component:

- `setUpComponentDependencies` shrinks to `createComponentDependencySlots` — only the per-component map slots are created at construction (they are indexed unconditionally by `markUpstreamDependentsStale` and `resetCircularCheckPassed`).
- A new idempotent `DependencyHandler.ensureStateVariableDependenciesSetUp` builds a variable's dependencies (whole `additionalStateVariablesDefined` group at once) on first demand. The "already set up" marker is the existence of the variable's `downstreamDependencies` slot; empty slots are pre-created for the whole group before the async setup so zero-dependency variables flip the marker and re-entrant demands can't double-build.
- The gate lives in `resolveIfReady` and `resolveItem` for `type === "stateVariable"`. This is the crux: an empty blocker ledger no longer means "resolvable" — `processNewlyResolved` (the resolution step that flips `isResolved` to `true`, reachable only through `resolveIfReady`) can now only run after the variable's dependencies exist and have recorded their blockers. `resolveItem`'s existing retry loop picks up blockers discovered during on-demand setup.
- The construction-time per-state-variable resolve pass is gone (it created the idle pending-resolution ledger entries); only the component-identity resolution other components' blockers rely on stays eager.
- `createFromArrayEntry` routes through the same wrapper, so the array-entry path and the new path share one setup discipline.

State variables that are never demanded — most variables on shadow (copy/`repeat`) components — now skip dependency construction, producer-side upstream registrations, blocker-ledger entries, and circular-check work entirely. This subsumes the blocked-resolution-ledger redesign flagged as a follow-up in the earlier dependency-graph work (#1435 item 2): on a repeat-250 document the `neededToResolve` ledger holds **0** entries after load, down from **205,535**.

## Behavioral deltas

- `component.state[v].isResolved` stays `false` after load for undemanded variables (previously `true` for blocker-free ones). The existing "extrema not resolved if not requested" test still passes; renderer-demanded variables resolve as before.
- Definition-time warnings and attribute-validation infos surface in demand order, which follows document order; the affected order-sensitive tests were updated (their old expected order was construction order, not document order).
- Circular-dependency author errors surface at first demand instead of at construction (existing circular-error tests pass unchanged).

## Validation

- New tests in `lazyStateVariables.test.ts`: no dependency slot / no ledger entries / unresolved for an undemanded variable, with correct first-read materialization; inverse-setting a never-read variable of a never-rendered component; state restore into a never-rendered component.
- Targeted local vitest across the risky paths (staleness, inverse definitions, essential restore, action chaining, composites, copies) passes; full groups run in CI on this PR.
- Diagnostic counter `numDependencySetups` on `DependencyHandler`: 114,854 group setups on repeat-250 vs ~all variables before.

Part of #1459; memory measurements for the full series are on the stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

