### PR TITLE
chore(claude): block high-risk agent commands via permission rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,33 @@
 {
+    "permissions": {
+        "deny": [
+            "Bash(gh pr merge:*)",
+            "Bash(gh repo delete:*)",
+            "Bash(gh repo edit:*)",
+            "Bash(gh repo rename:*)",
+            "Bash(gh repo archive:*)",
+            "Bash(git push upstream:*)",
+            "Bash(npm run publish:*)",
+            "Bash(npm publish:*)",
+            "Bash(pnpm publish:*)",
+            "Bash(yarn publish:*)",
+            "Bash(npx changeset publish:*)",
+            "Bash(sudo:*)",
+            "Bash(gh release create:*)",
+            "Bash(gh release delete:*)",
+            "Bash(gh secret:*)",
+            "Bash(git filter-branch:*)",
+            "Bash(git filter-repo:*)",
+            "Bash(dd:*)",
+            "Bash(mkfs:*)"
+        ],
+        "ask": [
+            "Bash(git push --force:*)",
+            "Bash(git push -f:*)",
+            "Bash(git reset --hard:*)",
+            "Bash(git clean:*)"
+        ]
+    },
     "hooks": {
         "PreToolUse": [
             {


### PR DESCRIPTION
## What

Adds a `permissions` block to the checked-in Claude Code settings (`.claude/settings.json`) so that AI agents working in this repo cannot autonomously run irreversible or outward-facing commands.

### `deny` (hard block, no override prompt)
- **PR / repo administration:** `gh pr merge`, `gh repo delete/edit/rename/archive`
- **Pushes to the canonical repo:** any `git push upstream …`
- **npm-registry publishing:** `npm run publish` (the root release script), `npm/pnpm/yarn publish`, `npx changeset publish`
- **Privilege escalation & CI credentials:** `sudo`, `gh secret`, `gh release create/delete`
- **History / disk destruction:** `git filter-branch`, `git filter-repo`, `dd`, `mkfs`

### `ask` (confirmation prompt, not blocked)
Destructive but sometimes-legitimate git commands used during rebasing/recovery: `git push --force`/`-f`, `git reset --hard`, `git clean`.

## Why

An agent misread an ambiguous "merge in upstream/main" instruction and squash-merged a PR, because the local allow-list blanket-approved `gh pr *` with no confirmation. `deny` rules take precedence over `allow`, so this blocks the dangerous operations while leaving everyday `gh pr view/diff`, fork pushes, and `npm run <script>` untouched.

## Scope & limitations

Permission rules match a command's text prefix, so a few equivalent invocations are intentionally out of scope here and are better handled by a follow-up `PreToolUse` hook that parses the whole command:

- **Leading-token prefixes** that push the real subcommand past the match window: `git -C <path> push upstream …` bypasses the `git push upstream:*` deny, and `git -C <path> push --force` bypasses the corresponding `ask` rule. This matters because agents in this repo routinely invoke git as `git -C <path> <subcommand>` (see the `git -C …` entries in `.claude/settings.local.json`), so this bypass is not hypothetical.
- **Reordered-flag pushes:** `git push origin main --force` (the `--force` lands after the positional args, past the prefix).
- **API-equivalent admin:** `gh api --method PUT/DELETE/PATCH` (merge/delete/edit via the REST API rather than the `gh pr`/`gh repo` subcommands).
- **Piped/opaque execution:** `curl … | sh`, `rm -rf`.

These are known, accepted deferrals — the robust fix for the whole class is the follow-up `PreToolUse` hook that parses the tokenized command, not an ever-growing list of prefix rules.

Only `.claude/settings.json` changes; the existing prettier/footer/PR-title hooks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
