### PR TITLE
0.6: backport the `<image>` attribution attributes (imageName, authorName, licenseCodes, ...)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17281,7 +17281,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.6.16",
+            "version": "0.6.17",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -18750,7 +18750,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.6.16",
+            "version": "0.6.17",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {
                 "vite": "^4.5.0"

--- a/packages/doenetml-worker/src/components/Image.js
+++ b/packages/doenetml-worker/src/components/Image.js
@@ -7,6 +7,9 @@ import {
     widthFractions,
     percentWidthsBySize,
     returnSelectedStyleStateVariableDefinition,
+    getMediaLicenseInfo,
+    creativeCommonsVersions,
+    defaultCreativeCommonsVersion,
 } from "@doenet/utils";
 import me from "math-expressions";
 import {
@@ -76,6 +79,82 @@ export default class Image extends BlockComponent {
             createComponentOfType: "text",
             createStateVariable: "source",
             defaultValue: "",
+            public: true,
+            forRenderer: true,
+        };
+        attributes.authorName = {
+            description: "Name of the author of the image.",
+            createComponentOfType: "text",
+            createStateVariable: "authorName",
+            defaultValue: null,
+            public: true,
+            forRenderer: true,
+        };
+        attributes.authorUrl = {
+            description:
+                "URL to link the author's name to in the attribution (e.g. the author's profile page).",
+            createComponentOfType: "text",
+            createStateVariable: "authorUrl",
+            defaultValue: null,
+            public: true,
+            forRenderer: true,
+        };
+        attributes.imageName = {
+            description:
+                "Name of the image, used in place of the generic word “Image” in the attribution.",
+            createComponentOfType: "text",
+            createStateVariable: "imageName",
+            defaultValue: null,
+            public: true,
+            forRenderer: true,
+        };
+        attributes.originalUrl = {
+            description:
+                "Original URL where the image can be found, used to link the image name in the attribution.",
+            createComponentOfType: "text",
+            createStateVariable: "originalUrl",
+            defaultValue: null,
+            public: true,
+            forRenderer: true,
+        };
+        attributes.licenseName = {
+            description: "Name of the license for the image.",
+            createComponentOfType: "text",
+            createStateVariable: "licenseNamePreliminary",
+            defaultValue: null,
+        };
+        attributes.licenseUrl = {
+            description: "URL for the license of the image.",
+            createComponentOfType: "text",
+            createStateVariable: "licenseUrlPreliminary",
+            defaultValue: null,
+        };
+        // Unlike DoenetML 0.7, this 0.6 core validates a `textList` attribute's
+        // value as a whole (it lowercases and checks `validValues` against the
+        // entire array, not each item). So `licenseCodes` deliberately omits
+        // `toLowerCase`/`validValues` here — doing otherwise would crash on the
+        // array. Codes are matched case-insensitively and unknown codes are
+        // skipped downstream via `getMediaLicenseInfo` (in the `licenseNames`
+        // and `licenseUrls` definitions below and in the renderer).
+        attributes.licenseCodes = {
+            description:
+                "License code(s) for the image. Specify two codes to indicate the image is dual licensed.",
+            createComponentOfType: "textList",
+            createStateVariable: "licenseCodes",
+            defaultValue: null,
+            public: true,
+            forRenderer: true,
+        };
+        // `licenseVersion` is a scalar text attribute, so this core's
+        // `validValues`/`toLowerCase` handling works as intended here.
+        attributes.licenseVersion = {
+            description:
+                "Version of the Creative Commons license(s) given in `licenseCodes` (ignored by non-Creative-Commons licenses).",
+            createComponentOfType: "text",
+            createStateVariable: "licenseVersion",
+            defaultValue: defaultCreativeCommonsVersion,
+            toLowerCase: true,
+            validValues: creativeCommonsVersions,
             public: true,
             forRenderer: true,
         };
@@ -425,6 +504,117 @@ export default class Image extends BlockComponent {
                         ],
                     };
                 }
