### PR TITLE
Rename doenetMediaUrl prop to doenetImagesUrl

### DIFF
--- a/.changeset/image-doenet-images-url.md
+++ b/.changeset/image-doenet-images-url.md
@@ -8,6 +8,6 @@
 
 Image: resolve `source="doenet:<id>"` against a configurable media URL.
 
-When an `<image>` specifies `source="doenet:abcdefg"`, the image now loads from `doenetMediaUrl + "/" + imageId` (the middle slash is omitted when `doenetMediaUrl` already ends with `/`). The `doenetMediaUrl` is a new optional prop on `<DoenetViewer>` and `<DoenetEditor>` (defaulting to `https://doenet.org/api/media`), mirroring the existing `doenetViewerUrl` prop.
+When an `<image>` specifies `source="doenet:abcdefg"`, the image now loads from `doenetImagesUrl + "/" + imageId` (the middle slash is omitted when `doenetImagesUrl` already ends with `/`). The `doenetImagesUrl` is a new optional prop on `<DoenetViewer>` and `<DoenetEditor>` (defaulting to `https://doenet.org/api/media`), mirroring the existing `doenetViewerUrl` prop.
 
 Only a source that is exactly `doenet:<id>` (an alphanumeric id) is treated as a media reference; any other `doenet:` source (such as a legacy `doenet:cid=<hash>` form) renders the image placeholder rather than requesting an unknown URL.

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -87,7 +87,7 @@ type EditorViewerProps = {
     activityId?: string;
     prefixForIds?: string;
     doenetViewerUrl?: string;
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     darkMode?: ResolvedTheme;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -176,7 +176,7 @@ export const EditorViewer = React.forwardRef<
         activityId: specifiedActivityId,
         prefixForIds = "",
         doenetViewerUrl,
-        doenetMediaUrl,
+        doenetImagesUrl,
         darkMode = "light",
         showAnswerResponseButton = false,
         answerResponseCounts = {},
@@ -1099,7 +1099,7 @@ export const EditorViewer = React.forwardRef<
                         documentStructureThenChangeCallback
                     }
                     doenetViewerUrl={doenetViewerUrl}
