### PR TITLE
Let @doenet/utils raise coded diagnostics

### DIFF
--- a/.changeset/utils-coded-style-diagnostics.md
+++ b/.changeset/utils-coded-style-diagnostics.md
@@ -6,7 +6,8 @@
 "doenet-vscode-extension": patch
 ---
 
-Style-contrast accessibility alerts can now be translated.
+Style-contrast accessibility alerts can now be translated, as can the warning
+that a section selected more than one `<stylePalette>`.
 
 The contrast alerts named the colors they compared — "text color against
 background color", " (dark mode)" — by building the sentence out of English

--- a/.changeset/utils-coded-style-diagnostics.md
+++ b/.changeset/utils-coded-style-diagnostics.md
@@ -1,0 +1,21 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Style-contrast accessibility alerts can now be translated, and the DoenetML
+language server no longer carries message catalogs it never reads.
+
+The contrast alerts named the colors they compared — "text color against
+background color", " (dark mode)" — by building the sentence out of English
+fragments, so no translation could reposition or reword them. The pair and the
+mode are now data the message renders, and the dark-mode advice is a variant of
+the message rather than a second sentence appended to it.
+
+The language server imports the style utilities for something unrelated and
+gained 20 KB gzipped of catalog text as a side effect of that work, with none
+of the code that reads it. The catalogs are now declared side-effect-free, which
+takes the bundle back to its previous size, and the build fails if they return.

--- a/.changeset/utils-coded-style-diagnostics.md
+++ b/.changeset/utils-coded-style-diagnostics.md
@@ -6,8 +6,7 @@
 "doenet-vscode-extension": patch
 ---
 
-Style-contrast accessibility alerts can now be translated, and the DoenetML
-language server no longer carries message catalogs it never reads.
+Style-contrast accessibility alerts can now be translated.
 
 The contrast alerts named the colors they compared — "text color against
 background color", " (dark mode)" — by building the sentence out of English
@@ -15,7 +14,10 @@ fragments, so no translation could reposition or reword them. The pair and the
 mode are now data the message renders, and the dark-mode advice is a variant of
 the message rather than a second sentence appended to it.
 
-The language server imports the style utilities for something unrelated and
-gained 20 KB gzipped of catalog text as a side effect of that work, with none
-of the code that reads it. The catalogs are now declared side-effect-free, which
-takes the bundle back to its previous size, and the build fails if they return.
+Translating them gives the style utilities a runtime dependency on the message
+catalogs, and the DoenetML language server — embedded in the code editor as
+well as in the VS Code extension — imports those utilities for something
+unrelated. That would have added 20 KB gzipped of catalog text to it with none
+of the code that reads it. The catalogs are declared side-effect-free instead,
+so the language server is unchanged byte for byte, and a new build check fails
+if they ever arrive.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             # The language server ships embedded in the code editor as well as
             # in the VS Code extension, so its size is editor startup cost. It
             # also has no locale, so a message catalog reaching it is always a
-            # tree-shaking leak — one arrived this way in #1518.
+            # tree-shaking leak — one nearly arrived this way in #1557.
             - name: Check language server bundle
               run: npm run check:size -w packages/lsp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
             - name: Check standalone bundle size
               run: npm run check:size -w packages/standalone
 
+            # The language server ships embedded in the code editor as well as
+            # in the VS Code extension, so its size is editor startup cost. It
+            # also has no locale, so a message catalog reaching it is always a
+            # tree-shaking leak — one arrived this way in #1518.
+            - name: Check language server bundle
+              run: npm run check:size -w packages/lsp
+
             - name: Debug Build Artifacts
               run: |
                   ls -la ./packages/*/.wireit/ || echo "No .wireit directory found"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26603,6 +26603,7 @@
             "version": "1.0.0",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
+                "@doenet/i18n": "*",
                 "color-name": "^1.1.4",
                 "colord": "^2.9.3",
                 "math-expressions": "^2.0.0-alpha93",

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/styleContrastAccessibility.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/styleContrastAccessibility.test.ts
@@ -317,3 +317,61 @@ describe("Style definition accessibility diagnostics @group4", async () => {
         }
     });
 });
+
+describe("style contrast diagnostics carry their code @group4", async () => {
+    // The English these assert is checked exhaustively above; what is checked
+    // here is the half of the record the main thread renders from. A message
+    // that reads correctly but arrives with no code cannot be translated, and
+    // nothing else in the suite would notice.
+
+    it("names the color pair and the mode as data, not as a phrase", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<styleDefinition styleNumber="9" lineColor="#000000" />
+<styleDefinition styleNumber="9" lineOpacity="0.2" />
+`,
+        });
+
+        const { accessibility } = getDiagnosticsByType(core);
+        expect(accessibility.length).eq(2);
+
+        for (const diagnostic of accessibility) {
+            expect(diagnostic.code).eq("doenet-a0007");
+            // `context` used to be the English phrase itself, concatenated
+            // with a " (dark mode)" suffix. Both are symbolic now, so the
+            // catalog owns every word of the sentence.
+            expect(diagnostic.args?.context).eq("line");
+            expect(diagnostic.args?.styleNumber).eq("9");
+            expect(typeof diagnostic.args?.ratio).eq("number");
+            expect(diagnostic.args?.threshold).eq(3);
+        }
+
+        expect(accessibility.map((d) => d.args?.mode)).toEqual([
+            "light",
+            "dark",
+        ]);
+    });
+
+    it("carries the suggested replacement colors as arguments", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<styleDefinition styleNumber="23" textColor="#a14545" />
+`,
+        });
+
+        const { accessibility } = getDiagnosticsByType(core);
+        const derived = accessibility.filter((d) => d.code === "doenet-a0009");
+        expect(derived.length).eq(1);
+
+        // The advice is a variant of the message rather than a sentence glued
+        // on after it, so which advice applied is readable from the record.
+        expect(derived[0].args?.suggestion).eq("available");
+        expect(derived[0].args?.lightColor).toMatch(/^#/);
+        expect(derived[0].args?.darkColor).toMatch(/^#/);
+        // The colors are DoenetML source and stay as they are in every
+        // language, so they belong in the message as written.
+        expect(derived[0].message).toContain(
+            String(derived[0].args?.darkColor),
+        );
+    });
+});

--- a/packages/doenetml-worker-javascript/src/utils/diagnostics.ts
+++ b/packages/doenetml-worker-javascript/src/utils/diagnostics.ts
@@ -4,72 +4,18 @@ import {
     type DiagnosticArgs,
     type DiagnosticCode,
 } from "@doenet/i18n";
-import type {
-    DiagnosticLevel,
-    DiagnosticRecord,
-    Position,
-} from "@doenet/utils";
 
 /**
- * Build a diagnostic from its stable code and the values that fill it in.
+ * Re-exported from `@doenet/utils`, where it now lives beside the
+ * `DiagnosticRecord` it builds.
  *
- * The alternative to a record whose message is a literal English string. Both
- * shapes are valid records and both keep working — that is what lets the ~200
- * messages still holding a literal migrate a few at a time rather than all at
- * once (#1518). The coded form additionally carries the code and the arguments
- * to the main thread, where the message can be rendered in the reader's
- * language. `packages/i18n/README.md` shows the before and after.
- *
- * Do not write an example call in a comment here: `lint:i18n` counts a `code`
- * property naming a diagnostic code, and a `type` property naming a severity,
- * wherever they appear — comments included — so an illustration would land in
- * the migration burn-down as if it were a real call site.
- *
- * `message` is filled in from the English catalog rather than by the caller,
- * so the English and the catalog cannot drift, and everything that reads
- * `message` inside the worker — the dedupe in `DiagnosticsManager`, the tests
- * that assert exact strings — sees what it saw before. (`DocViewer` re-renders
- * it in `uiLocale` on the way out, which is the whole point; that is the one
- * consumer for which it is deliberately not the same string.)
- *
- * Note that the reader's language is `uiLocale`, not the `documentLocale` the
- * core computes content in: a diagnostic is addressed to whoever is looking at
- * the screen, not to the document. The worker has no business knowing it, and
- * doesn't — it emits English plus the pieces, and the main thread decides.
+ * The worker is no longer the only place that raises a coded diagnostic — the
+ * style-contrast checks in `@doenet/utils` do too — and a record assembled two
+ * different ways in two packages is a record whose shape can drift. Kept
+ * exported from here so the ~150 call sites that import it from this module
+ * are unaffected by where it lives.
  */
