### PR TITLE
ci(publish): pin Doenet site DoenetML version on publish

### DIFF
--- a/.github/scripts/notify-site-version.sh
+++ b/.github/scripts/notify-site-version.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Pin the Doenet site's tracked DoenetML version to a concrete published version.
+#
+# Called by publish.yml after a dev or production npm publish. POSTs to the
+# site's /api/info/updateTrackedDoenetmlVersion endpoint, which updates the
+# doenetmlVersions row that tracks the given npm dist-tag so the jsDelivr bundle
+# URL becomes immutable (browser-cacheable) instead of a moving tag — users get
+# the new bundle without clearing their cache.
+#
+# Environment:
+#   SECRET  - shared bearer secret (repo secret DOENET_VERSION_UPDATE_SECRET)
+#   TAG     - npm dist-tag being pinned: "dev" or "latest"
+#   VERSION - concrete version just published (e.g. 0.7.21 or 0.7.21-dev.343)
+#
+# Production (doenet.org) is REQUIRED: a failure fails the job so GitHub notifies
+# and the job can be re-run. dev3 is BEST-EFFORT because it auto-scales to zero
+# and may be asleep when a publish happens.
+
+set -u
+
+if [[ -z "${SECRET:-}" ]]; then
+    echo "::error::DOENET_VERSION_UPDATE_SECRET is not set — add it as a repository secret"
+    exit 1
+fi
+if [[ -z "${TAG:-}" || -z "${VERSION:-}" ]]; then
+    echo "::error::TAG and VERSION must both be set (TAG='${TAG:-}', VERSION='${VERSION:-}')"
+    exit 1
+fi
+
+# $1 = site base URL, $2 = required ("true" fails the job on error)
+post() {
+    local url="$1" required="$2"
+    echo "Pinning ${TAG} -> ${VERSION} on ${url} ..."
+    if curl -fsS --connect-timeout 15 --max-time 60 \
+        -X POST "${url}/api/info/updateTrackedDoenetmlVersion" \
+        -H "Authorization: Bearer ${SECRET}" \
+        -H "Content-Type: application/json" \
+        -d "{\"tag\":\"${TAG}\",\"version\":\"${VERSION}\"}"; then
+        echo ""
+        echo "  updated ${url}"
+    elif [[ "${required}" == "true" ]]; then
+        echo ""
+        echo "::error::Failed to pin DoenetML version on ${url}"
+        exit 1
+    else
+        echo ""
+        echo "::warning::Failed to pin DoenetML version on ${url} (best-effort; the site may be asleep)"
+    fi
+}
+
+post "https://doenet.org" true
+post "https://dev3.doenet.org" false
+
+echo "Done."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,8 @@ jobs:
     dev-release:
         name: Dev Release
         runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.compute-version.outputs.version }}
         if: >-
             (github.event_name == 'workflow_run' &&
             github.event.workflow_run.conclusion == 'success' &&
@@ -71,10 +73,14 @@ jobs:
               run: node .github/scripts/verify-ci.mjs
 
             - name: Update versions
+              id: compute-version
               run: |
                   CURRENT_VERSION=$(node -p "require('./packages/doenetml/package.json').version")
                   VERSION="${CURRENT_VERSION}-dev.${{ github.run_number }}"
                   npm run version -- ${VERSION} --no-git-tag-version
+                  # Exposed as a job output so the notify-site-dev job can pin the
+                  # Doenet site to the exact version published here.
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
             - name: Build workspaces
               run: |
@@ -206,6 +212,8 @@ jobs:
         name: Production Release
         runs-on: ubuntu-latest
         environment: production
+        outputs:
+            version: ${{ steps.release-tag.outputs.version }}
         if: >-
             github.event_name == 'release' ||
             (github.event_name == 'workflow_dispatch' && inputs.channel == 'production')
@@ -298,3 +306,48 @@ jobs:
               run: npm run publish -w @doenet/vscode-extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+    # After a dev publish, pin the Doenet site's tracked dev DoenetML version to
+    # the exact version just published, so users get the new bundle immediately
+    # from an immutable jsDelivr URL instead of waiting out a browser cache.
+    #
+    # This runs as a separate job so a failure here does NOT republish to npm:
+    # GitHub notifies on the failed job and "Re-run failed jobs" retries only
+    # this step. The site endpoint is idempotent, so retries are safe.
+    #
+    # Requires the repository-level secret DOENET_VERSION_UPDATE_SECRET (must be
+    # repo-level, not only in the `production` environment, so both this dev job
+    # and the production job below can read it — same requirement as VSCE_PAT).
+    notify-site-dev:
+        name: Pin dev version on Doenet sites
+        needs: dev-release
+        runs-on: ubuntu-latest
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Pin tracked dev version
+              env:
+                  SECRET: ${{ secrets.DOENET_VERSION_UPDATE_SECRET }}
+                  TAG: dev
+                  VERSION: ${{ needs.dev-release.outputs.version }}
+              run: bash .github/scripts/notify-site-version.sh
+
+    # After a production publish, pin the site's tracked `latest` DoenetML version
+    # to the released version. Same rationale and retry behavior as the dev job.
+    notify-site-prod:
+        name: Pin latest version on Doenet sites
+        needs: production-release
+        runs-on: ubuntu-latest
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Pin tracked latest version
+              env:
+                  SECRET: ${{ secrets.DOENET_VERSION_UPDATE_SECRET }}
+                  TAG: latest
+                  VERSION: ${{ needs.production-release.outputs.version }}
+              run: bash .github/scripts/notify-site-version.sh


### PR DESCRIPTION
## Context

When we publish a new DoenetML version, the Doenet site loads `@doenet/standalone` from jsDelivr keyed by the version string stored in its `doenetmlVersions` table. That string is currently a moving npm tag (`latest`/`dev`), so the CDN URL doesn't change on a new publish and browsers keep serving the cached old bundle until users clear their cache.

The companion site PR (Doenet/DoenetApps#3011) makes the site store a **concrete** version and adds a `POST /api/info/updateTrackedDoenetmlVersion` endpoint. This PR calls that endpoint from the publish workflow so the site pins to the exact version we just published — an immutable jsDelivr URL, no browser-cache wait.

## Changes

- Expose the published version as a job output (`dev-release`, `production-release`).
- Add `notify-site-dev` / `notify-site-prod` as **separate jobs** (needs the corresponding release job). Running them separately means a failure here does not republish to npm — GitHub notifies on the failed job and **Re-run failed jobs** retries only this step. The site endpoint is idempotent, so retries are safe. Both skip on dry-run.
- Shared `.github/scripts/notify-site-version.sh` (mirrors the existing `purge-jsdelivr.sh` convention): posts to **doenet.org** (required — fails the job loudly) and **dev3.doenet.org** (best-effort warning, since dev3 auto-scales to zero).

## Requirements

- Add repository secret **`DOENET_VERSION_UPDATE_SECRET`** (repo-level, like `VSCE_PAT`, so both the dev and production jobs can read it). Its value must match `DOENETML_VERSION_UPDATE_SECRET` on the site.
- Merge after the site PR is deployed and the initial versions are pinned.

## Verification

- `bash -n` + full YAML parse (all 5 jobs recognized).
- Script control flow driven locally against the real site endpoint: success pins the row; a down best-effort target → `::warning::` + exit 0; a down required target → `::error::` + exit 1. The version is validated by the site's SemVer check.
- Version scheme independence: the notify jobs send the exact string the publish job produced (via job output), so they work regardless of the dev-version format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
