### PR TITLE
Let a rectangle with a self-referential size move and resize

### DIFF
--- a/.changeset/rectangle-self-referential-size.md
+++ b/.changeset/rectangle-self-referential-size.md
@@ -6,6 +6,6 @@
 
 Graphing: a `<rectangle>` that binds one of its sizes to the other, such as `<rectangle name="R" width="4" height="$R.width" />`, can now be dragged and resized.
 
-Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner follows the pointer, resizing the rectangle about the opposite corner while keeping it square. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
+Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner resizes it about the opposite corner, staying square and following the pointer as closely as that constraint allows. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
 
 Rectangles without a self-referential size are unaffected.

--- a/.changeset/rectangle-self-referential-size.md
+++ b/.changeset/rectangle-self-referential-size.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Graphing: a `<rectangle>` that binds one of its sizes to the other, such as `<rectangle name="R" width="4" height="$R.width" />`, can now be dragged and resized.
+
+Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer.
+
+Setting a rectangle's width or height drives that size attribute's inverse. When the attribute refers back to the rectangle's own other dimension, that request came around again and re-derived the corners from the rectangle's pre-update center, overriding whatever the drag was doing to its position. A rectangle now leaves an unchanged width or height alone, so translating it — which changes neither size — triggers no write-back at all; and it establishes its width and height before its position, so a drag wins over the stale position that a write-back derives.
+
+A rectangle bound this way now translates freely, and dragging a corner resizes it about the opposite corner while keeping it square. Rectangles without a self-referential size are unaffected.

--- a/.changeset/rectangle-self-referential-size.md
+++ b/.changeset/rectangle-self-referential-size.md
@@ -6,6 +6,6 @@
 
 Graphing: a `<rectangle>` that binds one of its sizes to the other, such as `<rectangle name="R" width="4" height="$R.width" />`, can now be dragged and resized.
 
-Previously, dragging such a rectangle could leave it pinned along one axis, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner resizes it about the opposite corner — or about the center, when a center is specified — staying square and following the pointer as closely as that constraint allows. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
+Previously, dragging such a rectangle could leave it pinned along one axis, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner resizes it while keeping it square. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
 
 Rectangles without a self-referential size are unaffected.

--- a/.changeset/rectangle-self-referential-size.md
+++ b/.changeset/rectangle-self-referential-size.md
@@ -6,6 +6,6 @@
 
 Graphing: a `<rectangle>` that binds one of its sizes to the other, such as `<rectangle name="R" width="4" height="$R.width" />`, can now be dragged and resized.
 
-Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner resizes it about the opposite corner, staying square and following the pointer as closely as that constraint allows. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
+Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner resizes it about the opposite corner — or about the center, when a center is specified — staying square and following the pointer as closely as that constraint allows. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
 
 Rectangles without a self-referential size are unaffected.

--- a/.changeset/rectangle-self-referential-size.md
+++ b/.changeset/rectangle-self-referential-size.md
@@ -6,6 +6,6 @@
 
 Graphing: a `<rectangle>` that binds one of its sizes to the other, such as `<rectangle name="R" width="4" height="$R.width" />`, can now be dragged and resized.
 
-Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner resizes it about the opposite corner — or about the center, when a center is specified — staying square and following the pointer as closely as that constraint allows. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
+Previously, dragging such a rectangle could leave it pinned along one axis, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner resizes it about the opposite corner — or about the center, when a center is specified — staying square and following the pointer as closely as that constraint allows. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
 
 Rectangles without a self-referential size are unaffected.

--- a/.changeset/rectangle-self-referential-size.md
+++ b/.changeset/rectangle-self-referential-size.md
@@ -6,8 +6,6 @@
 
 Graphing: a `<rectangle>` that binds one of its sizes to the other, such as `<rectangle name="R" width="4" height="$R.width" />`, can now be dragged and resized.
 
-Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer.
+Previously such a rectangle could not be moved off the axis its bound size referenced, and dragging a corner resized it in unpredictable ways rather than following the pointer. It now translates freely, and dragging a corner follows the pointer, resizing the rectangle about the opposite corner while keeping it square. This applies whether the rectangle is anchored on a center, on a specified vertex, or on neither.
 
-Setting a rectangle's width or height drives that size attribute's inverse. When the attribute refers back to the rectangle's own other dimension, that request came around again and re-derived the corners from the rectangle's pre-update center, overriding whatever the drag was doing to its position. A rectangle now leaves an unchanged width or height alone, so translating it — which changes neither size — triggers no write-back at all; and it establishes its width and height before its position, so a drag wins over the stale position that a write-back derives.
-
-A rectangle bound this way now translates freely, and dragging a corner resizes it about the opposite corner while keeping it square. Rectangles without a self-referential size are unaffected.
+Rectangles without a self-referential size are unaffected.