-export function codedDiagnostic({
-    type,
-    code,
-    args,
-    position,
-    sourceDoc,
-    level,
-}: {
-    type: DiagnosticRecord["type"];
-    code: DiagnosticCode;
-    args?: DiagnosticArgs;
-    position?: Position;
-    sourceDoc?: number;
-    /** Required when `type` is `"accessibility"`, meaningless otherwise. */
-    level?: DiagnosticLevel;
-}): DiagnosticRecord {
-    // Optional fields are omitted rather than set to `undefined`, so a coded
-    // record has the same shape a legacy one does and anything comparing or
-    // serializing whole records sees no keys that aren't carrying anything.
-    //
-    // The cast is for the accessibility branch: `level` is required there and
-    // meaningless elsewhere, which the caller knows and the union cannot infer
-    // from a `type` that is still the whole union at this point.
-    return {
-        type,
-        message: formatEnglishDiagnostic(code, args),
-        code,
-        ...(args === undefined ? {} : { args }),
-        ...(position === undefined ? {} : { position }),
-        ...(sourceDoc === undefined ? {} : { sourceDoc }),
-        ...(level === undefined ? {} : { level }),
-    } as DiagnosticRecord;
-}
+export { codedDiagnostic } from "@doenet/utils";
 
 /**
  * An error that names its diagnostic by code rather than only by prose.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -364,6 +364,26 @@ Pass `{ list, type: "unit" }` instead of a bare array for a bare enumeration
 ("x, y, z") rather than a conjunction ("x, y, and z") — English distinguishes
 them and other languages distinguish them differently.
 
+## Bundling
+
+`package.json` declares `"sideEffects": false`, and that is load-bearing rather
+than tidiness. The English catalogs are `?raw` imports assembled by a
+module-level call in `catalogs.ts`; without the declaration a bundler has to
+assume that call might do something observable, so it keeps it — and keeping it
+keeps all four FTL files — in **any** bundle that reaches this package for any
+reason, even one where every function has already been tree-shaken away.
+
+That is not hypothetical. When `@doenet/utils` took its runtime dependency on
+this package (#1518), the DoenetML language server gained 20 KB gzipped of
+catalog text without gaining a single line of code that reads it: it imports
+`@doenet/utils/style` for something unrelated, and the strings came along.
+`packages/lsp/scripts/check-server-bundle.mjs` fails the build if they come
+back.
+
+Nothing here registers globals, patches prototypes, or imports for effect, so
+the claim is true today. Anything added that breaks it has to remove the
+declaration and pay the cost everywhere.
+
 ## Commands
 
 ```bash

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -373,11 +373,12 @@ assume that call might do something observable, so it keeps it — and keeping i
 keeps all four FTL files — in **any** bundle that reaches this package for any
 reason, even one where every function has already been tree-shaken away.
 
-That is not hypothetical. When `@doenet/utils` took its runtime dependency on
-this package (#1518), the DoenetML language server gained 20 KB gzipped of
-catalog text without gaining a single line of code that reads it: it imports
-`@doenet/utils/style` for something unrelated, and the strings came along.
-`packages/lsp/scripts/check-server-bundle.mjs` fails the build if they come
+That is not hypothetical — it was measured. When `@doenet/utils` took its
+runtime dependency on this package (#1557), the DoenetML language server grew
+by 20 KB gzipped of catalog text without gaining a single line of code that
+reads it: it imports `@doenet/utils/style` for something unrelated, and the
+strings came along. The declaration is what kept that off `main`, and
+`packages/lsp/scripts/check-server-bundle.mjs` fails the build if it comes
 back.
 
 Nothing here registers globals, patches prototypes, or imports for effect, so

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -227,7 +227,12 @@ sendDiagnostics.push(
 );
 ```
 
-`codedDiagnostic` (in `@doenet/doenetml-worker-javascript/src/utils`) fills
+`codedDiagnostic` lives in `@doenet/utils`, beside the `DiagnosticRecord` it
+builds, because the worker is no longer the only place that raises one — the
+style-contrast checks in that package do too, and a record assembled two
+different ways in two packages is a record whose shape can drift.
+`@doenet/doenetml-worker-javascript/src/utils/diagnostics.ts` re-exports it, so
+the worker's call sites import it from where they always did. It fills
 `message` in from the English catalog, so the English and the catalog cannot
 drift and everything that reads `message` inside the worker — the dedupe in
 `DiagnosticsManager`, the tests that assert exact strings — sees what it saw
@@ -262,7 +267,8 @@ throw new DiagnosticError({
 });
 ```
 
-`DiagnosticError` (alongside `codedDiagnostic`) is an `Error` subclass whose
+`DiagnosticError` (in the worker's `utils/diagnostics.ts`, alongside its
+re-export of `codedDiagnostic`) is an `Error` subclass whose
 `message` comes from the same English catalog, so it drops straight into a
 `throw` site: `instanceof Error` still holds and a `catch` reading `e.message`
 sees what it saw before. `errorComponentState` puts the code and arguments on

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -5,6 +5,9 @@
     "doenet-a0004": "accessibility-answer-input-short-description-or-label",
     "doenet-a0005": "accessibility-short-description-contains-math",
     "doenet-a0006": "accessibility-section-title-insufficient-contrast",
+    "doenet-a0007": "style-definition-insufficient-contrast",
+    "doenet-a0008": "style-definition-dark-mode-text-background-contrast",
+    "doenet-a0009": "style-definition-dark-mode-text-canvas-contrast",
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",
     "doenet-e0003": "attribute-repeated",
@@ -111,5 +114,6 @@
     "doenet-w0079": "conditional-content-condition-ignored",
     "doenet-w0080": "slider-markers-type-mismatch",
     "doenet-w0081": "nested-section-wide-check-work-max-num-attempts",
-    "doenet-w0082": "math-input-invalid-function-names"
+    "doenet-w0082": "math-input-invalid-function-names",
+    "doenet-w0083": "section-multiple-style-palettes"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -420,3 +420,37 @@ component-type-invalid = Invalid component type: `<{ $componentType }>`
 attribute-repeated = Cannot repeat attribute { $attribute }.
 
 attribute-invalid-for-component = Invalid attribute "{ $attribute }" for a component of type `<{ $componentType }>`.
+
+## Style definition contrast
+
+# $context names the pair being compared, $mode which colour scheme it was
+# rendered in. Both are symbolic — the phrase is chosen here so a translator
+# can rewrite it, rather than being handed over already in English.
+style-definition-insufficient-contrast =
+    Style definition { $styleNumber } has insufficient contrast for { $context ->
+        [text-on-background] text color against background color
+        [high-contrast] high-contrast color against the canvas
+        [line] line color against the canvas
+        [marker] marker color against the canvas
+       *[text-on-canvas] text color against the canvas
+    }{ $mode ->
+        [dark] { " (dark mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; requires at least { $threshold }:1).
+
+# $suggestion says whether a concrete replacement colour could be computed.
+# The attribute names and colour values in the `available` branch are
+# DoenetML source, not prose, and stay as they are in every language.
+style-definition-dark-mode-text-background-contrast =
+    Although style definition { $styleNumber } has specified colors that provide sufficient contrast for light mode, the dark-mode colors derived from these values have insufficient contrast for the text color against the background color ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; requires at least { $threshold }:1). { $suggestion ->
+        [available] To ensure sufficient contrast in dark mode, either increase the light-mode contrast (e.g., set { $lightAttribute }="{ $lightColor }") or override the dark-mode color (e.g., set { $darkAttribute }="{ $darkColor }").
+       *[none] To ensure sufficient contrast in dark mode, increase the light-mode contrast or override the derived colors with textColorDarkMode and/or backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Although style definition { $styleNumber } has a specified text color that provides sufficient contrast for light mode, the dark-mode text color derived from this value has insufficient contrast against the canvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; requires at least { $threshold }:1). { $suggestion ->
+        [available] To ensure sufficient contrast in dark mode, either increase the light-mode contrast (e.g., set textColor="{ $lightColor }") or override the dark-mode color (e.g., set textColorDarkMode="{ $darkColor }").
+       *[none] To ensure sufficient contrast in dark mode, increase the light-mode contrast or override the derived color with textColorDarkMode.
+    }
+
+section-multiple-style-palettes = A section can select only one <stylePalette>; using the last one.

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -347,3 +347,31 @@ component-type-invalid = Tipo de componente no válido: `<{ $componentType }>`
 attribute-repeated = No se puede repetir el atributo { $attribute }.
 
 attribute-invalid-for-component = Atributo "{ $attribute }" no válido para un componente de tipo `<{ $componentType }>`.
+
+## Contraste de las definiciones de estilo
+
+style-definition-insufficient-contrast =
+    La definición de estilo { $styleNumber } no tiene suficiente contraste para { $context ->
+        [text-on-background] el color del texto sobre el color de fondo
+        [high-contrast] el color de alto contraste sobre el lienzo
+        [line] el color de las líneas sobre el lienzo
+        [marker] el color de los marcadores sobre el lienzo
+       *[text-on-canvas] el color del texto sobre el lienzo
+    }{ $mode ->
+        [dark] { " (modo oscuro)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; se requiere al menos { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Aunque la definición de estilo { $styleNumber } especifica colores con suficiente contraste en modo claro, los colores de modo oscuro derivados de esos valores no tienen suficiente contraste entre el color del texto y el color de fondo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; se requiere al menos { $threshold }:1). { $suggestion ->
+        [available] Para lograr suficiente contraste en modo oscuro, aumenta el contraste en modo claro (por ejemplo, con { $lightAttribute }="{ $lightColor }") o define el color de modo oscuro (por ejemplo, con { $darkAttribute }="{ $darkColor }").
+       *[none] Para lograr suficiente contraste en modo oscuro, aumenta el contraste en modo claro o sustituye los colores derivados mediante textColorDarkMode o backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Aunque la definición de estilo { $styleNumber } especifica un color de texto con suficiente contraste en modo claro, el color de texto de modo oscuro derivado de ese valor no tiene suficiente contraste sobre el lienzo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; se requiere al menos { $threshold }:1). { $suggestion ->
+        [available] Para lograr suficiente contraste en modo oscuro, aumenta el contraste en modo claro (por ejemplo, con textColor="{ $lightColor }") o define el color de modo oscuro (por ejemplo, con textColorDarkMode="{ $darkColor }").
+       *[none] Para lograr suficiente contraste en modo oscuro, aumenta el contraste en modo claro o sustituye el color derivado mediante textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Una sección solo puede seleccionar un <stylePalette>; se usará el último.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@doenet/i18n",
     "type": "module",
+    "sideEffects": false,
     "description": "Message catalogs and translation utilities for DoenetML",
     "version": "1.0.0",
     "license": "AGPL-3.0-or-later",

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -154,6 +154,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0080": "slider-markers-type-mismatch",
     "doenet-w0081": "nested-section-wide-check-work-max-num-attempts",
     "doenet-w0082": "math-input-invalid-function-names",
+    "doenet-w0083": "section-multiple-style-palettes",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",
@@ -166,6 +167,9 @@ export const DIAGNOSTIC_CODES = {
     "doenet-a0004": "accessibility-answer-input-short-description-or-label",
     "doenet-a0005": "accessibility-short-description-contains-math",
     "doenet-a0006": "accessibility-section-title-insufficient-contrast",
+    "doenet-a0007": "style-definition-insufficient-contrast",
+    "doenet-a0008": "style-definition-dark-mode-text-background-contrast",
+    "doenet-a0009": "style-definition-dark-mode-text-canvas-contrast",
 } as const satisfies Record<string, MessageKey>;
 
 export type DiagnosticCode = keyof typeof DIAGNOSTIC_CODES;

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -225,7 +225,11 @@ export type MessageKey =
     | "math-input-invalid-function-names"
     | "component-type-invalid"
     | "attribute-repeated"
-    | "attribute-invalid-for-component";
+    | "attribute-invalid-for-component"
+    | "style-definition-insufficient-contrast"
+    | "style-definition-dark-mode-text-background-contrast"
+    | "style-definition-dark-mode-text-canvas-contrast"
+    | "section-multiple-style-palettes";
 
 /** Every key in the English catalogs, in catalog order. */
 export const MESSAGE_KEYS: readonly MessageKey[] = [
@@ -448,4 +452,8 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "component-type-invalid",
     "attribute-repeated",
     "attribute-invalid-for-component",
+    "style-definition-insufficient-contrast",
+    "style-definition-dark-mode-text-background-contrast",
+    "style-definition-dark-mode-text-canvas-contrast",
+    "section-multiple-style-palettes",
 ];

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -21,6 +21,7 @@
     "scripts": {
         "watch": "vite build --watch",
         "build": "wireit",
+        "check:size": "node scripts/check-server-bundle.mjs",
         "test": "vitest",
         "compile_grammar": "npx lezer-generator --output src/generated-assets/lezer-doenet.ts src/doenet.grammar"
     },

