### PR TITLE
Align list-item section numbers with a fixed-width grid column

### DIFF
--- a/.changeset/align-list-item-numbers.md
+++ b/.changeset/align-list-item-numbers.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Align list-item section numbers consistently.
+
+Section numbers for list-rendered sections (for example `<problem>`s inside `<problems>`, including through a `<cascade>`) now line up at the decimal regardless of how the content wraps, the container width, or whether an item starts with text or with an element. Previously a number could drift horizontally as its content wrapped, as the viewport narrowed, or when the item's first child was a plain string.

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -668,6 +668,36 @@ export class SectioningComponent extends BlockComponent {
             },
         };
 
+        // Whether the renderer should lay out this list item with the
+        // hanging-number grid (a fixed number column + a content column). This
+        // is what keeps the section number's horizontal position independent of
+        // the content's width/wrapping and of whether the first child is a
+        // string or a component. Unlike `firstVisibleChildAdjustedForListItem`
+        // (which stays component-only because it drives first-child top-margin
+        // suppression), this applies to any non-empty untitled/unboxed list
+        // item, including string-first ones.
+        stateVariableDefinitions.useListItemGridLayout = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                nonBoxedListItemWithoutTitle: {
+                    dependencyType: "stateVariable",
+                    variableName: "nonBoxedListItemWithoutTitle",
+                },
+                firstVisibleChild: {
+                    dependencyType: "stateVariable",
+                    variableName: "firstVisibleChild",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const useListItemGridLayout = Boolean(
+                    dependencyValues.nonBoxedListItemWithoutTitle &&
+                    dependencyValues.firstVisibleChild != null,
+                );
+
+                return { setValue: { useListItemGridLayout } };
+            },
+        };
+
         stateVariableDefinitions.firstChildListItemAlignment = {
             stateVariablesDeterminingDependencies: ["firstVisibleChild"],
             forRenderer: true,

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -41,6 +41,7 @@ interface SectionSVs {
     justSubmitted: boolean;
     firstChildListItemAlignment?: string;
     firstVisibleChildAdjustedForListItem?: any;
+    useListItemGridLayout?: boolean;
 }
 
 export default React.memo(function Section(props: UseDoenetRendererProps) {
@@ -78,8 +79,16 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
 
     const hasAdjustedFirstChildForListItem =
         SVs.firstVisibleChildAdjustedForListItem;
+    // Use the hanging-number grid for any non-empty untitled/unboxed list item
+    // (string-first or component-first) so the number's horizontal position is
+    // content-independent. `hasAdjustedFirstChildForListItem` remains the
+    // narrower, component-only signal used for first-child margin suppression.
+    const useListItemGridLayout = SVs.useListItemGridLayout;
+    // Baseline is the correct default for a text/inline first line (and for a
+    // string first child, where `firstChildListItemAlignment` is "none"); only
+    // an explicit "flex-start" first child (e.g. a block choiceInput) opts out.
     const shouldBaselineAlignFirstChild =
-        SVs.firstChildListItemAlignment === "baseline";
+        SVs.firstChildListItemAlignment !== "flex-start";
 
     // Helper function to generate CSS for section number ::before pseudo-element
     // Used for list-item sections to display hanging section numbers
@@ -210,22 +219,15 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
 
         // For non-boxed sections without heading
         if (!SVs.collapsible && !SVs.boxed && !hasTitle) {
-            cssRules.push(`
-                #${escapedId}::before {
-                    content: "${SVs.sectionNumber}.";
-                    display: inline-block;
-                    width: calc(${LIST_ITEM_INDENT} - ${LIST_ITEM_SPACING});
-                    margin-left: calc(-1 * ${LIST_ITEM_INDENT});
-                    margin-right: ${LIST_ITEM_SPACING};
-                    text-align: right;
-                    vertical-align: baseline;
-                }
-            `);
-
-            if (hasAdjustedFirstChildForListItem) {
+            if (useListItemGridLayout) {
+                // Hanging-number grid: a fixed-width number column keeps the
+                // number's horizontal position (the decimal) independent of the
+                // content's width, wrapping, and whether the first child is a
+                // string or a component, so sibling numbers always line up.
                 cssRules.push(`
                     #${escapedId} {
-                        display: flex;
+                        display: grid;
+                        grid-template-columns: ${LIST_ITEM_INDENT} minmax(0, 1fr);
                         align-items: ${
                             shouldBaselineAlignFirstChild
                                 ? "baseline"
@@ -233,13 +235,41 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
                         };
                     }
 
-                    #${escapedContentWrapperId} {
-                        flex: 1 1 auto;
-                        min-width: 0;
+                    #${escapedId}::before {
+                        content: "${SVs.sectionNumber}.";
+                        grid-column: 1;
+                        text-align: right;
+                        padding-right: ${LIST_ITEM_SPACING};
                     }
 
-                    #${escapedContentWrapperId} > :first-child {
-                        margin-block-start: 0;
+                    #${escapedContentWrapperId} {
+                        grid-column: 2;
+                        min-width: 0;
+                    }
+                `);
+
+                // Only suppress the top margin of a *component* first child: a
+                // string first child has no margin to suppress, and a block that
+                // merely follows leading text keeps its normal margins.
+                if (hasAdjustedFirstChildForListItem) {
+                    cssRules.push(`
+                        #${escapedContentWrapperId} > :first-child {
+                            margin-block-start: 0;
+                        }
+                    `);
+                }
+            } else {
+                // Empty untitled list item (number only, no content): hang the
+                // number into the container's left indent.
+                cssRules.push(`
+                    #${escapedId}::before {
+                        content: "${SVs.sectionNumber}.";
+                        display: inline-block;
+                        width: calc(${LIST_ITEM_INDENT} - ${LIST_ITEM_SPACING});
+                        margin-left: calc(-1 * ${LIST_ITEM_INDENT});
+                        margin-right: ${LIST_ITEM_SPACING};
+                        text-align: right;
+                        vertical-align: baseline;
                     }
                 `);
             }
@@ -291,6 +321,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         SVs.boxed,
         hasTitle,
         hasAdjustedFirstChildForListItem,
+        useListItemGridLayout,
         shouldBaselineAlignFirstChild,
         id,
     ]);
@@ -447,7 +478,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         !SVs.collapsible &&
         !SVs.boxed &&
         !heading &&
-        hasAdjustedFirstChildForListItem;
+        useListItemGridLayout;
 
     if (needsContentWrapper) {
         let startInd = 0;
@@ -599,11 +630,17 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
 
     // Render non-boxed list-item sections with hanging section numbers
     if (SVs.isListItem && !SVs.collapsible && !SVs.boxed) {
-        const containerStyle: React.CSSProperties = {
-            margin: "12px 0",
-            position: "relative",
-            marginLeft: LIST_ITEM_INDENT,
-        };
+        // With the hanging-number grid the number lives in the grid's fixed
+        // first column, so the container must NOT also add a left indent
+        // (that would double the gutter). Titled/empty list items still use the
+        // legacy hanging indent via a container margin.
+        const containerStyle: React.CSSProperties = useListItemGridLayout
+            ? { margin: "12px 0" }
+            : {
+                  margin: "12px 0",
+                  position: "relative",
+                  marginLeft: LIST_ITEM_INDENT,
+              };
 
         return renderContainer(content, containerStyle);
     }

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -1,5 +1,6 @@
 import { cesc } from "@doenet/utils";
 import { verifySideBySideColumnTopAlignment } from "./utils/listItemAlignment";
+import { verifyListItemNumbersAlign } from "./utils/listItemNumberAlignment";
 
 describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
     beforeEach(() => {
@@ -1277,11 +1278,13 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
     }
 
     /**
-     * Verifies untitled, unboxed list items use the flex-row layout that keeps
-     * the section number and first child on the same line, even when first child
-     * is a block-level renderer.
+     * Verifies untitled, unboxed list items use the hanging-number grid layout:
+     * a fixed number column (holding the ::before marker) plus a content column,
+     * which keeps the number and first child on the same line — even when the
+     * first child is a block-level renderer — and keeps the number's horizontal
+     * position independent of the content.
      */
-    function verifyUntitledUnboxedListItemUsesFlexLayout(
+    function verifyUntitledUnboxedListItemUsesGridLayout(
         itemId,
         expectedNumber,
     ) {
@@ -1291,7 +1294,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(`#${escapedItemId}`).then(($el) => {
             const win = $el[0].ownerDocument.defaultView;
             const style = win.getComputedStyle($el[0]);
-            expect(style.getPropertyValue("display")).to.equal("flex");
+            expect(style.getPropertyValue("display")).to.equal("grid");
         });
 
         withBeforeStyle(itemId, (before) => {
@@ -1301,12 +1304,14 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             expect(before.getPropertyValue("position")).to.not.equal(
                 "absolute",
             );
+            // The number lives in the fixed first grid column.
+            expect(before.getPropertyValue("grid-column-start")).to.equal("1");
         });
 
         cy.get(`#${escapedContentWrapperId}`).then(($el) => {
             const win = $el[0].ownerDocument.defaultView;
             const style = win.getComputedStyle($el[0]);
-            expect(style.getPropertyValue("flex-grow")).to.equal("1");
+            expect(style.getPropertyValue("grid-column-start")).to.equal("2");
             expect(style.getPropertyValue("min-width")).to.equal("0px");
         });
     }
@@ -1471,14 +1476,14 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        verifyUntitledUnboxedListItemUsesFlexLayout("task1", 1);
-        verifyUntitledUnboxedListItemUsesFlexLayout("task2", 2);
-        verifyUntitledUnboxedListItemUsesFlexLayout("task3", 3);
-        verifyUntitledUnboxedListItemUsesFlexLayout("task4", 4);
-        verifyUntitledUnboxedListItemUsesFlexLayout("task5", 5);
-        verifyUntitledUnboxedListItemUsesFlexLayout("task8", 8);
-        verifyUntitledUnboxedListItemUsesFlexLayout("task9", 9);
-        verifyUntitledUnboxedListItemUsesFlexLayout("task10", 10);
+        verifyUntitledUnboxedListItemUsesGridLayout("task1", 1);
+        verifyUntitledUnboxedListItemUsesGridLayout("task2", 2);
+        verifyUntitledUnboxedListItemUsesGridLayout("task3", 3);
+        verifyUntitledUnboxedListItemUsesGridLayout("task4", 4);
+        verifyUntitledUnboxedListItemUsesGridLayout("task5", 5);
+        verifyUntitledUnboxedListItemUsesGridLayout("task8", 8);
+        verifyUntitledUnboxedListItemUsesGridLayout("task9", 9);
+        verifyUntitledUnboxedListItemUsesGridLayout("task10", 10);
         verifySideBySideColumnTopAlignment({
             sideBySideId: "sbs",
             expectedAlignment: "baseline",
@@ -1503,7 +1508,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(`#${cesc("task6")}`).then(($el) => {
             const win = $el[0].ownerDocument.defaultView;
             const style = win.getComputedStyle($el[0]);
-            expect(style.getPropertyValue("display")).to.not.equal("flex");
+            expect(style.getPropertyValue("display")).to.not.equal("grid");
         });
 
         verifyBoxedListItemNumberInHeadingBox("task7", 7);
@@ -1529,7 +1534,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(`#${cesc("task1")}`).then(($el) => {
             const win = $el[0].ownerDocument.defaultView;
             const style = win.getComputedStyle($el[0]);
-            expect(style.getPropertyValue("display")).to.equal("flex");
+            expect(style.getPropertyValue("display")).to.equal("grid");
             expect(style.getPropertyValue("align-items")).to.equal("baseline");
         });
 
@@ -1537,7 +1542,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(`#${cesc("task2")}`).then(($el) => {
             const win = $el[0].ownerDocument.defaultView;
             const style = win.getComputedStyle($el[0]);
-            expect(style.getPropertyValue("display")).to.equal("flex");
+            expect(style.getPropertyValue("display")).to.equal("grid");
             expect(style.getPropertyValue("align-items")).to.equal("baseline");
         });
 
@@ -1545,7 +1550,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(`#${cesc("task3")}`).then(($el) => {
             const win = $el[0].ownerDocument.defaultView;
             const style = win.getComputedStyle($el[0]);
-            expect(style.getPropertyValue("display")).to.equal("flex");
+            expect(style.getPropertyValue("display")).to.equal("grid");
             expect(style.getPropertyValue("align-items")).to.equal(
                 "flex-start",
             );
@@ -1604,5 +1609,91 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         verifyBeforeContent("problem1", '"1."');
         verifyBeforeContent("problem2", '"2."');
         verifyBeforeContent("problem3", '"3."');
+    });
+
+    // ---------------------------------------------------------------------
+    // Outcome-based list-item number alignment (regression guard for #1482).
+    //
+    // These assert the RENDERED geometry — that sibling list-item numbers line
+    // up at the decimal / content is not shifted — which is technique-
+    // independent and would have caught #1482. See
+    // ./utils/listItemNumberAlignment.js for why this measures content-left.
+    // ---------------------------------------------------------------------
+
+    it("list-item numbers align across first-child types at narrow width (#1482)", () => {
+        cy.viewport(500, 800);
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <problems name="problems">
+            <problem name="p1"><text>Hello plus more text to make it longer so that it wraps to the next line here</text></problem>
+            <problem name="p2">Hello plus more text to make it longer so that it wraps to the next line here</problem>
+            <problem name="p3"><p>Hello plus more text to make it longer so that it wraps to the next line here</p></problem>
+            <problem name="p4">Hello <text>plus more text to make it longer so that it wraps to the next line here</text></problem>
+        </problems>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#p4").should("exist");
+
+        verifyListItemNumbersAlign(["p1", "p2", "p3", "p4"], {
+            label: "first-child types at 500px",
+        });
+    });
+
+    it("list-item numbers align across single- and multi-line items at narrow width (#1482)", () => {
+        cy.viewport(500, 800);
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <problems name="problems">
+            <problem name="p1"><answer><label>Hello.</label>x</answer></problem>
+            <problem name="p2"><answer><label>Hello plus more text to make it longer</label>x</answer></problem>
+            <problem name="p3"><answer><label>Hello plus more text to make it longer so that we wrap to the next line</label>x</answer></problem>
+            <problem name="p4"><answer><label>Write an unsimplified equation that shows the function evaluated. Do not simplify or rearrange any terms.</label>x</answer></problem>
+        </problems>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#p4").should("exist");
+
+        verifyListItemNumbersAlign(["p1", "p2", "p3", "p4"], {
+            label: "single- vs multi-line at 500px",
+        });
+    });
+
+    it("list-item numbers align through a cascade at narrow width (#1482)", () => {
+        cy.viewport(500, 800);
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <problems name="problems">
+            <cascade revealAll name="cascade">
+                <problem name="p1"><answer><label>Hello.</label>x</answer></problem>
+                <problem name="p2"><answer><label>Hello plus more text to make it longer</label>x</answer></problem>
+                <problem name="p3"><answer><label>Hello plus more text to make it longer so that we wrap to the next line</label>x</answer></problem>
+                <problem name="p4"><answer><label>Write an unsimplified equation that shows the function evaluated. Do not simplify or rearrange any terms.</label>x</answer></problem>
+            </cascade>
+        </problems>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#p4").should("exist");
+
+        verifyListItemNumbersAlign(["p1", "p2", "p3", "p4"], {
+            label: "cascade single- vs multi-line at 500px",
+        });
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemNumberAlignment.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemNumberAlignment.js
@@ -1,0 +1,64 @@
+import { cesc } from "@doenet/utils";
+
+/**
+ * Return the viewport-x of the left edge of an element's rendered CONTENT,
+ * excluding the CSS `::before` section-number marker.
+ *
+ * The section number ("1.", "2.", …) is a `::before` pseudo-element. Pseudo
+ * elements are not part of the DOM, so they have no `getBoundingClientRect()`.
+ * A `Range` over the element's contents measures only the real (text / replaced)
+ * content, so its left edge is the content's hanging-indent position.
+ *
+ * In every list-item layout the number and the content share the same layout
+ * row / columns, so if the content's left edge is identical across sibling list
+ * items then their numbers line up at the decimal too. Measuring rendered
+ * geometry this way is technique-independent (it works for flex, grid, or
+ * absolute positioning) — unlike computed-style assertions, which are identical
+ * on the (buggy) flex layout even when the rendered numbers are visibly
+ * misaligned. That is the gap that let issue #1482 through the existing suite.
+ */
+function measureContentLeft(el) {
+    const doc = el.ownerDocument;
+    const range = doc.createRange();
+    range.selectNodeContents(el);
+    return range.getBoundingClientRect().left;
+}
+
+/**
+ * Assert that a set of sibling list items render their content — and therefore
+ * their section numbers — at the same horizontal position, i.e. the numbers
+ * line up at the decimal and no content is shifted right.
+ *
+ * This is the outcome-based regression guard for #1482 and the recurring
+ * list-item-alignment regressions. It is deliberately technique-independent so
+ * it survives a change of layout technique (e.g. flex -> grid).
+ *
+ * @param {string[]} ids Doenet component ids of the sibling list items.
+ * @param {Object} [options]
+ * @param {number} [options.maxDriftPx=1.5] Allowed left-edge drift in px.
+ * @param {string} [options.label] Optional label for the assertion message.
+ */
+export function verifyListItemNumbersAlign(
+    ids,
+    { maxDriftPx = 1.5, label = "" } = {},
+) {
+    const lefts = [];
+    ids.forEach((id) => {
+        cy.get(`#${cesc(id)}`)
+            .should("be.visible")
+            .then(($el) => {
+                lefts.push(measureContentLeft($el[0]));
+            });
+    });
+    cy.then(() => {
+        const min = Math.min(...lefts);
+        const max = Math.max(...lefts);
+        const detail = ids
+            .map((id, i) => `${id}=${lefts[i].toFixed(2)}`)
+            .join(", ");
+        expect(
+            max - min,
+            `list-item content-left drift ${label} [${detail}]`,
+        ).to.be.lessThan(maxDriftPx);
+    });
+}


### PR DESCRIPTION
## Problem

Section numbers for list-rendered sections did not line up at the decimal — they "snaked." Reported for `<problem>`s inside a `<cascade>`, but it is **not** cascade-specific: a plain `<problems>` reproduces it. It is one underlying bug, not several.

The number was rendered as a `::before` **flex item** hung into a 2em gutter with a negative margin and baseline alignment, so its horizontal position was decided by flex sizing. That made it depend on:

- **content width / wrapping** — a multi-line item's number drifts, and the drift grows continuously as the viewport narrows; and
- **first-child type** — a string-first item took a different (non-flex) path than a component-first item, shifting its content and marker.

## Fix

Give the number a content-independent horizontal position while keeping baseline vertical alignment. Untitled, unboxed list-item sections now render as a **CSS grid**:

```
display: grid;
grid-template-columns: 2em minmax(0, 1fr);
align-items: baseline;   /* number sits on the first content line's baseline */
```

with the number in the fixed first column and the content in the second. A fixed column can't move with content, so numbers align at every width and for every first-child type; baseline alignment preserves the reason absolute positioning was previously rejected (numbers must sit on the first line, e.g. inline math or a `choiceInput`).

A new `forRenderer` flag `useListItemGridLayout` (`nonBoxedListItemWithoutTitle && firstVisibleChild != null`) routes **string-first** items through the same grid path, whose content wrapper collapses their leading whitespace. The component-only first-child margin-suppression signals are left untouched. Boxed / collapsible / titled / empty list items are unchanged.

## Why the old tests missed this — and the new guard

This layout has been reworked repeatedly, and each round could reintroduce misalignment because the tests were **structural** (assert `display:flex`, `::before` content, content-wrapper `flex-grow`) and never checked that numbers actually align, nor varied viewport width. Computed styles are identical on the buggy layout even when the rendered numbers are misaligned.

This PR adds an **outcome-based, technique-independent** guard: `verifyListItemNumbersAlign` (`utils/listItemNumberAlignment.js`) measures rendered content-left via a `Range` (which excludes the `::before` pseudo, so it works for flex, grid, or absolute) and asserts sub-pixel drift across sibling items. New tests cover first-child types, single/multi-line, and cascade contexts at a narrow viewport; they were confirmed to fail before the fix and pass after. The existing flex-coupled structural helpers were updated to the grid contract.

## Verification

- `problem.cy.js` — all pass (new alignment tests + existing list-item tests)
- `sectioning.cy.js`, `image.cy.js` — pass
- worker `sectioning.test.ts` + `cascade.test.ts` — pass
- Visual check at wide and narrow widths: numbers align at the decimal, including wrapping items, inline-math labels, string-first, and component-first.

Closes #1482

🤖 Generated with [Claude Code](https://claude.com/claude-code)
