### PR TITLE
Reach @doenet/utils through a subpath from the language server

### DIFF
--- a/.changeset/lsp-utils-subpath-boundary.md
+++ b/.changeset/lsp-utils-subpath-boundary.md
@@ -1,9 +1,17 @@
 ---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
 "@doenet/vscode-extension": patch
 "doenet-vscode-extension": patch
 ---
 
-Stop the language server from pulling `@doenet/utils`' root barrel in for a
-single function. The math-input function-name helpers now have their own entry
-point, which shrinks that import from 65 KB to under 1 KB and keeps the
-extension's startup path clear of math-expressions and the AST helpers.
+Editor: cut the bundled DoenetML language server roughly in half.
+
+The server reached `@doenet/utils` through its root barrel for a single
+function, dragging math-expressions, the AST helpers and the URL utilities into
+the bundle alongside it. Those math-input function-name helpers now have an
+entry point of their own, taking the built server from 2.2 MB to 1.0 MB
+minified (642 KB to 316 KB gzipped). The server ships inline inside the code
+editor, so every package that embeds the editor downloads and parses that much
+less before the first cursor-help request can be answered.

--- a/.changeset/lsp-utils-subpath-boundary.md
+++ b/.changeset/lsp-utils-subpath-boundary.md
@@ -11,7 +11,7 @@ Editor: cut the bundled DoenetML language server roughly in half.
 The server reached `@doenet/utils` through its root barrel for a single
 function, dragging math-expressions, the AST helpers and the URL utilities into
 the bundle alongside it. Those math-input function-name helpers now have an
-entry point of their own, taking the built server from 2.2 MB to 1.0 MB
-minified (642 KB to 316 KB gzipped). The server ships inline inside the code
+entry point of their own, taking the built server from 2.3 MB to 1.1 MB
+minified (640 KB to 317 KB gzipped). The server ships inline inside the code
 editor, so every package that embeds the editor downloads and parses that much
 less before the first cursor-help request can be answered.

--- a/.changeset/lsp-utils-subpath-boundary.md
+++ b/.changeset/lsp-utils-subpath-boundary.md
@@ -1,0 +1,9 @@
+---
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop the language server from pulling `@doenet/utils`' root barrel in for a
+single function. The math-input function-name helpers now have their own entry
+point, which shrinks that import from 65 KB to under 1 KB and keeps the
+extension's startup path clear of math-expressions and the AST helpers.

--- a/packages/lsp-tools/src/context-help/computeContextHelp.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.ts
@@ -1,9 +1,8 @@
 import type { DastElement } from "@doenet/parser";
