### PR TITLE
fix: detect a MathJax 4 engine provided by the host page

### DIFF
--- a/.changeset/detect-mathjax4-host-engine.md
+++ b/.changeset/detect-mathjax4-host-engine.md
@@ -1,0 +1,21 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Viewer: reliably render math when embedded in a page that provides its own MathJax 4.
+
+When a Doenet activity is embedded inline in a page that loads its own MathJax 4
+(e.g. a PreTeXt book), the viewer reuses the host engine instead of loading its
+own. The check that recognizes a live engine required `MathJax.startup` to be a
+plain object, but MathJax 4 exposes `startup` as a function, so the host engine
+was never recognized: the viewer waited until it timed out and every piece of
+math rendered blank (with a couple of spots showing raw LaTeX). A live engine is
+now detected whether `startup` is a function (MathJax 4) or an object
+(MathJax 3).
+
+As a safety net, if a host-provided MathJax is present but never becomes usable
+within the timeout, the viewer now falls back to loading — and taking over with —
+its own MathJax instead of leaving math blank, and a failed load no longer
+prevents later attempts from retrying.

--- a/packages/utils/src/math/mathjax-loader.test.ts
+++ b/packages/utils/src/math/mathjax-loader.test.ts
@@ -71,11 +71,19 @@ function installFakeDom() {
     return { fakeWindow, fakeDocument };
 }
 
-/** A stand-in for a fully loaded MathJax engine. */
+/**
+ * A stand-in for a fully loaded MathJax engine. `startup` is a *function* with
+ * a `.promise` attached — the real shape MathJax 4 exposes (MathJax 3 used a
+ * plain object). Using the function shape here keeps the suite honest: a mock
+ * with an object `startup` hid the bug where `isMathJaxEngine` rejected every
+ * MathJax 4 host engine.
+ */
 function makeEngine() {
+    const startup: any = () => {};
+    startup.promise = Promise.resolve();
     return {
         version: "4.1.3",
-        startup: { promise: Promise.resolve() },
+        startup,
         typesetPromise: () => Promise.resolve(),
         typesetClear: () => {},
     };
@@ -93,6 +101,21 @@ describe("isMathJaxEngine", () => {
         expect(isMathJaxEngine({ tex: { tags: "ams" } })).toBe(false);
         // A config may carry a `startup` option, but no `startup.promise`.
         expect(isMathJaxEngine({ startup: { typeset: false } })).toBe(false);
+    });
+
+    it("recognizes both MathJax 4 (function startup) and MathJax 3 (object startup)", () => {
+        // MathJax 4: `startup` is a callable function with `.promise` attached.
+        const v4Startup: any = () => {};
+        v4Startup.promise = Promise.resolve();
+        expect(isMathJaxEngine({ startup: v4Startup })).toBe(true);
+
+        // MathJax 3: `startup` is a plain object with `.promise`.
+        expect(
+            isMathJaxEngine({ startup: { promise: Promise.resolve() } }),
+        ).toBe(true);
+
+        // A bare function with no thenable `.promise` is still not an engine.
+        expect(isMathJaxEngine({ startup: () => {} })).toBe(false);
     });
 });
 
@@ -208,27 +231,96 @@ describe("loadMathJax", () => {
         await expect(promise).rejects.toThrow(/failed to load MathJax/);
     });
 
