### PR TITLE
Make dark-mode code-editor selection highlight legible

### DIFF
--- a/.changeset/dark-mode-editor-selection-contrast.md
+++ b/.changeset/dark-mode-editor-selection-contrast.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: fix the code editor's text-selection highlight so highlighted (selected) text stays legible, especially in dark mode.
+
+The selection highlight was rendering with CodeMirror's built-in light lavender (`#d7d4f0`) in every mode: the theme's own selection rule never took effect (CodeMirror's base theme targets the selection with a higher-specificity selector), and the editor was never told it was in dark mode, so it also fell back to CodeMirror's light-mode defaults. On the dark canvas the near-white and brightly-colored syntax tokens were then washed out under the pale highlight — and clicking away from the editor made it worse, reverting the blurred selection to the base light-gray default.
+
+The dark-mode selection is now a dark navy (`#092c4d`) that keeps every syntax token — down to the dim comment gray — at WCAG AA contrast (≥ 4.5:1) while still reading as a selection, and light mode now correctly uses its intended neutral gray. The override matches CodeMirror's base-theme selector for both the focused and blurred states, and the theme now passes the real brightness to CodeMirror so its base defaults align.
+
+Adds `@doenet/codemirror` Cypress component tests (`selectionAccessibility.cy.tsx`) that select highlighted code and assert the WCAG contrast between each rendered token color and the actual selection-background color, in light mode, dark mode, and after the editor is blurred. (`cy.checkA11y` can't be used for this: axe-core cannot resolve CodeMirror's separate selection layer / `::selection` pseudo-element and instead compares tokens against a phantom white background.)

--- a/.changeset/dark-mode-editor-selection-contrast.md
+++ b/.changeset/dark-mode-editor-selection-contrast.md
@@ -12,4 +12,6 @@ The selection highlight was rendering with CodeMirror's built-in light lavender 
 
 The dark-mode selection is now a dark navy (`#092c4d`) that keeps every syntax token — down to the dim comment gray — at WCAG AA contrast (≥ 4.5:1) while still reading as a selection, and light mode now correctly uses its intended neutral gray. The override matches CodeMirror's base-theme selector for both the focused and blurred states, and the theme now passes the real brightness to CodeMirror so its base defaults align.
 
+The light-mode comment color is also darkened slightly (`#656d76` → `#5c636d`) so highlighted comments clear WCAG AA against the light selection background too (they previously sat at ~4.1:1); it remains above AA on the white canvas.
+
 Adds `@doenet/codemirror` Cypress component tests (`selectionAccessibility.cy.tsx`) that select highlighted code and assert the WCAG contrast between each rendered token color and the actual selection-background color, in light mode, dark mode, and after the editor is blurred. (`cy.checkA11y` can't be used for this: axe-core cannot resolve CodeMirror's separate selection layer / `::selection` pseudo-element and instead compares tokens against a phantom white background.)

--- a/packages/codemirror/src/extensions/syntax-highlighting.ts
+++ b/packages/codemirror/src/extensions/syntax-highlighting.ts
@@ -92,7 +92,7 @@ const customHighlightStyle = createHighlightStyle({
     tagName: "#0550ae", // Blue - 7.67:1 on white
     propertyName: "#953800", // Burnt orange - 5.17:1 on white
     invalid: "#a80000", // Dark red - 6.23:1 on white
-    blockComment: "#656d76", // Gray - 4.54:1 on white
+    blockComment: "#5c636d", // Gray - 6.1:1 on white, 4.7:1 on the --mainGray selection
     macroName: "#6f42c1", // Purple - 5.01:1 on white
     content: "#24292f", // Near black - 15.3:1 on white
 });

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -2,6 +2,47 @@ import { EditorView } from "@codemirror/view";
 
 export type ThemeMode = "dark" | "light";
 
+/**
+ * Text-selection (highlight) background, shared by the editable and read-only
+ * themes so they can't drift.
+ *
+ *  - light: neutral `--mainGray` (#e3e3e3) behind dark syntax tokens.
+ *  - dark:  a dark navy (#092c4d) rather than `--mainGray` (#a9a9a9). The dark
+ *           syntax palette is near-white/bright (verified ≥4.5:1 on the #121212
+ *           canvas); a light-gray selection painted behind those tokens washed
+ *           them out — most visibly the near-white content color. #092c4d keeps
+ *           every token, down to the dim comment gray, at WCAG AA contrast while
+ *           still reading as a selection against the canvas. Covered by
+ *           `selectionAccessibility.cy.tsx`.
+ */
+function getSelectionBackgroundColor(darkMode: ThemeMode) {
+    return darkMode === "dark" ? "#092c4d" : "var(--mainGray)";
+}
+
+/**
+ * Selection-highlight rules shared by the editable and read-only themes.
+ *
+ * CodeMirror's base theme colors the selection itself, and does so with a
+ * high-specificity selector for the *focused* state
+ * (`&<light|dark>.cm-focused > .cm-scroller > .cm-selectionLayer
+ * .cm-selectionBackground`). We mirror that full path so our color actually
+ * wins when focused, and add a focus-agnostic rule so the *blurred* selection
+ * (base default `#d9d9d9` light / `#222` dark) is overridden too — otherwise
+ * clicking away from the editor reverts the highlight to the washed-out base
+ * color. `::selection` covers the native-selection fallback.
+ */
+function selectionThemeRules(darkMode: ThemeMode) {
+    const backgroundColor = getSelectionBackgroundColor(darkMode);
+    return {
+        "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground":
+            { backgroundColor },
+        "& > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
+            backgroundColor,
+        },
+        "::selection": { backgroundColor },
+    };
+}
+
 // Shared gutter palette used by both the editable and read-only themes to keep colors aligned per mode.
 function getGutterColors(darkMode: ThemeMode) {
     if (darkMode === "dark") {
@@ -37,42 +78,46 @@ function getGutterColors(darkMode: ThemeMode) {
  */
 export function colorTheme(darkMode: ThemeMode) {
     const gutterColors = getGutterColors(darkMode);
-    return EditorView.theme({
-        "&": {
-            color: "var(--canvasText)",
-            height: "100%",
-            backgroundColor: "var(--canvas)",
+    return EditorView.theme(
+        {
+            "&": {
+                color: "var(--canvasText)",
+                height: "100%",
+                backgroundColor: "var(--canvas)",
+            },
+            ".cm-content": {
+                caretColor: "#0e9",
+            },
+            "&.cm-focused .cm-cursor": {
+                borderLeftColor: "var(--canvasText)",
+            },
+            ...selectionThemeRules(darkMode),
+            "&.cm-focused": {
+                color: "var(--canvasText)",
+            },
+            ".cm-gutters": {
+                backgroundColor: gutterColors.backgroundColor,
+                color: gutterColors.textColor,
+                border: "none",
+                borderRight: gutterColors.borderRight,
+            },
+            ".cm-activeLine": {
+                backgroundColor: "#50505020",
+                // Must be explicit: CodeMirror's base theme sets activeLine color
+                // to a dark value which is invisible on a dark canvas.
+                color: "var(--canvasText)",
+            },
+            // Subtle gutter highlight on the active line — CodeMirror's base
+            // theme uses #e2f2ff (light blue) which is glaring on a dark gutter.
+            ".cm-activeLineGutter": {
+                backgroundColor: gutterColors.activeLineBackgroundColor,
+            },
         },
-        ".cm-content": {
-            caretColor: "#0e9",
-        },
-        "&.cm-focused .cm-cursor": {
-            borderLeftColor: "var(--canvasText)",
-        },
-        "&.cm-focused .cm-selectionBackground, ::selection": {
-            backgroundColor: "var(--mainGray)",
-        },
-        "&.cm-focused": {
-            color: "var(--canvasText)",
-        },
-        ".cm-gutters": {
-            backgroundColor: gutterColors.backgroundColor,
-            color: gutterColors.textColor,
-            border: "none",
-            borderRight: gutterColors.borderRight,
-        },
-        ".cm-activeLine": {
-            backgroundColor: "#50505020",
-            // Must be explicit: CodeMirror's base theme sets activeLine color
-            // to a dark value which is invisible on a dark canvas.
-            color: "var(--canvasText)",
-        },
-        // Subtle gutter highlight on the active line — CodeMirror's base
-        // theme uses #e2f2ff (light blue) which is glaring on a dark gutter.
-        ".cm-activeLineGutter": {
-            backgroundColor: gutterColors.activeLineBackgroundColor,
-        },
-    });
+        // Tell CodeMirror the actual brightness so its base theme applies
+        // dark-appropriate defaults (e.g. the blurred selection color) instead
+        // of light ones.
+        { dark: darkMode === "dark" },
+    );
 }
 
 // Shared icon palette so all completion types flip together between modes.
@@ -171,39 +216,40 @@ export function readOnlyColorTheme(darkMode: ThemeMode) {
     const lineTextColor = darkMode === "dark" ? "#c8c8c8" : "#595959";
     const activeLineBackgroundColor =
         darkMode === "dark" ? "#50505020" : "var(--mainGray)";
-    return EditorView.theme({
-        "&": {
-            color: "var(--canvasText)",
-            height: "100%",
+    return EditorView.theme(
+        {
+            "&": {
+                color: "var(--canvasText)",
+                height: "100%",
+            },
+            ".cm-content": {
+                caretColor: "#0e9",
+                backgroundColor: "#77777720",
+            },
+            "&.cm-focused .cm-cursor": {
+                borderLeftColor: "var(--canvasText)",
+            },
+            ...selectionThemeRules(darkMode),
+            "&.cm-focused": {
+                color: "var(--canvasText)",
+            },
+            ".cm-gutters": {
+                backgroundColor: gutterColors.backgroundColor,
+                color: gutterColors.textColor,
+                border: "none",
+                borderRight: gutterColors.borderRight,
+            },
+            ".cm-activeLine": {
+                backgroundColor: activeLineBackgroundColor,
+                color: "var(--canvasText)",
+            },
+            ".cm-activeLineGutter": {
+                backgroundColor: gutterColors.activeLineBackgroundColor,
+            },
+            ".cm-line": {
+                color: lineTextColor,
+            },
         },
-        ".cm-content": {
-            caretColor: "#0e9",
-            backgroundColor: "#77777720",
-        },
-        "&.cm-focused .cm-cursor": {
-            borderLeftColor: "var(--canvasText)",
-        },
-        "&.cm-focused .cm-selectionBackground, ::selection": {
-            backgroundColor: "var(--mainGray)",
-        },
-        "&.cm-focused": {
-            color: "var(--canvasText)",
-        },
-        ".cm-gutters": {
-            backgroundColor: gutterColors.backgroundColor,
-            color: gutterColors.textColor,
-            border: "none",
-            borderRight: gutterColors.borderRight,
-        },
-        ".cm-activeLine": {
-            backgroundColor: activeLineBackgroundColor,
-            color: "var(--canvasText)",
-        },
-        ".cm-activeLineGutter": {
-            backgroundColor: gutterColors.activeLineBackgroundColor,
-        },
-        ".cm-line": {
-            color: lineTextColor,
-        },
-    });
+        { dark: darkMode === "dark" },
+    );
 }

--- a/packages/codemirror/test/cypress/component/selectionAccessibility.cy.tsx
+++ b/packages/codemirror/test/cypress/component/selectionAccessibility.cy.tsx
@@ -1,0 +1,194 @@
+import React from "react";
+import { CodeMirror } from "../../../src/CodeMirror";
+import type { ThemeMode } from "../../../src/extensions/theme";
+
+/**
+ * Accessibility coverage for *selected* (highlighted) text in the editor.
+ *
+ * When an author drags to highlight code, the selection background is painted
+ * behind the syntax-highlighted tokens. The tokens keep their own colors, so
+ * the selection background must contrast with every token color — including the
+ * near-white content color used on the dark canvas. A too-bright dark-mode
+ * selection washes those tokens out (the reported illegibility).
+ *
+ * Why not `cy.checkA11y` here?  axe-core's `color-contrast` rule cannot see the
+ * selection: CodeMirror paints it in a separate, negative-z-index layer
+ * (`.cm-selectionLayer > .cm-selectionBackground`), and the native fallback is a
+ * `::selection` pseudo-element — neither is a DOM background axe can resolve.
+ * Pointed at highlighted code, axe compares each token to a *phantom white*
+ * background and reports nonsense. So this spec measures the real thing
+ * directly: it reads the rendered selection color and each visible token color
+ * and asserts the WCAG 2.1 contrast between them is at least AA (4.5:1).
+ *
+ * The editor theme reads a few colors from CSS custom properties defined in
+ * `@doenet/doenetml`'s `DoenetML.css` (not in this package); the mount wrapper
+ * re-declares them per mode so the component renders with the real app colors.
+ */
+
+// Mirrors the light/dark values in `packages/doenetml/src/DoenetML.css`.
+const THEME_VARS: Record<ThemeMode, Record<string, string>> = {
+    light: {
+        "--canvas": "white",
+        "--canvasText": "black",
+        "--mainGray": "#e3e3e3",
+    },
+    dark: {
+        "--canvas": "#121212",
+        "--canvasText": "white",
+        "--mainGray": "#a9a9a9",
+    },
+};
+
+// Exercises the main token categories: tag names / angle brackets, attribute
+// names, attribute-value strings, macros, and (near-white) text content.
+const DOENET_SOURCE = `<section name="s">
+  <title>Highlighted text should stay legible</title>
+  <p>Body text with a macro $s and the number 42.</p>
+  <point name="P" coords="(3, 4)" />
+</section>`;
+
+const AA_CONTRAST = 4.5;
+
+type Rgb = { r: number; g: number; b: number; a: number };
+
+function parseColor(value: string): Rgb {
+    const m = value.match(/rgba?\(([^)]+)\)/);
+    if (!m) {
+        throw new Error(`Cannot parse color "${value}"`);
+    }
+    const parts = m[1].split(",").map((p) => parseFloat(p.trim()));
+    return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+}
+
+// Flatten a (possibly translucent) color over an opaque backdrop.
+function flatten(fg: Rgb, backdrop: Rgb): Rgb {
+    if (fg.a >= 1) {
+        return fg;
+    }
+    return {
+        r: fg.r * fg.a + backdrop.r * (1 - fg.a),
+        g: fg.g * fg.a + backdrop.g * (1 - fg.a),
+        b: fg.b * fg.a + backdrop.b * (1 - fg.a),
+        a: 1,
+    };
+}
+
+function relativeLuminance({ r, g, b }: Rgb): number {
+    const channel = (c: number) => {
+        const s = c / 255;
+        return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    };
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(a: Rgb, b: Rgb): number {
+    const l1 = relativeLuminance(a);
+    const l2 = relativeLuminance(b);
+    const [hi, lo] = l1 > l2 ? [l1, l2] : [l2, l1];
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+function mountAndSelectAll(mode: ThemeMode) {
+    const style = {
+        height: "500px",
+        width: "700px",
+        background: THEME_VARS[mode]["--canvas"],
+        ...THEME_VARS[mode],
+    } as React.CSSProperties;
+
+    cy.mount(
+        <div style={style}>
+            {/* An element outside the editor to blur onto. */}
+            <button id="outside-editor" type="button">
+                outside
+            </button>
+            <CodeMirror value={DOENET_SOURCE} darkMode={mode} />
+        </div>,
+    );
+
+    // Focus the editor and select the whole document so the selection layer is
+    // painted behind every token.
+    cy.get(".cm-content").click().type("{selectall}");
+    cy.get(".cm-selectionBackground").should("exist");
+}
+
+/**
+ * Assert every visible, highlighted token has >= AA contrast against the
+ * rendered selection background.
+ */
+function expectHighlightedTextIsLegible(mode: ThemeMode) {
+    const canvas = parseColor(
+        // Normalize the CSS keyword/hex to rgb via a throwaway element.
+        (() => {
+            const el = document.createElement("span");
+            el.style.color = THEME_VARS[mode]["--canvas"];
+            document.body.appendChild(el);
+            const rgb = getComputedStyle(el).color;
+            el.remove();
+            return rgb;
+        })(),
+    );
+
+    cy.window().then((win) => {
+        const selEl = win.document.querySelector(".cm-selectionBackground");
+        expect(selEl, "selection background element").to.exist;
+        const selectionBg = flatten(
+            parseColor(win.getComputedStyle(selEl!).backgroundColor),
+            canvas,
+        );
+
+        const spans = Array.from(
+            win.document.querySelectorAll(".cm-content .cm-line span"),
+        ) as HTMLElement[];
+
+        const failures = spans
+            .filter(
+                (span) =>
+                    (span.textContent ?? "").trim().length > 0 &&
+                    // leaf spans only, so nested markup isn't counted twice
+                    span.querySelector("span") === null,
+            )
+            .map((span) => {
+                const fg = parseColor(win.getComputedStyle(span).color);
+                const ratio = contrastRatio(
+                    flatten(fg, selectionBg),
+                    selectionBg,
+                );
+                return {
+                    text: (span.textContent ?? "").trim().slice(0, 40),
+                    color: win.getComputedStyle(span).color,
+                    ratio: Number(ratio.toFixed(2)),
+                };
+            })
+            .filter((entry) => entry.ratio < AA_CONTRAST);
+
+        const selectionCss = win.getComputedStyle(selEl!).backgroundColor;
+        expect(
+            failures,
+            `Tokens below ${AA_CONTRAST}:1 on selection ${selectionCss}:\n` +
+                JSON.stringify(failures, null, 2),
+        ).to.have.length(0);
+    });
+}
+
+describe("CodeMirror selection-highlight accessibility", () => {
+    it("light mode: highlighted syntax-colored text meets contrast", () => {
+        mountAndSelectAll("light");
+        expectHighlightedTextIsLegible("light");
+    });
+
+    it("dark mode: highlighted syntax-colored text meets contrast", () => {
+        mountAndSelectAll("dark");
+        expectHighlightedTextIsLegible("dark");
+    });
+
+    // The blurred selection is colored by a separate CodeMirror base-theme rule;
+    // clicking away from the editor must not revert the highlight to the
+    // washed-out base color.
+    it("dark mode: highlighted text stays legible after the editor is blurred", () => {
+        mountAndSelectAll("dark");
+        cy.get("#outside-editor").focus();
+        cy.get(".cm-editor").should("not.have.class", "cm-focused");
+        expectHighlightedTextIsLegible("dark");
+    });
+});

--- a/packages/codemirror/test/cypress/component/selectionAccessibility.cy.tsx
+++ b/packages/codemirror/test/cypress/component/selectionAccessibility.cy.tsx
@@ -40,8 +40,10 @@ const THEME_VARS: Record<ThemeMode, Record<string, string>> = {
 };
 
 // Exercises the main token categories: tag names / angle brackets, attribute
-// names, attribute-value strings, macros, and (near-white) text content.
+// names, attribute-value strings, macros, (near-white) text content, and the
+// dim comment gray — the tightest-contrast token in both palettes.
 const DOENET_SOURCE = `<section name="s">
+  <!-- comments must stay legible when highlighted too -->
   <title>Highlighted text should stay legible</title>
   <p>Body text with a macro $s and the number 42.</p>
   <point name="P" coords="(3, 4)" />

--- a/packages/codemirror/test/cypress/component/selectionAccessibility.cy.tsx
+++ b/packages/codemirror/test/cypress/component/selectionAccessibility.cy.tsx
@@ -141,7 +141,7 @@ function expectHighlightedTextIsLegible(mode: ThemeMode) {
             win.document.querySelectorAll(".cm-content .cm-line span"),
         ) as HTMLElement[];
 
-        const failures = spans
+        const measured = spans
             .filter(
                 (span) =>
                     (span.textContent ?? "").trim().length > 0 &&
@@ -159,8 +159,17 @@ function expectHighlightedTextIsLegible(mode: ThemeMode) {
                     color: win.getComputedStyle(span).color,
                     ratio: Number(ratio.toFixed(2)),
                 };
-            })
-            .filter((entry) => entry.ratio < AA_CONTRAST);
+            });
+
+        // Guard against a vacuous pass: if syntax highlighting stopped
+        // producing token spans, there would be nothing to check and the
+        // contrast assertion below would trivially succeed.
+        expect(
+            measured.length,
+            "highlighted tokens measured",
+        ).to.be.greaterThan(0);
+
+        const failures = measured.filter((entry) => entry.ratio < AA_CONTRAST);
 
         const selectionCss = win.getComputedStyle(selEl!).backgroundColor;
         expect(


### PR DESCRIPTION
## Problem

In dark mode, highlighting (selecting) text in the code editor made the highlighted text nearly illegible — worst for the near-white content color. The selection highlight was also "quite bright."

The root cause turned out to be deeper than a single color value:

- The editor's own selection rule (`var(--mainGray)`) **never applied**. CodeMirror's base theme targets the selection with a higher-specificity selector (`&<light|dark>.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground`), so it always won.
- The editor was **never told it was in dark mode** (`EditorView.theme` was called without `{ dark }`), so CodeMirror also applied its *light-mode* base defaults.

The net effect: the highlight rendered as CodeMirror's built-in light lavender (`#d7d4f0`) in **every** mode, and on blur reverted to the base light-gray default (`#d9d9d9`) — the "click away and it goes light again" behavior.

## Fix

- Dark-mode selection is now a dark navy (`#092c4d`) that keeps every syntax token — down to the dim comment gray — at WCAG AA contrast (≥ 4.5:1) while still reading as a selection against the `#121212` canvas. Light mode now correctly uses its intended neutral gray (`#e3e3e3`).
- The override mirrors CodeMirror's base-theme selector for **both** the focused and blurred states, so clicking away from the editor no longer reverts the highlight.
- Both themes now pass the real brightness to CodeMirror (`{ dark: darkMode === "dark" }`) so its base defaults align.
- The light-mode comment color is darkened slightly (`#656d76` → `#5c636d`) so highlighted comments clear WCAG AA against the light selection too (they previously sat at ~4.1:1); it stays above AA on the white canvas.

## Tests

Adds `@doenet/codemirror` Cypress component tests (`selectionAccessibility.cy.tsx`) that select highlighted code and assert the WCAG contrast between each rendered token color and the actual selection-background color — in light mode, dark mode, and after the editor is blurred. The fixture includes a comment so the dim comment gray (the tightest-contrast token in both palettes) is covered.

**Note on why not `cy.checkA11y`:** axe-core's `color-contrast` rule cannot resolve CodeMirror's selection. It is painted in a separate negative-z-index layer (`.cm-selectionLayer > .cm-selectionBackground`), and the native fallback is a `::selection` pseudo-element — neither is a DOM background axe can read. Pointed at highlighted code, axe compares each token against a phantom white background and reports nonsense, so the tests compute the real contrast directly.

Verified that the tests **fail** against the pre-fix `theme.ts` (selection renders `#d7d4f0`; even light mode's green string is illegible on it) and **pass** with the fix. The full 69-test codemirror component suite passes.

## Note

Light-mode selection changes from the accidental lavender to the intended `#e3e3e3` gray — the color the code always meant to use. It passes AA, but it is a minor visible change to light mode as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
