### PR TITLE
Delete copies created for reference-path indices

### DIFF
--- a/.changeset/delete-reference-path-index-copies.md
+++ b/.changeset/delete-reference-path-index-copies.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix a "Found a duplicate componentIdx" crash when content containing a dynamic index reference (such as `$p[$i]`) is repeatedly removed and recreated.
+
+A reference with a dynamic index creates a hidden copy to resolve the index (for example, the copy that evaluates `$i` in `$p[$i]`). That copy lives in the referencing component's internal reference resolution rather than among its children or attributes, so deleting the component left the copy behind. When the surrounding composite — for instance a `<conditionalContent>` case or the branch of a `<triggerSet>` — later recreated its replacement and reused the same reserved component indices, the leaked copy's index collided and the activity errored. Deletion now also removes the copies created for reference-path indices, so such content can be recreated cleanly.

--- a/packages/doenetml-worker-javascript/src/core/DeletionEngine.ts
+++ b/packages/doenetml-worker-javascript/src/core/DeletionEngine.ts
@@ -369,6 +369,24 @@ export function determineComponentsToDelete({
             }
         }
 
+        // recurse on components created for reference-path indices,
+        // e.g. the copy resolving `$oldIndex` in `$p[$oldIndex]`. These live
+        // in the component's `refResolution` rather than in its children or
+        // attributes, so they would otherwise leak when the component is
+        // deleted (and their reserved component indices could then collide
+        // with those of a recreated replacement).
+        if (component.refResolution?.originalPath) {
+            for (let pathPart of component.refResolution.originalPath) {
+                for (let indexPiece of pathPart.index) {
+                    for (let valueComp of indexPiece.value) {
+                        if (typeof valueComp === "object") {
+                            componentsToRecurse.push(valueComp);
+                        }
+                    }
+                }
+            }
+        }
+
         // if delete an adapter, also delete component it is adapting
         if (component.adaptedFrom !== undefined) {
             componentsToRecurse.push(component.adaptedFrom);

--- a/packages/doenetml-worker-javascript/src/core/DeletionEngine.ts
+++ b/packages/doenetml-worker-javascript/src/core/DeletionEngine.ts
@@ -324,9 +324,11 @@ export async function deleteComponents({
 /**
  * Recursively populate `componentsToDelete` with the transitive
  * deletion set rooted at `components`: each component's
- * `allChildren`, attribute components/references, the source of any
- * adapter, and (when `deleteUpstreamDependencies`) shadows, the
- * adapter the component itself produced, and any replacements.
+ * `allChildren`, attribute components/references, any copies created
+ * to resolve reference-path indices (`refResolution.originalPath`),
+ * the source of any adapter, and (when `deleteUpstreamDependencies`)
+ * shadows, the adapter the component itself produced, and any
+ * replacements.
  */
 export function determineComponentsToDelete({
     core,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
@@ -1711,9 +1711,13 @@ describe("Conditional content tag tests @group2", async () => {
         // indices). Before the fix, the recreation threw "Found a duplicate
         // componentIdx"; now it recreates cleanly and the reference again
         // resolves to 3.
+        //
+        // Deliberately do not evaluate state variables between the two
+        // toggles: a full evaluation while the first case is active masks
+        // the collision (it fails later with a different error), so an
+        // intermediate check here would stop this test from reproducing the
+        // documented "Found a duplicate componentIdx" crash.
         await updateBooleanInputValue({ boolean: true, componentIdx: b, core });
-        expect(await wrapText()).eq("h e l l o");
-
         await updateBooleanInputValue({
             boolean: false,
             componentIdx: b,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
@@ -1687,31 +1687,38 @@ describe("Conditional content tag tests @group2", async () => {
         <number name="i">1</number>
         <pointList name="p">(3,4) (5,6)</pointList>
         <booleanInput name="b" />
-        <conditionalContent>
+        <p name="wrap"><conditionalContent>
             <case condition="$b"><math>hello</math></case>
             <case condition="not $b"><math>$p[$i].x</math></case>
-        </conditionalContent>
+        </conditionalContent></p>
   `,
         });
 
         const b = await resolvePathToNodeIdx("b");
+        const wrap = await resolvePathToNodeIdx("wrap");
+
+        const wrapText = async () =>
+            (await core.returnAllStateVariables(false, true))[wrap].stateValues
+                .text;
 
         // b=false selects the second case, creating the `$p[$i]` index copy.
-        // Toggle to the first case (deletes the second case's replacement),
-        // then back (recreates it). The recreation used to throw.
+        // The reference resolves to `$p[1].x`, i.e. 3.
+        expect(await wrapText()).eq("3");
+
+        // Toggle to the first case (deletes the second case's replacement,
+        // which must also delete the leaked `$p[$i]` index copy), then back
+        // (recreates the replacement, reusing the same reserved component
+        // indices). Before the fix, the recreation threw "Found a duplicate
+        // componentIdx"; now it recreates cleanly and the reference again
+        // resolves to 3.
         await updateBooleanInputValue({ boolean: true, componentIdx: b, core });
+        expect(await wrapText()).eq("h e l l o");
+
         await updateBooleanInputValue({
             boolean: false,
             componentIdx: b,
             core,
         });
-
-        // Reaching a full evaluation without throwing confirms the fix.
-        let stateVariables = await core.returnAllStateVariables(false, true);
-        expect(
-            stateVariables[
-                await resolvePathToNodeIdx("p[1]")
-            ].stateValues.xs.map((v: any) => v.tree),
-        ).eqls([3, 4]);
+        expect(await wrapText()).eq("3");
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
@@ -1673,4 +1673,45 @@ describe("Conditional content tag tests @group2", async () => {
         expect(diagnosticsByType.warnings[0].position.end.line).eq(2);
         expect(diagnosticsByType.warnings[0].position.end.column).eq(45);
     });
+
+    it("can recreate a case containing a dynamic index reference", async () => {
+        // Regression test: a case whose content contains a dynamic index
+        // reference (`$p[$i]`) creates a hidden copy to resolve the index.
+        // That copy lives in the component's `refResolution` rather than in
+        // its children/attributes, so deleting the case's replacement used to
+        // leak it. When the case was later reselected and its replacement
+        // recreated (reusing the same reserved component indices), the leaked
+        // copy's index collided: "Found a duplicate componentIdx".
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+        <number name="i">1</number>
+        <pointList name="p">(3,4) (5,6)</pointList>
+        <booleanInput name="b" />
+        <conditionalContent>
+            <case condition="$b"><math>hello</math></case>
+            <case condition="not $b"><math>$p[$i].x</math></case>
+        </conditionalContent>
+  `,
+        });
+
+        const b = await resolvePathToNodeIdx("b");
+
+        // b=false selects the second case, creating the `$p[$i]` index copy.
+        // Toggle to the first case (deletes the second case's replacement),
+        // then back (recreates it). The recreation used to throw.
+        await updateBooleanInputValue({ boolean: true, componentIdx: b, core });
+        await updateBooleanInputValue({
+            boolean: false,
+            componentIdx: b,
+            core,
+        });
+
+        // Reaching a full evaluation without throwing confirms the fix.
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("p[1]")
+            ].stateValues.xs.map((v: any) => v.tree),
+        ).eqls([3, 4]);
+    });
 });


### PR DESCRIPTION
## Summary

Fixes a `Found a duplicate componentIdx` crash that occurred when content containing a **dynamic index reference** (such as `$p[$oldIndex]`) was repeatedly removed and recreated — for example inside a `<conditionalContent>` case or a `<triggerSet>` branch whose selected content toggles.

## Root cause

A reference with a dynamic index creates a hidden copy to resolve the index expression (the copy that evaluates `$oldIndex` in `$p[$oldIndex]`). That copy is stored in the referencing component's internal **`refResolution`** (`refResolution.originalPath[].index[].value`), *not* among its `children` or `attributes`.

`determineComponentsToDelete` in `DeletionEngine.ts` recurses into `allChildren`, `attributes`, adapters, shadows, and `replacements` — but never into `refResolution`. So whenever a component holding such a reference was deleted, the index-resolver copy **leaked** (created once, never deleted).

`<conditionalContent>` correctly reuses its cases' reserved component indices when it re-instantiates a case. But because the leaked copy still occupied its reserved index, recreating the case content tried to build a component at an index that was still live → `Found a duplicate componentIdx`. The orphaned components also corrupted the dependency graph, which surfaced as secondary errors during evaluation.

## Fix

`determineComponentsToDelete` now also recurses into the components created for reference-path indices, so they are deleted together with their owning component instead of leaking.

## Test

Added a regression test in `conditionalcontent.test.ts`: a two-case `<conditionalContent>` whose content contains `$p[$i]`, toggled via a boolean input so the replacement is deleted and recreated. It fails without the fix (`Found a duplicate componentIdx`) and passes with it.

## Verification

- New regression test passes; fails without the fix.
- No regressions in the conditionalContent / select / repeat / triggerSet / copy / extend / reference / deletion suites.
- No new TypeScript errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwCb1H2mM6SQ6Er73987uu
