### PR TITLE
Show graph-label mask border only while hovering a draggable object

### DIFF
--- a/.changeset/legible-graph-labels.md
+++ b/.changeset/legible-graph-labels.md
@@ -6,7 +6,7 @@
 "doenet-vscode-extension": patch
 ---
 
-Graph labels now render with an opaque background by default so they stay legible when they overlap an axis, grid line, or another object. Hovering or dragging the labeled object raises the label's background/border further so overlapping labels stay readable.
+Graph labels now render with an opaque background by default so they stay legible when they overlap an axis, grid line, or another object. Labels show no border at rest; hovering a draggable object outlines its label as a cue that the object can be dragged.
 
 Previously, labels had a transparent background, so a label positioned over an axis or another graphical object could become unreadable.
 

--- a/packages/doenetml/src/Viewer/renderers/angle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/angle.tsx
@@ -266,7 +266,6 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
             if (angleJXG.current.hasLabel && angleJXG.current.label) {
                 angleJXG.current.label.needsUpdate = true;
                 syncLabelMaskCssStyle(angleJXG.current.label, SVs.layer, {
-                    highlighted: angleJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
                 angleJXG.current.label.update();

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -790,7 +790,6 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                 const label = circleJXG.current.label;
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, lineColor);
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: circleJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
                 label.needsUpdate = true;
@@ -867,7 +866,6 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                         markerColor,
                     );
                     syncLabelMaskCssStyle(label, SVs.layer, {
-                        highlighted: indicatorJXG.current.highlighted,
                         maskLabel: SVs.maskLabel,
                     });
 

--- a/packages/doenetml/src/Viewer/renderers/cobwebPolyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/cobwebPolyline.tsx
@@ -465,7 +465,6 @@ export default React.memo(function CobwebPolyline(
             }
             if (polylineJXG.current.hasLabel && polylineJXG.current.label) {
                 syncLabelMaskCssStyle(polylineJXG.current.label, SVs.layer, {
-                    highlighted: polylineJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
             }
@@ -477,7 +476,6 @@ export default React.memo(function CobwebPolyline(
                 });
                 if (lastPoint.label) {
                     syncLabelMaskCssStyle(lastPoint.label, SVs.layer, {
-                        highlighted: lastPoint.highlighted,
                         maskLabel: SVs.maskLabel,
                     });
                     lastPoint.label.needsUpdate = true;

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -909,7 +909,6 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
                 label.visPropCalc.visible = SVs.labelForGraph !== "";
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, lineColor);
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: curveJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
                 label.update();

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -105,6 +105,11 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             // combines with the background alpha and makes the highlighted
             // mask look transparent (jsxgraph issue #777). Force it to 1.
             highlightStrokeOpacity: 1,
+            // JSXGraph's native hover highlight applies the bordered mask
+            // style on hover, gated on `highlight` — enabled only when the
+            // label is draggable. Native highlight clears reliably on
+            // pointer-out (via the board's dehighlightAll), unlike a custom
+            // over/out on this HTML-overlay text element.
             highlight: !fixLocation.current,
             useMathJax: SVs.hasLatex,
             parse: false,

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -322,7 +322,6 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
                 label.needsUpdate = true;
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, lineColor);
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: lineJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
 

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -491,7 +491,6 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
                 label.needsUpdate = true;
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, lineColor);
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: lineSegmentJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
 

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -368,19 +368,9 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                     shadowPointJXG.current.visProp.highlightstrokeopacity =
                         pointJXG.current.visProp.strokeopacity;
                 }
-                // Raise the label's mask style while dragging, since the
-                // pointer may not stay over the shadow point (which drives
-                // "over"/"out") during a drag. See attachLabelHoverHighlight.
-                if (pointJXG.current?.label) {
-                    const label = pointJXG.current.label;
-                    label.visProp.cssstyle = computeLabelMaskCssStyle({
-                        layer: SVs.layer,
-                        masked: SVs.maskLabel,
-                    }).highlightCssStyle;
-                    label.needsUpdate = true;
-                    label.update();
-                    board.updateRenderer();
-                }
+                // The label's hover mask style (border + raised z-index) is
+                // driven centrally by `attachLabelHoverHighlight` on the shadow
+                // point's over/out events, so nothing to do here.
             },
             onUpExtra: () => {
                 if (
@@ -389,25 +379,6 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                 ) {
                     shadowPointJXG.current.visProp.highlightfillopacity = 0;
                     shadowPointJXG.current.visProp.highlightstrokeopacity = 0;
-                }
-                if (pointJXG.current?.label) {
-                    const label = pointJXG.current.label;
-                    const { cssStyle, highlightCssStyle } =
-                        computeLabelMaskCssStyle({
-                            layer: SVs.layer,
-                            masked: SVs.maskLabel,
-                        });
-                    // If the pointer is still over the shadow point when the
-                    // drag ends, keep the highlighted mask: the "out" handler
-                    // won't re-fire (the pointer never left), so reverting to
-                    // the base style here would leave the label un-highlighted
-                    // while still hovered.
-                    label.visProp.cssstyle = shadowPointJXG.current?.highlighted
-                        ? highlightCssStyle
-                        : cssStyle;
-                    label.needsUpdate = true;
-                    label.update();
-                    board.updateRenderer();
                 }
             },
             onHitExtra: () => {
@@ -615,10 +586,8 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, markerColor);
                 // Keep the point's label mask (and its live `highlightcssstyle`,
                 // which `attachLabelHoverHighlight` reads on hover) in sync with