+            },
+        };
+
+        stateVariableDefinitions.licenseNames = {
+            description:
+                "The license name(s) for the image. Derived from `licenseCodes` when given; otherwise from the `licenseName` attribute.",
+            public: true,
+            forRenderer: true,
+            shadowingInstructions: {
+                createComponentOfType: "textList",
+            },
+            returnDependencies: () => ({
+                licenseCodes: {
+                    dependencyType: "stateVariable",
+                    variableName: "licenseCodes",
+                },
+                licenseNamePreliminary: {
+                    dependencyType: "stateVariable",
+                    variableName: "licenseNamePreliminary",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const { licenseCodes, licenseNamePreliminary } =
+                    dependencyValues;
+
+                // Codes take precedence over the preliminary `licenseName`.
+                if (licenseCodes && licenseCodes.length > 0) {
+                    const licenseNames = [];
+                    for (const code of licenseCodes) {
+                        const info = getMediaLicenseInfo(code);
+                        // Unknown codes are skipped here (matched
+                        // case-insensitively); `getMediaLicenseInfo` returns
+                        // undefined for anything not in `mediaLicenses`.
+                        if (info) {
+                            licenseNames.push(info.name);
+                        }
+                    }
+                    return { setValue: { licenseNames } };
+                }
+
+                if (licenseNamePreliminary !== null) {
+                    return {
+                        setValue: { licenseNames: [licenseNamePreliminary] },
+                    };
+                }
+
+                return { setValue: { licenseNames: [] } };
+            },
+        };
+
+        stateVariableDefinitions.licenseUrls = {
+            description:
+                "The license URL(s) for the image. Derived from `licenseCodes` (and `licenseVersion`) when given; otherwise from the `licenseUrl` attribute.",
+            public: true,
+            forRenderer: true,
+            shadowingInstructions: {
+                createComponentOfType: "textList",
+            },
+            returnDependencies: () => ({
+                licenseCodes: {
+                    dependencyType: "stateVariable",
+                    variableName: "licenseCodes",
+                },
+                licenseVersion: {
+                    dependencyType: "stateVariable",
+                    variableName: "licenseVersion",
+                },
+                licenseNamePreliminary: {
+                    dependencyType: "stateVariable",
+                    variableName: "licenseNamePreliminary",
+                },
+                licenseUrlPreliminary: {
+                    dependencyType: "stateVariable",
+                    variableName: "licenseUrlPreliminary",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const {
+                    licenseCodes,
+                    licenseVersion,
+                    licenseNamePreliminary,
+                    licenseUrlPreliminary,
+                } = dependencyValues;
+
+                // Codes take precedence over the preliminary `licenseUrl`.
+                // The order mirrors `licenseNames`: both skip the same unknown
+                // codes, so the two lists stay index-aligned for the renderer.
+                if (licenseCodes && licenseCodes.length > 0) {
+                    const licenseUrls = [];
+                    for (const code of licenseCodes) {
+                        const info = getMediaLicenseInfo(code);
+                        if (info) {
+                            licenseUrls.push(info.url(licenseVersion));
+                        }
+                    }
+                    return { setValue: { licenseUrls } };
+                }
+
+                // The fallback URL is gated on the preliminary `licenseName`:
+                // `licenseNames` only contains an entry when a name is given, so
+                // the URL list must follow suit to stay index-aligned. When a
+                // name is present but no URL, emit an empty string (no link).
+                if (licenseNamePreliminary !== null) {
+                    return {
+                        setValue: {
+                            licenseUrls: [licenseUrlPreliminary ?? ""],
+                        },
+                    };
+                }
+
+                return { setValue: { licenseUrls: [] } };
             },
         };
 

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.6.16",
+    "version": "0.6.17",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/renderers/image.jsx
+++ b/packages/doenetml/src/Viewer/renderers/image.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext, useRef } from "react";
 import { BoardContext, IMAGE_LAYER_OFFSET } from "./graph";
-import { retrieveMediaForCid } from "@doenet/utils";
+import { retrieveMediaForCid, getMediaLicenseDisplay } from "@doenet/utils";
 import useDoenetRenderer from "../useDoenetRenderer";
 import { PageContext } from "../PageViewer";
 import { sizeToCSS } from "./utils/css";
@@ -590,6 +590,40 @@ export default React.memo(function Image(props) {
         imageStyle.border = "var(--mainBorder)";
     }
 
+    const media = urlOrSource ? (
+        <img id={id} src={urlOrSource} style={imageStyle} alt={SVs.description} />
+    ) : (
+        <div id={id} style={imageStyle}>
+            {SVs.description}
+        </div>
+    );
+
+    // The author/license attribution is shown as a caption beneath the image.
+    // (DoenetML 0.7 shows it inside the image's description info popover/details
+    // UI, which this 0.6 line does not have, so a caption is the closest fit.)
+    const attribution = renderImageAttribution({
+        idPrefix: id,
+        imageName: SVs.imageName,
+        authorName: SVs.authorName,
+        authorUrl: SVs.authorUrl,
+        originalUrl: SVs.originalUrl,
+        licenseCodes: SVs.licenseCodes,
+        licenseVersion: SVs.licenseVersion,
+        licenseNames: SVs.licenseNames,
+        licenseUrls: SVs.licenseUrls,
+    });
+
+    // When there is an attribution, stack it below the image in a column so it
+    // reads as a caption; the column's alignment follows `horizontalAlign`.
+    // Without an attribution, the image is rendered directly so existing markup
+    // is unchanged.
+    const alignItems =
+        SVs.horizontalAlign === "left"
+            ? "flex-start"
+            : SVs.horizontalAlign === "right"
+              ? "flex-end"
+              : "center";
+
     return (
         <VisibilitySensor
             partialVisibility={true}
@@ -597,22 +631,200 @@ export default React.memo(function Image(props) {
         >
             <div style={outerStyle}>
                 <a name={id} />
-                {urlOrSource ? (
-                    <img
-                        id={id}
-                        src={urlOrSource}
-                        style={imageStyle}
-                        alt={SVs.description}
-                    />
-                ) : (
-                    <div id={id} style={imageStyle}>
-                        {SVs.description}
+                {attribution ? (
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems,
+                        }}
+                    >
+                        {media}
+                        {attribution}
                     </div>
+                ) : (
+                    media
                 )}
             </div>
         </VisibilitySensor>
     );
 });
+
+/**
+ * Whether `url` is safe to place in an `href`. Authors supply the attribution
+ * URLs (`originalUrl`, `authorUrl`, and the fallback `licenseUrl`), so guard
+ * against script-bearing schemes (`javascript:`, `data:`, `vbscript:`, …) that
+ * could run on click. Whitespace and ASCII control characters are stripped
+ * first so obfuscated schemes (e.g. `java\tscript:`) cannot slip through. A URL
+ * with no scheme (relative or protocol-relative) is treated as safe.
+ */
+function isSafeHref(url) {
+    const stripped = url.replace(/[\u0000-\u001f\u007f\s]/g, "").toLowerCase();
+    const schemeMatch = stripped.match(/^([a-z][a-z0-9+.-]*):/);
+    if (!schemeMatch) {
+        return true;
+    }
+    const scheme = schemeMatch[1];
+    return scheme === "http" || scheme === "https" || scheme === "mailto";
+}
+
+/**
+ * Render `text` as an external link when `url` is given and safe, otherwise as
+ * a plain `<span>`. Shared by the attribution's subject, author, and license
+ * nodes so the link-or-span branching lives in one place. `key` is for use in
+ * lists.
+ */
+function maybeLink(text, url, key) {
+    return url && isSafeHref(url) ? (
+        <a key={key} href={url} target="_blank" rel="noopener noreferrer">
+            {text}
+        </a>
+    ) : (
+        <span key={key}>{text}</span>
+    );
+}
+
+/**
+ * Render the author/license attribution shown beneath the image, or `null` when
+ * there is nothing to attribute.
+ *
+ * The text follows Creative Commons' recommended practice of a single
+ * self-describing credit sentence. Following the TASL convention (Title,
+ * Author, Source, License), the subject is the quoted `imageName` when supplied,
+ * otherwise the generic word "Image"; it links to the source (`originalUrl`),
+ * and the author name links to `authorUrl`. The license clause is phrased by
+ * kind so each reads naturally:
+ *   - Creative Commons: "is licensed under a <name> <version> license"
+ *   - other licenses (MIT, Apache, GFDL, …): "is licensed under the <name>"
+ *   - public domain (CC0, PDM): "is in the public domain (<name>)"
+ * Dual licensing (two codes) joins the licenses with "or" since the reuser may
+ * choose either. License info is resolved from `licenseCodes` + `licenseVersion`
+ * via `@doenet/utils`; when no codes are given, the `licenseNames`/`licenseUrls`
+ * fallback is shown with generic phrasing.
+ */
+function renderImageAttribution({
+    idPrefix,
+    imageName,
+    authorName,
+    authorUrl,
+    originalUrl,
+    licenseCodes,
+    licenseVersion,
+    licenseNames,
+    licenseUrls,
+}) {
+    // Resolve each license into kind/label/url. Codes take precedence and carry
+    // full phrasing info; otherwise fall back to the preliminary name/url pair
+    // (rendered with generic phrasing since its kind is unknown).
+    let licenses;
+    if (licenseCodes && licenseCodes.length > 0) {
+        licenses = [];
+        for (const code of licenseCodes) {
+            const display = getMediaLicenseDisplay(code, licenseVersion);
+            // Unknown codes are already dropped by the worker; guard anyway.
+            if (display) {
+                licenses.push({
+                    kind: display.kind,
+                    label: display.label,
+                    url: display.url,
+                });
+            }
+        }
+    } else {
+        const names = licenseNames ?? [];
+        const urls = licenseUrls ?? [];
+        licenses = names.map((name, i) => ({
+            kind: "generic",
+            label: name,
+            url: urls[i] ?? null,
+        }));
+    }
+
+    const hasAuthor = Boolean(authorName);
+    const hasLicense = licenses.length > 0;
+
+    if (!hasAuthor && !hasLicense) {
+        return null;
+    }
+
+    // The subject of the sentence is the work itself: a quoted `imageName` when
+    // supplied (TASL "Title"), otherwise the generic word "Image". It carries
+    // the source link (`originalUrl`) since the title is where the work is
+    // found.
+    const subjectText = imageName ? `“${imageName}”` : "Image";
+    const subjectNode = maybeLink(subjectText, originalUrl);
+
+    const subjectAndAuthor = hasAuthor ? (
+        <>
+            {subjectNode} by {maybeLink(authorName, authorUrl)}
+        </>
+    ) : (
+        subjectNode
+    );
+
+    // Join an array of nodes with " or " (the dual-license connector).
+    function joinWithOr(nodes) {
+        return nodes.map((node, i) =>
+            i === 0 ? (
+                <React.Fragment key={i}>{node}</React.Fragment>
+            ) : (
+                <React.Fragment key={i}> or {node}</React.Fragment>
+            ),
+        );
+    }
+
+    let sentence;
+    if (!hasLicense) {
+        // Author only.
+        sentence = <>{subjectAndAuthor}.</>;
+    } else if (licenses.every((l) => l.kind === "public-domain")) {
+        // Public-domain works are dedicated/marked, not "licensed under".
+        const links = joinWithOr(
+            licenses.map((l, i) => maybeLink(l.label, l.url, i)),
+        );
+        sentence = (
+            <>
+                {subjectAndAuthor} is in the public domain ({links}).
+            </>
+        );
+    } else {
+        // Licensed works. Each license becomes a clause phrased by kind, joined
+        // with "or" for dual licensing. (A public-domain entry mixed into a
+        // license list — not a realistic combination — falls through to the
+        // "the <name>" form.)
+        const clauses = licenses.map((l, i) => {
+            const link = maybeLink(l.label, l.url, i);
+            if (l.kind === "creative-commons") {
+                return <>a {link} license</>;
+            } else if (l.kind === "generic") {
+                return <>{link}</>;
+            } else {
+                return <>the {link}</>;
+            }
+        });
+        sentence = (
+            <>
+                {subjectAndAuthor} is licensed under {joinWithOr(clauses)}.
+            </>
+        );
+    }
+
+    return (
+        <p
+            id={`${idPrefix}-attribution`}
+            className="image-attribution"
+            style={{
+                margin: "0.35em 0 0",
+                maxWidth: "100%",
+                fontSize: "0.85em",
+                fontStyle: "italic",
+                opacity: 0.85,
+            }}
+        >
+            {sentence}
+        </p>
+    );
+}
 
 /**
  * Resolve the URL to use for an image.

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.6.16",
+    "version": "0.6.17",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -928,4 +928,132 @@ describe("Image Tag Tests", function () {
         cy.get(cesc("#\\/image1")).should("exist");
         cy.get("img" + cesc("#\\/image1")).should("not.exist");
     });
+
+    it("attribution attributes render a Creative Commons credit with no error", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:6J2fuCmNnXjpn1yJRHr416" imageName="A giant anteater" authorName="Duane Nykamp" licenseCodes="CC-BY" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // The image itself still resolves through the doenet: source path.
+        cy.get(cesc("#\\/image1"))
+            .should("have.attr", "src")
+            .and("eq", "https://media.doenet.org/images/6J2fuCmNnXjpn1yJRHr416");
+
+        // The credit is a single self-describing sentence beneath the image.
+        cy.get(cesc("#\\/image1-attribution")).should(
+            "contain.text",
+            "by Duane Nykamp is licensed under a Creative Commons Attribution 4.0 license.",
+        );
+
+        // The license name links to the canonical (versioned) license URL.
+        cy.get(cesc("#\\/image1-attribution") + " a")
+            .should("have.attr", "href")
+            .and("eq", "https://creativecommons.org/licenses/by/4.0/");
+
+        // The tag must parse cleanly: no "Invalid attribute" (or any) error.
+        cy.window().then(async (win) => {
+            let errorWarnings = await win.returnErrorWarnings1();
+            expect(errorWarnings.errors.length).eq(0);
+            expect(errorWarnings.warnings.length).eq(0);
+        });
+    });
+
+    it("dual licensing joins two licenses with 'or'", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" imageName="Some art" authorName="An Artist" licenseCodes="CC-BY CC-BY-SA" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        cy.get(cesc("#\\/image1-attribution")).should(
+            "contain.text",
+            "is licensed under a Creative Commons Attribution 4.0 license or a Creative Commons Attribution-ShareAlike 4.0 license.",
+        );
+    });
+
+    it("CC0 renders public-domain phrasing", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" imageName="Freely usable" authorName="A Donor" licenseCodes="CC0" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        cy.get(cesc("#\\/image1-attribution")).should(
+            "contain.text",
+            "is in the public domain (CC0 1.0 Public Domain Dedication).",
+        );
+    });
+
+    it("license codes are matched case-insensitively", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" imageName="Mixed case" authorName="Someone" licenseCodes="cc-by" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        cy.get(cesc("#\\/image1-attribution")).should(
+            "contain.text",
+            "is licensed under a Creative Commons Attribution 4.0 license.",
+        );
+    });
+
+    it("an unknown attribute on image still errors", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" notarealattribute="oops" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // The new attribution attributes must not blanket-allow unknown
+        // attributes: a genuinely unknown attribute still produces an error.
+        cy.window().then(async (win) => {
+            let errorWarnings = await win.returnErrorWarnings1();
+            expect(errorWarnings.errors.length).eq(1);
+            expect(errorWarnings.errors[0].message).contain(
+                `Invalid attribute "notarealattribute" for a component of type <image>`,
+            );
+        });
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -1056,4 +1056,62 @@ describe("Image Tag Tests", function () {
             );
         });
     });
+
+    it("licenseName/licenseUrl fall back to generic phrasing when no codes given", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" imageName="A local drawing" authorName="Jo" licenseName="My Custom License" licenseUrl="https://example.com/license" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // With no `licenseCodes`, the credit falls back to the author-supplied
+        // `licenseName`/`licenseUrl`, rendered with generic phrasing (just the
+        // name, no CC/"the" wording).
+        cy.get(cesc("#\\/image1-attribution")).should(
+            "contain.text",
+            "by Jo is licensed under My Custom License.",
+        );
+
+        // The generic license name links to the author-supplied `licenseUrl`.
+        cy.get(cesc("#\\/image1-attribution") + " a")
+            .should("have.attr", "href")
+            .and("eq", "https://example.com/license");
+    });
+
+    it("a dangerous attribution URL is not turned into a link", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <image name="image1" source="doenet:abcDEF123" imageName="Sketchy" originalUrl="javascript:alert(1)" authorName="Someone" licenseCodes="CC-BY" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#\\/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // The image name would normally link to `originalUrl`, but a
+        // `javascript:` URL is unsafe (`isSafeHref` rejects it) so the subject
+        // must render as plain text, and no anchor may carry the scheme.
+        cy.get(cesc("#\\/image1-attribution")).should("contain.text", "Sketchy");
+        cy.get(cesc("#\\/image1-attribution") + " a").each(($a) => {
+            expect($a.attr("href") || "").not.to.match(/javascript:/i);
+        });
+
+        // The (safe) CC license link is still rendered.
+        cy.get(cesc("#\\/image1-attribution") + " a")
+            .should("have.attr", "href")
+            .and("eq", "https://creativecommons.org/licenses/by/4.0/");
+    });
 });

--- a/packages/utils/src/components/mediaLicense.ts
+++ b/packages/utils/src/components/mediaLicense.ts
@@ -1,0 +1,250 @@
+/**
+ * Open-licensing metadata for media (images, and potentially other media in the
+ * future). A DoenetML author tags a `<image>` with one or more license *codes*
+ * (e.g. `CC-BY-SA`); the codes are matched case-insensitively but are displayed
+ * to authors in the canonical case defined here. From the codes (and, for
+ * Creative Commons licenses, a license version) the worker derives
+ * human-readable license names and canonical license URLs.
+ *
+ * This list is exported publicly from `@doenet/doenetml` and
+ * `@doenet/doenetml-iframe` so apps embedding the editor/viewer can build their
+ * own license pickers from the same source of truth.
+ */
+
+/** A Creative Commons license version whose URL embeds the version number. */
+export type CreativeCommonsVersion = "1.0" | "2.0" | "2.5" | "3.0" | "4.0";
+
+/** The Creative Commons license versions DoenetML recognizes, oldest first. */
+export const creativeCommonsVersions: CreativeCommonsVersion[] = [
+    "1.0",
+    "2.0",
+    "2.5",
+    "3.0",
+    "4.0",
+];
+
+/** The default Creative Commons version used when an author omits it. */
+export const defaultCreativeCommonsVersion: CreativeCommonsVersion = "4.0";
+
+/**
+ * How a license is phrased in an attribution sentence:
+ *  - `"creative-commons"`: "licensed under a <name> license" (and its URL
+ *    embeds the Creative Commons version).
+ *  - `"license"`: "licensed under the <name>" — for licenses whose name
+ *    already contains the word "License"/"Licence" (e.g. MIT, Apache, GFDL).
+ *  - `"public-domain"`: "in the public domain (<name>)" — for CC0 and the
+ *    Public Domain Mark, which are dedications/marks, not licenses.
+ */
+export type MediaLicenseKind = "creative-commons" | "license" | "public-domain";
+
+/** Information about a single recognized media license. */
+export type MediaLicenseInfo = {
+    /** Canonical code as displayed to authors (e.g. `"CC-BY-SA"`). */
+    code: string;
+    /** Human-readable license name (e.g. `"Creative Commons Attribution-ShareAlike"`). */
+    name: string;
+    /** One-sentence description, surfaced in editor autocomplete and help. */
+    description: string;
+    /**
+     * How the license is phrased in an attribution and whether its URL is
+     * versioned. Only `"creative-commons"` licenses embed the version in
+     * `url(version)`; the others ignore the argument.
+     */
+    kind: MediaLicenseKind;
+    /**
+     * Build the canonical URL for this license. For Creative Commons licenses
+     * the URL embeds the version; other licenses ignore the argument and return
+     * a fixed URL.
+     */
+    url: (version?: CreativeCommonsVersion) => string;
+};
+
+/**
+ * Helper to build a Creative Commons license entry whose URL embeds the
+ * version, e.g. `https://creativecommons.org/licenses/by-sa/4.0/`. The
+ * display name is prefixed with "Creative Commons " so an attribution link
+ * reads e.g. "Creative Commons Attribution-ShareAlike" rather than the
+ * ambiguous bare "Attribution-ShareAlike".
+ */
+function creativeCommonsLicense(
+    code: string,
+    name: string,
+    urlSlug: string,
+    description: string,
+): MediaLicenseInfo {
+    return {
+        code,
+        name: `Creative Commons ${name}`,
+        description,
+        kind: "creative-commons",
+        url: (version = defaultCreativeCommonsVersion) =>
+            `https://creativecommons.org/licenses/${urlSlug}/${version}/`,
+    };
+}
+
+/** Helper to build a license entry with a fixed (version-independent) URL. */
+function fixedUrlLicense(
+    code: string,
+    name: string,
+    url: string,
+    description: string,
+    kind: MediaLicenseKind,
+): MediaLicenseInfo {
+    return {
+        code,
+        name,
+        description,
+        kind,
+        url: () => url,
+    };
+}
+
+/**
+ * The recognized media licenses, in the order they should be offered to
+ * authors (most permissive / most common first).
+ */
+export const mediaLicenses: MediaLicenseInfo[] = [
+    creativeCommonsLicense(
+        "CC-BY",
+        "Attribution",
+        "by",
+        "Creative Commons Attribution: reuse with credit, including commercially.",
+    ),
+    creativeCommonsLicense(
+        "CC-BY-SA",
+        "Attribution-ShareAlike",
+        "by-sa",
+        "Creative Commons Attribution-ShareAlike: reuse with credit; adaptations keep the same license.",
+    ),
+    creativeCommonsLicense(
+        "CC-BY-ND",
+        "Attribution-NoDerivatives",
+        "by-nd",
+        "Creative Commons Attribution-NoDerivatives: reuse unchanged, with credit.",
+    ),
+    creativeCommonsLicense(
+        "CC-BY-NC",
+        "Attribution-NonCommercial",
+        "by-nc",
+        "Creative Commons Attribution-NonCommercial: reuse with credit for noncommercial purposes.",
+    ),
+    creativeCommonsLicense(
+        "CC-BY-NC-SA",
+        "Attribution-NonCommercial-ShareAlike",
+        "by-nc-sa",
+        "Creative Commons Attribution-NonCommercial-ShareAlike: noncommercial reuse with credit; adaptations keep the same license.",
+    ),
+    creativeCommonsLicense(
+        "CC-BY-NC-ND",
+        "Attribution-NonCommercial-NoDerivatives",
+        "by-nc-nd",
+        "Creative Commons Attribution-NonCommercial-NoDerivatives: reuse unchanged for noncommercial purposes, with credit.",
+    ),
+    fixedUrlLicense(
+        "CC0",
+        "CC0 1.0 Public Domain Dedication",
+        "https://creativecommons.org/publicdomain/zero/1.0/",
+        "Creative Commons Zero: the creator has dedicated the work to the public domain.",
+        "public-domain",
+    ),
+    fixedUrlLicense(
+        "PDM",
+        "Public Domain Mark 1.0",
+        "https://creativecommons.org/publicdomain/mark/1.0/",
+        "Public Domain Mark: the work is free of known copyright restrictions.",
+        "public-domain",
+    ),
+    fixedUrlLicense(
+        "GFDL",
+        "GNU Free Documentation License",
+        "https://www.gnu.org/licenses/fdl-1.3.html",
+        "GNU Free Documentation License: copyleft license common on Wikimedia.",
+        "license",
+    ),
+    fixedUrlLicense(
+        "FAL",
+        "Free Art License 1.3",
+        "https://artlibre.org/licence/lal/en/",
+        "Free Art License: copyleft license for artistic works.",
+        "license",
+    ),
+    fixedUrlLicense(
+        "OGL",
+        "Open Government Licence v3.0 (UK)",
+        "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+        "UK Open Government Licence: reuse government material with attribution.",
+        "license",
+    ),
+    fixedUrlLicense(
+        "MIT",
+        "MIT License",
+        "https://opensource.org/license/mit",
+        "MIT License: permissive license common for icon and illustration sets.",
+        "license",
+    ),
+    fixedUrlLicense(
+        "APACHE-2.0",
+        "Apache License 2.0",
+        "https://www.apache.org/licenses/LICENSE-2.0",
+        "Apache License 2.0: permissive license common for icon and illustration sets.",
+        "license",
+    ),
+];
+
+/**
+ * Lookup of license info by lower-cased code. Built once so case-insensitive
+ * lookups (e.g. of the worker's lower-cased `licenseCodes`) are O(1).
+ */
+const mediaLicensesByLowerCode: Record<string, MediaLicenseInfo> =
+    Object.fromEntries(
+        mediaLicenses.map((info) => [info.code.toLowerCase(), info]),
+    );
+
+/**
+ * Return the license info for a code, matched case-insensitively, or
+ * `undefined` if the code is not recognized.
+ */
+export function getMediaLicenseInfo(
+    code: string,
+): MediaLicenseInfo | undefined {
+    return mediaLicensesByLowerCode[code.toLowerCase()];
+}
+
+/** A license resolved for display in an attribution sentence. */
+export type MediaLicenseDisplay = {
+    /** How the license should be phrased (see `MediaLicenseKind`). */
+    kind: MediaLicenseKind;
+    /**
+     * Display label, including the Creative Commons version when applicable
+     * (e.g. `"Creative Commons Attribution 4.0"`); for non-CC licenses this is
+     * just the license name (the version, if any, is already part of the name).
+     */
+    label: string;
+    /** Canonical URL for the license (versioned for Creative Commons). */
+    url: string;
+};
+
+/**
+ * Resolve a license code (case-insensitively) into the pieces an attribution
+ * renderer needs: its phrasing `kind`, a display `label` that includes the
+ * Creative Commons version where applicable, and its canonical `url`. Returns
+ * `undefined` for an unrecognized code.
+ */
+export function getMediaLicenseDisplay(
+    code: string,
+    version?: CreativeCommonsVersion,
+): MediaLicenseDisplay | undefined {
+    const info = getMediaLicenseInfo(code);
+    if (!info) {
+        return undefined;
+    }
+    // Resolve the version once so the label and URL stay consistent: a
+    // Creative Commons label and URL both reflect the same version (the
+    // provided one, or the default when omitted).
+    const resolvedVersion = version ?? defaultCreativeCommonsVersion;
+    const label =
+        info.kind === "creative-commons"
+            ? `${info.name} ${resolvedVersion}`
+            : info.name;
+    return { kind: info.kind, label, url: info.url(resolvedVersion) };
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,6 +9,7 @@ export * from "./copy/parseStringify";
 export * from "./components/domain";
 export * from "./components/enumeration";
 export * from "./components/function";
+export * from "./components/mediaLicense";
 export * from "./components/naming";
 export * from "./components/sequence";
 export * from "./components/size";


### PR DESCRIPTION
Backport of #1508 to the `0.6` branch (→ release 0.6.17). Third follow-up in the legacy-content-migration series (after #1500 `doenetImagesUrl` images and #1503 default `linkSettings`).

## Problem

The legacy-content migration now emits `<image>` tags with the attribution vocabulary DoenetML 0.7 added:

```xml
<image source="doenet:6J2fuCmNnXjpn1yJRHr416" imageName="A giant anteater" authorName="Duane Nykamp" licenseCodes="CC-BY" />
```

Migrated documents stay on DoenetML 0.6, which did not know these attributes. Because unknown attributes **throw** (`Invalid attribute "…" for a component of type <image>`), documents containing these tags failed to render on 0.6.16.

## Change

Backport the `<image>` attribution attributes from `main`:

- **`@doenet/utils`** — port `mediaLicense` (`mediaLicenses`, `creativeCommonsVersions`, `defaultCreativeCommonsVersion`, `getMediaLicenseInfo`, `getMediaLicenseDisplay`, and the license types), copied verbatim from `main`, and export it from the package index.
- **`Image` component** (`packages/doenetml-worker/src/components/Image.js`) — add the attribution attributes `authorName`, `authorUrl`, `imageName`, `originalUrl`, `licenseName`, `licenseUrl`, `licenseCodes`, `licenseVersion`, plus derived `licenseNames`/`licenseUrls` state variables (resolved from `licenseCodes`+`licenseVersion`, falling back to the preliminary `licenseName`/`licenseUrl`).
- **Renderer** (`packages/doenetml/src/Viewer/renderers/image.jsx`) — render the author/license credit as a single self-describing caption beneath the image, ported from `main`'s `renderImageAttribution` (including the `isSafeHref` `href` guard). When no attribution is present the image markup is unchanged.
- **Versions** — bump `@doenet/doenetml` and `@doenet/standalone` to **0.6.17**.

### 0.6-specific adaptation

Unlike 0.7, this 0.6 core (`validateAttributeValue`) validates a `textList` attribute's value **as a whole** — it would call `.toLowerCase()` on the array and check `validValues.includes(array)`. So `licenseCodes` deliberately omits `toLowerCase`/`validValues` (using them would crash on a supplied value). Case-insensitive matching and skipping of unknown codes are handled downstream by `getMediaLicenseInfo` (in the `licenseNames`/`licenseUrls` definitions and in the renderer's `getMediaLicenseDisplay`), which lowercase internally. `licenseVersion` is scalar, so its `validValues` (`creativeCommonsVersions`) works as in 0.7.

0.7 shows the credit inside the image's description info popover/`<details>` UI; that description-UI redesign is not in the 0.6 line, so a caption beneath the image is the closest fit. The rendered credit *sentence* matches 0.7's for the same tag.

## Acceptance criteria

- A 0.6 document containing the example tag renders the image with **no "Invalid attribute" error**. ✅
- All attribution attributes are accepted. ✅
- `licenseCodes` accepts the same codes as 0.7 (CC family, CC0, PDM, GFDL, FAL, OGL, MIT, APACHE-2.0), including dual licensing. ✅
- Rendered credit matches 0.7's sentence. ✅
- Existing `<image>` behavior (source/description/width/`doenet:<id>` resolution, `doenet:cid=` legacy path, graph rendering) unchanged. ✅
- A genuinely unknown attribute still errors. ✅

## Tests

Added to `packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js`:

- the example tag renders a Creative Commons credit (with the versioned license link) and produces no errors or warnings;
- dual licensing (`CC-BY CC-BY-SA`) joins the two with "or";
- `CC0` renders public-domain phrasing;
- license codes match case-insensitively (`cc-by`);
- a genuinely unknown attribute still errors;
- with no `licenseCodes`, the author-supplied `licenseName`/`licenseUrl` fall back to generic phrasing with the license name linked to the supplied URL;
- a dangerous attribution URL (`javascript:`) is rejected by `isSafeHref` and rendered as plain text, while the safe CC license link still renders.

All 20 tests in the image spec pass (7 new + 13 pre-existing, verified with `cypress run`).

## Release / follow-ups

- Publish `@doenet/standalone@0.6.17` from the `0.6` branch.
- DoenetTools follow-up (not this PR): bump the seeded 0.6 `fullVersion` from `0.6.16` to `0.6.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vf6eXKcCyg13iUmLDf2Nu