-    it("rejects after the timeout when a promised host MathJax never appears", async () => {
+    it("falls back to loading its own copy after the timeout when a promised host MathJax never appears", async () => {
         vi.useFakeTimers();
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         try {
+            const win = (globalThis as any).window;
             const promise = loadMathJax({
                 useExistingMathJax: true,
                 timeoutMs: 1000,
+                config: { tex: { tags: "ams" } },
             });
-            // Attach the rejection handler before advancing so the rejection is
-            // never observed as unhandled.
-            const assertion = expect(promise).rejects.toThrow(/timed out/);
+            // Waiting on the host — nothing injected yet.
+            expect(appendedScripts).toHaveLength(0);
 
-            // Drive the poll loop past the deadline; MathJax never shows up.
+            // Drive the poll loop past the deadline; the host never provides one.
             await vi.advanceTimersByTimeAsync(1100);
 
-            await assertion;
-            expect(appendedScripts).toHaveLength(0); // never injected our own
+            // Instead of failing, the loader injects — and takes over with — its
+            // own copy, staging the config even though we had been waiting.
+            expect(appendedScripts).toHaveLength(1);
+            expect(appendedScripts[0]._attrs["data-doenet-mathjax"]).toBe(
+                "true",
+            );
+            expect(win.MathJax).toEqual({ tex: { tags: "ams" } });
             expect(warnSpy).toHaveBeenCalled();
+
+            // Our own script loads and installs the engine.
+            const engine = makeEngine();
+            win.MathJax = engine;
+            appendedScripts[0]._fire("load");
+            await expect(promise).resolves.toBe(engine);
         } finally {
             warnSpy.mockRestore();
             vi.useRealTimers();
         }
+    });
+
+    it("force-clobbers a host global it could not recognize as an engine", async () => {
+        vi.useFakeTimers();
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const win = (globalThis as any).window;
+            // A host script is present, and window.MathJax holds a value the
+            // loader never recognizes as a live engine (the failure mode a
+            // mis-detected MathJax 4 engine produced).
+            domScripts.push(
+                makeScript(
+                    "https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js",
+                ),
+            );
+            win.MathJax = { unrecognized: true };
+
+            const promise = loadMathJax({
+                config: { tex: { tags: "ams" } },
+                timeoutMs: 1000,
+            });
+            expect(appendedScripts).toHaveLength(0); // waiting on the host script
+
+            await vi.advanceTimersByTimeAsync(1100);
+
+            // Fallback overwrites the stale global and loads our own.
+            expect(appendedScripts).toHaveLength(1);
+            expect(win.MathJax).toEqual({ tex: { tags: "ams" } });
+
+            const engine = makeEngine();
+            win.MathJax = engine;
+            appendedScripts[0]._fire("load");
+            await expect(promise).resolves.toBe(engine);
+        } finally {
+            warnSpy.mockRestore();
+            vi.useRealTimers();
+        }
+    });
+
+    it("clears the memo when an attempt rejects, so a later call retries instead of reusing the failure", async () => {
+        const win = (globalThis as any).window;
+
+        const first = loadMathJax({ config: { tex: {} } });
+        expect(appendedScripts).toHaveLength(1);
+        // Our own injected script fails to load (e.g. offline CDN).
+        appendedScripts[0]._fire("error");
+        await expect(first).rejects.toThrow(/failed to load MathJax/);
+
+        // The rejected promise must not be memoized: a fresh call retries.
+        const second = loadMathJax({ config: { tex: {} } });
+        expect(second).not.toBe(first);
+        expect(appendedScripts).toHaveLength(2);
+
+        const engine = makeEngine();
+        win.MathJax = engine;
+        appendedScripts[1]._fire("load");
+        await expect(second).resolves.toBe(engine);
     });
 });

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -68,8 +68,10 @@ declare global {
 export interface LoadMathJaxOptions {
     /**
      * MathJax configuration object. Staged as `window.MathJax` before our own
-     * script loads. Ignored when a host MathJax engine or script is detected,
-     * so a host's configuration is never overwritten.
+     * script loads. Left unset while a host MathJax engine or script is in play,
+     * so a host's configuration is never overwritten — unless that host engine
+     * never becomes usable and the timeout fallback takes over (see
+     * {@link loadMathJax}), in which case this config is staged instead.
      */
     config?: object;
     /**
@@ -78,10 +80,11 @@ export interface LoadMathJaxOptions {
      */
     src?: string;
     /**
-     * When `true`, always reuse a host-provided MathJax: wait for `window.MathJax`
-     * to become a live engine instead of ever injecting our own copy. Use this
+     * When `true`, prefer a host-provided MathJax: wait for `window.MathJax` to
+     * become a live engine rather than injecting our own copy up front. Use this
      * when the host loads MathJax but does so after Doenet mounts (so no script
-     * is detectable yet).
+     * is detectable yet). If the host engine never becomes usable within
+     * `timeoutMs`, we fall back to loading our own copy.
      */
     useExistingMathJax?: boolean;
     /**

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -15,7 +15,11 @@
  *  - If a live MathJax engine is already present, reuse it and never touch
  *    `window.MathJax`.
  *  - If a MathJax `<script>` is already on the page (possibly deferred and not
- *    yet executed), wait for it instead of injecting a second copy.
+ *    yet executed), wait for it instead of injecting a second copy. If it never
+ *    becomes a usable engine within the timeout, fall back to loading — and
+ *    taking over `window.MathJax` with — our own copy, so a broken or
+ *    unrecognized host engine degrades to Doenet's ≤0.7.20 behavior rather than
+ *    leaving all math blank.
  *  - Otherwise, inject our own copy — and only stage `window.MathJax = config`
  *    when nothing else has claimed that global.
  *
@@ -82,8 +86,9 @@ export interface LoadMathJaxOptions {
     useExistingMathJax?: boolean;
     /**
      * How long, in milliseconds, to wait for a host-provided MathJax before
-     * rejecting. Only applies when we are waiting on someone else's MathJax
-     * (an existing script or `useExistingMathJax`). Defaults to 30000.
+     * giving up and loading our own copy instead. Only applies when we are
+     * waiting on someone else's MathJax (an existing script or
+     * `useExistingMathJax`). Defaults to 30000.
      */
     timeoutMs?: number;
 }
@@ -121,9 +126,16 @@ export function isMathJaxEngine(
         return false;
     }
     const startup = (candidate as MathJaxEngine).startup;
+    // On a live engine, `startup` is the startup *module*. In MathJax 4 that is
+    // a callable function (with `.promise`, `.document`, … attached), so its
+    // `typeof` is "function", not "object"; MathJax 3 exposes it as a plain
+    // object. Accept either — the definitive live-engine signal is a thenable
+    // `startup.promise`, which a plain config object never has. Requiring
+    // `typeof startup === "object"` here silently rejected every MathJax 4 host
+    // engine, so Doenet waited for one forever and blanked all math.
     return (
         !!startup &&
-        typeof startup === "object" &&
+        (typeof startup === "object" || typeof startup === "function") &&
         typeof (startup.promise as Promise<unknown> | undefined)?.then ===
             "function"
     );
@@ -150,7 +162,10 @@ function findMathJaxScript(): HTMLScriptElement | null {
 /**
  * Polls until `window.MathJax` becomes a live engine, then resolves. Rejects if
  * the engine has not appeared within `timeoutMs`. Used when we are waiting on a
- * host-provided MathJax rather than loading our own.
+ * host-provided MathJax rather than loading our own. The caller
+ * ({@link createMathJaxPromise}) recovers from the rejection by loading Doenet's
+ * own copy, so this only signals "the host engine never became usable" — it does
+ * not mean math will fail to render.
  */
 function waitForExistingMathJax(timeoutMs: number): Promise<MathJaxEngine> {
     return new Promise((resolve, reject) => {
@@ -162,11 +177,11 @@ function waitForExistingMathJax(timeoutMs: number): Promise<MathJaxEngine> {
                 return;
             }
             if (Date.now() > deadline) {
-                const message =
-                    "DoenetViewer: timed out waiting for a host-provided MathJax. " +
-                    "Ensure the page loads MathJax, or unset `useExistingMathJax`.";
-                console.warn(message);
-                reject(new Error(message));
+                reject(
+                    new Error(
+                        "DoenetViewer: timed out waiting for a host-provided MathJax",
+                    ),
+                );
                 return;
             }
             window.setTimeout(poll, 50);
@@ -176,16 +191,23 @@ function waitForExistingMathJax(timeoutMs: number): Promise<MathJaxEngine> {
 }
 
 /**
- * Injects our own MathJax `<script>` and resolves once it has loaded. Only
- * stages `window.MathJax = config` when nothing else has already claimed that
- * global, so a host configuration is never clobbered.
+ * Injects our own MathJax `<script>` and resolves once it has loaded.
+ *
+ * Normally (`force` off) it stages `window.MathJax = config` only when nothing
+ * else has already claimed that global, so a host configuration is never
+ * clobbered. When `force` is on, it overwrites `window.MathJax` unconditionally:
+ * this is the takeover fallback used after a host-provided MathJax was detected
+ * but never became usable. Overwriting the stale global with our config (as
+ * Doenet ≤0.7.20 always did) is what lets our own engine initialize cleanly,
+ * rather than colliding with a half-loaded or unrecognized host engine.
  */
 function injectMathJax(
     src: string,
     config: object | undefined,
+    { force = false }: { force?: boolean } = {},
 ): Promise<MathJaxEngine> {
     return new Promise((resolve, reject) => {
-        if (config && window.MathJax == null) {
+        if (config && (force || window.MathJax == null)) {
             window.MathJax = config;
         }
         const script = document.createElement("script");
@@ -222,8 +244,19 @@ function createMathJaxPromise(
 
     // A MathJax script is already on the page (possibly deferred), or the host
     // told us to reuse theirs — wait for it rather than injecting a second copy.
+    // If it never becomes usable within the window (a broken/blocked host, or an
+    // engine we failed to recognize), don't fail permanently: fall back to
+    // loading — and taking over with — our own copy, so math still renders. This
+    // is what makes a mis-detected host non-fatal instead of blanking all math.
     if (useExistingMathJax || findMathJaxScript()) {
-        return waitForExistingMathJax(timeoutMs);
+        return waitForExistingMathJax(timeoutMs).catch((reason) => {
+            console.warn(
+                "DoenetViewer: a host-provided MathJax did not become usable in " +
+                    "time; falling back to loading Doenet's own copy.",
+                reason,
+            );
+            return injectMathJax(src, config, { force: true });
+        });
     }
 
     // Nothing else provides MathJax — load our own copy.
@@ -255,5 +288,16 @@ export function loadMathJax(
     const promise = createMathJaxPromise(options);
     (window as unknown as Record<string, unknown>)[GLOBAL_PROMISE_KEY] =
         promise;
+    // A rejected attempt must not poison the page: drop the memo so a later
+    // mount retries from scratch instead of resolving to the same failed
+    // promise. (With the takeover fallback above, the only way to reach here is
+    // our own copy failing to load — e.g. an offline CDN — where a retry is
+    // exactly what we want.)
+    promise.catch(() => {
+        const store = window as unknown as Record<string, unknown>;
+        if (store[GLOBAL_PROMISE_KEY] === promise) {
+            delete store[GLOBAL_PROMISE_KEY];
+        }
+    });
     return promise;
 }

--- a/packages/utils/src/math/mathjax-loader.ts
+++ b/packages/utils/src/math/mathjax-loader.ts
@@ -198,9 +198,10 @@ function waitForExistingMathJax(timeoutMs: number): Promise<MathJaxEngine> {
  *
  * Normally (`force` off) it stages `window.MathJax = config` only when nothing
  * else has already claimed that global, so a host configuration is never
- * clobbered. When `force` is on, it overwrites `window.MathJax` unconditionally:
- * this is the takeover fallback used after a host-provided MathJax was detected
- * but never became usable. Overwriting the stale global with our config (as
+ * clobbered. When `force` is on, a provided `config` is staged even if the
+ * global is already claimed, overwriting whatever stale value is there: this is
+ * the takeover fallback used after a host-provided MathJax was detected but
+ * never became usable. Overwriting the stale global with our config (as
  * Doenet ≤0.7.20 always did) is what lets our own engine initialize cleanly,
  * rather than colliding with a half-loaded or unrecognized host engine.
  */


### PR DESCRIPTION
## Problem

When a DoenetML activity is embedded **inline** in a page that loads its own **MathJax 4** (e.g. a PreTeXt book), the viewer reuses the host's MathJax engine instead of loading its own (behavior added in #1446). Detection hinges on `isMathJaxEngine()`, which required `MathJax.startup` to be a plain **object** — but **MathJax 4 exposes `startup` as a function** (with `.promise`, `.document`, … attached). So the host engine was never recognized: the viewer polled until its 30 s timeout, rejected, and — because the rejected promise is memoized — left **every piece of embedded math blank** (a couple of spots flash raw LaTeX).

PreTeXt's core switched to MathJax 4, and the newly released PreTeXt CLI ships that — which is why dev DoenetML suddenly broke while `0.7.20` (which predates the reuse code and always injects its own MathJax) kept working. The failure is deterministic for any MathJax 4 host.

## Fix

- **Detection:** accept a live engine whether `startup` is a function (MathJax 4) or an object (MathJax 3); the definitive signal remains a thenable `startup.promise`, which a plain config object never has.
- **Robustness (safety net):** if a host-provided MathJax is present but never becomes usable within the timeout, fall back to loading — and taking over `window.MathJax` with (`force`) — Doenet's own copy, rather than failing permanently. This degrades a broken/unrecognized host to Doenet's ≤0.7.20 behavior instead of blank math.
- **No poisoned memo:** a rejected attempt now clears `window.__doenetMathJaxPromise`, so a later mount can retry instead of reusing the failure.

## Testing

- Root-caused and reproduced in a headless browser against a real MathJax 4 host: with the buggy check the engine was live yet `isMathJaxEngine` returned `false`; with the fix the embedded math renders. The takeover fallback was also verified end-to-end against a live MathJax 4 host.
- Unit tests in `mathjax-loader.test.ts` now use MathJax 4's real *function*-shaped `startup` (the previous object-shaped mock is what hid the bug), and cover the timeout→fallback, force-clobber-over-an-unrecognized-global, and memo-clearing-on-reject paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
