### PR TITLE
Give patterned fills a translucent canvas-colored background

### DIFF
--- a/.changeset/fill-pattern-canvas-background.md
+++ b/.changeset/fill-pattern-canvas-background.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Give patterned fills a translucent background instead of a fully transparent one.
+
+A closed shape with a non-solid `fillStyle` (horizontal, vertical, diagonal, backdiagonal, dots, diamonds) now renders as two layers: a background the color of the graph canvas at `fillOpacity`, and the pattern itself in `fillColor` at `fillPatternOpacity`. Previously the area behind the pattern was fully transparent. A `solid` fill is unchanged — `fillColor` at `fillOpacity`.

--- a/packages/doenetml/src/Viewer/renderers/angle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/angle.tsx
@@ -20,7 +20,11 @@ import {
     computeLabelMaskCssStyle,
 } from "./utils/labelMaskStyle";
 import { getPatternFillAttributes } from "./utils/fillPatterns";
-import { resolveLineColor, resolveFillColor } from "./utils/styleColors";
+import {
+    resolveLineColor,
+    resolveFillColor,
+    resolveCanvasColor,
+} from "./utils/styleColors";
 
 interface AngleSVs extends GraphicalSVs {
     numericalPoints: [number, number][];
@@ -82,6 +86,7 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
             fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
             fillColor: resolveFillColor(SVs.selectedStyle, darkMode),
             fillOpacity: SVs.selectedStyle.fillOpacity,
+            canvasColor: resolveCanvasColor(darkMode),
             fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
         });
 
@@ -227,6 +232,7 @@ export default React.memo(function Angle(props: UseDoenetRendererProps) {
                 fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
                 fillColor: resolveFillColor(SVs.selectedStyle, darkMode),
                 fillOpacity: SVs.selectedStyle.fillOpacity,
+                canvasColor: resolveCanvasColor(darkMode),
                 fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
             });
             const angleFillColor = fillAttributes.fillColor;

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -31,6 +31,7 @@ import {
     resolveLineColor,
     resolveFillColor,
     resolveMarkerColor,
+    resolveCanvasColor,
 } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import {
@@ -144,6 +145,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                     fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
                     fillColor: jsxCircleAttributes.fillColor,
                     fillOpacity: SVs.selectedStyle.fillOpacity,
+                    canvasColor: resolveCanvasColor(darkMode),
                     fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
                     highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
                 }),
@@ -737,6 +739,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                           fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
                           fillColor: resolvedFillColor,
                           fillOpacity: SVs.selectedStyle.fillOpacity,
+                          canvasColor: resolveCanvasColor(darkMode),
                           fillPatternOpacity:
                               SVs.selectedStyle.fillPatternOpacity,
                           highlightFillOpacity:

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -14,6 +14,7 @@ import {
     resolveLineColor,
     resolveFillColor,
     resolveHandleColor,
+    resolveCanvasColor,
 } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
@@ -119,6 +120,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                       fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
                       fillColor: resolvedFillColor,
                       fillOpacity: SVs.selectedStyle.fillOpacity,
+                      canvasColor: resolveCanvasColor(darkMode),
                       fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
                       highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
                   })
@@ -614,6 +616,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                           fillStyle: SVs.selectedStyle.fillStyle ?? "solid",
                           fillColor: resolvedFillColor,
                           fillOpacity: SVs.selectedStyle.fillOpacity,
+                          canvasColor: resolveCanvasColor(darkMode),
                           fillPatternOpacity:
                               SVs.selectedStyle.fillPatternOpacity,
                           highlightFillOpacity:

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
@@ -9,6 +9,7 @@ import { DocContext } from "../DocViewer";
 import { GraphicalSVs } from "./utils/graphicalSVs";
 import { JXGCurve, JXGElement, JXGPoint } from "./jsxgraph-distrib/types";
 import { getPatternFillAttributes } from "./utils/fillPatterns";