-                // the current layer. Use the shadow point's highlight state,
-                // since that is what drives the point's hover/drag highlighting.
+                // the current layer, preserving an active hover highlight.
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: shadowPointJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
 

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -633,7 +633,6 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 const label = polygonJXG.current.label;
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, lineColor);
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: polygonJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
                 label.needsUpdate = true;

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -550,7 +550,6 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
                 const label = polylineJXG.current.label;
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, lineColor);
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: polylineJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
                 label.needsUpdate = true;

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -323,7 +323,6 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
                 const label = rayJXG.current.label;
                 syncLabelStrokeColor(label, SVs.applyStyleToLabel, lineColor);
                 syncLabelMaskCssStyle(label, SVs.layer, {
-                    highlighted: rayJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
 

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
@@ -211,7 +211,6 @@ export default React.memo(function RegionBetweenCurveXAxis(
 
             if (integralJXG.current.hasLabel && integralJXG.current.label) {
                 syncLabelMaskCssStyle(integralJXG.current.label, SVs.layer, {
-                    highlighted: integralJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
             }

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
@@ -288,7 +288,6 @@ export default React.memo(function RegionBetweenCurves(
 
             if (regionJXG.current.hasLabel && regionJXG.current.label) {
                 syncLabelMaskCssStyle(regionJXG.current.label, SVs.layer, {
-                    highlighted: regionJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
             }

--- a/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
@@ -907,8 +907,8 @@ export function syncLabelStrokeColor(
  * Since these object-attached labels are created with `highlight: false`,
  * JSXGraph never automatically applies `highlightcssstyle`; instead,
  * `attachLabelHoverHighlight` directly toggles `label.visProp.cssstyle`
- * between the returned `cssStyle` and `highlightCssStyle` on the object's /
- * label's over/out events.
+ * between the returned `cssStyle` and `highlightCssStyle` on the object's
+ * over/out events.
  *
  * This preserves an active hover highlight across a re-render: the hover
  * handler records its desired state on `label.visProp.labelMaskHovered`, and

--- a/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
@@ -907,27 +907,30 @@ export function syncLabelStrokeColor(
  * Since these object-attached labels are created with `highlight: false`,
  * JSXGraph never automatically applies `highlightcssstyle`; instead,
  * `attachLabelHoverHighlight` directly toggles `label.visProp.cssstyle`
- * between the returned `cssStyle` and `highlightCssStyle` when the object
- * is hovered/dragged. Pass `highlighted: true` (e.g. from the object's own
- * `.highlighted` flag) when syncing mid-render so an active hover/drag
- * highlight isn't clobbered back to the non-highlighted style.
+ * between the returned `cssStyle` and `highlightCssStyle` on the object's /
+ * label's over/out events.
+ *
+ * This preserves an active hover highlight across a re-render: the hover
+ * handler records its desired state on `label.visProp.labelMaskHovered`, and
+ * we re-apply the freshly recomputed highlight style when it is set rather
+ * than clobbering the border back to the base style.
  */
 export function syncLabelMaskCssStyle(
     label: { visProp: Record<string, any> },
     layer: number,
     options: {
         backgroundColor?: string;
-        highlighted?: boolean;
         maskLabel?: boolean;
     } = {},
 ): { cssStyle: string; highlightCssStyle: string } {
-    const { backgroundColor, highlighted, maskLabel = true } = options;
+    const { backgroundColor, maskLabel = true } = options;
     const { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
         layer,
         backgroundColor,
         masked: maskLabel,
     });
-    label.visProp.cssstyle = highlighted ? highlightCssStyle : cssStyle;
+    const hovered = label.visProp.labelMaskHovered === true;
+    label.visProp.cssstyle = hovered ? highlightCssStyle : cssStyle;
     label.visProp.highlightcssstyle = highlightCssStyle;
     label.visProp.highlightstrokeopacity = 1;
     return { cssStyle, highlightCssStyle };

--- a/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.test.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.test.ts
@@ -46,26 +46,31 @@ describe("computeLabelMaskCssStyle", () => {
         expect(highlightCssStyle).not.toContain("transparent");
     });
 
-    it("raises the z-index and darkens the border on highlight", () => {
+    it("has no visible border in the base style; only the hover style is bordered", () => {
         const { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
             layer: 0,
         });
-        // Highlighted label sits above non-highlighted siblings.
-        expect(zIndexOf(highlightCssStyle)).toBeGreaterThan(zIndexOf(cssStyle));
-        // Border alpha increases from 0.3 (base) to 0.8 (highlight).
-        expect(cssStyle).toContain("rgba(128, 128, 128, 0.3)");
+        // Un-hovered labels show no border, so they look identical whether or
+        // not masking is enabled (until they overlap something). The base
+        // style explicitly resets `border`, since JSXGraph applies css
+        // additively and would otherwise leave a prior hover border stuck.
+        expect(cssStyle).toContain("border: none");
+        expect(cssStyle).not.toContain("solid");
+        // The hover style gains a visible border as a "draggable" cue...
         expect(highlightCssStyle).toContain("rgba(128, 128, 128, 0.8)");
+        // ...and sits above non-hovered siblings.
+        expect(zIndexOf(highlightCssStyle)).toBeGreaterThan(zIndexOf(cssStyle));
     });
 
-    it("orders z-index by layer within each of the base and highlight bands", () => {
+    it("orders z-index by layer within each of the base and hover bands", () => {
         const low = computeLabelMaskCssStyle({ layer: 0 });
         const high = computeLabelMaskCssStyle({ layer: 5 });
         expect(zIndexOf(high.cssStyle)).toBeGreaterThan(zIndexOf(low.cssStyle));
         expect(zIndexOf(high.highlightCssStyle)).toBeGreaterThan(
             zIndexOf(low.highlightCssStyle),
         );
-        // A highlighted label always outranks a non-highlighted one, even a
-        // non-highlighted label on a higher layer.
+        // A hovered label always outranks a non-hovered one, even a
+        // non-hovered label on a higher layer.
         expect(zIndexOf(low.highlightCssStyle)).toBeGreaterThan(
             zIndexOf(high.cssStyle),
         );
@@ -80,8 +85,8 @@ describe("computeLabelMaskCssStyle", () => {
             expect(cssStyle).toContain("background-color: transparent");
             expect(cssStyle).not.toContain("border");
             expect(cssStyle).not.toContain("z-index");
-            // Base and highlight are identical, so hovering/dragging the
-            // labeled object leaves the label unchanged.
+            // Base and hover are identical, so hovering the labeled object
+            // leaves the label unchanged.
             expect(highlightCssStyle).toBe(cssStyle);
         });
 
@@ -99,24 +104,31 @@ describe("computeLabelMaskCssStyle", () => {
 });
 
 describe("attachLabelHoverHighlight", () => {
-    function makeHarness() {
-        const handlers: Record<string, () => void> = {};
+    function makeHarness({
+        isDraggable = true,
+    }: { isDraggable?: boolean } = {}) {
+        const objectHandlers: Record<string, () => void> = {};
+        const labelHandlers: Record<string, () => void> = {};
         const label = {
             visProp: {} as Record<string, any>,
             needsUpdate: false,
             update: vi.fn(),
+            on: (event: string, fn: () => void) => {
+                labelHandlers[event] = fn;
+            },
         };
         const hoverTargetJXG = {
+            isDraggable,
             on: (event: string, fn: () => void) => {
-                handlers[event] = fn;
+                objectHandlers[event] = fn;
             },
         };
         const board = { updateRenderer: vi.fn() };
-        return { handlers, label, hoverTargetJXG, board };
+        return { objectHandlers, labelHandlers, label, hoverTargetJXG, board };
     }
 
-    it("applies the highlight style on over and the base style on out", () => {
-        const { handlers, label, hoverTargetJXG, board } = makeHarness();
+    it("shows the highlight on over and restores the base on out", () => {
+        const { objectHandlers, label, hoverTargetJXG, board } = makeHarness();
         const { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
             layer: 0,
         });
@@ -129,16 +141,60 @@ describe("attachLabelHoverHighlight", () => {
             board,
         });
 
-        handlers.over();
+        objectHandlers.over();
         expect(label.visProp.cssstyle).toBe(highlightCssStyle);
+        expect(label.visProp.labelMaskHovered).toBe(true);
         expect(board.updateRenderer).toHaveBeenCalled();
 
-        handlers.out();
+        objectHandlers.out();
         expect(label.visProp.cssstyle).toBe(cssStyle);
+        expect(label.visProp.labelMaskHovered).toBe(false);
+    });
+
+    it("does not show a border when the object is not draggable", () => {
+        const { objectHandlers, label, hoverTargetJXG, board } = makeHarness({
+            isDraggable: false,
+        });
+        const { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
+            layer: 0,
+        });
+
+        attachLabelHoverHighlight({
+            hoverTargetJXG,
+            getLabelJXG: () => label,
+            cssStyle,
+            highlightCssStyle,
+            board,
+        });
+
+        objectHandlers.over();
+        expect(label.visProp.cssstyle).not.toBe(highlightCssStyle);
+        expect(label.visProp.labelMaskHovered).toBe(false);
+    });
+
+    it("does not light the border when only the label (not the object) is hovered", () => {
+        const { objectHandlers, labelHandlers, label, hoverTargetJXG, board } =
+            makeHarness();
+        const { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
+            layer: 0,
+        });
+
+        attachLabelHoverHighlight({
+            hoverTargetJXG,
+            getLabelJXG: () => label,
+            cssStyle,
+            highlightCssStyle,
+            board,
+        });
+
+        // The helper wires only the object's over/out; hovering the label
+        // itself is never observed and must not show the border.
+        expect(labelHandlers.over).toBeUndefined();
+        expect(label.visProp.cssstyle).not.toBe(highlightCssStyle);
     });
 
     it("prefers the label's live highlightcssstyle so layer changes are reflected on hover", () => {
-        const { handlers, label, hoverTargetJXG, board } = makeHarness();
+        const { objectHandlers, label, hoverTargetJXG, board } = makeHarness();
         const stale = computeLabelMaskCssStyle({ layer: 0 });
         const fresh = computeLabelMaskCssStyle({ layer: 7 });
 
@@ -154,13 +210,13 @@ describe("attachLabelHoverHighlight", () => {
         // label's highlight style after a runtime layer change.
         label.visProp.highlightcssstyle = fresh.highlightCssStyle;
 
-        handlers.over();
+        objectHandlers.over();
         expect(label.visProp.cssstyle).toBe(fresh.highlightCssStyle);
         expect(label.visProp.cssstyle).not.toBe(stale.highlightCssStyle);
     });
 
     it("does nothing when the label does not yet exist", () => {
-        const { handlers, hoverTargetJXG, board } = makeHarness();
+        const { objectHandlers, hoverTargetJXG, board } = makeHarness();
         const { cssStyle, highlightCssStyle } = computeLabelMaskCssStyle({
             layer: 0,
         });
@@ -173,7 +229,7 @@ describe("attachLabelHoverHighlight", () => {
             board,
         });
 
-        expect(() => handlers.over()).not.toThrow();
+        expect(() => objectHandlers.over()).not.toThrow();
         expect(board.updateRenderer).not.toHaveBeenCalled();
     });
 });

--- a/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.ts
@@ -9,7 +9,6 @@ export interface LabelLikeJXG {
     visProp: Record<string, any>;
     needsUpdate: boolean;
     update: () => void;
-    on?: (event: string, fn: () => void) => void;
 }
 
 /**
@@ -30,11 +29,12 @@ export interface LabelLikeJXG {
  * or not masking is enabled (until it overlaps something, where the opaque
  * background keeps it legible). The label gains a visible border (and a
  * raised z-index so it rises above other overlapping labels/objects) only
- * while the pointer is over a *draggable* object or its label — a hover cue
- * that the object can be grabbed. That hover styling is applied by
- * `attachLabelHoverHighlight` below, which toggles the label between
- * `cssStyle` and `highlightCssStyle` on the object's / label's over/out
- * events.
+ * while the pointer is over the *draggable* object it labels — a hover cue
+ * that the object can be grabbed. For an object-attached label that styling
+ * is applied by `attachLabelHoverHighlight` below, which toggles the label
+ * between `cssStyle` and `highlightCssStyle` on the object's over/out events.
+ * A standalone `<label>`, which the user drags directly, instead gets
+ * `highlightCssStyle` from JSXGraph's own native hover highlight.
  *
  * NOTE: jsxgraph's own `highlightStrokeOpacity` for text elements defaults
  * to a non-1 value, which combines with any alpha in the background color

--- a/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.ts
@@ -107,9 +107,11 @@ export function computeLabelMaskCssStyle({
  * `dragToTopOfLayer`, which does not yet support labels in any published
  * release (see the note in `computeLabelMaskCssStyle` above).
  *
- * The highlight is gated on `hoverTargetJXG.isDraggable` (which every renderer
- * keeps in sync with the component's `fixed`/`fixLocation` state), so the
- * border acts as a "you can grab this" cue and never appears on fixed objects.
+ * The highlight is gated on `hoverTargetJXG.isDraggable`: renderers whose
+ * objects can be dragged set it from the component's `fixed`/`fixLocation`
+ * state, while object types that are never draggable (curves, regions, angles)
+ * keep JSXGraph's own `false` default. Either way the border acts as a "you can
+ * grab this" cue and never appears on a fixed or otherwise non-draggable object.
  *
  * Only the *object's* own `over`/`out` drive the border — hovering the label
  * itself does nothing. An object-attached label can only be moved by dragging

--- a/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/labelMaskStyle.ts
@@ -9,6 +9,7 @@ export interface LabelLikeJXG {
     visProp: Record<string, any>;
     needsUpdate: boolean;
     update: () => void;
+    on?: (event: string, fn: () => void) => void;
 }
 
 /**
@@ -24,9 +25,16 @@ export interface LabelLikeJXG {
  * `selectedStyle.backgroundColor`), that color is used instead so an
  * explicit author choice is respected.
  *
- * On highlight (hovering the label, or hovering/dragging the object the
- * label belongs to), the border darkens and the z-index is raised so the
- * label rises above other overlapping labels/objects.
+ * The base style intentionally has NO border: with a `var(--canvas)`
+ * background that already matches the graph, a label looks identical whether
+ * or not masking is enabled (until it overlaps something, where the opaque
+ * background keeps it legible). The label gains a visible border (and a
+ * raised z-index so it rises above other overlapping labels/objects) only
+ * while the pointer is over a *draggable* object or its label — a hover cue
+ * that the object can be grabbed. That hover styling is applied by
+ * `attachLabelHoverHighlight` below, which toggles the label between
+ * `cssStyle` and `highlightCssStyle` on the object's / label's over/out
+ * events.
  *
  * NOTE: jsxgraph's own `highlightStrokeOpacity` for text elements defaults
  * to a non-1 value, which combines with any alpha in the background color
@@ -38,8 +46,8 @@ export interface LabelLikeJXG {
  * `dragToTopOfLayer` support for labels (commit `2a498682884c`,
  * https://github.com/jsxgraph/jsxgraph/issues/778), we should switch to
  * `dragToTopOfLayer: true` on labels instead of manually wiring
- * over/out/drag-start/drag-end listeners to raise/lower z-index, as is done
- * with `attachLabelHoverHighlight` below. As of jsxgraph 1.12.2 (the latest
+ * over/out listeners to raise/lower z-index, as is done with
+ * `attachLabelHoverHighlight` below. As of jsxgraph 1.12.2 (the latest
  * published release at the time this was written), that fix has not yet
  * shipped.
  *
@@ -47,8 +55,8 @@ export interface LabelLikeJXG {
  * component), the mask is disabled and this restores the pre-mask behavior:
  * a transparent background (or the explicit style-definition
  * `backgroundColor`, if one is set), no border, no z-index bump, and a
- * highlight style identical to the base style so hovering/dragging leaves
- * the label unchanged.
+ * highlight style identical to the base style so hovering leaves the label
+ * unchanged.
  */
 export function computeLabelMaskCssStyle({
     layer,
@@ -68,9 +76,9 @@ export function computeLabelMaskCssStyle({
     // Labels are HTML elements overlaid on the JSXGraph board. The base
     // z-index lifts a label just above sibling labels/objects on the same
     // Doenet layer without escaping the board's own stacking context, while
-    // the highlight z-index lifts a hovered/dragged label clearly above the
-    // others. `+ layer` preserves the relative ordering of Doenet layers in
-    // both states. Two non-highlighted labels on the same layer intentionally
+    // the highlight z-index lifts a hovered label clearly above the others.
+    // `+ layer` preserves the relative ordering of Doenet layers in both
+    // states. Two non-highlighted labels on the same layer intentionally
     // share a z-index, so their DOM order breaks the tie. The base offset (9)
     // and highlight offset (100) are chosen to leave headroom between the two
     // bands for the small per-layer increments.
@@ -81,28 +89,44 @@ export function computeLabelMaskCssStyle({
     // treat any falsy value as "no explicit color".
     const background = backgroundColor || "var(--canvas)";
 
-    const cssStyle = `background-color: ${background}; border: 1px solid rgba(128, 128, 128, 0.3); border-radius: 3px; z-index: ${baseZIndex};`;
+    // JSXGraph's `updateTextStyle` applies a label's css string *additively*:
+    // it sets each declared property on the DOM node but never removes a
+    // property the previous style declared. So the base style must explicitly
+    // reset `border`/`border-radius` — omitting them would leave the hover
+    // border stuck on the element after the pointer leaves.
+    const cssStyle = `background-color: ${background}; border: none; border-radius: 0; z-index: ${baseZIndex};`;
     const highlightCssStyle = `background-color: ${background}; border: 1px solid rgba(128, 128, 128, 0.8); border-radius: 3px; z-index: ${highlightZIndex};`;
 
     return { cssStyle, highlightCssStyle };
 }
 
 /**
- * Wires up "over"/"out" handlers on `hoverTargetJXG` (e.g. a point, line, or
- * other graphical object) so that hovering the object itself — not just its
- * label — switches the associated label's CSS style to the highlighted
- * (opaque, higher z-index) mask style. This is an interim stand-in for
- * jsxgraph's `dragToTopOfLayer`, which does not yet support labels in any
- * published release (see the note in `computeLabelMaskCssStyle` above).
+ * Wires up `over`/`out` handlers so that a label gains its bordered "mask"
+ * highlight while the pointer is over the associated *draggable* object and
+ * loses it when the pointer leaves. This is an interim stand-in for jsxgraph's
+ * `dragToTopOfLayer`, which does not yet support labels in any published
+ * release (see the note in `computeLabelMaskCssStyle` above).
  *
- * `getLabelJXG` is called lazily on each hover event so callers can pass a
+ * The highlight is gated on `hoverTargetJXG.isDraggable` (which every renderer
+ * keeps in sync with the component's `fixed`/`fixLocation` state), so the
+ * border acts as a "you can grab this" cue and never appears on fixed objects.
+ *
+ * Only the *object's* own `over`/`out` drive the border — hovering the label
+ * itself does nothing. An object-attached label can only be moved by dragging
+ * the object (not the label), so lighting the border on label hover would
+ * wrongly imply the label is draggable. (A standalone `<label>`, which the
+ * user does drag directly, gets its own hover border via JSXGraph's native
+ * highlight instead of this helper.) The base css explicitly resets the border
+ * (see `computeLabelMaskCssStyle`), so an `out` reliably clears it.
+ *
+ * `getLabelJXG` is called lazily on each event so callers can pass a
  * ref-based getter for a label that may not exist yet at wiring time.
  *
- * The `"over"`/`"out"` handlers are intentionally not tracked for later
- * removal (unlike the handlers in `removeJXGEventHandlers`): they are wired
- * only inside a renderer's create-JXG path, so they live and die with the
- * freshly created `hoverTargetJXG`. If a label is re-created, a new object
- * (and new handlers) replaces the old one rather than accumulating on it.
+ * The handlers are intentionally not tracked for later removal (unlike the
+ * handlers in `removeJXGEventHandlers`): they are wired only inside a
+ * renderer's create-JXG path, so they live and die with the freshly created
+ * `hoverTargetJXG`. If a label is re-created, a new object (and new handlers)
+ * replaces the old one rather than accumulating on it.
  */
 export function attachLabelHoverHighlight({
     hoverTargetJXG,
@@ -111,36 +135,44 @@ export function attachLabelHoverHighlight({
     highlightCssStyle,
     board,
 }: {
-    hoverTargetJXG: { on: (event: string, fn: () => void) => void };
+    hoverTargetJXG: {
+        on: (event: string, fn: () => void) => void;
+        isDraggable?: boolean;
+    };
     getLabelJXG: () => LabelLikeJXG | null | undefined;
     cssStyle: string;
     highlightCssStyle: string;
     board: { updateRenderer: () => void } | null;
 }) {
-    function applyLabelCssStyle(labelJXG: LabelLikeJXG, style: string) {
+    function applyHover(hovered: boolean) {
+        const labelJXG = getLabelJXG();
+        if (!labelJXG) {
+            return;
+        }
+        // Only draggable objects get the hover border. `isDraggable` is `false`
+        // when the component is fixed / has a fixed location; treat any other
+        // value (true, or an unset default) as draggable.
+        const draggable = hoverTargetJXG.isDraggable !== false;
+        const show = hovered && draggable;
+        // Record the desired state so a mid-hover re-render
+        // (`syncLabelMaskCssStyle`) preserves it instead of clobbering the
+        // border back to the base style.
+        labelJXG.visProp.labelMaskHovered = show;
+        // Prefer the label's live `highlightcssstyle`, which the update path
+        // keeps in sync with the current layer/z-index, so a runtime layer
+        // change is reflected on hover. Fall back to the captured value.
+        const style = show
+            ? (labelJXG.visProp.highlightcssstyle ?? highlightCssStyle)
+            : cssStyle;
+        if (labelJXG.visProp.cssstyle === style) {
+            return;
+        }
         labelJXG.visProp.cssstyle = style;
         labelJXG.needsUpdate = true;
         labelJXG.update();
         board?.updateRenderer();
     }
 
-    hoverTargetJXG.on("over", () => {
-        const labelJXG = getLabelJXG();
-        if (labelJXG) {
-            // Prefer the label's live `highlightcssstyle`, which the renderer's
-            // update path (`syncLabelMaskCssStyle`) keeps in sync with the
-            // current layer/z-index, so a runtime layer change is reflected on
-            // hover. Fall back to the value captured when the handler was wired.
-            applyLabelCssStyle(
-                labelJXG,
-                labelJXG.visProp.highlightcssstyle ?? highlightCssStyle,
-            );
-        }
-    });
-    hoverTargetJXG.on("out", () => {
-        const labelJXG = getLabelJXG();
-        if (labelJXG) {
-            applyLabelCssStyle(labelJXG, cssStyle);
-        }
-    });
+    hoverTargetJXG.on("over", () => applyHover(true));
+    hoverTargetJXG.on("out", () => applyHover(false));
 }

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -500,7 +500,6 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
                     lineColor,
                 );
                 syncLabelMaskCssStyle(vectorJXG.current.label, SVs.layer, {
-                    highlighted: vectorJXG.current.highlighted,
                     maskLabel: SVs.maskLabel,
                 });
 


### PR DESCRIPTION
## Summary

Follow-up to #1420 (opaque "mask" background for graph labels), refining the label border so it no longer reads as clutter or implies the label is draggable.

Graph labels keep their opaque mask background (legible over axes/objects) but now show **no border at rest** — so a masked label looks identical to an unmasked one until it overlaps something. A border appears on the label **only while the pointer is over the labeled object and that object is draggable**, as a cue that it can be grabbed, and clears reliably when the pointer leaves.

### Behavior
- **Object-attached labels** (point, line, circle, …): the border tracks hover over the *object*, gated on `isDraggable`. Hovering the label itself does nothing — you drag the object, not the label.
- **Standalone `<label>`**: keeps JSXGraph's native hover highlight (it is dragged directly), now borderless at rest.
- **Fixed / non-draggable objects**: never show the border.
- **`maskLabel="false"`**: unchanged — transparent, borderless label.

### Notable fix
The base label style now explicitly resets `border`/`border-radius`. JSXGraph's `updateTextStyle` applies CSS *additively* (it sets declared properties but never removes ones the previous style declared), so omitting `border` from the base style left the hover border stuck on the element after the pointer left.

## Testing
- Unit tests in `labelMaskStyle.test.ts` cover the borderless base, the draggable gate, and object-only hover.
- Verified end-to-end in the dev viewer: the border appears on object hover, not on label-only hover, and clears on leave / click-elsewhere; fixed objects show no border; standalone labels behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
