### PR TITLE
Code the last of the worker's author-facing diagnostics

### DIFF
--- a/.changeset/i18n-remaining-worker-diagnostics.md
+++ b/.changeset/i18n-remaining-worker-diagnostics.md
@@ -1,0 +1,16 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Translate the last of the worker's author-facing diagnostics: circular
+dependencies in a copy or composite, references that resolve to nothing or to
+several things, children that do not match what a component accepts, an
+attribute value that falls back to its default, and the embed's
+DoenetML-version failure.
+
+Circular dependencies were reported by two components in two places with the
+same wording; they now share one code, so a host filtering on it catches both.

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -1768,10 +1768,19 @@ export const DoenetEditor = React.forwardRef<
             setIgnoreDetectedVersion(true);
             setInErrorState("");
             // Reached through `@doenet/utils`, which already depends on
-            // `@doenet/i18n`, so this costs no new dependency. The fallback
-            // clause is a variant of the message rather than a sentence
-            // appended to it: whether there is a fallback is data, and a
-            // translator has to be able to place it.
+            // `@doenet/i18n`, so this costs no new dependency — but it is not
+            // free: this is the embed's only coded diagnostic, and it pulls
+            // the English catalogs and `@fluent/bundle` into a bundle that
+            // held neither (3641 kB → 3769 kB, 811 kB → 845 kB gzipped).
+            // Worth it only because the alternative is a hand-written English
+            // string that the catalog cannot hold to, and because the record
+            // has to carry a `message` whichever way it is built.
+            //
+            // The fallback clause is a variant of the message rather than a
+            // sentence appended to it: whether there is a fallback is data,
+            // and a translator has to be able to place it. `message` here is
+            // the English fallback only — the viewer inside the iframe
+            // re-renders the record from its code and arguments in `uiLocale`.
             const versionDiagnostic = codedDiagnostic({
                 type: "error",
                 code: "doenet-e0006",

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -4,6 +4,7 @@ import * as Comlink from "comlink";
 
 import { MdError } from "react-icons/md";
 import {
+    codedDiagnostic,
     findAllNewlines,
     getLineCharRange,
     getSystemTheme,
@@ -1766,10 +1767,23 @@ export const DoenetEditor = React.forwardRef<
         if (foundAutoVersion) {
             setIgnoreDetectedVersion(true);
             setInErrorState("");
-            let message = `DoenetML version ${detectedVersion} not found.`;
-            if (!specifiedStandaloneUrl) {
-                message += ` Falling back to version ${specifiedDoenetmlVersion ?? latestDoenetmlVersion}`;
-            }
+            // Reached through `@doenet/utils`, which already depends on
+            // `@doenet/i18n`, so this costs no new dependency. The fallback
+            // clause is a variant of the message rather than a sentence
+            // appended to it: whether there is a fallback is data, and a
+            // translator has to be able to place it.
+            const versionDiagnostic = codedDiagnostic({
+                type: "error",
+                code: "doenet-e0006",
+                args: {
+                    version: String(detectedVersion),
+                    fallback: specifiedStandaloneUrl
+                        ? "none"
+                        : String(
+                              specifiedDoenetmlVersion ?? latestDoenetmlVersion,
+                          ),
+                },
+            });
 
             // add line number to the doenetML range of the error
             let allNewlines = findAllNewlines(doenetML);
@@ -1779,7 +1793,7 @@ export const DoenetEditor = React.forwardRef<
             );
 
             setInitialDiagnostics([
-                { position: detectedDoenetMLrange!, message, type: "error" },
+                { ...versionDiagnostic, position: detectedDoenetMLrange! },
             ]);
             return null;
         }

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -15,9 +15,14 @@ import {
 import {
     createTranslatorFromLocaleData,
     DEFAULT_LOCALE_DATA,
+    type DiagnosticArgs,
+    type DiagnosticCode,
     type LocaleData,
     type Translator,
 } from "@doenet/i18n";
+
+/** A coded diagnostic `ChildMatcher` recorded for `Core` to raise later. */
+type UnmatchedChildren = { code: DiagnosticCode; args: DiagnosticArgs };
 import { getNumVariants } from "./utils/variants";
 import { removeFunctionsMathExpressionClass } from "./utils/math";
 import { reportTimerError, TimerLabels } from "./utils/timerErrors";
@@ -223,7 +228,12 @@ export default class Core {
     errorComponentsToAdd!: any[];
     essentialValuesSavedInDefinition!: Record<string, any>;
     rendererVariablesByComponentType!: Record<string, any>;
-    unmatchedChildren!: Record<number, any>;
+    /**
+     * The diagnostic to raise for each parent whose children did not match,
+     * keyed by parent index. `ChildMatcher` writes it and `Core` raises it a
+     * pass later, so the two are typed rather than left to agree by hand.
+     */
+    unmatchedChildren!: Record<number, UnmatchedChildren>;
     updateInfo: UpdateInfo;
     /** Set by `ComponentBuilder` once the document renderer tree exists. */
     documentRendererInstructions?: any;

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -1,4 +1,5 @@
 import ParameterStack from "./ParameterStack";
+import { codedDiagnostic } from "./utils/diagnostics";
 // `Numerics.js` is still JavaScript; cast at the import site once.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import Numerics from "./Numerics";
@@ -651,13 +652,17 @@ export default class Core {
         if (Object.keys(this.unmatchedChildren).length > 0) {
             for (const componentIdxStr in this.unmatchedChildren) {
                 let parent = this._components[Number(componentIdxStr)];
-                this.addDiagnostic({
-                    type: "warning",
-                    message:
-                        this.unmatchedChildren[Number(componentIdxStr)].message,
-                    position: parent.position,
-                    sourceDoc: parent.sourceDoc,
-                });
+                const unmatched =
+                    this.unmatchedChildren[Number(componentIdxStr)];
+                this.addDiagnostic(
+                    codedDiagnostic({
+                        type: "warning",
+                        code: unmatched.code,
+                        args: unmatched.args,
+                        position: parent.position,
+                        sourceDoc: parent.sourceDoc,
+                    }),
+                );
             }
         }
 

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -20,9 +20,6 @@ import {
     type LocaleData,
     type Translator,
 } from "@doenet/i18n";
-
-/** A coded diagnostic `ChildMatcher` recorded for `Core` to raise later. */
-type UnmatchedChildren = { code: DiagnosticCode; args: DiagnosticArgs };
 import { getNumVariants } from "./utils/variants";
 import { removeFunctionsMathExpressionClass } from "./utils/math";
 import { reportTimerError, TimerLabels } from "./utils/timerErrors";
@@ -49,6 +46,9 @@ import { UpdateExecutor } from "./core/UpdateExecutor";
 import { VisibilityTracker } from "./core/VisibilityTracker";
 import * as nameResolver from "./StateVariableNameResolver";
 import { numberAnswers } from "./utils/answer";
+
+/** A coded diagnostic `ChildMatcher` recorded for `Core` to raise later. */
+type UnmatchedChildren = { code: DiagnosticCode; args: DiagnosticArgs };
 
 /**
  * Constructor arguments passed in from `CoreWorker`. The resolver callbacks

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -14,6 +14,7 @@ import {
 } from "../../utils/dast/convertNormalizedDast";
 import { createNewComponentIndices } from "../../utils/componentIndices";
 import { codedDiagnostic } from "../../utils/diagnostics";
+import { errorComponentState } from "../../utils/dast/errors";
 
 export default class Copy extends CompositeComponent {
     static componentType = "_copy";

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -1537,27 +1537,29 @@ export default class Copy extends CompositeComponent {
             }
 
             console.error("we're calling this circular", e);
-            let message = "Circular dependency detected";
-            if (component.attributes.createComponentOfType?.primitive) {
-                message += ` involving \`<${component.attributes.createComponentOfType.primitive.value}>\` component`;
-            }
-            message += ".";
+            // Same situation the composite expander reports, so the same code.
+            const circular = codedDiagnostic({
+                type: "error",
+                code: "doenet-e0005",
+                args: {
+                    componentType:
+                        component.attributes.createComponentOfType?.primitive
+                            ?.value ?? "none",
+                },
+            });
             serializedReplacements = [
                 {
                     type: "serialized",
                     componentType: "_error",
                     componentIdx: nComponents++,
                     stateId: `${stateIdInfo.prefix}${stateIdInfo.num++}`,
-                    state: { message },
+                    state: errorComponentState(circular.message, circular),
                     attributes: {},
                     doenetAttributes: {},
                     children: [],
                 },
             ];
-            diagnostics.push({
-                message,
-                type: "error",
-            });
+            diagnostics.push(circular);
             return { serializedReplacements, diagnostics, nComponents };
         }
 

--- a/packages/doenetml-worker-javascript/src/core/ChildMatcher.ts
+++ b/packages/doenetml-worker-javascript/src/core/ChildMatcher.ts
@@ -162,15 +162,19 @@ export async function deriveChildResultsFromDefiningChildren({
                 let attributeForComponentType =
                     parent.ancestors[0].componentClass.componentType;
                 core.unmatchedChildren[parent.componentIdx] = {
-                    message: `Invalid format for attribute ${parent.doenetAttributes.isAttributeChildFor} of \`<${attributeForComponentType}>\`.`,
+                    code: "doenet-w0106",
+                    args: {
+                        attribute: parent.doenetAttributes.isAttributeChildFor,
+                        componentType: attributeForComponentType,
+                    },
                 };
             } else {
                 core.unmatchedChildren[parent.componentIdx] = {
-                    message: `Invalid children for \`<${
-                        parent.componentType
-                    }>\`: Found invalid children: ${unmatchedChildrenTypes.join(
-                        ", ",
-                    )}`,
+                    code: "doenet-w0107",
+                    args: {
+                        componentType: parent.componentType,
+                        children: unmatchedChildrenTypes.join(", "),
+                    },
                 };
             }
         }

--- a/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/core/CompositeExpander.ts
@@ -1,4 +1,6 @@
 import type Core from "../Core";
+import { codedDiagnostic } from "../utils/diagnostics";
+import { errorComponentState } from "../utils/dast/errors";
 import { deepClone } from "@doenet/utils";
 import {
     deriveChildResultsFromDefiningChildren,
@@ -594,11 +596,20 @@ async function expandShadowingComposite({
     while (shadowedByShadowed?.length > 0) {
         if (shadowedByShadowed.includes(nameOfCompositeMediatingTheShadow)) {
             foundCircular = true;
-            let message = "Circular dependency detected";
-            if (component.attributes.createComponentOfType?.primitive) {
-                message += ` involving \`<${component.attributes.createComponentOfType.primitive.value}>\` component`;
-            }
-            message += ".";
+            // The same situation `<copy>` reports, so the same code. The
+            // component type is an argument rather than a clause spliced into
+            // the sentence, which is what lets the catalog say it either way.
+            const circular = codedDiagnostic({
+                type: "error",
+                code: "doenet-e0005",
+                args: {
+                    componentType:
+                        component.attributes.createComponentOfType?.primitive
+                            ?.value ?? "none",
+                },
+                position: compositeMediatingTheShadow.position,
+                sourceDoc: compositeMediatingTheShadow.sourceDoc,
+            });
             serializedReplacements = [
                 {
                     type: "serialized",
@@ -607,17 +618,12 @@ async function expandShadowingComposite({
                     attributes: {},
                     doenetAttributes: {},
                     children: [],
-                    state: { message },
+                    state: errorComponentState(circular.message, circular),
                     position: compositeMediatingTheShadow.position,
                     sourceDoc: compositeMediatingTheShadow.sourceDoc,
                 },
             ];
-            core.addDiagnostic({
-                type: "error",
-                message,
-                position: compositeMediatingTheShadow.position,
-                sourceDoc: compositeMediatingTheShadow.sourceDoc,
-            });
+            core.addDiagnostic(circular);
 
             break;
         }
@@ -805,6 +811,7 @@ export async function createAndSetReplacements({
         component.replacements = await core.setErrorReplacements({
             composite: component,
             message: e.message,
+            source: e,
         });
     }
     core.parameterStack.pop();

--- a/packages/doenetml-worker-javascript/src/core/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/core/CompositeReplacementUpdater.ts
@@ -1,4 +1,5 @@
 import type Core from "../Core";
+import { diagnosticCodeFrom } from "../utils/diagnostics";
 import type { ComponentInstance } from "../types/componentInstance";
 import type { ComponentIdx } from "@doenet/utils";
 import { createIsolatedComponents } from "./ComponentBuilder";
@@ -351,6 +352,7 @@ export class CompositeReplacementUpdater {
                     newComponents = await this.setErrorReplacements({
                         composite: component,
                         message: e.message,
+                        source: e,
                     });
                 }
 
@@ -594,15 +596,24 @@ export class CompositeReplacementUpdater {
     async setErrorReplacements({
         composite,
         message,
+        source,
     }: {
         composite: ComponentInstance;
         message: string;
+        /**
+         * The caught value the message came from, when there is one. Every
+         * caller passes `e.message`, so this is what carries the code across
+         * when the thrower named one — the same forwarding the `catch` blocks
+         * in `convertNormalizedDast` do (#1518).
+         */
+        source?: unknown;
     }) {
         // display error for replacements and set composite to error state
 
         this.core.addDiagnostic({
             type: "error",
             message,
+            ...diagnosticCodeFrom(source),
             position: composite.position,
             sourceDoc: composite.sourceDoc,
         });
@@ -1016,6 +1027,7 @@ export class CompositeReplacementUpdater {
                     newComponents = await this.setErrorReplacements({
                         composite: shadowingComponent,
                         message: e.message,
+                        source: e,
                     });
                 }
 

--- a/packages/doenetml-worker-javascript/src/core/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/core/CompositeReplacementUpdater.ts
@@ -1,5 +1,6 @@
 import type Core from "../Core";
 import { diagnosticCodeFrom } from "../utils/diagnostics";
+import { errorComponentState } from "../utils/dast/errors";
 import type { ComponentInstance } from "../types/componentInstance";
 import type { ComponentIdx } from "@doenet/utils";
 import { createIsolatedComponents } from "./ComponentBuilder";
@@ -622,7 +623,10 @@ export class CompositeReplacementUpdater {
                 type: "serialized",
                 componentType: "_error",
                 componentIdx: this.core._components.length,
-                state: { message },
+                // The same code the record above forwards. Coding one and not
+                // the other would leave the error on screen in English while
+                // the diagnostics panel showed it translated.
+                state: errorComponentState(message, source),
                 position: composite.position,
                 sourceDoc: composite.sourceDoc,
                 children: [],

--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -1,4 +1,5 @@
 import type { ComponentIdx } from "@doenet/utils";
+import { codedDiagnostic } from "../utils/diagnostics";
 import type Core from "../Core";
 import {
     preprocessAttributesObject,
@@ -1712,10 +1713,17 @@ function validateAttributeValue({
                     );
                 }
             }
-            diagnostics.push({
-                message: `Invalid value \`${valueOrig}\` for attribute \`${attribute}\`, using value \`${defaultValue}\``,
-                type: "info",
-            });
+            diagnostics.push(
+                codedDiagnostic({
+                    type: "info",
+                    code: "doenet-i0048",
+                    args: {
+                        value: String(valueOrig),
+                        attribute,
+                        default: String(defaultValue),
+                    },
+                }),
+            );
             value = defaultValue;
         }
     } else if (attributeSpecification.clamp) {

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -5,9 +5,9 @@
  */
 
 import { Dependency } from "./Dependency";
+import { codedDiagnostic } from "../../utils/diagnostics";
 import { doenetMLStringForReference } from "../../utils/sourceLocation";
 
-import { codedDiagnostic } from "../../utils/diagnostics";
 export class RefResolutionIndexDependencies extends Dependency {
     static dependencyType = "refResolutionIndexDependencies";
 

--- a/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
+++ b/packages/doenetml-worker-javascript/src/core/dependencies/refResolutionDependencies.ts
@@ -7,6 +7,7 @@
 import { Dependency } from "./Dependency";
 import { doenetMLStringForReference } from "../../utils/sourceLocation";
 
+import { codedDiagnostic } from "../../utils/diagnostics";
 export class RefResolutionIndexDependencies extends Dependency {
     static dependencyType = "refResolutionIndexDependencies";
 
@@ -347,17 +348,20 @@ export class RefResolutionDependency extends Dependency {
                 // TODO: these message match the messages from `format_error_message` of `ref_resolve.ts`.
                 // Rather than duplicating code to make the messages,
                 // we could make sure that `ref_resolve` formats the messages in this case, too.
-                const message =
-                    e === "NonUniqueReferent"
-                        ? `Multiple referents found for reference: \`$${referenceText}\``
-                        : `No referent found for reference: \`$${referenceText}\``;
-
-                this.dependencyHandler.core.addDiagnostic({
-                    type: "warning",
-                    message,
-                    position: composite.position,
-                    sourceDoc: composite.sourceDoc,
-                });
+                this.dependencyHandler.core.addDiagnostic(
+                    codedDiagnostic({
+                        type: "warning",
+                        // Spread rather than a ternary on the value: the
+                        // code has to sit next to `code:` as a literal, or
+                        // `lint:i18n` reads it as a code nothing raises.
+                        ...(e === "NonUniqueReferent"
+                            ? { code: "doenet-w0105" as const }
+                            : { code: "doenet-w0104" as const }),
+                        args: { reference: `$${referenceText}` },
+                        position: composite.position,
+                        sourceDoc: composite.sourceDoc,
+                    }),
+                );
 
                 this.extendIdx = -1;
                 this.unresolvedPath = this.originalPath;
@@ -450,12 +454,15 @@ export class RefResolutionDependency extends Dependency {
             // then there is no replacement at that index, and we obtained no referent for the reference.
             const referenceText = getDoenetMLStringForReference();
 
-            this.dependencyHandler.core.addDiagnostic({
-                type: "warning",
-                message: `No referent found for reference: \`$${referenceText}\``,
-                position: composite.position,
-                sourceDoc: composite.sourceDoc,
-            });
+            this.dependencyHandler.core.addDiagnostic(
+                codedDiagnostic({
+                    type: "warning",
+                    code: "doenet-w0104",
+                    args: { reference: `$${referenceText}` },
+                    position: composite.position,
+                    sourceDoc: composite.sourceDoc,
+                }),
+            );
 
             this.compositeReplacementDependencies.push(
                 newRefComponent.componentIdx,

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -273,4 +273,65 @@ describe("coded diagnostics reach the record @group4", () => {
             "Cannot call notAnAction on component `$p`",
         );
     });
+
+    // The diagnostics that are built for a caller rather than at the site that
+    // knows the situation: a composite reporting a cycle, `ChildMatcher`
+    // recording a mismatch for `Core` to raise a pass later, and reference
+    // resolution failing only once the group's replacements are known. Each
+    // crosses a boundary between where the arguments are gathered and where
+    // the record is made, which is where a code is easiest to drop.
+    it("codes a circular dependency a composite reports", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<point name="a">(2,3)
+  <label><answer>$a</answer></label>
+</point>
+`,
+        });
+
+        const { errors } = getDiagnosticsByType(core);
+        expect(errors.length).eq(1);
+        expect(errors[0].code).eq("doenet-e0005");
+        // `none` is the variant for a composite that never named a type, so
+        // the clause the concatenated version appended is simply absent.
+        expect(errors[0].args).eqls({ componentType: "none" });
+        expect(errors[0].message).eq("Circular dependency detected.");
+    });
+
+    it("codes children that did not match, across the pass that raises them", async () => {
+        const { core } = await createTestCore({
+            doenetML: `<point><graph /></point>`,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0107");
+        expect(warnings[0].args).eqls({
+            componentType: "coords",
+            children: "`<graph>`",
+        });
+        expect(warnings[0].message).eq(
+            "Invalid children for `<coords>`: Found invalid children: `<graph>`",
+        );
+    });
+
+    it("codes a reference resolved too late for the first pass", async () => {
+        // Extending with an index defers resolution until core knows the
+        // group's replacements, so this warning is the worker's own rather
+        // than the one the Rust resolver raises for a plainly absent name.
+        const { core } = await createTestCore({
+            doenetML: `
+<group name="g"></group>
+<text extend="$g[1]" />
+`,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0104");
+        expect(warnings[0].args).eqls({ reference: "$g[1]" });
+        expect(warnings[0].message).eq(
+            "No referent found for reference: `$g[1]`",
+        );
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/diagnosticCodes.test.ts
@@ -334,4 +334,50 @@ describe("coded diagnostics reach the record @group4", () => {
             "No referent found for reference: `$g[1]`",
         );
     });
+
+    // The other branch of the same `catch`. Both codes have to sit next to
+    // `code:` as literals for `lint:i18n` to see them raised, which is why
+    // that site spreads a ternary of objects rather than choosing the value —
+    // and a workaround that only one branch exercises is a workaround nobody
+    // would notice breaking.
+    it("codes the other resolution failure the same catch reports", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<repeat name="r" for="1 2" valueName="v">
+  <p><text name="z">$v</text><text name="z">$v</text></p>
+</repeat>
+<text extend="$r[1].z" />
+`,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0105");
+        expect(warnings[0].args).eqls({ reference: "$r[1].z" });
+        expect(warnings[0].message).eq(
+            "Multiple referents found for reference: `$r[1].z`",
+        );
+    });
+
+    // Built in `validateAttributeValue` and pushed onto a list its caller
+    // raises, so this too is gathered somewhere other than where the record is
+    // made. The value the author wrote is echoed back as a string: the
+    // attribute's own text, not a quantity to be formatted.
+    it("codes an attribute value that fell back to its default", async () => {
+        const { core } = await createTestCore({
+            doenetML: `<math name="m" format="new1">x</math>`,
+        });
+
+        const { infos } = getDiagnosticsByType(core);
+        expect(infos.length).eq(1);
+        expect(infos[0].code).eq("doenet-i0048");
+        expect(infos[0].args).eqls({
+            value: "new1",
+            attribute: "format",
+            default: "text",
+        });
+        expect(infos[0].message).eq(
+            "Invalid value `new1` for attribute `format`, using value `text`",
+        );
+    });
 });

--- a/packages/doenetml-worker-javascript/src/utils/dast/errors.ts
+++ b/packages/doenetml-worker-javascript/src/utils/dast/errors.ts
@@ -17,21 +17,20 @@ export type ErrorComponentState = {
 /**
  * Build the {@link ErrorComponentState} for an `_error` component.
  *
- * The one definition of that shape, for the three places that build an
- * `_error` out of something that might be carrying a code —
+ * The one definition of that shape, for every place that builds an `_error`
+ * out of something that might be carrying a code —
  * {@link convertToErrorComponent}, the parser-error branch of
- * `convertNormalizedDast`, and the state-variable queue that
- * `addQueuedErrorComponentsFromStateVariables` drains. The component is the
- * only thing carrying the diagnostic to where the builder re-raises it, so a
- * place that forgets the code silently un-translates its error.
+ * `convertNormalizedDast`, the state-variable queue that
+ * `addQueuedErrorComponentsFromStateVariables` drains, the circular-dependency
+ * reports in `Copy` and `CompositeExpander`, and `setErrorReplacements`. The
+ * component is the only thing carrying the diagnostic to where the builder
+ * re-raises it, so a place that forgets the code silently un-translates its
+ * error.
  *
- * Half a dozen other sites build an `_error` too — the `<select>` family's
- * `errorMessage`, the circular-dependency reports in `Copy`,
- * `CompositeExpander` and `CompositeReplacementUpdater` — but each composes
- * its own English string and has no code to lose, so they still write
- * `state: { message }` directly. They belong here once those messages migrate
- * to the catalogs (#1518); until then routing them through this would only
- * add a call that could not do anything.
+ * What is left outside is the `<select>` family's `errorMessage`, a state
+ * variable holding a finished English string with no code behind it: routing
+ * it through this would add a call that could not do anything. It belongs here
+ * once that message migrates to the catalogs (#1518).
  *
  * `source` is whatever the message came from: a caught value (a thrown
  * `DiagnosticError`, a bare `Error`, or a string), a parser `DastError` node,

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -12,6 +12,8 @@
     "doenet-e0002": "component-type-invalid",
     "doenet-e0003": "attribute-repeated",
     "doenet-e0004": "attribute-invalid-for-component",
+    "doenet-e0005": "composite-circular-dependency",
+    "doenet-e0006": "doenetml-version-not-found",
     "doenet-i0001": "line-segment-attributes-ignored-with-endpoints",
     "doenet-i0002": "line-segment-midpoint-offset-without-midpoint",
     "doenet-i0003": "line-segment-attributes-ignored-with-endpoint-and-midpoint",
@@ -46,6 +48,7 @@
     "doenet-i0032": "variant-exclude-combinations-not-implemented",
     "doenet-i0033": "variant-math-exclude-not-implemented",
     "doenet-i0034": "variant-non-constant-exclude-not-implemented",
+    "doenet-i0048": "attribute-value-invalid-using-default",
     "doenet-w0001": "line-points-undetermined-dimensions",
     "doenet-w0002": "line-points-too-few-dimensions",
     "doenet-w0003": "line-points-depend-on-variables",
@@ -146,5 +149,9 @@
     "doenet-w0098": "annotation-ref-unsupported-target",
     "doenet-w0099": "annotation-text-missing",
     "doenet-w0100": "reference-index-unavailable",
-    "doenet-w0102": "component-action-unavailable"
+    "doenet-w0102": "component-action-unavailable",
+    "doenet-w0104": "reference-no-referent",
+    "doenet-w0105": "reference-multiple-referents",
+    "doenet-w0106": "children-invalid-attribute-format",
+    "doenet-w0107": "children-invalid"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -562,3 +562,39 @@ annotation-ref-outside-graph = `<annotation>`: invalid `ref`; target is outside 
 annotation-ref-unsupported-target = `<annotation>`: invalid `ref`; target is not a supported graphical object in prefigure conversion. Annotation omitted.
 
 annotation-text-missing = `<annotation>`: missing or empty `text`; emitting empty text.
+
+## Composites and references
+
+# $componentType is the type the composite was asked to create, when it is
+# known; `none` when the composite did not say.
+composite-circular-dependency =
+    { $componentType ->
+        [none] Circular dependency detected.
+       *[other] Circular dependency detected involving `<{ $componentType }>` component.
+    }
+
+# $reference is the reference as the author wrote it, already carrying its `$`.
+reference-no-referent = No referent found for reference: `{ $reference }`
+
+reference-multiple-referents = Multiple referents found for reference: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Invalid format for attribute { $attribute } of `<{ $componentType }>`.
+
+# $children is the list of child types that did not match, already joined.
+children-invalid = Invalid children for `<{ $componentType }>`: Found invalid children: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Invalid value `{ $value }` for attribute `{ $attribute }`, using value `{ $default }`
+
+## Loading a DoenetML version
+
+# $fallback is the version that will be used instead, or `none` when the
+# embedding page named a standalone bundle of its own.
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML version { $version } not found.
+       *[other] DoenetML version { $version } not found. Falling back to version { $fallback }
+    }

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -455,3 +455,33 @@ annotation-ref-outside-graph = `<annotation>`: `ref` no válido; el destino est�
 annotation-ref-unsupported-target = `<annotation>`: `ref` no válido; el destino no es un objeto gráfico admitido en la conversión a prefigure. Se omite la anotación.
 
 annotation-text-missing = `<annotation>`: falta `text` o está vacío; se emite texto vacío.
+
+## Composites y referencias
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Se detectó una dependencia circular.
+       *[other] Se detectó una dependencia circular en la que participa un componente `<{ $componentType }>`.
+    }
+
+reference-no-referent = No se encontró ningún referente para la referencia: `{ $reference }`
+
+reference-multiple-referents = Se encontraron varios referentes para la referencia: `{ $reference }`
+
+## Hijos que no coinciden
+
+children-invalid-attribute-format = Formato no válido para el atributo { $attribute } de `<{ $componentType }>`.
+
+children-invalid = Hijos no válidos para `<{ $componentType }>`: se encontraron hijos no válidos: { $children }
+
+## Se recurre a un valor predeterminado
+
+attribute-value-invalid-using-default = Valor no válido `{ $value }` para el atributo `{ $attribute }`; se usa el valor `{ $default }`
+
+## Carga de una versión de DoenetML
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] No se encontró la versión { $version } de DoenetML.
+       *[other] No se encontró la versión { $version } de DoenetML. Se recurrirá a la versión { $fallback }
+    }

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -84,6 +84,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-i0032": "variant-exclude-combinations-not-implemented",
     "doenet-i0033": "variant-math-exclude-not-implemented",
     "doenet-i0034": "variant-non-constant-exclude-not-implemented",
+    "doenet-i0048": "attribute-value-invalid-using-default",
 
     "doenet-w0001": "line-points-undetermined-dimensions",
     "doenet-w0002": "line-points-too-few-dimensions",
@@ -186,11 +187,17 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0099": "annotation-text-missing",
     "doenet-w0100": "reference-index-unavailable",
     "doenet-w0102": "component-action-unavailable",
+    "doenet-w0104": "reference-no-referent",
+    "doenet-w0105": "reference-multiple-referents",
+    "doenet-w0106": "children-invalid-attribute-format",
+    "doenet-w0107": "children-invalid",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",
     "doenet-e0003": "attribute-repeated",
     "doenet-e0004": "attribute-invalid-for-component",
+    "doenet-e0005": "composite-circular-dependency",
+    "doenet-e0006": "doenetml-version-not-found",
 
     "doenet-a0001": "accessibility-short-description-or-decorative",
     "doenet-a0002": "accessibility-video-short-description",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -260,7 +260,14 @@ export type MessageKey =
     | "annotation-ref-multiple-targets"
     | "annotation-ref-outside-graph"
     | "annotation-ref-unsupported-target"
-    | "annotation-text-missing";
+    | "annotation-text-missing"
+    | "composite-circular-dependency"
+    | "reference-no-referent"
+    | "reference-multiple-referents"
+    | "children-invalid-attribute-format"
+    | "children-invalid"
+    | "attribute-value-invalid-using-default"
+    | "doenetml-version-not-found";
 
 /** Every key in the English catalogs, in catalog order. */
 export const MESSAGE_KEYS: readonly MessageKey[] = [
@@ -518,4 +525,11 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "annotation-ref-outside-graph",
     "annotation-ref-unsupported-target",
     "annotation-text-missing",
+    "composite-circular-dependency",
+    "reference-no-referent",
+    "reference-multiple-referents",
+    "children-invalid-attribute-format",
+    "children-invalid",
+    "attribute-value-invalid-using-default",
+    "doenetml-version-not-found",
 ];


### PR DESCRIPTION
> **#1562, which this was stacked on, has merged.** This is rebased onto `main`, so the diff is now just its own six commits: `Code the last of the worker's author-facing diagnostics` — with the changeset folded in — plus five review fix-ups: `Import errorComponentState where Copy.js uses it`, `Type unmatchedChildren and cover the helper-built codes`, `Carry the code onto the error component setErrorReplacements builds`, `Move the UnmatchedChildren alias out of Core's import block`, and `Group the codedDiagnostic import with the others`.
>
> Along the way #1562 was rewritten — the `internal` namespace it used to add is gone, so most of what it coded is no longer a diagnostic at all. Nothing here changed through any of the rebases that followed: all seven codes and every message below are as they were, this branch's diff is byte-identical across each move, and `generate-message-keys.ts` reproduces both generated files unchanged.

Everything #1518 has left outside the parser. Eight sites, seven codes.

## Two of them were one situation

`<copy>` and the composite expander both report a circular dependency, and both build the sentence identically — `"Circular dependency detected"`, plus `" involving \`<x>\` component"` when the composite named a type, plus a period. Nothing connected them, so they were counted and would have been coded separately.

One code now, with the type as an argument and the clause as a message variant. A host filtering on it catches both, and the clause is a variant rather than a fragment appended in code, so a translator can place it.

Both also build an `_error` component, so both go through `errorComponentState` — the code rides on the component, not just the record.

## Four "core-internal" ones weren't

#1518 grouped these with the invariants. They are not: the referent-resolution messages, the unmatched-children messages, and the attribute-value fallback are all addressed to an author about their own document. They are in the translated catalog — which is now the only place a diagnostic can be, since #1562 established that anything English-forever is a developer log rather than a diagnostic.

The unmatched-children messages are built in `ChildMatcher` and raised in `Core`, so `unmatchedChildren` now stores the code and its arguments rather than a finished sentence.

## `setErrorReplacements` is a forwarding site, not a coded one

Every caller passes `e.message` from a `catch`, so it holds no English of its own to migrate. It now takes the caught value as well and forwards whatever code the thrower named — the same pattern as the `catch` blocks in `convertNormalizedDast` (#1556). Three call sites updated.

Review caught that the forwarding stopped half way: the diagnostic got the code and the `_error` component the function builds alongside it kept a bare `{ message }`. The two would disagree the moment a coded throw reached it — panel translated, error on screen English — so it goes through `errorComponentState` like the other five sites. That helper's doc named it as one of the places with nothing to lose, which stopped being true the moment `Copy` and `CompositeExpander` came through it in this same PR; the doc is corrected. What the doc now says is left outside — the `<select>` family's `errorMessage`, in `Select.js`, `SelectFromSequence.js` and `SelectPrimeNumbers.js` — is the whole of it: those are the only three `state: { message }` literals remaining in the worker.

## The iframe needed no new dependency, but it isn't free

This was left open in #1557 as a separate packaging call. It answered itself: the iframe already imports `@doenet/utils`, which took its dependency on `@doenet/i18n` in that same PR, so `codedDiagnostic` was already reachable. The fallback clause is a message variant rather than a sentence appended to the base.

The cost is not zero, though, and the comment now says so. This is the embed's only coded diagnostic and it pulls the English catalogs and `@fluent/bundle` into a bundle that held neither: `dist/component/index.js` goes 3641 kB → 3769 kB, **811 kB → 845 kB gzipped**, measured by building the package with and without this one hunk. Worth it because the alternative is a hand-written English string the catalog cannot hold to, and because the record has to carry a `message` whichever way it is built — but worth knowing before the next embed-side migration.

Nothing in CI watches that number. `packages/standalone` and `packages/lsp` each have a `check:size` script that CI runs; `packages/doenetml-iframe` has no equivalent, so the figure above lives only in this description and in the comment at the call site. Not proposing a budget here — just saying plainly that there isn't one.

The English there is a fallback only: the viewer inside the iframe re-renders the record from its code and arguments in `uiLocale`.

## Two things worth knowing for #1549

**A code has to sit next to `code:` as a literal.** `lint:i18n` finds raised codes by scanning for exactly that, so

```ts
code: e === "NonUniqueReferent" ? "doenet-w0105" : "doenet-w0104",
```

reads to it as a code nothing raises, and fails the build. Spreading a ternary of objects keeps both literals visible. (The same trap caught a `const INVALID_REF_CODE` in #1559.)

**The English was pinned in places; the code and arguments were pinned nowhere.** Four of these messages were already asserted as text — `point.test.ts` on the circular-dependency sentence, `warningsInfos.test.ts` on `Invalid children for`, `Invalid format for attribute` and `No referent found for reference`, and `collect`/`line`/`functionTag` on the reference and attribute ones — and that existing coverage is exactly what caught the `Copy.js` regression below. The other three had nothing at all: the second branch of the resolution `catch` (`doenet-w0105`), the attribute-value fallback (`doenet-i0048`) and the embed's version failure (`doenet-e0006`).

What no test held anywhere was the *code and the arguments*, which is the half a `contain` on the message cannot see and the half that has to stay in step with the wording. The English is additionally held to being byte-identical by rendering every new code directly and comparing against the pre-migration string, including both variants of each message that has a select.

That second gap cost something before review closed it. `Copy.js` used `errorComponentState` without importing it; the file is JavaScript, so `tsc` said nothing and the break surfaced only as a red `point.test.ts` in CI. Five of these paths now assert their code and arguments — see Testing.

## Testing

- `lint:i18n`: `220 coded call site(s) covering 155/155 code(s); 162/183 diagnostic construction(s) migrated, 21 still holding a literal`
- All nine rendered messages verified byte-identical against the originals
- Five new cases in `diagnostics/diagnosticCodes.test.ts`, all for diagnostics gathered somewhere other than where the record is made: a composite reporting a cycle, `ChildMatcher` recording a mismatch for `Core` to raise a pass later, a reference resolved only once the group's replacements are known, the *other* branch of that same `catch` (`doenet-w0105`, so the ternary-spread workaround is not half untested), and an attribute value falling back to its default. The first fails if `Copy.js` loses its import again — verified by removing the import and watching it go red.
- `Core.unmatchedChildren` was `Record<number, any>`, so `ChildMatcher` switching it from a sentence to `{code, args}` was unchecked on both sides. It is typed now; putting the old `message` key back is a type error.
- worker `diagnostics/`, `copying/`, `utils/`, `point`, `callAction`, `updateValue`, `answer` — 553 passed, 11 skipped
- `@doenet/i18n` 138, `@doenet/doenetml` 88, `@doenet/utils` 544. `@doenet/doenetml-iframe` has no vitest suite; its typecheck is clean and it is covered by Cypress.
- Worker typecheck reports exactly the errors `main` reports, line-shifted (`CompositeExpander` and `StateVariableDefinitionFactory` carry pre-existing ones); `prettier --check` clean on every touched file

## What is left of #1518

**21**: 19 parser (→ #1549) and 2 PreFigure curve piecewise (→ #1560). Both have an issue and a stated blocker; nothing else remains.

Part of #1518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



