### PR TITLE
Windowed mounting for docs examples to cut memory footprint

### DIFF
--- a/packages/docs-nextra/components/doenet.tsx
+++ b/packages/docs-nextra/components/doenet.tsx
@@ -1,6 +1,15 @@
 import React from "react";
 import dynamic from "next/dynamic";
 import "@doenet/virtual-keyboard/style.css";
+import type { MountPolicy } from "@doenet/doenetml-iframe";
+import {
+    VIEWER_MAX_CONCURRENT_BOOTS,
+    VIEWER_MAX_LIVE,
+    VIEWER_PARK_DELAY_MS,
+    VIEWER_VISIBLE_MARGIN,
+    WINDOWING_ENABLED,
+} from "./windowing-config";
+import { WindowedEditor } from "./windowed-editor";
 
 /**
  * The iframe components generate a random per-instance id that is baked into the
@@ -37,12 +46,38 @@ const versionProps =
         : { doenetmlVersion: "dev" };
 
 /**
+ * Windowed mounting for viewer examples (#1441 stream B, docs host): reuse the
+ * built-in `mountPolicy` from `@doenet/doenetml-iframe`, so a page keeps at most
+ * `VIEWER_MAX_LIVE` viewers live and parks off-screen ones. `allowSaveState`
+ * makes parking lossless (the wrapper snapshots the flushed report in memory and
+ * reseeds it on restore); it is otherwise inert here — no docs host consumes
+ * `SPLICE.reportScoreAndState` and nothing hits the network.
+ */
+const viewerMountPolicy: MountPolicy = {
+    mode: "windowed",
+    maxLiveViewers: VIEWER_MAX_LIVE,
+    maxConcurrentBoots: VIEWER_MAX_CONCURRENT_BOOTS,
+    visibleMargin: VIEWER_VISIBLE_MARGIN,
+    parkDelayMs: VIEWER_PARK_DELAY_MS,
+};
+
+const windowedViewerProps = WINDOWING_ENABLED
+    ? { flags: { allowSaveState: true }, mountPolicy: viewerMountPolicy }
+    : {};
+
+/**
  * Render DoenetML in an iframe so that its styling/state is completely isolated from the page.
  */
 export function DoenetViewer({
     source,
 }: React.PropsWithChildren<{ source: string }>) {
-    return <DoenetViewerOrig doenetML={source} {...versionProps} />;
+    return (
+        <DoenetViewerOrig
+            doenetML={source}
+            {...windowedViewerProps}
+            {...versionProps}
+        />
+    );
 }
 
 export function DoenetEditor({
@@ -56,15 +91,16 @@ export function DoenetEditor({
     viewerLocation?: "left" | "right" | "top" | "bottom";
     height?: string;
 }>) {
+    // Editors have no built-in `mountPolicy`, so the docs-layer `WindowedEditor`
+    // adds lazy mounting + a live-count budget for them (#1441 stream B).
     return (
-        <div className="doenet-editor-container">
-            <DoenetEditorOrig
-                doenetML={source}
-                showFormatter={showFormatter}
-                viewerLocation={viewerLocation}
-                height={height}
-                {...versionProps}
-            />
-        </div>
+        <WindowedEditor
+            source={source}
+            showFormatter={showFormatter}
+            viewerLocation={viewerLocation}
+            height={height}
+            versionProps={versionProps}
+            DoenetEditorOrig={DoenetEditorOrig}
+        />
     );
 }

--- a/packages/docs-nextra/components/editor-mount-manager.ts
+++ b/packages/docs-nextra/components/editor-mount-manager.ts
@@ -115,7 +115,7 @@ export function requestMountSlot(id: string, grant: () => void) {
         return;
     }
     bootQueue.push({ id, requestOrder: ++bootRequestCounter, grant });
-    pumpBootQueue();
+    grantBootSlots();
 }
 
 /** Withdraw a queued boot request (e.g. the editor scrolled away again). */
@@ -132,11 +132,17 @@ export function cancelMountRequest(id: string) {
  */
 export function releaseMountSlot(id: string) {
     if (bootSlotHolders.delete(id)) {
-        pumpBootQueue();
+        grantBootSlots();
     }
 }
 
-function pumpBootQueue() {
+/**
+ * Hand free boot slots to waiting editors, up to the concurrency cap, choosing
+ * visible editors first and then by request order. Called whenever a slot may
+ * have opened up (a boot finished/was released) or a new waiter joined the
+ * queue.
+ */
+function grantBootSlots() {
     const max = effectiveMaxBoots ?? Infinity;
     while (bootQueue.length > 0 && bootSlotHolders.size < max) {
         // Visible-first, then request order.

--- a/packages/docs-nextra/components/editor-mount-manager.ts
+++ b/packages/docs-nextra/components/editor-mount-manager.ts
@@ -1,0 +1,308 @@
+/**
+ * Page-wide lifecycle manager for windowed editor examples in the docs site
+ * (#1441 stream B, docs host).
+ *
+ * The iframe `<DoenetViewer>` has a built-in windowed `mountPolicy`, but the
+ * iframe `<DoenetEditor>` does not — and editors are the dominant example type
+ * in the docs. This module is the editor counterpart: a deliberately
+ * simplified sibling of `@doenet/doenetml-iframe`'s `viewer-lifecycle-manager`
+ * (whose register/boot-slot functions are internal and not exported, so they
+ * cannot be reused). It owns two page-wide budgets:
+ *
+ * - a live-count budget with least-recently-visible eviction (unload the
+ *   off-screen editors beyond `maxLive`), and
+ * - a boot-slot semaphore (`maxConcurrentBoots`) that caps how many editors
+ *   evaluate the multi-MB standalone bundle at once, visible-first.
+ *
+ * It is pure policy (no React, no DOM): *when* an editor may mount and *when*
+ * it must unload. The `WindowedEditor` wrapper owns the mechanics (the
+ * `IntersectionObserver`, mounting/unmounting the iframe) and reports outcomes
+ * back here. Editor eviction is always safe — unloading a docs editor just
+ * reboots it from its documented source — so, unlike the viewer manager, there
+ * is no persistence/`canPark` gate and no state-flush handshake. Module-level
+ * state is intentional: the budget is shared by every editor on the page.
+ *
+ * Rules (mirroring the viewer manager):
+ * - A currently-visible editor is never unloaded (the budget is soft).
+ * - An editor is eligible to unload only after `parkDelayMs` off-screen.
+ * - Eviction order is least-recently-visible first.
+ */
+
+/** "mounted" = live iframe; "unmounting" = eviction in flight; "unmounted" = placeholder. */
+export type EditorMountState = "mounted" | "unmounting" | "unmounted";
+
+type EditorRecord = {
+    id: string;
+    state: EditorMountState;
+    visible: boolean;
+    /** Monotonic counter value from when this editor was last visible. */
+    lastVisibleOrder: number;
+    /** Timestamp when this editor last became invisible. */
+    invisibleSince: number;
+    parkDelayMs: number;
+    /** Ask the wrapper to unload (unmount the iframe, show the placeholder). */
+    requestEvict: () => void;
+};
+
+const records = new Map<string, EditorRecord>();
+let visibleOrderCounter = 0;
+let effectiveMaxLive: number | null = null;
+
+let evaluateTimerId: ReturnType<typeof setTimeout> | null = null;
+let evaluateTimerAt = Infinity;
+
+// ---- Boot-slot semaphore ----
+// Caps how many editors boot their iframe realm simultaneously.
+let effectiveMaxBoots: number | null = null;
+const bootSlotHolders = new Set<string>();
+type BootRequest = { id: string; requestOrder: number; grant: () => void };
+let bootRequestCounter = 0;
+const bootQueue: BootRequest[] = [];
+
+/**
+ * Register an editor. It starts as a placeholder (`"unmounted"`) and only
+ * counts against the live budget once it actually mounts. Returns an
+ * unregister function for the wrapper's unmount cleanup.
+ */
+export function registerEditor({
+    id,
+    maxLive,
+    maxConcurrentBoots,
+    parkDelayMs,
+    requestEvict,
+}: {
+    id: string;
+    maxLive: number;
+    maxConcurrentBoots: number;
+    parkDelayMs: number;
+    requestEvict: () => void;
+}): () => void {
+    effectiveMaxBoots =
+        effectiveMaxBoots === null
+            ? maxConcurrentBoots
+            : Math.min(effectiveMaxBoots, maxConcurrentBoots);
+    effectiveMaxLive =
+        effectiveMaxLive === null
+            ? maxLive
+            : Math.min(effectiveMaxLive, maxLive);
+
+    records.set(id, {
+        id,
+        state: "unmounted",
+        visible: false,
+        lastVisibleOrder: 0,
+        invisibleSince: Date.now(),
+        parkDelayMs,
+        requestEvict,
+    });
+
+    return () => {
+        records.delete(id);
+        cancelMountRequest(id);
+        releaseMountSlot(id);
+        scheduleEvaluate(0);
+    };
+}
+
+/**
+ * Request a boot slot; `grant` is called (synchronously when a slot is free)
+ * once this editor may create its iframe. Visible editors are served before
+ * off-screen ones, then request order. A duplicate request for an id already
+ * queued or already holding a slot is ignored.
+ */
+export function requestMountSlot(id: string, grant: () => void) {
+    if (bootSlotHolders.has(id) || bootQueue.some((r) => r.id === id)) {
+        return;
+    }
+    bootQueue.push({ id, requestOrder: ++bootRequestCounter, grant });
+    pumpBootQueue();
+}
+
+/** Withdraw a queued boot request (e.g. the editor scrolled away again). */
+export function cancelMountRequest(id: string) {
+    const idx = bootQueue.findIndex((r) => r.id === id);
+    if (idx !== -1) {
+        bootQueue.splice(idx, 1);
+    }
+}
+
+/**
+ * Release a held boot slot (the editor finished booting, was evicted, or
+ * unregistered). Idempotent.
+ */
+export function releaseMountSlot(id: string) {
+    if (bootSlotHolders.delete(id)) {
+        pumpBootQueue();
+    }
+}
+
+function pumpBootQueue() {
+    const max = effectiveMaxBoots ?? Infinity;
+    while (bootQueue.length > 0 && bootSlotHolders.size < max) {
+        // Visible-first, then request order.
+        let best = 0;
+        for (let i = 1; i < bootQueue.length; i++) {
+            const bestVisible = Boolean(
+                records.get(bootQueue[best].id)?.visible,
+            );
+            const thisVisible = Boolean(records.get(bootQueue[i].id)?.visible);
+            if (
+                (thisVisible && !bestVisible) ||
+                (thisVisible === bestVisible &&
+                    bootQueue[i].requestOrder < bootQueue[best].requestOrder)
+            ) {
+                best = i;
+            }
+        }
+        const [request] = bootQueue.splice(best, 1);
+        bootSlotHolders.add(request.id);
+        request.grant();
+    }
+}
+
+/** Report a visibility change from the wrapper's IntersectionObserver. */
+export function reportEditorVisibility(id: string, visible: boolean) {
+    const record = records.get(id);
+    if (!record || record.visible === visible) {
+        return;
+    }
+    record.visible = visible;
+    if (visible) {
+        record.lastVisibleOrder = ++visibleOrderCounter;
+        scheduleEvaluate(0);
+    } else {
+        record.invisibleSince = Date.now();
+        scheduleEvaluate(record.parkDelayMs);
+    }
+}
+
+/**
+ * Report a mount-state change from the wrapper (which owns the actual
+ * mount/unmount and reports the outcome here). Only `"mounted"` editors count
+ * against the live budget.
+ */
+export function notifyEditorState(id: string, state: EditorMountState) {
+    const record = records.get(id);
+    if (!record || record.state === state) {
+        return;
+    }
+    record.state = state;
+    scheduleEvaluate(0);
+}
+
+/** Snapshot for tests and manual verification. */
+export function getEditorMountStats() {
+    let mounted = 0,
+        unmounting = 0,
+        unmounted = 0;
+    for (const record of records.values()) {
+        if (record.state === "mounted") {
+            mounted++;
+        } else if (record.state === "unmounting") {
+            unmounting++;
+        } else {
+            unmounted++;
+        }
+    }
+    return {
+        registered: records.size,
+        mounted,
+        unmounting,
+        unmounted,
+        booting: bootSlotHolders.size,
+        bootQueue: bootQueue.length,
+    };
+}
+
+/** Test-only: forget every registration and reset module state. */
+export function __resetEditorMountManagerForTests() {
+    records.clear();
+    visibleOrderCounter = 0;
+    effectiveMaxLive = null;
+    if (evaluateTimerId !== null) {
+        clearTimeout(evaluateTimerId);
+        evaluateTimerId = null;
+    }
+    evaluateTimerAt = Infinity;
+    effectiveMaxBoots = null;
+    bootSlotHolders.clear();
+    bootQueue.length = 0;
+    bootRequestCounter = 0;
+}
+
+/**
+ * Schedule an `evaluate()` after `delayMs`, coalescing with any
+ * already-scheduled evaluation (the earlier of the two wins).
+ */
+function scheduleEvaluate(delayMs: number) {
+    const at = Date.now() + delayMs;
+    if (evaluateTimerId !== null) {
+        if (at >= evaluateTimerAt) {
+            return;
+        }
+        clearTimeout(evaluateTimerId);
+    }
+    evaluateTimerAt = at;
+    evaluateTimerId = setTimeout(() => {
+        evaluateTimerId = null;
+        evaluateTimerAt = Infinity;
+        evaluate();
+    }, delayMs);
+}
+
+/**
+ * Enforce the budget: if more editors are mounted than `maxLive`, ask the
+ * least-recently-visible eligible off-screen editors to unload. If some
+ * over-budget editors are only ineligible because their off-screen debounce
+ * hasn't elapsed, re-evaluate when it does. Editors mid-unload
+ * (`"unmounting"`) are already committed to freeing their slot, so they do not
+ * count here (mirrors the viewer manager not counting `"parking"`).
+ */
+function evaluate() {
+    if (effectiveMaxLive === null) {
+        return;
+    }
+    const now = Date.now();
+
+    let mounted = 0;
+    for (const record of records.values()) {
+        if (record.state === "mounted") {
+            mounted++;
+        }
+    }
+    let excess = mounted - effectiveMaxLive;
+    if (excess <= 0) {
+        return;
+    }
+
+    const candidates: EditorRecord[] = [];
+    let nextDebounceExpiry = Infinity;
+    for (const record of records.values()) {
+        if (record.state !== "mounted" || record.visible) {
+            continue;
+        }
+        const eligibleAt = record.invisibleSince + record.parkDelayMs;
+        if (eligibleAt > now) {
+            nextDebounceExpiry = Math.min(nextDebounceExpiry, eligibleAt);
+            continue;
+        }
+        candidates.push(record);
+    }
+
+    candidates.sort((a, b) => a.lastVisibleOrder - b.lastVisibleOrder);
+
+    for (const record of candidates) {
+        if (excess <= 0) {
+            break;
+        }
+        // Mark optimistically so a single pass doesn't evict the same editor
+        // twice; the wrapper confirms via `notifyEditorState("unmounted")`.
+        record.state = "unmounting";
+        excess--;
+        record.requestEvict();
+    }
+
+    if (excess > 0 && nextDebounceExpiry < Infinity) {
+        scheduleEvaluate(Math.max(0, nextDebounceExpiry - now));
+    }
+}

--- a/packages/docs-nextra/components/windowed-editor.tsx
+++ b/packages/docs-nextra/components/windowed-editor.tsx
@@ -1,0 +1,204 @@
+import React from "react";
+import {
+    EDITOR_BOOT_WATCHDOG_MS,
+    EDITOR_MAX_CONCURRENT_BOOTS,
+    EDITOR_MAX_LIVE,
+    EDITOR_PARK_DELAY_MS,
+    EDITOR_VISIBLE_MARGIN,
+    WINDOWING_ENABLED,
+} from "./windowing-config";
+import {
+    cancelMountRequest,
+    notifyEditorState,
+    registerEditor,
+    releaseMountSlot,
+    reportEditorVisibility,
+    requestMountSlot,
+} from "./editor-mount-manager";
+
+type WindowedEditorProps = {
+    source: string;
+    showFormatter: boolean;
+    viewerLocation: "left" | "right" | "top" | "bottom";
+    height: string;
+    /** `standaloneUrl`/`cssUrl` (dev) or `doenetmlVersion` (prod). */
+    versionProps: Record<string, unknown>;
+    /**
+     * The real (iframe) editor, passed in so the single
+     * `next/dynamic(..., {ssr:false})` definition stays in `doenet.tsx`.
+     */
+    DoenetEditorOrig: React.ComponentType<any>;
+};
+
+/**
+ * Lazy-mount / windowing wrapper for a docs editor example (#1441 stream B,
+ * docs host). The iframe `<DoenetEditor>` has no built-in `mountPolicy`, so
+ * this wrapper adds one at the docs layer: it renders a fixed-height
+ * placeholder (editors have a known height, so mount/unmount never shifts the
+ * layout) until the example nears the viewport, then mounts the real editor —
+ * subject to a page-wide boot-concurrency cap and live-count budget enforced
+ * by `editor-mount-manager`. Off-screen editors beyond the budget are unloaded
+ * (least-recently-visible first) and reboot from their documented source when
+ * scrolled back.
+ */
+export function WindowedEditor({
+    source,
+    showFormatter,
+    viewerLocation,
+    height,
+    versionProps,
+    DoenetEditorOrig,
+}: WindowedEditorProps) {
+    const id = React.useId();
+    const [mounted, setMounted] = React.useState(false);
+
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const intersectingRef = React.useRef(false);
+    const mountedRef = React.useRef(false);
+    const watchdogRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+        null,
+    );
+    const bootCompleteRef = React.useRef(false);
+
+    React.useEffect(() => {
+        mountedRef.current = mounted;
+    }, [mounted]);
+
+    const clearWatchdog = React.useCallback(() => {
+        if (watchdogRef.current !== null) {
+            clearTimeout(watchdogRef.current);
+            watchdogRef.current = null;
+        }
+    }, []);
+
+    // Fires once the editor's document renders — the boot is done, so free the
+    // slot for the next queued editor. Stable identity (only depends on the
+    // stable `id`/`clearWatchdog`) so it is not re-proxied across the iframe
+    // Comlink boundary on every render (which would leak a MessagePort).
+    const onDocumentStructure = React.useCallback(() => {
+        if (bootCompleteRef.current) {
+            return;
+        }
+        bootCompleteRef.current = true;
+        clearWatchdog();
+        releaseMountSlot(id);
+    }, [id, clearWatchdog]);
+
+    React.useEffect(() => {
+        if (!WINDOWING_ENABLED) {
+            return;
+        }
+        const el = containerRef.current;
+        if (!el) {
+            return;
+        }
+
+        // The manager asks us to unload when this editor is over budget and
+        // off-screen.
+        const requestEvict = () => {
+            clearWatchdog();
+            bootCompleteRef.current = false;
+            releaseMountSlot(id); // no-op if the boot already completed
+            mountedRef.current = false;
+            setMounted(false);
+            notifyEditorState(id, "unmounted");
+        };
+
+        const unregister = registerEditor({
+            id,
+            maxLive: EDITOR_MAX_LIVE,
+            maxConcurrentBoots: EDITOR_MAX_CONCURRENT_BOOTS,
+            parkDelayMs: EDITOR_PARK_DELAY_MS,
+            requestEvict,
+        });
+
+        const tryMount = () => {
+            if (mountedRef.current) {
+                return;
+            }
+            requestMountSlot(id, () => {
+                // Granted (possibly asynchronously). If we scrolled back out
+                // of the margin meanwhile, give the slot up for someone else.
+                if (!intersectingRef.current) {
+                    releaseMountSlot(id);
+                    return;
+                }
+                bootCompleteRef.current = false;
+                mountedRef.current = true;
+                setMounted(true);
+                notifyEditorState(id, "mounted");
+                clearWatchdog();
+                watchdogRef.current = setTimeout(() => {
+                    releaseMountSlot(id);
+                }, EDITOR_BOOT_WATCHDOG_MS);
+            });
+        };
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const entry = entries[entries.length - 1];
+                const intersecting = entry.isIntersecting;
+                intersectingRef.current = intersecting;
+                reportEditorVisibility(id, intersecting);
+                if (intersecting) {
+                    tryMount();
+                } else {
+                    cancelMountRequest(id);
+                }
+            },
+            { rootMargin: EDITOR_VISIBLE_MARGIN },
+        );
+        observer.observe(el);
+
+        return () => {
+            observer.disconnect();
+            clearWatchdog();
+            cancelMountRequest(id);
+            releaseMountSlot(id);
+            unregister();
+        };
+    }, [id, clearWatchdog]);
+
+    // Windowing off: render the editor the historical (immediate) way.
+    if (!WINDOWING_ENABLED) {
+        return (
+            <div className="doenet-editor-container">
+                <DoenetEditorOrig
+                    doenetML={source}
+                    showFormatter={showFormatter}
+                    viewerLocation={viewerLocation}
+                    height={height}
+                    {...versionProps}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div
+            ref={containerRef}
+            className="doenet-editor-container"
+            style={{ width: "100%" }}
+        >
+            {mounted ? (
+                <DoenetEditorOrig
+                    doenetML={source}
+                    showFormatter={showFormatter}
+                    viewerLocation={viewerLocation}
+                    height={height}
+                    documentStructureCallback={onDocumentStructure}
+                    {...versionProps}
+                />
+            ) : (
+                <div
+                    data-doenet-editor-placeholder="true"
+                    style={{
+                        width: "100%",
+                        height,
+                        boxSizing: "border-box",
+                    }}
+                />
+            )}
+        </div>
+    );
+}

--- a/packages/docs-nextra/components/windowing-config.ts
+++ b/packages/docs-nextra/components/windowing-config.ts
@@ -1,0 +1,57 @@
+/**
+ * Page-wide budgets for windowed mounting of embedded DoenetML examples in the
+ * docs site (#1441 stream B, applied to the docs host).
+ *
+ * A live example is its own iframe realm plus a ~100 MB-class core worker;
+ * reference pages embed up to ~24 of them, so a page that mounts every example
+ * at once can cost multiple GB. Windowing keeps only what the reader can see
+ * live: viewers use the built-in `mountPolicy` from `@doenet/doenetml-iframe`;
+ * editors (which have no built-in support) use the docs-layer wrapper and
+ * manager. These constants configure both paths from one place.
+ */
+
+/**
+ * Master switch. Set to `false` to render every example the historical way
+ * (immediate mount, no windowing) — a clean rollback / A-B toggle.
+ */
+export const WINDOWING_ENABLED = true;
+
+// ---- Viewers (built-in @doenet/doenetml-iframe `mountPolicy`) ----
+
+/** Page-wide budget of simultaneously live viewers. */
+export const VIEWER_MAX_LIVE = 3;
+/** Page-wide cap on how many viewers may boot their iframe realm at once. */
+export const VIEWER_MAX_CONCURRENT_BOOTS = 2;
+/**
+ * `IntersectionObserver` rootMargin for viewers. Kept below the package
+ * default ("1000px") because the built-in soft-budget rule never parks a
+ * currently-visible viewer, so the live count floors at the number
+ * simultaneously inside this margin — a large margin undercuts the budget on a
+ * dense page. Viewers auto-size, so a modest lead still lets height correction
+ * happen before the example scrolls into view.
+ */
+export const VIEWER_VISIBLE_MARGIN = "600px";
+/** How long a viewer must be off-screen before it may be parked. */
+export const VIEWER_PARK_DELAY_MS = 2000;
+
+// ---- Editors (docs-layer wrapper + manager) ----
+
+/** Page-wide budget of simultaneously mounted editors. */
+export const EDITOR_MAX_LIVE = 3;
+/** Page-wide cap on how many editors may boot their iframe realm at once. */
+export const EDITOR_MAX_CONCURRENT_BOOTS = 2;
+/**
+ * `IntersectionObserver` rootMargin for editors. Smaller than the viewer
+ * margin: editors have a fixed known height (no layout-shift risk from booting
+ * late), so we keep the near-viewport set tight.
+ */
+export const EDITOR_VISIBLE_MARGIN = "400px";
+/** How long an editor must be off-screen before it may be unloaded. */
+export const EDITOR_PARK_DELAY_MS = 2000;
+/**
+ * Fallback for releasing an editor's boot slot if the boot never signals
+ * completion (load error, wedged worker), so the boot queue can't wedge. The
+ * `documentStructureCallback` normally frees the slot as soon as the editor
+ * renders; this is only the backstop.
+ */
+export const EDITOR_BOOT_WATCHDOG_MS = 30000;

--- a/packages/docs-nextra/package.json
+++ b/packages/docs-nextra/package.json
@@ -11,7 +11,7 @@
         "/dist"
     ],
     "scripts": {
-        "test": "echo \"No tests\"",
+        "test": "vitest",
         "dev": "npm run build:pre && next",
         "build": "npm run build:pre && next build",
         "start": "next start",

--- a/packages/docs-nextra/test/editor-mount-manager.test.ts
+++ b/packages/docs-nextra/test/editor-mount-manager.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+    __resetEditorMountManagerForTests as reset,
+    cancelMountRequest,
+    getEditorMountStats as stats,
+    notifyEditorState,
+    registerEditor,
+    releaseMountSlot,
+    reportEditorVisibility,
+    requestMountSlot,
+} from "../components/editor-mount-manager";
+
+/**
+ * Unit tests for the page-wide editor windowing policy engine (#1441 stream B,
+ * docs host). The manager is pure policy — no React, no DOM — so these drive
+ * its API directly and assert via `getEditorMountStats()` and the `grant` /
+ * `requestEvict` spies. Fake timers make the `parkDelayMs` debounce and the
+ * coalesced `scheduleEvaluate` deterministic.
+ */
+
+const DELAY = 2000;
+
+/** Register an editor with the given knobs; returns its spies + unregister. */
+function makeEditor(
+    id: string,
+    {
+        maxLive = 10,
+        maxConcurrentBoots = 10,
+    }: { maxLive?: number; maxConcurrentBoots?: number } = {},
+) {
+    const requestEvict = vi.fn();
+    const unregister = registerEditor({
+        id,
+        maxLive,
+        maxConcurrentBoots,
+        parkDelayMs: DELAY,
+        requestEvict,
+    });
+    return { id, requestEvict, unregister };
+}
+
+/** Drive an editor to "mounted" after having been visible then scrolled off. */
+function mountOffScreen(id: string) {
+    reportEditorVisibility(id, true); // stamps recency order
+    reportEditorVisibility(id, false); // starts the off-screen debounce
+    notifyEditorState(id, "mounted");
+}
+
+beforeEach(() => {
+    reset();
+    vi.useFakeTimers();
+});
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("boot-slot semaphore", () => {
+    test("caps concurrent grants and queues the rest, granting on release", () => {
+        const grants = [vi.fn(), vi.fn(), vi.fn()];
+        ["a", "b", "c"].forEach((id) =>
+            makeEditor(id, { maxConcurrentBoots: 2 }),
+        );
+        ["a", "b", "c"].forEach((id, i) => requestMountSlot(id, grants[i]));
+
+        expect(grants[0]).toHaveBeenCalledTimes(1);
+        expect(grants[1]).toHaveBeenCalledTimes(1);
+        expect(grants[2]).not.toHaveBeenCalled();
+        expect(stats()).toMatchObject({ booting: 2, bootQueue: 1 });
+
+        releaseMountSlot("a");
+        expect(grants[2]).toHaveBeenCalledTimes(1);
+        expect(stats()).toMatchObject({ booting: 2, bootQueue: 0 });
+    });
+
+    test("ignores a duplicate request for an id already holding a slot", () => {
+        makeEditor("a", { maxConcurrentBoots: 2 });
+        const grant = vi.fn();
+        requestMountSlot("a", grant);
+        requestMountSlot("a", grant);
+        expect(grant).toHaveBeenCalledTimes(1);
+        expect(stats()).toMatchObject({ booting: 1, bootQueue: 0 });
+    });
+
+    test("cancelMountRequest withdraws a queued (not-yet-granted) request", () => {
+        const g = { a: vi.fn(), b: vi.fn(), c: vi.fn() };
+        ["a", "b", "c"].forEach((id) =>
+            makeEditor(id, { maxConcurrentBoots: 1 }),
+        );
+        requestMountSlot("a", g.a); // granted (cap 1)
+        requestMountSlot("b", g.b); // queued
+        requestMountSlot("c", g.c); // queued
+        expect(stats().bootQueue).toBe(2);
+
+        cancelMountRequest("b");
+        expect(stats().bootQueue).toBe(1);
+
+        releaseMountSlot("a");
+        expect(g.b).not.toHaveBeenCalled();
+        expect(g.c).toHaveBeenCalledTimes(1);
+    });
+
+    test("releaseMountSlot is idempotent — a stale release grants nothing extra", () => {
+        const g = { a: vi.fn(), b: vi.fn() };
+        ["a", "b"].forEach((id) => makeEditor(id, { maxConcurrentBoots: 1 }));
+        requestMountSlot("a", g.a);
+        requestMountSlot("b", g.b);
+
+        releaseMountSlot("a");
+        expect(g.b).toHaveBeenCalledTimes(1);
+
+        releaseMountSlot("a"); // already released
+        releaseMountSlot("a");
+        expect(g.b).toHaveBeenCalledTimes(1);
+        expect(stats().booting).toBe(1); // only b holds a slot
+    });
+
+    test("a freed slot goes to a visible waiter first, then by request order", () => {
+        const g = { a: vi.fn(), b: vi.fn(), c: vi.fn() };
+        ["a", "b", "c"].forEach((id) =>
+            makeEditor(id, { maxConcurrentBoots: 1 }),
+        );
+        requestMountSlot("a", g.a); // granted (cap 1)
+        requestMountSlot("b", g.b); // queued first
+        requestMountSlot("c", g.c); // queued second
+        reportEditorVisibility("c", true); // c visible → should win over b
+
+        releaseMountSlot("a");
+        expect(g.c).toHaveBeenCalledTimes(1);
+        expect(g.b).not.toHaveBeenCalled();
+    });
+});
+
+describe("live-count budget + eviction", () => {
+    test("evicts the least-recently-visible off-screen editor when over budget", () => {
+        const e = ["e0", "e1", "e2", "e3"].map((id) =>
+            makeEditor(id, { maxLive: 3 }),
+        );
+        // Recency e0 (oldest) … e3 (newest); all now off-screen and mounted.
+        e.forEach(({ id }) => mountOffScreen(id));
+        expect(stats().mounted).toBe(4);
+
+        vi.advanceTimersByTime(DELAY);
+        expect(e[0].requestEvict).toHaveBeenCalledTimes(1); // least-recently-visible
+        e.slice(1).forEach(({ requestEvict }) =>
+            expect(requestEvict).not.toHaveBeenCalled(),
+        );
+        expect(stats()).toMatchObject({ mounted: 3, unmounting: 1 });
+
+        notifyEditorState("e0", "unmounted"); // wrapper confirms the unload
+        expect(stats()).toMatchObject({
+            mounted: 3,
+            unmounting: 0,
+            unmounted: 1,
+        });
+    });
+
+    test("never evicts a currently-visible editor (soft budget)", () => {
+        const e = ["e0", "e1", "e2", "e3"].map((id) =>
+            makeEditor(id, { maxLive: 3 }),
+        );
+        e.forEach(({ id }) => {
+            reportEditorVisibility(id, true);
+            notifyEditorState(id, "mounted");
+        });
+
+        vi.advanceTimersByTime(10 * DELAY);
+        e.forEach(({ requestEvict }) =>
+            expect(requestEvict).not.toHaveBeenCalled(),
+        );
+        expect(stats().mounted).toBe(4);
+    });
+
+    test("waits out parkDelayMs before evicting an off-screen editor", () => {
+        const e = ["e0", "e1", "e2", "e3"].map((id) =>
+            makeEditor(id, { maxLive: 3 }),
+        );
+        e.forEach(({ id }) => mountOffScreen(id));
+
+        vi.advanceTimersByTime(DELAY - 1);
+        e.forEach(({ requestEvict }) =>
+            expect(requestEvict).not.toHaveBeenCalled(),
+        );
+
+        vi.advanceTimersByTime(1);
+        expect(e[0].requestEvict).toHaveBeenCalledTimes(1);
+    });
+
+    test("evicts exactly the excess and does not double-evict while unmounting", () => {
+        const e = ["e0", "e1", "e2", "e3", "e4"].map((id) =>
+            makeEditor(id, { maxLive: 3 }),
+        );
+        e.forEach(({ id }) => mountOffScreen(id));
+
+        vi.advanceTimersByTime(DELAY);
+        const evicted = () =>
+            e.filter(
+                ({ requestEvict }) => requestEvict.mock.calls.length === 1,
+            );
+        expect(evicted().map((x) => x.id)).toEqual(["e0", "e1"]); // 5 mounted − 3 budget
+        expect(stats()).toMatchObject({ mounted: 3, unmounting: 2 });
+
+        // A re-evaluation triggered while the two are still unmounting must not
+        // shed more (they no longer count against the budget).
+        notifyEditorState("e0", "unmounted");
+        vi.advanceTimersByTime(DELAY);
+        expect(evicted()).toHaveLength(2);
+    });
+
+    test("the effective live budget is the smallest across registrations", () => {
+        const e0 = makeEditor("e0", { maxLive: 5 });
+        makeEditor("e1", { maxLive: 2 }); // smallest → page budget is 2
+        const e2 = makeEditor("e2", { maxLive: 5 });
+        ["e0", "e1", "e2"].forEach(mountOffScreen);
+
+        vi.advanceTimersByTime(DELAY);
+        expect(e0.requestEvict).toHaveBeenCalledTimes(1); // least-recently-visible over the budget of 2
+        expect(e2.requestEvict).not.toHaveBeenCalled();
+        expect(stats().mounted).toBe(2);
+    });
+});
+
+describe("registration lifecycle", () => {
+    test("unregister releases a held boot slot and pumps the queue", () => {
+        const a = makeEditor("a", { maxConcurrentBoots: 1 });
+        makeEditor("b", { maxConcurrentBoots: 1 });
+        const gA = vi.fn();
+        const gB = vi.fn();
+        requestMountSlot("a", gA); // granted (cap 1)
+        requestMountSlot("b", gB); // queued
+        expect(gB).not.toHaveBeenCalled();
+
+        a.unregister(); // frees the slot → b is granted
+        expect(gB).toHaveBeenCalledTimes(1);
+        expect(stats().registered).toBe(1);
+    });
+
+    test("__resetEditorMountManagerForTests clears all state", () => {
+        makeEditor("a", { maxLive: 3, maxConcurrentBoots: 2 });
+        requestMountSlot("a", vi.fn());
+        mountOffScreen("a");
+
+        reset();
+        expect(stats()).toEqual({
+            registered: 0,
+            mounted: 0,
+            unmounting: 0,
+            unmounted: 0,
+            booting: 0,
+            bootQueue: 0,
+        });
+    });
+});

--- a/packages/docs-nextra/test/editor-mount-manager.test.ts
+++ b/packages/docs-nextra/test/editor-mount-manager.test.ts
@@ -220,7 +220,7 @@ describe("live-count budget + eviction", () => {
 });
 
 describe("registration lifecycle", () => {
-    test("unregister releases a held boot slot and pumps the queue", () => {
+    test("unregister releases a held boot slot and grants it to the next waiter", () => {
         const a = makeEditor("a", { maxConcurrentBoots: 1 });
         makeEditor("b", { maxConcurrentBoots: 1 });
         const gA = vi.fn();

--- a/packages/docs-nextra/vitest.config.ts
+++ b/packages/docs-nextra/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+// Unit tests for the pure-policy modules under `components/` (currently the
+// windowed-mounting `editor-mount-manager`). They exercise plain TypeScript
+// with no DOM, so the default node environment suffices. Defining this config
+// also stops Vitest from inheriting `vite.config.ts`, which is the lib build
+// for the Next.js remark plugins (not relevant to these tests).
+export default defineConfig({
+    test: {
+        environment: "node",
+        include: ["test/**/*.test.ts"],
+    },
+});

--- a/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
+++ b/packages/doenetml-iframe/src/viewer-lifecycle-manager.ts
@@ -191,7 +191,7 @@ export function requestBootSlot(id: string, grant: () => void) {
         return;
     }
     bootQueue.push({ id, requestOrder: ++bootRequestCounter, grant });
-    pumpBootQueue();
+    grantBootSlots();
 }
 
 /** Withdraw a queued boot request (e.g. the viewer scrolled away again). */
@@ -208,11 +208,11 @@ export function cancelBootRequest(id: string) {
  */
 export function releaseBootSlot(id: string) {
     if (bootSlotHolders.delete(id)) {
-        pumpBootQueue();
+        grantBootSlots();
     }
 }
 
-function pumpBootQueue() {
+function grantBootSlots() {
     const max = effectiveMaxBoots ?? Infinity;
     while (bootQueue.length > 0 && bootSlotHolders.size < max) {
         // Visible-first, then request order.

--- a/packages/standalone/src/coordinator.ts
+++ b/packages/standalone/src/coordinator.ts
@@ -152,7 +152,7 @@ export function initializeDoenetCoordinator(
             return;
         }
         bootQueue.push(record);
-        pumpBootQueue();
+        grantBootSlots();
     }
 
     function cancelBootRequest(record: ActivityRecord) {
@@ -168,11 +168,11 @@ export function initializeDoenetCoordinator(
             record.bootWatchdogId = null;
         }
         if (bootSlotHolders.delete(record)) {
-            pumpBootQueue();
+            grantBootSlots();
         }
     }
 
-    function pumpBootQueue() {
+    function grantBootSlots() {
         while (
             bootQueue.length > 0 &&
             bootSlotHolders.size < opts.maxConcurrentBoots


### PR DESCRIPTION
## Summary

Applies issue #1441 **stream B** (bound how many DoenetML instances a page keeps live) to the documentation host. Reference pages embed up to ~24 examples, each a live iframe (~200 MB core worker + realm), so a single page could cost multiple GB. This keeps only what the reader can see live.

## What changed

- **Viewers / `DoenetExample`** reuse the built-in `mountPolicy` from `@doenet/doenetml-iframe`; `flags.allowSaveState` makes parking lossless (in-memory snapshot; no host listener, no network).
- **Editors** (72% of examples: `doenet-editor-horiz` / `doenet-editor`) have no built-in windowing, so a docs-layer `WindowedEditor` wrapper + a page-wide `editor-mount-manager` add lazy mounting, a boot-concurrency cap, and least-recently-visible eviction. Editors have a fixed known height, so the placeholder is shift-free; unloaded editors reboot from their documented source on scroll-back (per design decision).
- Everything is wired centrally in `components/doenet.tsx`, so every fenced example inherits windowing with no MDX or remark-plugin changes. `WINDOWING_ENABLED` in `components/windowing-config.ts` is a kill-switch.
- **Internal rename (no behavior change):** the three stream-B boot-slot schedulers now share one descriptive name — the module-private `pumpBootQueue` helper becomes `grantBootSlots` in the new docs `editor-mount-manager` and, for consistency, in `@doenet/doenetml-iframe`'s `viewer-lifecycle-manager` and `@doenet/standalone`'s `coordinator`.

New docs files: `windowing-config.ts`, `editor-mount-manager.ts`, `windowed-editor.tsx`. Edited: `doenet.tsx` (+ the two shared files above, rename only).

## Tests

Adds a Vitest suite for `editor-mount-manager` (the pure boot-slot + eviction policy engine) — the package's first tests, so this also wires Vitest into `docs-nextra` (`"test": "vitest"` + a node-environment `vitest.config.ts`). 12 tests cover: the boot-concurrency cap and queueing (visible-first, FIFO ties, idempotent release, cancel), the soft live-count budget with LRU eviction and `parkDelayMs` debounce (fake timers), the over-eviction guard (evict exactly the excess, never double-evict while unmounting), smallest-budget-wins aggregation, and register/unregister slot handoff.

## Verification (Playwright against `next dev`)

- `reference/image` (24 editors): on load → **2 live iframes + 22 placeholders** (not 24); the live count stays pinned at **3** (`EDITOR_MAX_LIVE`) through a full scroll — off-screen editors evict as new ones mount.
- `reference/point` (14 editors + 10 viewers): on load → **1 live iframe, 10 parked viewers**; live iframes stay bounded at **~6** (≈3 editors + ≈3 viewers), with viewers parking/unparking on scroll. Editors confirmed to boot/render; 0 console errors / 404s.

Net: ~24 embeds → ~3–6 live iframes, so idle memory tracks what is visible. `vitest run` (12 passing) and `tsc --noEmit` (docs, `@doenet/doenetml-iframe`, `@doenet/standalone`) all pass clean.

## Notes

- The two page-wide budgets (built-in viewers + docs-layer editors) are intentional; a mixed page keeps at most `VIEWER_MAX_LIVE + EDITOR_MAX_LIVE` live. All budgets/margins are tunable in `windowing-config.ts`.
- **No changeset:** the docs package is never published to npm (no `transform-package-json` in its `vite.config.ts`), and the change to `@doenet/doenetml-iframe` / `@doenet/standalone` is a private internal-helper rename with no user-visible or API effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
