### PR TITLE
chore: retarget color-word changeset to the published packages

### DIFF
--- a/.changeset/perceptual-color-words.md
+++ b/.changeset/perceptual-color-words.md
@@ -1,5 +1,7 @@
 ---
-"@doenet/utils": patch
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
 ---
 
 Improve the hex/rgb-to-color-word algorithm used for style descriptions.


### PR DESCRIPTION
## Problem

`.changeset/perceptual-color-words.md` (added in #1530, still unreleased — no `chore: version packages` has landed since) lists a single package:

```
"@doenet/utils": patch
```

`@doenet/utils` is never published. Its `vite.config.ts` has no `scripts/transform-package-json.ts` step, and it is not in the publish targets in `.github/workflows/publish.yml`. Its source is bundled into `@doenet/doenetml`.

The practical effect: Changesets bumps the private `packages/utils/package.json` version and writes the entry into `packages/utils/CHANGELOG.md`, which no consumer reads. Meanwhile the actual behavior change — style descriptions such as "thick red line" now naming author-supplied colors with a perceptual (CIEDE2000) match instead of raw RGB distance — reaches users through `@doenet/doenetml` with no changelog entry at all.

## Change

Retarget the changeset to the packages that carry the change to users, per the forward-propagation rule in `.github/skills/changesets/SKILL.md` (`@doenet/doenetml` → `@doenet/standalone` → `@doenet/doenetml-iframe`). The body text is unchanged.

This is a metadata-only change; no source is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
