### PR TITLE
0.6: default linkSettings to the new site's routes (/activityViewer, /documentEditor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17281,7 +17281,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.6.15",
+            "version": "0.6.16",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -18750,7 +18750,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.6.15",
+            "version": "0.6.16",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {
                 "vite": "^4.5.0"

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.6.15",
+    "version": "0.6.16",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/PageViewer.jsx
+++ b/packages/doenetml/src/Viewer/PageViewer.jsx
@@ -63,7 +63,7 @@ export function PageViewer({
     apiURLs = {},
     location = {},
     navigate,
-    linkSettings = { viewURL: "/portfolioviewer", editURL: "/publiceditor" },
+    linkSettings = { viewURL: "/activityViewer", editURL: "/documentEditor" },
     errorsActivitySpecific = {},
     scrollableContainer,
     darkMode,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.6.15",
+    "version": "0.6.16",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/tagSpecific/ref.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/ref.cy.js
@@ -181,7 +181,71 @@ describe("ref Tag Tests", function () {
         cy.get(cesc("#\\/_ref1"))
             .should("have.text", "a Doenet doc")
             .invoke("attr", "href")
-            .then((href) => expect(href).eq("/portfolioviewer/abcdefg"));
+            .then((href) => expect(href).eq("/activityViewer/abcdefg"));
+    });
+
+    it("ref to activityId uses the default view route", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <p>A link to <ref uri="doenet:activityId=AbC123">a Doenet doc</ref>.</p>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_p1")).should("have.text", "A link to a Doenet doc.");
+
+        cy.get(cesc("#\\/_ref1"))
+            .should("have.text", "a Doenet doc")
+            .invoke("attr", "href")
+            .then((href) => expect(href).eq("/activityViewer/AbC123"));
+    });
+
+    it("ref to activityId with edit=true uses the default edit route", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <p>A link to <ref uri="doenet:activityId=AbC123&edit=true">a Doenet doc</ref>.</p>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_p1")).should("have.text", "A link to a Doenet doc.");
+
+        cy.get(cesc("#\\/_ref1"))
+            .should("have.text", "a Doenet doc")
+            .invoke("attr", "href")
+            .then((href) => expect(href).eq("/documentEditor/AbC123"));
+    });
+
+    it("host-supplied linkSettings overrides the default route", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <p>A link to <ref uri="doenet:activityId=AbC123">a Doenet doc</ref>.</p>
+  `,
+                    linkSettings: {
+                        viewURL: "/custom-view",
+                        editURL: "/custom-edit",
+                    },
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_p1")).should("have.text", "A link to a Doenet doc.");
+
+        cy.get(cesc("#\\/_ref1"))
+            .should("have.text", "a Doenet doc")
+            .invoke("attr", "href")
+            .then((href) => expect(href).eq("/custom-view/AbC123"));
     });
 
     it("url with no link text", () => {

--- a/packages/test-cypress/src/CypressTest.jsx
+++ b/packages/test-cypress/src/CypressTest.jsx
@@ -32,12 +32,15 @@ export function CypressTest() {
         );
     }
 
-    const [{ doenetMLstring, attemptNumber, doenetImagesUrl }, setBaseState] =
-        useState({
-            doenetMLstring: null,
-            attemptNumber: testSettings.attemptNumber,
-            doenetImagesUrl: undefined,
-        });
+    const [
+        { doenetMLstring, attemptNumber, doenetImagesUrl, linkSettings },
+        setBaseState,
+    ] = useState({
+        doenetMLstring: null,
+        attemptNumber: testSettings.attemptNumber,
+        doenetImagesUrl: undefined,
+        linkSettings: undefined,
+    });
 
     const [updateNumber, setUpdateNumber] = useState(testSettings.updateNumber);
     const [controlsVisible, setControlsVisible] = useState(
@@ -84,7 +87,8 @@ export function CypressTest() {
     window.onmessage = (e) => {
         let newDoenetMLstring = null,
             newAttemptNumber = attemptNumber,
-            newDoenetImagesUrl;
+            newDoenetImagesUrl,
+            newLinkSettings;
 
         if (e.data.doenetML !== undefined) {
             newDoenetMLstring = e.data.doenetML;
@@ -101,6 +105,9 @@ export function CypressTest() {
         if (e.data.doenetImagesUrl !== undefined) {
             newDoenetImagesUrl = e.data.doenetImagesUrl;
         }
+        if (e.data.linkSettings !== undefined) {
+            newLinkSettings = e.data.linkSettings;
+        }
 
         // don't do anything if receive a message from another source (like the youtube player)
         if (newDoenetMLstring || newAttemptNumber !== attemptNumber) {
@@ -108,6 +115,7 @@ export function CypressTest() {
                 doenetMLstring: newDoenetMLstring,
                 attemptNumber: newAttemptNumber,
                 doenetImagesUrl: newDoenetImagesUrl,
+                linkSettings: newLinkSettings,
             });
         }
     };
@@ -453,10 +461,7 @@ export function CypressTest() {
                 paginate={paginate}
                 location={location}
                 navigate={navigate}
-                linkSettings={{
-                    viewURL: "/portfolioviewer",
-                    editURL: "/publiceditor",
-                }}
+                linkSettings={linkSettings}
                 darkMode={darkMode}
                 doenetImagesUrl={doenetImagesUrl}
             />


### PR DESCRIPTION
## Summary

Change the default `linkSettings` on the 0.6 line to the new site's routes. Closes #1501; follow-up to #1498/#1500.

Content migrated from legacy.doenet.org stays on DoenetML 0.6 and can contain cross-activity links like `<ref uri="doenet:activityId=<id>">…</ref>`. When the host supplies no `linkSettings`, the 0.6 engine fell back to legacy-site routes (`/portfolioviewer`, `/publiceditor`), which 404 on the new site. Documents rendered through `@doenet/assignment-viewer` (every page of a problem set) can't receive an explicit `linkSettings` prop, so changing the **default** is the only fix that reaches those contexts.

## Changes

- **`packages/doenetml/src/Viewer/PageViewer.jsx`**: the destructuring default becomes `{ viewURL: "/activityViewer", editURL: "/documentEditor" }`. Paths stay **relative** so each deployment (dev3, beta, prod) links within itself. Any host-supplied `linkSettings` still overrides it — prop threading is unchanged.
- **`packages/test-cypress/src/CypressTest.jsx`**: the harness previously hardwired `linkSettings={{ viewURL: "/portfolioviewer", … }}` on `<DoenetViewer>`, which meant the "ref to DoenetId" test was actually asserting the harness override, not the default. Thread `linkSettings` from the `postMessage` payload instead (mirroring the existing `doenetImagesUrl` handling), defaulting to unset so the engine's default applies — and tests can still opt into an override.
- **`packages/test-cypress/cypress/e2e/tagSpecific/ref.cy.js`**: update the `ref to DoenetId` expectation to `/activityViewer/abcdefg`, and add tests for the `activityId` view default, the `edit=true` default (`/documentEditor/AbC123`), and a host-supplied override winning.
- **Version bump**: `@doenet/doenetml` and `@doenet/standalone` 0.6.15 → **0.6.16** (published under the `legacy` dist-tag).

## Note on the test-harness change

Issue #1501 suggested leaving the harness's explicit `linkSettings` and only editing the expectation, but as written the harness applied that override to the very test meant to verify the default — so that combination would fail. Threading the prop through `postMessage` resolves it cleanly: the default is genuinely exercised, and the new override test covers the "host-supplied `linkSettings` still overrides" acceptance criterion. A repo-wide grep confirms `ref.cy.js` is the only spec that asserts on these routes.

## Verification

`ref.cy.js` (15 passing, incl. the 3 new tests) and `image.cy.js` (13 passing — confirms dropping the hardwired override didn't regress other specs) both green headless in Chrome against the built harness.

## Acceptance criteria

- [x] `<ref uri="doenet:activityId=AbC123">` without a `linkSettings` prop → `/activityViewer/AbC123`.
- [x] `edit=true` in the uri → `/documentEditor/AbC123`.
- [x] Host-supplied `linkSettings` still overrides the default.
- [x] `doenet:cid=` and plain-URL `<ref>`s unchanged (existing tests still pass).
- [x] Tests updated for the new default.

## Follow-ups (not in this PR)

- Publish `@doenet/standalone@0.6.16` from the `0.6` branch (under the `legacy` tag).
- DoenetTools: bump the seeded `doenetmlVersions` `fullVersion` for 0.6 from `0.6.15` to `0.6.16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)