-                    doenetMediaUrl={doenetMediaUrl}
+                    doenetImagesUrl={doenetImagesUrl}
                     darkMode={darkMode}
                     showAnswerResponseButton={showAnswerResponseButton}
                     answerResponseCounts={answerResponseCounts}

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -48,7 +48,7 @@ export { renderersLoadComponent } from "./renderersLoadComponent";
 
 export const DocContext = createContext<{
     doenetViewerUrl?: string;
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     darkMode?: ResolvedTheme;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -77,7 +77,7 @@ export function DocViewer({
     setIsInErrorState,
     prefixForIds = "",
     doenetViewerUrl,
-    doenetMediaUrl,
+    doenetImagesUrl,
     darkMode,
     showAnswerResponseButton = false,
     answerResponseCounts = {},
@@ -115,7 +115,7 @@ export function DocViewer({
     setIsInErrorState?: Function;
     prefixForIds?: string;
     doenetViewerUrl?: string;
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     darkMode?: ResolvedTheme;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -264,7 +264,7 @@ export function DocViewer({
 
     const contextForRenderers = {
         doenetViewerUrl,
-        doenetMediaUrl,
+        doenetImagesUrl,
         darkMode,
         showAnswerResponseButton,
         answerResponseCounts,

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -79,7 +79,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
     // @ts-ignore
     Image.ignoreActionsWithoutCore = () => true;
 
-    const { doenetMediaUrl } = useContext(DocContext) || {};
+    const { doenetImagesUrl } = useContext(DocContext) || {};
 
     let imageJXG = useRef<JXGImage | null>(null);
     let anchorPointJXG = useRef<JXGPoint | null>(null);
@@ -119,9 +119,9 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
             getUrlForImage({
                 source: SVs.source,
                 imageId: SVs.imageId,
-                doenetMediaUrl,
+                doenetImagesUrl,
             }),
-        [SVs.source, SVs.imageId, doenetMediaUrl],
+        [SVs.source, SVs.imageId, doenetImagesUrl],
     );
 
     const ref = useRef<HTMLDivElement | null>(null);
@@ -756,8 +756,8 @@ function renderImageAttribution({
  * Resolve the URL to use for an image.
  *
  * When the image references a Doenet-hosted media item (`source="doenet:<id>"`),
- * `imageId` holds the `<id>` and the URL is built from `doenetMediaUrl` and that
- * id (avoiding a doubled slash when `doenetMediaUrl` already ends with `/`).
+ * `imageId` holds the `<id>` and the URL is built from `doenetImagesUrl` and that
+ * id (avoiding a doubled slash when `doenetImagesUrl` already ends with `/`).
  *
  * A `doenet:` source that did not yield an `imageId` is an unsupported media
  * reference (e.g. a legacy `doenet:cid=<hash>` form); rather than passing the
@@ -768,15 +768,15 @@ function renderImageAttribution({
 function getUrlForImage({
     source,
     imageId,
-    doenetMediaUrl = "https://doenet.org/api/media",
+    doenetImagesUrl = "https://doenet.org/api/media",
 }: {
     source: string;
     imageId: string | null;
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
 }) {
     if (imageId) {
-        const separator = doenetMediaUrl.endsWith("/") ? "" : "/";
-        return doenetMediaUrl + separator + imageId;
+        const separator = doenetImagesUrl.endsWith("/") ? "" : "/";
+        return doenetImagesUrl + separator + imageId;
     } else if (/^\s*doenet:/i.test(source)) {
         return "";
     } else {

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -93,7 +93,7 @@ export function DoenetViewer({
     addVirtualKeyboard = true,
     externalVirtualKeyboardProvided = false,
     doenetViewerUrl,
-    doenetMediaUrl,
+    doenetImagesUrl,
     darkMode = "system",
     showAnswerResponseButton = false,
     answerResponseCounts = {},
@@ -143,7 +143,7 @@ export function DoenetViewer({
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
     doenetViewerUrl?: string;
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     /**
      * Theme for the rendered content. `"light"` / `"dark"` pin a theme;
      * `"system"` (the default) follows the user's OS/browser
@@ -304,7 +304,7 @@ export function DoenetViewer({
             forceShowSolution={forceShowSolution}
             forceUnsuppressCheckWork={forceUnsuppressCheckWork}
             doenetViewerUrl={doenetViewerUrl}
-            doenetMediaUrl={doenetMediaUrl}
+            doenetImagesUrl={doenetImagesUrl}
             darkMode={resolvedTheme}
             showAnswerResponseButton={showAnswerResponseButton}
             answerResponseCounts={answerResponseCounts}
@@ -354,7 +354,7 @@ type DoenetEditorProps = {
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
     doenetViewerUrl?: string;
-    doenetMediaUrl?: string;
+    doenetImagesUrl?: string;
     /**
      * Theme for the rendered content. `"light"` / `"dark"` pin a theme;
      * `"system"` (the default) follows the user's OS/browser
@@ -424,7 +424,7 @@ export const DoenetEditor = React.forwardRef<
         addVirtualKeyboard = true,
         externalVirtualKeyboardProvided = false,
         doenetViewerUrl,
-        doenetMediaUrl,
+        doenetImagesUrl,
         darkMode = "system",
         showAnswerResponseButton = false,
         answerResponseCounts = {},
@@ -502,7 +502,7 @@ export const DoenetEditor = React.forwardRef<
             activityId={activityId}
             prefixForIds={prefixForIds}
             doenetViewerUrl={doenetViewerUrl}
-            doenetMediaUrl={doenetMediaUrl}
+            doenetImagesUrl={doenetImagesUrl}
             darkMode={resolvedTheme}
             showAnswerResponseButton={showAnswerResponseButton}
             answerResponseCounts={answerResponseCounts}

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -708,7 +708,7 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             .and("eq", "https://doenet.org/api/media/abcDEF123");
     });
 
-    it("doenet: source resolves against a custom doenetMediaUrl", () => {
+    it("doenet: source resolves against a custom doenetImagesUrl", () => {
         cy.window().then(async (win) => {
             win.postMessage(
                 {
@@ -717,7 +717,7 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
     <shortDescription>A Doenet-hosted image</shortDescription>
   </image>
   `,
-                    doenetMediaUrl: "https://example.com/media",
+                    doenetImagesUrl: "https://example.com/media",
                 },
                 "*",
             );
@@ -728,7 +728,7 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             .and("eq", "https://example.com/media/abcDEF123");
     });
 
-    it("trailing slash on doenetMediaUrl is not doubled", () => {
+    it("trailing slash on doenetImagesUrl is not doubled", () => {
         cy.window().then(async (win) => {
             win.postMessage(
                 {
@@ -737,7 +737,7 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
     <shortDescription>A Doenet-hosted image</shortDescription>
   </image>
   `,
-                    doenetMediaUrl: "https://example.com/media/",
+                    doenetImagesUrl: "https://example.com/media/",
                 },
                 "*",
             );
@@ -757,7 +757,7 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
     <shortDescription>The Doenet logo</shortDescription>
   </image>
   `,
-                    doenetMediaUrl: "https://example.com/media",
+                    doenetImagesUrl: "https://example.com/media",
                 },
                 "*",
             );

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -65,7 +65,7 @@ export function CypressTest() {
             attemptNumber,
             externalDoenetMLs,
             answerResponseCounts,
-            doenetMediaUrl,
+            doenetImagesUrl,
             usePrototype,
             prototypeCoreType,
         },
@@ -75,7 +75,7 @@ export function CypressTest() {
         attemptNumber: number;
         externalDoenetMLs: Record<string, string>;
         answerResponseCounts?: Record<string, number>;
-        doenetMediaUrl?: string;
+        doenetImagesUrl?: string;
         usePrototype?: boolean;
         prototypeCoreType?: "rust" | "javascript";
     }>({
@@ -166,7 +166,7 @@ export function CypressTest() {
         let newExternalDoenetMLs: Record<string, string> = {};
         let newAnswerResponseCounts: Record<string, number> | undefined =
             undefined;
-        let newDoenetMediaUrl: string | undefined = undefined;
+        let newDoenetImagesUrl: string | undefined = undefined;
         // Keep the selected renderer sticky across incremental messages (e.g. a
         // later message that only changes `attemptNumber` or re-sends
         // `doenetML`): default to the current values and only override when the
@@ -202,8 +202,8 @@ export function CypressTest() {
             newAnswerResponseCounts = e.data.answerResponseCounts;
         }
 
-        if (e.data.doenetMediaUrl !== undefined) {
-            newDoenetMediaUrl = e.data.doenetMediaUrl;
+        if (e.data.doenetImagesUrl !== undefined) {
+            newDoenetImagesUrl = e.data.doenetImagesUrl;
         }
 
         if (e.data.usePrototype !== undefined) {
@@ -224,7 +224,7 @@ export function CypressTest() {
                 attemptNumber: newAttemptNumber,
                 externalDoenetMLs: newExternalDoenetMLs,
                 answerResponseCounts: newAnswerResponseCounts,
-                doenetMediaUrl: newDoenetMediaUrl,
+                doenetImagesUrl: newDoenetImagesUrl,
                 usePrototype: newUsePrototype,
                 prototypeCoreType: newPrototypeCoreType,
             });
@@ -645,7 +645,7 @@ export function CypressTest() {
                 fetchExternalDoenetML={fetchExternalDoenetML}
                 showAnswerResponseButton={answerResponseCounts !== undefined}
                 answerResponseCounts={answerResponseCounts}
-                doenetMediaUrl={doenetMediaUrl}
+                doenetImagesUrl={doenetImagesUrl}
                 readOnly={readOnly}
                 darkMode={darkMode}
                 diagnosticsSummaryCallback={(
@@ -695,7 +695,7 @@ export function CypressTest() {
                 showAnswerResponseButton={answerResponseCounts !== undefined}
                 answerResponseCounts={answerResponseCounts}
                 includeVariantSelector={includeVariantSelector}
-                doenetMediaUrl={doenetMediaUrl}
+                doenetImagesUrl={doenetImagesUrl}
             />
         );
 


### PR DESCRIPTION
Renames the optional `doenetMediaUrl` prop on `<DoenetViewer>` and `<DoenetEditor>` to `doenetImagesUrl`.

This prop resolves `source="doenet:<id>"` images against a configurable URL prefix. Naming it after "images" specifically means that if we later add support for other media types, applications aren't forced to colocate different media types under one URL.

Since `doenetMediaUrl` was never released, no deprecation pathway for the old name is provided — it's a straight rename.

### Changes
- `doenetml.tsx` — public `doenetImagesUrl` prop on `DoenetViewer` / `DoenetEditor`
- `EditorViewer.tsx`, `DocViewer.tsx` — prop + `DocContext` wiring
- `image.tsx` — context consumer, `getUrlForImage` param (default endpoint unchanged)
- `CypressTest.tsx` + `image.cy.js` — test harness message field and specs
- Changeset updated and renamed

Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)