### PR TITLE
fix: don't leave the viewer permanently blank when reported off-page at zero size

### DIFF
--- a/.changeset/unhide-zero-height-viewer.md
+++ b/.changeset/unhide-zero-height-viewer.md
@@ -1,0 +1,21 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Viewer: don't stay permanently blank when the browser reports the not-yet-rendered viewer as off-page.
+
+The viewer starts hidden and unhides once an IntersectionObserver sees its
+wrapper on the page (a guard that keeps JSXGraph from initializing while
+actually hidden). But while hidden the viewer renders nothing, so the observed
+wrapper has zero height — and some browsers (observed in branded Chrome 149,
+with activities embedded in a same-origin iframe as in PreTeXt books) report a
+zero-area target as non-intersecting even with the observer's huge rootMargin.
+The viewer then deadlocked as a silent blank box: hidden ⇒ zero height ⇒
+reported off-page ⇒ stays hidden.
+
+A zero-area element that still generates a layout box cannot meaningfully be
+off the page, so it now counts as on-page; `display: none` — the state the
+guard exists to detect — generates no layout boxes and still keeps the viewer
+hidden.

--- a/packages/doenetml/src/utils/visibility.test.ts
+++ b/packages/doenetml/src/utils/visibility.test.ts
@@ -24,13 +24,15 @@ function makeEntry({
 describe("isEntryOnPage", () => {
     it("is true for an intersecting entry", () => {
         expect(
-            makeEntry({
-                isIntersecting: true,
-                width: 600,
-                height: 400,
-                clientRectCount: 1,
-            }),
-        ).toSatisfy(isEntryOnPage);
+            isEntryOnPage(
+                makeEntry({
+                    isIntersecting: true,
+                    width: 600,
+                    height: 400,
+                    clientRectCount: 1,
+                }),
+            ),
+        ).toBe(true);
     });
 
     it("is false for a non-intersecting entry with area", () => {
@@ -46,19 +48,35 @@ describe("isEntryOnPage", () => {
         ).toBe(false);
     });
 
-    it("is true for a zero-area target that still generates layout boxes", () => {
+    it("is true for a zero-height target that still generates layout boxes", () => {
         // Branded Chrome 149 can report a zero-height target inside an iframe
         // as non-intersecting even with a huge rootMargin. While hidden,
         // DocViewer renders nothing, so the observed wrapper is zero-height —
         // trusting the report would deadlock the viewer as permanently hidden.
         expect(
-            makeEntry({
-                isIntersecting: false,
-                width: 600,
-                height: 0,
-                clientRectCount: 1,
-            }),
-        ).toSatisfy(isEntryOnPage);
+            isEntryOnPage(
+                makeEntry({
+                    isIntersecting: false,
+                    width: 600,
+                    height: 0,
+                    clientRectCount: 1,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("is true for a zero-width target that still generates layout boxes", () => {
+        // Either dimension collapsing to zero yields the same zero-area report.
+        expect(
+            isEntryOnPage(
+                makeEntry({
+                    isIntersecting: false,
+                    width: 0,
+                    height: 400,
+                    clientRectCount: 1,
+                }),
+            ),
+        ).toBe(true);
     });
 
     it("is false for a display:none target (zero area, no layout boxes)", () => {

--- a/packages/doenetml/src/utils/visibility.test.ts
+++ b/packages/doenetml/src/utils/visibility.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { isEntryOnPage } from "./visibility";
+
+function makeEntry({
+    isIntersecting,
+    width,
+    height,
+    clientRectCount,
+}: {
+    isIntersecting: boolean;
+    width: number;
+    height: number;
+    clientRectCount: number;
+}): IntersectionObserverEntry {
+    return {
+        isIntersecting,
+        boundingClientRect: { width, height },
+        target: {
+            getClientRects: () => ({ length: clientRectCount }),
+        },
+    } as unknown as IntersectionObserverEntry;
+}
+
+describe("isEntryOnPage", () => {
+    it("is true for an intersecting entry", () => {
+        expect(
+            makeEntry({
+                isIntersecting: true,
+                width: 600,
+                height: 400,
+                clientRectCount: 1,
+            }),
+        ).toSatisfy(isEntryOnPage);
+    });
+
+    it("is false for a non-intersecting entry with area", () => {
+        expect(
+            isEntryOnPage(
+                makeEntry({
+                    isIntersecting: false,
+                    width: 600,
+                    height: 400,
+                    clientRectCount: 1,
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it("is true for a zero-area target that still generates layout boxes", () => {
+        // Branded Chrome 149 can report a zero-height target inside an iframe
+        // as non-intersecting even with a huge rootMargin. While hidden,
+        // DocViewer renders nothing, so the observed wrapper is zero-height —
+        // trusting the report would deadlock the viewer as permanently hidden.
+        expect(
+            makeEntry({
+                isIntersecting: false,
+                width: 600,
+                height: 0,
+                clientRectCount: 1,
+            }),
+        ).toSatisfy(isEntryOnPage);
+    });
+
+    it("is false for a display:none target (zero area, no layout boxes)", () => {
+        expect(
+            isEntryOnPage(
+                makeEntry({
+                    isIntersecting: false,
+                    width: 0,
+                    height: 0,
+                    clientRectCount: 0,
+                }),
+            ),
+        ).toBe(false);
+    });
+});

--- a/packages/doenetml/src/utils/visibility.ts
+++ b/packages/doenetml/src/utils/visibility.ts
@@ -39,6 +39,29 @@ export function useRecordVisibilityChanges(
 }
 
 /**
+ * Interpret an IntersectionObserver entry from `useIsOnPage`'s observer as
+ * "the element is on the page".
+ *
+ * Usually that is just `entry.isIntersecting`, but a zero-area target needs
+ * care: branded Chrome 149 (inside a same-origin iframe, e.g. a PreTeXt book)
+ * can report a zero-area target as non-intersecting even with the huge
+ * `rootMargin`. Taking that at face value deadlocks the viewer — `DocViewer`
+ * renders nothing while hidden, so the observed wrapper has zero height, gets
+ * reported off-page, and stays hidden forever. A zero-area element that still
+ * generates a layout box cannot meaningfully be off the page, so count it as
+ * on-page; `display: none` — the hidden state this hook exists to detect —
+ * generates no boxes at all and so still reports false.
+ */
+export function isEntryOnPage(entry: IntersectionObserverEntry): boolean {
+    if (entry.isIntersecting) {
+        return true;
+    }
+    const rect = entry.boundingClientRect;
+    const zeroArea = rect.width === 0 || rect.height === 0;
+    return zeroArea && entry.target.getClientRects().length > 0;
+}
+
+/**
  * Returns true if the element referenced by `ref` is anywhere on the page
  * (more precisely, within 1000000px of the browser's viewport).
  *
@@ -49,7 +72,7 @@ export function useIsOnPage(ref: RefObject<HTMLElement | null>) {
 
     useEffect(() => {
         const observer = new IntersectionObserver(
-            ([entry]) => setIntersecting(entry.isIntersecting),
+            ([entry]) => setIntersecting(isEntryOnPage(entry)),
             { rootMargin: "1000000px" },
         );
 

--- a/packages/doenetml/src/utils/visibility.ts
+++ b/packages/doenetml/src/utils/visibility.ts
@@ -63,7 +63,8 @@ export function isEntryOnPage(entry: IntersectionObserverEntry): boolean {
 
 /**
  * Returns true if the element referenced by `ref` is anywhere on the page
- * (more precisely, within 1000000px of the browser's viewport).
+ * (more precisely, within 1000000px of the browser's viewport), or if it is
+ * laid out but has zero area — see `isEntryOnPage` for why.
  *
  * Used to approximately detect if the element is not hidden.
  */


### PR DESCRIPTION
## Problem

Doenet activities embedded in PreTeXt books (e.g. Active Calculus) sometimes never initialize — a silent, blank, tall box with no console errors, while sibling activities on the same page load fine. Pop-out always works. Reported at https://community.doenet.org/t/doenet-activities-not-loading-in-pretext-sometimes/247.

## Root cause

`DoenetViewer` starts with `hidden = true` and unhides when `useIsOnPage` sees its wrapper intersect an IntersectionObserver with `rootMargin: "1000000px"` (a guard that keeps JSXGraph from initializing while actually hidden). But while hidden, `DocViewer` renders `null`, so the observed wrapper is 0px tall — and branded Chrome 149 (not Chromium-for-testing at the same version, suggesting a field-trial rollout) can report a zero-area target inside a same-origin iframe as non-intersecting despite the huge rootMargin. The result is a permanent deadlock: hidden ⇒ zero height ⇒ reported off-page ⇒ stays hidden.

Diagnosis was confirmed causally on the live page: the blank frame's wrapper reported `isIntersecting: false` at 600×0, and setting `min-height: 10px` on it made the activity render immediately. The failure reproduces identically with `standalone@0.7.19`, so it predates the recent memory-footprint releases; the trigger is a Chrome-side behavior change hitting a long-standing fragile gate.

## Fix

`useIsOnPage` now interprets observer entries via a new `isEntryOnPage()`: a zero-area target that still generates a layout box (`getClientRects().length > 0`) counts as on-page — a laid-out zero-area element cannot meaningfully be off the page. `display: none`, the state the guard exists to detect, generates no layout boxes and still reports hidden.

## Verification

- Drove the affected Active Calculus page in branded Chrome 149 with Playwright, fulfilling the CDN `@doenet/standalone` requests from the local build (the page still sees jsdelivr URLs, so worker resolution is untouched): the previously-blank first activity (`int-PA-8-5-D`) renders in 3/3 runs; an unfixed CDN control run in the same setup still blanks it every time.
- New unit tests cover the intersecting, non-intersecting, zero-area-deadlock (zero height and zero width), and `display: none` cases; the full `@doenet/doenetml` vitest suite passes (68 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuVosZzCPzRZKJrptJFjPP
