### PR TITLE
0.6: support `doenet:<id>` image sources resolved via `doenetImagesUrl`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17281,7 +17281,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.6.14",
+            "version": "0.6.15",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -18750,7 +18750,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.6.14",
+            "version": "0.6.15",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {
                 "vite": "^4.5.0"

--- a/packages/doenetml-worker/src/components/Image.js
+++ b/packages/doenetml-worker/src/components/Image.js
@@ -459,6 +459,34 @@ export default class Image extends BlockComponent {
             },
         };
 
+        stateVariableDefinitions.imageId = {
+            forRenderer: true,
+
+            returnDependencies: () => ({
+                source: {
+                    dependencyType: "stateVariable",
+                    variableName: "source",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                // A `doenet:<id>` source references an image in Doenet's media
+                // library; expose the `<id>` so the renderer can build its URL.
+                // The whole source must be exactly `doenet:<id>` (an
+                // alphanumeric id) — any other source, including the
+                // `doenet:cid=<hash>` forms handled by the `cid` state
+                // variable, has no imageId.
+                if (!dependencyValues.source) {
+                    return { setValue: { imageId: null } };
+                }
+
+                let result = dependencyValues.source
+                    .trim()
+                    .match(/^doenet:([a-zA-Z0-9]+)$/i);
+
+                return { setValue: { imageId: result ? result[1] : null } };
+            },
+        };
+
         return stateVariableDefinitions;
     }
 

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.6.14",
+    "version": "0.6.15",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -34,6 +34,7 @@ export function EditorViewer({
     linkSettings,
     addBottomPadding = false,
     darkMode,
+    doenetImagesUrl,
     showAnswerTitles,
     width = "100%",
     height = "500px",
@@ -59,6 +60,7 @@ export function EditorViewer({
     linkSettings?: { viewURL: string; editURL: string };
     addBottomPadding?: boolean;
     darkMode?: string;
+    doenetImagesUrl?: string;
     showAnswerTitles?: boolean;
     width?: string;
     height?: string;
@@ -505,6 +507,7 @@ export function EditorViewer({
                             scrollableContainer.current ?? undefined
                         }
                         darkMode={darkMode}
+                        doenetImagesUrl={doenetImagesUrl}
                         showAnswerTitles={showAnswerTitles}
                     />
                 </Box>

--- a/packages/doenetml/src/Viewer/ActivityViewer.tsx
+++ b/packages/doenetml/src/Viewer/ActivityViewer.tsx
@@ -66,6 +66,7 @@ export function ActivityViewer({
     addBottomPadding = true,
     scrollableContainer = window,
     darkMode,
+    doenetImagesUrl,
     showAnswerTitles,
 }: {
     doenetML: string;
@@ -100,6 +101,7 @@ export function ActivityViewer({
     addBottomPadding?: boolean;
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: string;
+    doenetImagesUrl?: string;
     showAnswerTitles?: boolean;
 }) {
     const [errMsg, setErrMsg] = useState("");
@@ -1576,6 +1578,7 @@ export function ActivityViewer({
                     errorsActivitySpecific={errorsActivitySpecific.current}
                     scrollableContainer={scrollableContainer}
                     darkMode={darkMode}
+                    doenetImagesUrl={doenetImagesUrl}
                     showAnswerTitles={showAnswerTitles}
                 />
             );

--- a/packages/doenetml/src/Viewer/PageViewer.jsx
+++ b/packages/doenetml/src/Viewer/PageViewer.jsx
@@ -67,6 +67,7 @@ export function PageViewer({
     errorsActivitySpecific = {},
     scrollableContainer,
     darkMode,
+    doenetImagesUrl,
     showAnswerTitles,
 }) {
     const updateRendererSVsWithRecoil = useRecoilCallback(
@@ -204,6 +205,7 @@ export function PageViewer({
         linkSettings,
         scrollableContainer,
         darkMode,
+        doenetImagesUrl,
         showAnswerTitles,
     };
 

--- a/packages/doenetml/src/Viewer/renderers/image.jsx
+++ b/packages/doenetml/src/Viewer/renderers/image.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useContext, useRef } from "react";
 import { BoardContext, IMAGE_LAYER_OFFSET } from "./graph";
 import { retrieveMediaForCid } from "@doenet/utils";
 import useDoenetRenderer from "../useDoenetRenderer";
+import { PageContext } from "../PageViewer";
 import { sizeToCSS } from "./utils/css";
 import VisibilitySensor from "react-visibility-sensor-v2";
 import me from "math-expressions";
@@ -19,6 +20,8 @@ export default React.memo(function Image(props) {
     let anchorPointJXG = useRef(null);
 
     const board = useContext(BoardContext);
+
+    const { doenetImagesUrl } = useContext(PageContext) || {};
 
     let pointerAtDown = useRef(null);
     let pointAtDown = useRef(null);
@@ -44,7 +47,16 @@ export default React.memo(function Image(props) {
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
-    const urlOrSource = (SVs.cid ? url : SVs.source) || "";
+    // cid sources resolve asynchronously to a blob URL (`url` state);
+    // everything else resolves synchronously from the source/imageId.
+    const urlOrSource =
+        (SVs.cid
+            ? url
+            : getUrlForImage({
+                  source: SVs.source || "",
+                  imageId: SVs.imageId,
+                  doenetImagesUrl,
+              })) || "";
 
     let onChangeVisibility = (isVisible) => {
         callAction({
@@ -423,7 +435,10 @@ export default React.memo(function Image(props) {
         lastPositionFromCore.current = anchorCoords;
 
         if (imageJXG.current === null) {
-            if (SVs.cid && !url) {
+            // Don't create the JSXGraph image until we have a non-empty URL,
+            // e.g., while a cid is still resolving to a blob URL, or for an
+            // unsupported doenet: source that has no URL at all.
+            if (!urlOrSource) {
                 return null;
             }
             createImageJXG();
@@ -598,3 +613,31 @@ export default React.memo(function Image(props) {
         </VisibilitySensor>
     );
 });
+
+/**
+ * Resolve the URL to use for an image.
+ *
+ * When the image references a Doenet-hosted media item (`source="doenet:<id>"`),
+ * `imageId` holds the `<id>` and the URL is built from `doenetImagesUrl` and that
+ * id (avoiding a doubled slash when `doenetImagesUrl` already ends with `/`).
+ *
+ * A `doenet:` source that did not yield an `imageId` and is not handled
+ * elsewhere (the `doenet:cid=` form is resolved separately into a blob URL)
+ * is an unsupported media reference; return "" so the placeholder UI is used
+ * rather than handing the `doenet:` URI to an <img> or JSXGraph. Any other
+ * source is an ordinary URL/path and is returned unchanged.
+ */
+function getUrlForImage({
+    source,
+    imageId,
+    doenetImagesUrl = "https://media.doenet.org/images",
+}) {
+    if (imageId) {
+        const separator = doenetImagesUrl.endsWith("/") ? "" : "/";
+        return doenetImagesUrl + separator + imageId;
+    } else if (/^\s*doenet:/i.test(source)) {
+        return "";
+    } else {
+        return source;
+    }
+}

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -127,6 +127,7 @@ export function DoenetViewer({
     linkSettings,
     scrollableContainer,
     darkMode,
+    doenetImagesUrl,
     showAnswerTitles = false,
     includeVariantSelector = false,
 }: {
@@ -164,6 +165,7 @@ export function DoenetViewer({
     linkSettings?: { viewURL: string; editURL: string };
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: string;
+    doenetImagesUrl?: string;
     showAnswerTitles?: boolean;
     includeVariantSelector?: boolean;
 }) {
@@ -291,6 +293,7 @@ export function DoenetViewer({
             addBottomPadding={addBottomPadding}
             scrollableContainer={scrollableContainer}
             darkMode={darkMode}
+            doenetImagesUrl={doenetImagesUrl}
             showAnswerTitles={showAnswerTitles}
         />
     );
@@ -331,6 +334,7 @@ export function DoenetEditor({
     idsIncludeActivityId = true,
     linkSettings,
     darkMode,
+    doenetImagesUrl,
     showAnswerTitles = false,
     width,
     height,
@@ -358,6 +362,7 @@ export function DoenetEditor({
     idsIncludeActivityId?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: string;
+    doenetImagesUrl?: string;
     showAnswerTitles?: boolean;
     width?: string;
     height?: string;
@@ -391,6 +396,7 @@ export function DoenetEditor({
             linkSettings={linkSettings}
             addBottomPadding={addBottomPadding}
             darkMode={darkMode}
+            doenetImagesUrl={doenetImagesUrl}
             showAnswerTitles={showAnswerTitles}
             width={width}
             height={height}

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.6.14",
+    "version": "0.6.15",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -819,4 +819,113 @@ describe("Image Tag Tests", function () {
             .eq(0)
             .should("have.text", "q");
     });
+
+    it("doenet: source resolves against the default media URL", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" description="A Doenet-hosted image" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        cy.get(cesc("#\\/image1"))
+            .should("have.attr", "src")
+            .and("eq", "https://media.doenet.org/images/abcDEF123");
+    });
+
+    it("doenet: source resolves against a custom doenetImagesUrl", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" description="A Doenet-hosted image" />
+  `,
+                    doenetImagesUrl: "https://example.com/media",
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        cy.get(cesc("#\\/image1"))
+            .should("have.attr", "src")
+            .and("eq", "https://example.com/media/abcDEF123");
+    });
+
+    it("trailing slash on doenetImagesUrl is not doubled", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" description="A Doenet-hosted image" />
+  `,
+                    doenetImagesUrl: "https://example.com/media/",
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        cy.get(cesc("#\\/image1"))
+            .should("have.attr", "src")
+            .and("eq", "https://example.com/media/abcDEF123");
+    });
+
+    it("doenet: source resolves against a custom doenetImagesUrl inside a graph", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <graph name="g">
+    <image name="image1" source="doenet:abcDEF123" anchor="(1,1)" description="A Doenet-hosted image" />
+  </graph>
+  `,
+                    doenetImagesUrl: "https://example.com/media",
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // JSXGraph's SVG renderer sets the image URL via the xlink:href
+        // attribute of an svg <image> element inside the board container.
+        cy.get(cesc("#\\/g") + " image")
+            .should("have.attr", "xlink:href")
+            .and("eq", "https://example.com/media/abcDEF123");
+    });
+
+    it("an unsupported doenet: source renders the placeholder, not a broken image", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:foo-bar" description="An unsupported source" />
+  `,
+                    doenetImagesUrl: "https://example.com/media",
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // The placeholder is a <div> carrying the component id, so no <img>
+        // is rendered and the raw doenet: URI never reaches an <img src>.
+        cy.get(cesc("#\\/image1")).should("exist");
+        cy.get("img" + cesc("#\\/image1")).should("not.exist");
+    });
 });

--- a/packages/test-cypress/src/CypressTest.jsx
+++ b/packages/test-cypress/src/CypressTest.jsx
@@ -32,10 +32,12 @@ export function CypressTest() {
         );
     }
 
-    const [{ doenetMLstring, attemptNumber }, setBaseState] = useState({
-        doenetMLstring: null,
-        attemptNumber: testSettings.attemptNumber,
-    });
+    const [{ doenetMLstring, attemptNumber, doenetImagesUrl }, setBaseState] =
+        useState({
+            doenetMLstring: null,
+            attemptNumber: testSettings.attemptNumber,
+            doenetImagesUrl: undefined,
+        });
 
     const [updateNumber, setUpdateNumber] = useState(testSettings.updateNumber);
     const [controlsVisible, setControlsVisible] = useState(
@@ -81,7 +83,8 @@ export function CypressTest() {
     //For Cypress Test Use
     window.onmessage = (e) => {
         let newDoenetMLstring = null,
-            newAttemptNumber = attemptNumber;
+            newAttemptNumber = attemptNumber,
+            newDoenetImagesUrl;
 
         if (e.data.doenetML !== undefined) {
             newDoenetMLstring = e.data.doenetML;
@@ -95,12 +98,16 @@ export function CypressTest() {
             testSettings.attemptNumber = newAttemptNumber;
             localStorage.setItem("test settings", JSON.stringify(testSettings));
         }
+        if (e.data.doenetImagesUrl !== undefined) {
+            newDoenetImagesUrl = e.data.doenetImagesUrl;
+        }
 
         // don't do anything if receive a message from another source (like the youtube player)
         if (newDoenetMLstring || newAttemptNumber !== attemptNumber) {
             setBaseState({
                 doenetMLstring: newDoenetMLstring,
                 attemptNumber: newAttemptNumber,
+                doenetImagesUrl: newDoenetImagesUrl,
             });
         }
     };
@@ -451,6 +458,7 @@ export function CypressTest() {
                     editURL: "/publiceditor",
                 }}
                 darkMode={darkMode}
+                doenetImagesUrl={doenetImagesUrl}
             />
         );
     }


### PR DESCRIPTION
## Summary

Backports the new-site image resolution from the 0.7 line (`main`) to the `0.6` branch. Closes #1498.

User content is being migrated from legacy.doenet.org to the new doenet.org. Migrated documents remain **DoenetML 0.6** (rendered through `doenetml-iframe` loading `@doenet/standalone@0.6.x` from the CDN), and their image references are rewritten from the legacy `doenet:cid=<cid>` form to the new-site `doenet:<id>` form, resolved against a host-supplied `doenetImagesUrl` as `<doenetImagesUrl>/<id>`. Before this change such sources fell through verbatim into `<img src="doenet:...">` and rendered a broken image.

## Changes

- **Worker** (`packages/doenetml-worker/src/components/Image.js`): add an `imageId` state variable that extracts the id from a `source` matching exactly `doenet:<id>` (anchored regex, so the legacy `doenet:cid=<hash>` form yields no `imageId` and is unaffected). The existing `cid` state variable is untouched.
- **Renderer** (`packages/doenetml/src/Viewer/renderers/image.jsx`): read `doenetImagesUrl` from `PageContext` and add a `getUrlForImage` helper (ported from `main`) that:
  - builds `doenetImagesUrl + "/" + imageId`, avoiding a doubled slash when `doenetImagesUrl` ends with `/`;
  - returns `""` for an unsupported `doenet:` source so the placeholder UI is shown instead of handing the `doenet:` URI to `<img>`/JSXGraph;
  - returns ordinary URL/relative sources unchanged.
  The single resolved URL feeds both the `<img>` and the JSXGraph (`<graph>`) paths.
- **Prop threading**: thread `doenetImagesUrl` from `DoenetViewer`/`DoenetEditor` down to renderers via `PageContext` (`doenetml.tsx`, `EditorViewer.tsx`, `ActivityViewer.tsx`, `PageViewer.jsx`), mirroring how `darkMode` flows on this line.
- **Purely additive**: the legacy `doenet:cid=<cid>` path (`retrieveMediaForCid` → `/media/<cid>.<ext>`) and ordinary/relative sources are left entirely unchanged. `packages/utils/src/media/retrieveMedia.ts` is not touched.
- **Version bump**: `@doenet/doenetml` and `@doenet/standalone` 0.6.14 → **0.6.15** (npm currently tops out at 0.6.14). These are the only packages versioned in lockstep on the 0.6 line; `doenetml-iframe` is versioned from `main` and is not part of this branch.

## Behavior note

An `<image/>` with an empty (or unsupported `doenet:`) source inside a `<graph>` now renders no JSXGraph image rather than one with an empty href — the same normalization `main` made.

## Tests

Added to `packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js` (with `doenetImagesUrl` postMessage support in `CypressTest.jsx`):

- `doenet:` source resolves against the default media URL
- `doenet:` source resolves against a custom `doenetImagesUrl`
- trailing slash on `doenetImagesUrl` is not doubled
- `doenet:` source resolves against a custom `doenetImagesUrl` inside a `<graph>` (asserts the JSXGraph svg `xlink:href`)
- an unsupported `doenet:` source renders the placeholder, not a broken image

The full `image.cy.js` spec passes **13/13** (5 new + 8 pre-existing, which cover ordinary-URL and in-graph behavior as the regression net for the additive requirement).

## Acceptance criteria

- [x] A 0.6 doc with `<image source="doenet:AbC123xyz" />` rendered with `doenetImagesUrl="https://example.com/media"` requests `https://example.com/media/AbC123xyz` (standalone and inside `<graph>`).
- [x] Trailing slash on `doenetImagesUrl` is not doubled.
- [x] `<image source="doenet:cid=bafk..." />` behavior is unchanged.
- [x] `<image source="https://..." />` and relative-path sources are unchanged.
- [x] Tests covering the above.

## Follow-ups (not in this PR)

- Publish `@doenet/standalone` 0.6.15 from the `0.6` branch.
- `doenetml-iframe` (on `main`) already forwards `doenetImagesUrl` to bundles ungated — no change needed there; the new doenet.org pin (`fullVersion`) and the DoenetTools-side attribute rename are tracked in Doenet/DoenetTools#2993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)