### PR TITLE
Fail the build when the standalone bundles grow silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,15 @@ jobs:
               run: |
                   export NODE_OPTIONS="--max_old_space_size=6114"
                   npm run build:all-no-docs
+              # set the environmental variable WIREIT_CACHE="local" so that the wireit cache is saved in the .wireit directory.
+              env:
+                  WIREIT_CACHE: "local"
 
             # The standalone bundles have grown by megabytes before, when the
             # Rust core ended up inlined twice, and nothing failed. Checked here
             # rather than in a test job because this is where the bundles exist.
             - name: Check standalone bundle size
-              run: npm run check:size --workspace packages/standalone
-              # set the environmental variable WIREIT_CACHE="local" so that the wireit cache is saved in the .wireit directory.
-              env:
-                  WIREIT_CACHE: "local"
+              run: npm run check:size -w packages/standalone
 
             - name: Debug Build Artifacts
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,10 @@ jobs:
               env:
                   WIREIT_CACHE: "local"
 
-            # The standalone bundles have grown by megabytes before, when the
-            # Rust core ended up inlined twice, and nothing failed. Checked here
-            # rather than in a test job because this is where the bundles exist.
+            # The standalone bundle has carried megabytes it should not have
+            # before — the Rust core was inlined into it until #1465 — and
+            # nothing failed. Checked here rather than in a test job because
+            # this is where the bundles exist.
             - name: Check standalone bundle size
               run: npm run check:size -w packages/standalone
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
               run: |
                   export NODE_OPTIONS="--max_old_space_size=6114"
                   npm run build:all-no-docs
