### PR TITLE
Materialize state-variable objects on first need

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -72,30 +72,13 @@ export default class BaseComponent {
             // are the same object. The runtime deletes
             // (`delete stateVarObj.value` etc.) only ever target runtime
             // fields, which live on the wrapper.
+            // Per-instance copies of nested mutable fields and workspaces
+            // are made when a state variable materializes
+            // (`ensureStateVariableMaterialized`), not here.
             for (let stateVariable in stateVariableDefinitions) {
-                let def = Object.create(
+                this.state[stateVariable] = Object.create(
                     stateVariableDefinitions[stateVariable],
                 );
-                // Nested fields that get mutated in place at runtime need
-                // their own per-instance copies; a prototype read would hand
-                // back the shared object.
-                if (def.shadowingInstructions) {
-                    def.shadowingInstructions = Object.assign(
-                        {},
-                        def.shadowingInstructions,
-                    );
-                }
-                if (def.additionalStateVariablesDefined) {
-                    def.additionalStateVariablesDefined = [
-                        ...def.additionalStateVariablesDefined,
-                    ];
-                }
-                if (def.stateVariablesDeterminingDependencies) {
-                    def.stateVariablesDeterminingDependencies = [
-                        ...def.stateVariablesDeterminingDependencies,
-                    ];
-                }
-                this.state[stateVariable] = def;
             }
         } else {
             // Adapter / reference-shadow definitions: the factory already
@@ -109,29 +92,6 @@ export default class BaseComponent {
             }
         }
 
-        // Definitions mutate their workspace across evaluations, so each
-        // instance needs a fresh one in place of the workspace on the (shared)
-        // definition. State variables defined together via
-        // additionalStateVariablesDefined share a single workspace.
-        let workspaceAssigned = new Set();
-        for (let stateVariable in this.state) {
-            let def = this.state[stateVariable];
-            if (!def.createWorkspace || workspaceAssigned.has(stateVariable)) {
-                continue;
-            }
-            let workspace = {};
-            def.workspace = workspace;
-            workspaceAssigned.add(stateVariable);
-            if (def.additionalStateVariablesDefined) {
-                for (let otherVar of def.additionalStateVariablesDefined) {
-                    let otherDef = this.state[otherVar];
-                    if (otherDef?.createWorkspace) {
-                        otherDef.workspace = workspace;
-                        workspaceAssigned.add(otherVar);
-                    }
-                }
-            }
-        }
         this.stateValues = new Proxy(this.state, createStateProxyHandler());
 
         this.essentialState = {};

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -72,11 +72,6 @@ export default class BaseComponent {
             // are the same object. The runtime deletes
             // (`delete stateVarObj.value` etc.) only ever target runtime
             // fields, which live on the wrapper.
-            // (Prototype wrappers are only used over the class-shared
-            // definitions — a few per class — because using the per-instance
-            // adapter/shadow clones below as prototypes made every clone the
-            // root of its own V8 shape tree, costing more in hidden-class
-            // metadata than the shared property backing saved.)
             for (let stateVariable in stateVariableDefinitions) {
                 let def = Object.create(
                     stateVariableDefinitions[stateVariable],
@@ -104,8 +99,9 @@ export default class BaseComponent {
             }
         } else {
             // Adapter / reference-shadow definitions: the factory already
-            // produced per-instance clones (one distinct object per state
-            // variable, nested mutable fields included), so they can be used
+            // produced per-instance prototype wrappers over the class
+            // definitions (with own copies of the nested mutable fields and
+            // the adapter/shadow overrides applied), so they can be used
             // directly as the state variable objects.
             for (let stateVariable in stateVariableDefinitions) {
                 this.state[stateVariable] =

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -83,9 +83,12 @@ export default class BaseComponent {
         } else {
             // Adapter / reference-shadow definitions: the factory already
             // produced per-instance prototype wrappers over the class
-            // definitions (with own copies of the nested mutable fields and
-            // the adapter/shadow overrides applied), so they can be used
-            // directly as the state variable objects.
+            // definitions and recorded (but did not yet apply) their
+            // adapter/shadow modifications as own `isShadow` / `svShadow*`
+            // markers. The nested mutable-field copies and the shadow
+            // overrides are applied when each variable materializes
+            // (`ensureStateVariableMaterialized`), so the wrappers can be
+            // used directly as the state variable objects here.
             for (let stateVariable in stateVariableDefinitions) {
                 this.state[stateVariable] =
                     stateVariableDefinitions[stateVariable];

--- a/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
@@ -4,6 +4,7 @@ import type { ComponentIdx } from "@doenet/utils";
 import me from "math-expressions";
 import { processNewDefiningChildren } from "./ComponentLifecycle";
 import { expandAllComposites } from "./CompositeExpander";
+import { ensureStateVariableMaterialized } from "./StateVariableInitializer";
 import {
     preprocessMathInverseDefinition,
     removeFunctionsMathExpressionClass,
@@ -266,6 +267,17 @@ export class EssentialValueWriter {
 
             for (let vName in newComponentStateVariables) {
                 let compStateObj = comp.state[vName];
+                if (compStateObj) {
+                    // the writes below read materialized-only fields
+                    // (`essentialVarName` overrides from shadow plans,
+                    // array machinery like `setArrayValue` /
+                    // `arraySizeStateVariable`)
+                    await ensureStateVariableMaterialized({
+                        core: this.core,
+                        component: comp,
+                        stateVariable: vName,
+                    });
+                }
                 if (compStateObj === undefined) {
                     let match = vName.match(/^__def_primitive_(\d+)$/);
 
@@ -485,6 +497,14 @@ export class EssentialValueWriter {
         let componentWorkspace = workspace[instruction.componentIdx];
 
         let stateVarObj = component.state[stateVariable];
+
+        // materialize before reading the definition group and the inverse
+        // definition: pending shadow modifications can change both
+        await ensureStateVariableMaterialized({
+            core: this.core,
+            component,
+            stateVariable,
+        });
 
         let additionalStateVariablesDefined =
             stateVarObj.additionalStateVariablesDefined;

--- a/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
+++ b/packages/doenetml-worker-javascript/src/core/StalenessPropagator.ts
@@ -2,6 +2,7 @@ import type Core from "../Core";
 import type { ComponentInstance } from "../types/componentInstance";
 import { returnActiveChildrenIndicesToRender } from "./ChildMatcher";
 import {
+    ensureStateVariableMaterialized,
     initializeStateVariable,
     installStaleValueGetter,
 } from "./StateVariableInitializer";
@@ -63,6 +64,14 @@ export class StalenessPropagator {
             ) {
                 let arrayVariableName =
                     component.arrayEntryPrefixes[arrayEntryPrefix];
+                // entry initialization copies materialized-only fields off
+                // the array object (definition, freshnessInfo, entry-name
+                // bookkeeping), so build the array first
+                await ensureStateVariableMaterialized({
+                    core: this.core,
+                    component,
+                    stateVariable: arrayVariableName,
+                });
                 let arrayStateVarObj = component.state[arrayVariableName];
                 let arrayKeys = arrayStateVarObj.getArrayKeysFromVarName({
                     arrayEntryPrefix,

--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -106,29 +106,12 @@ function getClassStateVariableDefinitions(core: Core, componentClass: any) {
  * `field = undefined` rather than `delete` — a delete of an inherited
  * field is a no-op.)
  *
- * The nested fields the shadow paths mutate in place (rather than
- * reassign) get their own per-instance copies, mirroring what the
- * constructor does for class-shared definitions.
+ * Per-instance copies of the nested fields that get mutated in place are
+ * made at materialization time (`materializeNestedDefinitionFields` in
+ * `StateVariableInitializer`), not here.
  */
 function wrapStateVariableDefinition(def: Record<string, any>) {
-    const wrapper = Object.create(def);
-    if (def.shadowingInstructions) {
-        wrapper.shadowingInstructions = Object.assign(
-            {},
-            def.shadowingInstructions,
-        );
-    }
-    if (def.additionalStateVariablesDefined) {
-        wrapper.additionalStateVariablesDefined = [
-            ...def.additionalStateVariablesDefined,
-        ];
-    }
-    if (def.stateVariablesDeterminingDependencies) {
-        wrapper.stateVariablesDeterminingDependencies = [
-            ...def.stateVariablesDeterminingDependencies,
-        ];
-    }
-    return wrapper;
+    return Object.create(def);
 }
 
 /**
@@ -1087,6 +1070,9 @@ function modifyStateDefsToBeShadows({
             }
         }
 
+        // `isShadow` is written eagerly: the shadow scans over a target
+        // component's state (including scans by later chained copies) read
+        // it before this variable is ever materialized.
         stateDef.isShadow = true;
 
         if (stateDef.additionalStateVariablesDefined) {
@@ -1101,62 +1087,95 @@ function modifyStateDefsToBeShadows({
                 }
             }
         }
-        // assign `undefined` rather than `delete`: these definitions are
-        // prototype wrappers, so the field must be shadowed with an own
-        // property (a delete of an inherited field is a no-op); all
-        // consumers of both fields test truthiness, never presence
-        stateDef.additionalStateVariablesDefined = undefined;
-        if (!foundReadyToExpandWhenResolved) {
-            // if didn't find a readyToExpandWhenResolved,
-            // then won't use original dependencies so can remove any
+
+        // The rest of the modification (shared shadow function refs,
+        // severing the definition group, the shadow parameters) is recorded
+        // as a compact plan and applied by
+        // `applyPendingShadowModification` when the variable materializes.
+        stateDef.svShadowParams = {
+            targetComponentIdx: targetComponent.componentIdx,
+            overrideVarName: differentStateVariablesInTarget[varInd],
+            keepOriginalDependencies: Boolean(foundReadyToExpandWhenResolved),
+        };
+    }
+    for (let varName in deleteStateVariablesFromDefinition) {
+        stateVariableDefinitions[varName].svShadowDeleteVars =
+            deleteStateVariablesFromDefinition[varName];
+    }
+}
+
+/**
+ * Apply the shadow modification planned by `modifyStateDefsToBeShadows`
+ * to one state-variable object, at materialization time. Executes the
+ * same per-variable mutations the plan deferred; no-op for variables
+ * without pending markers.
+ */
+export function applyPendingShadowModification(stateVarObj: any) {
+    const params = stateVarObj.svShadowParams;
+    if (params) {
+        delete stateVarObj.svShadowParams;
+
+        const varName = stateVarObj.svVarName;
+
+        // assign `undefined` rather than `delete`: these state-variable
+        // objects are prototype wrappers, so the field must be shadowed
+        // with an own property (a delete of an inherited field is a
+        // no-op); all consumers of both fields test truthiness, never
+        // presence
+        const originalReturnDependencies = stateVarObj.returnDependencies;
+        stateVarObj.additionalStateVariablesDefined = undefined;
+        if (!params.keepOriginalDependencies) {
+            // won't use original dependencies so can remove any
             // stateVariablesDeterminingDependencies
-            stateDef.stateVariablesDeterminingDependencies = undefined;
+            stateVarObj.stateVariablesDeterminingDependencies = undefined;
         }
 
         let copyComponentType =
-            stateDef.public &&
-            stateDef.shadowingInstructions.hasVariableComponentType;
+            stateVarObj.public &&
+            stateVarObj.shadowingInstructions.hasVariableComponentType;
 
         // Parameters for the shared shadow definition functions (see the
         // module-level `shadow*` functions above), stored on the
-        // per-instance definition instead of captured in per-variable
-        // closures.
-        stateDef.shadowOfComponentIdx = targetComponent.componentIdx;
-        stateDef.shadowVarName = varName;
-        stateDef.shadowCopyComponentType = copyComponentType;
+        // per-instance state-variable object instead of captured in
+        // per-variable closures.
+        stateVarObj.shadowOfComponentIdx = params.targetComponentIdx;
+        stateVarObj.shadowVarName = varName;
+        stateVarObj.shadowCopyComponentType = copyComponentType;
 
-        if (stateDef.isArray) {
-            stateDef.shadowOverrideVarName =
-                differentStateVariablesInTarget[varInd];
+        if (stateVarObj.isArray) {
+            stateVarObj.shadowOverrideVarName = params.overrideVarName;
 
-            stateDef.returnArrayDependenciesByKey =
+            stateVarObj.returnArrayDependenciesByKey =
                 shadowReturnArrayDependenciesByKey;
-            stateDef.arrayDefinitionByKey = shadowArrayDefinitionByKey;
-            stateDef.inverseArrayDefinitionByKey =
+            stateVarObj.arrayDefinitionByKey = shadowArrayDefinitionByKey;
+            stateVarObj.inverseArrayDefinitionByKey =
                 shadowInverseArrayDefinitionByKey;
         } else {
-            if (foundReadyToExpandWhenResolved) {
+            if (params.keepOriginalDependencies) {
                 // even though won't use original dependencies
                 // if found a readyToExpandWhenResolved
                 // keep original dependencies so that readyToExpandWhenResolved
                 // won't be resolved until all its dependent variables are resolved
-                stateDef.shadowOriginalReturnDependencies =
-                    stateDef.returnDependencies.bind(stateDef);
+                stateVarObj.shadowOriginalReturnDependencies =
+                    originalReturnDependencies.bind(stateVarObj);
             }
 
-            stateDef.shadowVarNameInTarget =
-                differentStateVariablesInTarget[varInd] || varName;
+            stateVarObj.shadowVarNameInTarget =
+                params.overrideVarName || varName;
 
-            stateDef.returnDependencies = shadowReturnDependencies;
-            stateDef.definition = shadowDefinition;
-            stateDef.excludeDependencyValuesInInverseDefinition = true;
-            stateDef.inverseDefinition = shadowInverseDefinition;
+            stateVarObj.returnDependencies = shadowReturnDependencies;
+            stateVarObj.definition = shadowDefinition;
+            stateVarObj.excludeDependencyValuesInInverseDefinition = true;
+            stateVarObj.inverseDefinition = shadowInverseDefinition;
         }
     }
-    for (let varName in deleteStateVariablesFromDefinition) {
+
+    const deleteVars = stateVarObj.svShadowDeleteVars;
+    if (deleteVars) {
+        delete stateVarObj.svShadowDeleteVars;
         modifyStateDefToDeleteVariableReferences({
-            varNamesToDelete: deleteStateVariablesFromDefinition[varName],
-            stateDef: stateVariableDefinitions[varName],
+            varNamesToDelete: deleteVars,
+            stateDef: stateVarObj,
         });
     }
 }

--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -98,30 +98,37 @@ function getClassStateVariableDefinitions(core: Core, componentClass: any) {
 }
 
 /**
- * Shallow-clone a cached state-variable definition so the adapter /
- * reference-shadow code can freely assign and delete fields on it.
- * The nested fields those paths mutate in place (rather than reassign)
- * are cloned one level deeper.
+ * Wrap a cached state-variable definition in a per-instance prototype
+ * wrapper so the adapter / reference-shadow code can freely override
+ * fields on it: writes create own properties that shadow the shared
+ * definition, exactly like the wrappers `BaseComponent`'s constructor
+ * makes over class-shared definitions. (Removals must be written as
+ * `field = undefined` rather than `delete` — a delete of an inherited
+ * field is a no-op.)
+ *
+ * The nested fields the shadow paths mutate in place (rather than
+ * reassign) get their own per-instance copies, mirroring what the
+ * constructor does for class-shared definitions.
  */
-function cloneStateVariableDefinition(def: Record<string, any>) {
-    const clone = Object.assign({}, def);
-    if (clone.shadowingInstructions) {
-        clone.shadowingInstructions = Object.assign(
+function wrapStateVariableDefinition(def: Record<string, any>) {
+    const wrapper = Object.create(def);
+    if (def.shadowingInstructions) {
+        wrapper.shadowingInstructions = Object.assign(
             {},
-            clone.shadowingInstructions,
+            def.shadowingInstructions,
         );
     }
-    if (clone.additionalStateVariablesDefined) {
-        clone.additionalStateVariablesDefined = [
-            ...clone.additionalStateVariablesDefined,
+    if (def.additionalStateVariablesDefined) {
+        wrapper.additionalStateVariablesDefined = [
+            ...def.additionalStateVariablesDefined,
         ];
     }
-    if (clone.stateVariablesDeterminingDependencies) {
-        clone.stateVariablesDeterminingDependencies = [
-            ...clone.stateVariablesDeterminingDependencies,
+    if (def.stateVariablesDeterminingDependencies) {
+        wrapper.stateVariablesDeterminingDependencies = [
+            ...def.stateVariablesDeterminingDependencies,
         ];
     }
-    return clone;
+    return wrapper;
 }
 
 /**
@@ -210,10 +217,11 @@ export async function createStateVariableDefinitions({
     }
 
     // The adapter / reference-shadow paths mutate the definition objects,
-    // so give them per-instance clones of the class definitions.
+    // so give them per-instance prototype wrappers over the class
+    // definitions (own-property writes shadow the shared definition).
     let stateVariableDefinitions: Record<string, any> = {};
     for (const varName in classDefinitions.normalized) {
-        stateVariableDefinitions[varName] = cloneStateVariableDefinition(
+        stateVariableDefinitions[varName] = wrapStateVariableDefinition(
             classDefinitions.normalized[varName],
         );
     }
@@ -1093,12 +1101,16 @@ function modifyStateDefsToBeShadows({
                 }
             }
         }
-        delete stateDef.additionalStateVariablesDefined;
+        // assign `undefined` rather than `delete`: these definitions are
+        // prototype wrappers, so the field must be shadowed with an own
+        // property (a delete of an inherited field is a no-op); all
+        // consumers of both fields test truthiness, never presence
+        stateDef.additionalStateVariablesDefined = undefined;
         if (!foundReadyToExpandWhenResolved) {
             // if didn't find a readyToExpandWhenResolved,
-            // then won't use original dependencies so can delete any
+            // then won't use original dependencies so can remove any
             // stateVariablesDeterminingDependencies
-            delete stateDef.stateVariablesDeterminingDependencies;
+            stateDef.stateVariablesDeterminingDependencies = undefined;
         }
 
         let copyComponentType =

--- a/packages/doenetml-worker-javascript/src/core/StateVariableEvaluator.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableEvaluator.ts
@@ -1,6 +1,7 @@
 import type Core from "../Core";
 import type { ComponentInstance } from "../types/componentInstance";
 import type { ComponentIdx } from "@doenet/utils";
+import { ensureStateVariableMaterialized } from "./StateVariableInitializer";
 /**
  * Resolves a state variable's value: walks the dependency graph to gather
  * fresh inputs, invokes the variable's `definition` function (or
@@ -62,6 +63,14 @@ export class StateVariableEvaluator {
                 `Can't get value of ${stateVariable} of ${component.componentIdx} as it doesn't exist.`,
             );
         }
+
+        // first read of a placeholder builds the full runtime object
+        // (including its definition group) before anything below touches it
+        await ensureStateVariableMaterialized({
+            core: this.core,
+            component,
+            stateVariable,
+        });
 
         if (component.reprocessAfterEvaluate) {
             // This is a kludge

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -1,6 +1,7 @@
 import type Core from "../Core";
 import { deepClone, flattenDeep } from "@doenet/utils";
 import type { ComponentInstance } from "../types/componentInstance";
+import { applyPendingShadowModification } from "./StateVariableDefinitionFactory";
 import {
     returnDefaultArrayVarNameFromPropIndex,
     returnDefaultGetArrayKeysFromVarName,
@@ -1053,12 +1054,19 @@ export function normalizeArrayStateVariableDefaults(def: any, varName: string) {
     if (!def.returnEntryDimensions) {
         def.returnEntryDimensions = defaultReturnEntryDimensions;
     }
-    if (
-        def.shadowingInstructions &&
-        !def.shadowingInstructions.returnWrappingComponents
-    ) {
-        def.shadowingInstructions.returnWrappingComponents =
-            defaultReturnWrappingComponents;
+    if (def.shadowingInstructions) {
+        if (!def.shadowingInstructions.returnWrappingComponents) {
+            def.shadowingInstructions.returnWrappingComponents =
+                defaultReturnWrappingComponents;
+        }
+        // Precompute the whole-array wrapping components at class level:
+        // consumers (e.g. `allPotentialRendererTypes`, dependency setup on
+        // a producer, shadow serialization) read `wrappingComponents` off
+        // state-variable objects that may never materialize. The
+        // `returnWrappingComponents` implementations are pure functions of
+        // the entry prefix, so the result is class-invariant.
+        def.wrappingComponents =
+            def.shadowingInstructions.returnWrappingComponents();
     }
 }
 
@@ -1173,12 +1181,188 @@ export async function initializeComponentStateVariables({
             // TODO: do we want to delete alias from state?
             delete component.state[stateVariable];
         } else {
-            await initializeStateVariable({
+            initializeStateVariablePlaceholder({
                 core,
                 component,
                 stateVariable,
             });
         }
+    }
+}
+
+/**
+ * Give a state variable the minimal runtime shape it needs before it is
+ * ever used: the back-pointers the shared runtime functions read, the
+ * stale `value` getter (whose evaluation path materializes the variable),
+ * and — for arrays — the component's entry-prefix registration, which
+ * `checkIfArrayEntry` consults before any materialization.
+ *
+ * Everything else (nested per-instance field copies, workspaces, array
+ * machinery, the `__array_size_*` companion variable, pending shadow
+ * modifications) is deferred to `ensureStateVariableMaterialized`, so
+ * variables that are never demanded never pay for it.
+ */
+function initializeStateVariablePlaceholder({
+    core,
+    component,
+    stateVariable,
+}: {
+    core: Core;
+    component: ComponentInstance;
+    stateVariable: string;
+}) {
+    const stateVarObj = component.state[stateVariable];
+    stateVarObj.svComponent = component;
+    stateVarObj.svVarName = stateVariable;
+    stateVarObj.isResolved = false;
+    installStaleValueGetter(stateVarObj);
+
+    if (stateVarObj.isArray) {
+        // register entry prefixes up front: array-entry names must be
+        // recognizable (and creatable) before the array itself materializes
+        if (!component.arrayEntryPrefixes) {
+            component.arrayEntryPrefixes = {};
+        }
+        const entryPrefixes = stateVarObj.entryPrefixes ?? [stateVariable];
+        for (const prefix of entryPrefixes) {
+            component.arrayEntryPrefixes[prefix] = stateVariable;
+        }
+    }
+
+    if (stateVarObj.triggerActionOnChange) {
+        let componentTriggers =
+            core.stateVariableChangeTriggers[component.componentIdx];
+        if (!componentTriggers) {
+            componentTriggers = core.stateVariableChangeTriggers[
+                component.componentIdx
+            ] = {};
+        }
+        componentTriggers[stateVariable] = {
+            action: stateVarObj.triggerActionOnChange,
+        };
+    }
+}
+
+/**
+ * Build the full runtime state-variable object for `stateVariable` (and
+ * the rest of its definition group) if it is still a placeholder.
+ * Called on first demand: from the evaluator, from dependency setup, and
+ * from the inverse-definition/essential writers.
+ *
+ * Materializes in place — state-variable object identity never changes.
+ */
+export async function ensureStateVariableMaterialized({
+    core,
+    component,
+    stateVariable,
+}: {
+    core: Core;
+    component: ComponentInstance;
+    stateVariable: string;
+}) {
+    const stateVarObj = component.state[stateVariable];
+    if (
+        !stateVarObj ||
+        stateVarObj.svMaterialized ||
+        stateVarObj.isArrayEntry
+    ) {
+        // absent names error downstream exactly as before; array entries
+        // are fully built by `createFromArrayEntry`
+        return;
+    }
+
+    // Copy nested definition fields that get mutated in place, then apply
+    // any shadow modifications planned at construction. Order matters: the
+    // shadow application can sever the `additionalStateVariablesDefined`
+    // group (writing an own `undefined` over the copy), and the group
+    // below must be the effective, post-shadow one.
+    materializeNestedDefinitionFields(stateVarObj);
+    applyPendingShadowModification(stateVarObj);
+
+    const allStateVariablesAffected = [stateVariable];
+    if (stateVarObj.additionalStateVariablesDefined) {
+        allStateVariablesAffected.push(
+            ...stateVarObj.additionalStateVariablesDefined,
+        );
+    }
+
+    // mark the whole group before any await so a re-entrant demand during
+    // array initialization cannot materialize the group twice
+    for (const varName of allStateVariablesAffected) {
+        const obj = component.state[varName];
+        if (obj) {
+            obj.svMaterialized = true;
+        }
+    }
+    core.dependencies.numMaterializedStateVariables +=
+        allStateVariablesAffected.length;
+
+    // definitions with createWorkspace share one workspace per group
+    let workspace: Record<string, any> | undefined;
+
+    for (const varName of allStateVariablesAffected) {
+        const obj = component.state[varName];
+        if (!obj) {
+            continue;
+        }
+        if (varName !== stateVariable) {
+            materializeNestedDefinitionFields(obj);
+            applyPendingShadowModification(obj);
+        }
+        if (obj.createWorkspace) {
+            if (!workspace) {
+                workspace = {};
+            }
+            obj.workspace = workspace;
+        }
+        await initializeStateVariable({
+            core,
+            component,
+            stateVariable: varName,
+        });
+    }
+}
+
+/**
+ * Nested definition fields that get mutated in place at runtime need
+ * per-instance copies; a prototype read would hand back the shared
+ * (class-level) object. Skips fields that already have own values —
+ * including own `undefined` written by the shadow machinery.
+ */
+function materializeNestedDefinitionFields(stateVarObj: any) {
+    if (
+        stateVarObj.shadowingInstructions &&
+        !Object.prototype.hasOwnProperty.call(
+            stateVarObj,
+            "shadowingInstructions",
+        )
+    ) {
+        stateVarObj.shadowingInstructions = Object.assign(
+            {},
+            stateVarObj.shadowingInstructions,
+        );
+    }
+    if (
+        stateVarObj.additionalStateVariablesDefined &&
+        !Object.prototype.hasOwnProperty.call(
+            stateVarObj,
+            "additionalStateVariablesDefined",
+        )
+    ) {
+        stateVarObj.additionalStateVariablesDefined = [
+            ...stateVarObj.additionalStateVariablesDefined,
+        ];
+    }
+    if (
+        stateVarObj.stateVariablesDeterminingDependencies &&
+        !Object.prototype.hasOwnProperty.call(
+            stateVarObj,
+            "stateVariablesDeterminingDependencies",
+        )
+    ) {
+        stateVarObj.stateVariablesDeterminingDependencies = [
+            ...stateVarObj.stateVariablesDeterminingDependencies,
+        ];
     }
 }
 
@@ -1206,6 +1390,9 @@ export async function initializeStateVariable({
     stateVarObj.svComponent = component;
     stateVarObj.svVarName = stateVariable;
     stateVarObj.isResolved = false;
+    // this function fully builds the runtime object, so anything it
+    // touches (array-size variables, array entries) is materialized
+    stateVarObj.svMaterialized = true;
     installStaleValueGetter(stateVarObj);
 
     if (arrayEntryPrefix !== undefined) {
@@ -1235,9 +1422,15 @@ export async function initializeStateVariable({
                 component.componentIdx
             ] = {};
         }
-        componentTriggers[stateVariable] = {
-            action: stateVarObj.triggerActionOnChange,
-        };
+        if (!componentTriggers[stateVariable]) {
+            // don't replace an existing record: the placeholder pass
+            // registers the trigger at construction, and the poller stores
+            // `previousValue` on the record — replacing it at
+            // materialization would swallow a value transition
+            componentTriggers[stateVariable] = {
+                action: stateVarObj.triggerActionOnChange,
+            };
+        }
     }
 }
 
@@ -1640,13 +1833,11 @@ async function initializeArrayStateVariable({
         // before calculating wrapping components.
         // We should rework wrapping components (and other array features)
         // to make array indexing (maybe even including slices) be the basis.
-
-        if (!stateVarObj.shadowingInstructions.returnWrappingComponents) {
-            stateVarObj.shadowingInstructions.returnWrappingComponents =
-                defaultReturnWrappingComponents;
-        }
-        stateVarObj.wrappingComponents =
-            stateVarObj.shadowingInstructions.returnWrappingComponents();
+        //
+        // The default returnWrappingComponents and the whole-array
+        // `wrappingComponents` are installed at class level by
+        // `normalizeArrayStateVariableDefaults`, so nothing is (re)computed
+        // per instance here.
     }
 
     stateVarObj.usedDefaultByArrayKey = {};

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -2,7 +2,10 @@ import { deepClone } from "@doenet/utils";
 import type { ComponentIdx } from "@doenet/utils";
 import type { ComponentInstance } from "../../types/componentInstance";
 import type { DependencyHandler } from "./DependencyHandler";
-import { arrayEntryNamesFromPropIndex } from "../StateVariableInitializer";
+import {
+    arrayEntryNamesFromPropIndex,
+    ensureStateVariableMaterialized,
+} from "../StateVariableInitializer";
 
 /**
  * Base class shared by every concrete dependency type. Concrete subclasses
@@ -403,15 +406,33 @@ export class Dependency {
             });
 
             if ((this.constructor as typeof Dependency).convertToArraySize) {
-                mappedVarNames = mappedVarNames.map(function (vName: string) {
+                // `arraySizeStateVariable` exists only once the array has
+                // materialized, so build arrays before converting names
+                // (which is why this is a loop rather than a sync map)
+                const convertedVarNames: string[] = [];
+                for (const vName of mappedVarNames) {
                     let stateVarObj = downComponent.state[vName];
                     if (stateVarObj) {
-                        if (stateVarObj.arraySizeStateVariable) {
-                            return stateVarObj.arraySizeStateVariable;
-                        } else {
-                            return `__${vName}_is_not_an_array`;
+                        if (stateVarObj.isArray) {
+                            await ensureStateVariableMaterialized({
+                                core: this.dependencyHandler.core,
+                                component: downComponent,
+                                stateVariable: vName,
+                            });
                         }
+                        if (stateVarObj.arraySizeStateVariable) {
+                            convertedVarNames.push(
+                                stateVarObj.arraySizeStateVariable,
+                            );
+                        } else {
+                            convertedVarNames.push(
+                                `__${vName}_is_not_an_array`,
+                            );
+                        }
+                        continue;
                     }
+
+                    let converted = `__${vName}_is_not_an_array`;
 
                     // check if vName begins when an arrayEntry
                     if (downComponent.arrayEntryPrefixes) {
@@ -440,15 +461,22 @@ export class Dependency {
                                     });
 
                                 if (arrayKeys.length > 0) {
-                                    return downComponent.state[
-                                        arrayVariableName
-                                    ].arraySizeStateVariable;
+                                    await ensureStateVariableMaterialized({
+                                        core: this.dependencyHandler.core,
+                                        component: downComponent,
+                                        stateVariable: arrayVariableName,
+                                    });
+                                    converted =
+                                        downComponent.state[arrayVariableName]
+                                            .arraySizeStateVariable;
+                                    break;
                                 }
                             }
                         }
                     }
-                    return `__${vName}_is_not_an_array`;
-                });
+                    convertedVarNames.push(converted);
+                }
+                mappedVarNames = convertedVarNames;
             }
 
             if (this.propIndex !== undefined) {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/DependencyHandler.ts
@@ -14,7 +14,10 @@ import {
     expandCompositeComponent,
     recursivelyReplaceCompositesWithReplacements,
 } from "../CompositeExpander";
-import { arrayEntryNamesFromPropIndex } from "../StateVariableInitializer";
+import {
+    arrayEntryNamesFromPropIndex,
+    ensureStateVariableMaterialized,
+} from "../StateVariableInitializer";
 import {
     ancestorsIncludingComposites,
     gatherDescendants,
@@ -150,6 +153,12 @@ export class DependencyHandler {
      * (on demand). Diagnostic counter for the lazy-materialization work.
      */
     numDependencySetups: number;
+    /**
+     * Number of state variables materialized from placeholders (grouped
+     * with `numDependencySetups` for the lazy-materialization work; lives
+     * here so it survives per-core, not per-module).
+     */
+    numMaterializedStateVariables: number;
 
     constructor({
         _components,
@@ -190,6 +199,7 @@ export class DependencyHandler {
         };
 
         this.numDependencySetups = 0;
+        this.numMaterializedStateVariables = 0;
 
         this.attributeRefResolutionDependenciesByReferenced = {};
 
@@ -410,6 +420,15 @@ export class DependencyHandler {
         ) {
             return;
         }
+
+        // materialize before reading the definition group below: pending
+        // shadow modifications can sever `additionalStateVariablesDefined`,
+        // and `returnDependencies` must be the effective (post-shadow) one
+        await ensureStateVariableMaterialized({
+            core: this.core,
+            component,
+            stateVariable,
+        });
 
         // Every member of an `additionalStateVariablesDefined` group lists
         // its siblings (see `returnNormalizedStateVariableDefinitions`),

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/lazyStateVariables.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/lazyStateVariables.test.ts
@@ -112,4 +112,26 @@ describe("Lazy state variable tests @group4", async () => {
             stateVariables[await resolvePathToNodeIdx("n")].stateValues.value,
         ).eq(8);
     });
+
+    it("array entry of a never-rendered shadow list materializes on demand", async () => {
+        // `ml2` shadows `ml` and is never rendered, so its array object stays
+        // a placeholder with its shadow modification only planned. Demanding a
+        // single entry (`$ml2[2]`) must apply that plan (the array-shadow
+        // definition) and build just that entry — exercising the lazy shadow
+        // path for arrays, which the scalar cases above do not reach.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <setup>
+      <mathList name="ml">a b c</mathList>
+      <mathList extend="$ml" name="ml2" />
+    </setup>
+    <p name="p">second: $ml2[2]</p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p")].stateValues.text,
+        ).eq("second: b");
+    });
 });


### PR DESCRIPTION
Builds on #1480 (now merged) to complete the lazy state-variable materialization project: component construction now creates lightweight placeholders instead of fully-built state-variable objects, and everything else is built at first demand. Closes #1459 (part of #1441 stream D).

## What changes

**Shadow definition clones become prototype wrappers.** Adapter and reference-shadow components no longer get a full `Object.assign` clone of every state-variable definition: they get the same prototype-wrapper treatment `BaseComponent`'s constructor applies to class-shared definitions, with the adapter/shadow overrides written as own properties. The two `delete`s in `modifyStateDefsToBeShadows` become `= undefined` assignments (a delete of an inherited field is a no-op; all consumers of both fields test truthiness, never presence).

**Placeholder state-variable objects.** A placeholder is the prototype wrapper plus the back-pointers, the stale `value` getter, entry-prefix registration for arrays, and trigger-on-change registration. Deferred to `ensureStateVariableMaterialized` at first demand: per-instance copies of nested mutable definition fields, workspaces, the array machinery, the `__array_size_*` companion variable, and the shadow modifications.

- Shadow modifications are **planned eagerly, applied lazily**: `modifyStateDefsToBeShadows` records compact `svShadowParams` / `svShadowDeleteVars` markers plus the eager own `isShadow` flag (chained-copy scans over a target's state read it before materialization); `applyPendingShadowModification` executes the deferred mutations.
- Whole-array `wrappingComponents` moves to the per-class definition normalization (the `returnWrappingComponents` implementations are pure functions of the entry prefix), so consumers like `allPotentialRendererTypes` can read it off never-materialized variables.
- Materialization triggers: the evaluator, dependency setup (which must see the effective post-shadow definition group), the inverse-definition and essential-value writers, array-entry creation, and the `convertToArraySize` name mapping (now an async loop, since `arraySizeStateVariable` exists only after the array materializes).
- Trigger-on-change registration became idempotent: re-registering at materialization previously replaced the record carrying the poller's `previousValue`, swallowing a value transition.

## Measurements (repeat-250, same machine, main vs this branch)

| Metric | main | branch |
|---|---|---|
| Node worker heap on document load | 1691 MB | 726 MB (**−57%**) |
| Document load time | 40.2 s | 16.8 s (**−58%**) |
| State-variable objects materialized after load | 704,514 (all) | 127,619 of 699,264 (**18%**) |
| `neededToResolve` ledger entries after load | 205,535 | 0 |
| Browser PSS, repeat-250 | ~1267 MB (post-#1462 records, ±35) | **958 MB** |
| Document-scaling cost | ~0.58 MB/component | **~0.37 MB/component** |

Browser numbers from `packages/memory-benchmark` (`--only repeat`); this session also measured direct-1 at 492 MB and repeat-25 at 570 MB. Document construction gets faster because setup work for never-used variables is skipped, contributing to the startup-time goal of #1441, not just memory.

## Validation

- Targeted local vitest (~1,000 tests) across shadow chains, arrays, triggers, inverse definitions, essential restore, composites, variants, and circular-error diagnostics; full groups run in CI on this PR.
- Dedicated `lazyStateVariables` regressions pin the never-demanded paths, including array-entry materialization of a never-rendered shadow list (a case the scalar tests do not reach).
- Diagnostic counters on `DependencyHandler`: `numDependencySetups`, `numMaterializedStateVariables`.
- Typecheck unchanged from baseline (35 pre-existing errors, none in touched files).

Closes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