-// Its own subpath rather than the root export, for the reason
-// `resolve-active-style.ts` already documents: the root barrel drags in
-// math-expressions, the AST helpers and the URL utilities, and this worker
-// loads on the critical path before the editor can answer a cursor-help
-// request. `noRootUtilsImport.test.ts` keeps it that way.
+// Its own subpath rather than the root export, which would drag
+// math-expressions and the AST and URL helpers onto the boot path of a worker
+// the editor waits on. `test/no-root-utils-import.test.ts` explains it in full
+// and keeps it that way.
 import { buildEffectiveMathInputFunctionNames } from "@doenet/utils/components/mathInputFunctionNames";
 import {
     AutoCompleter,

--- a/packages/lsp-tools/src/context-help/computeContextHelp.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.ts
@@ -1,5 +1,10 @@
 import type { DastElement } from "@doenet/parser";
-import { buildEffectiveMathInputFunctionNames } from "@doenet/utils";
+// Its own subpath rather than the root export, for the reason
+// `resolve-active-style.ts` already documents: the root barrel drags in
+// math-expressions, the AST helpers and the URL utilities, and this worker
+// loads on the critical path before the editor can answer a cursor-help
+// request. `noRootUtilsImport.test.ts` keeps it that way.
+import { buildEffectiveMathInputFunctionNames } from "@doenet/utils/components/mathInputFunctionNames";
 import {
     AutoCompleter,
     type AliasedElementSchema,

--- a/packages/lsp-tools/test/no-root-utils-import.test.ts
+++ b/packages/lsp-tools/test/no-root-utils-import.test.ts
@@ -24,21 +24,37 @@ import { describe, expect, it } from "vitest";
  * extension to do it. This costs nothing and catches the mistake at the point
  * it is made — someone typing the import they are used to.
  */
-const SRC = path.resolve(
+const PACKAGES = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
-    "src",
+    "..",
 );
 
-/** `@doenet/utils` with nothing after it: the root export. */
-const ROOT_IMPORT = /from\s*["']@doenet\/utils["']/;
+/**
+ * Everything that ends up in the language-server bundle: `@doenet/lsp` is the
+ * server itself and bundles `@doenet/lsp-tools` wholesale. Only `lsp-tools`
+ * imports `@doenet/utils` today, but the guard is about where the next import
+ * could land, not where the current ones are.
+ */
+const SCANNED_ROOTS = ["lsp-tools/src", "lsp/src"].map((dir) =>
+    path.join(PACKAGES, dir),
+);
+
+/**
+ * A specifier of exactly `@doenet/utils` — no subpath — reached by any form
+ * that survives to runtime: `import`/`export … from`, a bare side-effect
+ * `import`, and a dynamic `import(…)`.
+ */
+const ROOT_IMPORT = /(?:from|import)\s*\(?\s*["']@doenet\/utils["']/g;
+
+/** The `import`/`export` opening a statement, searched for backwards. */
+const STATEMENT_KEYWORD = /\b(?:import|export)\b/g;
 
 function* sourceFiles(dir: string): Generator<string> {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        if (
-            entry.name === "generated-assets" ||
-            entry.name === "node_modules"
-        ) {
+        // The Lezer parser the `compile_grammar` script writes here is
+        // machine-generated, and not ours to hold to this rule.
+        if (entry.name === "generated-assets") {
             continue;
         }
         const full = path.join(dir, entry.name);
@@ -50,29 +66,54 @@ function* sourceFiles(dir: string): Generator<string> {
     }
 }
 
+/**
+ * Report every root-barrel import in `contents` as `line: statement`, the
+ * statement collapsed onto one line so that a wrapped import still reads.
+ *
+ * Statements are located from the specifier backwards rather than line by
+ * line, so a multi-line `import type { … } from "@doenet/utils"` is still
+ * recognized as type-only. Type-only imports are allowed through: they cost
+ * nothing at runtime, being erased before the bundler ever sees them. An
+ * inline `import { type Foo }` is not — that statement is still emitted.
+ */
+function rootImportsIn(contents: string): string[] {
+    const found: string[] = [];
+    for (const match of contents.matchAll(ROOT_IMPORT)) {
+        // A bare or dynamic `import` is matched from its own keyword, so it
+        // opens its own statement; a `from` has the keyword somewhere behind
+        // it, possibly several lines back.
+        const head = contents.slice(0, match.index);
+        const start = match[0].startsWith("import")
+            ? match.index
+            : ([...head.matchAll(STATEMENT_KEYWORD)].at(-1)?.index ??
+              match.index);
+        const statement = contents.slice(start, match.index + match[0].length);
+        if (/^(?:import|export)\s+type\b/.test(statement)) {
+            continue;
+        }
+        const line = contents.slice(0, start).split("\n").length;
+        found.push(`${line}: ${statement.replace(/\s+/g, " ")}`);
+    }
+    return found;
+}
+
 describe("the language server's dependency on @doenet/utils", () => {
     it("goes through a subpath, never the root barrel", () => {
         const offenders: string[] = [];
-        for (const file of sourceFiles(SRC)) {
-            const contents = fs.readFileSync(file, "utf-8");
-            contents.split("\n").forEach((line, index) => {
-                // A `import type` costs nothing at runtime, so it is allowed
-                // through: it is erased before the bundler ever sees it.
-                if (/^\s*import\s+type\b/.test(line)) {
-                    return;
+        for (const root of SCANNED_ROOTS) {
+            for (const file of sourceFiles(root)) {
+                const relative = path.relative(PACKAGES, file);
+                const contents = fs.readFileSync(file, "utf-8");
+                for (const found of rootImportsIn(contents)) {
+                    offenders.push(`${relative}:${found}`);
                 }
-                if (ROOT_IMPORT.test(line)) {
-                    offenders.push(
-                        `${path.relative(SRC, file)}:${index + 1}: ${line.trim()}`,
-                    );
-                }
-            });
+            }
         }
 
         expect(
             offenders,
-            `Import the specific entry instead, adding one to @doenet/utils'
-\`exports\` and its vite \`lib.entry\` if it does not exist yet:\n  ${offenders.join("\n  ")}\n`,
+            "Import the specific entry instead, adding one to @doenet/utils'" +
+                " `exports` and its vite `lib.entry` if it does not exist yet.",
         ).toEqual([]);
     });
 });

--- a/packages/lsp-tools/test/no-root-utils-import.test.ts
+++ b/packages/lsp-tools/test/no-root-utils-import.test.ts
@@ -16,18 +16,20 @@
  * single self-contained function, more than doubled the built server:
  * 1.1 MB minified against 2.3 MB with it (317 KB gzipped against 640 KB).
  *
- * That reasoning lived only in a code comment, and the second import reached
- * the root barrel anyway. A comment cannot fail; this can.
+ * That reasoning lived only in a code comment, and a second import reached the
+ * root barrel anyway. A comment cannot fail; this can.
  *
- * A bundle-size assertion would catch more, but it would have to build the
- * server to do it. This costs nothing and catches the mistake at the point it
- * is made — someone typing the import they are used to.
+ * A bundle-size assertion would catch more — including a subpath that itself
+ * grows heavy — but it would have to build the server to do it. This costs
+ * nothing and catches the mistake at the point it is made: someone typing the
+ * import they are used to.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 /** The `packages/` directory, which the scanned roots are relative to. */
@@ -47,19 +49,8 @@ const SCANNED_ROOTS = ["lsp-tools/src", "lsp/src"].map((dir) =>
     path.join(PACKAGES, dir),
 );
 
-/**
- * A specifier of exactly `@doenet/utils` — no subpath — reached by any form
- * that survives to runtime: `import`/`export … from`, a bare side-effect
- * `import`, and a dynamic `import(…)`.
- */
-const ROOT_IMPORT = /(?:from|import)\s*\(?\s*["']@doenet\/utils["']/g;
-
-/**
- * The `import`/`export` opening a statement, searched for backwards. Anchored
- * to the start of a line so that the same word in a trailing comment or in a
- * braced specifier list cannot be mistaken for the head of the statement.
- */
-const STATEMENT_START = /^[ \t]*(?:import|export)\b/gm;
+/** The root barrel: the specifier with no subpath after it. */
+const ROOT_BARREL = "@doenet/utils";
 
 function* sourceFiles(dir: string): Generator<string> {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -72,183 +63,143 @@ function* sourceFiles(dir: string): Generator<string> {
     }
 }
 
-/**
- * Report every root-barrel import in `contents` as `line: statement`, the
- * statement collapsed onto one line so that a wrapped import still reads.
- *
- * Statements are located from the specifier backwards — to the nearest
- * {@link STATEMENT_START} — rather than line by line, so a prettier-wrapped
- * `import type { … } from "@doenet/utils"` is still recognized as type-only
- * instead of failing on its closing `} from "@doenet/utils";` line. Type-only
- * imports are allowed through: they cost nothing at runtime, being erased
- * before the bundler ever sees them. An inline `import { type Foo }` is not —
- * that statement is still emitted.
- */
-function rootImportsIn(contents: string): string[] {
-    const found: string[] = [];
-    for (const match of contents.matchAll(ROOT_IMPORT)) {
-        // A bare or dynamic `import` is matched from its own keyword, so it
-        // opens its own statement; a `from` has the keyword somewhere behind
-        // it, possibly several lines back.
-        const heads = match[0].startsWith("import")
-            ? []
-            : [...contents.slice(0, match.index).matchAll(STATEMENT_START)];
-        const start = heads[heads.length - 1]?.index ?? match.index;
-        const statement = contents
-            .slice(start, match.index + match[0].length)
-            .replace(/\s+/g, " ")
-            .trim();
-        if (/^(?:import|export)\s+type\b/.test(statement)) {
-            continue;
-        }
-        const line = contents.slice(0, start).split("\n").length;
-        found.push(`${line}: ${statement}`);
-    }
-    return found;
+/** The literal text of `node` if it is a string literal, else `undefined`. */
+function literalText(node: ts.Node): string | undefined {
+    return ts.isStringLiteralLike(node) ? node.text : undefined;
 }
 
 /**
- * Every import form {@link rootImportsIn} claims a verdict on, so those
- * verdicts are checked by the suite rather than re-derived by hand each time
- * the matching is touched. Anything that survives to runtime must be reported;
- * type-only statements and subpath specifiers must not be.
+ * The module `node` pulls in *at runtime*, or `undefined` if it pulls in
+ * nothing — either because it is not an import at all, or because TypeScript
+ * erases it before a bundler ever sees it.
  *
- * The comment cases are the ones that rule out the obvious one-regex
- * formulations: scanning line by line mistakes the closing
- * `} from "@doenet/utils";` of a wrapped type-only import for a statement of
- * its own, matching `import`/`export` anywhere behind the specifier picks up
- * the word from a trailing comment, and bounding a forward match at the
- * nearest `;` stops early on a comment that contains one.
+ * Type-only statements are erased and so cost no bytes; they are deliberately
+ * allowed through. An inline `import { type Foo }` is not erased — the
+ * statement is still emitted — so it counts as a runtime import.
  */
-const MATCHER_CASES: { form: string; source: string; flagged: boolean }[] = [
-    {
-        form: "a named import",
-        source: `import { cesc } from "@doenet/utils";`,
-        flagged: true,
-    },
-    {
-        form: "a single-quoted specifier",
-        source: `import { cesc } from '@doenet/utils';`,
-        flagged: true,
-    },
-    {
-        form: "a re-export",
-        source: `export { deepClone } from "@doenet/utils";`,
-        flagged: true,
-    },
-    {
-        form: "a star re-export",
-        source: `export * from "@doenet/utils";`,
-        flagged: true,
-    },
-    {
-        form: "a side-effect import",
-        source: `import "@doenet/utils";`,
-        flagged: true,
-    },
-    {
-        form: "a dynamic import",
-        source: `const utils = await import("@doenet/utils");`,
-        flagged: true,
-    },
-    {
-        form: "an inline type modifier, whose statement is still emitted",
-        source: `import { type Foo } from "@doenet/utils";`,
-        flagged: true,
-    },
-    {
-        form: "a wrapped import whose body comment says export",
-        source: `import {\n    isMacPlatform, // re-export below\n} from "@doenet/utils";`,
-        flagged: true,
-    },
-    {
-        form: "a wrapped import whose body comment contains a semicolon",
-        source: `import {\n    cesc, // escapes foo(x); bar\n} from "@doenet/utils";`,
-        flagged: true,
-    },
-    {
-        form: "a type-only import",
-        source: `import type { Foo } from "@doenet/utils";`,
-        flagged: false,
-    },
-    {
-        form: "a wrapped type-only import",
-        source: `import type {\n    Foo,\n} from "@doenet/utils";`,
-        flagged: false,
-    },
-    {
-        form: "a wrapped type-only import whose body comment says export",
-        source: `import type {\n    Foo, // re-export below\n} from "@doenet/utils";`,
-        flagged: false,
-    },
-    {
-        form: "a wrapped type-only import whose body comment contains a semicolon",
-        source: `import type {\n    Foo, // as in foo(x); bar\n} from "@doenet/utils";`,
-        flagged: false,
-    },
-    {
-        form: "a type-only re-export",
-        source: `export type { Foo } from "@doenet/utils";`,
-        flagged: false,
-    },
-    {
-        form: "a wrapped type-only re-export",
-        source: `export type {\n    Foo,\n} from "@doenet/utils";`,
-        flagged: false,
-    },
-    {
-        form: "a subpath import",
-        source: `import { STYLE_PALETTES } from "@doenet/utils/style";`,
-        flagged: false,
-    },
-    {
-        form: "a dynamic subpath import",
-        source: `const style = await import("@doenet/utils/style");`,
-        flagged: false,
-    },
-    {
-        form: "another package entirely",
-        source: `import { toXml } from "@doenet/parser";`,
-        flagged: false,
-    },
-];
+function runtimeImportOf(node: ts.Node): string | undefined {
+    if (ts.isImportDeclaration(node)) {
+        // A side-effect `import "…"` has no clause at all, and is emitted.
+        return node.importClause?.isTypeOnly
+            ? undefined
+            : literalText(node.moduleSpecifier);
+    }
+    if (ts.isExportDeclaration(node)) {
+        // A local `export { x }` has no module specifier to reach through.
+        return node.isTypeOnly || !node.moduleSpecifier
+            ? undefined
+            : literalText(node.moduleSpecifier);
+    }
+    if (
+        ts.isCallExpression(node) &&
+        node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+        return node.arguments[0] && literalText(node.arguments[0]);
+    }
+    return undefined;
+}
 
-describe("the guard's matcher", () => {
-    it.each(MATCHER_CASES.filter((matcherCase) => matcherCase.flagged))(
-        "reports $form",
-        ({ source }) => {
-            expect(rootImportsIn(source)).toHaveLength(1);
-        },
+/**
+ * Report every runtime import of the root barrel in `source` as
+ * `line: statement`, the statement collapsed onto one line so that a
+ * prettier-wrapped import still reads in the failure message.
+ *
+ * The source is parsed rather than pattern-matched. A regex over the raw text
+ * looks tempting and is a trap: it fires on a specifier that merely appears in
+ * a comment or a string — no small thing in files whose subject matter *is*
+ * this import — and it has to guess at the type-only, wrapped and dynamic
+ * forms that the parser simply knows.
+ */
+function rootImportsIn(source: string, fileName = "scan.ts"): string[] {
+    const parsed = ts.createSourceFile(
+        fileName,
+        source,
+        ts.ScriptTarget.Latest,
+        /* setParentNodes */ true,
     );
+    const found: string[] = [];
 
-    it.each(MATCHER_CASES.filter((matcherCase) => !matcherCase.flagged))(
-        "allows $form",
-        ({ source }) => {
-            expect(rootImportsIn(source)).toEqual([]);
-        },
-    );
+    ts.forEachChild(parsed, function visit(node: ts.Node) {
+        if (runtimeImportOf(node) === ROOT_BARREL) {
+            const { line } = parsed.getLineAndCharacterOfPosition(
+                node.getStart(parsed),
+            );
+            const statement = node.getText(parsed).replace(/\s+/g, " ");
+            found.push(`${line + 1}: ${statement}`);
+        }
+        ts.forEachChild(node, visit);
+    });
+
+    return found;
+}
+
+// The two tables below hold one case per distinction the guard draws, so the
+// policy is pinned by the suite rather than re-derived by hand whenever the
+// scan is touched.
+
+/** Forms that survive to runtime, and so must be reported. */
+const REPORTED = {
+    "a named import": `import { cesc } from "@doenet/utils";`,
+    "a re-export": `export { deepClone } from "@doenet/utils";`,
+    "a star re-export": `export * from "@doenet/utils";`,
+    "a side-effect import": `import "@doenet/utils";`,
+    "a dynamic import": `const utils = await import("@doenet/utils");`,
+    "an inline type modifier, still emitted": `import { type Foo } from "@doenet/utils";`,
+};
+
+/**
+ * Forms that cost nothing, and so must not be reported: type-only statements
+ * are erased before a bundler sees them, a subpath is the whole point, and a
+ * specifier sitting in a comment or a string is not an import at all.
+ */
+const ALLOWED = {
+    "a type-only import": `import type { Foo } from "@doenet/utils";`,
+    "a type-only re-export": `export type { Foo } from "@doenet/utils";`,
+    "a subpath import": `import { STYLE_PALETTES } from "@doenet/utils/style";`,
+    "a dynamic subpath import": `const s = await import("@doenet/utils/style");`,
+    "another package entirely": `import { toXml } from "@doenet/parser";`,
+    "a commented-out import": `// import { cesc } from "@doenet/utils";`,
+    "a doc comment naming the barrel": `/** Never import "@doenet/utils". */\nexport const a = 1;`,
+    "the specifier inside a string": `const barrel = "@doenet/utils";`,
+};
+
+describe("the guard's scan", () => {
+    it.each(Object.entries(REPORTED))("reports %s", (_form, source) => {
+        expect(rootImportsIn(source)).toHaveLength(1);
+    });
+
+    it.each(Object.entries(ALLOWED))("allows %s", (_form, source) => {
+        expect(rootImportsIn(source)).toEqual([]);
+    });
 
     it("points at the head of a wrapped statement, collapsed onto one line", () => {
         expect(
             rootImportsIn(
                 `const x = 1;\nimport {\n    cesc,\n} from "@doenet/utils";\n`,
             ),
-        ).toEqual([`2: import { cesc, } from "@doenet/utils"`]);
+        ).toEqual([`2: import { cesc, } from "@doenet/utils";`]);
     });
 });
 
 describe("the language server's dependency on @doenet/utils", () => {
     it("goes through a subpath, never the root barrel", () => {
         const offenders: string[] = [];
+        let scanned = 0;
+
         for (const root of SCANNED_ROOTS) {
             for (const file of sourceFiles(root)) {
+                scanned++;
                 const relative = path.relative(PACKAGES, file);
                 const contents = fs.readFileSync(file, "utf-8");
-                for (const found of rootImportsIn(contents)) {
+                for (const found of rootImportsIn(contents, file)) {
                     offenders.push(`${relative}:${found}`);
                 }
             }
         }
+
+        // Without this the guard would pass silently if the scanned roots
+        // were ever moved or renamed out from under it.
+        expect(scanned, "no source files were scanned").toBeGreaterThan(0);
 
         expect(
             offenders,

--- a/packages/lsp-tools/test/no-root-utils-import.test.ts
+++ b/packages/lsp-tools/test/no-root-utils-import.test.ts
@@ -8,21 +8,26 @@ import { describe, expect, it } from "vitest";
  * The language server must reach `@doenet/utils` through a subpath, never
  * through its root export.
  *
- * The root barrel pulls in math-expressions, the AST helpers and the URL
- * utilities. This worker loads on the critical path before the editor can
- * answer a cursor-help request, and boot lag here has surfaced before as a
- * flaky "no help on first cursor change" in CI — which is why
- * `resolve-active-style.ts` imports `@doenet/utils/style` rather than the
- * root.
+ * The root barrel re-exports math-expressions, the AST helpers and the URL
+ * utilities, and nothing externalizes them on the way into the server bundle.
+ * That bundle is not only the VS Code extension's server: `@doenet/codemirror`
+ * embeds the built IIFE verbatim (`@doenet/lsp/language-server.js?raw`) to
+ * start it as a blob worker, so every byte rides along into the editor too —
+ * where it sits on the critical path before the editor can answer a
+ * cursor-help request. Boot lag here has surfaced before as a flaky "no help
+ * on first cursor change" in CI, which is why `resolve-active-style.ts`
+ * imports `@doenet/utils/style` rather than the root.
  *
- * That reasoning lived only in a code comment, and a second import reached the
- * root barrel anyway: `computeContextHelp.ts` pulled the whole thing in for a
- * single self-contained function, which now has its own entry. A comment
- * cannot fail; this can.
+ * The cost is not marginal. One root import in `computeContextHelp.ts`, for a
+ * single self-contained function, more than doubled the built server:
+ * 1.0 MB minified against 2.2 MB with it (316 KB gzipped against 642 KB).
+ *
+ * That reasoning lived only in a code comment, and the second import reached
+ * the root barrel anyway. A comment cannot fail; this can.
  *
  * A bundle-size assertion would catch more, but it would have to build the
- * extension to do it. This costs nothing and catches the mistake at the point
- * it is made — someone typing the import they are used to.
+ * server to do it. This costs nothing and catches the mistake at the point it
+ * is made — someone typing the import they are used to.
  */
 const PACKAGES = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
@@ -47,16 +52,15 @@ const SCANNED_ROOTS = ["lsp-tools/src", "lsp/src"].map((dir) =>
  */
 const ROOT_IMPORT = /(?:from|import)\s*\(?\s*["']@doenet\/utils["']/g;
 
-/** The `import`/`export` opening a statement, searched for backwards. */
-const STATEMENT_KEYWORD = /\b(?:import|export)\b/g;
+/**
+ * The `import`/`export` opening a statement, searched for backwards. Anchored
+ * to the start of a line so that the same word in a trailing comment or in a
+ * braced specifier list cannot be mistaken for the head of the statement.
+ */
+const STATEMENT_START = /^[ \t]*(?:import|export)\b/gm;
 
 function* sourceFiles(dir: string): Generator<string> {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        // The Lezer parser the `compile_grammar` script writes here is
-        // machine-generated, and not ours to hold to this rule.
-        if (entry.name === "generated-assets") {
-            continue;
-        }
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
             yield* sourceFiles(full);
@@ -70,11 +74,13 @@ function* sourceFiles(dir: string): Generator<string> {
  * Report every root-barrel import in `contents` as `line: statement`, the
  * statement collapsed onto one line so that a wrapped import still reads.
  *
- * Statements are located from the specifier backwards rather than line by
- * line, so a multi-line `import type { … } from "@doenet/utils"` is still
- * recognized as type-only. Type-only imports are allowed through: they cost
- * nothing at runtime, being erased before the bundler ever sees them. An
- * inline `import { type Foo }` is not — that statement is still emitted.
+ * Statements are located from the specifier backwards — to the nearest
+ * {@link STATEMENT_START} — rather than line by line, so a prettier-wrapped
+ * `import type { … } from "@doenet/utils"` is still recognized as type-only
+ * instead of failing on its closing `} from "@doenet/utils";` line. Type-only
+ * imports are allowed through: they cost nothing at runtime, being erased
+ * before the bundler ever sees them. An inline `import { type Foo }` is not —
+ * that statement is still emitted.
  */
 function rootImportsIn(contents: string): string[] {
     const found: string[] = [];
@@ -82,17 +88,19 @@ function rootImportsIn(contents: string): string[] {
         // A bare or dynamic `import` is matched from its own keyword, so it
         // opens its own statement; a `from` has the keyword somewhere behind
         // it, possibly several lines back.
-        const head = contents.slice(0, match.index);
-        const start = match[0].startsWith("import")
-            ? match.index
-            : ([...head.matchAll(STATEMENT_KEYWORD)].at(-1)?.index ??
-              match.index);
-        const statement = contents.slice(start, match.index + match[0].length);
+        const heads = match[0].startsWith("import")
+            ? []
+            : [...contents.slice(0, match.index).matchAll(STATEMENT_START)];
+        const start = heads[heads.length - 1]?.index ?? match.index;
+        const statement = contents
+            .slice(start, match.index + match[0].length)
+            .replace(/\s+/g, " ")
+            .trim();
         if (/^(?:import|export)\s+type\b/.test(statement)) {
             continue;
         }
         const line = contents.slice(0, start).split("\n").length;
-        found.push(`${line}: ${statement.replace(/\s+/g, " ")}`);
+        found.push(`${line}: ${statement}`);
     }
     return found;
 }

--- a/packages/lsp-tools/test/no-root-utils-import.test.ts
+++ b/packages/lsp-tools/test/no-root-utils-import.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The language server must reach `@doenet/utils` through a subpath, never
+ * through its root export.
+ *
+ * The root barrel pulls in math-expressions, the AST helpers and the URL
+ * utilities. This worker loads on the critical path before the editor can
+ * answer a cursor-help request, and boot lag here has surfaced before as a
+ * flaky "no help on first cursor change" in CI — which is why
+ * `resolve-active-style.ts` imports `@doenet/utils/style` rather than the
+ * root.
+ *
+ * That reasoning lived only in a code comment, and a second import reached the
+ * root barrel anyway: `computeContextHelp.ts` pulled the whole thing in for a
+ * single self-contained function, which now has its own entry. A comment
+ * cannot fail; this can.
+ *
+ * A bundle-size assertion would catch more, but it would have to build the
+ * extension to do it. This costs nothing and catches the mistake at the point
+ * it is made — someone typing the import they are used to.
+ */
+const SRC = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "src",
+);
+
+/** `@doenet/utils` with nothing after it: the root export. */
+const ROOT_IMPORT = /from\s*["']@doenet\/utils["']/;
+
+function* sourceFiles(dir: string): Generator<string> {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (
+            entry.name === "generated-assets" ||
+            entry.name === "node_modules"
+        ) {
+            continue;
+        }
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            yield* sourceFiles(full);
+        } else if (/\.tsx?$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+            yield full;
+        }
+    }
+}
+
+describe("the language server's dependency on @doenet/utils", () => {
+    it("goes through a subpath, never the root barrel", () => {
+        const offenders: string[] = [];
+        for (const file of sourceFiles(SRC)) {
+            const contents = fs.readFileSync(file, "utf-8");
+            contents.split("\n").forEach((line, index) => {
+                // A `import type` costs nothing at runtime, so it is allowed
+                // through: it is erased before the bundler ever sees it.
+                if (/^\s*import\s+type\b/.test(line)) {
+                    return;
+                }
+                if (ROOT_IMPORT.test(line)) {
+                    offenders.push(
+                        `${path.relative(SRC, file)}:${index + 1}: ${line.trim()}`,
+                    );
+                }
+            });
+        }
+
+        expect(
+            offenders,
+            `Import the specific entry instead, adding one to @doenet/utils'
+\`exports\` and its vite \`lib.entry\` if it does not exist yet:\n  ${offenders.join("\n  ")}\n`,
+        ).toEqual([]);
+    });
+});

--- a/packages/lsp-tools/test/no-root-utils-import.test.ts
+++ b/packages/lsp-tools/test/no-root-utils-import.test.ts
@@ -52,6 +52,11 @@ const SCANNED_ROOTS = ["lsp-tools/src", "lsp/src"].map((dir) =>
 /** The root barrel: the specifier with no subpath after it. */
 const ROOT_BARREL = "@doenet/utils";
 
+/**
+ * Every `.ts`/`.tsx` file under `dir`, recursively. Co-located tests are
+ * skipped: they never reach the server bundle, so what they import is not this
+ * guard's business.
+ */
 function* sourceFiles(dir: string): Generator<string> {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         const full = path.join(dir, entry.name);
@@ -73,9 +78,12 @@ function literalText(node: ts.Node): string | undefined {
  * nothing — either because it is not an import at all, or because TypeScript
  * erases it before a bundler ever sees it.
  *
- * Type-only statements are erased and so cost no bytes; they are deliberately
- * allowed through. An inline `import { type Foo }` is not erased — the
- * statement is still emitted — so it counts as a runtime import.
+ * A whole-statement `import type` / `export type` is erased and so costs no
+ * bytes; those are deliberately allowed through. An inline `import { type Foo
+ * }` is reported anyway, even though today's toolchain happens to drop it when
+ * nothing else in the clause is a value: whether the statement survives turns
+ * on the rest of the clause and on compiler settings this scan has no view of,
+ * and `import type` states the same intent without the ambiguity.
  */
 function runtimeImportOf(node: ts.Node): string | undefined {
     if (ts.isImportDeclaration(node)) {
@@ -137,20 +145,21 @@ function rootImportsIn(source: string, fileName = "scan.ts"): string[] {
 // policy is pinned by the suite rather than re-derived by hand whenever the
 // scan is touched.
 
-/** Forms that survive to runtime, and so must be reported. */
+/** Forms that may survive to runtime, and so must be reported. */
 const REPORTED = {
     "a named import": `import { cesc } from "@doenet/utils";`,
     "a re-export": `export { deepClone } from "@doenet/utils";`,
     "a star re-export": `export * from "@doenet/utils";`,
     "a side-effect import": `import "@doenet/utils";`,
     "a dynamic import": `const utils = await import("@doenet/utils");`,
-    "an inline type modifier, still emitted": `import { type Foo } from "@doenet/utils";`,
+    "an inline type modifier, whose fate depends on the clause": `import { type Foo } from "@doenet/utils";`,
 };
 
 /**
- * Forms that cost nothing, and so must not be reported: type-only statements
- * are erased before a bundler sees them, a subpath is the whole point, and a
- * specifier sitting in a comment or a string is not an import at all.
+ * Forms that cost nothing, and so must not be reported: whole-statement
+ * type-only imports and re-exports are erased before a bundler sees them, a
+ * subpath is the whole point, and a specifier sitting in a comment or a string
+ * is not an import at all.
  */
 const ALLOWED = {
     "a type-only import": `import type { Foo } from "@doenet/utils";`,
@@ -204,7 +213,9 @@ describe("the language server's dependency on @doenet/utils", () => {
         expect(
             offenders,
             "Import the specific entry instead, adding one to @doenet/utils'" +
-                " `exports` and its vite `lib.entry` if it does not exist yet.",
+                " `exports` and its vite `lib.entry` if it does not exist yet." +
+                " If you only need types, a whole-statement `import type` is" +
+                " erased and allowed.",
         ).toEqual([]);
     });
 });

--- a/packages/lsp-tools/test/no-root-utils-import.test.ts
+++ b/packages/lsp-tools/test/no-root-utils-import.test.ts
@@ -1,9 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-import { describe, expect, it } from "vitest";
-
 /**
  * The language server must reach `@doenet/utils` through a subpath, never
  * through its root export.
@@ -20,7 +14,7 @@ import { describe, expect, it } from "vitest";
  *
  * The cost is not marginal. One root import in `computeContextHelp.ts`, for a
  * single self-contained function, more than doubled the built server:
- * 1.0 MB minified against 2.2 MB with it (316 KB gzipped against 642 KB).
+ * 1.1 MB minified against 2.3 MB with it (317 KB gzipped against 640 KB).
  *
  * That reasoning lived only in a code comment, and the second import reached
  * the root barrel anyway. A comment cannot fail; this can.
@@ -29,6 +23,14 @@ import { describe, expect, it } from "vitest";
  * server to do it. This costs nothing and catches the mistake at the point it
  * is made — someone typing the import they are used to.
  */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/** The `packages/` directory, which the scanned roots are relative to. */
 const PACKAGES = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
@@ -104,6 +106,136 @@ function rootImportsIn(contents: string): string[] {
     }
     return found;
 }
+
+/**
+ * Every import form {@link rootImportsIn} claims a verdict on, so those
+ * verdicts are checked by the suite rather than re-derived by hand each time
+ * the matching is touched. Anything that survives to runtime must be reported;
+ * type-only statements and subpath specifiers must not be.
+ *
+ * The comment cases are the ones that rule out the obvious one-regex
+ * formulations: scanning line by line mistakes the closing
+ * `} from "@doenet/utils";` of a wrapped type-only import for a statement of
+ * its own, matching `import`/`export` anywhere behind the specifier picks up
+ * the word from a trailing comment, and bounding a forward match at the
+ * nearest `;` stops early on a comment that contains one.
+ */
+const MATCHER_CASES: { form: string; source: string; flagged: boolean }[] = [
+    {
+        form: "a named import",
+        source: `import { cesc } from "@doenet/utils";`,
+        flagged: true,
+    },
+    {
+        form: "a single-quoted specifier",
+        source: `import { cesc } from '@doenet/utils';`,
+        flagged: true,
+    },
+    {
+        form: "a re-export",
+        source: `export { deepClone } from "@doenet/utils";`,
+        flagged: true,
+    },
+    {
+        form: "a star re-export",
+        source: `export * from "@doenet/utils";`,
+        flagged: true,
+    },
+    {
+        form: "a side-effect import",
+        source: `import "@doenet/utils";`,
+        flagged: true,
+    },
+    {
+        form: "a dynamic import",
+        source: `const utils = await import("@doenet/utils");`,
+        flagged: true,
+    },
+    {
+        form: "an inline type modifier, whose statement is still emitted",
+        source: `import { type Foo } from "@doenet/utils";`,
+        flagged: true,
+    },
+    {
+        form: "a wrapped import whose body comment says export",
+        source: `import {\n    isMacPlatform, // re-export below\n} from "@doenet/utils";`,
+        flagged: true,
+    },
+    {
+        form: "a wrapped import whose body comment contains a semicolon",
+        source: `import {\n    cesc, // escapes foo(x); bar\n} from "@doenet/utils";`,
+        flagged: true,
+    },
+    {
+        form: "a type-only import",
+        source: `import type { Foo } from "@doenet/utils";`,
+        flagged: false,
+    },
+    {
+        form: "a wrapped type-only import",
+        source: `import type {\n    Foo,\n} from "@doenet/utils";`,
+        flagged: false,
+    },
+    {
+        form: "a wrapped type-only import whose body comment says export",
+        source: `import type {\n    Foo, // re-export below\n} from "@doenet/utils";`,
+        flagged: false,
+    },
+    {
+        form: "a wrapped type-only import whose body comment contains a semicolon",
+        source: `import type {\n    Foo, // as in foo(x); bar\n} from "@doenet/utils";`,
+        flagged: false,
+    },
+    {
+        form: "a type-only re-export",
+        source: `export type { Foo } from "@doenet/utils";`,
+        flagged: false,
+    },
+    {
+        form: "a wrapped type-only re-export",
+        source: `export type {\n    Foo,\n} from "@doenet/utils";`,
+        flagged: false,
+    },
+    {
+        form: "a subpath import",
+        source: `import { STYLE_PALETTES } from "@doenet/utils/style";`,
+        flagged: false,
+    },
+    {
+        form: "a dynamic subpath import",
+        source: `const style = await import("@doenet/utils/style");`,
+        flagged: false,
+    },
+    {
+        form: "another package entirely",
+        source: `import { toXml } from "@doenet/parser";`,
+        flagged: false,
+    },
+];
+
+describe("the guard's matcher", () => {
+    it.each(MATCHER_CASES.filter((matcherCase) => matcherCase.flagged))(
+        "reports $form",
+        ({ source }) => {
+            expect(rootImportsIn(source)).toHaveLength(1);
+        },
+    );
+
+    it.each(MATCHER_CASES.filter((matcherCase) => !matcherCase.flagged))(
+        "allows $form",
+        ({ source }) => {
+            expect(rootImportsIn(source)).toEqual([]);
+        },
+    );
+
+    it("points at the head of a wrapped statement, collapsed onto one line", () => {
+        expect(
+            rootImportsIn(
+                `const x = 1;\nimport {\n    cesc,\n} from "@doenet/utils";\n`,
+            ),
+        ).toEqual([`2: import { cesc, } from "@doenet/utils"`]);
+    });
+});
 
 describe("the language server's dependency on @doenet/utils", () => {
     it("goes through a subpath, never the root barrel", () => {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,6 +23,9 @@
         "./style": {
             "import": "./dist/style.js"
         },
+        "./components/mathInputFunctionNames": {
+            "import": "./dist/mathInputFunctionNames.js"
+        },
         "./mathjax": {
             "import": "./dist/mathjax.js"
         }

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
                     "./src/diagnostics/renderDiagnosticMarkdownHtml.ts",
                 parseInlineMarkdown: "./src/markdown/parseInlineMarkdown.ts",
                 style: "./src/style/index.ts",
+                // Its own entry so the language server can reach it without
+                // the root barrel. See the `exports` note in package.json.
+                mathInputFunctionNames:
+                    "./src/components/mathInputFunctionNames.ts",
                 mathjax: "./src/math/MathJaxContext.tsx",
             },
             formats: ["es"],

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -15,8 +15,10 @@ export default defineConfig({
                     "./src/diagnostics/renderDiagnosticMarkdownHtml.ts",
                 parseInlineMarkdown: "./src/markdown/parseInlineMarkdown.ts",
                 style: "./src/style/index.ts",
-                // Its own entry so the language server can reach it without
-                // the root barrel. See the `exports` note in package.json.
+                // Its own entry, paired with the matching `exports` subpath in
+                // package.json, so the language server can reach it without
+                // the root barrel. See
+                // `packages/lsp-tools/test/no-root-utils-import.test.ts`.
                 mathInputFunctionNames:
                     "./src/components/mathInputFunctionNames.ts",
                 mathjax: "./src/math/MathJaxContext.tsx",


### PR DESCRIPTION
Branched from `main`, independent of the #1550 → #1551 → #1552 diagnostics stack — the 60 files that stack touches include nothing under `packages/utils/` or `packages/lsp*` and no build config. These can land in either order.

Groundwork for #1518's remaining `@doenet/utils` diagnostics: before `@doenet/utils` can gain a runtime dependency on `@doenet/i18n`, the boundary that keeps heavy code out of the language server needs to be real rather than incidental.

## The leak

`resolve-active-style.ts` already imports `@doenet/utils/style` rather than the root export, and explains itself:

> the root export drags in math-expressions / AST helpers / URL utilities the resolver doesn't need, and the worker is loaded on the critical path before the editor can answer cursor-help requests (boot lag here surfaces as flaky "no help on first cursor change" in CI)

`computeContextHelp.ts` reached the root barrel anyway, for exactly one function. `buildEffectiveMathInputFunctionNames` and its module import **nothing**, so giving it its own entry is a line of build config.

Measured from real before/after builds, with only that one import changed:

| Artifact | with the root import | via the new subpath |
| --- | ---: | ---: |
| `packages/lsp-tools/dist/index.js` (unminified ESM) | 1,861,269 B | **379,651 B** |
| `packages/lsp/dist/index.js` (minified IIFE server) | 2,304,013 B | **1,069,050 B** |
| … gzipped (`gzip -6`) | 639,909 B | **316,650 B** |
| `packages/codemirror/dist/index.js` (minified) | 5,831,995 B | **3,104,360 B** |

The server more than doubles on one import. And it is not only the VS Code extension that pays: `@doenet/codemirror` inlines the built server verbatim via `@doenet/lsp/language-server.js?raw` so it can start it as a blob worker, and `@doenet/doenetml` externalizes only `react`/`react-dom` — so that ~1.2 MB rides into every package that embeds the code editor.

The new `dist/mathInputFunctionNames.js` entry is 2,131 B and self-contained: no imports, no shared chunk.

## Why a test and not just a comment

The reasoning was living in a code comment, which is precisely why a second import walked past it. `no-root-utils-import.test.ts` fails on any runtime import of the root export, naming file, line and statement and saying what to do instead.

It scans `packages/lsp-tools/src` **and** `packages/lsp/src` — the server itself bundles lsp-tools wholesale, and the guard is about where the *next* import could land, not where the current ones are. `@doenet/lsp` has no `@doenet/utils` import today; that is the state worth keeping.

The scan **parses** each file with the TypeScript compiler rather than pattern-matching its text. That is what lets it be exact about the forms that matter:

| Form | Verdict |
| --- | --- |
| `import { x } from "@doenet/utils"` | flagged |
| `export { x } from "@doenet/utils"` | flagged |
| `export * from "@doenet/utils"` | flagged |
| `import "@doenet/utils"` (side-effect) | flagged |
| `import("@doenet/utils")` (dynamic) | flagged |
| `import { type Foo } from "@doenet/utils"` (inline type) | flagged — whether it erases turns on the rest of the clause and on compiler settings the scan has no view of, so it is reported and `import type` is the way to say it |
| `import { x } from "@doenet/utils/style"` | allowed — subpath |
| `import type { T } from "@doenet/utils"` (whole statement) | allowed — erased before a bundler sees it |
| `export type { T } from "@doenet/utils"` | allowed — same |
| the specifier in a comment or a string | allowed — not an import at all |

Every row is a case in the file's own `describe("the guard's scan")` block, so the verdicts are pinned by the suite rather than re-derived by hand whenever the scan is touched.

That last row is why the parser earns its place. A text-level regex fires on a specifier that only *appears* in a comment — and the files this guard scans are exactly the ones whose comments discuss the root barrel, `computeContextHelp.ts` included. Parsing also makes the type-only, prettier-wrapped and dynamic forms fall out for free, instead of needing edge-case regexes that have to be re-argued every time they are touched.

The scan also asserts it actually visited files, so it cannot pass silently if the scanned roots are ever moved or renamed out from under it.

A bundle-size assertion would catch more — including the transitive case where a subpath itself grows heavy — but it would have to build the server to do it. This costs nothing and catches the mistake at the point it is made: someone typing the import they are used to.

## Changeset

`.changeset/lsp-utils-subpath-boundary.md` lists `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe` alongside the two VS Code extension packages. The editor packages are there because the shrunk server ships inside them, not merely because they depend on `lsp-tools`.

## Testing

`@doenet/lsp-tools`: 620 pass across 20 files. The guard was mutation-checked both ways — reintroducing the root import in `computeContextHelp.ts` fails it with `lsp-tools/src/context-help/computeContextHelp.ts:6: …`, a root `export *` planted in `packages/lsp/src` fails it too, and a comment naming the barrel does not.

`tsc --noEmit` reports nothing for the new file under either `packages/lsp-tools/tsconfig.json` or `packages/lsp-tools/test/tsconfig.json` — which is what confirms the new subpath resolves its types. (The test tsconfig has pre-existing errors in three other test files, unchanged by this branch.)

`@doenet/utils` builds clean from a removed `dist/`; `@doenet/lsp` and `@doenet/codemirror` build clean. Prettier clean.

## Not here

The third step — actually adding `@doenet/i18n` to `@doenet/utils` — is deliberately separate, so this can land and be judged on its own. Worth noting for whoever reviews that: `@doenet/i18n` depends on no workspace package **by design**, and `translator.ts` says so explicitly, naming `@doenet/utils` as an intended future consumer. So the direction is the one Phase 0 planned for, not a new coupling.

### The `style` chunk, traced

`dist/style.js` is a 2.5 KB rollup *entry*, but it is a pure re-export shim whose entire body is one `import { … } from "./index-NyI5Q1NE.js"` — so entry sizes are the wrong way to read the subpath boundary. What `@doenet/utils/style` actually costs, measured by bundling exactly the symbols `resolve-active-style.ts` imports, is 58,277 B raw / 15,387 B gzipped — genuinely-used palette, style-definition and colour-word code, not dead weight.

The part that matters for #1518 shakes out cleanly: `insufficient contrast`, `contrastAccessibilityDiagnosticsForStyleDefinitions` and `compositedContrastRatio` are all **absent** from that bundle, matching the built language server containing none of them either.

So the shared chunk is not a defect to fix: rollup splits it, and the consuming bundler recovers the separation. It does mean the boundary rests on downstream tree-shaking rather than on the dist layout — which is the argument for the test in this PR rather than trusting the entry sizes. It also settles step 3 empirically: since `styleContrastAccessibility.ts` is shaken out of the language server entirely, giving it an `@doenet/i18n` import **cannot** reach that bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