--- a/packages/doenetml-worker-javascript/src/components/Rectangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Rectangle.js
@@ -1233,13 +1233,16 @@ export default class Rectangle extends Polygon {
                 // over-constrains a self-referential rectangle — i.e. the pointer
                 // is off the square's diagonal, so "follow the pointer" and "hold
                 // the opposite corner" cannot both hold. The anchor request lands
-                // last and wins, and which corner the anchor is decides the
-                // outcome: dragging V0/V1/V3 moves the anchor itself, so the
-                // pointer is followed exactly and the opposite corner slides;
-                // dragging V2 leaves the anchor at the opposite corner, so that
-                // corner holds and the pointer is not reached. Either way the
-                // rectangle stays square. This is a consequence of the anchoring,
-                // not a free choice.
+                // last and wins, so the outcome falls out of what anchors the
+                // rectangle, and is a consequence of the anchoring rather than a
+                // free choice. When the anchor is a vertex (the essential- and
+                // specified-vertex branches, anchored on v0): dragging V0/V1/V3
+                // moves the anchor itself, so the pointer is followed exactly and
+                // the opposite corner slides; dragging V2 leaves the anchor at the
+                // opposite corner, so that corner holds and the pointer is not
+                // reached. When the anchor is the center, it is the center that
+                // holds, and both the pointer and the opposite corner give. The
+                // rectangle stays square in every case.
                 //
                 // Each caller below is ordered and gated accordingly.
 

--- a/packages/doenetml-worker-javascript/src/components/Rectangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Rectangle.js
@@ -1202,128 +1202,103 @@ export default class Rectangle extends Polygon {
 
                 let instructions = [];
 
+                // The center that `workspace` implies along dimension `dim`.
+                const centerComponent = (dim) =>
+                    workspace.v2[dim]
+                        .add(workspace.v0[dim])
+                        .divide(2)
+                        .simplify();
+
+                // Request `specifiedWidth`/`specifiedHeight` along dimension
+                // `dim`, but only if the size actually changed.
+                //
+                // A size attribute may be a self-reference such as
+                // height="$R.width". Writing a size drives that attribute's
+                // inverse, which for a self-reference comes back around into the
+                // *other* public size's inverse — and that re-derives both
+                // vertices from the rectangle's pre-update center, fighting
+                // whatever this update is doing to its position. Two rules keep
+                // that write-back from pinning the rectangle:
+                //
+                //   1. Request a size only if it changed (this function). A pure
+                //      translation changes neither size, so it triggers no
+                //      write-back at all and the position moves freely.
+                //   2. Request the position — the anchor vertex or the center —
+                //      for every dimension this update touches, after the sizes.
+                //      Landing last, it wins over the stale position the
+                //      write-back derives. It must not be gated on the anchor
+                //      itself having moved: dragging the far corner alone changes
+                //      a size without moving the anchor, and an unrequested
+                //      anchor is one the write-back is free to re-center. Each
+                //      caller below is ordered and gated accordingly.
+                const sizeVarNames = ["specifiedWidth", "specifiedHeight"];
+                const pushSizeIfChanged = async (dim, arrayKey) => {
+                    let sizeVarName = sizeVarNames[dim];
+                    let size = workspace.v2[dim]
+                        .subtract(workspace.v0[dim])
+                        .evaluate_to_constant();
+
+                    if (size !== (await stateValues[sizeVarName])) {
+                        instructions.push({
+                            setDependency:
+                                dependencyNamesByKey[arrayKey][sizeVarName],
+                            desiredValue: size,
+                        });
+                    }
+                };
+
                 if (globalDependencyValues.numVerticesSpecified === 0) {
                     if (globalDependencyValues.haveSpecifiedCenter) {
                         // width, height, center
-                        //
-                        // Same two rules as the essential-vertex case below: skip
-                        // unchanged sizes, and request the sizes before the center
-                        // so a self-referential size attribute cannot pin the
-                        // center from its pre-update value.
-                        let desiredCenter = {};
 
                         if (keyX !== undefined) {
-                            let width = workspace.v2[0]
-                                .subtract(workspace.v0[0])
-                                .evaluate_to_constant();
-                            desiredCenter[keyX] = workspace.v2[0]
-                                .add(workspace.v0[0])
-                                .divide(2)
-                                .simplify();
-
-                            if (width !== (await stateValues.specifiedWidth)) {
-                                instructions.push({
-                                    setDependency:
-                                        dependencyNamesByKey[keyX]
-                                            .specifiedWidth,
-                                    desiredValue: width,
-                                });
-                            }
+                            await pushSizeIfChanged(0, keyX);
                         }
-
                         if (keyY !== undefined) {
-                            let height = workspace.v2[1]
-                                .subtract(workspace.v0[1])
-                                .evaluate_to_constant();
-                            desiredCenter[keyY] = workspace.v2[1]
-                                .add(workspace.v0[1])
-                                .divide(2)
-                                .simplify();
-
-                            if (
-                                height !== (await stateValues.specifiedHeight)
-                            ) {
-                                instructions.push({
-                                    setDependency:
-                                        dependencyNamesByKey[keyY]
-                                            .specifiedHeight,
-                                    desiredValue: height,
-                                });
-                            }
+                            await pushSizeIfChanged(1, keyY);
                         }
 
-                        for (let key in desiredCenter) {
+                        // Rule 2: the center lands after the sizes.
+                        if (keyX !== undefined) {
                             instructions.push({
                                 setDependency:
-                                    dependencyNamesByKey[key].specifiedCenter,
-                                desiredValue: desiredCenter[key],
+                                    dependencyNamesByKey[keyX].specifiedCenter,
+                                desiredValue: centerComponent(0),
+                            });
+                        }
+                        if (keyY !== undefined) {
+                            instructions.push({
+                                setDependency:
+                                    dependencyNamesByKey[keyY].specifiedCenter,
+                                desiredValue: centerComponent(1),
                             });
                         }
                     } else {
                         // width, height, essential vertex
-                        //
-                        // A size attribute may be a self-reference such as
-                        // height="$R.width". Writing the size then drives the
-                        // inverse of `width`, which re-derives both vertices from
-                        // the pre-update center and so fights whatever this update
-                        // is doing to the anchor vertex. Two rules keep that from
-                        // pinning the rectangle in place:
-                        //
-                        // 1. Only request a size that actually changed. A pure
-                        //    translation leaves both sizes alone, so no write-back
-                        //    is triggered and the anchor moves freely.
-                        // 2. Request the sizes before the anchor vertex, so that
-                        //    when a size does change, the anchor requested here
-                        //    wins over the stale one the write-back derives.
-                        if (keyV2X !== undefined) {
-                            let width = workspace.v2[0]
-                                .subtract(workspace.v0[0])
-                                .evaluate_to_constant();
 
-                            if (width !== (await stateValues.specifiedWidth)) {
-                                instructions.push({
-                                    setDependency:
-                                        dependencyNamesByKey[keyV2X]
-                                            .specifiedWidth,
-                                    desiredValue: width,
-                                });
-                            }
+                        if (keyV2X !== undefined) {
+                            await pushSizeIfChanged(0, keyV2X);
                         }
                         if (keyV2Y !== undefined) {
-                            let height = workspace.v2[1]
-                                .subtract(workspace.v0[1])
-                                .evaluate_to_constant();
-
-                            if (
-                                height !== (await stateValues.specifiedHeight)
-                            ) {
-                                instructions.push({
-                                    setDependency:
-                                        dependencyNamesByKey[keyV2Y]
-                                            .specifiedHeight,
-                                    desiredValue: height,
-                                });
-                            }
+                            await pushSizeIfChanged(1, keyV2Y);
                         }
 
-                        if (keyV0X !== undefined) {
-                            let vert = workspace.v0[0].simplify();
-
+                        // Rule 2: the anchor lands after the sizes. Every array
+                        // key in this branch carries the `essentialVertex`
+                        // dependency for its dimension, so the anchor can be
+                        // pinned off whichever key touched the dimension.
+                        if (keyX !== undefined) {
                             instructions.push({
                                 setDependency:
-                                    dependencyNamesByKey[keyV0X]
-                                        .essentialVertex,
-                                desiredValue: vert,
+                                    dependencyNamesByKey[keyX].essentialVertex,
+                                desiredValue: workspace.v0[0].simplify(),
                             });
                         }
-                        if (keyV0Y !== undefined) {
-                            let vert = workspace.v0[1].simplify();
-
+                        if (keyY !== undefined) {
                             instructions.push({
                                 setDependency:
-                                    dependencyNamesByKey[keyV0Y]
-                                        .essentialVertex,
-                                desiredValue: vert,
+                                    dependencyNamesByKey[keyY].essentialVertex,
+                                desiredValue: workspace.v0[1].simplify(),
                             });
                         }
                     }
@@ -1342,16 +1317,11 @@ export default class Rectangle extends Polygon {
                             });
                         }
                         if (keyV2X !== undefined) {
-                            let center = workspace.v2[0]
-                                .add(workspace.v0[0])
-                                .divide(2)
-                                .simplify();
-
                             instructions.push({
                                 setDependency:
                                     dependencyNamesByKey[keyV2X]
                                         .specifiedCenter,
-                                desiredValue: center,
+                                desiredValue: centerComponent(0),
                             });
                         }
 
@@ -1366,63 +1336,45 @@ export default class Rectangle extends Polygon {
                             });
                         }
                         if (keyV2Y !== undefined) {
-                            let center = workspace.v2[1]
-                                .add(workspace.v0[1])
-                                .divide(2)
-                                .simplify();
-
                             instructions.push({
                                 setDependency:
                                     dependencyNamesByKey[keyV2Y]
                                         .specifiedCenter,
-                                desiredValue: center,
+                                desiredValue: centerComponent(1),
                             });
                         }
                     } else {
                         // 1 vertex, width, height
+                        //
+                        // A size attribute here can be a self-reference just as in
+                        // the `numVerticesSpecified === 0` cases above, so the same
+                        // two rules apply.
 
-                        if (keyV0X !== undefined) {
-                            let vert = workspace.v0[0].simplify();
-
-                            instructions.push({
-                                setDependency:
-                                    dependencyNamesByKey[keyV0X].verticesAttr,
-                                desiredValue: vert,
-                                variableIndex: 0,
-                            });
-                        }
                         if (keyV2X !== undefined) {
-                            let width = workspace.v2[0]
-                                .subtract(workspace.v0[0])
-                                .evaluate_to_constant();
-
-                            instructions.push({
-                                setDependency:
-                                    dependencyNamesByKey[keyV2X].specifiedWidth,
-                                desiredValue: width,
-                            });
-                        }
-
-                        if (keyV0Y !== undefined) {
-                            let vert = workspace.v0[1].simplify();
-
-                            instructions.push({
-                                setDependency:
-                                    dependencyNamesByKey[keyV0Y].verticesAttr,
-                                desiredValue: vert,
-                                variableIndex: 0,
-                            });
+                            await pushSizeIfChanged(0, keyV2X);
                         }
                         if (keyV2Y !== undefined) {
-                            let height = workspace.v2[1]
-                                .subtract(workspace.v0[1])
-                                .evaluate_to_constant();
+                            await pushSizeIfChanged(1, keyV2Y);
+                        }
 
+                        // Rule 2: the anchor lands after the sizes. Every array
+                        // key in this branch carries the `verticesAttr`
+                        // dependency for its dimension, so the anchor can be
+                        // pinned off whichever key touched the dimension.
+                        if (keyX !== undefined) {
                             instructions.push({
                                 setDependency:
-                                    dependencyNamesByKey[keyV2Y]
-                                        .specifiedHeight,
-                                desiredValue: height,
+                                    dependencyNamesByKey[keyX].verticesAttr,
+                                desiredValue: workspace.v0[0].simplify(),
+                                variableIndex: 0,
+                            });
+                        }
+                        if (keyY !== undefined) {
+                            instructions.push({
+                                setDependency:
+                                    dependencyNamesByKey[keyY].verticesAttr,
+                                desiredValue: workspace.v0[1].simplify(),
+                                variableIndex: 0,
                             });
                         }
                     }
@@ -1704,13 +1656,13 @@ export default class Rectangle extends Polygon {
             vertexComponents[ind + ",0"] = me.fromAst(pointCoords[ind][0]);
             vertexComponents[ind + ",1"] = me.fromAst(pointCoords[ind][1]);
         }
-        updateInstructions.push({
+        let verticesInstruction = {
             updateType: "updateValue",
             componentIdx: this.componentIdx,
             stateVariable: "vertices",
             value: vertexComponents,
             sourceDetails,
-        });
+        };
 
         if (numVerticesMoved === 1) {
             // When dragging a rectangle corner, add additional instructions
@@ -1787,6 +1739,14 @@ export default class Rectangle extends Polygon {
                 }
             }
         }
+
+        // The vertices go last, for the same reason the inverse of `vertices`
+        // requests the sizes before the position: a size set just above may be a
+        // self-reference such as height="$R.width", whose write-back re-derives
+        // the vertices from the rectangle's pre-update center. Requesting the
+        // dragged vertices afterwards puts the drag's own position last, so it
+        // wins over that stale one.
+        updateInstructions.push(verticesInstruction);
 
         // Note: we set skipRendererUpdate to true
         // so that we can make further adjustments before the renderers are updated

--- a/packages/doenetml-worker-javascript/src/components/Rectangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Rectangle.js
@@ -1202,6 +1202,47 @@ export default class Rectangle extends Polygon {
 
                 let instructions = [];
 
+                // Reconciling sizes with a position, when a size may be a
+                // self-reference.
+                //
+                // A size attribute may refer back to the rectangle's other
+                // dimension, as in `<rectangle name="R" width="4"
+                // height="$R.width" />`. Writing a size drives that attribute's
+                // inverse, which for such a self-reference comes back around into
+                // the *other* public size's inverse — and that re-derives both
+                // vertices from the rectangle's PRE-UPDATE center, fighting
+                // whatever this update is doing to its position. Two rules keep
+                // that write-back from pinning the rectangle:
+                //
+                //   1. Do not request a size that did not change
+                //      (`pushSizeIfChanged`). An exact translation leaves both
+                //      sizes alone, so it drives no write-back at all. The
+                //      comparison is exact, so rounding in the dragged
+                //      coordinates can still let a nominally-unchanged size
+                //      through; rule 2 is what keeps the result correct when it
+                //      does.
+                //   2. Request the position — the anchor vertex or the center —
+                //      for every dimension this update touches, AFTER the sizes.
+                //      Landing last, it wins over the stale position the
+                //      write-back derives. It must not be gated on the anchor
+                //      itself having moved: dragging the far corner alone changes
+                //      a size without moving the anchor, and an unrequested
+                //      anchor is one the write-back is free to re-center.
+                //
+                // Rule 2 also settles which constraint gives when a corner drag
+                // over-constrains a self-referential rectangle — i.e. the pointer
+                // is off the square's diagonal, so "follow the pointer" and "hold
+                // the opposite corner" cannot both hold. The anchor request lands
+                // last and wins, and which corner the anchor is decides the
+                // outcome: dragging V0/V1/V3 moves the anchor itself, so the
+                // pointer is followed exactly and the opposite corner slides;
+                // dragging V2 leaves the anchor at the opposite corner, so that
+                // corner holds and the pointer is not reached. Either way the
+                // rectangle stays square. This is a consequence of the anchoring,
+                // not a free choice.
+                //
+                // Each caller below is ordered and gated accordingly.
+
                 // The center that `workspace` implies along dimension `dim`.
                 const centerComponent = (dim) =>
                     workspace.v2[dim]
@@ -1210,27 +1251,7 @@ export default class Rectangle extends Polygon {
                         .simplify();
 
                 // Request `specifiedWidth`/`specifiedHeight` along dimension
-                // `dim`, but only if the size actually changed.
-                //
-                // A size attribute may be a self-reference such as
-                // height="$R.width". Writing a size drives that attribute's
-                // inverse, which for a self-reference comes back around into the
-                // *other* public size's inverse — and that re-derives both
-                // vertices from the rectangle's pre-update center, fighting
-                // whatever this update is doing to its position. Two rules keep
-                // that write-back from pinning the rectangle:
-                //
-                //   1. Request a size only if it changed (this function). A pure
-                //      translation changes neither size, so it triggers no
-                //      write-back at all and the position moves freely.
-                //   2. Request the position — the anchor vertex or the center —
-                //      for every dimension this update touches, after the sizes.
-                //      Landing last, it wins over the stale position the
-                //      write-back derives. It must not be gated on the anchor
-                //      itself having moved: dragging the far corner alone changes
-                //      a size without moving the anchor, and an unrequested
-                //      anchor is one the write-back is free to re-center. Each
-                //      caller below is ordered and gated accordingly.
+                // `dim`, but only if the size actually changed (rule 1 above).
                 const sizeVarNames = ["specifiedWidth", "specifiedHeight"];
                 const pushSizeIfChanged = async (dim, arrayKey) => {
                     let sizeVarName = sizeVarNames[dim];
@@ -1656,13 +1677,6 @@ export default class Rectangle extends Polygon {
             vertexComponents[ind + ",0"] = me.fromAst(pointCoords[ind][0]);
             vertexComponents[ind + ",1"] = me.fromAst(pointCoords[ind][1]);
         }
-        let verticesInstruction = {
-            updateType: "updateValue",
-            componentIdx: this.componentIdx,
-            stateVariable: "vertices",
-            value: vertexComponents,
-            sourceDetails,
-        };
 
         if (numVerticesMoved === 1) {
             // When dragging a rectangle corner, add additional instructions
@@ -1746,7 +1760,13 @@ export default class Rectangle extends Polygon {
         // the vertices from the rectangle's pre-update center. Requesting the
         // dragged vertices afterwards puts the drag's own position last, so it
         // wins over that stale one.
-        updateInstructions.push(verticesInstruction);
+        updateInstructions.push({
+            updateType: "updateValue",
+            componentIdx: this.componentIdx,
+            stateVariable: "vertices",
+            value: vertexComponents,
+            sourceDetails,
+        });
 
         // Note: we set skipRendererUpdate to true
         // so that we can make further adjustments before the renderers are updated

--- a/packages/doenetml-worker-javascript/src/components/Rectangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Rectangle.js
@@ -1205,58 +1205,106 @@ export default class Rectangle extends Polygon {
                 if (globalDependencyValues.numVerticesSpecified === 0) {
                     if (globalDependencyValues.haveSpecifiedCenter) {
                         // width, height, center
+                        //
+                        // Same two rules as the essential-vertex case below: skip
+                        // unchanged sizes, and request the sizes before the center
+                        // so a self-referential size attribute cannot pin the
+                        // center from its pre-update value.
+                        let desiredCenter = {};
 
                         if (keyX !== undefined) {
                             let width = workspace.v2[0]
                                 .subtract(workspace.v0[0])
                                 .evaluate_to_constant();
-                            let center = workspace.v2[0]
+                            desiredCenter[keyX] = workspace.v2[0]
                                 .add(workspace.v0[0])
                                 .divide(2)
                                 .simplify();
 
-                            instructions.push(
-                                {
+                            if (width !== (await stateValues.specifiedWidth)) {
+                                instructions.push({
                                     setDependency:
                                         dependencyNamesByKey[keyX]
                                             .specifiedWidth,
                                     desiredValue: width,
-                                },
-                                {
-                                    setDependency:
-                                        dependencyNamesByKey[keyX]
-                                            .specifiedCenter,
-                                    desiredValue: center,
-                                },
-                            );
+                                });
+                            }
                         }
 
                         if (keyY !== undefined) {
                             let height = workspace.v2[1]
                                 .subtract(workspace.v0[1])
                                 .evaluate_to_constant();
-                            let center = workspace.v2[1]
+                            desiredCenter[keyY] = workspace.v2[1]
                                 .add(workspace.v0[1])
                                 .divide(2)
                                 .simplify();
 
-                            instructions.push(
-                                {
+                            if (
+                                height !== (await stateValues.specifiedHeight)
+                            ) {
+                                instructions.push({
                                     setDependency:
                                         dependencyNamesByKey[keyY]
                                             .specifiedHeight,
                                     desiredValue: height,
-                                },
-                                {
-                                    setDependency:
-                                        dependencyNamesByKey[keyY]
-                                            .specifiedCenter,
-                                    desiredValue: center,
-                                },
-                            );
+                                });
+                            }
+                        }
+
+                        for (let key in desiredCenter) {
+                            instructions.push({
+                                setDependency:
+                                    dependencyNamesByKey[key].specifiedCenter,
+                                desiredValue: desiredCenter[key],
+                            });
                         }
                     } else {
                         // width, height, essential vertex
+                        //
+                        // A size attribute may be a self-reference such as
+                        // height="$R.width". Writing the size then drives the
+                        // inverse of `width`, which re-derives both vertices from
+                        // the pre-update center and so fights whatever this update
+                        // is doing to the anchor vertex. Two rules keep that from
+                        // pinning the rectangle in place:
+                        //
+                        // 1. Only request a size that actually changed. A pure
+                        //    translation leaves both sizes alone, so no write-back
+                        //    is triggered and the anchor moves freely.
+                        // 2. Request the sizes before the anchor vertex, so that
+                        //    when a size does change, the anchor requested here
+                        //    wins over the stale one the write-back derives.
+                        if (keyV2X !== undefined) {
+                            let width = workspace.v2[0]
+                                .subtract(workspace.v0[0])
+                                .evaluate_to_constant();
+
+                            if (width !== (await stateValues.specifiedWidth)) {
+                                instructions.push({
+                                    setDependency:
+                                        dependencyNamesByKey[keyV2X]
+                                            .specifiedWidth,
+                                    desiredValue: width,
+                                });
+                            }
+                        }
+                        if (keyV2Y !== undefined) {
+                            let height = workspace.v2[1]
+                                .subtract(workspace.v0[1])
+                                .evaluate_to_constant();
+
+                            if (
+                                height !== (await stateValues.specifiedHeight)
+                            ) {
+                                instructions.push({
+                                    setDependency:
+                                        dependencyNamesByKey[keyV2Y]
+                                            .specifiedHeight,
+                                    desiredValue: height,
+                                });
+                            }
+                        }
 
                         if (keyV0X !== undefined) {
                             let vert = workspace.v0[0].simplify();
@@ -1268,18 +1316,6 @@ export default class Rectangle extends Polygon {
                                 desiredValue: vert,
                             });
                         }
-                        if (keyV2X !== undefined) {
-                            let width = workspace.v2[0]
-                                .subtract(workspace.v0[0])
-                                .evaluate_to_constant();
-
-                            instructions.push({
-                                setDependency:
-                                    dependencyNamesByKey[keyV2X].specifiedWidth,
-                                desiredValue: width,
-                            });
-                        }
-
                         if (keyV0Y !== undefined) {
                             let vert = workspace.v0[1].simplify();
 
@@ -1288,18 +1324,6 @@ export default class Rectangle extends Polygon {
                                     dependencyNamesByKey[keyV0Y]
                                         .essentialVertex,
                                 desiredValue: vert,
-                            });
-                        }
-                        if (keyV2Y !== undefined) {
-                            let height = workspace.v2[1]
-                                .subtract(workspace.v0[1])
-                                .evaluate_to_constant();
-
-                            instructions.push({
-                                setDependency:
-                                    dependencyNamesByKey[keyV2Y]
-                                        .specifiedHeight,
-                                desiredValue: height,
                             });
                         }
                     }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
@@ -1,0 +1,739 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+import { updateMathInputValue } from "../utils/actions";
+import { PublicDoenetMLCore } from "../../CoreWorker";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+/**
+ * BACKWARD-COMPATIBILITY CHARACTERIZATION SUITE FOR <rectangle>.
+ *
+ * This suite pins the CURRENT observable behavior of the rectangle across all
+ * of its definition modes (corner+size, center+size, 1 vertex ± center/size,
+ * 2 vertices). It is the safety net for the planned refactor that makes
+ * width/height/center the primary essentials (center-primary) in the
+ * width/height/center family, so that a self-referential attribute such as
+ * `height="$R.width"` no longer creates a cyclic/over-constrained inverse.
+ *
+ * Three invariants must be preserved by that refactor (verified below in every
+ * mode):
+ *   (I1) Changing width or height PRESERVES THE CENTER (symmetric expansion),
+ *        regardless of how the rectangle was defined.
+ *   (I2) Dragging the whole rectangle is a clean translation
+ *        (center shifts by the drag vector; width/height unchanged).
+ *   (I3) Dragging one corner keeps the DIAGONALLY OPPOSITE corner fixed.
+ *
+ * The separate "KNOWN BUG" block at the bottom documents the current *broken*
+ * behavior for the self-referential case. Those assertions are EXPECTED TO
+ * CHANGE when the refactor lands — a failure there is the signal the fix works,
+ * at which point update them to the corrected values.
+ */
+
+type Snap = { v: number[][]; w: number; h: number; c: number[] };
+
+function scene(rectAttrs: string) {
+    return `
+  <graph><rectangle name="R" ${rectAttrs} draggable verticesDraggable /></graph>
+  <mathInput name="miw" bindValueTo="$R.width" />
+  <mathInput name="mih" bindValueTo="$R.height" />`;
+}
+
+async function fresh(attrs: string) {
+    const { core, resolvePathToNodeIdx } = await createTestCore({
+        doenetML: scene(attrs),
+    });
+    return { core, r: resolvePathToNodeIdx };
+}
+
+async function readVertices(core: PublicDoenetMLCore, idx: number) {
+    const sv = await core.returnAllStateVariables(false, true);
+    return sv[idx].stateValues.vertices.map((x: any[]) =>
+        x.map((y: any) => y.evaluate_to_constant()),
+    );
+}
+
+async function expectRect(
+    core: PublicDoenetMLCore,
+    r: (s: string) => Promise<number>,
+    exp: Snap,
+) {
+    const sv = await core.returnAllStateVariables(false, true);
+    const R = sv[await r("R")];
+    expect(
+        R.stateValues.vertices.map((x: any[]) =>
+            x.map((y: any) => y.evaluate_to_constant()),
+        ),
+    ).eqls(exp.v);
+    expect(R.stateValues.width).eq(exp.w);
+    expect(R.stateValues.height).eq(exp.h);
+    expect(R.stateValues.center.map((x: any) => x.evaluate_to_constant())).eqls(
+        exp.c,
+    );
+}
+
+async function dragBy(
+    core: PublicDoenetMLCore,
+    idx: number,
+    pointCoords: Record<number, number[]>,
+) {
+    await core.requestAction({
+        componentIdx: idx,
+        actionName: "movePolygon",
+        args: { pointCoords },
+    });
+}
+
+type ModeSpec = {
+    label: string;
+    attrs: string;
+    initial: Snap;
+    afterWidth10: Snap; // set $R.width := 10   -> expect center preserved (I1)
+    afterHeight12: Snap; // set $R.height := 12  -> expect center preserved (I1)
+    afterDragWhole: Snap; // translate all 4 verts by (+5,+3) (I2)
+    afterDragV2: Snap; // drag corner index 2 by (+5,+3); V0 must stay put (I3)
+};
+
+const MODES: ModeSpec[] = [
+    {
+        label: "corner-primary: default unit square",
+        attrs: "",
+        initial: {
+            v: [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+            ],
+            w: 1,
+            h: 1,
+            c: [0.5, 0.5],
+        },
+        afterWidth10: {
+            v: [
+                [-4.5, 0],
+                [5.5, 0],
+                [5.5, 1],
+                [-4.5, 1],
+            ],
+            w: 10,
+            h: 1,
+            c: [0.5, 0.5],
+        },
+        afterHeight12: {
+            v: [
+                [0, -5.5],
+                [1, -5.5],
+                [1, 6.5],
+                [0, 6.5],
+            ],
+            w: 1,
+            h: 12,
+            c: [0.5, 0.5],
+        },
+        afterDragWhole: {
+            v: [
+                [5, 3],
+                [6, 3],
+                [6, 4],
+                [5, 4],
+            ],
+            w: 1,
+            h: 1,
+            c: [5.5, 3.5],
+        },
+        afterDragV2: {
+            v: [
+                [0, 0],
+                [6, 0],
+                [6, 4],
+                [0, 4],
+            ],
+            w: 6,
+            h: 4,
+            c: [3, 2],
+        },
+    },
+    {
+        label: "corner-primary: width=4 height=2",
+        attrs: 'width="4" height="2"',
+        initial: {
+            v: [
+                [0, 0],
+                [4, 0],
+                [4, 2],
+                [0, 2],
+            ],
+            w: 4,
+            h: 2,
+            c: [2, 1],
+        },
+        afterWidth10: {
+            v: [
+                [-3, 0],
+                [7, 0],
+                [7, 2],
+                [-3, 2],
+            ],
+            w: 10,
+            h: 2,
+            c: [2, 1],
+        },
+        afterHeight12: {
+            v: [
+                [0, -5],
+                [4, -5],
+                [4, 7],
+                [0, 7],
+            ],
+            w: 4,
+            h: 12,
+            c: [2, 1],
+        },
+        afterDragWhole: {
+            v: [
+                [5, 3],
+                [9, 3],
+                [9, 5],
+                [5, 5],
+            ],
+            w: 4,
+            h: 2,
+            c: [7, 4],
+        },
+        afterDragV2: {
+            v: [
+                [0, 0],
+                [9, 0],
+                [9, 5],
+                [0, 5],
+            ],
+            w: 9,
+            h: 5,
+            c: [4.5, 2.5],
+        },
+    },
+    {
+        label: "center-primary: width=4 center=(1,3)",
+        attrs: 'width="4" center="(1,3)"',
+        initial: {
+            v: [
+                [-1, 2.5],
+                [3, 2.5],
+                [3, 3.5],
+                [-1, 3.5],
+            ],
+            w: 4,
+            h: 1,
+            c: [1, 3],
+        },
+        afterWidth10: {
+            v: [
+                [-4, 2.5],
+                [6, 2.5],
+                [6, 3.5],
+                [-4, 3.5],
+            ],
+            w: 10,
+            h: 1,
+            c: [1, 3],
+        },
+        afterHeight12: {
+            v: [
+                [-1, -3],
+                [3, -3],
+                [3, 9],
+                [-1, 9],
+            ],
+            w: 4,
+            h: 12,
+            c: [1, 3],
+        },
+        afterDragWhole: {
+            v: [
+                [4, 5.5],
+                [8, 5.5],
+                [8, 6.5],
+                [4, 6.5],
+            ],
+            w: 4,
+            h: 1,
+            c: [6, 6],
+        },
+        afterDragV2: {
+            v: [
+                [-1, 2.5],
+                [8, 2.5],
+                [8, 6.5],
+                [-1, 6.5],
+            ],
+            w: 9,
+            h: 4,
+            c: [3.5, 4.5],
+        },
+    },
+    {
+        label: "center-primary: center=(1,3) only",
+        attrs: 'center="(1,3)"',
+        initial: {
+            v: [
+                [0.5, 2.5],
+                [1.5, 2.5],
+                [1.5, 3.5],
+                [0.5, 3.5],
+            ],
+            w: 1,
+            h: 1,
+            c: [1, 3],
+        },
+        afterWidth10: {
+            v: [
+                [-4, 2.5],
+                [6, 2.5],
+                [6, 3.5],
+                [-4, 3.5],
+            ],
+            w: 10,
+            h: 1,
+            c: [1, 3],
+        },
+        afterHeight12: {
+            v: [
+                [0.5, -3],
+                [1.5, -3],
+                [1.5, 9],
+                [0.5, 9],
+            ],
+            w: 1,
+            h: 12,
+            c: [1, 3],
+        },
+        afterDragWhole: {
+            v: [
+                [5.5, 5.5],
+                [6.5, 5.5],
+                [6.5, 6.5],
+                [5.5, 6.5],
+            ],
+            w: 1,
+            h: 1,
+            c: [6, 6],
+        },
+        afterDragV2: {
+            v: [
+                [0.5, 2.5],
+                [6.5, 2.5],
+                [6.5, 6.5],
+                [0.5, 6.5],
+            ],
+            w: 6,
+            h: 4,
+            c: [3.5, 4.5],
+        },
+    },
+    {
+        label: "1 vertex (2,3)",
+        attrs: 'vertices="(2,3)"',
+        initial: {
+            v: [
+                [2, 3],
+                [3, 3],
+                [3, 4],
+                [2, 4],
+            ],
+            w: 1,
+            h: 1,
+            c: [2.5, 3.5],
+        },
+        afterWidth10: {
+            v: [
+                [-2.5, 3],
+                [7.5, 3],
+                [7.5, 4],
+                [-2.5, 4],
+            ],
+            w: 10,
+            h: 1,
+            c: [2.5, 3.5],
+        },
+        afterHeight12: {
+            v: [
+                [2, -2.5],
+                [3, -2.5],
+                [3, 9.5],
+                [2, 9.5],
+            ],
+            w: 1,
+            h: 12,
+            c: [2.5, 3.5],
+        },
+        afterDragWhole: {
+            v: [
+                [7, 6],
+                [8, 6],
+                [8, 7],
+                [7, 7],
+            ],
+            w: 1,
+            h: 1,
+            c: [7.5, 6.5],
+        },
+        afterDragV2: {
+            v: [
+                [2, 3],
+                [8, 3],
+                [8, 7],
+                [2, 7],
+            ],
+            w: 6,
+            h: 4,
+            c: [5, 5],
+        },
+    },
+    {
+        label: "1 vertex (2,3) width=5 height=7",
+        attrs: 'vertices="(2,3)" width="5" height="7"',
+        initial: {
+            v: [
+                [2, 3],
+                [7, 3],
+                [7, 10],
+                [2, 10],
+            ],
+            w: 5,
+            h: 7,
+            c: [4.5, 6.5],
+        },
+        afterWidth10: {
+            v: [
+                [-0.5, 3],
+                [9.5, 3],
+                [9.5, 10],
+                [-0.5, 10],
+            ],
+            w: 10,
+            h: 7,
+            c: [4.5, 6.5],
+        },
+        afterHeight12: {
+            v: [
+                [2, 0.5],
+                [7, 0.5],
+                [7, 12.5],
+                [2, 12.5],
+            ],
+            w: 5,
+            h: 12,
+            c: [4.5, 6.5],
+        },
+        afterDragWhole: {
+            v: [
+                [7, 6],
+                [12, 6],
+                [12, 13],
+                [7, 13],
+            ],
+            w: 5,
+            h: 7,
+            c: [9.5, 9.5],
+        },
+        afterDragV2: {
+            v: [
+                [2, 3],
+                [12, 3],
+                [12, 13],
+                [2, 13],
+            ],
+            w: 10,
+            h: 10,
+            c: [7, 8],
+        },
+    },
+    {
+        label: "1 vertex (2,3) center=(4,5)",
+        attrs: 'vertices="(2,3)" center="(4,5)"',
+        initial: {
+            v: [
+                [2, 3],
+                [6, 3],
+                [6, 7],
+                [2, 7],
+            ],
+            w: 4,
+            h: 4,
+            c: [4, 5],
+        },
+        afterWidth10: {
+            v: [
+                [-1, 3],
+                [9, 3],
+                [9, 7],
+                [-1, 7],
+            ],
+            w: 10,
+            h: 4,
+            c: [4, 5],
+        },
+        afterHeight12: {
+            v: [
+                [2, -1],
+                [6, -1],
+                [6, 11],
+                [2, 11],
+            ],
+            w: 4,
+            h: 12,
+            c: [4, 5],
+        },
+        afterDragWhole: {
+            v: [
+                [7, 6],
+                [11, 6],
+                [11, 10],
+                [7, 10],
+            ],
+            w: 4,
+            h: 4,
+            c: [9, 8],
+        },
+        afterDragV2: {
+            v: [
+                [2, 3],
+                [11, 3],
+                [11, 10],
+                [2, 10],
+            ],
+            w: 9,
+            h: 7,
+            c: [6.5, 6.5],
+        },
+    },
+    {
+        label: "2 vertices (2,3)(6,9)",
+        attrs: 'vertices="(2,3) (6,9)"',
+        initial: {
+            v: [
+                [2, 3],
+                [6, 3],
+                [6, 9],
+                [2, 9],
+            ],
+            w: 4,
+            h: 6,
+            c: [4, 6],
+        },
+        afterWidth10: {
+            v: [
+                [-1, 3],
+                [9, 3],
+                [9, 9],
+                [-1, 9],
+            ],
+            w: 10,
+            h: 6,
+            c: [4, 6],
+        },
+        afterHeight12: {
+            v: [
+                [2, 0],
+                [6, 0],
+                [6, 12],
+                [2, 12],
+            ],
+            w: 4,
+            h: 12,
+            c: [4, 6],
+        },
+        afterDragWhole: {
+            v: [
+                [7, 6],
+                [11, 6],
+                [11, 12],
+                [7, 12],
+            ],
+            w: 4,
+            h: 6,
+            c: [9, 9],
+        },
+        afterDragV2: {
+            v: [
+                [2, 3],
+                [11, 3],
+                [11, 12],
+                [2, 12],
+            ],
+            w: 9,
+            h: 9,
+            c: [6.5, 7.5],
+        },
+    },
+];
+
+describe("rectangle backward-compatibility characterization @group3", async () => {
+    for (const mode of MODES) {
+        describe(mode.label, () => {
+            it("initial geometry", async () => {
+                const { core, r } = await fresh(mode.attrs);
+                await expectRect(core, r, mode.initial);
+            });
+
+            it("I1: changing width preserves the center", async () => {
+                const { core, r } = await fresh(mode.attrs);
+                await updateMathInputValue({
+                    latex: "10",
+                    componentIdx: await r("miw"),
+                    core,
+                });
+                await expectRect(core, r, mode.afterWidth10);
+                // center must equal the initial center
+                expect(mode.afterWidth10.c).eqls(mode.initial.c);
+            });
+
+            it("I1: changing height preserves the center", async () => {
+                const { core, r } = await fresh(mode.attrs);
+                await updateMathInputValue({
+                    latex: "12",
+                    componentIdx: await r("mih"),
+                    core,
+                });
+                await expectRect(core, r, mode.afterHeight12);
+                expect(mode.afterHeight12.c).eqls(mode.initial.c);
+            });
+
+            it("I2: dragging whole rectangle translates cleanly", async () => {
+                const { core, r } = await fresh(mode.attrs);
+                const idx = await r("R");
+                const V = await readVertices(core, idx);
+                const shifted: Record<number, number[]> = {};
+                for (let i = 0; i < 4; i++)
+                    shifted[i] = [V[i][0] + 5, V[i][1] + 3];
+                await dragBy(core, idx, shifted);
+                await expectRect(core, r, mode.afterDragWhole);
+                // width/height unchanged; center shifted by exactly (5,3)
+                expect(mode.afterDragWhole.w).eq(mode.initial.w);
+                expect(mode.afterDragWhole.h).eq(mode.initial.h);
+                expect(mode.afterDragWhole.c).eqls([
+                    mode.initial.c[0] + 5,
+                    mode.initial.c[1] + 3,
+                ]);
+            });
+
+            it("I3: dragging corner V2 keeps opposite corner V0 fixed", async () => {
+                const { core, r } = await fresh(mode.attrs);
+                const idx = await r("R");
+                const V = await readVertices(core, idx);
+                await dragBy(core, idx, { 2: [V[2][0] + 5, V[2][1] + 3] });
+                await expectRect(core, r, mode.afterDragV2);
+                // opposite corner (index 0) is unchanged from initial
+                expect(mode.afterDragV2.v[0]).eqls(mode.initial.v[0]);
+            });
+        });
+    }
+});
+
+/**
+ * Self-referential sizes — a rectangle constrained to stay square by binding one
+ * size to the other.
+ *
+ * Writing a size drives that size attribute's inverse; when the attribute is a
+ * self-reference, that comes back around as a request on the *other* dimension,
+ * whose inverse re-derives the vertices from the pre-update center. The inverse
+ * of `vertices` avoids letting that pin the rectangle by (1) not requesting a
+ * size that did not change, so a pure translation triggers no write-back at all,
+ * and (2) requesting the sizes before the anchor/center, so the position
+ * requested here wins over the stale one the write-back derives.
+ *
+ * Both orientations are covered: they are mirror images of each other, and each
+ * one exercises the pinning on a different axis.
+ */
+describe("rectangle self-reference height=$R.width @group3", async () => {
+    it("translates freely (the center is not pinned)", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" width="4" height="$R.width" draggable /></graph>`,
+        });
+        const idx = await r("R");
+        // request translation by (5,3): [0,0]..[0,4] -> [5,3]..[5,7]
+        await dragBy(core, idx, { 0: [5, 3], 1: [9, 3], 2: [9, 7], 3: [5, 7] });
+        // the whole translation is honored; the rectangle stays 4x4
+        await expectRect(core, r, {
+            v: [
+                [5, 3],
+                [9, 3],
+                [9, 7],
+                [5, 7],
+            ],
+            w: 4,
+            h: 4,
+            c: [7, 5],
+        });
+    });
+
+    it("dragging a corner resizes it as a square, holding the opposite corner", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" width="4" height="$R.width" draggable verticesDraggable /></graph>`,
+        });
+        const idx = await r("R");
+        // drag corner V3 (starts at (0,4)) to (-2,6)
+        await dragBy(core, idx, { 3: [-2, 6] });
+        // V3 lands exactly where dragged, the opposite corner V1 stays at (4,0),
+        // and height still tracks width, so it remains square (6x6).
+        await expectRect(core, r, {
+            v: [
+                [-2, 0],
+                [4, 0],
+                [4, 6],
+                [-2, 6],
+            ],
+            w: 6,
+            h: 6,
+            c: [1, 3],
+        });
+    });
+});
+
+describe("rectangle self-reference width=$R.height @group3", async () => {
+    // The mirror image of the height="$R.width" cases above. Here the write-back
+    // lands on `height`, so it is the y-coordinates that would be pinned.
+    it("translates freely (the center is not pinned)", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" height="4" width="$R.height" draggable /></graph>`,
+        });
+        const idx = await r("R");
+        // request translation by (5,3): [0,0]..[4,4] -> [5,3]..[9,7]
+        await dragBy(core, idx, { 0: [5, 3], 1: [9, 3], 2: [9, 7], 3: [5, 7] });
+        await expectRect(core, r, {
+            v: [
+                [5, 3],
+                [9, 3],
+                [9, 7],
+                [5, 7],
+            ],
+            w: 4,
+            h: 4,
+            c: [7, 5],
+        });
+    });
+
+    it("dragging a corner resizes it as a square, holding the opposite corner", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" height="4" width="$R.height" draggable verticesDraggable /></graph>`,
+        });
+        const idx = await r("R");
+        // drag corner V1 (starts at (4,0)) to (6,-2)
+        await dragBy(core, idx, { 1: [6, -2] });
+        // V1 lands exactly where dragged, the opposite corner V3 stays at (0,4),
+        // and width still tracks height, so it remains square (6x6).
+        await expectRect(core, r, {
+            v: [
+                [0, -2],
+                [6, -2],
+                [6, 4],
+                [0, 4],
+            ],
+            w: 6,
+            h: 6,
+            c: [3, 1],
+        });
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
@@ -10,25 +10,25 @@ vi.mock("hyperformula");
 /**
  * BACKWARD-COMPATIBILITY CHARACTERIZATION SUITE FOR <rectangle>.
  *
- * This suite pins the CURRENT observable behavior of the rectangle across all
- * of its definition modes (corner+size, center+size, 1 vertex ± center/size,
- * 2 vertices). It is the safety net for the planned refactor that makes
- * width/height/center the primary essentials (center-primary) in the
- * width/height/center family, so that a self-referential attribute such as
- * `height="$R.width"` no longer creates a cyclic/over-constrained inverse.
+ * This suite pins the observable behavior of the rectangle across all of its
+ * definition modes (corner+size, center+size, 1 vertex ± center/size,
+ * 2 vertices), so that changes to the inverse of `vertices` — which has to
+ * reconcile several ways of specifying the same geometry — cannot silently
+ * alter one mode while fixing another.
  *
- * Three invariants must be preserved by that refactor (verified below in every
- * mode):
+ * Three invariants are verified below in every mode:
  *   (I1) Changing width or height PRESERVES THE CENTER (symmetric expansion),
  *        regardless of how the rectangle was defined.
  *   (I2) Dragging the whole rectangle is a clean translation
  *        (center shifts by the drag vector; width/height unchanged).
  *   (I3) Dragging one corner keeps the DIAGONALLY OPPOSITE corner fixed.
  *
- * The separate "KNOWN BUG" block at the bottom documents the current *broken*
- * behavior for the self-referential case. Those assertions are EXPECTED TO
- * CHANGE when the refactor lands — a failure there is the signal the fix works,
- * at which point update them to the corrected values.
+ * The expected values here were read off actual behavior. If one of them starts
+ * failing, that is a signal to investigate the change in behavior, not to
+ * rewrite the expectation to match.
+ *
+ * The blocks at the bottom cover rectangles whose size attribute is a
+ * self-reference (`height="$R.width"`), which constrains them to stay square.
  */
 
 type Snap = { v: number[][]; w: number; h: number; c: number[] };
