### PR TITLE
Report the core's broken invariants on the console, not as diagnostics

### DIFF
--- a/.changeset/i18n-internal-diagnostics.md
+++ b/.changeset/i18n-internal-diagnostics.md
@@ -8,7 +8,7 @@
 
 Stop reporting the core's broken invariants as diagnostics.
 
-Fourteen messages raised when something inside the core does not add up — a
+Eighteen messages raised when something inside the core does not add up — a
 state variable that should exist and doesn't, an array index past the end of
 its own array, a parent that vanished before its children were added — no
 longer reach the diagnostics list. They name state variables and component
@@ -16,9 +16,10 @@ indices, never anything in the document, and there is nothing an author can do
 about one. They are now plain English lines on the console, worded exactly as
 before.
 
-Two of them named something an author had written, and those become translated
-warnings that say only that part: an index that cannot be applied now reads
-``Cannot reference index `$p.styleDescription[1]` ``, and a `<callAction>`
-whose `actionName` the target does not have now reads
+Three more named something an author had written, and those become two
+translated warnings that say only that part: an index that cannot be applied
+now reads ``Cannot reference index `$p.styleDescription[1]` `` and is marked on
+the reference that wrote it rather than on whatever it pointed at, and a
+`<callAction>` whose `actionName` the target does not have now reads
 ``Cannot call submitAnswer on component `$p` `` rather than quoting a component
 index no author has seen.

--- a/.changeset/i18n-internal-diagnostics.md
+++ b/.changeset/i18n-internal-diagnostics.md
@@ -1,0 +1,24 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop reporting the core's broken invariants as diagnostics.
+
+Fourteen messages raised when something inside the core does not add up — a
+state variable that should exist and doesn't, an array index past the end of
+its own array, a parent that vanished before its children were added — no
+longer reach the diagnostics list. They name state variables and component
+indices, never anything in the document, and there is nothing an author can do
+about one. They are now plain English lines on the console, worded exactly as
+before.
+
+Two of them named something an author had written, and those become translated
+warnings that say only that part: an index that cannot be applied now reads
+``Cannot reference index `$p.styleDescription[1]` ``, and a `<callAction>`
+whose `actionName` the target does not have now reads
+``Cannot call submitAnswer on component `$p` `` rather than quoting a component
+index no author has seen.

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -21,6 +21,7 @@ import { getNumVariants } from "./utils/variants";
 import { removeFunctionsMathExpressionClass } from "./utils/math";
 import { reportTimerError, TimerLabels } from "./utils/timerErrors";
 import {
+    doenetMLStringForReference,
     getSourceLocationForComponent,
     narrowPositionToOpeningTag,
 } from "./utils/sourceLocation";
