### PR TITLE
Publish 0.6 packages under the "legacy" dist-tag

### DIFF
--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -26,7 +26,7 @@
         "preview": "vite preview",
         "test": "echo \"No tests \"",
         "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-        "publish": "npm run build && cd dist && npm publish"
+        "publish": "npm run build && cd dist && npm publish --tag legacy"
     },
     "wireit": {
         "build": {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -23,7 +23,7 @@
         "build": "wireit",
         "test": "echo \"No tests \"",
         "preview": "vite preview",
-        "publish": "npm run build && cd dist && npm publish"
+        "publish": "npm run build && cd dist && npm publish --tag legacy"
     },
     "wireit": {
         "build": {


### PR DESCRIPTION
## Summary

Pin the `publish` scripts of `@doenet/doenetml` and `@doenet/standalone` on the 0.6 line to `npm publish --tag legacy`.

The 0.6 line is a maintenance branch kept alive for content migrated from legacy.doenet.org, while `latest` on npm now tracks the 0.7 line (currently `latest` → 0.7.21). A bare `npm publish` defaults to the `latest` dist-tag, so publishing a 0.6.x release with the stock script would **regress `latest` backward** to the 0.6 line. Adding `--tag legacy` makes 0.6 releases land on a dedicated `legacy` dist-tag and can never clobber `latest`.

## Changes

- `packages/doenetml/package.json`: `"publish"` → `npm run build && cd dist && npm publish --tag legacy`
- `packages/standalone/package.json`: same.

## Context

There was no dedicated dist-tag for the 0.6 line — the old 0.6.x versions (last was 0.6.14, Sept 2024) were published as `latest` before 0.7 existed, and `latest` has since advanced to 0.7. The `legacy` tag was chosen for the 0.6.15 release; consumers can also install via the `@0.6` semver range or pin an exact version. Follow-up to #1500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)