@@ -638,14 +638,21 @@ describe("rectangle backward-compatibility characterization @group3", async () =
  *
  * Writing a size drives that size attribute's inverse; when the attribute is a
  * self-reference, that comes back around as a request on the *other* dimension,
- * whose inverse re-derives the vertices from the pre-update center. The inverse
- * of `vertices` avoids letting that pin the rectangle by (1) not requesting a
- * size that did not change, so a pure translation triggers no write-back at all,
- * and (2) requesting the sizes before the anchor/center, so the position
- * requested here wins over the stale one the write-back derives.
+ * whose inverse re-derives the vertices from the pre-update center. Left alone,
+ * that write-back pins the rectangle. Three things keep it from doing so: the
+ * inverse of `vertices` (1) does not request a size that did not change, so a
+ * pure translation triggers no write-back at all, and (2) requests the position
+ * for every dimension it touches, after the sizes, so the drag's position lands
+ * last and wins over the stale one; and (3) `movePolygon`, which sets sizes
+ * directly when a corner is dragged, likewise requests the vertices last.
  *
  * Both orientations are covered: they are mirror images of each other, and each
  * one exercises the pinning on a different axis.
+ *
+ * Corner drags are covered on both diagonals. The two are not equivalent: a
+ * corner on the main diagonal (V0/V2) reaches the inverse of `vertices` without
+ * any anchor request of its own, while `movePolygon` writes a size directly for
+ * V0/V1/V3 but not for V2 — so each corner exercises a different path.
  */
 describe("rectangle self-reference height=$R.width @group3", async () => {
     it("translates freely (the center is not pinned)", async () => {
@@ -688,6 +695,98 @@ describe("rectangle self-reference height=$R.width @group3", async () => {
             w: 6,
             h: 6,
             c: [1, 3],
+        });
+    });
+
+    it("dragging corner V2 outward grows the square, holding V0", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" width="4" height="$R.width" draggable verticesDraggable /></graph>`,
+        });
+        const idx = await r("R");
+        // drag corner V2 (starts at (4,4)) to (6,6), along the main diagonal
+        await dragBy(core, idx, { 2: [6, 6] });
+        await expectRect(core, r, {
+            v: [
+                [0, 0],
+                [6, 0],
+                [6, 6],
+                [0, 6],
+            ],
+            w: 6,
+            h: 6,
+            c: [3, 3],
+        });
+    });
+
+    it("dragging corner V0 inward shrinks the square, holding V2", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" width="4" height="$R.width" draggable verticesDraggable /></graph>`,
+        });
+        const idx = await r("R");
+        // drag corner V0 (starts at (0,0)) to (2,2), along the main diagonal
+        await dragBy(core, idx, { 0: [2, 2] });
+        await expectRect(core, r, {
+            v: [
+                [2, 2],
+                [4, 2],
+                [4, 4],
+                [2, 4],
+            ],
+            w: 2,
+            h: 2,
+            c: [3, 3],
+        });
+    });
+});
+
+describe("rectangle self-reference with a specified vertex @group3", async () => {
+    // `vertices="(2,3)" width="4" height="$R.width"` anchors the square on a
+    // specified vertex rather than an essential one, which is a separate branch
+    // of the inverse of `vertices` with the same self-reference exposure.
+    const ml = `<graph><rectangle name="R" vertices="(2,3)" width="4" height="$R.width" draggable verticesDraggable /></graph>`;
+
+    it("translates freely (the anchor vertex is not pinned)", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // request translation by (5,3): [2,3]..[6,7] -> [7,6]..[11,10]
+        await dragBy(core, idx, {
+            0: [7, 6],
+            1: [11, 6],
+            2: [11, 10],
+            3: [7, 10],
+        });
+        await expectRect(core, r, {
+            v: [
+                [7, 6],
+                [11, 6],
+                [11, 10],
+                [7, 10],
+            ],
+            w: 4,
+            h: 4,
+            c: [9, 8],
+        });
+    });
+
+    it("dragging corner V2 outward grows the square, holding V0", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // drag corner V2 (starts at (6,7)) to (8,9), along the main diagonal
+        await dragBy(core, idx, { 2: [8, 9] });
+        await expectRect(core, r, {
+            v: [
+                [2, 3],
+                [8, 3],
+                [8, 9],
+                [2, 9],
+            ],
+            w: 6,
+            h: 6,
+            c: [5, 6],
         });
     });
 });