--- a/packages/lsp/scripts/check-server-bundle.mjs
+++ b/packages/lsp/scripts/check-server-bundle.mjs
@@ -15,16 +15,17 @@
  *    Nothing it does needs a translation, so a catalog in this bundle is
  *    always a leak rather than a judgement call, and needs no threshold.
  *
- *    It leaked once already. `@doenet/utils` took a runtime dependency on
+ *    One nearly arrived. `@doenet/utils` took a runtime dependency on
  *    `@doenet/i18n` so its style-contrast checks could raise coded diagnostics
- *    (#1518), and the server imports `@doenet/utils/style` for something else
+ *    (#1557), and the server imports `@doenet/utils/style` for something else
  *    entirely. Tree-shaking removed the *code* — `formatEnglishDiagnostic` was
  *    nowhere in the output — and left 20 KB gzipped of FTL text behind,
  *    because `@doenet/i18n` had not declared itself side-effect-free and a
  *    bundler must therefore keep every module-level statement in any module it
  *    reaches. Declaring `"sideEffects": false` there took the bundle back to
- *    the byte. Nothing about that is obvious from either package, and the next
- *    dependency to reach the server will not announce itself either.
+ *    the byte, so nothing shipped — but nothing about any of it is obvious
+ *    from either package, and the next dependency to reach the server will not
+ *    announce itself either.
  *
  *  - **A size budget**, in `server-budget.json`. The catalog check only knows
  *    about one payload; the budget catches the general case, including a
@@ -127,14 +128,21 @@ function kib(bytes) {
     return `${(bytes / 1024).toFixed(0)} KiB`;
 }
 
-/** Every problem with `contents` against `maxBytes`, as printable lines. */
+/**
+ * Every problem with `contents` against `maxBytes`, as printable lines.
+ *
+ * `maxBytes` may be `undefined` when the budget file could not be read. Only
+ * the size comparison depends on it: the catalog check does not, and skipping
+ * it because of an unrelated typo would mean a leak only turns up on the run
+ * after the budget is fixed.
+ */
 export function checkBundle({ contents, size, maxBytes }) {
     const problems = catalogLeaksIn(contents).map(
         (leak) =>
             `${leak}. The language server renders no messages; see the header` +
-            ` of this script for how the catalogs got in last time.`,
+            ` of this script for how the catalogs nearly got in last time.`,
     );
-    if (size > maxBytes) {
+    if (maxBytes !== undefined && size > maxBytes) {
         problems.push(
             `dist/index.js is ${kib(size)}, over its ${kib(maxBytes)} budget.` +
                 ` Raising the budget is fine when the growth is intended —` +
@@ -162,15 +170,13 @@ function main() {
     problems.push(...budget.problems);
 
     const buffer = fs.readFileSync(BUNDLE_FILE);
-    if (budget.maxBytes !== undefined) {
-        problems.push(
-            ...checkBundle({
-                contents: buffer.toString("utf-8"),
-                size: buffer.length,
-                maxBytes: budget.maxBytes,
-            }),
-        );
-    }
+    problems.push(
+        ...checkBundle({
+            contents: buffer.toString("utf-8"),
+            size: buffer.length,
+            maxBytes: budget.maxBytes,
+        }),
+    );
 
     if (problems.length > 0) {
         console.error(

--- a/packages/lsp/scripts/check-server-bundle.mjs
+++ b/packages/lsp/scripts/check-server-bundle.mjs
@@ -1,0 +1,193 @@
+/**
+ * Guards the built DoenetML language server against the two ways it has grown
+ * without anyone noticing.
+ *
+ * The server is not only the VS Code extension's: `@doenet/codemirror` embeds
+ * the built IIFE verbatim (`@doenet/lsp/language-server.js?raw`) to start it as
+ * a blob worker, so every byte rides into the editor and sits on the critical
+ * path before the first cursor-help request can be answered. Boot lag here has
+ * surfaced before as a flaky "no help on first cursor change" in CI.
+ *
+ * Two checks, doing different jobs:
+ *
+ *  - **The message catalogs must not be here at all.** The server renders no
+ *    messages — it has no locale, and #1549 is the issue for giving it one.
+ *    Nothing it does needs a translation, so a catalog in this bundle is
+ *    always a leak rather than a judgement call, and needs no threshold.
+ *
+ *    It leaked once already. `@doenet/utils` took a runtime dependency on
+ *    `@doenet/i18n` so its style-contrast checks could raise coded diagnostics
+ *    (#1518), and the server imports `@doenet/utils/style` for something else
+ *    entirely. Tree-shaking removed the *code* — `formatEnglishDiagnostic` was
+ *    nowhere in the output — and left 20 KB gzipped of FTL text behind,
+ *    because `@doenet/i18n` had not declared itself side-effect-free and a
+ *    bundler must therefore keep every module-level statement in any module it
+ *    reaches. Declaring `"sideEffects": false` there took the bundle back to
+ *    the byte. Nothing about that is obvious from either package, and the next
+ *    dependency to reach the server will not announce itself either.
+ *
+ *  - **A size budget**, in `server-budget.json`. The catalog check only knows
+ *    about one payload; the budget catches the general case, including a
+ *    subpath that grows heavy on its own. #1553 cut this bundle roughly in
+ *    half — 2.3 MB to 1.1 MB minified — by routing one import through a
+ *    subpath, and left a note that a size assertion would catch more than its
+ *    import scan could but would have to build the server to do it. CI builds
+ *    everything before this runs, so it can.
+ *
+ * Run via `npm run check:size -w packages/lsp`. Exits non-zero, printing every
+ * problem rather than just the first.
+ *
+ * The exported helpers exist so `check-server-bundle.test.mjs` can exercise the
+ * decision logic without a build; only `main()` reads the real `dist/`.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+);
+const BUDGET_FILE = path.join(PACKAGE_ROOT, "server-budget.json");
+const BUNDLE_FILE = path.join(PACKAGE_ROOT, "dist", "index.js");
+
+/**
+ * Fingerprints of a message catalog or the runtime that reads one.
+ *
+ * Deliberately a mix of the library's identifiers and the catalogs' own text.
+ * An identifier alone would miss exactly the leak that happened, where the
+ * code was shaken out and only the strings survived; catalog text alone would
+ * miss a bundle that carries the Fluent runtime for some other reason. Each
+ * needle names what it proves so the failure says which of the two occurred.
+ */
+export const CATALOG_NEEDLES = [
+    { needle: "FluentBundle", what: "the Fluent runtime" },
+    { needle: "FluentResource", what: "the Fluent runtime" },
+    { needle: "@fluent/bundle", what: "the Fluent runtime" },
+    // A Fluent select expression's default variant: no other content in this
+    // bundle is written in a syntax that looks like this, and it appears
+    // thirteen times in the English diagnostics catalog alone.
+    { needle: "*[other]", what: "FTL catalog source" },
+    // The first line of `locales/en/diagnostics.ftl`, which `?raw` imports
+    // whole — so a bundle carrying that file carries this comment.
+    { needle: "Errors and warnings surfaced", what: "FTL catalog source" },
+    { needle: "formatEnglishDiagnostic", what: "the diagnostic formatter" },
+];
+
+/**
+ * Report every catalog fingerprint present in `contents`, grouped by what it
+ * proves, so one leak produces one line per payload rather than one per
+ * needle.
+ */
+export function catalogLeaksIn(contents) {
+    const byWhat = new Map();
+    for (const { needle, what } of CATALOG_NEEDLES) {
+        if (!contents.includes(needle)) {
+            continue;
+        }
+        if (!byWhat.has(what)) {
+            byWhat.set(what, []);
+        }
+        byWhat.get(what).push(needle);
+    }
+    return [...byWhat].map(
+        ([what, needles]) =>
+            `${what} is in the bundle (found ${needles.map((n) => JSON.stringify(n)).join(", ")})`,
+    );
+}
+
+/**
+ * Read `server-budget.json`, rejecting a shape the check cannot enforce.
+ *
+ * A missing or non-numeric `maxBytes` would compare `size > undefined`, which
+ * is `false`: the bundle would be reported as within a `NaN` budget and the
+ * check would pass. A budget that silently stops guarding is worse than none,
+ * because the passing check is what everyone reads.
+ */
+export function readBudget(text) {
+    let parsed;
+    try {
+        parsed = JSON.parse(text);
+    } catch (error) {
+        return { problems: [`server-budget.json is not valid JSON: ${error}`] };
+    }
+    const maxBytes = parsed?.maxBytes;
+    if (typeof maxBytes !== "number" || !Number.isFinite(maxBytes)) {
+        return {
+            problems: [
+                "server-budget.json needs a numeric `maxBytes`; found " +
+                    JSON.stringify(maxBytes),
+            ],
+        };
+    }
+    return { maxBytes, problems: [] };
+}
+
+function kib(bytes) {
+    return `${(bytes / 1024).toFixed(0)} KiB`;
+}
+
+/** Every problem with `contents` against `maxBytes`, as printable lines. */
+export function checkBundle({ contents, size, maxBytes }) {
+    const problems = catalogLeaksIn(contents).map(
+        (leak) =>
+            `${leak}. The language server renders no messages; see the header` +
+            ` of this script for how the catalogs got in last time.`,
+    );
+    if (size > maxBytes) {
+        problems.push(
+            `dist/index.js is ${kib(size)}, over its ${kib(maxBytes)} budget.` +
+                ` Raising the budget is fine when the growth is intended —` +
+                ` the point is that it lands in the diff.`,
+        );
+    }
+    return problems;
+}
+
+function main() {
+    const problems = [];
+
+    if (!fs.existsSync(BUNDLE_FILE)) {
+        console.error(
+            `No dist/index.js. Build the language server first:` +
+                ` npm run build -w @doenet/lsp`,
+        );
+        process.exit(1);
+    }
+
+    const budgetText = fs.existsSync(BUDGET_FILE)
+        ? fs.readFileSync(BUDGET_FILE, "utf-8")
+        : "";
+    const budget = readBudget(budgetText);
+    problems.push(...budget.problems);
+
+    const buffer = fs.readFileSync(BUNDLE_FILE);
+    if (budget.maxBytes !== undefined) {
+        problems.push(
+            ...checkBundle({
+                contents: buffer.toString("utf-8"),
+                size: buffer.length,
+                maxBytes: budget.maxBytes,
+            }),
+        );
+    }
+
+    if (problems.length > 0) {
+        console.error(
+            `\nLanguage server bundle check found ${problems.length} problem(s):`,
+        );
+        for (const problem of problems) {
+            console.error(`  - ${problem}`);
+        }
+        process.exit(1);
+    }
+
+    console.log(
+        `Language server bundle OK: ${kib(buffer.length)} of` +
+            ` ${kib(budget.maxBytes)}, no message catalogs.`,
+    );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/packages/lsp/scripts/check-server-bundle.test.mjs
+++ b/packages/lsp/scripts/check-server-bundle.test.mjs
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+    CATALOG_NEEDLES,
+    catalogLeaksIn,
+    checkBundle,
+    readBudget,
+} from "./check-server-bundle.mjs";
+
+/** A bundle that carries nothing the checks object to. */
+const CLEAN = `var e=function(t){return t+1};export{e as bump};`;
+
+describe("catalog detection", () => {
+    it("passes a bundle with no catalog in it", () => {
+        expect(catalogLeaksIn(CLEAN)).toEqual([]);
+    });
+
+    it("catches catalog text with the formatter shaken away", () => {
+        // The leak that actually happened: `@doenet/i18n` had not declared
+        // itself side-effect-free, so a bundler kept the module-level
+        // statements — and therefore the `?raw` FTL files — in a bundle whose
+        // only reason to reach the package had already been eliminated. An
+        // identifier-only check would have reported this bundle as clean.
+        const leaked = `${CLEAN}var ftl="# Errors and warnings surfaced to the reader\\nx = { $n ->\\n *[other] many\\n}";`;
+        const problems = catalogLeaksIn(leaked);
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("FTL catalog source");
+        expect(leaked).not.toContain("formatEnglishDiagnostic");
+    });
+
+    it("catches the Fluent runtime with no catalog text", () => {
+        // The other direction: a bundle that pulls the library in for some
+        // reason that has nothing to do with the catalogs.
+        const problems = catalogLeaksIn(`${CLEAN}import{FluentBundle}from"x";`);
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("the Fluent runtime");
+    });
+
+    it("reports one line per payload, not one per needle", () => {
+        // Three runtime fingerprints, one problem — otherwise a single leak
+        // reads like three unrelated failures.
+        const problems = catalogLeaksIn(
+            `FluentBundle FluentResource "@fluent/bundle"`,
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("FluentBundle");
+        expect(problems[0]).toContain("FluentResource");
+    });
+
+    it("names every needle it matched, so the failure is actionable", () => {
+        for (const { needle } of CATALOG_NEEDLES) {
+            expect(catalogLeaksIn(needle)[0]).toContain(JSON.stringify(needle));
+        }
+    });
+});
+
+describe("the size budget", () => {
+    it("passes a bundle at exactly its budget", () => {
+        expect(
+            checkBundle({ contents: CLEAN, size: 1000, maxBytes: 1000 }),
+        ).toEqual([]);
+    });
+
+    it("fails a bundle one byte over", () => {
+        const problems = checkBundle({
+            contents: CLEAN,
+            size: 1001,
+            maxBytes: 1000,
+        });
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("over its");
+    });
+
+    it("reports a size problem and a leak together", () => {
+        // Both checks run; the first failure must not mask the second, or
+        // fixing one turns up the other only on the next CI run.
+        expect(
+            checkBundle({
+                contents: `${CLEAN}FluentBundle`,
+                size: 5000,
+                maxBytes: 1000,
+            }),
+        ).toHaveLength(2);
+    });
+});
+
+describe("reading the budget file", () => {
+    it("accepts a numeric maxBytes", () => {
+        expect(readBudget(`{"maxBytes": 1155000}`)).toEqual({
+            maxBytes: 1155000,
+            problems: [],
+        });
+    });
+
+    it.each([
+        ["not JSON at all", "{"],
+        ["a missing maxBytes", `{"_comment": "oops"}`],
+        ["a string maxBytes", `{"maxBytes": "1155000"}`],
+        ["a NaN maxBytes", `{"maxBytes": null}`],
+    ])("refuses %s rather than passing vacuously", (_case, text) => {
+        // `size > undefined` is `false`, so a malformed budget would report
+        // the bundle as within a `NaN` budget and pass. A check that has
+        // silently stopped guarding is worse than no check, because the green
+        // tick is what everyone reads.
+        const { maxBytes, problems } = readBudget(text);
+        expect(maxBytes).toBeUndefined();
+        expect(problems).toHaveLength(1);
+    });
+});

--- a/packages/lsp/scripts/check-server-bundle.test.mjs
+++ b/packages/lsp/scripts/check-server-bundle.test.mjs
@@ -70,6 +70,20 @@ describe("the size budget", () => {
         expect(problems[0]).toContain("over its");
     });
 
+    it("still checks the catalogs when there is no usable budget", () => {
+        // A typo in `server-budget.json` is not a reason to stop looking for
+        // a leak: the catalog check does not need a threshold, and skipping
+        // it here would surface the leak only on the run after the budget is
+        // fixed — the same masking the previous case rules out.
+        const problems = checkBundle({
+            contents: `${CLEAN}FluentBundle`,
+            size: 5000,
+            maxBytes: undefined,
+        });
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("the Fluent runtime");
+    });
+
     it("reports a size problem and a leak together", () => {
         // Both checks run; the first failure must not mask the second, or
         // fixing one turns up the other only on the next CI run.

--- a/packages/lsp/server-budget.json
+++ b/packages/lsp/server-budget.json
@@ -1,0 +1,15 @@
+{
+    "_comment": [
+        "Size ceiling for the built language server (dist/index.js), checked by",
+        "scripts/check-server-bundle.mjs. The bundle is embedded verbatim in",
+        "@doenet/codemirror and starts as a blob worker, so this is download and",
+        "parse cost on the editor's critical path, not just the VS Code",
+        "extension's.",
+        "",
+        "Set with roughly 8% headroom over the build at the time, so ordinary",
+        "drift does not trip it and a new heavy dependency does. Raising it is",
+        "fine when the growth is intended; the point is that raising it lands in",
+        "the diff and someone has to say why."
+    ],
+    "maxBytes": 1155000
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -59,6 +59,7 @@
         }
     },
     "dependencies": {
+        "@doenet/i18n": "*",
         "color-name": "^1.1.4",
         "colord": "^2.9.3",
         "math-expressions": "^2.0.0-alpha93",

--- a/packages/utils/src/diagnostics/coded.ts
+++ b/packages/utils/src/diagnostics/coded.ts
@@ -1,0 +1,73 @@
+import {
+    formatEnglishDiagnostic,
+    type DiagnosticArgs,
+    type DiagnosticCode,
+} from "@doenet/i18n";
+import type { DiagnosticLevel, DiagnosticRecord, Position } from "./types";
+
+/**
+ * Build a diagnostic from its stable code and the values that fill it in.
+ *
+ * The alternative to a record whose message is a literal English string. Both
+ * shapes are valid records and both keep working — that is what lets the ~200
+ * messages still holding a literal migrate a few at a time rather than all at
+ * once (#1518). The coded form additionally carries the code and the arguments
+ * to the main thread, where the message can be rendered in the reader's
+ * language. `packages/i18n/README.md` shows the before and after.
+ *
+ * Do not write an example call in a comment here: `lint:i18n` counts a `code`
+ * property naming a diagnostic code, and a `type` property naming a severity,
+ * wherever they appear — comments included — so an illustration would land in
+ * the migration burn-down as if it were a real call site.
+ *
+ * `message` is filled in from the English catalog rather than by the caller,
+ * so the English and the catalog cannot drift, and everything that reads
+ * `message` inside the worker — the dedupe in `DiagnosticsManager`, the tests
+ * that assert exact strings — sees what it saw before. (`DocViewer` re-renders
+ * it in `uiLocale` on the way out, which is the whole point; that is the one
+ * consumer for which it is deliberately not the same string.)
+ *
+ * Note that the reader's language is `uiLocale`, not the `documentLocale` the
+ * core computes content in: a diagnostic is addressed to whoever is looking at
+ * the screen, not to the document. The worker has no business knowing it, and
+ * doesn't — it emits English plus the pieces, and the main thread decides.
+ *
+ * This lives beside {@link DiagnosticRecord} rather than in the worker because
+ * the worker is no longer the only place that raises one: the style-contrast
+ * checks in this package do too, and a record built two different ways in two
+ * packages is a record whose shape can drift. The worker's
+ * `utils/diagnostics.ts` re-exports it, so its call sites are unaffected.
+ */
+export function codedDiagnostic({
+    type,
+    code,
+    args,
+    position,
+    sourceDoc,
+    level,
+}: {
+    type: DiagnosticRecord["type"];
+    code: DiagnosticCode;
+    args?: DiagnosticArgs;
+    position?: Position;
+    sourceDoc?: number;
+    /** Required when `type` is `"accessibility"`, meaningless otherwise. */
+    level?: DiagnosticLevel;
+}): DiagnosticRecord {
+    // Optional fields are omitted rather than set to `undefined`, so a coded
+    // record has the same shape a legacy one does and anything comparing or
+    // serializing whole records sees no keys that aren't carrying anything.
+    //
+    // The cast is for the accessibility branch: `level` is required there and
+    // meaningless elsewhere, which the caller knows and the union cannot infer
+    // from a `type` that is still the whole union at this point.
+    return {
+        type,
+        message: formatEnglishDiagnostic(code, args),
+        code,
+        ...(args === undefined ? {} : { args }),
+        ...(position === undefined ? {} : { position }),
+        ...(sourceDoc === undefined ? {} : { sourceDoc }),
+        ...(level === undefined ? {} : { level }),
+    } as DiagnosticRecord;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./ast/logging";
 export * from "./diagnostics/types";
+export * from "./diagnostics/coded";
 export * from "./keyboard/keyboardShortcuts";
 export * from "./media/cid";
 export * from "./media/retrieveTextFile";

--- a/packages/utils/src/style/style.ts
+++ b/packages/utils/src/style/style.ts
@@ -1,3 +1,4 @@
+import { codedDiagnostic } from "../diagnostics/coded";
 import { colorValueToWord } from "./colorWords";
 import {
     DEFAULT_STYLE_VALUES,
@@ -1286,12 +1287,13 @@ export function returnStyleDefinitionStateVariables(): StateVariableDefinitions 
             const diagnostics = [];
             if (stylePaletteChildren.length > 1) {
                 for (const child of stylePaletteChildren.slice(0, -1)) {
-                    diagnostics.push({
-                        type: "warning",
-                        message:
-                            "A section can select only one <stylePalette>; using the last one.",
-                        position: child.position,
-                    });
+                    diagnostics.push(
+                        codedDiagnostic({
+                            type: "warning",
+                            code: "doenet-w0083",
+                            position: child.position,
+                        }),
+                    );
                 }
             }
 

--- a/packages/utils/src/style/styleContrastAccessibility.ts
+++ b/packages/utils/src/style/styleContrastAccessibility.ts
@@ -15,6 +15,7 @@
  *    opacity) makes the result fail WCAG AA.
  */
 import type { Position } from "@doenet/parser";
+import { codedDiagnostic } from "../diagnostics/coded";
 import type { AccessibilityRecord } from "../diagnostics/types";
 import {
     getStyleValueNumber,
@@ -43,41 +44,53 @@ const CANVAS_FOR_MODE: Record<Mode, string> = {
     dark: CANVAS_DARK_MODE_COLOR,
 };
 
-/** Suffix added to diagnostic context strings in dark mode. */
-const MODE_SUFFIX: Record<Mode, string> = {
-    light: "",
-    dark: " (dark mode)",
-};
-
 /**
- * Formats a contrast ratio for diagnostic text.
+ * Which pair of colors a contrast check compared.
+ *
+ * Symbolic rather than the phrase itself. The message names the pair in
+ * prose, and prose is the translator's to write — handing one over as an
+ * argument would nail the English into the record and leave nothing for the
+ * catalog to say. The catalog selects on these; `text-on-canvas` is the
+ * default variant there, so a value the catalog does not know still renders a
+ * sentence.
  */
-function formatRatio(value: number): string {
-    return value.toFixed(2);
-}
+type ContrastContext =
+    | "text-on-background"
+    | "text-on-canvas"
+    | "high-contrast"
+    | "line"
+    | "marker";
 
 /**
  * Creates a standardized style-contrast accessibility diagnostic.
+ *
+ * The mode travels as an argument for the same reason the context does: dark
+ * mode used to be a " (dark mode)" suffix concatenated onto the context, which
+ * is a phrase in the middle of a sentence and cannot be positioned by a
+ * translator once it has been glued on.
  */
 function createContrastAccessibilityDiagnostic({
     styleNumber,
     context,
+    mode,
     ratio,
     threshold,
     position,
 }: {
     styleNumber: string;
-    context: string;
+    context: ContrastContext;
+    mode: Mode;
     ratio: number;
     threshold: number;
     position?: Position;
 }): AccessibilityRecord {
-    return {
+    return codedDiagnostic({
         type: "accessibility",
         level: 1,
-        message: `Style definition ${styleNumber} has insufficient contrast for ${context} (${formatRatio(ratio)}:1; requires at least ${threshold}:1).`,
+        code: "doenet-a0007",
+        args: { styleNumber, context, mode, ratio, threshold },
         position,
-    };
+    }) as AccessibilityRecord;
 }
 
 /**
@@ -92,13 +105,15 @@ function appendContrastAccessibilityDiagnosticIfNeeded({
     diagnostics,
     styleNumber,
     context,
+    mode,
     ratio,
     threshold,
     position,
 }: {
     diagnostics: AccessibilityRecord[];
     styleNumber: string;
-    context: string;
+    context: ContrastContext;
+    mode: Mode;
     ratio: number | null;
     threshold: number;
     position?: Position;
@@ -111,6 +126,7 @@ function appendContrastAccessibilityDiagnosticIfNeeded({
         createContrastAccessibilityDiagnostic({
             styleNumber,
             context,
+            mode,
             ratio,
             threshold,
             position,
@@ -137,7 +153,6 @@ function contrastDiagnosticsForMode(
 ): AccessibilityRecord[] {
     const diagnostics: AccessibilityRecord[] = [];
     const canvas = CANVAS_FOR_MODE[mode];
-    const suffix = MODE_SUFFIX[mode];
 
     // --- Text color against background (or canvas). ---
     const textColor = getStyleValueString(styleDef, colorKey("text", mode));
@@ -159,10 +174,8 @@ function contrastDiagnosticsForMode(
         appendContrastAccessibilityDiagnosticIfNeeded({
             diagnostics,
             styleNumber,
-            context:
-                (backgroundColor
-                    ? "text color against background color"
-                    : "text color against the canvas") + suffix,
+            context: backgroundColor ? "text-on-background" : "text-on-canvas",
+            mode,
             ratio,
             threshold: TEXT_CONTRAST_THRESHOLD,
             position: diagnosticPosition,
@@ -184,7 +197,8 @@ function contrastDiagnosticsForMode(
         appendContrastAccessibilityDiagnosticIfNeeded({
             diagnostics,
             styleNumber,
-            context: "high-contrast color against the canvas" + suffix,
+            context: "high-contrast",
+            mode,
             ratio,
             threshold: TEXT_CONTRAST_THRESHOLD,
             position: highContrastPosition,
@@ -213,7 +227,8 @@ function contrastDiagnosticsForMode(
         appendContrastAccessibilityDiagnosticIfNeeded({
             diagnostics,
             styleNumber,
-            context: "line color against the canvas" + suffix,
+            context: "line",
+            mode,
             ratio,
             threshold: GRAPHIC_CONTRAST_THRESHOLD,
             position: diagnosticPosition,
@@ -241,7 +256,8 @@ function contrastDiagnosticsForMode(
         appendContrastAccessibilityDiagnosticIfNeeded({
             diagnostics,
             styleNumber,
-            context: "marker color against the canvas" + suffix,
+            context: "marker",
+            mode,
             ratio,
             threshold: GRAPHIC_CONTRAST_THRESHOLD,
             position: diagnosticPosition,
@@ -357,27 +373,38 @@ function derivedDarkModeCombinationDiagnostics(
         }
     }
 
-    const baseMessage = `Although style definition ${styleNumber} has specified colors that provide sufficient contrast for light mode, the dark-mode colors derived from these values have insufficient contrast for the text color against the background color (${formatRatio(darkRatio)}:1; requires at least ${TEXT_CONTRAST_THRESHOLD}:1).`;
-    let fixMessage: string;
-    if (suggestion) {
-        // The dark color is derived from the light color by inverting its
-        // lightness, and that inversion is its own inverse — so a light value
-        // that derives to the accessible dark color is just the inverted dark
-        // color. Offering both lets the author keep their dark color and fix the
-        // light contrast, or keep their light color and override the dark one.
-        const lightColor = invertLightness(suggestion.darkColor);
-        fixMessage = ` To ensure sufficient contrast in dark mode, either increase the light-mode contrast (e.g., set ${suggestion.lightAttribute}="${lightColor}") or override the dark-mode color (e.g., set ${suggestion.darkAttribute}="${suggestion.darkColor}").`;
-    } else {
-        fixMessage = ` To ensure sufficient contrast in dark mode, increase the light-mode contrast or override the derived colors with textColorDarkMode and/or backgroundColorDarkMode.`;
-    }
-
+    // The advice is a variant of the message rather than a second sentence
+    // appended to it: which advice applies is data (did a replacement color
+    // come out of the derivation?), and a sentence built by `base + fix` puts
+    // the join in the code, where a translator cannot move it.
     return [
-        {
+        codedDiagnostic({
             type: "accessibility",
             level: 1,
-            message: baseMessage + fixMessage,
+            code: "doenet-a0008",
+            args: {
+                styleNumber,
+                ratio: darkRatio,
+                threshold: TEXT_CONTRAST_THRESHOLD,
+                ...(suggestion
+                    ? {
+                          suggestion: "available",
+                          lightAttribute: suggestion.lightAttribute,
+                          // The dark color is derived from the light color by
+                          // inverting its lightness, and that inversion is its
+                          // own inverse — so a light value that derives to the
+                          // accessible dark color is just the inverted dark
+                          // color. Offering both lets the author keep their
+                          // dark color and fix the light contrast, or keep
+                          // their light color and override the dark one.
+                          lightColor: invertLightness(suggestion.darkColor),
+                          darkAttribute: suggestion.darkAttribute,
+                          darkColor: suggestion.darkColor,
+                      }
+                    : { suggestion: "none" }),
+            },
             position,
-        },
+        }) as AccessibilityRecord,
     ];
 }
 
@@ -438,19 +465,29 @@ function derivedDarkModeTextCanvasDiagnostics(
         foreground: suggestedDark,
         canvas: CANVAS_DARK_MODE_COLOR,
     });
-    const fixMessage =
+    const haveSuggestion =
         suggestedDarkRatio !== null &&
-        suggestedDarkRatio >= TEXT_CONTRAST_THRESHOLD
-            ? ` To ensure sufficient contrast in dark mode, either increase the light-mode contrast (e.g., set textColor="${invertLightness(suggestedDark)}") or override the dark-mode color (e.g., set textColorDarkMode="${suggestedDark}").`
-            : ` To ensure sufficient contrast in dark mode, increase the light-mode contrast or override the derived color with textColorDarkMode.`;
+        suggestedDarkRatio >= TEXT_CONTRAST_THRESHOLD;
 
     return [
-        {
+        codedDiagnostic({
             type: "accessibility",
             level: 1,
-            message: `Although style definition ${styleNumber} has a specified text color that provides sufficient contrast for light mode, the dark-mode text color derived from this value has insufficient contrast against the canvas (${formatRatio(darkRatio)}:1; requires at least ${TEXT_CONTRAST_THRESHOLD}:1).${fixMessage}`,
+            code: "doenet-a0009",
+            args: {
+                styleNumber,
+                ratio: darkRatio,
+                threshold: TEXT_CONTRAST_THRESHOLD,
+                ...(haveSuggestion
+                    ? {
+                          suggestion: "available",
+                          lightColor: invertLightness(suggestedDark),
+                          darkColor: suggestedDark,
+                      }
+                    : { suggestion: "none" }),
+            },
             position,
-        },
+        }) as AccessibilityRecord,
     ];
 }
 

--- a/packages/utils/src/style/styleContrastAccessibility.ts
+++ b/packages/utils/src/style/styleContrastAccessibility.ts
@@ -62,44 +62,17 @@ type ContrastContext =
     | "marker";
 
 /**
- * Creates a standardized style-contrast accessibility diagnostic.
- *
- * The mode travels as an argument for the same reason the context does: dark
- * mode used to be a " (dark mode)" suffix concatenated onto the context, which
- * is a phrase in the middle of a sentence and cannot be positioned by a
- * translator once it has been glued on.
- */
-function createContrastAccessibilityDiagnostic({
-    styleNumber,
-    context,
-    mode,
-    ratio,
-    threshold,
-    position,
-}: {
-    styleNumber: string;
-    context: ContrastContext;
-    mode: Mode;
-    ratio: number;
-    threshold: number;
-    position?: Position;
-}): AccessibilityRecord {
-    return codedDiagnostic({
-        type: "accessibility",
-        level: 1,
-        code: "doenet-a0007",
-        args: { styleNumber, context, mode, ratio, threshold },
-        position,
-    }) as AccessibilityRecord;
-}
-
-/**
  * Conditionally appends a contrast accessibility diagnostic when the ratio is
  * insufficient.
  *
  * `position` is the latest authored contributor to the rendered contrast, such
  * as a foreground color, background color, or opacity attribute. Preset and
  * derived values carry no position, so default styles remain silent.
+ *
+ * The mode travels as an argument for the same reason the context does: dark
+ * mode used to be a " (dark mode)" suffix concatenated onto the context, which
+ * is a phrase in the middle of a sentence and cannot be positioned by a
+ * translator once it has been glued on.
  */
 function appendContrastAccessibilityDiagnosticIfNeeded({
     diagnostics,
@@ -123,14 +96,13 @@ function appendContrastAccessibilityDiagnosticIfNeeded({
     }
 
     diagnostics.push(
-        createContrastAccessibilityDiagnostic({
-            styleNumber,
-            context,
-            mode,
-            ratio,
-            threshold,
+        codedDiagnostic({
+            type: "accessibility",
+            level: 1,
+            code: "doenet-a0007",
+            args: { styleNumber, context, mode, ratio, threshold },
             position,
-        }),
+        }) as AccessibilityRecord,
     );
 }
 

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -33,6 +33,15 @@ export default defineConfig({
                 "@fortawesome/react-fontawesome",
                 "better-react-mathjax",
                 "math-expressions",
+                // Left as a bare import rather than inlined. Consumers of this
+                // package overwhelmingly depend on `@doenet/i18n` themselves —
+                // the viewer formats diagnostics with it, the worker raises
+                // them — and inlining a second copy here would put two Fluent
+                // bundles, two message catalogs and two parsers in the same
+                // application. Externalized, the consumer's bundler resolves
+                // one. See `packages/lsp/scripts/check-server-bundle.mjs` for
+                // the check that it also stays out of the language server.
+                "@doenet/i18n",
             ],
         },
     },


### PR DESCRIPTION
> **Stacked on #1556, which has now merged** — so this diff is standalone: its seven commits are `Let @doenet/utils raise coded diagnostics`, `Keep the message catalogs out of the language server`, the changeset, and four review fix-ups. Opened against `main` because a cross-fork PR cannot take a fork branch as its base.

Step 3 of the plan for closing #1518: `@doenet/utils` takes the runtime dependency on `@doenet/i18n` that #1518 settled, and its four diagnostics become translatable.

## What the messages were doing

The style-contrast alerts named the pair of colors they compared in English — `"text color against background color"` — and handed that phrase to the message as an argument, with `" (dark mode)"` concatenated onto it. A phrase passed as an argument never reaches a translator, and one glued into the middle of a sentence could not be repositioned even if it did. The pair and the mode are symbolic values now (`text-on-background`, `dark`), and the catalog writes every word of the sentence.

The dark-mode alerts were `baseMessage + fixMessage`. Which advice applies is data — did the derivation produce a usable replacement color? — so it is a variant of the message rather than a second sentence appended to it. The attribute names and color values inside it are DoenetML source and stay as they are in every language.

The English is byte-identical, which the 14 existing assertions in `styleContrastAccessibility.test.ts` (two of them exact full-message arrays) hold it to.

`codedDiagnostic` moves to `@doenet/utils`, beside the `DiagnosticRecord` it builds, now that the worker is not the only thing raising one. The worker's `utils/diagnostics.ts` re-exports it, so its ~150 call sites are untouched.

## The dependency does reach the language server

#1518 settled this on a measurement — that `styleContrastAccessibility.ts` is tree-shaken out of the language-server bundle, so the cost lands only where a diagnostic is actually raised. **That turned out to be wrong**, and it is worth being precise about how, because the reasoning was sound and the conclusion still wasn't.

Measured on `packages/lsp/dist/index.js` after `npm run build -w @doenet/lsp`:

| | bytes | gzip -9 |
| --- | --- | --- |
| `upstream/main` | 1,069,418 | 315,394 |
| this branch, with the dependency and no `sideEffects` declaration | 1,138,899 | 335,339 |
| this branch as it stands | 1,069,418 | 315,394 |

Tree-shaking did its job: `formatEnglishDiagnostic` appears **nowhere** in the bundle, and neither does the Fluent runtime. What survived was 20 KB gzipped of raw FTL text with nothing left that could read it.

The cause is that `@doenet/i18n` never declared itself side-effect-free. Its English catalogs are `?raw` imports assembled by a module-level call, and a bundler that cannot assume the call is pure has to keep it — which keeps all four FTL files, in any bundle that reaches the package for any reason at all. Declaring `"sideEffects": false` takes the server back to **the same 1,069,418 bytes — byte for byte, same md5** as the `upstream/main` build. Nothing in the package registers globals, patches prototypes, or imports for effect, so the claim is true today; the README now says so and says what breaking it would cost.

Because the leak is fixed in the same commit range that introduces it, nothing ever shipped carrying the catalogs. The prose in the changeset, the README and the check itself says it that way rather than describing a past regression.

I verified the other direction too, at the built-artifact level rather than from source: the viewer bundle still contains the English catalogs, the Spanish catalogs, and the Fluent runtime. Tree-shaking drops them only where nothing reads them.

## The check that would have caught it

`packages/lsp/scripts/check-server-bundle.mjs`, run in CI after the build, alongside #1554's standalone check.

It looks for the Fluent runtime **and** for catalog text. That is not belt-and-braces: this leak had the second without the first, so an identifier-only scan would have reported the bundle as clean. Each needle names what it proves, so the failure says which of the two occurred.

Alongside it, a size budget — the thing #1553 explicitly wanted and could not afford, because it "would have to build the server to do it". CI builds everything before the standalone check runs, so it can now. `server-budget.json` is set at 1,155,000 bytes, about 8% over the current build.

**Verified by reintroducing the regression**, not by reasoning about it: with `sideEffects` removed, the catalog check fails and names the payload — while the bundle is still comfortably inside its size budget at 1112 KiB of 1128 KiB. One check would not have been enough, which is why there are two.

## Testing

- 14 unit tests for the check's decision logic, including that a malformed budget file is refused rather than passing vacuously (`size > undefined` is `false`, so a typo would report the bundle as within a `NaN` budget and go green), and that an unusable budget does not also switch off the catalog scan.
- 2 new worker tests asserting the codes and arguments reach the record — the half of it the main thread renders from, which no existing assertion covers. Confirmed by mutation: pinning `mode` to `"light"` in `@doenet/utils` fails them.
- `lint:i18n`, and the full `utils` (544), `doenetml` (88), `lsp` (45 + 1 skipped), `lsp-tools` (626) and `i18n` (132) suites, plus the worker's `diagnostics/` (75) and `stylePalette` + `sectioning` (56) suites.

## What is left in `@doenet/utils`

Nothing — all four sites are coded. The one remaining message in this group is in `@doenet/doenetml-iframe` ("DoenetML version X not found"), and I have left it alone deliberately: it is a host-level version-resolution failure rather than a document diagnostic, and the iframe shim does not bundle Fluent today, so it is a separate packaging call rather than one this decision settles.

Part of #1518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