+import { resolveCanvasColor } from "./utils/styleColors";
 import {
     attachLabelHoverHighlight,
     computeLabelMaskCssStyle,
@@ -72,6 +73,7 @@ export default React.memo(function RegionBetweenCurveXAxis(
                     ? SVs.selectedStyle.fillColorDarkMode
                     : SVs.selectedStyle.fillColor,
             fillOpacity: SVs.selectedStyle.fillOpacity,
+            canvasColor: resolveCanvasColor(darkMode),
             fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
         });
         // Note: actual content of label is being ignored
@@ -190,6 +192,7 @@ export default React.memo(function RegionBetweenCurveXAxis(
                         ? SVs.selectedStyle.fillColorDarkMode
                         : SVs.selectedStyle.fillColor,
                 fillOpacity: SVs.selectedStyle.fillOpacity,
+                canvasColor: resolveCanvasColor(darkMode),
                 fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
             });
 

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
@@ -9,6 +9,7 @@ import { GraphicalSVs } from "./utils/graphicalSVs";
 import { JXGCurve } from "./jsxgraph-distrib/types";
 import { styleToDash } from "./utils/styleToDash";
 import { getPatternFillAttributes } from "./utils/fillPatterns";
+import { resolveCanvasColor } from "./utils/styleColors";
 import {
     attachLabelHoverHighlight,
     computeLabelMaskCssStyle,
@@ -78,6 +79,7 @@ export default React.memo(function RegionBetweenCurves(
                     ? SVs.selectedStyle.fillColorDarkMode
                     : SVs.selectedStyle.fillColor,
             fillOpacity: SVs.selectedStyle.fillOpacity,
+            canvasColor: resolveCanvasColor(darkMode),
             fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
         });
 
@@ -269,6 +271,7 @@ export default React.memo(function RegionBetweenCurves(
                         ? SVs.selectedStyle.fillColorDarkMode
                         : SVs.selectedStyle.fillColor,
                 fillOpacity: SVs.selectedStyle.fillOpacity,
+                canvasColor: resolveCanvasColor(darkMode),
                 fillPatternOpacity: SVs.selectedStyle.fillPatternOpacity,
             });
 

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.test.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getOrInjectPattern } from "./fillPatterns";
+import { getOrInjectPattern, getPatternFillAttributes } from "./fillPatterns";
 
 /**
  * Minimal in-memory stand-in for the SVG `<defs>` element and its owner
@@ -53,7 +53,7 @@ function makeFakeDefs() {
     return { defsEl };
 }
 
-describe("fillPatterns", () => {
+describe("getOrInjectPattern", () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
@@ -64,26 +64,26 @@ describe("fillPatterns", () => {
             .mockImplementation(() => undefined);
 
         expect(
-            getOrInjectPattern(
-                null,
-                "board1",
-                "zigzag",
-                "#abc",
-                0.3,
-                "white",
-                1,
-            ),
+            getOrInjectPattern({
+                defsEl: null,
+                boardId: "board1",
+                fillStyle: "zigzag",
+                fillColor: "#abc",
+                fillOpacity: 0.3,
+                canvasColor: "white",
+                fillPatternOpacity: 1,
+            }),
         ).toBe("#abc");
         expect(
-            getOrInjectPattern(
-                null,
-                "board2",
-                "zigzag",
-                "#def",
-                0.3,
-                "white",
-                1,
-            ),
+            getOrInjectPattern({
+                defsEl: null,
+                boardId: "board2",
+                fillStyle: "zigzag",
+                fillColor: "#def",
+                fillOpacity: 0.3,
+                canvasColor: "white",
+                fillPatternOpacity: 1,
+            }),
         ).toBe("#def");
 
         expect(warnSpy).toHaveBeenCalledTimes(1);
@@ -96,32 +96,32 @@ describe("fillPatterns", () => {
             .mockImplementation(() => undefined);
 
         expect(
-            getOrInjectPattern(
-                null,
-                "board1",
-                "solid",
-                "#abc",
-                0.3,
-                "white",
-                1,
-            ),
+            getOrInjectPattern({
+                defsEl: null,
+                boardId: "board1",
+                fillStyle: "solid",
+                fillColor: "#abc",
+                fillOpacity: 0.3,
+                canvasColor: "white",
+                fillPatternOpacity: 1,
+            }),
         ).toBe("#abc");
 
         expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it("injects a background layer (canvas color at fillOpacity) plus a foreground pattern (fillColor at fillPatternOpacity)", () => {
+    it("injects a background layer (canvas color at fillOpacity) plus a stroked foreground pattern (fillColor at fillPatternOpacity)", () => {
         const { defsEl } = makeFakeDefs();
 
-        const url = getOrInjectPattern(
+        const url = getOrInjectPattern({
             defsEl,
-            "board1",
-            "horizontal",
-            "#abc",
-            0.3,
-            "white",
-            0.8,
-        );
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "white",
+            fillPatternOpacity: 0.8,
+        });
 
         expect(url).toMatch(/^url\(#doenet-fill-pattern-/);
 
@@ -141,27 +141,52 @@ describe("fillPatterns", () => {
         expect(foreground.attributes["stroke-opacity"]).toBe("0.8");
     });
 
+    it("bakes fillPatternOpacity into fill-opacity for filled foreground patterns (diamonds)", () => {
+        const { defsEl } = makeFakeDefs();
+
+        getOrInjectPattern({
+            defsEl,
+            boardId: "board1",
+            fillStyle: "diamonds",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "white",
+            fillPatternOpacity: 0.8,
+        });
+
+        const [pattern] = (defsEl as any).children;
+        const [background, foreground] = pattern.children;
+        expect(background.tag).toBe("rect");
+        expect(background.attributes["fill-opacity"]).toBe("0.3");
+
+        // Filled patterns paint the mark with `fill` (not `stroke`).
+        expect(foreground.tag).toBe("path");
+        expect(foreground.attributes.fill).toBe("#abc");
+        expect(foreground.attributes["fill-opacity"]).toBe("0.8");
+        expect(foreground.attributes.stroke).toBe("none");
+    });
+
     it("reuses an already-injected pattern instead of injecting it twice", () => {
         const { defsEl } = makeFakeDefs();
 
-        const first = getOrInjectPattern(
+        const first = getOrInjectPattern({
             defsEl,
-            "board1",
-            "horizontal",
-            "#abc",
-            0.3,
-            "white",
-            1,
-        );
-        const second = getOrInjectPattern(
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "white",
+            fillPatternOpacity: 1,
+        });
+        const second = getOrInjectPattern({
             defsEl,
-            "board1",
-            "horizontal",
-            "#abc",
-            0.3,
-            "white",
-            1,
-        );
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "white",
+            fillPatternOpacity: 1,
+        });
 
         expect(first).toBe(second);
         expect((defsEl as any).children).toHaveLength(1);
@@ -170,26 +195,71 @@ describe("fillPatterns", () => {
     it("gives patterns that differ only in background opacity distinct ids", () => {
         const { defsEl } = makeFakeDefs();
 
-        const faint = getOrInjectPattern(
+        const faint = getOrInjectPattern({
             defsEl,
-            "board1",
-            "horizontal",
-            "#abc",
-            0.2,
-            "white",
-            1,
-        );
-        const strong = getOrInjectPattern(
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.2,
+            canvasColor: "white",
+            fillPatternOpacity: 1,
+        });
+        const strong = getOrInjectPattern({
             defsEl,
-            "board1",
-            "horizontal",
-            "#abc",
-            0.8,
-            "white",
-            1,
-        );
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.8,
+            canvasColor: "white",
+            fillPatternOpacity: 1,
+        });
 
         expect(faint).not.toBe(strong);
         expect((defsEl as any).children).toHaveLength(2);
+    });
+});
+
+describe("getPatternFillAttributes", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns fillOpacity 1 (and highlight 0.5) for a pattern fill, since both opacities are baked into the tile", () => {
+        const { defsEl } = makeFakeDefs();
+
+        const attrs = getPatternFillAttributes({
+            defsEl,
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "white",
+            fillPatternOpacity: 0.8,
+        });
+
+        expect(attrs.fillColor).toMatch(/^url\(#doenet-fill-pattern-/);
+        expect(attrs.highlightFillColor).toBe(attrs.fillColor);
+        expect(attrs.fillOpacity).toBe(1);
+        expect(attrs.highlightFillOpacity).toBe(0.5);
+    });
+
+    it("passes a solid fill through unchanged (plain color, authored opacities)", () => {
+        const { defsEl } = makeFakeDefs();
+
+        const attrs = getPatternFillAttributes({
+            defsEl,
+            boardId: "board1",
+            fillStyle: "solid",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "white",
+            fillPatternOpacity: 0.8,
+            highlightFillOpacity: 0.15,
+        });
+
+        expect(attrs.fillColor).toBe("#abc");
+        expect(attrs.highlightFillColor).toBe("#abc");
+        expect(attrs.fillOpacity).toBe(0.3);
+        expect(attrs.highlightFillOpacity).toBe(0.15);
     });
 });

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.test.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.test.ts
@@ -1,6 +1,58 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getOrInjectPattern } from "./fillPatterns";
 
+/**
+ * Minimal in-memory stand-in for the SVG `<defs>` element and its owner
+ * document, exercising only the DOM surface `getOrInjectPattern` touches
+ * (`createElementNS`, `setAttribute`, `appendChild`, `getElementById`). This
+ * keeps the test runnable in vitest's default node environment (no DOM).
+ */
+function makeFakeDefs() {
+    const registry = new Map<string, FakeElement>();
+
+    type FakeElement = {
+        tag: string;
+        attributes: Record<string, string>;
+        children: FakeElement[];
+        setAttribute(name: string, value: string): void;
+        appendChild(child: FakeElement): FakeElement;
+    };
+
+    function createElementNS(_ns: string, tag: string): FakeElement {
+        return {
+            tag,
+            attributes: {},
+            children: [],
+            setAttribute(name, value) {
+                this.attributes[name] = value;
+                if (name === "id") {
+                    registry.set(value, this);
+                }
+            },
+            appendChild(child) {
+                this.children.push(child);
+                return child;
+            },
+        };
+    }
+
+    const ownerDocument = {
+        createElementNS,
+        getElementById: (id: string) => registry.get(id) ?? null,
+    };
+
+    const defsEl = {
+        ownerDocument,
+        children: [] as FakeElement[],
+        appendChild(child: FakeElement) {
+            this.children.push(child);
+            return child;
+        },
+    } as unknown as SVGDefsElement & { children: FakeElement[] };
+
+    return { defsEl };
+}
+
 describe("fillPatterns", () => {
     afterEach(() => {
         vi.restoreAllMocks();
@@ -11,12 +63,28 @@ describe("fillPatterns", () => {
             .spyOn(console, "warn")
             .mockImplementation(() => undefined);
 
-        expect(getOrInjectPattern(null, "board1", "zigzag", "#abc")).toBe(
-            "#abc",
-        );
-        expect(getOrInjectPattern(null, "board2", "zigzag", "#def")).toBe(
-            "#def",
-        );
+        expect(
+            getOrInjectPattern(
+                null,
+                "board1",
+                "zigzag",
+                "#abc",
+                0.3,
+                "white",
+                1,
+            ),
+        ).toBe("#abc");
+        expect(
+            getOrInjectPattern(
+                null,
+                "board2",
+                "zigzag",
+                "#def",
+                0.3,
+                "white",
+                1,
+            ),
+        ).toBe("#def");
 
         expect(warnSpy).toHaveBeenCalledTimes(1);
         expect(warnSpy.mock.calls[0][0]).toContain("zigzag");
@@ -27,10 +95,101 @@ describe("fillPatterns", () => {
             .spyOn(console, "warn")
             .mockImplementation(() => undefined);
 
-        expect(getOrInjectPattern(null, "board1", "solid", "#abc")).toBe(
-            "#abc",
-        );
+        expect(
+            getOrInjectPattern(
+                null,
+                "board1",
+                "solid",
+                "#abc",
+                0.3,
+                "white",
+                1,
+            ),
+        ).toBe("#abc");
 
         expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("injects a background layer (canvas color at fillOpacity) plus a foreground pattern (fillColor at fillPatternOpacity)", () => {
+        const { defsEl } = makeFakeDefs();
+
+        const url = getOrInjectPattern(
+            defsEl,
+            "board1",
+            "horizontal",
+            "#abc",
+            0.3,
+            "white",
+            0.8,
+        );
+
+        expect(url).toMatch(/^url\(#doenet-fill-pattern-/);
+
+        const patterns = (defsEl as any).children;
+        expect(patterns).toHaveLength(1);
+        const [pattern] = patterns;
+        expect(pattern.tag).toBe("pattern");
+
+        // Background rect drawn first, then the foreground path on top.
+        const [background, foreground] = pattern.children;
+        expect(background.tag).toBe("rect");
+        expect(background.attributes.fill).toBe("white");
+        expect(background.attributes["fill-opacity"]).toBe("0.3");
+
+        expect(foreground.tag).toBe("path");
+        expect(foreground.attributes.stroke).toBe("#abc");
+        expect(foreground.attributes["stroke-opacity"]).toBe("0.8");
+    });
+
+    it("reuses an already-injected pattern instead of injecting it twice", () => {
+        const { defsEl } = makeFakeDefs();
+
+        const first = getOrInjectPattern(
+            defsEl,
+            "board1",
+            "horizontal",
+            "#abc",
+            0.3,
+            "white",
+            1,
+        );
+        const second = getOrInjectPattern(
+            defsEl,
+            "board1",
+            "horizontal",
+            "#abc",
+            0.3,
+            "white",
+            1,
+        );
+
+        expect(first).toBe(second);
+        expect((defsEl as any).children).toHaveLength(1);
+    });
+
+    it("gives patterns that differ only in background opacity distinct ids", () => {
+        const { defsEl } = makeFakeDefs();
+
+        const faint = getOrInjectPattern(
+            defsEl,
+            "board1",
+            "horizontal",
+            "#abc",
+            0.2,
+            "white",
+            1,
+        );
+        const strong = getOrInjectPattern(
+            defsEl,
+            "board1",
+            "horizontal",
+            "#abc",
+            0.8,
+            "white",
+            1,
+        );
+
+        expect(faint).not.toBe(strong);
+        expect((defsEl as any).children).toHaveLength(2);
     });
 });

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.test.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.test.ts
@@ -217,6 +217,34 @@ describe("getOrInjectPattern", () => {
         expect(faint).not.toBe(strong);
         expect((defsEl as any).children).toHaveLength(2);
     });
+
+    it("gives patterns that differ only in canvas color distinct ids", () => {
+        const { defsEl } = makeFakeDefs();
+
+        // Same board/style/fillColor, but different canvas backgrounds (as in
+        // light vs. dark mode) must not alias onto one cached tile.
+        const light = getOrInjectPattern({
+            defsEl,
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "white",
+            fillPatternOpacity: 1,
+        });
+        const dark = getOrInjectPattern({
+            defsEl,
+            boardId: "board1",
+            fillStyle: "horizontal",
+            fillColor: "#abc",
+            fillOpacity: 0.3,
+            canvasColor: "#121212",
+            fillPatternOpacity: 1,
+        });
+
+        expect(light).not.toBe(dark);
+        expect((defsEl as any).children).toHaveLength(2);
+    });
 });
 
 describe("getPatternFillAttributes", () => {

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
@@ -101,20 +101,34 @@ function encodeOpacityToken(value: number): string {
 }
 
 /**
- * Returns a stable pattern element ID for a given board + fill style + colors +
- * opacities. Every input that affects the rendered pattern contents is folded
- * into the ID so patterns with different backgrounds or opacities never alias.
- * The encoded color tokens let arbitrary CSS names or functional notation be
- * embedded safely.
+ * Inputs (other than the target `<defs>`) that determine a fill pattern's
+ * rendered contents, and therefore its cache ID. Bundled into one options
+ * object so callers name each field: colors are all strings and opacities are
+ * all numbers, so positional arguments would be easy to transpose silently.
  */
-function buildPatternId(
-    boardId: string,
-    fillStyle: string,
-    fillColor: string,
-    canvasColor: string,
-    fillOpacity: number,
-    fillPatternOpacity: number,
-): string {
+type PatternFillInputs = {
+    boardId: string;
+    fillStyle: string;
+    fillColor: string;
+    fillOpacity: number;
+    canvasColor: string;
+    fillPatternOpacity: number;
+};
+
+/**
+ * Returns a stable pattern element ID for the given fill inputs. Every input
+ * that affects the rendered pattern contents is folded into the ID so patterns
+ * with different backgrounds or opacities never alias. The encoded color tokens
+ * let arbitrary CSS names or functional notation be embedded safely.
+ */
+function buildPatternId({
+    boardId,
+    fillStyle,
+    fillColor,
+    canvasColor,
+    fillOpacity,
+    fillPatternOpacity,
+}: PatternFillInputs): string {
     return [
         "doenet-fill-pattern",
         boardId,
@@ -140,15 +154,15 @@ function buildPatternId(
  * If `fillStyle` is `"solid"` or unrecognised, returns `fillColor` unchanged
  * so callers can always use the return value as the JSXGraph `fillColor`.
  */
-export function getOrInjectPattern(
-    defsEl: SVGDefsElement | null,
-    boardId: string,
-    fillStyle: string,
-    fillColor: string,
-    fillOpacity: number,
-    canvasColor: string,
-    fillPatternOpacity: number,
-): string {
+export function getOrInjectPattern({
+    defsEl,
+    boardId,
+    fillStyle,
+    fillColor,
+    fillOpacity,
+    canvasColor,
+    fillPatternOpacity,
+}: PatternFillInputs & { defsEl: SVGDefsElement | null }): string {
     const def = FILL_PATTERN_DEFS[fillStyle];
     if (!def) {
         if (fillStyle !== "solid") {
@@ -162,14 +176,14 @@ export function getOrInjectPattern(
         return fillColor;
     }
 
-    const id = buildPatternId(
+    const id = buildPatternId({
         boardId,
         fillStyle,
         fillColor,
-        canvasColor,
         fillOpacity,
+        canvasColor,
         fillPatternOpacity,
-    );
+    });
 
     // Avoid injecting the same pattern twice (e.g. after state updates).
     if (defsEl.ownerDocument?.getElementById(id)) {
@@ -250,7 +264,7 @@ export function getPatternFillAttributes({
     highlightFillColor: string;
     highlightFillOpacity: number;
 } {
-    const resolvedFillColor = getOrInjectPattern(
+    const resolvedFillColor = getOrInjectPattern({
         defsEl,
         boardId,
         fillStyle,
@@ -258,7 +272,7 @@ export function getPatternFillAttributes({
         fillOpacity,
         canvasColor,
         fillPatternOpacity,
-    );
+    });
     const usesPatternFill = resolvedFillColor !== fillColor;
 
     return {

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
@@ -95,22 +95,47 @@ const FILL_PATTERN_DEFS: Record<string, PatternDef> = {
     },
 };
 
+/** Turns an opacity number into an id-safe token (e.g. `0.3` → `0_3`). */
+function encodeOpacityToken(value: number): string {
+    return String(value).replace(/[^0-9]/g, "_");
+}
+
 /**
- * Returns a stable pattern element ID for a given board + fill style + color.
- * The encoded color token is included so different fill colors get different
- * patterns, even when the authored color is a CSS name or functional notation.
+ * Returns a stable pattern element ID for a given board + fill style + colors +
+ * opacities. Every input that affects the rendered pattern contents is folded
+ * into the ID so patterns with different backgrounds or opacities never alias.
+ * The encoded color tokens let arbitrary CSS names or functional notation be
+ * embedded safely.
  */
 function buildPatternId(
     boardId: string,
     fillStyle: string,
     fillColor: string,
+    canvasColor: string,
+    fillOpacity: number,
+    fillPatternOpacity: number,
 ): string {
-    return `doenet-fill-pattern-${boardId}-${fillStyle}-${encodeFillPatternColorToken(fillColor)}`;
+    return [
+        "doenet-fill-pattern",
+        boardId,
+        fillStyle,
+        encodeFillPatternColorToken(fillColor),
+        encodeFillPatternColorToken(canvasColor),
+        encodeOpacityToken(fillOpacity),
+        encodeOpacityToken(fillPatternOpacity),
+    ].join("-");
 }
 
 /**
- * Ensures an SVG `<pattern>` element for the given style + color exists in
- * `defsEl`, then returns the `url(#…)` CSS reference string.
+ * Ensures an SVG `<pattern>` element for the given style + colors + opacities
+ * exists in `defsEl`, then returns the `url(#…)` CSS reference string.
+ *
+ * Each pattern tile has two layers: a background `<rect>` of `canvasColor` at
+ * `fillOpacity` (so a patterned shape reads like a translucent solid fill) and
+ * a foreground pattern (lines/dots/diamonds) of `fillColor` at
+ * `fillPatternOpacity`. Both opacities are baked into the pattern so the
+ * referencing element can keep `fillOpacity` at 1 (and drop to 0.5 on
+ * highlight, halving both layers together).
  *
  * If `fillStyle` is `"solid"` or unrecognised, returns `fillColor` unchanged
  * so callers can always use the return value as the JSXGraph `fillColor`.
@@ -120,6 +145,9 @@ export function getOrInjectPattern(
     boardId: string,
     fillStyle: string,
     fillColor: string,
+    fillOpacity: number,
+    canvasColor: string,
+    fillPatternOpacity: number,
 ): string {
     const def = FILL_PATTERN_DEFS[fillStyle];
     if (!def) {
@@ -134,7 +162,14 @@ export function getOrInjectPattern(
         return fillColor;
     }
 
-    const id = buildPatternId(boardId, fillStyle, fillColor);
+    const id = buildPatternId(
+        boardId,
+        fillStyle,
+        fillColor,
+        canvasColor,
+        fillOpacity,
+        fillPatternOpacity,
+    );
 
     // Avoid injecting the same pattern twice (e.g. after state updates).
     if (defsEl.ownerDocument?.getElementById(id)) {
@@ -152,14 +187,25 @@ export function getOrInjectPattern(
     // endpoints meet without a sub-pixel anti-aliasing seam.
     pattern.setAttribute("overflow", "visible");
 
+    // Background layer: the canvas color at `fillOpacity`. Drawn first so the
+    // pattern's foreground marks paint over it.
+    const background = ownerDocument.createElementNS(svgNS, "rect");
+    background.setAttribute("width", String(def.width));
+    background.setAttribute("height", String(def.height));
+    background.setAttribute("fill", canvasColor);
+    background.setAttribute("fill-opacity", String(fillOpacity));
+    pattern.appendChild(background);
+
     const path = ownerDocument.createElementNS(svgNS, "path");
     path.setAttribute("d", def.path);
     if (def.useFill) {
         path.setAttribute("fill", fillColor);
+        path.setAttribute("fill-opacity", String(fillPatternOpacity));
         path.setAttribute("stroke", "none");
     } else {
         path.setAttribute("stroke", fillColor);
         path.setAttribute("stroke-width", String(def.strokeWidth ?? 1.5));
+        path.setAttribute("stroke-opacity", String(fillPatternOpacity));
         path.setAttribute("fill", "none");
         if (def.strokeLinecap) {
             path.setAttribute("stroke-linecap", def.strokeLinecap);
@@ -174,8 +220,11 @@ export function getOrInjectPattern(
 
 /**
  * Resolves fill props for patterned SVG fills. When a non-solid pattern is
- * active, `fillPatternOpacity` is used (defaulting to 1) so the authored
- * `fillOpacity` (which is low by default for solid fills) does not apply.
+ * active, the pattern bakes in both the background opacity (`fillOpacity`) and
+ * the foreground opacity (`fillPatternOpacity`), so the element's own
+ * `fillOpacity` is 1 (dropping to 0.5 on highlight to dim both layers). For a
+ * `solid` (or unsupported) fill, the plain color and `fillOpacity` are returned
+ * unchanged.
  */
 export function getPatternFillAttributes({
     defsEl,
@@ -183,6 +232,7 @@ export function getPatternFillAttributes({
     fillStyle,
     fillColor,
     fillOpacity,
+    canvasColor,
     fillPatternOpacity = 1,
     highlightFillOpacity = fillOpacity * 0.5,
 }: {
@@ -191,6 +241,7 @@ export function getPatternFillAttributes({
     fillStyle: string;
     fillColor: string;
     fillOpacity: number;
+    canvasColor: string;
     fillPatternOpacity?: number;
     highlightFillOpacity?: number;
 }): {
@@ -204,15 +255,16 @@ export function getPatternFillAttributes({
         boardId,
         fillStyle,
         fillColor,
+        fillOpacity,
+        canvasColor,
+        fillPatternOpacity,
     );
     const usesPatternFill = resolvedFillColor !== fillColor;
 
     return {
         fillColor: resolvedFillColor,
-        fillOpacity: usesPatternFill ? fillPatternOpacity : fillOpacity,
+        fillOpacity: usesPatternFill ? 1 : fillOpacity,
         highlightFillColor: resolvedFillColor,
-        highlightFillOpacity: usesPatternFill
-            ? fillPatternOpacity * 0.5
-            : highlightFillOpacity,
+        highlightFillOpacity: usesPatternFill ? 0.5 : highlightFillOpacity,
     };
 }

--- a/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/fillPatterns.ts
@@ -115,6 +115,11 @@ type PatternFillInputs = {
     fillPatternOpacity: number;
 };
 
+/** {@link PatternFillInputs} plus the `<defs>` element to inject the pattern into. */
+type PatternInjectionInputs = PatternFillInputs & {
+    defsEl: SVGDefsElement | null;
+};
+
 /**
  * Returns a stable pattern element ID for the given fill inputs. Every input
  * that affects the rendered pattern contents is folded into the ID so patterns
@@ -162,7 +167,7 @@ export function getOrInjectPattern({
     fillOpacity,
     canvasColor,
     fillPatternOpacity,
-}: PatternFillInputs & { defsEl: SVGDefsElement | null }): string {
+}: PatternInjectionInputs): string {
     const def = FILL_PATTERN_DEFS[fillStyle];
     if (!def) {
         if (fillStyle !== "solid") {
@@ -249,13 +254,7 @@ export function getPatternFillAttributes({
     canvasColor,
     fillPatternOpacity = 1,
     highlightFillOpacity = fillOpacity * 0.5,
-}: {
-    defsEl: SVGDefsElement | null;
-    boardId: string;
-    fillStyle: string;
-    fillColor: string;
-    fillOpacity: number;
-    canvasColor: string;
+}: Omit<PatternInjectionInputs, "fillPatternOpacity"> & {
     fillPatternOpacity?: number;
     highlightFillOpacity?: number;
 }): {

--- a/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
@@ -46,3 +46,18 @@ export function resolveMarkerColor(
 export function resolveHandleColor(darkMode: DarkMode): string {
     return darkMode === "dark" ? "#b0b0b0" : "#404040";
 }
+
+/**
+ * The graph canvas background color. Mirrors the `--canvas` CSS variable
+ * (white in light mode, `#121212` in dark mode). Used as the background layer
+ * behind fill patterns so a patterned shape reads as a translucent solid fill
+ * with the pattern drawn on top.
+ *
+ * Returns a resolved value rather than `var(--canvas)` for the same reason as
+ * `resolveHandleColor`: patterns are injected into the board SVG whose theme is
+ * driven by an inner wrapper's `data-theme`, so we resolve against `darkMode`
+ * directly instead of relying on CSS-variable inheritance.
+ */
+export function resolveCanvasColor(darkMode: DarkMode): string {
+    return darkMode === "dark" ? "#121212" : "white";
+}


### PR DESCRIPTION
## Summary

PRs #1387, #1396, and #1405 added fill-pattern support for closed shapes on a graph. Until now, the area *behind* a pattern was fully transparent. This PR gives a patterned fill a background so it reads like a translucent solid fill with the pattern drawn on top.

A closed shape with a non-solid `fillStyle` (horizontal, vertical, diagonal, backdiagonal, dots, diamonds) now renders as **two layers**:

1. **Background** — the color of the graph canvas (`--canvas`: white in light mode, `#121212` in dark mode) at `fillOpacity`.
2. **Foreground** — the pattern in `fillColor` at `fillPatternOpacity`.

A `solid` fill is unchanged: `fillColor` at `fillOpacity`.

## Implementation

- **`fillPatterns.ts`** — `getOrInjectPattern` now injects a background `<rect>` (canvas color, `fill-opacity=fillOpacity`) as the pattern tile's first child, drawn behind the foreground path. Both the background opacity and the foreground opacity (`fillPatternOpacity`, now baked into the path's `stroke-opacity`/`fill-opacity`) live inside the pattern, so `getPatternFillAttributes` sets the JSXGraph element's `fillOpacity` to `1` — and `highlightFillOpacity` to `0.5`, so hovering dims both layers together, matching how a solid fill dims. The pattern ID now folds in the canvas color and both opacities so tiles with different backgrounds/opacities never alias. `getOrInjectPattern` and its ID builder take a single options object, since their fields are same-typed (colors are strings, opacities are numbers) and would be easy to transpose positionally.
- **`styleColors.ts`** — added `resolveCanvasColor(darkMode)`, mirroring the existing `resolveHandleColor` (resolved hex rather than `var(--canvas)`, because the board SVG's theme is driven by an inner wrapper's `data-theme`).
- **Renderers** (`circle`, `polygon`, `angle`, `regionBetweenCurves`, `regionBetweenCurveXAxis`) — each `getPatternFillAttributes` call site now passes `canvasColor: resolveCanvasColor(darkMode)`.

## PreFigure left untouched

PreFigure's renderer has no native background-behind-pattern feature: its `add_texture` (diagram.py) emits foreground marks only, and `get_2d_attr` (utilities.py) drops `fill-opacity` for patterned fills entirely. Per the requirement to use only PreFigure's native features, the PreFigure conversion (`prefigure/style.ts`) is intentionally unchanged, so this two-layer treatment applies to the JSXGraph renderer only.

## Testing

- New Vitest unit tests in `fillPatterns.test.ts` exercise the real injection path: they assert the background `<rect>` (canvas color at `fillOpacity`) plus the foreground mark for both stroked patterns (`stroke-opacity`) and filled patterns like `diamonds` (`fill-opacity`), pattern reuse (no double injection), and distinct IDs for fills differing only in canvas color (the light/dark aliasing guard) or background opacity. Further tests pin the `getPatternFillAttributes` contract: a patterned fill yields element `fillOpacity` `1` / highlight `0.5`, while a `solid` fill passes its color and authored opacities through unchanged.
- Existing solid-fill behavior (e.g. the `per-component fillOpacity` guard in `circle.cy.js`) is unaffected — the solid branch returns the plain color and `fillOpacity` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)