### PR TITLE
Remove errant doenetml-prototype changeset

### DIFF
--- a/.changeset/composite-aslist-flatdast.md
+++ b/.changeset/composite-aslist-flatdast.md
@@ -1,9 +1,0 @@
----
-"@doenet/doenetml-prototype": patch
----
-
-Prototype: wrap composite list replacements in synthetic `<asList>` parents in the FlatDast.
-
-When the JS core reports a `_compositeReplacementActiveRange` for a renderable parent, the FlatDast bridge now wraps the relevant replacement range in an `<asList>` element (and, where nested composites require grouping, a passthrough `<_fragment>`), while treating whitespace-only replacement slots as spacing rather than comma-delimited list items. This applies to both the initial FlatDast and FlatDast updates, so prototype renderers no longer need to inspect `_compositeReplacementActiveRange` to decide where to insert commas.
-
-Closes #1334.


### PR DESCRIPTION
## Summary

The auto-generated release PR (#1303) was bumping `@doenet/doenetml-prototype@0.9.0`, which shouldn't happen since we don't version `doenetml-prototype` with changesets.

The culprit was `.changeset/composite-aslist-flatdast.md`, whose only entry was:

```
"@doenet/doenetml-prototype": patch
```

Since the changeset was **exclusively** for `doenetml-prototype`, this deletes the whole file rather than editing a package out of it. `doenetml-prototype` is a private, separately-versioned package (not part of the changesets `fixed` group), so this changeset was purely spurious.

Once this merges to `main`, the changesets bot will regenerate #1303 without the `doenetml-prototype` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)