### PR TITLE
fix(prefigure): retry transient download failures in build fetch scripts

### DIFF
--- a/packages/prefigure/scripts/lib/download-utils.ts
+++ b/packages/prefigure/scripts/lib/download-utils.ts
@@ -1,12 +1,106 @@
 import fs from "fs";
 import crypto from "crypto";
 
-export async function fetchUrl(url: string): Promise<Response> {
-    const res = await fetch(url);
-    if (!res.ok) {
-        throw new Error(`HTTP ${res.status} ${res.statusText} fetching ${url}`);
+/** HTTP statuses worth retrying: request timeout, rate limiting, and any 5xx. */
+function isRetryableStatus(status: number): boolean {
+    return status === 408 || status === 429 || status >= 500;
+}
+
+/** Read integer configuration from the environment and fail loudly on typos. */
+function readIntegerEnv(
+    name: string,
+    defaultValue: number,
+    minValue: number,
+): number {
+    const rawValue = process.env[name];
+    if (rawValue == null || rawValue.trim() === "") {
+        return defaultValue;
     }
-    return res;
+    const parsed = Number(rawValue);
+    if (!Number.isInteger(parsed) || parsed < minValue) {
+        throw new Error(
+            `${name} must be an integer greater than or equal to ${minValue}; received ${JSON.stringify(
+                rawValue,
+            )}.`,
+        );
+    }
+    return parsed;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type FetchRetryOptions = {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+};
+
+/**
+ * Fetch a URL, retrying transient failures with exponential backoff.
+ *
+ * The CDN/registry downloads these scripts perform (jsDelivr for pyodide wheels,
+ * PyPI for the prefig wheel, GitHub raw for liblouis) occasionally fail with a
+ * network-level "fetch failed" or a transient 5xx/429, which would otherwise
+ * abort the whole build. Network errors and transient server-side statuses are
+ * retried; permanent client errors (e.g. 404) fail immediately.
+ *
+ * Defaults can be overridden per call, or globally via the environment:
+ *   DOWNLOAD_MAX_ATTEMPTS     total attempts before giving up (default 4)
+ *   DOWNLOAD_RETRY_DELAY_MS   base backoff delay in ms (default 500)
+ *   DOWNLOAD_MAX_DELAY_MS     backoff delay cap in ms (default 8000)
+ */
+export async function fetchUrl(
+    url: string,
+    options: FetchRetryOptions = {},
+): Promise<Response> {
+    const maxAttempts =
+        options.maxAttempts ?? readIntegerEnv("DOWNLOAD_MAX_ATTEMPTS", 4, 1);
+    const baseDelayMs =
+        options.baseDelayMs ??
+        readIntegerEnv("DOWNLOAD_RETRY_DELAY_MS", 500, 0);
+    const maxDelayMs =
+        options.maxDelayMs ?? readIntegerEnv("DOWNLOAD_MAX_DELAY_MS", 8_000, 0);
+
+    let lastError: Error | undefined;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        let res: Response | undefined;
+        try {
+            res = await fetch(url);
+        } catch (err) {
+            // Network-level failure (DNS, reset connection, "fetch failed").
+            lastError = err instanceof Error ? err : new Error(String(err));
+        }
+
+        if (res) {
+            if (res.ok) {
+                return res;
+            }
+            const statusError = new Error(
+                `HTTP ${res.status} ${res.statusText} fetching ${url}`,
+            );
+            // Fail fast on permanent client errors (e.g. 404); only transient
+            // server-side statuses are worth retrying.
+            if (!isRetryableStatus(res.status)) {
+                throw statusError;
+            }
+            lastError = statusError;
+        }
+
+        if (attempt < maxAttempts) {
+            const delay = Math.min(
+                baseDelayMs * 2 ** (attempt - 1),
+                maxDelayMs,
+            );
+            console.warn(
+                `  fetch attempt ${attempt}/${maxAttempts} for ${url} failed: ${lastError?.message}; retrying in ${delay}ms`,
+            );
+            await sleep(delay);
+        }
+    }
+
+    throw lastError ?? new Error(`Failed to fetch ${url}`);
 }
 
 export async function downloadBuffer(url: string): Promise<Buffer> {

--- a/packages/prefigure/test/download-utils.test.ts
+++ b/packages/prefigure/test/download-utils.test.ts
@@ -78,4 +78,18 @@ describe("fetchUrl", () => {
         ).rejects.toThrow(/fetch failed/);
         expect(fetchMock).toHaveBeenCalledTimes(3);
     });
+
+    it("throws the HTTP status error after exhausting retries on a transient status", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(new Response(null, { status: 503 }));
+
+        await expect(
+            fetchUrl("https://example.test/file", {
+                ...NO_WAIT,
+                maxAttempts: 3,
+            }),
+        ).rejects.toThrow(/HTTP 503/);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
 });

--- a/packages/prefigure/test/download-utils.test.ts
+++ b/packages/prefigure/test/download-utils.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchUrl } from "../scripts/lib/download-utils.ts";
+
+// Keep backoff instant so the retry tests don't actually wait.
+const NO_WAIT = { baseDelayMs: 0, maxDelayMs: 0 };
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("fetchUrl", () => {
+    it("returns the response on the first successful fetch", async () => {
+        const ok = new Response("ok", { status: 200 });
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(ok);
+
+        const res = await fetchUrl("https://example.test/file", NO_WAIT);
+
+        expect(res).toBe(ok);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries a network-level failure and then succeeds", async () => {
+        const ok = new Response("ok", { status: 200 });
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockRejectedValueOnce(new TypeError("fetch failed"))
+            .mockRejectedValueOnce(new TypeError("fetch failed"))
+            .mockResolvedValue(ok);
+
+        const res = await fetchUrl("https://example.test/file", {
+            ...NO_WAIT,
+            maxAttempts: 4,
+        });
+
+        expect(res).toBe(ok);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("retries a transient 5xx status and then succeeds", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(new Response(null, { status: 503 }))
+            .mockResolvedValue(new Response("ok", { status: 200 }));
+
+        const res = await fetchUrl("https://example.test/file", {
+            ...NO_WAIT,
+            maxAttempts: 4,
+        });
+
+        expect(res.ok).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("fails fast on a permanent client error without retrying", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(new Response(null, { status: 404 }));
+
+        await expect(
+            fetchUrl("https://example.test/missing", {
+                ...NO_WAIT,
+                maxAttempts: 4,
+            }),
+        ).rejects.toThrow(/HTTP 404/);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up after exhausting all attempts", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockRejectedValue(new TypeError("fetch failed"));
+
+        await expect(
+            fetchUrl("https://example.test/file", {
+                ...NO_WAIT,
+                maxAttempts: 3,
+            }),
+        ).rejects.toThrow(/fetch failed/);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+});


### PR DESCRIPTION
## Problem

The `Build` CI job intermittently fails while fetching pyodide/prefig/liblouis assets, e.g.:

```
fetch-pyodide-packages failed: fetch failed
[vite-plugin-static-copy] Error: No file was found to copy on pyodide_packages/**/*.whl,pyodide_packages/**/*.zip src.
```

The prefigure build downloads pyodide wheels from the jsDelivr CDN, the prefig wheel from PyPI, and liblouis assets from GitHub raw. All of these funnel through `fetchUrl` in `packages/prefigure/scripts/lib/download-utils.ts`, which did a single `fetch()` with **no retry**. A transient network blip there (a bare `fetch failed`) aborts the whole build — no wheels land, and `vite-plugin-static-copy` then errors on the empty `pyodide_packages` glob. This flake shows up often enough to be an annoyance across PRs.

## Fix

Add retry-with-exponential-backoff to `fetchUrl`, mirroring the existing [`npm-publish-with-retry.mjs`](https://github.com/Doenet/DoenetML/blob/main/.github/scripts/npm-publish-with-retry.mjs) convention:

- **Retries** network-level failures (`fetch` rejection / `fetch failed`) and transient HTTP statuses (408, 429, 5xx).
- **Fails fast** on permanent client errors such as 404 — no pointless retries on a genuine "not found".
- 4 attempts, 500 ms base backoff capped at 8 s, all overridable via `DOWNLOAD_MAX_ATTEMPTS` / `DOWNLOAD_RETRY_DELAY_MS` / `DOWNLOAD_MAX_DELAY_MS`.

Because `fetchUrl` is the shared choke point for every download the build performs, this hardens the pyodide wheels, the prefig wheel, and the liblouis JS/braille tables all at once.

This is fixed at the fetch layer rather than with a workflow-level step retry on purpose: a step retry would re-run the entire multi-minute build (including the Rust compile) for one flaky wheel download, and it wouldn't help local builds. This retries only the failed download.

## Verification

- New `packages/prefigure/test/download-utils.test.ts` — 6 tests (first-try success, retry-then-succeed on network error, retry-then-succeed on 503, fail-fast on 404, give-up after exhausting attempts on network error, and surfacing the HTTP status error after exhausting attempts on a transient 503): all pass.
- Prettier clean, no new type errors.
- Ran the real `fetch-pyodide-packages.ts` script — still idempotent, exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)