@@ -356,6 +357,12 @@ export default class Core {
             copyToClipboard: this.copyToClipboard.bind(this),
             navigateToTarget: (args: any) =>
                 navigateToTarget({ core: this, args }),
+            // The DoenetML behind a reference a component holds, so a
+            // component can name a `target` back to the author as they wrote
+            // it. The source text lives on core; the resolved path a
+            // component has is the half that needs looking up in it.
+            doenetMLStringForReference: (originalPath: any) =>
+                doenetMLStringForReference(originalPath, this.allDoenetMLs),
             // State-variable runtime plumbing, not component-facing API:
             // the shared state-variable functions in StateVariableInitializer
             // reach core through `svComponent.coreFunctions`.

--- a/packages/doenetml-worker-javascript/src/components/CallAction.js
+++ b/packages/doenetml-worker-javascript/src/components/CallAction.js
@@ -14,6 +14,7 @@ import {
 } from "../utils/triggering";
 import InlineComponent from "./abstract/InlineComponent";
 import { returnSelectedStyleStateVariableDefinition } from "@doenet/utils";
+import { codedDiagnostic } from "../utils/diagnostics";
 
 export default class CallAction extends InlineComponent {
     constructor(args) {
@@ -151,7 +152,14 @@ export default class CallAction extends InlineComponent {
         };
 
         stateVariableDefinitions.targetComponentIdx = {
-            additionalStateVariablesDefined: ["unresolvedPath"],
+            // `targetOriginalPath` is the resolved path of the `target`
+            // reference, kept so that a failure can quote back the `$…` the
+            // author typed. The component index alone is no use for that:
+            // it never appeared in the document.
+            additionalStateVariablesDefined: [
+                "unresolvedPath",
+                "targetOriginalPath",
+            ],
             returnDependencies: () => ({
                 target: {
                     dependencyType: "attributeRefResolutions",
@@ -167,6 +175,7 @@ export default class CallAction extends InlineComponent {
                             setValue: {
                                 targetComponentIdx: target.componentIdx,
                                 unresolvedPath: target.unresolvedPath,
+                                targetOriginalPath: target.originalPath,
                             },
                         };
                     }
@@ -175,6 +184,7 @@ export default class CallAction extends InlineComponent {
                     setValue: {
                         targetComponentIdx: null,
                         unresolvedPath: null,
+                        targetOriginalPath: null,
                     },
                 };
             },
@@ -208,7 +218,7 @@ export default class CallAction extends InlineComponent {
                 args.actionId = actionId;
             }
 
-            await this.coreFunctions.performAction({
+            const result = await this.coreFunctions.performAction({
                 componentIdx: targetIdx,
                 actionName,
                 args,
@@ -222,6 +232,16 @@ export default class CallAction extends InlineComponent {
                 caseInsensitiveMatch: true,
             });
 
+            if (result?.actionUnavailable) {
+                // The target resolved but has no action by this name — a
+                // misspelled `actionName`, or one that belongs to a different
+                // component type. Raised here rather than where the lookup
+                // failed because this is the only place that still knows what
+                // the author wrote: `performAction` has a component index, and
+                // an author has never seen one of those.
+                await this.warnActionUnavailable(actionName);
+            }
+
             await this.coreFunctions.triggerChainedActions({
                 componentIdx: this.componentIdx,
                 actionId,
@@ -229,6 +249,33 @@ export default class CallAction extends InlineComponent {
                 skipRendererUpdate,
             });
         }
+    }
+
+    /**
+     * Warn that `actionName` is not an action of the component `target`
+     * names, quoting the reference as the author wrote it.
+     *
+     * Says nothing when the reference has no source behind it — a `target`
+     * a composite built rather than a document supplied. There is no text to
+     * quote then, and a warning that names an empty reference tells an author
+     * less than the console line `performAction` has already written.
+     */
+    async warnActionUnavailable(actionName) {
+        const referenceText = this.coreFunctions.doenetMLStringForReference(
+            await this.stateValues.targetOriginalPath,
+        );
+        if (!referenceText) {
+            return;
+        }
+        this.coreFunctions.addDiagnostic(
+            codedDiagnostic({
+                type: "warning",
+                code: "doenet-w0102",
+                args: { action: actionName, reference: `$${referenceText}` },
+                position: this.position,
+                sourceDoc: this.sourceDoc,
+            }),
+        );
     }
 
     async callActionIfTriggerNewlyTrue({

--- a/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
@@ -1,4 +1,5 @@
 import type Core from "../Core";
+import { reportInternalError } from "../utils/internalErrors";
 import type { ComponentIdx } from "@doenet/utils";
 import { deriveChildResultsFromDefiningChildren } from "./ChildMatcher";
 import {
@@ -94,10 +95,9 @@ export async function addComponents({
     if (!initialAdd) {
         parent = core._components[parentIdx!];
         if (!parent) {
-            core.addDiagnostic({
-                type: "warning",
-                message: `Cannot add children to parent ${parentIdx} as ${parentIdx} does not exist`,
-            });
+            reportInternalError(
+                `Cannot add children to parent ${parentIdx} as ${parentIdx} does not exist`,
+            );
             return [];
         }
 

--- a/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
@@ -1,4 +1,5 @@
 import type Core from "../Core";
+import { reportInternalError } from "../utils/internalErrors";
 import type { ComponentInstance } from "../types/componentInstance";
 import type { ComponentIdx } from "@doenet/utils";
 import me from "math-expressions";
@@ -318,22 +319,16 @@ export class EssentialValueWriter {
                         }
                     }
 
-                    this.core.addDiagnostic({
-                        type: "info",
-                        message: `can't update state variable ${vName} of component ${cIdx}, as it doesn't exist.`,
-                        position: this.core._components[cIdx].position,
-                        sourceDoc: this.core._components[cIdx].sourceDoc,
-                    });
+                    reportInternalError(
+                        `can't update state variable ${vName} of component ${cIdx}, as it doesn't exist.`,
+                    );
                     continue;
                 }
 
                 if (!compStateObj.hasEssential) {
-                    this.core.addDiagnostic({
-                        type: "info",
-                        message: `can't update state variable ${vName} of component ${cIdx}, as it does not have an essential state variable.`,
-                        position: this.core._components[cIdx].position,
-                        sourceDoc: this.core._components[cIdx].sourceDoc,
-                    });
+                    reportInternalError(
+                        `can't update state variable ${vName} of component ${cIdx}, as it does not have an essential state variable.`,
+                    );
                     continue;
                 }
 
@@ -648,12 +643,9 @@ export class EssentialValueWriter {
                         varName2,
                     )
                 ) {
-                    this.core.addDiagnostic({
-                        type: "info",
-                        message: `Can't invert ${varName2} at the same time as ${stateVariable}, as not an additional state variable defined`,
-                        position: component.position,
-                        sourceDoc: component.sourceDoc,
-                    });
+                    reportInternalError(
+                        `Can't invert ${varName2} at the same time as ${stateVariable}, as not an additional state variable defined`,
+                    );
                     continue;
                 }
                 // Note: don't check if varName2 is an array
@@ -664,12 +656,9 @@ export class EssentialValueWriter {
         }
 
         if (!stateVarObj.inverseDefinition) {
-            this.core.addDiagnostic({
-                type: "info",
-                message: `Cannot change state variable ${stateVariable} of ${component.componentIdx} as it doesn't have an inverse definition`,
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportInternalError(
+                `Cannot change state variable ${stateVariable} of ${component.componentIdx} as it doesn't have an inverse definition`,
+            );
             return;
         }
 
@@ -678,12 +667,9 @@ export class EssentialValueWriter {
             !stateVarObj.ignoreFixed &&
             (await component.stateValues.fixed)
         ) {
-            this.core.addDiagnostic({
-                type: "info",
-                message: `Changing ${stateVariable} of ${component.componentIdx} did not succeed because fixed is true.`,
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportInternalError(
+                `Changing ${stateVariable} of ${component.componentIdx} did not succeed because fixed is true.`,
+            );
             return;
         }
 
@@ -692,12 +678,9 @@ export class EssentialValueWriter {
             stateVarObj.isLocation &&
             (await component.stateValues.fixLocation)
         ) {
-            this.core.addDiagnostic({
-                type: "info",
-                message: `Changing ${stateVariable} of ${component.componentIdx} did not succeed because fixLocation is true.`,
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportInternalError(
+                `Changing ${stateVariable} of ${component.componentIdx} did not succeed because fixLocation is true.`,
+            );
             return;
         }
 
@@ -705,12 +688,9 @@ export class EssentialValueWriter {
             initialChange ||
             (await component.stateValues.modifyIndirectly) !== false
         )) {
-            this.core.addDiagnostic({
-                type: "info",
-                message: `Changing ${stateVariable} of ${component.componentIdx} did not succeed because modifyIndirectly is false.`,
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportInternalError(
+                `Changing ${stateVariable} of ${component.componentIdx} did not succeed because modifyIndirectly is false.`,
+            );
             return;
         }
 
@@ -1031,12 +1011,9 @@ export class EssentialValueWriter {
                             !stateVarObj.ignoreFixed &&
                             (await baseComponent.stateValues.fixed)
                         ) {
-                            this.core.addDiagnostic({
-                                type: "info",
-                                message: `Changing ${stateVariable} of ${baseComponent.componentIdx} did not succeed because fixed is true.`,
-                                position: baseComponent.position,
-                                sourceDoc: baseComponent.sourceDoc,
-                            });
+                            reportInternalError(
+                                `Changing ${stateVariable} of ${baseComponent.componentIdx} did not succeed because fixed is true.`,
+                            );
                             return;
                         }
 
@@ -1046,12 +1023,9 @@ export class EssentialValueWriter {
                             !stateVarObj.isLocation &&
                             (await baseComponent.stateValues.fixLocation)
                         ) {
-                            this.core.addDiagnostic({
-                                type: "info",
-                                message: `Changing ${stateVariable} of ${baseComponent.componentIdx} did not succeed because fixLocation is true.`,
-                                position: baseComponent.position,
-                                sourceDoc: baseComponent.sourceDoc,
-                            });
+                            reportInternalError(
+                                `Changing ${stateVariable} of ${baseComponent.componentIdx} did not succeed because fixLocation is true.`,
+                            );
                             return;
                         }
                     }
@@ -1259,16 +1233,9 @@ export class EssentialValueWriter {
                                 ].includes(dep2.dependencyType) &&
                                 dep2.downstreamComponentIndices.length === 1
                             )) {
-                                this.core.addDiagnostic({
-                                    type: "info",
-                                    message: `Can't simultaneously set additional dependency value ${dependencyName2} if it isn't a state variable`,
-                                    position:
-                                        this.core._components[dComponentIdx]
-                                            .position,
-                                    sourceDoc:
-                                        this.core._components[dComponentIdx]
-                                            .sourceDoc,
-                                });
+                                reportInternalError(
+                                    `Can't simultaneously set additional dependency value ${dependencyName2} if it isn't a state variable`,
+                                );
                                 continue;
                             }
 
@@ -1282,16 +1249,9 @@ export class EssentialValueWriter {
                                     varName2,
                                 )
                             ) {
-                                this.core.addDiagnostic({
-                                    type: "info",
-                                    message: `Can't simultaneously set additional dependency value ${dependencyName2} if it doesn't correspond to additional state variable defined of ${dependencyName}'s state variable`,
-                                    position:
-                                        this.core._components[dComponentIdx]
-                                            .position,
-                                    sourceDoc:
-                                        this.core._components[dComponentIdx]
-                                            .sourceDoc,
-                                });
+                                reportInternalError(
+                                    `Can't simultaneously set additional dependency value ${dependencyName2} if it doesn't correspond to additional state variable defined of ${dependencyName}'s state variable`,
+                                );
                                 continue;
                             }
                             if (!inst.additionalStateVariableValues) {

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -1,4 +1,6 @@
 import type Core from "../Core";
+import { codedDiagnostic } from "../utils/diagnostics";
+import { reportInternalError } from "../utils/internalErrors";
 import { deepClone, flattenDeep } from "@doenet/utils";
 import type { ComponentInstance } from "../types/componentInstance";
 import { applyPendingShadowModification } from "./StateVariableDefinitionFactory";
@@ -179,8 +181,6 @@ function multiDimSetArrayValue(
     this: any,
     { value, arrayKey, arraySize, arrayValues = this.arrayValues }: any,
 ) {
-    const component = this.svComponent;
-    const addDiagnostic = component.coreFunctions.addDiagnostic;
     const numDimensions = this.numDimensions;
 
     let index = this.keyToIndex(arrayKey);
@@ -190,13 +190,9 @@ function multiDimSetArrayValue(
     // evaluates to `false > number === false` for any positive
     // integer, so the diagnostic was unreachable.
     if (numDimensionsInArrayKey > numDimensions) {
-        addDiagnostic({
-            type: "info",
-            message:
-                "Cannot set array value.  Number of dimensions is too large.",
-            position: component.position,
-            sourceDoc: component.sourceDoc,
-        });
+        reportInternalError(
+            "Cannot set array value.  Number of dimensions is too large.",
+        );
         return { nFailures: 1 };
     }
     let arrayValuesDrillDown = arrayValues;
@@ -209,12 +205,7 @@ function multiDimSetArrayValue(
             arrayValuesDrillDown = arrayValuesDrillDown[indComponent];
             arraySizeDrillDown = arraySizeDrillDown.slice(1);
         } else {
-            addDiagnostic({
-                type: "info",
-                message: "ignore setting array value out of bounds",
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportInternalError("ignore setting array value out of bounds");
             return { nFailures: 1 };
         }
     }
@@ -235,13 +226,9 @@ function multiDimSetArrayValue(
             // given that size of arrayValuesPieces is arraySizePiece
 
             if (!Array.isArray(desiredValue)) {
-                addDiagnostic({
-                    type: "info",
-                    message:
-                        "ignoring array values with insufficient dimensions",
-                    position: component.position,
-                    sourceDoc: component.sourceDoc,
-                });
+                reportInternalError(
+                    "ignoring array values with insufficient dimensions",
+                );
                 return { nFailures: 1 };
             }
 
@@ -249,12 +236,7 @@ function multiDimSetArrayValue(
 
             let currentSize = arraySizePiece[0];
             if (desiredValue.length > currentSize) {
-                addDiagnostic({
-                    type: "info",
-                    message: "ignoring array values out of bounds",
-                    position: component.position,
-                    sourceDoc: component.sourceDoc,
-                });
+                reportInternalError("ignoring array values out of bounds");
                 nFailuresSub += desiredValue.length - currentSize;
                 desiredValue = desiredValue.slice(0, currentSize);
             }
@@ -307,13 +289,9 @@ function oneDimSetArrayValue(
         arrayValues[ind] = value;
         return { nFailures: 0 };
     } else {
-        const component = this.svComponent;
-        component.coreFunctions.addDiagnostic({
-            type: "info",
-            message: `Ignoring setting array values out of bounds: ${arrayKey} of ${this.svVarName}`,
-            position: component.position,
-            sourceDoc: component.sourceDoc,
-        });
+        reportInternalError(
+            `Ignoring setting array values out of bounds: ${arrayKey} of ${this.svVarName}`,
+        );
         return { nFailures: 1 };
     }
 }
@@ -1972,19 +1950,54 @@ async function createArraySizeStateVariable({
 // (See above description of arrayVarNameFromPropIndex for technical debt commentary.)
 // It calls arrayVarNameFromPropIndex on each of an array of stateVariables,
 // first creating any missing array entry state variables,
-// logs diagnostics,
+// reports the ones it cannot map,
 // and returns an array of the resulting state variables.
 export async function arrayEntryNamesFromPropIndex({
     core,
     stateVariables,
     component,
     propIndex,
+    reference,
 }: {
     core: Core;
     stateVariables: string[];
     component: ComponentInstance;
     propIndex: number[];
+    /**
+     * The reference the author wrote, `$` and all — `$p.styleDescription[1]`
+     * — so a failure here can be reported in terms of the document rather
+     * than in terms of the state variable it resolved to. Empty when the
+     * source offsets aren't available, in which case nothing is raised: a
+     * warning naming an empty reference tells an author less than silence.
+     */
+    reference: string;
 }) {
+    /**
+     * Report that the index the author wrote cannot be applied.
+     *
+     * Two things are said, to two audiences. The author gets a translated
+     * warning naming the reference they wrote, which is the only part of this
+     * they can act on. We get the state variable and the component index on
+     * the console, which is what a bug report needs and what an author can do
+     * nothing with.
+     */
+    function reportPropIndexFailure(varName: string, detail: string) {
+        reportInternalError(
+            `Cannot get propIndex from ${varName} of ${component.componentIdx}${detail}`,
+        );
+        if (reference) {
+            core.addDiagnostic(
+                codedDiagnostic({
+                    type: "warning",
+                    code: "doenet-w0100",
+                    args: { reference },
+                    position: component.position,
+                    sourceDoc: component.sourceDoc,
+                }),
+            );
+        }
+    }
+
     let newVarNames = [];
     for (let varName of stateVariables) {
         let stateVarObj = component.state[varName];
@@ -2017,23 +2030,16 @@ export async function arrayEntryNamesFromPropIndex({
                 varName,
             );
         } else {
-            core.addDiagnostic({
-                type: "warning",
-                message: `Cannot get propIndex from ${varName} of ${component.componentIdx} as it is not an array or array entry state variable`,
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportPropIndexFailure(
+                varName,
+                " as it is not an array or array entry state variable",
+            );
             newName = varName;
         }
         if (newName) {
             newVarNames.push(newName);
         } else {
-            core.addDiagnostic({
-                type: "warning",
-                message: `Cannot get propIndex from ${varName} of ${component.componentIdx}`,
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportPropIndexFailure(varName, "");
             newVarNames.push(varName);
         }
     }

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -1,7 +1,7 @@
 import type Core from "../Core";
 import { codedDiagnostic } from "../utils/diagnostics";
 import { reportInternalError } from "../utils/internalErrors";
-import { deepClone, flattenDeep } from "@doenet/utils";
+import { deepClone, flattenDeep, type Position } from "@doenet/utils";
 import type { ComponentInstance } from "../types/componentInstance";
 import { applyPendingShadowModification } from "./StateVariableDefinitionFactory";
 import {
@@ -1964,13 +1964,26 @@ export async function arrayEntryNamesFromPropIndex({
     component: ComponentInstance;
     propIndex: number[];
     /**
-     * The reference the author wrote, `$` and all — `$p.styleDescription[1]`
-     * — so a failure here can be reported in terms of the document rather
-     * than in terms of the state variable it resolved to. Empty when the
-     * source offsets aren't available, in which case nothing is raised: a
-     * warning naming an empty reference tells an author less than silence.
+     * The reference the author wrote and where they wrote it, so a failure
+     * here can be reported in terms of the document rather than in terms of
+     * the state variable it resolved to.
+     *
+     * `component` is the wrong place to attribute that failure to: it is what
+     * the reference *resolved to*, so two references to the same target would
+     * both be marked on the target and neither on itself. `position` here is
+     * the referring component's instead.
+     *
+     * Absent when the source text isn't available — a reference a composite
+     * built rather than a document supplied — in which case nothing is
+     * raised: a warning naming an empty reference tells an author less than
+     * silence.
      */
-    reference: string;
+    reference?: {
+        /** The reference as written, `$` and all: `$p.styleDescription[1]`. */
+        text: string;
+        position?: Position;
+        sourceDoc?: number;
+    };
 }) {
     /**
      * Report that the index the author wrote cannot be applied.
@@ -1990,9 +2003,9 @@ export async function arrayEntryNamesFromPropIndex({
                 codedDiagnostic({
                     type: "warning",
                     code: "doenet-w0100",
-                    args: { reference },
-                    position: component.position,
-                    sourceDoc: component.sourceDoc,
+                    args: { reference: reference.text },
+                    position: reference.position,
+                    sourceDoc: reference.sourceDoc,
                 }),
             );
         }

--- a/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableInitializer.ts
@@ -1966,12 +1966,8 @@ export async function arrayEntryNamesFromPropIndex({
     /**
      * The reference the author wrote and where they wrote it, so a failure
      * here can be reported in terms of the document rather than in terms of
-     * the state variable it resolved to.
-     *
-     * `component` is the wrong place to attribute that failure to: it is what
-     * the reference *resolved to*, so two references to the same target would
-     * both be marked on the target and neither on itself. `position` here is
-     * the referring component's instead.
+     * the state variable it resolved to. `position` is the referring
+     * component's, so each reference is marked where it was written.
      *
      * Absent when the source text isn't available — a reference a composite
      * built rather than a document supplied — in which case nothing is

--- a/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
@@ -1,4 +1,5 @@
 import type Core from "../Core";
+import { reportInternalError } from "../utils/internalErrors";
 import type { ComponentIdx } from "@doenet/utils";
 import { addComponents } from "./ComponentBuilder";
 import { deleteComponents } from "./DeletionEngine";
@@ -138,8 +139,13 @@ export class UpdateExecutor {
      * Main path: look up `component.actions[actionName]` (with optional
      * case-insensitive fallback when `caseInsensitiveMatch` is set), record
      * the `event` if provided, and `await` the action. Returns
-     * `{ actionId }` on success. If the component exists but the action
-     * does not, a warning diagnostic is added and `{}` is returned.
+     * `{ actionId }` on success. If the component exists but the action does
+     * not, `{ actionUnavailable: true }` is returned: what an author can be
+     * told about that depends on how the action was asked for, and only the
+     * caller knows. `<callAction>` turns it into a warning naming the
+     * `target` the author wrote; everything else reaches here from a
+     * renderer or from the core itself, where there is nothing an author
+     * wrote to name, so all that is left is a line on the console.
      */
     async performAction({
         componentIdx,
@@ -236,12 +242,10 @@ export class UpdateExecutor {
         }
 
         if (component) {
-            this.core.addDiagnostic({
-                type: "warning",
-                message: `Cannot run action ${actionName} on component ${componentIdx}`,
-                position: component.position,
-                sourceDoc: component.sourceDoc,
-            });
+            reportInternalError(
+                `Cannot run action ${actionName} on component ${componentIdx}`,
+            );
+            return { actionUnavailable: true };
         }
 
         return {};
@@ -360,10 +364,9 @@ export class UpdateExecutor {
                         if (component) {
                             componentsToDelete.push(component);
                         } else {
-                            this.core.addDiagnostic({
-                                type: "info",
-                                message: `Cannot delete ${componentIdx} as it doesn't exist.`,
-                            });
+                            reportInternalError(
+                                `Cannot delete ${componentIdx} as it doesn't exist.`,
+                            );
                         }
                     }
 

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -489,10 +489,12 @@ export class Dependency {
                 // from. Reconstructing it here rather than inside
                 // `arrayEntryNamesFromPropIndex` keeps that lookup on the one
                 // path that has an authored reference behind it.
-                const referenceText = doenetMLStringForReference(
+                const referringComponent =
                     this.dependencyHandler.core._components[
                         this.upstreamComponentIdx
-                    ]?.refResolution?.originalPath,
+                    ];
+                const referenceText = doenetMLStringForReference(
+                    referringComponent?.refResolution?.originalPath,
                     this.dependencyHandler.core.allDoenetMLs,
                 );
                 mappedVarNames = await arrayEntryNamesFromPropIndex({
@@ -500,7 +502,15 @@ export class Dependency {
                     stateVariables: mappedVarNames,
                     component: downComponent,
                     propIndex: this.propIndex,
-                    reference: referenceText ? `$${referenceText}` : "",
+                    reference: referenceText
+                        ? {
+                              text: `$${referenceText}`,
+                              // The referring component, not `downComponent`:
+                              // the mistake is where the index was written.
+                              position: referringComponent.position,
+                              sourceDoc: referringComponent.sourceDoc,
+                          }
+                        : undefined,
                 });
             }
 

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -6,6 +6,7 @@ import {
     arrayEntryNamesFromPropIndex,
     ensureStateVariableMaterialized,
 } from "../StateVariableInitializer";
+import { doenetMLStringForReference } from "../../utils/sourceLocation";
 
 /**
  * Base class shared by every concrete dependency type. Concrete subclasses
@@ -480,11 +481,26 @@ export class Dependency {
             }
 
             if (this.propIndex !== undefined) {
+                // The reference the author wrote — `$p.styleDescription[1]` —
+                // reconstructed from the source so that a propIndex that
+                // cannot be applied is reported in those terms. The upstream
+                // component is the one that carries the reference; its
+                // resolution remembers where in the document it was read
+                // from. Reconstructing it here rather than inside
+                // `arrayEntryNamesFromPropIndex` keeps that lookup on the one
+                // path that has an authored reference behind it.
+                const referenceText = doenetMLStringForReference(
+                    this.dependencyHandler.core._components[
+                        this.upstreamComponentIdx
+                    ]?.refResolution?.originalPath,
+                    this.dependencyHandler.core.allDoenetMLs,
+                );
                 mappedVarNames = await arrayEntryNamesFromPropIndex({
                     core: this.dependencyHandler.core,
                     stateVariables: mappedVarNames,
                     component: downComponent,
                     propIndex: this.propIndex,
+                    reference: referenceText ? `$${referenceText}` : "",
                 });
             }
 

--- a/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/Dependency.ts
@@ -486,9 +486,7 @@ export class Dependency {
                 // cannot be applied is reported in those terms. The upstream
                 // component is the one that carries the reference; its
                 // resolution remembers where in the document it was read
-                // from. Reconstructing it here rather than inside
-                // `arrayEntryNamesFromPropIndex` keeps that lookup on the one
-                // path that has an authored reference behind it.
+                // from, which is why the lookup belongs here.
                 const referringComponent =
                     this.dependencyHandler.core._components[
                         this.upstreamComponentIdx
@@ -505,8 +503,7 @@ export class Dependency {
                     reference: referenceText
                         ? {
                               text: `$${referenceText}`,
-                              // The referring component, not `downComponent`:
-                              // the mistake is where the index was written.
+                              // Marked where the index was written.
                               position: referringComponent.position,
                               sourceDoc: referringComponent.sourceDoc,
                           }

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -5,6 +5,7 @@
  */
 
 import { Dependency } from "./Dependency";
+import { doenetMLStringForReference } from "../../utils/sourceLocation";
 
 export class RefResolutionIndexDependencies extends Dependency {
     static dependencyType = "refResolutionIndexDependencies";
@@ -315,22 +316,11 @@ export class RefResolutionDependency extends Dependency {
          * and the DoenetML string from `this.dependencyHandler.core.allDoenetMLs[0]`,
          * return the substring of DoenetML corresponding to the resolution's `originalPath`.
          */
-        const getDoenetMLStringForReference = () => {
-            const originalPath = composite.refResolution.originalPath;
-            const startOffset = originalPath[0].position?.start.offset;
-            const endOffset =
-                originalPath[originalPath.length - 1].position?.end.offset;
-            const sourceDoc = originalPath[0].sourceDoc ?? 0;
-
-            let doenetMLString = "";
-            if (startOffset != undefined && endOffset != undefined) {
-                doenetMLString =
-                    this.dependencyHandler.core.allDoenetMLs?.[
-                        sourceDoc
-                    ]?.substring(startOffset, endOffset) ?? "";
-            }
-            return doenetMLString;
-        };
+        const getDoenetMLStringForReference = () =>
+            doenetMLStringForReference(
+                composite.refResolution.originalPath,
+                this.dependencyHandler.core.allDoenetMLs,
+            );
 
         // We skip parent search only if we start with no path,
         // which will happen from references to items created in a repeat

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -201,16 +201,15 @@ describe("coded diagnostics reach the record @group4", () => {
     });
 
     // The two warnings that survived the core's invariant diagnostics becoming
-    // developer logs (#1518). What separates them from the fourteen that did
+    // developer logs (#1518). What separates them from the eighteen that did
     // not is that an author wrote something these can name: an index in a
     // reference, an `actionName` on a `target`. Everything the core knows and
     // the author doesn't — the state variable, the component index — went to
     // the console instead, so what is checked here is that the argument that
     // reaches the record is the source text and nothing else.
     it("names the reference an index cannot be applied to", async () => {
-        const { core } = await createTestCore({
-            doenetML: `<point name="p" /><text extend="$p.styleDescription[1]" />`,
-        });
+        const doenetML = `<point name="p" /><text extend="$p.styleDescription[1]" />`;
+        const { core } = await createTestCore({ doenetML });
 
         const { warnings } = getDiagnosticsByType(core);
         expect(warnings.length).eq(1);
@@ -220,6 +219,13 @@ describe("coded diagnostics reach the record @group4", () => {
         });
         expect(warnings[0].message).eq(
             "Cannot reference index `$p.styleDescription[1]`",
+        );
+        // Marked on the `<text>` that wrote the index, not on the `<point>`
+        // the reference resolved to. Attributing it to the referent would
+        // put every reference to `$p` on `$p` itself.
+        const { start, end } = warnings[0].position!;
+        expect(doenetML.substring(start.offset, end.offset)).eq(
+            `<text extend="$p.styleDescription[1]" />`,
         );
     });
 

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -229,21 +229,24 @@ describe("coded diagnostics reach the record @group4", () => {
         );
     });
 
-    // The same warning from the other branch of `arrayEntryNamesFromPropIndex`
-    // — here `value` is a plain state variable rather than an array — which is
-    // why one code covers both: the author's mistake is the same one, and the
-    // difference between the two is a fact about the core that only the
-    // console line carries.
-    it("names the reference for a non-array state variable too", async () => {
+    // The same warning from the other site in `arrayEntryNamesFromPropIndex`.
+    // Above, `styleDescription` is not an array at all; here `vertexX1_1` is
+    // an entry of one, and it is `arrayVarNameFromPropIndex` that can make no
+    // name out of the index. One code covers both because the author's
+    // mistake is the same one — the difference is a fact about the core, and
+    // only the console line carries it (`… of 1`, with no trailing clause).
+    it("names the reference when the array can make no name for the index", async () => {
         const { core } = await createTestCore({
-            doenetML: `<text name="t">hi</text><text extend="$t.value[1]" />`,
+            doenetML: `<polyline name="pg" vertices="(1,2) (3,4)" /><math extend="$pg.vertexX1_1[1]" />`,
         });
 
         const { warnings } = getDiagnosticsByType(core);
         expect(warnings.length).eq(1);
         expect(warnings[0].code).eq("doenet-w0100");
-        expect(warnings[0].args).eqls({ reference: "$t.value[1]" });
-        expect(warnings[0].message).eq("Cannot reference index `$t.value[1]`");
+        expect(warnings[0].args).eqls({ reference: "$pg.vertexX1_1[1]" });
+        expect(warnings[0].message).eq(
+            "Cannot reference index `$pg.vertexX1_1[1]`",
+        );
     });
 
     it("names the target a missing action was asked of", async () => {

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@doenet/i18n";
 import { createTestCore } from "../utils/test-core";
 import { getDiagnosticsByType } from "../utils/diagnostics";
+import { callAction } from "../utils/actions";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -197,5 +198,70 @@ describe("coded diagnostics reach the record @group4", () => {
                 ).toContain(diagnostic.code);
             }
         }
+    });
+
+    // The two warnings that survived the core's invariant diagnostics becoming
+    // developer logs (#1518). What separates them from the fourteen that did
+    // not is that an author wrote something these can name: an index in a
+    // reference, an `actionName` on a `target`. Everything the core knows and
+    // the author doesn't — the state variable, the component index — went to
+    // the console instead, so what is checked here is that the argument that
+    // reaches the record is the source text and nothing else.
+    it("names the reference an index cannot be applied to", async () => {
+        const { core } = await createTestCore({
+            doenetML: `<point name="p" /><text extend="$p.styleDescription[1]" />`,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0100");
+        expect(warnings[0].args).eqls({
+            reference: "$p.styleDescription[1]",
+        });
+        expect(warnings[0].message).eq(
+            "Cannot reference index `$p.styleDescription[1]`",
+        );
+    });
+
+    // The same warning from the other branch of `arrayEntryNamesFromPropIndex`
+    // — here `value` is a plain state variable rather than an array — which is
+    // why one code covers both: the author's mistake is the same one, and the
+    // difference between the two is a fact about the core that only the
+    // console line carries.
+    it("names the reference for a non-array state variable too", async () => {
+        const { core } = await createTestCore({
+            doenetML: `<text name="t">hi</text><text extend="$t.value[1]" />`,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0100");
+        expect(warnings[0].args).eqls({ reference: "$t.value[1]" });
+        expect(warnings[0].message).eq("Cannot reference index `$t.value[1]`");
+    });
+
+    it("names the target a missing action was asked of", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<point name="p" />
+<callAction name="ca" target="$p" actionName="notAnAction" />`,
+        });
+        // The warning is raised when the action is invoked, not when the
+        // document is built: until then nothing has asked the point for an
+        // action it doesn't have.
+        await callAction({
+            componentIdx: await resolvePathToNodeIdx("ca"),
+            core,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0102");
+        expect(warnings[0].args).eqls({
+            action: "notAnAction",
+            reference: "$p",
+        });
+        expect(warnings[0].message).eq(
+            "Cannot call notAnAction on component `$p`",
+        );
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/utils/sourceLocation.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/sourceLocation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { Position } from "@doenet/utils";
+import { doenetMLStringForReference } from "../../utils/sourceLocation";
+
+const doenetML = `<point name="p" /><text extend="$p.styleDescription[1]" />`;
+const secondDoc = `<text name="t">a different document entirely</text>`;
+
+/** A path part spanning `[start, end)` of a document, as the resolver hands it back. */
+function part(start: number, end: number, sourceDoc?: number) {
+    const at = (offset: number): Position["start"] => ({
+        line: 1,
+        column: offset + 1,
+        offset,
+    });
+    return { position: { start: at(start), end: at(end) }, sourceDoc };
+}
+
+// The `p` and the `styleDescription[1]` of `$p.styleDescription[1]`, at their
+// offsets in `doenetML`.
+const namePart = part(33, 34);
+const propPart = part(35, 54);
+
+// `doenetMLStringForReference` is the only way a diagnostic can name a
+// reference back to the author, and the sites that call it all treat `""` as
+// "say nothing at all". Which inputs produce `""` is therefore behavior, not
+// an implementation detail: a change that made it return a partial string
+// instead would turn silence into a warning quoting half a reference.
+describe("doenetMLStringForReference @group4", () => {
+    it("spans the first part's start to the last part's end", () => {
+        // The reference is everything from the first part to the last,
+        // including the `.` between them that is part of neither. The leading
+        // `$` is left to the caller.
+        expect(doenetMLStringForReference([namePart, propPart], [doenetML])).eq(
+            "p.styleDescription[1]",
+        );
+        // Only the ends are read, so a positionless part between them is no
+        // obstacle.
+        expect(
+            doenetMLStringForReference([namePart, {}, propPart], [doenetML]),
+        ).eq("p.styleDescription[1]");
+    });
+
+    it("reads from the document the reference's first part names", () => {
+        expect(
+            doenetMLStringForReference([part(6, 10, 1)], [doenetML, secondDoc]),
+        ).eq("name");
+        // No `sourceDoc` means document 0, which is what a single-document
+        // activity leaves the field as.
+        expect(doenetMLStringForReference([part(1, 6)], [doenetML])).eq(
+            "point",
+        );
+    });
+
+    it("says nothing when there is no path", () => {
+        expect(doenetMLStringForReference(undefined, [doenetML])).eq("");
+        expect(doenetMLStringForReference(null, [doenetML])).eq("");
+        expect(doenetMLStringForReference([], [doenetML])).eq("");
+    });
+
+    it("says nothing when an end of the path carries no position", () => {
+        // What a composite builds rather than a document supplies: `<repeat>`
+        // synthesizes `originalPath` entries with no `position` at all.
+        expect(doenetMLStringForReference([{}], [doenetML])).eq("");
+        expect(doenetMLStringForReference([namePart, {}], [doenetML])).eq("");
+        expect(doenetMLStringForReference([{}, propPart], [doenetML])).eq("");
+    });
+
+    it("says nothing when the source it names is not there", () => {
+        expect(doenetMLStringForReference([namePart], undefined)).eq("");
+        expect(doenetMLStringForReference([part(33, 34, 4)], [doenetML])).eq(
+            "",
+        );
+    });
+});

--- a/packages/doenetml-worker-javascript/src/utils/internalErrors.ts
+++ b/packages/doenetml-worker-javascript/src/utils/internalErrors.ts
@@ -1,0 +1,33 @@
+/**
+ * Report a broken invariant inside the core to the browser console.
+ *
+ * These are the messages the core writes when something about *itself* does
+ * not add up: a state variable it just asked for that isn't there, an array
+ * index past the end of the array it belongs to, a parent that vanished
+ * between deciding to add children and adding them. An author can do nothing
+ * about any of them. They name state variables, dependency names and
+ * component indices — none of which appear in a document — and they show up
+ * only when we have a bug.
+ *
+ * So they are deliberately *not* diagnostics. A diagnostic is addressed to
+ * whoever is reading the document, is rendered in that reader's language, and
+ * is something they can act on; anything that fails those tests is a developer
+ * log, and belongs here. There is no code and no catalog entry: a code exists
+ * to be filtered on and cited, and a catalog entry exists to be translated,
+ * and neither is wanted for a line whose only audience is us, on the occasion
+ * we ask someone to open the console and read back what it says.
+ *
+ * The message is plain English composed at the call site, and each one is
+ * word-for-word what the diagnostic used to say, so a line someone recognizes
+ * from before still reads the same. The `DoenetML internal:` prefix is the
+ * only addition — it makes the family greppable in a console full of
+ * everything else on the page.
+ *
+ * `console.warn` rather than `console.error` follows what the worker already
+ * does for "this shouldn't have happened, carrying on anyway" (see
+ * `Point.js`'s invalid `pointRole`, `Sort.js`'s invalid `type`);
+ * `console.error` is kept for the genuinely thrown.
+ */
+export function reportInternalError(message: string) {
+    console.warn(`DoenetML internal: ${message}`);
+}

--- a/packages/doenetml-worker-javascript/src/utils/internalErrors.ts
+++ b/packages/doenetml-worker-javascript/src/utils/internalErrors.ts
@@ -4,29 +4,24 @@
  * These are the messages the core writes when something about *itself* does
  * not add up: a state variable it just asked for that isn't there, an array
  * index past the end of the array it belongs to, a parent that vanished
- * between deciding to add children and adding them. An author can do nothing
- * about any of them. They name state variables, dependency names and
- * component indices — none of which appear in a document — and they show up
- * only when we have a bug.
+ * between deciding to add children and adding them. They name state
+ * variables, dependency names and component indices — none of which appear in
+ * a document — and they show up only when we have a bug.
  *
- * So they are deliberately *not* diagnostics. A diagnostic is addressed to
- * whoever is reading the document, is rendered in that reader's language, and
- * is something they can act on; anything that fails those tests is a developer
- * log, and belongs here. There is no code and no catalog entry: a code exists
- * to be filtered on and cited, and a catalog entry exists to be translated,
- * and neither is wanted for a line whose only audience is us, on the occasion
- * we ask someone to open the console and read back what it says.
+ * So they are developer logs rather than diagnostics: a diagnostic is
+ * addressed to whoever is reading the document, rendered in that reader's
+ * language, and something they can act on. These have no code and no catalog
+ * entry, because their only audience is us, on the occasion we ask someone to
+ * open the console and read back what it says.
  *
- * The message is plain English composed at the call site, and each one is
- * word-for-word what the diagnostic used to say, so a line someone recognizes
- * from before still reads the same. The `DoenetML internal:` prefix is the
- * only addition — it makes the family greppable in a console full of
+ * The message is plain English composed at the call site. The
+ * `DoenetML internal:` prefix makes the family greppable in a console full of
  * everything else on the page.
  *
- * `console.warn` rather than `console.error` follows what the worker already
- * does for "this shouldn't have happened, carrying on anyway" (see
- * `Point.js`'s invalid `pointRole`, `Sort.js`'s invalid `type`);
- * `console.error` is kept for the genuinely thrown.
+ * `console.warn` follows what the worker already does for "this shouldn't have
+ * happened, carrying on anyway" (see `Point.js`'s invalid `pointRole`,
+ * `Sort.js`'s invalid `type`); `console.error` is kept for the genuinely
+ * thrown.
  */
 export function reportInternalError(message: string) {
     console.warn(`DoenetML internal: ${message}`);

--- a/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
+++ b/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
@@ -30,6 +30,52 @@ export function getSourceLocationForComponent(
 }
 
 /**
+ * One part of a resolved reference path, as the resolver hands it back: the
+ * `p` and the `styleDescription[1]` of `$p.styleDescription[1]`, each carrying
+ * the span of source it was read from.
+ */
+type ReferencePathPart = {
+    position?: Position;
+    sourceDoc?: number;
+};
+
+/**
+ * The DoenetML an author wrote for a reference, read back out of the source.
+ *
+ * Given the `originalPath` of a ref resolution, returns the span it covers —
+ * `p.styleDescription[1]` for `$p.styleDescription[1]`, *without* the leading
+ * `$`, which every caller adds when it composes its message.
+ *
+ * Reconstructing the text is the only way to name a reference back to the
+ * author. By the time anything goes wrong the reference is a component index
+ * and a state-variable name, and neither of those is anything the author
+ * typed; the source they typed is the one description they can act on.
+ *
+ * Returns `""` when the offsets aren't there. A path part built by a composite
+ * rather than parsed from a document (a `<repeat>` remapping its body, say)
+ * has no position, and a message naming an empty reference is worse than no
+ * message — so a caller that gets `""` back should say nothing rather than
+ * quote nothing.
+ */
+export function doenetMLStringForReference(
+    originalPath: ReferencePathPart[] | undefined | null,
+    allDoenetMLs: readonly string[] | undefined,
+): string {
+    if (!originalPath || originalPath.length === 0) {
+        return "";
+    }
+    const startOffset = originalPath[0].position?.start.offset;
+    const endOffset =
+        originalPath[originalPath.length - 1].position?.end.offset;
+    const sourceDoc = originalPath[0].sourceDoc ?? 0;
+
+    if (startOffset == undefined || endOffset == undefined) {
+        return "";
+    }
+    return allDoenetMLs?.[sourceDoc]?.substring(startOffset, endOffset) ?? "";
+}
+
+/**
  * Matches the run of XML tag-name characters immediately after `<`.
  * Per XML 1.0 a name may contain a wider set of characters, but DoenetML
  * tag names only ever use these — keeping the class tight avoids accidentally

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -144,5 +144,7 @@
     "doenet-w0096": "annotation-ref-multiple-targets",
     "doenet-w0097": "annotation-ref-outside-graph",
     "doenet-w0098": "annotation-ref-unsupported-target",
-    "doenet-w0099": "annotation-text-missing"
+    "doenet-w0099": "annotation-text-missing",
+    "doenet-w0100": "reference-index-unavailable",
+    "doenet-w0102": "component-action-unavailable"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -351,6 +351,21 @@ collect-no-source = No source found for collect.
 
 collect-invalid-component-type = Cannot collect components of type `<{ $component }>` as it is an invalid component type.
 
+# $reference is the reference exactly as the author wrote it, `$` and all —
+# the `$p.styleDescription[1]` of `<text extend="$p.styleDescription[1]" />`.
+# An index only means something applied to an array, and the thing named here
+# is not one. The reference is quoted back rather than explained because the
+# text in front of the author is the only part of this they can act on: the
+# state variable and component index the core knows about are its own business
+# and go to the console instead.
+reference-index-unavailable = Cannot reference index `{ $reference }`
+
+## `<callAction>`
+
+# $action is the `actionName` the author asked for, part of the DoenetML
+# language, so it stays in English. $reference is the `target` as written.
+component-action-unavailable = Cannot call { $action } on component `{ $reference }`
+
 ## `<dataFrame>`
 
 # $componentIdx is an internal index, passed as a string so it is not grouped

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -290,6 +290,12 @@ collect-no-source = No se encontró ninguna fuente para collect.
 
 collect-invalid-component-type = No se pueden recolectar componentes de tipo `<{ $component }>` porque no es un tipo de componente válido.
 
+reference-index-unavailable = No se puede referenciar el índice `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = No se puede llamar a { $action } en el componente `{ $reference }`
+
 ## `<dataFrame>`
 
 data-frame-inconsistent-row-lengths = Los datos tienen una forma no válida.  Las filas tienen longitudes distintas. Encontrado en componentIdx :{ $componentIdx }

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -184,6 +184,8 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0097": "annotation-ref-outside-graph",
     "doenet-w0098": "annotation-ref-unsupported-target",
     "doenet-w0099": "annotation-text-missing",
+    "doenet-w0100": "reference-index-unavailable",
+    "doenet-w0102": "component-action-unavailable",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -206,6 +206,8 @@ export type MessageKey =
     | "copy-prop-not-found"
     | "collect-no-source"
     | "collect-invalid-component-type"
+    | "reference-index-unavailable"
+    | "component-action-unavailable"
     | "data-frame-inconsistent-row-lengths"
     | "data-frame-duplicate-column-names"
     | "data-frame-missing-column-name"
@@ -461,6 +463,8 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "copy-prop-not-found",
     "collect-no-source",
     "collect-invalid-component-type",
+    "reference-index-unavailable",
+    "component-action-unavailable",
     "data-frame-inconsistent-row-lengths",
     "data-frame-duplicate-column-names",
     "data-frame-missing-column-name",

--- a/packages/i18n/test/diagnostics.test.ts
+++ b/packages/i18n/test/diagnostics.test.ts
@@ -43,9 +43,26 @@ describe("the diagnostic code registry", () => {
     });
 
     it("points every code at a message English defines", () => {
+        // `diagnostics` specifically, not every catalog: a coded message
+        // belongs in the namespace the main thread loads to render one
+        // (`CHROME_NAMESPACES`). A key that drifted into `content` or
+        // `editor` would still resolve in English — the built-in English
+        // catalogs are appended whole — and then silently fall back to
+        // English in every other locale, because those namespaces are not
+        // shipped to the surface that renders diagnostics.
         const englishKeys = new Set(extractKeys(EN_CATALOGS.diagnostics));
         for (const [code, key] of Object.entries(DIAGNOSTIC_CODES)) {
             expect(englishKeys.has(key), `${code} → ${key}`).toBe(true);
+        }
+    });
+
+    it("renders every registered code as a message, not as its own name", () => {
+        // `formatEnglishDiagnostic` returns the code itself when it cannot
+        // resolve one, so a code whose key the runtime translator does not
+        // carry would pass the check above and still surface as
+        // "doenet-w0100" on screen.
+        for (const code of Object.keys(DIAGNOSTIC_CODES) as DiagnosticCode[]) {
+            expect(formatEnglishDiagnostic(code), code).not.toBe(code);
         }
     });
 


### PR DESCRIPTION
> **#1559 and #1557, which this was stacked on, have merged**, so this now sits directly on `main`. Three commits: `Report the core's broken invariants on the console, not as diagnostics`, with the changeset folded into it, plus two review fix-ups, `Mark the propIndex warning on the reference, not on its referent` and `Cover the propIndex site the second w0100 test was not reaching`. (Opened against `main` because a cross-fork PR cannot base on a fork branch.)
>
> **Substantially rewritten after review.** The first version of this PR gave these messages codes and an `internal` catalog namespace that said "English forever". That whole category is gone. A diagnostic is either author-facing and translated, or it is not a diagnostic. See below.

The next piece of #1518: the twenty-one call sites #1518 called the core's invariant diagnostics — a state variable that should exist and doesn't, an array index past the end of its own array, an action on a component that hasn't got it.

## A diagnostic is either translated or it is not a diagnostic

Eighteen of the twenty-one fail both halves of what a diagnostic is for. They are not addressed to whoever is reading the document — they name state variables, dependency names and component indices, none of which appear in a document — and there is nothing an author can do about one, because each of them means we have a bug. Coding them and exempting them from translation only made that category official; not raising them as diagnostics at all removes it.

They are now `reportInternalError` calls:

```ts
// packages/doenetml-worker-javascript/src/utils/internalErrors.ts
export function reportInternalError(message: string) {
    console.warn(`DoenetML internal: ${message}`);
}
```

Plain English composed at the call site, worded exactly as before so a line anyone recognizes still reads the same. No code, no catalog key, no `DiagnosticArgs` — a code exists to be filtered on and cited, a catalog entry exists to be translated, and neither is wanted for a line whose only audience is us, on the occasion we ask someone to open the console and read it back. `console.warn` rather than `console.error` follows what the worker already does for "this shouldn't have happened, carrying on anyway" (`Point.js`'s invalid `pointRole`, `Sort.js`'s invalid `type`). The one-line prefix is the only addition, so the family is greppable in a console full of everything else on the page.

That deletes the `internal` namespace and everything that propped it up: `locales/en/internal.ftl`, the `CATALOG_NAMESPACES` and `EN_CATALOGS` entries, `UNTRANSLATED_NAMESPACES`, the lint rule that made a translated counterpart an error, and the coverage-denominator filter. `lint-catalogs.ts` measures coverage over all English keys again, exactly as on `main`.

## Three of them did name something an author wrote

Those three keep a diagnostic — a translated one, saying only the part the author can act on.

**`doenet-w0100`**, both propIndex sites in `arrayEntryNamesFromPropIndex`:

```
Cannot reference index `$p.styleDescription[1]`
```

from `<point name="p" /><text extend="$p.styleDescription[1]" />`. The two sites — a state variable that is not an array, and an array that could not produce a name for the index — are the same mistake as far as the author is concerned, so they share one code and one message; what distinguishes them is a fact about the core, and that goes to the console with `Cannot get propIndex from styleDescription of 1`. `doenet-w0101` is therefore unused.

**`doenet-w0102`**, `<callAction>`:

```
Cannot call notAnAction on component `$p`
```

It used to read `Cannot run action notAnAction on component 1`, and `1` is a component index no author has ever seen. It is raised in `CallAction.js` rather than at the `performAction` site, because `performAction` has only that index and no way to know how the action was asked for; it now returns `{ actionUnavailable: true }` and leaves a console line for the callers that reach it from a renderer or from the core itself, where there is nothing an author wrote to name. **The path is reachable from ordinary DoenetML** — `<point name="p" /><callAction name="ca" target="$p" actionName="notAnAction" />`, with the action actually invoked — and there is a test that does exactly that.

### Naming the reference

`refResolutionDependencies.ts` already reconstructed the source text of a reference from the `originalPath` of its resolution. That closure is now a shared `doenetMLStringForReference` in `utils/sourceLocation.ts`, unchanged in behavior, and its two existing callers plus the two new ones use it. When the offsets are missing — a reference a composite built rather than a document supplied — it returns `""` and the site falls back to the console line alone, because a warning naming an empty reference tells an author less than silence. A unit test pins which inputs produce `""`: no path, a positionless part at either end of one, a `sourceDoc` naming a document that isn't there.

Reaching the `originalPath` from each site is the plumbing this does add:

- **`doenet-w0100`** is raised inside `arrayEntryNamesFromPropIndex`, which is handed the *resolved* component and knows nothing of the reference. `Dependency.ts` reconstructs the text from the upstream (referring) component's `refResolution` and passes it in, along with that component's `position` — the reference is the mistake, so it is what gets marked. Attributing it to the resolved component instead, which the first version of this branch did, puts every reference to `$p` on `$p` itself.
- **`doenet-w0102`** is raised in `CallAction.js`, whose `target` is an attribute reference rather than an `extending`, so there is no `refResolution` on the component to read. Its resolution already comes in as a dependency value, so `targetOriginalPath` joins `unresolvedPath` in the same `additionalStateVariablesDefined` — one more field off a dependency the definition was already taking, not a new dependency. It is not `forRenderer` and not public, so it neither ships to the main thread nor changes the schema (`build:schema` regenerates unchanged). Reading the source text off it needs core, which a component reaches only through `coreFunctions`, so `doenetMLStringForReference` is exposed there too.

## Not all 28 were core-internal, and now 18 of the 21 are not diagnostics

#1518 counted 28 remaining "core-internal invariant messages". Reading them, **21** are core-internal; that part of the earlier accounting stands. What has changed is what happens to those 21: **18 sites become console lines**, and **3 become 2 translated warnings**.

The other **7** are not core-internal and are left for #1563, which is where they belong:

- **4 are pass-throughs** — `refResolutionDependencies.ts:366`, `CompositeReplacementUpdater.ts:604`, `CompositeExpander.ts:616`, `Core.ts:648` construct from a `message` variable built elsewhere.
- **2 are genuinely author-facing**: `Copy.js:1559` ("Circular dependency detected involving `<x>` component") and `refResolutionDependencies.ts:464` ("No referent found for reference: `$foo`").
- **1** is `StateVariableDefinitionFactory.ts`, an attribute-specification invariant.

## Code numbering: gaps, on purpose

Issued here: **`doenet-w0100`** and **`doenet-w0102`**.

Left as unissued gaps: **`doenet-i0035`–`doenet-i0047`**, **`doenet-w0101`** and **`doenet-w0103`**. They were added by the first version of this branch, have never been released, and nothing can be citing them, so removing them from the lock is legitimate — `diagnostic-codes.lock.json` is append-only relative to `main`, and nothing that exists on `main` moves. They are not renumbered away because #1563 (stacked on this) has already taken `doenet-i0048` and `doenet-w0104`–`doenet-w0107`, and renumbering a stack to close a hole is how codes stop meaning one thing forever.

Confirmed there is no contiguity rule to violate: `lint:i18n` checks that a code is well-formed, that its key exists in English, that the lock never renumbers, and that every registered code is either raised or explicitly retired. Nothing looks at the sequence.

## The registry test

The first version of this PR widened "points every code at a message English defines" from `EN_CATALOGS.diagnostics` to every catalog, because `internal` was not `diagnostics`. With `internal` gone that reason has gone, and the narrow check is the better one: a coded message belongs in the namespace the main thread actually ships to render diagnostics (`CHROME_NAMESPACES`), and a key that drifted into `content` or `editor` would resolve in English — the built-in English catalogs are appended whole — and then silently fall back to English in every other locale. So it is back to `EN_CATALOGS.diagnostics`.

The companion check that PR added is kept on its own merits: every registered code must *render*, since `formatEnglishDiagnostic` returns the code itself when it cannot resolve one, so a code whose key the runtime translator does not carry would pass the first check and still surface as `doenet-w0100` on screen.

The `doenet-i0039` `it.each` covering its three `reason` branches is gone with the code.

## Testing

- `lint:i18n`: `211 coded call site(s) covering 148/148 code(s); 154/183 diagnostic construction(s) migrated, 29 still holding a literal`, then `i18n catalog lint passed: 254 key(s) across 2 locale(s), 114 call site(s)`. The burn-down moves 50 → 29 the same distance as before, by 21 literal constructions ceasing to exist rather than by being coded; the 2 new coded constructions add one to each side and cancel.
- No locale-coverage note, so Spanish is complete: both new messages are translated in `locales/es/diagnostics.ftl`.
- `@doenet/i18n` — 138 tests
- Three new cases in `diagnostics/diagnosticCodes.test.ts`, asserting code, arguments and exact English for both `doenet-w0100` sites and for `doenet-w0102`. The first also asserts the span the warning is marked on, which is what caught the referent-vs-reference mix-up. Review caught that the second was not reaching the second site: `$t.value[1]` takes the same "not an array at all" branch `$p.styleDescription[1]` does, since `value` is no more an array than `styleDescription` is. It is now `$pg.vertexX1_1[1]` on a `<polyline>`, which reaches the other site — `vertexX1_1` is an entry of `vertices`, and that array's `arrayVarNameFromPropIndex` returns null for it. Removing the diagnostic from that site turns the new case red and leaves the first green.
- A new `test/utils/sourceLocation.test.ts` — five cases over `doenetMLStringForReference`, since three call sites now read `""` as "say nothing" and which inputs produce it is behavior
- worker `diagnostics/`, `copying/`, `utils/`, `point`, `callAction`, `updateValue`, `answer` — 548 passed, 11 skipped
- `@doenet/doenetml` — 88 tests; `@doenet/utils` — 544 tests
- Searched the worker suite (and the docs) for every one of the console messages and for `doenet-i003*` / `doenet-i004*` / `doenet-w010*`: nothing else asserted them
- Worker typecheck reports exactly the errors `main` reports (`CompositeExpander` 6, `StateVariableDefinitionFactory` 29, all pre-existing); `prettier --check` clean on every touched file

## What is left of #1518

**29**: **19 parser** (→ #1549), **2** PreFigure curve piecewise (→ #1560), **1** iframe, and the **7** above, all of which #1563 takes.

Part of #1518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