@@ -734,6 +833,26 @@ describe("rectangle self-reference width=$R.height @group3", async () => {
             w: 6,
             h: 6,
             c: [3, 1],
+        });
+    });
+
+    it("dragging corner V2 outward grows the square, holding V0", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" height="4" width="$R.height" draggable verticesDraggable /></graph>`,
+        });
+        const idx = await r("R");
+        // drag corner V2 (starts at (4,4)) to (6,6), along the main diagonal
+        await dragBy(core, idx, { 2: [6, 6] });
+        await expectRect(core, r, {
+            v: [
+                [0, 0],
+                [6, 0],
+                [6, 6],
+                [0, 6],
+            ],
+            w: 6,
+            h: 6,
+            c: [3, 3],
         });
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
@@ -640,11 +640,16 @@ describe("rectangle backward-compatibility characterization @group3", async () =
  * self-reference, that comes back around as a request on the *other* dimension,
  * whose inverse re-derives the vertices from the pre-update center. Left alone,
  * that write-back pins the rectangle. Three things keep it from doing so: the
- * inverse of `vertices` (1) does not request a size that did not change, so a
- * pure translation triggers no write-back at all, and (2) requests the position
+ * inverse of `vertices` (1) does not request a size that did not change, so an
+ * exact translation triggers no write-back at all, and (2) requests the position
  * for every dimension it touches, after the sizes, so the drag's position lands
  * last and wins over the stale one; and (3) `movePolygon`, which sets sizes
  * directly when a corner is dragged, likewise requests the vertices last.
+ *
+ * Rule (1) compares sizes exactly, so a translation by a non-representable delta
+ * can still perturb the computed size and drive the write-back anyway; rule (2)
+ * is what keeps the position correct when it does. The non-integer translation
+ * test below pins that, since real pointer drags never land on integers.
  *
  * Both orientations are covered: they are mirror images of each other, and each
  * one exercises the pinning on a different axis.
@@ -653,6 +658,12 @@ describe("rectangle backward-compatibility characterization @group3", async () =
  * corner on the main diagonal (V0/V2) reaches the inverse of `vertices` without
  * any anchor request of its own, while `movePolygon` writes a size directly for
  * V0/V1/V3 but not for V2 — so each corner exercises a different path.
+ *
+ * A self-referential rectangle is over-constrained whenever the pointer lands off
+ * the square's diagonal: "stay square", "follow the pointer" and "hold the
+ * opposite corner" cannot all three hold. The drags in the tests immediately
+ * below are all square-compatible, so all three do hold. The over-constrained
+ * block at the end pins what gives when they cannot — see its comment.
  */
 describe("rectangle self-reference height=$R.width @group3", async () => {
     it("translates freely (the center is not pinned)", async () => {
@@ -676,12 +687,39 @@ describe("rectangle self-reference height=$R.width @group3", async () => {
         });
     });
 
+    it("translates freely by a non-integer delta", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: `<graph><rectangle name="R" width="4" height="$R.width" draggable /></graph>`,
+        });
+        const idx = await r("R");
+        // A real pointer drag never lands on integers. 4.1-0.1 is not exactly 4
+        // in floating point, so the size comparison sees a "change" and drives
+        // the write-back anyway; the position must still land where dragged.
+        await dragBy(core, idx, {
+            0: [0.1, 0.1],
+            1: [4.1, 0.1],
+            2: [4.1, 4.1],
+            3: [0.1, 4.1],
+        });
+        const V = await readVertices(core, idx);
+        expect(V[0][0]).closeTo(0.1, 1e-12);
+        expect(V[0][1]).closeTo(0.1, 1e-12);
+        expect(V[2][0]).closeTo(4.1, 1e-12);
+        expect(V[2][1]).closeTo(4.1, 1e-12);
+        // still square, to within the rounding of the drag itself
+        const sv = await core.returnAllStateVariables(false, true);
+        const R = sv[idx];
+        expect(R.stateValues.width).closeTo(4, 1e-12);
+        expect(R.stateValues.height).closeTo(4, 1e-12);
+    });
+
     it("dragging a corner resizes it as a square, holding the opposite corner", async () => {
         const { core, resolvePathToNodeIdx: r } = await createTestCore({
             doenetML: `<graph><rectangle name="R" width="4" height="$R.width" draggable verticesDraggable /></graph>`,
         });
         const idx = await r("R");
-        // drag corner V3 (starts at (0,4)) to (-2,6)
+        // drag corner V3 (starts at (0,4)) to (-2,6) — on the square's diagonal
+        // from the opposite corner V1, so this drag is not over-constrained
         await dragBy(core, idx, { 3: [-2, 6] });
         // V3 lands exactly where dragged, the opposite corner V1 stays at (4,0),
         // and height still tracks width, so it remains square (6x6).
@@ -736,6 +774,95 @@ describe("rectangle self-reference height=$R.width @group3", async () => {
             h: 2,
             c: [3, 3],
         });
+    });
+});
+
+/**
+ * Over-constrained corner drags on a self-referential (square) rectangle.
+ *
+ * When the pointer lands off the square's diagonal, "stay square", "follow the
+ * pointer" and "hold the opposite corner" cannot all hold. What gives is decided
+ * by the anchor: the inverse of `vertices` requests the anchor last, so the
+ * anchor always wins, and the anchor is the rectangle's v0 (min-x, min-y) corner.
+ *
+ *   - Dragging V0/V1/V3 moves the anchor itself, so the pointer is followed
+ *     exactly and the OPPOSITE CORNER SLIDES.
+ *   - Dragging V2 leaves the anchor at the opposite corner, so the OPPOSITE
+ *     CORNER HOLDS and the pointer is not reached.
+ *
+ * The rectangle stays square either way. This asymmetry is a consequence of
+ * which corner anchors the rectangle, not an independent choice: the anchor
+ * request is exactly what stops the self-reference write-back from re-centering
+ * the rectangle, so it cannot be dropped to make V2 follow the pointer.
+ *
+ * These values are pinned to make any future change to that trade-off visible.
+ */
+describe("rectangle self-reference, over-constrained corner drags @group3", async () => {
+    const ml = `<graph><rectangle name="R" width="4" height="$R.width" draggable verticesDraggable /></graph>`;
+
+    it("V3 dragged off the diagonal: pointer wins, opposite corner slides", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // V3 starts (0,4), opposite corner V1 is (4,0). Dragging V3 to (-2,7)
+        // asks for a 6-wide, 7-tall rectangle — impossible while square.
+        await dragBy(core, idx, { 3: [-2, 7] });
+        await expectRect(core, r, {
+            v: [
+                [-2, 0],
+                [5, 0],
+                [5, 7],
+                [-2, 7],
+            ],
+            w: 7,
+            h: 7,
+            c: [1.5, 3.5],
+        });
+        // V3 landed exactly on the pointer; V1 slid from (4,0) to (5,0).
+    });
+
+    it("V2 dragged off the diagonal: opposite corner wins, pointer slides", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // V2 starts (4,4), opposite corner V0 is (0,0) and is the anchor.
+        // Dragging V2 to (6,7) asks for 6-wide, 7-tall — impossible while square.
+        await dragBy(core, idx, { 2: [6, 7] });
+        await expectRect(core, r, {
+            v: [
+                [0, 0],
+                [7, 0],
+                [7, 7],
+                [0, 7],
+            ],
+            w: 7,
+            h: 7,
+            c: [3.5, 3.5],
+        });
+        // V0 held exactly; V2 landed at (7,7) rather than on the pointer (6,7).
+    });
+
+    it("V1 dragged off the diagonal: pointer wins, opposite corner slides", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // V1 starts (4,0), opposite corner V3 is (0,4).
+        await dragBy(core, idx, { 1: [7, -2] });
+        await expectRect(core, r, {
+            v: [
+                [-1, -2],
+                [7, -2],
+                [7, 6],
+                [-1, 6],
+            ],
+            w: 8,
+            h: 8,
+            c: [3, 2],
+        });
+        // V1 landed exactly on the pointer; V3 slid from (0,4) to (-1,6).
     });
 });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