+
+            # The standalone bundles have grown by megabytes before, when the
+            # Rust core ended up inlined twice, and nothing failed. Checked here
+            # rather than in a test job because this is where the bundles exist.
+            - name: Check standalone bundle size
+              run: npm run check:size --workspace packages/standalone
               # set the environmental variable WIREIT_CACHE="local" so that the wireit cache is saved in the .wireit directory.
               env:
                   WIREIT_CACHE: "local"

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -1,21 +1,15 @@
 {
     "comment": [
-        "Size ceilings for the built standalone bundles, in bytes, checked by",
-        "`npm run check:size -w packages/standalone` and by CI right after the",
-        "build. Growth is fine — silent growth is not. Raising a number here in",
-        "the same commit that causes it is the whole point: it puts the increase",
-        "in the diff where a reviewer can see it and ask about it.",
+        "Size ceilings in bytes for the built standalone bundles, enforced by",
+        "`npm run check:size -w packages/standalone`. See",
+        "`scripts/check-bundle-size.mjs` for what else that check does and why.",
         "",
-        "The budgets sit 7–8% above the sizes recorded in `observedBytes`, so",
-        "ordinary feature work does not trip them and a duplicated dependency",
-        "does. `observedBytes` is the size at the moment `maxBytes` was chosen:",
-        "documentation, not a second threshold — nothing enforces it — and what",
-        "makes the headroom in a raised `maxBytes` reviewable. Update the two",
-        "together.",
-        "",
-        "Only these files have ceilings. The separate check that the Rust core is",
-        "inlined exactly once, and only in the worker, scans every script under",
-        "`dist/`, budgeted or not — see `scripts/check-bundle-size.mjs`."
+        "Growth is fine; silent growth is not. Raising a `maxBytes` in the same",
+        "commit that causes the growth is the point — it puts the increase in",
+        "the diff where a reviewer can ask about it. Update `observedBytes` in",
+        "the same edit so the new headroom is visible: it records the size when",
+        "`maxBytes` was chosen and is documentation only, enforced by nothing.",
+        "Today's budgets sit 7–8% above it."
     ],
     "files": {
         "dist/doenet-standalone.js": {
@@ -26,7 +20,7 @@
         "dist/doenetml-worker/index.js": {
             "maxBytes": 15950000,
             "observedBytes": 14889393,
-            "note": "Carries the Rust core as a single inlined base64 wasm blob (~8.6 MB)."
+            "note": "Carries the Rust core as a single inlined base64 wasm blob (~8.3 MiB)."
         }
     }
 }

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -1,14 +1,23 @@
 {
     "comment": [
         "Size ceilings for the built standalone bundles, in bytes, checked by",
-        "`npm run check:size -w @doenet/standalone` and by CI right after the",
+        "`npm run check:size -w packages/standalone` and by CI right after the",
         "build. Growth is fine — silent growth is not. Raising a number here in",
         "the same commit that causes it is the whole point: it puts the increase",
         "in the diff where a reviewer can see it and ask about it.",
         "",
         "The budgets carry roughly 8% headroom over the sizes at the time they",
         "were set, so ordinary feature work does not trip them and a duplicated",
-        "dependency does."
+        "dependency does.",
+        "",
+        "`observedBytes` records the size at the moment `maxBytes` was chosen. It",
+        "is documentation, not a second threshold — nothing enforces it — and it",
+        "is what makes the headroom in a raised `maxBytes` reviewable. Update it",
+        "alongside `maxBytes`.",
+        "",
+        "Only these files have ceilings. The separate check that the Rust core is",
+        "inlined exactly once scans every script under `dist/`, budgeted or not,",
+        "so a copy landing in a newly emitted chunk is still caught."
     ],
     "files": {
         "dist/doenet-standalone.js": {

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -6,28 +6,26 @@
         "the same commit that causes it is the whole point: it puts the increase",
         "in the diff where a reviewer can see it and ask about it.",
         "",
-        "The budgets carry roughly 8% headroom over the sizes at the time they",
-        "were set, so ordinary feature work does not trip them and a duplicated",
-        "dependency does.",
-        "",
-        "`observedBytes` records the size at the moment `maxBytes` was chosen. It",
-        "is documentation, not a second threshold — nothing enforces it — and it",
-        "is what makes the headroom in a raised `maxBytes` reviewable. Update it",
-        "alongside `maxBytes`.",
+        "The budgets sit 7–8% above the sizes recorded in `observedBytes`, so",
+        "ordinary feature work does not trip them and a duplicated dependency",
+        "does. `observedBytes` is the size at the moment `maxBytes` was chosen:",
+        "documentation, not a second threshold — nothing enforces it — and what",
+        "makes the headroom in a raised `maxBytes` reviewable. Update the two",
+        "together.",
         "",
         "Only these files have ceilings. The separate check that the Rust core is",
-        "inlined exactly once scans every script under `dist/`, budgeted or not,",
-        "so a copy landing in a newly emitted chunk is still caught."
+        "inlined exactly once, and only in the worker, scans every script under",
+        "`dist/`, budgeted or not — see `scripts/check-bundle-size.mjs`."
     ],
     "files": {
         "dist/doenet-standalone.js": {
             "maxBytes": 15650000,
-            "observedBytes": 14487097,
+            "observedBytes": 14489401,
             "note": "No WebAssembly belongs in this bundle; the worker owns it."
         },
         "dist/doenetml-worker/index.js": {
             "maxBytes": 15950000,
-            "observedBytes": 14761863,
+            "observedBytes": 14889393,
             "note": "Carries the Rust core as a single inlined base64 wasm blob (~8.6 MB)."
         }
     }

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -1,0 +1,25 @@
+{
+    "comment": [
+        "Size ceilings for the built standalone bundles, in bytes, checked by",
+        "`npm run check:size -w @doenet/standalone` and by CI right after the",
+        "build. Growth is fine — silent growth is not. Raising a number here in",
+        "the same commit that causes it is the whole point: it puts the increase",
+        "in the diff where a reviewer can see it and ask about it.",
+        "",
+        "The budgets carry roughly 8% headroom over the sizes at the time they",
+        "were set, so ordinary feature work does not trip them and a duplicated",
+        "dependency does."
+    ],
+    "files": {
+        "dist/doenet-standalone.js": {
+            "maxBytes": 15650000,
+            "observedBytes": 14487097,
+            "note": "No WebAssembly belongs in this bundle; the worker owns it."
+        },
+        "dist/doenetml-worker/index.js": {
+            "maxBytes": 15950000,
+            "observedBytes": 14761863,
+            "note": "Carries the Rust core as a single inlined base64 wasm blob (~8.6 MB)."
+        }
+    }
+}

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -24,6 +24,7 @@
     "scripts": {
         "dev": "vite",
         "build": "wireit",
+        "check:size": "node scripts/check-bundle-size.mjs",
         "test": "echo \"No tests \"",
         "preview": "vite preview",
         "publish": "npm run build && node ../../.github/scripts/npm-publish-with-retry.mjs dist"

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -25,7 +25,7 @@
         "dev": "vite",
         "build": "wireit",
         "check:size": "node scripts/check-bundle-size.mjs",
-        "test": "echo \"No tests \"",
+        "test": "vitest",
         "preview": "vite preview",
         "publish": "npm run build && node ../../.github/scripts/npm-publish-with-retry.mjs dist"
     },

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -1,0 +1,135 @@
+/**
+ * Guards the built standalone bundles against silent growth, and against the
+ * specific way they have grown before: a second copy of the Rust core.
+ *
+ * The core ships as a single base64 `data:application/wasm` URI inlined into
+ * the worker bundle — roughly 8.6 MB of the worker's 14.8 MB. When a build or
+ * dependency change causes that blob to be emitted twice, or to be pulled into
+ * `doenet-standalone.js` as well, the bundle grows by megabytes and nothing
+ * fails. That has happened more than once.
+ *
+ * Two checks, doing different jobs:
+ *
+ *  - The duplication check needs no threshold and never needs adjusting. The
+ *    wasm blob is meant to exist exactly once, in the worker, and any other
+ *    arrangement is a bug rather than a judgement call.
+ *  - The size budgets in `bundle-budgets.json` catch the general case the
+ *    first check cannot see — a heavy dependency, a duplicated copy of
+ *    something that is not wasm. They are expected to be raised as the project
+ *    grows; the point is that raising one lands in the diff.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+);
+const BUDGETS_FILE = path.join(PACKAGE_ROOT, "bundle-budgets.json");
+
+/** A base64 run long enough that nothing but an embedded binary explains it. */
+const BIG_BLOB_MIN = 1_000_000;
+const WASM_URI = /data:application\/wasm;base64/g;
+
+/**
+ * Count maximal base64 runs of at least {@link BIG_BLOB_MIN} characters.
+ *
+ * Scanned by hand rather than with `/[A-Za-z0-9+/]{1000000,}/`, which throws
+ * `RangeError: Maximum call stack size exceeded` on a string this size — the
+ * bundles are ~15 MB and the engine backtracks itself to death. A single pass
+ * costs nothing and cannot blow up.
+ */
+function countBigBlobs(text) {
+    let count = 0;
+    let run = 0;
+    for (let i = 0; i < text.length; i++) {
+        const c = text.charCodeAt(i);
+        const isBase64 =
+            (c >= 48 && c <= 57) || // 0-9
+            (c >= 65 && c <= 90) || // A-Z
+            (c >= 97 && c <= 122) || // a-z
+            c === 43 || // +
+            c === 47; // /
+        if (isBase64) {
+            run++;
+        } else {
+            if (run >= BIG_BLOB_MIN) {
+                count++;
+            }
+            run = 0;
+        }
+    }
+    return run >= BIG_BLOB_MIN ? count + 1 : count;
+}
+
+function mib(bytes) {
+    return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+const budgets = JSON.parse(fs.readFileSync(BUDGETS_FILE, "utf-8"));
+const problems = [];
+const report = [];
+
+let totalWasmUris = 0;
+let totalBigBlobs = 0;
+
+for (const [relative, budget] of Object.entries(budgets.files)) {
+    const file = path.join(PACKAGE_ROOT, relative);
+    if (!fs.existsSync(file)) {
+        problems.push(
+            `${relative} does not exist — build the package before checking its size ` +
+                `(\`npm run build -w @doenet/standalone\`).`,
+        );
+        continue;
+    }
+
+    const contents = fs.readFileSync(file, "utf-8");
+    const size = Buffer.byteLength(contents);
+    const wasmUris = contents.match(WASM_URI)?.length ?? 0;
+    const bigBlobs = countBigBlobs(contents);
+    totalWasmUris += wasmUris;
+    totalBigBlobs += bigBlobs;
+
+    report.push(
+        `  ${relative}\n` +
+            `      ${mib(size)} of ${mib(budget.maxBytes)} budget` +
+            `  (${((size / budget.maxBytes) * 100).toFixed(1)}%)` +
+            `, ${wasmUris} wasm URI(s), ${bigBlobs} inlined blob(s)`,
+    );
+
+    if (size > budget.maxBytes) {
+        problems.push(
+            `${relative} is ${mib(size)}, over its ${mib(budget.maxBytes)} budget by ` +
+                `${mib(size - budget.maxBytes)}.\n` +
+                `    If the growth is intended, raise "maxBytes" for this file in\n` +
+                `    packages/standalone/bundle-budgets.json in the same commit, so the\n` +
+                `    increase is visible in review. If it is not intended, something was\n` +
+                `    pulled in twice — compare against the previous build before raising it.`,
+        );
+    }
+}
+
+// The core belongs to the worker, exactly once. `doenet-standalone.js` should
+// carry no copy of it at all.
+if (totalWasmUris !== 1 || totalBigBlobs !== 1) {
+    problems.push(
+        `Expected exactly one inlined wasm blob across the standalone output, in the\n` +
+            `    worker bundle. Found ${totalWasmUris} wasm data-URI(s) and ${totalBigBlobs} large inlined\n` +
+            `    blob(s). More than one means the Rust core was bundled twice, which adds\n` +
+            `    megabytes; one in doenet-standalone.js means it leaked out of the worker.`,
+    );
+}
+
+console.log("standalone bundle sizes:");
+console.log(report.join("\n"));
+
+if (problems.length > 0) {
+    console.error(`\n${problems.length} problem(s):\n`);
+    for (const problem of problems) {
+        console.error(`  - ${problem}\n`);
+    }
+    process.exit(1);
+}
+
+console.log("\nwithin budget, and the core is inlined exactly once.");

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -3,16 +3,16 @@
  * specific way they have grown before: a second copy of the Rust core.
  *
  * The core ships as a single base64 `data:application/wasm` URI inlined into
- * the worker bundle — roughly 8.6 MB of the worker's 14.8 MB. When a build or
+ * the worker bundle — roughly 8.6 MB of the worker's 14.2 MB. When a build or
  * dependency change causes that blob to be emitted twice, or to be pulled into
  * `doenet-standalone.js` as well, the bundle grows by megabytes and nothing
  * fails. That has happened more than once.
  *
  * Two checks, doing different jobs:
  *
- *  - The duplication check needs no threshold and never needs adjusting. The
- *    wasm blob is meant to exist exactly once, in the worker, and any other
- *    arrangement is a bug rather than a judgement call. It scans *every*
+ *  - The placement check needs no threshold and never needs adjusting. The
+ *    core is meant to sit in {@link WASM_CORE_SCRIPT} and nowhere else, and any
+ *    other arrangement is a bug rather than a judgement call. It scans *every*
  *    emitted script under `dist/`, not just the budgeted ones, so a copy that
  *    lands in a newly emitted chunk is still caught.
  *  - The size budgets in `bundle-budgets.json` catch the general case the
@@ -23,7 +23,10 @@
  * Run via `npm run check:size -w packages/standalone`. Exits non-zero, and
  * prints every problem it found rather than just the first, when a bundle is
  * over budget, when a budgeted file is missing, when `bundle-budgets.json` is
- * unusable, or when the wasm blob is not inlined exactly once.
+ * unusable, or when the core is not inlined exactly once in the right script.
+ *
+ * The exported helpers exist so `check-bundle-size.test.mjs` can exercise the
+ * decision logic against synthetic bundles; only `main()` touches `dist/`.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -36,9 +39,19 @@ const PACKAGE_ROOT = path.resolve(
 const BUDGETS_FILE = path.join(PACKAGE_ROOT, "bundle-budgets.json");
 const DIST_DIR = path.join(PACKAGE_ROOT, "dist");
 
+/**
+ * The one emitted script that is supposed to carry the inlined core. It is
+ * copied here from `@doenet/doenetml-worker` by `viteStaticCopy` in
+ * `vite.config.ts`; if that destination changes, change this key and the
+ * matching one in `bundle-budgets.json` together.
+ */
+export const WASM_CORE_SCRIPT = "dist/doenetml-worker/index.js";
+
 /** A base64 run long enough that nothing but an embedded binary explains it. */
 const BIG_BLOB_MIN = 1_000_000;
 const WASM_URI = /data:application\/wasm;base64/g;
+/** Emitted JavaScript, in any extension a bundler might choose. */
+const SCRIPT_EXTENSION = /\.[cm]?js$/;
 
 /**
  * Count maximal base64 runs of at least {@link BIG_BLOB_MIN} characters.
@@ -48,7 +61,7 @@ const WASM_URI = /data:application\/wasm;base64/g;
  * bundles are ~15 MB and the engine backtracks itself to death. A single pass
  * costs nothing and cannot blow up.
  */
-function countBigBlobs(text) {
+export function countBigBlobs(text) {
     let count = 0;
     let run = 0;
     for (let i = 0; i < text.length; i++) {
@@ -76,16 +89,16 @@ function mib(bytes) {
 }
 
 /**
- * Every `.js` file under `dist/`, keyed by its path relative to the package
- * root (matching the keys in `bundle-budgets.json`).
+ * Every emitted script under `dist/`, keyed by its path relative to the
+ * package root (matching the keys in `bundle-budgets.json`).
  *
  * Deliberately limited to scripts. Source maps (`*.js.map`) embed the very
  * blob they map, so counting them would report the core twice for a correct
  * build, and `dist/style.css` legitimately carries a ~1 MB base64 run of its
  * own (an inlined SVG webfont) that the blob heuristic cannot tell apart from
- * wasm. Only scripts can actually ship a duplicated Rust core.
+ * wasm. Only a script can actually execute a duplicated Rust core.
  */
-function collectEmittedScripts(dir) {
+export function collectEmittedScripts(dir = DIST_DIR) {
     const scripts = new Map();
     if (!fs.existsSync(dir)) {
         return scripts;
@@ -94,11 +107,12 @@ function collectEmittedScripts(dir) {
         withFileTypes: true,
         recursive: true,
     })) {
-        if (!entry.isFile() || !entry.name.endsWith(".js")) {
+        if (!entry.isFile() || !SCRIPT_EXTENSION.test(entry.name)) {
             continue;
         }
         const file = path.join(entry.parentPath, entry.name);
-        const contents = fs.readFileSync(file, "utf-8");
+        const buffer = fs.readFileSync(file);
+        const contents = buffer.toString("utf-8");
         // Keyed with forward slashes on every platform, so the keys in
         // `bundle-budgets.json` match on Windows too.
         const relative = path
@@ -106,7 +120,7 @@ function collectEmittedScripts(dir) {
             .split(path.sep)
             .join("/");
         scripts.set(relative, {
-            size: fs.statSync(file).size,
+            size: buffer.length,
             wasmUris: contents.match(WASM_URI)?.length ?? 0,
             bigBlobs: countBigBlobs(contents),
         });
@@ -121,14 +135,16 @@ function collectEmittedScripts(dir) {
  * which is `false` — the file would be reported as within a `NaN MiB` budget
  * and the check would pass. A budget that silently stops guarding is worse
  * than no budget at all.
+ *
+ * @returns the `files` entries, as `[relativePath, budget]` pairs.
  */
-function loadBudgets() {
+export function loadBudgets(budgetsFile = BUDGETS_FILE) {
     let parsed;
     try {
-        parsed = JSON.parse(fs.readFileSync(BUDGETS_FILE, "utf-8"));
+        parsed = JSON.parse(fs.readFileSync(budgetsFile, "utf-8"));
     } catch (e) {
         throw new Error(
-            `Could not read ${path.relative(PACKAGE_ROOT, BUDGETS_FILE)}: ${e.message}`,
+            `Could not read ${path.relative(PACKAGE_ROOT, budgetsFile)}: ${e.message}`,
         );
     }
     const files = parsed?.files;
@@ -155,17 +171,51 @@ function loadBudgets() {
     return entries;
 }
 
-function main() {
-    const budgets = loadBudgets();
-    const scripts = collectEmittedScripts(DIST_DIR);
+/**
+ * Describe a script whose inlined-blob count is not what it should be.
+ *
+ * `expected` is 1 for {@link WASM_CORE_SCRIPT} and 0 for everything else, so
+ * the two wordings cover every script.
+ */
+function blobPlacementProblem(relative, emitted, expected) {
+    const observed =
+        `${emitted.wasmUris} wasm data-URI(s) and ` +
+        `${emitted.bigBlobs} large inlined blob(s)`;
+    if (expected === 1) {
+        return (
+            `${relative} should carry the Rust core exactly once, but has ${observed}.\n` +
+            `    Zero means the core stopped being inlined — the worker would then have to\n` +
+            `    fetch it at runtime, which standalone hosting cannot do. More than one\n` +
+            `    means it was bundled twice, which adds megabytes.`
+        );
+    }
+    return (
+        `${relative} should carry no inlined binary — the Rust core belongs to\n` +
+        `    ${WASM_CORE_SCRIPT} alone — but has ${observed}.\n` +
+        `    A wasm URI here means the core leaked out of the worker or was bundled\n` +
+        `    twice. A large blob without one means some other multi-megabyte asset is\n` +
+        `    now inlined into JavaScript. Either way it should be a deliberate change.`
+    );
+}
+
+/**
+ * Compare the emitted scripts against the budgets, without touching the disk
+ * or the process.
+ *
+ * @param budgets `[relativePath, budget]` pairs, as returned by
+ *   {@link loadBudgets}.
+ * @param scripts the emitted scripts, as returned by
+ *   {@link collectEmittedScripts}.
+ * @returns `report` lines describing every emitted script, and `problems`
+ *   describing everything that should fail the build.
+ */
+export function findProblems(budgets, scripts) {
     const problems = [];
     const report = [];
-    let anyBudgetedFileMissing = false;
 
     for (const [relative, budget] of budgets) {
         const emitted = scripts.get(relative);
         if (!emitted) {
-            anyBudgetedFileMissing = true;
             problems.push(
                 `${relative} does not exist — build the package before checking its size ` +
                     `(\`npm run build -w packages/standalone\`).`,
@@ -182,8 +232,8 @@ function main() {
 
         if (emitted.size > budget.maxBytes) {
             problems.push(
-                `${relative} is ${mib(emitted.size)}, over its ${mib(budget.maxBytes)} budget by ` +
-                    `${mib(emitted.size - budget.maxBytes)}.\n` +
+                `${relative} is ${mib(emitted.size)} (${emitted.size} bytes), over its ` +
+                    `${mib(budget.maxBytes)} budget by ${mib(emitted.size - budget.maxBytes)}.\n` +
                     `    If the growth is intended, raise "maxBytes" for this file in\n` +
                     `    packages/standalone/bundle-budgets.json in the same commit, so the\n` +
                     `    increase is visible in review. If it is not intended, something was\n` +
@@ -207,30 +257,33 @@ function main() {
         }
     }
 
-    let totalWasmUris = 0;
-    let totalBigBlobs = 0;
-    for (const emitted of scripts.values()) {
-        totalWasmUris += emitted.wasmUris;
-        totalBigBlobs += emitted.bigBlobs;
+    // Where the core sits, not just how many copies exist: a single copy in
+    // the wrong script is as much a bug as two copies, and a total-only count
+    // cannot tell them apart.
+    for (const [relative, emitted] of scripts) {
+        const expected = relative === WASM_CORE_SCRIPT ? 1 : 0;
+        if (emitted.wasmUris !== expected || emitted.bigBlobs !== expected) {
+            problems.push(blobPlacementProblem(relative, emitted, expected));
+        }
     }
-
-    // The core belongs to the worker, exactly once. `doenet-standalone.js`
-    // should carry no copy of it at all. Only meaningful once the build has
-    // actually produced its bundles: on a half-built `dist/` the counts would
-    // be zero and the message would blame duplication for a missing build.
-    if (
-        !anyBudgetedFileMissing &&
-        (totalWasmUris !== 1 || totalBigBlobs !== 1)
-    ) {
+    // An unbuilt `dist/` has no scripts to check, and the budget loop above has
+    // already said to build; only complain about the core going missing once
+    // there is a build to complain about.
+    if (scripts.size > 0 && !scripts.has(WASM_CORE_SCRIPT)) {
         problems.push(
-            `Expected exactly one inlined wasm blob across the standalone scripts, in\n` +
-                `    the worker bundle. Found ${totalWasmUris} wasm data-URI(s) and ${totalBigBlobs} large inlined\n` +
-                `    blob(s). More than one means the Rust core was bundled twice, which adds\n` +
-                `    megabytes; one in doenet-standalone.js means it leaked out of the worker.\n` +
-                `    Zero means the core stopped being inlined at all — the worker would\n` +
-                `    then have to fetch it at runtime, which standalone hosting cannot do.`,
+            `${WASM_CORE_SCRIPT} was not emitted, so nothing carries the Rust core.\n` +
+                `    The worker bundle is copied into \`dist/\` by vite.config.ts; if it moved,\n` +
+                `    update WASM_CORE_SCRIPT in this script and the key in bundle-budgets.json.`,
         );
     }
+
+    return { report, problems };
+}
+
+function main() {
+    const budgets = loadBudgets();
+    const scripts = collectEmittedScripts();
+    const { report, problems } = findProblems(budgets, scripts);
 
     console.log("standalone bundle sizes:");
     console.log(report.join("\n"));
@@ -246,11 +299,20 @@ function main() {
     console.log("\nwithin budget, and the core is inlined exactly once.");
 }
 
-try {
-    main();
-} catch (e) {
-    // A configuration error is a failure of the check, not a stack trace to
-    // decipher in a CI log.
-    console.error(`\nbundle size check could not run:\n\n  - ${e.message}\n`);
-    process.exit(1);
+// Only when run as a command; importing this module (from its test) must not
+// check the real `dist/` or exit the process.
+if (
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+    try {
+        main();
+    } catch (e) {
+        // A configuration error is a failure of the check, not a stack trace to
+        // decipher in a CI log.
+        console.error(
+            `\nbundle size check could not run:\n\n  - ${e.message}\n`,
+        );
+        process.exit(1);
+    }
 }

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -1,12 +1,15 @@
 /**
  * Guards the built standalone bundles against silent growth, and against the
- * specific way they have grown before: a second copy of the Rust core.
+ * specific way they have grown before: the Rust core sitting somewhere it does
+ * not belong.
  *
  * The core ships as a single base64 `data:application/wasm` URI inlined into
- * the worker bundle — 8.3 MiB of the worker's 14.2 MiB. When a build or
- * dependency change causes that blob to be emitted twice, or to be pulled into
- * `doenet-standalone.js` as well, the bundle grows by megabytes and nothing
- * fails. That has happened more than once.
+ * the worker bundle — 8.3 MiB of the worker's 14.2 MiB. Until #1465 the whole
+ * worker, that blob included, was inlined into `doenet-standalone.js` instead,
+ * which is why that bundle was ~28 MB rather than today's ~14 MB — and nothing
+ * in the build noticed either its size or where the core had landed. A change
+ * that puts the blob back into `doenet-standalone.js`, or emits it twice, would
+ * be just as quiet.
  *
  * Two checks, doing different jobs:
  *
@@ -185,9 +188,10 @@ function blobPlacementProblem(relative, emitted, expected) {
     if (expected === 1) {
         return (
             `${relative} should carry the Rust core exactly once, but has ${observed}.\n` +
-            `    Zero means the core stopped being inlined — the worker would then have to\n` +
-            `    fetch it at runtime, which standalone hosting cannot do. More than one\n` +
-            `    means it was bundled twice, which adds megabytes.`
+            `    Zero means the core stopped being inlined, and vite.config.ts copies only\n` +
+            `    index.js (+ its map) into dist/ — there is no sibling .wasm left for the\n` +
+            `    worker to fetch. More than one means it was bundled twice, which adds\n` +
+            `    megabytes.`
         );
     }
     return (

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -3,7 +3,7 @@
  * specific way they have grown before: a second copy of the Rust core.
  *
  * The core ships as a single base64 `data:application/wasm` URI inlined into
- * the worker bundle — roughly 8.6 MB of the worker's 14.2 MB. When a build or
+ * the worker bundle — 8.3 MiB of the worker's 14.2 MiB. When a build or
  * dependency change causes that blob to be emitted twice, or to be pulled into
  * `doenet-standalone.js` as well, the bundle grows by megabytes and nothing
  * fails. That has happened more than once.

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -12,11 +12,18 @@
  *
  *  - The duplication check needs no threshold and never needs adjusting. The
  *    wasm blob is meant to exist exactly once, in the worker, and any other
- *    arrangement is a bug rather than a judgement call.
+ *    arrangement is a bug rather than a judgement call. It scans *every*
+ *    emitted script under `dist/`, not just the budgeted ones, so a copy that
+ *    lands in a newly emitted chunk is still caught.
  *  - The size budgets in `bundle-budgets.json` catch the general case the
  *    first check cannot see — a heavy dependency, a duplicated copy of
  *    something that is not wasm. They are expected to be raised as the project
  *    grows; the point is that raising one lands in the diff.
+ *
+ * Run via `npm run check:size -w packages/standalone`. Exits non-zero, and
+ * prints every problem it found rather than just the first, when a bundle is
+ * over budget, when a budgeted file is missing, when `bundle-budgets.json` is
+ * unusable, or when the wasm blob is not inlined exactly once.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -27,6 +34,7 @@ const PACKAGE_ROOT = path.resolve(
     "..",
 );
 const BUDGETS_FILE = path.join(PACKAGE_ROOT, "bundle-budgets.json");
+const DIST_DIR = path.join(PACKAGE_ROOT, "dist");
 
 /** A base64 run long enough that nothing but an embedded binary explains it. */
 const BIG_BLOB_MIN = 1_000_000;
@@ -67,69 +75,182 @@ function mib(bytes) {
     return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
 }
 
-const budgets = JSON.parse(fs.readFileSync(BUDGETS_FILE, "utf-8"));
-const problems = [];
-const report = [];
-
-let totalWasmUris = 0;
-let totalBigBlobs = 0;
-
-for (const [relative, budget] of Object.entries(budgets.files)) {
-    const file = path.join(PACKAGE_ROOT, relative);
-    if (!fs.existsSync(file)) {
-        problems.push(
-            `${relative} does not exist — build the package before checking its size ` +
-                `(\`npm run build -w @doenet/standalone\`).`,
-        );
-        continue;
+/**
+ * Every `.js` file under `dist/`, keyed by its path relative to the package
+ * root (matching the keys in `bundle-budgets.json`).
+ *
+ * Deliberately limited to scripts. Source maps (`*.js.map`) embed the very
+ * blob they map, so counting them would report the core twice for a correct
+ * build, and `dist/style.css` legitimately carries a ~1 MB base64 run of its
+ * own (an inlined SVG webfont) that the blob heuristic cannot tell apart from
+ * wasm. Only scripts can actually ship a duplicated Rust core.
+ */
+function collectEmittedScripts(dir) {
+    const scripts = new Map();
+    if (!fs.existsSync(dir)) {
+        return scripts;
     }
-
-    const contents = fs.readFileSync(file, "utf-8");
-    const size = Buffer.byteLength(contents);
-    const wasmUris = contents.match(WASM_URI)?.length ?? 0;
-    const bigBlobs = countBigBlobs(contents);
-    totalWasmUris += wasmUris;
-    totalBigBlobs += bigBlobs;
-
-    report.push(
-        `  ${relative}\n` +
-            `      ${mib(size)} of ${mib(budget.maxBytes)} budget` +
-            `  (${((size / budget.maxBytes) * 100).toFixed(1)}%)` +
-            `, ${wasmUris} wasm URI(s), ${bigBlobs} inlined blob(s)`,
-    );
-
-    if (size > budget.maxBytes) {
-        problems.push(
-            `${relative} is ${mib(size)}, over its ${mib(budget.maxBytes)} budget by ` +
-                `${mib(size - budget.maxBytes)}.\n` +
-                `    If the growth is intended, raise "maxBytes" for this file in\n` +
-                `    packages/standalone/bundle-budgets.json in the same commit, so the\n` +
-                `    increase is visible in review. If it is not intended, something was\n` +
-                `    pulled in twice — compare against the previous build before raising it.`,
-        );
+    for (const entry of fs.readdirSync(dir, {
+        withFileTypes: true,
+        recursive: true,
+    })) {
+        if (!entry.isFile() || !entry.name.endsWith(".js")) {
+            continue;
+        }
+        const file = path.join(entry.parentPath, entry.name);
+        const contents = fs.readFileSync(file, "utf-8");
+        // Keyed with forward slashes on every platform, so the keys in
+        // `bundle-budgets.json` match on Windows too.
+        const relative = path
+            .relative(PACKAGE_ROOT, file)
+            .split(path.sep)
+            .join("/");
+        scripts.set(relative, {
+            size: fs.statSync(file).size,
+            wasmUris: contents.match(WASM_URI)?.length ?? 0,
+            bigBlobs: countBigBlobs(contents),
+        });
     }
+    return scripts;
 }
 
-// The core belongs to the worker, exactly once. `doenet-standalone.js` should
-// carry no copy of it at all.
-if (totalWasmUris !== 1 || totalBigBlobs !== 1) {
-    problems.push(
-        `Expected exactly one inlined wasm blob across the standalone output, in the\n` +
-            `    worker bundle. Found ${totalWasmUris} wasm data-URI(s) and ${totalBigBlobs} large inlined\n` +
-            `    blob(s). More than one means the Rust core was bundled twice, which adds\n` +
-            `    megabytes; one in doenet-standalone.js means it leaked out of the worker.`,
-    );
+/**
+ * Read `bundle-budgets.json`, rejecting a shape the checks cannot enforce.
+ *
+ * Without this a typo'd or missing `maxBytes` would compare `size > undefined`,
+ * which is `false` — the file would be reported as within a `NaN MiB` budget
+ * and the check would pass. A budget that silently stops guarding is worse
+ * than no budget at all.
+ */
+function loadBudgets() {
+    let parsed;
+    try {
+        parsed = JSON.parse(fs.readFileSync(BUDGETS_FILE, "utf-8"));
+    } catch (e) {
+        throw new Error(
+            `Could not read ${path.relative(PACKAGE_ROOT, BUDGETS_FILE)}: ${e.message}`,
+        );
+    }
+    const files = parsed?.files;
+    if (typeof files !== "object" || files === null || Array.isArray(files)) {
+        throw new Error(
+            `bundle-budgets.json must have a "files" object mapping each bundle path ` +
+                `to a budget.`,
+        );
+    }
+    const entries = Object.entries(files);
+    if (entries.length === 0) {
+        throw new Error(
+            `bundle-budgets.json lists no files, so nothing would be checked.`,
+        );
+    }
+    for (const [relative, budget] of entries) {
+        if (!Number.isFinite(budget?.maxBytes) || budget.maxBytes <= 0) {
+            throw new Error(
+                `bundle-budgets.json entry "${relative}" needs a positive numeric ` +
+                    `"maxBytes"; got ${JSON.stringify(budget?.maxBytes)}.`,
+            );
+        }
+    }
+    return entries;
 }
 
-console.log("standalone bundle sizes:");
-console.log(report.join("\n"));
+function main() {
+    const budgets = loadBudgets();
+    const scripts = collectEmittedScripts(DIST_DIR);
+    const problems = [];
+    const report = [];
+    let anyBudgetedFileMissing = false;
 
-if (problems.length > 0) {
-    console.error(`\n${problems.length} problem(s):\n`);
-    for (const problem of problems) {
-        console.error(`  - ${problem}\n`);
+    for (const [relative, budget] of budgets) {
+        const emitted = scripts.get(relative);
+        if (!emitted) {
+            anyBudgetedFileMissing = true;
+            problems.push(
+                `${relative} does not exist — build the package before checking its size ` +
+                    `(\`npm run build -w packages/standalone\`).`,
+            );
+            continue;
+        }
+
+        report.push(
+            `  ${relative}\n` +
+                `      ${mib(emitted.size)} of ${mib(budget.maxBytes)} budget` +
+                `  (${((emitted.size / budget.maxBytes) * 100).toFixed(1)}%)` +
+                `, ${emitted.wasmUris} wasm URI(s), ${emitted.bigBlobs} inlined blob(s)`,
+        );
+
+        if (emitted.size > budget.maxBytes) {
+            problems.push(
+                `${relative} is ${mib(emitted.size)}, over its ${mib(budget.maxBytes)} budget by ` +
+                    `${mib(emitted.size - budget.maxBytes)}.\n` +
+                    `    If the growth is intended, raise "maxBytes" for this file in\n` +
+                    `    packages/standalone/bundle-budgets.json in the same commit, so the\n` +
+                    `    increase is visible in review. If it is not intended, something was\n` +
+                    `    pulled in twice — compare against the previous build before raising it.`,
+            );
+        }
     }
+
+    // Emitted scripts nobody has put a ceiling on. Not a failure — a new chunk
+    // is a normal thing for the bundler to do — but it is listed so that a
+    // chunk quietly growing into a second multi-megabyte payload is visible,
+    // and so somebody can decide whether it deserves a budget.
+    const budgeted = new Set(budgets.map(([relative]) => relative));
+    for (const [relative, emitted] of scripts) {
+        if (!budgeted.has(relative)) {
+            report.push(
+                `  ${relative}\n` +
+                    `      ${mib(emitted.size)}, no budget` +
+                    `, ${emitted.wasmUris} wasm URI(s), ${emitted.bigBlobs} inlined blob(s)`,
+            );
+        }
+    }
+
+    let totalWasmUris = 0;
+    let totalBigBlobs = 0;
+    for (const emitted of scripts.values()) {
+        totalWasmUris += emitted.wasmUris;
+        totalBigBlobs += emitted.bigBlobs;
+    }
+
+    // The core belongs to the worker, exactly once. `doenet-standalone.js`
+    // should carry no copy of it at all. Only meaningful once the build has
+    // actually produced its bundles: on a half-built `dist/` the counts would
+    // be zero and the message would blame duplication for a missing build.
+    if (
+        !anyBudgetedFileMissing &&
+        (totalWasmUris !== 1 || totalBigBlobs !== 1)
+    ) {
+        problems.push(
+            `Expected exactly one inlined wasm blob across the standalone scripts, in\n` +
+                `    the worker bundle. Found ${totalWasmUris} wasm data-URI(s) and ${totalBigBlobs} large inlined\n` +
+                `    blob(s). More than one means the Rust core was bundled twice, which adds\n` +
+                `    megabytes; one in doenet-standalone.js means it leaked out of the worker.\n` +
+                `    Zero means the core stopped being inlined at all — the worker would\n` +
+                `    then have to fetch it at runtime, which standalone hosting cannot do.`,
+        );
+    }
+
+    console.log("standalone bundle sizes:");
+    console.log(report.join("\n"));
+
+    if (problems.length > 0) {
+        console.error(`\n${problems.length} problem(s):\n`);
+        for (const problem of problems) {
+            console.error(`  - ${problem}\n`);
+        }
+        process.exit(1);
+    }
+
+    console.log("\nwithin budget, and the core is inlined exactly once.");
+}
+
+try {
+    main();
+} catch (e) {
+    // A configuration error is a failure of the check, not a stack trace to
+    // decipher in a CI log.
+    console.error(`\nbundle size check could not run:\n\n  - ${e.message}\n`);
     process.exit(1);
 }
-
-console.log("\nwithin budget, and the core is inlined exactly once.");

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -26,7 +26,8 @@
  * unusable, or when the core is not inlined exactly once in the right script.
  *
  * The exported helpers exist so `check-bundle-size.test.mjs` can exercise the
- * decision logic against synthetic bundles; only `main()` touches `dist/`.
+ * decision logic without a build, against synthetic bundles and throwaway
+ * budgets files; only `main()` reads the real `dist/`.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -98,12 +99,12 @@ function mib(bytes) {
  * own (an inlined SVG webfont) that the blob heuristic cannot tell apart from
  * wasm. Only a script can actually execute a duplicated Rust core.
  */
-export function collectEmittedScripts(dir = DIST_DIR) {
+function collectEmittedScripts() {
     const scripts = new Map();
-    if (!fs.existsSync(dir)) {
+    if (!fs.existsSync(DIST_DIR)) {
         return scripts;
     }
-    for (const entry of fs.readdirSync(dir, {
+    for (const entry of fs.readdirSync(DIST_DIR, {
         withFileTypes: true,
         recursive: true,
     })) {
@@ -216,10 +217,16 @@ export function findProblems(budgets, scripts) {
     for (const [relative, budget] of budgets) {
         const emitted = scripts.get(relative);
         if (!emitted) {
-            problems.push(
-                `${relative} does not exist — build the package before checking its size ` +
-                    `(\`npm run build -w packages/standalone\`).`,
-            );
+            // "Build the package" is the right advice only when there is no
+            // build. If other scripts were emitted and the core-carrying one
+            // was not, the build ran and the file moved — say that once, in
+            // the more specific message below, instead of twice and wrongly.
+            if (relative !== WASM_CORE_SCRIPT || scripts.size === 0) {
+                problems.push(
+                    `${relative} does not exist — build the package before checking its size ` +
+                        `(\`npm run build -w packages/standalone\`).`,
+                );
+            }
             continue;
         }
 

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
 import {
     WASM_CORE_SCRIPT,
     countBigBlobs,
     findProblems,
+    loadBudgets,
 } from "./check-bundle-size.mjs";
 
 const STANDALONE = "dist/doenet-standalone.js";
@@ -119,6 +123,36 @@ describe("findProblems", () => {
         ]);
     });
 
+    // The scenario a version bump could produce: the build ran, but the core
+    // landed under a name nobody budgeted. Saying "build the package" here
+    // would send the reader after a build they already have.
+    it("blames a moved core on the move, not on a missing build", () => {
+        const scripts = new Map([
+            [STANDALONE, script(500)],
+            ["dist/doenetml-worker/index.mjs", script(900, 1)],
+        ]);
+        const problems = problemsFor(scripts);
+        expect(problems).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining("nothing carries the Rust core"),
+                expect.stringContaining("dist/doenetml-worker/index.mjs"),
+            ]),
+        );
+        for (const problem of problems) {
+            expect(problem).not.toContain("build the package");
+        }
+    });
+
+    // Unlike every other case here, the two counts disagree — which is the
+    // only way to tell the `wasmUris || bigBlobs` check from an `&&`.
+    it("rejects a large inlined blob that is not wasm", () => {
+        const scripts = healthyBuild();
+        scripts.set(STANDALONE, { size: 500, wasmUris: 0, bigBlobs: 1 });
+        expect(problemsFor(scripts)).toEqual([
+            expect.stringContaining("should carry no inlined binary"),
+        ]);
+    });
+
     it("lists an unbudgeted chunk without failing on it", () => {
         const scripts = healthyBuild();
         scripts.set("dist/coordinator.js", script(11_000));
@@ -126,5 +160,59 @@ describe("findProblems", () => {
         expect(problems).toEqual([]);
         expect(report.join("\n")).toContain("dist/coordinator.js");
         expect(report.join("\n")).toContain("no budget");
+    });
+});
+
+describe("loadBudgets", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-budgets-"));
+    afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+    /** Write `contents` to a throwaway budgets file and load it. */
+    function load(contents, name) {
+        const file = path.join(tmpDir, `${name}.json`);
+        fs.writeFileSync(file, contents);
+        return () => loadBudgets(file);
+    }
+
+    it("rejects a budgets file that is absent or not JSON", () => {
+        expect(() => loadBudgets(path.join(tmpDir, "absent.json"))).toThrow(
+            /Could not read/,
+        );
+        expect(load("{ not json", "malformed")).toThrow(/Could not read/);
+    });
+
+    it("rejects a budgets file with no usable `files` object", () => {
+        expect(load('{"files": []}', "array")).toThrow(/"files" object/);
+        expect(load("{}", "absent-files")).toThrow(/"files" object/);
+        expect(load('{"files": {}}', "empty")).toThrow(/lists no files/);
+    });
+
+    // The branch that matters most: `size > undefined` is `false`, so without
+    // this the entry would report as within a `NaN MiB` budget and pass.
+    it("rejects an entry whose `maxBytes` could not act as a ceiling", () => {
+        expect(load('{"files":{"a.js":{"maxBytse":1}}}', "typo")).toThrow(
+            /needs a positive numeric "maxBytes"; got undefined/,
+        );
+        expect(load('{"files":{"a.js":{"maxBytes":"1"}}}', "string")).toThrow(
+            /needs a positive numeric "maxBytes"/,
+        );
+        expect(load('{"files":{"a.js":{"maxBytes":0}}}', "zero")).toThrow(
+            /needs a positive numeric "maxBytes"/,
+        );
+    });
+});
+
+describe("the committed bundle-budgets.json", () => {
+    // Everything above runs against synthetic budgets. This is the one check
+    // of the real file, and of the one way its contents can drift out of step
+    // with the script: `WASM_CORE_SCRIPT` and the budget keys are two records
+    // of the same path. Move the worker output and update only one of them and
+    // the placement check still passes while the largest bundle in the package
+    // quietly loses its ceiling — the exact silence this script exists to end.
+    it("puts a ceiling on the script that carries the core", () => {
+        const budgets = loadBudgets();
+        expect(budgets.map(([relative]) => relative)).toContain(
+            WASM_CORE_SCRIPT,
+        );
     });
 });

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -206,9 +206,11 @@ describe("the committed bundle-budgets.json", () => {
     // Everything above runs against synthetic budgets. This is the one check
     // of the real file, and of the one way its contents can drift out of step
     // with the script: `WASM_CORE_SCRIPT` and the budget keys are two records
-    // of the same path. Move the worker output and update only one of them and
-    // the placement check still passes while the largest bundle in the package
-    // quietly loses its ceiling — the exact silence this script exists to end.
+    // of the same path, so relocating the worker output means updating both.
+    // Updating only one does fail the check itself — as a budgeted file that
+    // does not exist, or as a wasm blob in an unexpected script — but only
+    // after a full build, and describing the symptom rather than the cause.
+    // This says it in a second, from the committed files alone.
     it("puts a ceiling on the script that carries the core", () => {
         const budgets = loadBudgets();
         expect(budgets.map(([relative]) => relative)).toContain(

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+    WASM_CORE_SCRIPT,
+    countBigBlobs,
+    findProblems,
+} from "./check-bundle-size.mjs";
+
+const STANDALONE = "dist/doenet-standalone.js";
+
+/** Budgets in the shape `loadBudgets` returns: `[relativePath, budget]` pairs. */
+const BUDGETS = [
+    [STANDALONE, { maxBytes: 1000 }],
+    [WASM_CORE_SCRIPT, { maxBytes: 1000 }],
+];
+
+/** One emitted script. `blobs` is the count of inlined wasm copies it holds. */
+function script(size, blobs = 0) {
+    return { size, wasmUris: blobs, bigBlobs: blobs };
+}
+
+/** A healthy build: the core inlined once, in the worker, both within budget. */
+function healthyBuild() {
+    return new Map([
+        [STANDALONE, script(500)],
+        [WASM_CORE_SCRIPT, script(900, 1)],
+    ]);
+}
+
+function problemsFor(scripts, budgets = BUDGETS) {
+    return findProblems(budgets, scripts).problems;
+}
+
+describe("countBigBlobs", () => {
+    it("ignores base64 runs below the threshold", () => {
+        expect(countBigBlobs("a".repeat(999_999))).toBe(0);
+    });
+
+    it("counts a run that reaches the threshold, including at end of input", () => {
+        expect(countBigBlobs("a".repeat(1_000_000))).toBe(1);
+        expect(countBigBlobs(`"${"a".repeat(1_000_000)}"`)).toBe(1);
+    });
+
+    it("counts each run separately, since a quote breaks the run", () => {
+        const blob = "a".repeat(1_000_000);
+        expect(countBigBlobs(`"${blob}","${blob}"`)).toBe(2);
+    });
+
+    it("does not treat non-base64 characters as part of a run", () => {
+        expect(countBigBlobs("-".repeat(2_000_000))).toBe(0);
+    });
+});
+
+describe("findProblems", () => {
+    it("accepts a healthy build", () => {
+        expect(problemsFor(healthyBuild())).toEqual([]);
+    });
+
+    it("reports a bundle over its budget", () => {
+        const scripts = healthyBuild();
+        scripts.set(STANDALONE, script(1001));
+        expect(problemsFor(scripts)).toEqual([
+            expect.stringContaining("over its"),
+        ]);
+    });
+
+    it("tells you to build when a budgeted file is missing, without blaming the core", () => {
+        const problems = problemsFor(new Map());
+        expect(problems).toHaveLength(2);
+        for (const problem of problems) {
+            expect(problem).toContain("does not exist");
+        }
+    });
+
+    it("rejects a second copy of the core in the standalone bundle", () => {
+        const scripts = healthyBuild();
+        scripts.set(STANDALONE, script(500, 1));
+        expect(problemsFor(scripts)).toEqual([
+            expect.stringContaining("should carry no inlined binary"),
+        ]);
+    });
+
+    it("rejects a copy of the core in an unbudgeted chunk", () => {
+        const scripts = healthyBuild();
+        scripts.set("dist/chunk-abc123.js", script(500, 1));
+        expect(problemsFor(scripts)).toEqual([
+            expect.stringContaining("dist/chunk-abc123.js"),
+        ]);
+    });
+
+    it("rejects the core moving out of the worker, not just being duplicated", () => {
+        const scripts = healthyBuild();
+        scripts.set(STANDALONE, script(500, 1));
+        scripts.set(WASM_CORE_SCRIPT, script(900, 0));
+        expect(problemsFor(scripts)).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(
+                    "should carry the Rust core exactly once",
+                ),
+                expect.stringContaining("should carry no inlined binary"),
+            ]),
+        );
+    });
+
+    it("rejects the core no longer being inlined at all", () => {
+        const scripts = healthyBuild();
+        scripts.set(WASM_CORE_SCRIPT, script(900, 0));
+        expect(problemsFor(scripts)).toEqual([
+            expect.stringContaining("should carry the Rust core exactly once"),
+        ]);
+    });
+
+    it("rejects the core-carrying script disappearing from a build that ran", () => {
+        const scripts = new Map([[STANDALONE, script(500)]]);
+        const problems = problemsFor(scripts, [
+            [STANDALONE, { maxBytes: 1000 }],
+        ]);
+        expect(problems).toEqual([
+            expect.stringContaining("nothing carries the Rust core"),
+        ]);
+    });
+
+    it("lists an unbudgeted chunk without failing on it", () => {
+        const scripts = healthyBuild();
+        scripts.set("dist/coordinator.js", script(11_000));
+        const { report, problems } = findProblems(BUDGETS, scripts);
+        expect(problems).toEqual([]);
+        expect(report.join("\n")).toContain("dist/coordinator.js");
+        expect(report.join("\n")).toContain("no budget");
+    });
+});

--- a/packages/standalone/tsconfig.json
+++ b/packages/standalone/tsconfig.json
@@ -14,6 +14,7 @@
     "exclude": [
         "vite.config.ts",
         "vite.config-coordinator.ts",
+        "vitest.config.ts",
         "node_modules",
         "runner-results",
         ".wireit",

--- a/packages/standalone/vitest.config.ts
+++ b/packages/standalone/vitest.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from "vitest/config";
 
 // The package ships no source tests — it is a bundling target. The one suite
 // here covers `scripts/check-bundle-size.mjs`, the guard that keeps the built
-// bundles from growing silently. Scoped to `scripts/` so vitest never walks the
-// multi-megabyte `dist/` output.
+// bundles from growing silently.
+//
+// This file exists mostly so the test run does not fall back to `vite.config.ts`,
+// which is the lib build: `vite-plugin-dts` and `vite-plugin-static-copy` have no
+// business loading to run a handful of unit tests. (`dist/` needs no exclusion of
+// its own — vitest already ignores `**/dist/**`.)
 export default defineConfig({
     test: {
         environment: "node",

--- a/packages/standalone/vitest.config.ts
+++ b/packages/standalone/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// The package ships no source tests — it is a bundling target. The one suite
+// here covers `scripts/check-bundle-size.mjs`, the guard that keeps the built
+// bundles from growing silently. Scoped to `scripts/` so vitest never walks the
+// multi-megabyte `dist/` output.
+export default defineConfig({
+    test: {
+        environment: "node",
+        include: ["scripts/**/*.test.mjs"],
+    },
+});


### PR DESCRIPTION
Branched from `main`, independent of everything else in flight.

The standalone output has carried megabytes it should not have before, and nothing failed — the bundle was just bigger until somebody noticed. Until #1465 the whole core worker, its inlined wasm blob included, was bundled into `doenet-standalone.js`, which is why that file was ~28 MB rather than today's ~14 MB; no build step objected to either the size or the placement. This makes both failures loud — the core landing back in the wrong file, and the core landing in two files at once.

## Two checks, doing different jobs

**Placement of the core — no threshold, should never need adjusting.** The core ships as a single base64 `data:application/wasm` URI: one blob of 8,744,768 characters — 8.3 MiB of the worker's 14.2 MiB. It belongs in `dist/doenetml-worker/index.js` and nowhere else, so the check is per file — `WASM_CORE_SCRIPT` must hold exactly one, every other emitted script exactly zero. Counting the total instead would pass a build where the core *moved* out of the worker into `doenet-standalone.js`, which is as much a bug as two copies.

It scans **every emitted script under `dist/`** (`.js`, `.mjs`, `.cjs`), budgeted or not, so a copy landing in a newly emitted chunk is still caught. Source maps and `style.css` are deliberately excluded: a map embeds the very blob it maps (a correct build would look like two copies — verified: `doenetml-worker/index.js.map` does contain the URI), and `style.css` legitimately carries a 1,063,192-character base64 run of its own — an inlined SVG webfont the blob heuristic cannot tell apart from wasm. Neither can execute a duplicated core, so neither can hide one.

**Size budgets — expected to move.** `bundle-budgets.json` catches what the placement check cannot see: a heavy dependency, or a duplicate of something that isn't wasm. Both sit 7–8% above today's sizes, so ordinary feature work doesn't trip them. When one does trip, the failure prints the exact byte count and says to raise it *in the same commit* — the goal isn't to prevent growth, it's to put growth in the diff where a reviewer can ask about it.

```
standalone bundle sizes:
  dist/doenet-standalone.js
      13.82 MiB of 14.93 MiB budget  (92.6%), 0 wasm URI(s), 0 inlined blob(s)
  dist/doenetml-worker/index.js
      14.20 MiB of 15.21 MiB budget  (93.4%), 1 wasm URI(s), 1 inlined blob(s)
  dist/coordinator.js
      0.01 MiB, no budget, 0 wasm URI(s), 0 inlined blob(s)

within budget, and the core is inlined exactly once.
```

Unbudgeted chunks are listed but not failed on: a new chunk is a normal thing for a bundler to do, and failing on one would be brittle. A chunk that grows into a second multi-megabyte payload is still visible in the report, and one that carries the core fails outright.

## Fails loudly, never silently

Every way this can go wrong exits non-zero, and all problems are reported rather than just the first:

| Scenario | Result |
| --- | --- |
| Bundle over its budget | fails, names the file, the overage, and the exact byte count |
| Core duplicated into `doenet-standalone.js` | fails |
| Core duplicated into an unbudgeted chunk (`.js`/`.mjs`/`.cjs`) | fails |
| Core *moved* out of the worker rather than duplicated | fails, on both files |
| Core stops being inlined at all | fails |
| The core-carrying script stops being emitted | fails |
| Budgeted file missing / package not built | fails, says to build first, and doesn't blame the core |
| The core-carrying script renamed or relocated by the bundler | fails, names the script that has it now and the two constants to update — and doesn't tell you to build a package you already built |
| `bundle-budgets.json` malformed or absent | fails with one clean line, not a stack trace |
| Budget entry with missing or non-numeric `maxBytes` | fails — it must not quietly stop guarding |

That last row matters: a bare `size > undefined` comparison is `false`, so an unusable budget would otherwise report the file as within a `NaN MiB` budget and pass. Budgets are validated before anything is measured.

## Tests

`scripts/check-bundle-size.test.mjs` covers the decision logic against synthetic bundles — every row of the table above, plus the `countBigBlobs` boundary cases (a run one character short, a run ending at end of input, two runs separated by a quote). The script exports `WASM_CORE_SCRIPT`, `countBigBlobs`, `loadBudgets` and `findProblems` for that, and only runs `main()` when invoked as a command, so importing it never touches the real `dist/`. This is the package's first test suite, so it comes with a `vitest.config.ts`, mostly so the run does not fall back to `vite.config.ts` — the lib build, whose `dts` and `static-copy` plugins have no business loading to run unit tests. It runs in CI as part of `test:all-no-worker-js`, whose hard-coded workspace list already includes `packages/standalone`.

The budget-validation rows of the table are covered against throwaway budgets files written to a temp dir (absent, malformed JSON, `files` missing or an array, empty, and `maxBytes` typo'd / stringly-typed / zero) — that is what `loadBudgets`' `budgetsFile` parameter is for.

One test runs against the committed `bundle-budgets.json` rather than a synthetic one: `WASM_CORE_SCRIPT` and the budget keys are two records of the same path, so relocating the worker output means updating both. Updating only one does fail the check itself — as a budgeted file that does not exist, or as a wasm blob in an unexpected script — but only after a full build, and describing the symptom rather than the cause; the test says it in a second, from the committed files alone. Another pins the distinction between a wasm URI and a large blob — every other case sets the two counts equal, so nothing else would notice the placement check's `||` turning into `&&`.

## Verified against the real failure

I spliced the worker's actual 8,744,797-character wasm URI into the built `doenet-standalone.js` and both checks fired:

```
- dist/doenet-standalone.js is 22.16 MiB (23234216 bytes), over its 14.93 MiB budget by 7.23 MiB.
  ...

- dist/doenet-standalone.js should carry no inlined binary — the Rust core belongs to
  dist/doenetml-worker/index.js alone — but has 1 wasm data-URI(s) and 1 large inlined blob(s).
  ...
```

Then restored the bundle and confirmed it passes again. The check takes ~0.25 s over ~29 MB of output.

Also exercised against a build with the worker output renamed to `doenetml-worker/index.mjs`, standing in for the bundler relocating it — two problems, naming the script that has the core now and the two constants to update, and no advice to build a package that was already built. And against an absent `dist/` (both budgeted files reported missing, no complaint about the core) and a malformed `bundle-budgets.json` (one line, no stack trace). Every failing case exits 1 through `npm run check:size`.

## Placement in CI

Runs in the `build` job right after `build:all-no-docs`, which is where the bundles already exist — a test job would have to rebuild ~15 MB of output to see them. It needs no `env:` of its own; `WIREIT_CACHE: "local"` stays attached to the Build step, where it populates the `.wireit` cache that the downstream jobs consume. The added step is the only change to `ci.yml`.

## Notes

- The blob scan is a hand-written single pass, not `/[A-Za-z0-9+/]{1000000,}/`. That pattern throws `RangeError: Maximum call stack size exceeded` on a 15 MB string, which is precisely the size being checked.
- `observedBytes` in `bundle-budgets.json` is documentation of the size when `maxBytes` was chosen — nothing enforces it — and is what makes the headroom in a raised budget reviewable.
- `dist/style.css` is scanned by neither check and has no budget. It cannot carry a duplicated core, and its own inlined webfont makes the blob heuristic useless on it; growth there is a separate concern from the one this PR is about.
- The rest of the diff is the wiring for that suite: `package.json`'s `test` goes from `echo "No tests "` to `vitest`, and `tsconfig.json` excludes `vitest.config.ts` alongside the two vite configs already listed there.
- Nothing here reaches the published package: `transform-package-json.ts` deletes `scripts` from the emitted `dist/package.json`, and `dist/` is the publish root.
- No changeset: CI and build tooling only. No published package behaves differently, matching how other `ci:` changes in this repo have landed (#1309, #1369, #1514 and others carry none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
