### PR TITLE
ci: retry the devcontainer image build to survive transient github.com blips

### DIFF
--- a/.github/scripts/devcontainer-up-with-retry.sh
+++ b/.github/scripts/devcontainer-up-with-retry.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Build and start the devcontainer, retrying transient failures.
+#
+# The devcontainer image build installs the Node feature, whose install script
+# git-clones nvm from github.com. A transient github.com outage makes that clone
+# — and therefore the whole `docker buildx build` — fail, which would otherwise
+# sink the CI job on a pure network blip (observed: "fatal: unable to access
+# 'https://github.com/nvm-sh/nvm/': Failed to connect to github.com port 443").
+# Retrying `devcontainer up` a few times with backoff lets a transient failure
+# recover instead of failing the run. The retry is scoped to the image build:
+# the tests themselves are run once by the caller (via `devcontainer exec`), so
+# a genuine test failure is never masked.
+#
+# Usage:
+#   bash .github/scripts/devcontainer-up-with-retry.sh [devcontainer up args...]
+#
+# All arguments are forwarded verbatim to `devcontainer up` (e.g.
+# `--workspace-folder .`).
+#
+# Configuration (environment variables):
+#   DEVCONTAINER_UP_MAX_ATTEMPTS   total attempts before giving up (default 3)
+#   DEVCONTAINER_UP_RETRY_DELAY    base backoff delay in seconds (default 30)
+
+set -euo pipefail
+
+max_attempts="${DEVCONTAINER_UP_MAX_ATTEMPTS:-3}"
+base_delay="${DEVCONTAINER_UP_RETRY_DELAY:-30}"
+
+attempt=1
+while true; do
+    echo "=== devcontainer up (attempt ${attempt}/${max_attempts}) ==="
+    if devcontainer up "$@"; then
+        exit 0
+    fi
+
+    if [ "${attempt}" -ge "${max_attempts}" ]; then
+        echo "devcontainer up failed after ${max_attempts} attempts" >&2
+        exit 1
+    fi
+
+    delay=$((base_delay * attempt))
+    echo "devcontainer up failed; retrying in ${delay}s..." >&2
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,15 +277,22 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
+            - name: Install devcontainer CLI
+              run: npm install -g @devcontainers/cli@0
+
             - name: Build and test in devcontainer
-              uses: devcontainers/ci@v0.3
-              with:
-                  runCmd: |
+              run: |
+                  set -eu
+                  # Retry only the image build (see the script for why); the
+                  # tests below run once, so a real failure is never masked.
+                  bash .github/scripts/devcontainer-up-with-retry.sh --workspace-folder .
+                  devcontainer exec --workspace-folder . /bin/bash -c '
                       set -eu
                       bash .devcontainer/npm-install-with-rollup-check.sh npm ci
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
+                  '
 
     test-doenetml-to-pretext-full-devcontainer:
         name: DoenetML to PreTeXt Tests
@@ -300,16 +307,23 @@ jobs:
               with:
                   name: build-artifacts
 
+            - name: Install devcontainer CLI
+              run: npm install -g @devcontainers/cli@0
+
             - name: Build and test in devcontainer
-              uses: devcontainers/ci@v0.3
-              with:
-                  runCmd: |
+              run: |
+                  set -eu
+                  # Retry only the image build (see the script for why); the
+                  # tests below run once, so a real failure is never masked.
+                  bash .github/scripts/devcontainer-up-with-retry.sh --workspace-folder .
+                  devcontainer exec --workspace-folder . /bin/bash -c '
                       set -eu
                       bash .devcontainer/npm-install-with-rollup-check.sh npm ci
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
                       npm run build -w packages/doenetml-to-pretext-python
                       npm run test -w packages/doenetml-to-pretext-python
+                  '
 
     lint:
         name: Lint Rust Code


### PR DESCRIPTION
## Problem

The two devcontainer CI jobs (`Devcontainer Runs Tests` and `DoenetML to PreTeXt Tests`) intermittently fail during the **image build**, before any test runs:

```
#22 134.8 fatal: unable to access 'https://github.com/nvm-sh/nvm/':
Failed to connect to github.com port 443 after 134659 ms: Couldn't connect to server
```

The `ghcr.io/devcontainers/features/node` feature installs Node by `git clone`-ing nvm from github.com. When github.com has a transient blip, that clone hangs and fails, and `docker buildx build` aborts the whole `devcontainers/ci@v0.3` step. This is a pure-network flake — not a test failure.

## Fix

Drive the official [`@devcontainers/cli`](https://github.com/devcontainers/cli) directly instead of the `devcontainers/ci` action, and wrap **only the image build** in a retry:

- A shared helper, `.github/scripts/devcontainer-up-with-retry.sh`, retries `devcontainer up` (the flaky build) up to 3 times with linear backoff.
- Then `devcontainer exec` runs the tests **once**.

Scoping the retry to the build is deliberate: the test phase takes several minutes, and retrying it would mask genuinely flaky/failing tests. Retrying only `devcontainer up` closes the network-flake gap without ever hiding a real test failure.

This mirrors the repo's existing roll-your-own retry convention (`.github/scripts/npm-publish-with-retry.mjs`) and adds no third-party action. `devcontainer up` + `devcontainer exec` on the same `--workspace-folder` is the same build-then-run flow the action performed under the hood, so behavior is unchanged on the happy path.

Retry counts/backoff are overridable via `DEVCONTAINER_UP_MAX_ATTEMPTS` / `DEVCONTAINER_UP_RETRY_DELAY`.

## Verification

- `ci.yml` passes YAML parse and `prettier --check`; the new script passes `bash -n`.
- End-to-end validation is this PR's own CI: both edited jobs run here, exercising the new `devcontainer up` + `exec` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)