@@ -1005,8 +1005,18 @@ describe("rectangle self-reference anchored on a center @group3", async () => {
 });
 
 describe("rectangle self-reference width=$R.height @group3", async () => {
-    // The mirror image of the height="$R.width" cases above. Here the write-back
-    // lands on `height`, so it is the y-coordinates that would be pinned.
+    // The opposite orientation to the height="$R.width" cases above: the
+    // write-back lands on `height` here, so it re-derives the y-coordinates.
+    //
+    // Not a mirror image of the other orientation before the fix — see the
+    // block comment above. Verified against main: the two tests below that are
+    // marked as guards already passed pre-fix, because the pre-fix inverse
+    // happened to request the y anchor after the height. They pin the ordering
+    // rule rather than reproduce the bug. Only the main-diagonal V2 drag failed
+    // pre-fix, since `movePolygon` writes no size for V2 and the pre-fix
+    // `vertices` inverse requested no anchor for it either.
+
+    // Guard: passes pre-fix.
     it("translates freely (the center is not pinned)", async () => {
         const { core, resolvePathToNodeIdx: r } = await createTestCore({
             doenetML: `<graph><rectangle name="R" height="4" width="$R.height" draggable /></graph>`,
@@ -1027,6 +1037,7 @@ describe("rectangle self-reference width=$R.height @group3", async () => {
         });
     });
 
+    // Guard: passes pre-fix.
     it("dragging a corner resizes it as a square, holding the opposite corner", async () => {
         const { core, resolvePathToNodeIdx: r } = await createTestCore({
             doenetML: `<graph><rectangle name="R" height="4" width="$R.height" draggable verticesDraggable /></graph>`,
@@ -1049,6 +1060,7 @@ describe("rectangle self-reference width=$R.height @group3", async () => {
         });
     });
 
+    // Fails pre-fix: the one case that is actually broken in this orientation.
     it("dragging corner V2 outward grows the square, holding V0", async () => {
         const { core, resolvePathToNodeIdx: r } = await createTestCore({
             doenetML: `<graph><rectangle name="R" height="4" width="$R.height" draggable verticesDraggable /></graph>`,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
@@ -671,7 +671,7 @@ describe("rectangle self-reference height=$R.width @group3", async () => {
             doenetML: `<graph><rectangle name="R" width="4" height="$R.width" draggable /></graph>`,
         });
         const idx = await r("R");
-        // request translation by (5,3): [0,0]..[0,4] -> [5,3]..[5,7]
+        // request translation by (5,3): [0,0]..[4,4] -> [5,3]..[9,7]
         await dragBy(core, idx, { 0: [5, 3], 1: [9, 3], 2: [9, 7], 3: [5, 7] });
         // the whole translation is honored; the rectangle stays 4x4
         await expectRect(core, r, {
@@ -783,7 +783,10 @@ describe("rectangle self-reference height=$R.width @group3", async () => {
  * When the pointer lands off the square's diagonal, "stay square", "follow the
  * pointer" and "hold the opposite corner" cannot all hold. What gives is decided
  * by the anchor: the inverse of `vertices` requests the anchor last, so the
- * anchor always wins, and the anchor is the rectangle's v0 (min-x, min-y) corner.
+ * anchor always wins.
+ *
+ * These cases are anchored on an essential vertex, so the anchor is the
+ * rectangle's v0 (min-x, min-y) corner:
  *
  *   - Dragging V0/V1/V3 moves the anchor itself, so the pointer is followed
  *     exactly and the OPPOSITE CORNER SLIDES.
@@ -793,7 +796,9 @@ describe("rectangle self-reference height=$R.width @group3", async () => {
  * The rectangle stays square either way. This asymmetry is a consequence of
  * which corner anchors the rectangle, not an independent choice: the anchor
  * request is exactly what stops the self-reference write-back from re-centering
- * the rectangle, so it cannot be dropped to make V2 follow the pointer.
+ * the rectangle, so it cannot be dropped to make V2 follow the pointer. A
+ * center-anchored rectangle resolves the same conflict about its center
+ * instead — see the center block below.
  *
  * These values are pinned to make any future change to that trade-off visible.
  */
@@ -914,6 +919,80 @@ describe("rectangle self-reference with a specified vertex @group3", async () =>
             w: 6,
             h: 6,
             c: [5, 6],
+        });
+    });
+});
+
+describe("rectangle self-reference anchored on a center @group3", async () => {
+    // `center="(1,2)" width="4" height="$R.width"` anchors the square on a
+    // center rather than on a vertex, which is the third branch of the inverse
+    // of `vertices` that reconciles sizes with a position.
+    //
+    // The anchor here is the center, not v0, so the over-constrained tie-break
+    // differs from the vertex-anchored blocks above: the center is what holds,
+    // and both the pointer and the opposite corner give.
+    const ml = `<graph><rectangle name="R" center="(1,2)" width="4" height="$R.width" draggable verticesDraggable /></graph>`;
+
+    it("translates freely (the center is not pinned)", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // request translation by (5,3): [-1,0]..[3,4] -> [4,3]..[8,7]
+        await dragBy(core, idx, { 0: [4, 3], 1: [8, 3], 2: [8, 7], 3: [4, 7] });
+        await expectRect(core, r, {
+            v: [
+                [4, 3],
+                [8, 3],
+                [8, 7],
+                [4, 7],
+            ],
+            w: 4,
+            h: 4,
+            c: [6, 5],
+        });
+    });
+
+    it("dragging corner V2 outward grows the square, holding V0", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // drag corner V2 (starts at (3,4)) to (5,6), along the main diagonal
+        await dragBy(core, idx, { 2: [5, 6] });
+        await expectRect(core, r, {
+            v: [
+                [-1, 0],
+                [5, 0],
+                [5, 6],
+                [-1, 6],
+            ],
+            w: 6,
+            h: 6,
+            c: [2, 3],
+        });
+    });
+
+    it("V2 dragged off the diagonal: the center wins, both corners slide", async () => {
+        const { core, resolvePathToNodeIdx: r } = await createTestCore({
+            doenetML: ml,
+        });
+        const idx = await r("R");
+        // V2 starts (3,4); dragging it to (5,7) asks for 6-wide, 7-tall —
+        // impossible while square. The center request lands last and wins, so
+        // the square is centered on the midpoint of the drag and grows about it:
+        // neither the pointer nor the opposite corner V0 is held.
+        await dragBy(core, idx, { 2: [5, 7] });
+        await expectRect(core, r, {
+            v: [
+                [-1.5, 0],
+                [5.5, 0],
+                [5.5, 7],
+                [-1.5, 7],
+            ],
+            w: 7,
+            h: 7,
+            c: [2, 3.5],
         });
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle-characterization.test.ts
@@ -651,8 +651,15 @@ describe("rectangle backward-compatibility characterization @group3", async () =
  * is what keeps the position correct when it does. The non-integer translation
  * test below pins that, since real pointer drags never land on integers.
  *
- * Both orientations are covered: they are mirror images of each other, and each
- * one exercises the pinning on a different axis.
+ * Both orientations are covered, but they are NOT symmetric before the fix, and
+ * only `height="$R.width"` is actually broken there. The pre-fix inverse
+ * interleaved its requests per dimension — x anchor, width, y anchor, height —
+ * so `width="$R.height"`, whose write-back re-derives y, happened to be followed
+ * by the y anchor and came out right, while `height="$R.width"`, whose
+ * write-back re-derives x, landed last and pinned x. That accident is why the
+ * bug is orientation-specific. The `width="$R.height"` block below therefore
+ * mostly guards the orientation that already worked against the reordering,
+ * rather than reproducing the bug.
  *
  * Corner drags are covered on both diagonals. The two are not equivalent: a
  * corner on the main diagonal (V0/V2) reaches the inverse of `vertices` without


### PR DESCRIPTION
## Problem

A `<rectangle>` that binds one of its sizes to the other is stuck:

```
<graph>
  <rectangle name="R" width="4" height="$R.width" draggable />
</graph>
```

It cannot be dragged off the y axis, and dragging a corner resizes it in unpredictable ways instead of following the pointer.

## Cause

Setting a rectangle's width or height drives that size attribute's inverse. When the attribute refers back to the rectangle's own other dimension, the request comes around again into the inverse of the *other* public size, which re-derives both corners from the rectangle's **pre-update center** — overriding whatever the drag was doing to its position.

Note that this write-back is *cross-dimensional*: writing `specifiedHeight` drives `$R.width`, which re-derives the **x** corners. So it is not enough to order each size before the position of its own dimension; every size has to precede every position.

Three distinct defects fell out of this:

1. **Unconditional size writes.** The inverse of `vertices` always requested `specifiedWidth`/`specifiedHeight`, even when unchanged. A pure translation changes neither size, but the no-op write still drove the write-back, which re-pinned the center.
2. **Request ordering.** The anchor/center was requested *before* the sizes, so the write-back's stale position landed last and won. This is what made a rectangle "stuck on the y axis" in every anchoring mode, including the center-anchored one.
3. **The position was gated on the anchor having moved.** The anchor was only requested when the anchor vertex itself was dragged. But dragging the *far* corner changes a size without moving the anchor — and an anchor nobody requested is one the write-back is free to re-center. The center-specified branch is the one branch that never had this third defect, since it requests the center for any dimension it touches — but it was still broken by defect 2.

The same shape of bug appears once more outside the inverse: `movePolygon` writes `specifiedWidth`/`specifiedHeight` directly when a corner is dragged, and it queued those *after* the vertices, so the write-back again landed last.

## Fix

In the inverse of `vertices`, for every branch that reconciles sizes with a position:

- Omit a width or height that did not actually change, so an exact translation triggers no write-back at all.
- Request the position — anchor vertex or center — for every dimension the update touches, after *all* the sizes, so the drag's position lands last and wins.

And in `movePolygon`, queue the vertices after the sizes, for the same reason.

This covers all three anchoring modes: essential vertex (`width`/`height` only), specified vertex (`vertices="(2,3)"`), and center. No new state variables and no dependency-structure change; rectangles without a self-referential size are unaffected.

The size comparison is exact, so a translation by a non-representable delta can still perturb the computed size and drive the write-back anyway. The ordering rule is what makes the result correct when that happens — real pointer drags never land on integers, and a test pins that case.

## Result

`<rectangle name="R" width="4" height="$R.width" />`, anchored on an essential vertex:

| | before | after |
|---|---|---|
| translate by (5,3) | center pinned at `(2,5)` — stuck on the y axis | `[[5,3],[9,3],[9,7],[5,7]]`, center `(7,5)` |
| translate by (0.1,0.1) | x pinned at `0` — stuck on the y axis | lands on `(0.1,0.1)..(4.1,4.1)`, still square |
| drag corner V3 `(0,4)` → `(-2,6)` | `[[-1,0],[5,0],[5,6],[-1,6]]` — misses the pointer, opposite corner drifts | `[[-2,0],[4,0],[4,6],[-2,6]]` — lands on the pointer, V1 held, stays square |
| drag corner V2 `(4,4)` → `(6,6)` | `[[-1,0],[5,0],[5,6],[-1,6]]` — misses the pointer, V0 drifts to `(-1,0)` | `[[0,0],[6,0],[6,6],[0,6]]` — lands on the pointer, V0 held, stays square |
| drag corner V0 `(0,0)` → `(2,2)` | `[[1,2],[3,2],[3,4],[1,4]]` — misses the pointer, V2 drifts to `(3,4)` | `[[2,2],[4,2],[4,4],[2,4]]` — lands on the pointer, V2 held, stays square |

The other two anchoring modes:

| | before | after |
|---|---|---|
| `vertices="(2,3)"` + `height="$R.width"`, translate by (5,3) | `[[2,6],[6,6],[6,10],[2,10]]` — x dropped entirely | `[[7,6],[11,6],[11,10],[7,10]]` |
| `center="(1,2)"` + `height="$R.width"`, translate by (5,3) | `[[-1,3],[3,3],[3,7],[-1,7]]` — x pinned at `1`, stuck on the y axis | `[[4,3],[8,3],[8,7],[4,7]]`, center `(6,5)` |
| `center="(1,2)"` + `height="$R.width"`, drag V2 `(3,4)` → `(5,6)` | `[[-2,0],[4,0],[4,6],[-2,6]]` — misses the pointer, V0 drifts to `(-2,0)` | `[[-1,0],[5,0],[5,6],[-1,6]]` — lands on the pointer, V0 held |

## Over-constrained corner drags

When the pointer lands off the square's diagonal, "stay square", "follow the pointer" and "hold the opposite corner" cannot all three hold. What gives falls out of the anchor: the anchor request lands last and wins, so the outcome depends on what anchors the rectangle.

When the anchor is a vertex (the essential- and specified-vertex modes, anchored on the rectangle's v0 (min-x, min-y) corner):

- Dragging **V0/V1/V3** moves the anchor itself → the pointer is followed exactly and the opposite corner slides.
- Dragging **V2** leaves the anchor at the opposite corner → that corner holds and the pointer is not reached.

When the anchor is the **center**, the center is what holds: the square grows about the midpoint of the drag, so both the pointer and the opposite corner give.

The rectangle stays square in every case, and all of these are a strict improvement on `main`, which holds neither the pointer nor the opposite corner. This asymmetry is a consequence of which anchor the rectangle has rather than an independent choice — the anchor request is exactly what stops the write-back from re-centering the rectangle, so it cannot be dropped to make V2 follow the pointer. The behavior is pinned by tests and documented in the inverse.

## Tests

Adds `rectangle-characterization.test.ts`, pinning the observable behavior of all eight definition modes (corner+size, center+size, 1 vertex ± center/size, 2 vertices) against three invariants:

- resizing via `$R.width`/`$R.height` preserves the center, in every mode;
- dragging the whole rectangle translates it cleanly;
- dragging a corner holds the diagonally opposite corner.

Self-referential rectangles are then covered in all three anchoring modes — essential vertex, specified vertex, and center — since each is a separate branch of the inverse. Corner drags are covered on both diagonals, since they take different paths: `movePolygon` writes a size directly for V0/V1/V3 but not for V2, and a main-diagonal corner reaches the inverse of `vertices` with no anchor request of its own. Non-integer translations and over-constrained corner drags are pinned separately, including the center-anchored tie-break.

Both self-reference orientations are covered for the essential-vertex mode — `height="$R.width"` and `width="$R.height"` — but they are **not** mirror images before the fix, and only `height="$R.width"` is actually broken there. The pre-fix inverse interleaved its requests per dimension — x anchor, width, y anchor, height — so `width="$R.height"`, whose write-back re-derives y, happened to be followed by the y anchor and came out right, while `height="$R.width"`, whose write-back re-derives x, landed last and pinned x. That accident is why the bug is orientation-specific.

Verified against `main`: 14 of the 16 self-reference tests fail there, so they reproduce the bug. The two that pass are `width="$R.height"`'s translation and its anti-diagonal (V1) corner drag — that orientation already worked for those, so they guard the ordering rule against regression rather than reproduce the bug, and are labeled as such in the test file. That orientation's main-diagonal (V2) drag does fail on `main`.

The rectangle, polygon, graph, intersection, legend, extend-references, diagnostics, and prefigure suites pass. The generated schema is unchanged, so no editor or schema package is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014c2CjF73FtVzf74FdmFdyN

