### PR TITLE
test(cypress): stop graph-controls prefigure tests from loading pyodide over the CDN

### DIFF
--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -1,4 +1,9 @@
-import { installPrefigureBuildIntercept } from "../../support/prefigure";
+import {
+    installDiagcessScriptStub,
+    installMockPrefigureModule,
+    installPrefigureBuildIntercept,
+    visitWithMockPrefigureModule,
+} from "../../support/prefigure";
 
 describe(
     "Graph controls renderer-agnostic behavior @group4",
@@ -32,10 +37,20 @@ describe(
                 cy.viewport(viewport[0], viewport[1]);
             }
 
-            cy.visit("/");
-
             if (prefigure) {
+                // These tests only care that graph controls behave the same next
+                // to a prefigure graph; they never inspect the rendered diagram.
+                // Point the renderer at a stubbed prefigure module so the page
+                // does not download the pyodide runtime and its wheels from the
+                // CDN. That download, and the main-thread work of initializing
+                // it, can stall the page long enough for control interactions to
+                // time out.
+                const modulePath = installMockPrefigureModule();
+                installDiagcessScriptStub();
                 installPrefigureBuildIntercept();
+                visitWithMockPrefigureModule(modulePath);
+            } else {
+                cy.visit("/");
             }
 
             postDoenetML(doenetML);
@@ -1691,16 +1706,20 @@ describe(
                 keyboardStepRangeRight(xSlider);
             }
 
+            // Retry until every step has landed in the slider's local state, so
+            // the value read below cannot be a partially accumulated one.
+            cy.get(xSlider).should(($slider) => {
+                const transientNumber = Number($slider.val());
+                expect(transientNumber).to.be.greaterThan(0.5);
+                expect(transientNumber).to.be.lessThan(0.9);
+            });
+
             // Actual point snaps to 1 even during the transient
 
             cy.get("#Px").should("have.text", "1");
             cy.get(xSlider)
                 .invoke("val")
                 .then((transientValue) => {
-                    const transientNumber = Number(transientValue);
-                    expect(transientNumber).to.be.greaterThan(0.5);
-                    expect(transientNumber).to.be.lessThan(0.9);
-
                     // Before blur: number input should show transient value
                     cy.get('input[aria-label="x value input for P"]').should(
                         "have.value",

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -1714,10 +1714,15 @@ describe(
             // captured string can pin a value the slider has already moved
             // past. `cy.$$` queries the application under test, so both reads
             // see the same document as `cy.get`.
+            //
+            // The slider step is (xMax - xMin) / 100 = 0.2 on the default
+            // -10..10 graph, so all four steps accumulating gives 0.8. The
+            // bounds bracket only that value: three steps (0.6) or five (1.0)
+            // fail, as does snapping to the constrained 1.
             cy.get(xSlider).should(($slider) => {
                 const transientValue = $slider.val();
                 const transientNumber = Number(transientValue);
-                expect(transientNumber).to.be.greaterThan(0.5);
+                expect(transientNumber).to.be.greaterThan(0.7);
                 expect(transientNumber).to.be.lessThan(0.9);
                 expect(
                     cy.$$(xNumberInput).val(),

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -38,13 +38,14 @@ describe(
             }
 
             if (prefigure) {
-                // These tests only care that graph controls behave the same next
-                // to a prefigure graph; they never inspect the rendered diagram.
-                // Point the renderer at a stubbed prefigure module so the page
-                // does not download the pyodide runtime and its wheels from the
-                // CDN. That download, and the main-thread work of initializing
-                // it, can stall the page long enough for control interactions to
-                // time out.
+                // These tests only check that graph controls behave the same
+                // next to a prefigure graph; they never inspect the rendered
+                // diagram. So stub every prefigure network dependency — the
+                // WASM module, the diagcess script, and the build service —
+                // and the page never reaches the CDN. Downloading the pyodide
+                // runtime and its wheels, and then initializing pyodide on the
+                // main thread, can otherwise starve the main thread long enough
+                // for control interactions to time out.
                 const modulePath = installMockPrefigureModule();
                 installDiagcessScriptStub();
                 installPrefigureBuildIntercept();
@@ -1706,8 +1707,11 @@ describe(
                 keyboardStepRangeRight(xSlider);
             }
 
-            // Retry until every step has landed in the slider's local state, so
-            // the value read below cannot be a partially accumulated one.
+            // The slider is React-controlled, so each keyboard step is only
+            // reflected in the DOM once the transient state update round-trips.
+            // Retry until the accumulated transient value is in range before
+            // reading its exact value below, which `.invoke("val")` would
+            // otherwise sample without retrying.
             cy.get(xSlider).should(($slider) => {
                 const transientNumber = Number($slider.val());
                 expect(transientNumber).to.be.greaterThan(0.5);

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -39,12 +39,13 @@ describe(
             if (prefigure) {
                 // These tests only check that graph controls behave the same
                 // next to a prefigure graph; they never inspect the rendered
-                // diagram. So serve a stub prefigure runtime and stub the
-                // build service, and the page never fetches the real prefigure
-                // runtime from the CDN. Downloading that runtime and its
-                // pyodide wheels, then initializing pyodide on the main
-                // thread, can otherwise starve the main thread long enough for
-                // control interactions to time out.
+                // diagram. So stub every prefigure dependency: a local ES
+                // module stands in for the CDN runtime, the build service is
+                // intercepted, and `visitWithMockPrefigureModule` also serves
+                // an empty diagcess bundle. Otherwise the page downloads the
+                // real runtime and its pyodide wheels and initializes pyodide
+                // on the main thread, which can starve the main thread long
+                // enough for control interactions to time out.
                 const modulePath = installMockPrefigureModule();
                 installPrefigureBuildIntercept();
                 visitWithMockPrefigureModule(modulePath);
@@ -1707,22 +1708,29 @@ describe(
             }
 
             // Before blur the slider holds the accumulated, unconstrained
-            // transient value, and the number input mirrors it. Each keyboard
-            // step round-trips through the worker, so read both elements in a
-            // single retried callback: capturing the slider value with a
-            // non-retrying command and then asserting the input against that
-            // captured string can pin a value the slider has already moved
-            // past. `cy.$$` queries the application under test, so both reads
-            // see the same document as `cy.get`.
+            // transient value, and the number input mirrors it. Read both
+            // elements in a single retried callback: capturing the slider
+            // value with a non-retrying command and then asserting the input
+            // against that captured string can pin a value the slider has
+            // already moved past. `cy.$$` queries the application under test,
+            // so both reads see the same document as `cy.get`.
             //
             // The slider step is (xMax - xMin) / 100 = 0.2 on the default
-            // -10..10 graph, so all four steps accumulating gives 0.8. The
-            // bounds bracket only that value: three steps (0.6) or five (1.0)
-            // fail, as does snapping to the constrained 1.
+            // -10..10 graph (`size` sets the graph's width, not its axis
+            // bounds), so four accumulated steps give 0.8. The lower bound is
+            // deliberately loose rather than pinned to 0.8: each step round
+            // trips through the worker, and `keyboardStepRangeRight` calls
+            // `stepUp()` on whatever value React last wrote to the slider, so
+            // a slow round trip legitimately drops one step and leaves 0.6.
+            // That was measured on cold page loads, so requiring 0.8 here
+            // reintroduces exactly the kind of flake this spec setup fixes.
+            // What the bounds do establish is that steps accumulated past a
+            // single 0.2 nudge and that the slider is not already showing the
+            // constrained value of 1.
             cy.get(xSlider).should(($slider) => {
                 const transientValue = $slider.val();
                 const transientNumber = Number(transientValue);
-                expect(transientNumber).to.be.greaterThan(0.7);
+                expect(transientNumber).to.be.greaterThan(0.5);
                 expect(transientNumber).to.be.lessThan(0.9);
                 expect(
                     cy.$$(xNumberInput).val(),

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -1,5 +1,4 @@
 import {
-    installDiagcessScriptStub,
     installMockPrefigureModule,
     installPrefigureBuildIntercept,
     visitWithMockPrefigureModule,
@@ -40,14 +39,12 @@ describe(
             if (prefigure) {
                 // These tests only check that graph controls behave the same
                 // next to a prefigure graph; they never inspect the rendered
-                // diagram. So stub every prefigure network dependency — the
-                // WASM module, the diagcess script, and the build service —
-                // and the page never reaches the CDN. Downloading the pyodide
-                // runtime and its wheels, and then initializing pyodide on the
-                // main thread, can otherwise starve the main thread long enough
-                // for control interactions to time out.
+                // diagram. So serve a stub prefigure runtime and stub the build
+                // service, and the page never reaches the CDN. Downloading the
+                // real pyodide runtime and its wheels, and then initializing
+                // pyodide on the main thread, can otherwise starve the main
+                // thread long enough for control interactions to time out.
                 const modulePath = installMockPrefigureModule();
-                installDiagcessScriptStub();
                 installPrefigureBuildIntercept();
                 visitWithMockPrefigureModule(modulePath);
             } else {
@@ -1707,40 +1704,34 @@ describe(
                 keyboardStepRangeRight(xSlider);
             }
 
-            // The slider is React-controlled, so each keyboard step is only
-            // reflected in the DOM once the transient state update round-trips.
-            // Retry until the accumulated transient value is in range before
-            // reading its exact value below, which `.invoke("val")` would
-            // otherwise sample without retrying.
+            // Before blur the slider holds the accumulated, unconstrained
+            // transient value, and the number input mirrors it. The slider is
+            // React-controlled and each keyboard step round-trips through the
+            // worker, so assert both facts in one retried callback: sampling
+            // the two elements in separate, non-retrying commands could catch
+            // them mid-update, disagreeing with each other.
             cy.get(xSlider).should(($slider) => {
-                const transientNumber = Number($slider.val());
+                const transientValue = $slider.val();
+                const transientNumber = Number(transientValue);
                 expect(transientNumber).to.be.greaterThan(0.5);
                 expect(transientNumber).to.be.lessThan(0.9);
+                expect(
+                    Cypress.$('input[aria-label="x value input for P"]').val(),
+                ).to.equal(transientValue);
             });
 
             // Actual point snaps to 1 even during the transient
-
             cy.get("#Px").should("have.text", "1");
-            cy.get(xSlider)
-                .invoke("val")
-                .then((transientValue) => {
-                    // Before blur: number input should show transient value
-                    cy.get('input[aria-label="x value input for P"]').should(
-                        "have.value",
-                        transientValue,
-                    );
 
-                    cy.get(xSlider).blur();
+            cy.get(xSlider).blur();
 
-                    // After blur: slider and input both snap to constrained value
-                    cy.get(xSlider).should("have.value", "1");
-                    cy.get('input[aria-label="x value input for P"]').should(
-                        "have.value",
-                        "1",
-                    );
-                    cy.get("#Px").should("have.text", "1");
-                });
+            // After blur: slider and input both snap to constrained value
             cy.get(xSlider).should("have.value", "1");
+            cy.get('input[aria-label="x value input for P"]').should(
+                "have.value",
+                "1",
+            );
+            cy.get("#Px").should("have.text", "1");
         });
 
         it("keyboard blur on constrained point does not send another movePoint", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -39,11 +39,12 @@ describe(
             if (prefigure) {
                 // These tests only check that graph controls behave the same
                 // next to a prefigure graph; they never inspect the rendered
-                // diagram. So serve a stub prefigure runtime and stub the build
-                // service, and the page never reaches the CDN. Downloading the
-                // real pyodide runtime and its wheels, and then initializing
-                // pyodide on the main thread, can otherwise starve the main
-                // thread long enough for control interactions to time out.
+                // diagram. So serve a stub prefigure runtime and stub the
+                // build service, and the page never fetches the real prefigure
+                // runtime from the CDN. Downloading that runtime and its
+                // pyodide wheels, then initializing pyodide on the main
+                // thread, can otherwise starve the main thread long enough for
+                // control interactions to time out.
                 const modulePath = installMockPrefigureModule();
                 installPrefigureBuildIntercept();
                 visitWithMockPrefigureModule(modulePath);
@@ -1698,6 +1699,7 @@ describe(
             );
 
             const xSlider = '[aria-label="x coordinate for P"]';
+            const xNumberInput = 'input[aria-label="x value input for P"]';
             cy.get(xSlider).focus();
 
             for (let i = 1; i <= 4; i++) {
@@ -1705,18 +1707,21 @@ describe(
             }
 
             // Before blur the slider holds the accumulated, unconstrained
-            // transient value, and the number input mirrors it. The slider is
-            // React-controlled and each keyboard step round-trips through the
-            // worker, so assert both facts in one retried callback: sampling
-            // the two elements in separate, non-retrying commands could catch
-            // them mid-update, disagreeing with each other.
+            // transient value, and the number input mirrors it. Each keyboard
+            // step round-trips through the worker, so read both elements in a
+            // single retried callback: capturing the slider value with a
+            // non-retrying command and then asserting the input against that
+            // captured string can pin a value the slider has already moved
+            // past. `cy.$$` queries the application under test, so both reads
+            // see the same document as `cy.get`.
             cy.get(xSlider).should(($slider) => {
                 const transientValue = $slider.val();
                 const transientNumber = Number(transientValue);
                 expect(transientNumber).to.be.greaterThan(0.5);
                 expect(transientNumber).to.be.lessThan(0.9);
                 expect(
-                    Cypress.$('input[aria-label="x value input for P"]').val(),
+                    cy.$$(xNumberInput).val(),
+                    "number input mirrors the transient slider value",
                 ).to.equal(transientValue);
             });
 
@@ -1727,10 +1732,7 @@ describe(
 
             // After blur: slider and input both snap to constrained value
             cy.get(xSlider).should("have.value", "1");
-            cy.get('input[aria-label="x value input for P"]').should(
-                "have.value",
-                "1",
-            );
+            cy.get(xNumberInput).should("have.value", "1");
             cy.get("#Px").should("have.text", "1");
         });
 

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -106,10 +106,9 @@ export async function compilePrefigure(_diagramXML, _options) {
  * Serve an empty diagcess bundle instead of letting the page pull the real one
  * from the CDN. The stub still loads, so the renderer's one-time script-load
  * effect settles as usual, but `window.diagcess` is never defined and the
- * diagcess re-init is skipped. Use only in tests that do not exercise
- * annotations.
+ * diagcess re-init is skipped.
  */
-export function installDiagcessScriptStub() {
+function installDiagcessScriptStub() {
     cy.intercept("GET", "**/diagcess*.js*", {
         statusCode: 200,
         headers: { "content-type": "application/javascript" },
@@ -118,11 +117,19 @@ export function installDiagcessScriptStub() {
 }
 
 /**
- * Visit the harness with the prefigure runtime overrides in place, so the
+ * Visit the harness with every prefigure CDN dependency stubbed out: the
  * renderer imports `modulePath` (see {@link installMockPrefigureModule})
- * instead of the CDN build and passes no pyodide index URL.
+ * instead of the published pyodide build, gets no pyodide index URL, and gets
+ * an empty diagcess bundle.
+ *
+ * Because `window.diagcess` is never defined, the diagcess re-init is skipped.
+ * Tests that exercise annotations should instead define `window.diagcess`
+ * themselves in an `onBeforeLoad` hook, and tests that need the real diagcess
+ * script should visit the harness directly.
  */
 export function visitWithMockPrefigureModule(modulePath) {
+    installDiagcessScriptStub();
+
     cy.visit("/", {
         onBeforeLoad(win) {
             win.__DOENET_PREFIGURE_MODULE_URL__ = new URL(

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -97,6 +97,19 @@ export async function compilePrefigure(_diagramXML, _options) {
     return modulePath;
 }
 
+/**
+ * Serve an empty diagcess bundle instead of letting the page pull it from the
+ * CDN. Tests that do not exercise annotations get the same behavior either way:
+ * `diagcessApi()` stays undefined, so the renderer skips its diagcess reinit.
+ */
+export function installDiagcessScriptStub() {
+    cy.intercept("GET", "**/diagcess*.js*", {
+        statusCode: 200,
+        headers: { "content-type": "application/javascript" },
+        body: "",
+    });
+}
+
 export function visitWithMockPrefigureModule(modulePath) {
     cy.visit("/", {
         onBeforeLoad(win) {

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -57,6 +57,11 @@ export function postDebounceTestDoenetML() {
     cy.get("#ready").should("have.text", "ready");
 }
 
+/**
+ * Serve a fake `@doenet/prefigure` ES module so the page never downloads the
+ * real pyodide runtime. Returns the path the stub is served from; pass it to
+ * {@link visitWithMockPrefigureModule}, which points the renderer at it.
+ */
 export function installMockPrefigureModule({
     modulePath = "/mock-prefigure-module.js",
     initDelayMs = 0,
@@ -98,9 +103,11 @@ export async function compilePrefigure(_diagramXML, _options) {
 }
 
 /**
- * Serve an empty diagcess bundle instead of letting the page pull it from the
- * CDN. Tests that do not exercise annotations get the same behavior either way:
- * `diagcessApi()` stays undefined, so the renderer skips its diagcess reinit.
+ * Serve an empty diagcess bundle instead of letting the page pull the real one
+ * from the CDN. The stub still loads, so the renderer's one-time script-load
+ * effect settles as usual, but `window.diagcess` is never defined and the
+ * diagcess re-init is skipped. Use only in tests that do not exercise
+ * annotations.
  */
 export function installDiagcessScriptStub() {
     cy.intercept("GET", "**/diagcess*.js*", {
@@ -110,6 +117,11 @@ export function installDiagcessScriptStub() {
     });
 }
 
+/**
+ * Visit the harness with the prefigure runtime overrides in place, so the
+ * renderer imports `modulePath` (see {@link installMockPrefigureModule})
+ * instead of the CDN build and passes no pyodide index URL.
+ */
 export function visitWithMockPrefigureModule(modulePath) {
     cy.visit("/", {
         onBeforeLoad(win) {


### PR DESCRIPTION
## Problem

The Cypress test `keyboard arrow keys accumulate as transient and commit final value on blur` in `graphicControls.cy.js` flaked on three separate merges to `main` (CI runs 30184489272, 30185212521, 30186611477). Every failure had the same signature: all 3 Cypress attempts timed out after 30000ms on `cy.get("#Px").should("have.text", "1")` with diff `-'0'` / `+'1'`.

The failure screenshots explain it: the slider had correctly reached 0.8, `Px`/`Py` were still 0, the prefigure graph was blank, and jsDelivr wheel fetches (`pytz`, `matplotlib_pyodide`, `prefig`) were still in flight.

## Root cause

`packages/doenetml/src/Viewer/renderers/prefigure.tsx` calls `warmupPrefigureInBackground()` on mount, which dynamically imports `@doenet/prefigure` from the jsDelivr CDN and then initializes pyodide **on the main thread**.

The spec's prefigure setup only called `installPrefigureBuildIntercept()`, which stubs the `POST /build` service call. It did nothing about the local WASM warmup, so every prefigure test in this spec really did download and boot pyodide.

The keyboard test depends on a deferred skippable action being released via `resolveAction` on the main thread (`DocViewer.tsx:1033`). When pyodide init monopolizes the main thread, that release is starved and `#Px` never updates within the timeout.

## Fix

Test-only. No application source changes.

1. **Stub every prefigure network dependency in `graphicControls.cy.js`.** The `prefigure: true` path in `loadGraphTest` now uses the existing `installMockPrefigureModule()` + `visitWithMockPrefigureModule()` support helpers, so the renderer imports a trivial local ES module instead of the CDN build and passes no pyodide index URL. Because `PREFIGURE_MODULE_URL` is read once from the `onBeforeLoad`-injected global, both entry points into `startPrefigureWarmup()` — the mount-time warmup and the cold-start race inside `buildPrefigureDiagram()` — resolve to the stub, including after a warmup failure and retry. `installPrefigureBuildIntercept()` is kept because that cold path still races the service backend. These tests only check that graph controls behave the same next to a prefigure graph; they never inspect the rendered diagram.

2. **Stub the diagcess script inside `visitWithMockPrefigureModule()`.** A visit that opts out of the prefigure CDN now opts out of it completely: an empty diagcess bundle is served, so the renderer's one-time script-load effect settles as usual without a jsDelivr round trip. This also removes the diagcess fetch from `prefigureWinner.cy.js` and `prefigureThemeQueue.cy.js`, which get it for free. `window.diagcess` stays undefined, so the diagcess re-init is skipped — none of the three specs on this path author `<annotations>`, so `hasAuthorAnnotations` is false and none of them reach it. The specs that do care about diagcess are unaffected: `prefigureAnnotationsAccessibility.cy.js` defines `window.diagcess` itself in `onBeforeLoad`, and `prefigureDiagcessScript.cy.js` / `prefigureLiveAccessibility.cy.js` visit the harness directly.

3. **Make the transient slider read retry.** Before blur, the slider holds the accumulated unconstrained value and the number input mirrors it. That pair used to be sampled by a non-retrying `.invoke("val")` followed by an assertion against the captured string, so a mid-update sample could pin a value the slider had already moved past. Both facts are now read inside a single retried `cy.get(...).should(callback)` — the number input via `cy.$$`, the jQuery instance bound to the application under test — and the post-blur assertions come out of the nested `.then()`.

   The transient bounds stay at `(0.5, 0.9)`. An earlier revision of this PR tightened the lower bound to `0.7`, reasoning that the slider step is `(xMax - xMin) / 100 = 0.2` on the default -10..10 graph, so four arrow steps must land on exactly 0.8. The arithmetic checks out — verified in-browser that the slider really is `min=-10 max=10 step=0.2`, and `size` sets the graph's width, not its axis bounds — but the premise that all four steps always accumulate does not. `keyboardStepRangeRight` calls `stepUp()` on whatever value React last wrote to the slider, and each step round trips through the worker; when a round trip is slow, the renderer's sync effect writes the committed coordinate back before the transient flag lands and one step is dropped. Measured over four batches of twelve cold page loads, the settled value was `0.6` twice — so `greaterThan(0.7)` would have reintroduced exactly the flake this PR removes. The `(0.5, 0.9)` bracket still establishes what the test is for: steps accumulated past a single 0.2 nudge, and the slider is not already showing the constrained value of 1. The reasoning is recorded in a comment next to the assertion.

Also added doc comments to `installMockPrefigureModule` and `visitWithMockPrefigureModule` describing the `modulePath` handoff between them and what the visit helper stubs.

## Verification

Run headless in Chrome against the preview server:

- `graphicControls.cy.js`: 47/47 passing, confirmed on repeated runs.
- `cypress/e2e/prefigure/*.cy.js`: 9 specs, 19 tests — 18 passing, 1 pending (the opt-in live-CDN accessibility spec), 0 failing.
- No prefigure, diagcess, pyodide, or wheel request is issued from `graphicControls.cy.js` — verified with a throwaway spec that spied on `https://cdn.jsdelivr.net/**` along the stubbed prefigure path. The spec does still make jsDelivr requests for MathJax (`mathjax@4.1.3/tex-mml-chtml.js` plus its fonts and speech-rule data), which the viewer loads on every page regardless of renderer.
- The transient value was measured with a throwaway spec that replayed the four arrow steps 12 times per browser session across 4 sessions and recorded the settled slider value: 46 × `0.8`, 2 × `0.6`, both `0.6` occurrences on the cold first load of a session. This is what set the lower bound.

Throwaway probe specs were deleted; `git status` is clean.

## Out of scope

`prefigureDebounce.cy.js`, `prefigureSanitize.cy.js`, `prefigureViewport.cy.js`, `prefigureDiagcessScript.cy.js`, and `prefigureAnnotationsAccessibility.cy.js` still `cy.visit("/")` without the mock module, so they continue to pull the real prefigure runtime from the CDN and carry the same latent starvation risk. They are deliberately left alone here: `prefigureDebounce.cy.js` in particular asserts against the cold-path 1000ms debounce, which an instantly-warm stub module would collapse to 40ms.

The dropped-step behavior itself is an application-side race in the transient sync effect of `PointControlCoordinator`, not a test bug. It is left as-is: this PR is intentionally test-only, and the assertion is written to tolerate it rather than to mask a regression.

## Changeset

None. `@doenet/test-cypress` is not published, by both of the signals `.github/skills/changesets/SKILL.md` calls reliable: its Vite config has no `scripts/transform-package-json.ts` step, and it does not appear among the publish targets in `.github/workflows/publish.yml`. (Its root `"private": true` settles nothing on its own — every published package in this repo carries that flag.) This PR also changes no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
