### PR TITLE
Localize the words the core computes into a document

### DIFF
--- a/.changeset/i18n-content-words.md
+++ b/.changeset/i18n-content-words.md
@@ -1,0 +1,23 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Translate more of the words the core computes into a document: boolean words, the default submit-button labels, and the `if`, `or` and `otherwise` a piecewise function writes around its branch conditions.
+
+A `<boolean>` or `<booleanInput>` in a Spanish activity now reads "verdadero" and "falso" where an author interpolates `$b.text` into their prose. The *value* is untouched: `true` and `false` are DoenetML syntax, so an `<award>` comparing against them, and saved state holding them, work the same in every language. Where a boolean is read back out of text — `$b.text` bound to an input — both spellings are accepted.
+
+An answer's submit button says "Revisar" instead of "Check Work" in a Spanish activity, and the same for a section-wide check-work button. Only the *default* is translated: `submitLabel="Ready?"` is the author's own wording and passes through verbatim in every language, including when it happens to match the English default.
+
+`<intComma>` groups by the document's own conventions rather than always in English — `25.236.501,35` in Spanish or German, `12,34,567` in Hindi. It still groups rather than rounds, so a value written with trailing zeros keeps them.
+
+`<pluralize>` works by running an English model over its text, and there is no equivalent for an arbitrary language. In a document written in another language it now leaves the text alone and says so, rather than silently doing nothing — unless the author supplied a `pluralForm`, which needs no model and is used in every language, with `basedOnNumber` choosing between the two forms. `<lorem>` stays Latin in every language, which is what placeholder text is for.
+
+Numbers inside mathematics keep `.` as their decimal separator in every language. A decimal comma is a real and wanted feature, but it has to arrive on the input side at the same time — until then, changing it would change what a grader compares rather than only how it looks.
+
+An answer's or section's `showCorrectness` and `colorCorrectness` are now properties an author can reference as `$a.showCorrectness` and `$a.colorCorrectness`, reporting the resolved values after any enclosing section's setting, hand-grading and the activity-wide flag are taken into account. The raw attribute values behind them, and the raw value behind a submit label, are no longer reachable under their internal names.
+
+With no locale configured, every one of these reads exactly as it did before.

--- a/packages/docs-nextra/pages/reference/boolean.mdx
+++ b/packages/docs-nextra/pages/reference/boolean.mdx
@@ -312,7 +312,10 @@ The `value` property of a named `<boolean>{:dn}` returns its value of `true` or 
 
 
 
-The `text` property of a named `<boolean>{:dn}` returns the text value of `true` or `false`.
+The `text` property of a named `<boolean>{:dn}` returns the text value of `true` or `false`,
+written in the language the document is in — `verdadero` or `falso` under `lang="es"{:dn}`.
+The `value` property does not change: `true` and `false` are DoenetML syntax, so an
+`<award>{:dn}` comparing against them behaves the same in every language.
 
 
 

--- a/packages/docs-nextra/pages/reference/intComma.mdx
+++ b/packages/docs-nextra/pages/reference/intComma.mdx
@@ -10,6 +10,12 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 `<intComma>{:dn}` is a [Math Operator](../concepts/essentialConcepts#component-types) 
 component which inserts commas into a large integer when rendering. 
 
+The grouping follows the language the document is written in, not always a
+comma: a document with `lang="es"{:dn}` or `lang="de"{:dn}` renders
+`25236501.35` as `25.236.501,35`, and one with `lang="hi"{:dn}` groups in twos
+above the first thousand (`12,34,567`). Digits are only regrouped, never
+rounded or dropped, so `1000.50` keeps its trailing zero.
+
 <AttrPropDisplay name='intComma'/>
 
 ## Examples

--- a/packages/docs-nextra/pages/reference/pluralize.mdx
+++ b/packages/docs-nextra/pages/reference/pluralize.mdx
@@ -18,6 +18,12 @@ displayed anywhere a text value is accepted. Pluralization uses the
 [`compromise`](https://compromise.cool/) NLP library and handles common
 English irregulars (`mouse → mice`, `goose → geese`, `pony → ponies`).
 
+**English only.** That model has no equivalent for an arbitrary language, so in
+a document written in another language automatic pluralization is skipped and a
+warning is raised. The [`pluralForm`](#attribute-example-pluralform) attribute
+still works in every language — supply the plural yourself and
+`basedOnNumber` will choose between the two forms.
+
 
 <AttrPropDisplay name='pluralize'/>
 

--- a/packages/doenetml-worker-javascript/src/components/Boolean.js
+++ b/packages/doenetml-worker-javascript/src/components/Boolean.js
@@ -5,6 +5,11 @@ import {
     returnChildrenByCodeStateVariableDefinitions,
 } from "../utils/booleanLogic";
 import { returnSimplifyExpandOnCompareWarning } from "../utils/answer";
+import { booleanFromWord, booleanWord } from "../utils/booleanWords";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 export default class BooleanComponent extends InlineComponent {
     static componentType = "boolean";
@@ -411,7 +416,7 @@ export default class BooleanComponent extends InlineComponent {
 
         stateVariableDefinitions.text = {
             description:
-                'The boolean rendered as a text string ("true" or "false").',
+                'The boolean rendered as a text string ("true" or "false", in the document\'s language).',
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",
@@ -422,25 +427,28 @@ export default class BooleanComponent extends InlineComponent {
                     dependencyType: "stateVariable",
                     variableName: "value",
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition: function ({ dependencyValues }) {
                 return {
                     setValue: {
-                        text: dependencyValues.value ? "true" : "false",
+                        text: booleanWord(
+                            dependencyValues.value,
+                            contentTranslator(dependencyValues),
+                        ),
                     },
                 };
             },
-            inverseDefinition({ desiredStateVariableValues }) {
-                let desiredText = String(
+            inverseDefinition({
+                desiredStateVariableValues,
+                dependencyValues,
+            }) {
+                // Either spelling: the reader hands back the word they were
+                // shown, an author's own DoenetML hands back the syntax.
+                let desiredBoolean = booleanFromWord(
                     desiredStateVariableValues.text,
-                ).toLowerCase();
-
-                let desiredBoolean;
-                if (desiredText === "true") {
-                    desiredBoolean = true;
-                } else if (desiredText === "false") {
-                    desiredBoolean = false;
-                }
+                    contentTranslator(dependencyValues),
+                );
 
                 if (desiredBoolean !== undefined) {
                     return {

--- a/packages/doenetml-worker-javascript/src/components/BooleanInput.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanInput.js
@@ -9,6 +9,11 @@ import {
     buildInputResponseEvent,
     defineSubmitAnswerExternalAction,
 } from "../utils/input";
+import { booleanWord } from "../utils/booleanWords";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 export default class BooleanInput extends Input {
     constructor(args) {
@@ -232,7 +237,7 @@ export default class BooleanInput extends Input {
 
         stateVariableDefinitions.text = {
             description:
-                'The current value rendered as a text string ("true" or "false").',
+                'The current value rendered as a text string ("true" or "false", in the document\'s language).',
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",
@@ -242,11 +247,15 @@ export default class BooleanInput extends Input {
                     dependencyType: "stateVariable",
                     variableName: "value",
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition: function ({ dependencyValues }) {
                 return {
                     setValue: {
-                        text: dependencyValues.value ? "true" : "false",
+                        text: booleanWord(
+                            dependencyValues.value,
+                            contentTranslator(dependencyValues),
+                        ),
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -12,6 +12,7 @@ import {
     submitAllAnswers,
 } from "../utils/scoredSection";
 import { codedDiagnostic } from "../utils/diagnostics";
+import { returnSubmitLabelStateVariableDefinitions } from "../utils/answer";
 
 export default class Document extends BaseComponent {
     constructor(args) {
@@ -137,6 +138,20 @@ export default class Document extends BaseComponent {
         // the scores of its children, so it drops the opt-in `aggregateScores`
         // state variable.
         delete stateVariableDefinitions.aggregateScores;
+
+        // The shared submit labels read the *enclosing* document's language,
+        // which is right for everything inside a document and wrong for the
+        // document itself: an ancestor dependency skips the component it runs
+        // on, so a root `<document lang="es">` would label its own
+        // section-wide check-work button against the host's locale rather than
+        // the one it declares. Re-take them, reading its own `locale`.
+        Object.assign(
+            stateVariableDefinitions,
+            returnSubmitLabelStateVariableDefinitions({
+                ownLocale: true,
+                button: "the section-wide submit button",
+            }),
+        );
 
         stateVariableDefinitions.titleChildName = {
             forRenderer: true,

--- a/packages/doenetml-worker-javascript/src/components/IntComma.js
+++ b/packages/doenetml-worker-javascript/src/components/IntComma.js
@@ -1,7 +1,21 @@
 import Text from "./Text";
+import { formatDecimalString } from "@doenet/i18n";
 import { renameStateVariable } from "../utils/stateVariables";
+import {
+    contentLocale,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 // convert number to number separated by commas, a la django humanize's intcomma
+
+/**
+ * The decimal number at the start of a value, if there is one.
+ *
+ * Anchored, because that is what this component has always done: it groups a
+ * number a value *begins* with and leaves the rest of the string alone, so
+ * `<intComma>` around prose is a no-op rather than a mangling.
+ */
+const LEADING_DECIMAL = /^-?\d+(?:\.\d+)?/;
 
 export default class IntComma extends Text {
     static componentType = "intComma";
@@ -9,7 +23,7 @@ export default class IntComma extends Text {
 
     static componentDocs = {
         summary:
-            "Renders a numeric value with thousands separators (e.g. 1,000,000)",
+            "Renders a numeric value with the thousands separators of the document's language (e.g. 1,000,000)",
     };
 
     static returnStateVariableDefinitions() {
@@ -23,7 +37,8 @@ export default class IntComma extends Text {
         });
 
         stateVariableDefinitions.value = {
-            description: "The numeric value with thousands separators.",
+            description:
+                "The numeric value, grouped as the document's language groups digits.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: this.componentType,
@@ -33,18 +48,30 @@ export default class IntComma extends Text {
                     dependencyType: "stateVariable",
                     variableName: "originalValue",
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition: function ({ dependencyValues }) {
-                let value = dependencyValues.originalValue;
-
-                let startAtLeastFourNumRegex = /^(-?\d+)(\d{3})/;
-                let matchObj = value.match(startAtLeastFourNumRegex);
-                while (matchObj !== null) {
-                    value = value.replace(startAtLeastFourNumRegex, `$1,$2`);
-                    matchObj = value.match(startAtLeastFourNumRegex);
+                // The grouping this component exists to add is a *convention*,
+                // not notation: German groups with periods and India groups in
+                // twos after the first thousand, and a document written in
+                // either should say so. That is why the separator comes from
+                // the document's language rather than from a hard-coded comma
+                // — and why `<number>` still does not, since a decimal point
+                // inside mathematics has to survive being read back.
+                const value = dependencyValues.originalValue;
+                const number = LEADING_DECIMAL.exec(value)?.[0];
+                if (number === undefined) {
+                    return { setValue: { value } };
                 }
-
-                return { setValue: { value } };
+                return {
+                    setValue: {
+                        value:
+                            formatDecimalString(
+                                contentLocale(dependencyValues),
+                                number,
+                            ) + value.slice(number.length),
+                    },
+                };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/Lorem.js
+++ b/packages/doenetml-worker-javascript/src/components/Lorem.js
@@ -2,6 +2,21 @@ import CompositeComponent from "./abstract/CompositeComponent";
 import { LoremIpsum } from "lorem-ipsum";
 import { setUpVariantSeedAndRng } from "../utils/variants";
 
+/**
+ * Latin in every language, deliberately.
+ *
+ * `<lorem>` is placeholder text: its job is to have the shape of prose and
+ * none of its meaning, so that whoever is looking at the page reads the
+ * layout instead of the words. Lorem ipsum does that in every language,
+ * which is why typesetters in every language use it — a "translated" one
+ * would be text a Spanish reader could almost read, which is the one thing
+ * placeholder text must not be.
+ *
+ * So this component is left out of the content localization (#1519), and no
+ * warning goes with it: nothing was asked for that wasn't delivered. That is
+ * the difference from `<pluralize>`, which is also English-only but silently
+ * *fails* to do its job outside English, and says so.
+ */
 export default class Lorem extends CompositeComponent {
     static componentType = "lorem";
 

--- a/packages/doenetml-worker-javascript/src/components/PiecewiseFunction.js
+++ b/packages/doenetml-worker-javascript/src/components/PiecewiseFunction.js
@@ -15,6 +15,10 @@ import {
     find_minima_of_piecewise,
 } from "../utils/extrema";
 import { roundForDisplay } from "../utils/math";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 export default class PiecewiseFunction extends Function {
     static componentType = "piecewiseFunction";
@@ -573,6 +577,7 @@ export default class PiecewiseFunction extends Function {
                     dependencyType: "stateVariable",
                     variableName: "avoidScientificNotation",
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition: function ({ dependencyValues }) {
                 let functionVariable = dependencyValues.variable;
@@ -740,7 +745,7 @@ export default class PiecewiseFunction extends Function {
                             formulaLatexByLine.push(formulaLatex);
                             subsetDomainsByLine.push([]);
                             nonNumericConditionsByLine.push([
-                                "\\text{otherwise}",
+                                conditionOtherwise(dependencyValues),
                             ]);
 
                             break;
@@ -798,25 +803,25 @@ export default class PiecewiseFunction extends Function {
 
                 let conditionLatexByLine = subsetDomainsByLine.map(
                     (subsetDomains, i) => {
+                        const otherwise = conditionOtherwise(dependencyValues);
                         if (
                             nonNumericConditionsByLine[i].length === 1 &&
-                            nonNumericConditionsByLine[i][0] ===
-                                "\\text{otherwise}"
+                            nonNumericConditionsByLine[i][0] === otherwise
                         ) {
-                            return "\\text{otherwise}";
+                            return otherwise;
                         } else {
-                            let conditionLatex = "\\text{if }";
+                            let conditionLatex = conditionIf(dependencyValues);
                             if (nonNumericConditionsByLine[i].length > 0) {
                                 conditionLatex +=
                                     " " +
                                     nonNumericConditionsByLine[i].join(
-                                        " \\text{ or } ",
+                                        ` ${conditionOr(dependencyValues)} `,
                                     );
                             }
 
                             if (subsetDomains.length > 0) {
                                 if (nonNumericConditionsByLine[i].length > 0) {
-                                    conditionLatex += " \\text{ or } ";
+                                    conditionLatex += ` ${conditionOr(dependencyValues)} `;
                                 } else {
                                     conditionLatex += " ";
                                 }
@@ -991,6 +996,38 @@ export default class PiecewiseFunction extends Function {
     }
 }
 
+/**
+ * The three words this component writes into a branch's condition:
+ * "if 1 < x < 2 or 4 < x < 5", and "otherwise" for the branch that catches
+ * what the others leave.
+ *
+ * The inequalities around them are notation and stay as they are. The words
+ * are prose — they are read aloud as prose, and `\\text{}` is literally the
+ * escape out of math mode into text — so they follow the document's language.
+ * `or` is the only conjunction the core composes into content; everything else
+ * that reads as "a, b, and c" is a diagnostic, joined by `Intl.ListFormat`
+ * once the reader's language is known.
+ */
+function conditionOr(dependencyValues) {
+    const t = contentTranslator(dependencyValues);
+    return `\\text{ ${t("piecewise-condition-or")} }`;
+}
+
+function conditionIf(dependencyValues) {
+    const t = contentTranslator(dependencyValues);
+    return `\\text{${t("piecewise-condition-if")} }`;
+}
+
+/**
+ * Also the marker for a branch with no condition of its own: the string is
+ * compared against itself a few lines later, which is safe because both sides
+ * are built for the same document.
+ */
+function conditionOtherwise(dependencyValues) {
+    const t = contentTranslator(dependencyValues);
+    return `\\text{${t("piecewise-condition-otherwise")}}`;
+}
+
 function latexFromSubsetDomain({
     subsetDomain,
     dependencyValues,
@@ -1014,7 +1051,7 @@ function latexFromSubsetDomain({
                     dependencyValues,
                 }).toLatex(toLatexParams),
             )
-            .join(" \\text{ or }");
+            .join(` ${conditionOr(dependencyValues)}`);
     } else {
         childDomainLatex = roundForDisplay({
             value: childDomainMath,

--- a/packages/doenetml-worker-javascript/src/components/Pluralize.js
+++ b/packages/doenetml-worker-javascript/src/components/Pluralize.js
@@ -3,15 +3,41 @@ import nlp from "compromise";
 import compromise_numbers from "compromise-numbers";
 
 import { renameStateVariable } from "../utils/stateVariables";
+import { codedDiagnostic } from "../utils/diagnostics";
+import {
+    contentLocale,
+    isEnglishContent,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 nlp.extend(compromise_numbers);
 
+/**
+ * `<pluralize>` is English-only, and stays that way.
+ *
+ * It works by running an English part-of-speech model (`compromise`) over the
+ * text, finding the nouns, and inflecting them. Nothing about that generalizes:
+ * a correct plural in another language needs that language's own morphology,
+ * usually its gender system, and often a dictionary — Spanish alone needs to
+ * know that "lápiz" pluralizes to "lápices" — and shipping a model per language
+ * is not a thing this component can grow into.
+ *
+ * So in a document written in anything else the model does not run. What still
+ * can is `pluralForm`, where the author has supplied their language's plural
+ * themselves — see {@link pluralizeWithoutTheModel}. With no `pluralForm` the
+ * text passes through unchanged and a warning says so; silence would be worse,
+ * since the author would see their singular in the output and have no way to
+ * tell that a component they asked for had declined to do anything. `<lorem>`
+ * is the neighbouring case that needs no warning — its output is Latin by
+ * design, in every locale, and a translated lorem ipsum is not a thing anyone
+ * wants.
+ */
 export default class Pluralize extends Text {
     static componentType = "pluralize";
 
     static componentDocs = {
         summary:
-            "Renders a word in its singular or plural form based on a count",
+            "Renders a word in its singular or plural form based on a count (English only)",
     };
     static rendererType = "text";
 
@@ -65,8 +91,13 @@ export default class Pluralize extends Text {
                     dependencyType: "stateVariable",
                     variableName: "basedOnNumber",
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition: function ({ dependencyValues }) {
+                if (!isEnglishContent(dependencyValues)) {
+                    return pluralizeWithoutTheModel(dependencyValues);
+                }
+
                 let text = nlp(dependencyValues.valuePrePluralize);
 
                 let allwords = text.values().toNumber().all().terms().json();
@@ -230,4 +261,45 @@ export default class Pluralize extends Text {
 
 function numberDesignatesPlural(num) {
     return num !== 1;
+}
+
+/**
+ * `<pluralize>` in a document that is not written in English.
+ *
+ * The part-of-speech model cannot run, but the one path through this component
+ * that never needed it still can: an author who wrote `pluralForm` has
+ * supplied their language's plural themselves, and `basedOnNumber` chooses
+ * between the two forms by arithmetic. That is the single-word English path
+ * with the model taken out of it, and it is exactly the remedy the warning
+ * recommends — so ignoring it while recommending it would be worse than not
+ * warning at all.
+ *
+ * Unlike the English path it does not require the text to be a single word:
+ * without a tokenizer for the language there is nothing to count, and an
+ * author who names the plural of a phrase means the phrase.
+ *
+ * Only a `<pluralize>` with no plural to fall back on is left as it was
+ * written, and only that one warns.
+ */
+function pluralizeWithoutTheModel(dependencyValues) {
+    const { valuePrePluralize, pluralForm, basedOnNumber } = dependencyValues;
+
+    if (pluralForm !== null) {
+        const makePlural =
+            basedOnNumber === null || numberDesignatesPlural(basedOnNumber);
+        return {
+            setValue: { value: makePlural ? pluralForm : valuePrePluralize },
+        };
+    }
+
+    return {
+        setValue: { value: valuePrePluralize },
+        sendDiagnostics: [
+            codedDiagnostic({
+                type: "warning",
+                code: "doenet-w0111",
+                args: { locale: contentLocale(dependencyValues) },
+            }),
+        ],
+    };
 }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -7883,6 +7883,31 @@ What is the derivative of <function name="f">x^2</function>?
         ).eqls(["description", "label", "award"]);
     });
 
+    it("exposes the resolved correctness settings, not the raw attribute values", async () => {
+        // Each attribute writes a `…Preliminary` variable so the resolved
+        // definition can tell an unspecified attribute from a specified one
+        // and fall back to the ancestor. Those raw variables are plumbing;
+        // the resolved names are the properties an author references.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <answer name="ans" colorCorrectness="false" showCorrectness="false">x</answer>
+    <text name="colorResolved" extend="$ans.colorCorrectness" />
+    <text name="colorRaw" extend="$ans.colorCorrectnessPreliminary" />
+    <text name="showResolved" extend="$ans.showCorrectness" />
+    <text name="showRaw" extend="$ans.showCorrectnessPreliminary" />
+  `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const value = async (name) =>
+            stateVariables[await resolvePathToNodeIdx(name)].stateValues.value;
+
+        expect(await value("colorResolved")).eq("false");
+        expect(await value("showResolved")).eq("false");
+        expect(await value("colorRaw")).eq("");
+        expect(await value("showRaw")).eq("");
+    });
+
     it("color correctness set on sugared inputs", async () => {
         const doenetML = `
     <answer name="ans1">x</answer>

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/contentWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/contentWordsLocale.test.ts
@@ -1,0 +1,493 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+import { getDiagnosticsByType } from "../utils/diagnostics";
+import { updateBooleanInputValue } from "../utils/actions";
+
+vi.mock("hyperformula");
+
+/**
+ * i18n Phase 4 (#1519): the remaining words the core computes into the
+ * document — boolean words, default submit labels, grouped integers, and the
+ * conjunction inside a piecewise function's condition.
+ *
+ * Two things are being checked throughout, and the second matters as much as
+ * the first: that the document's language reaches these definitions at all,
+ * and that English comes out character-for-character as it did before, so that
+ * every other assertion in this repo stays true of a document that declares no
+ * language.
+ */
+describe("content words follow the document locale @group4", () => {
+    async function values(
+        doenetML: string,
+        names: string[],
+        documentLocale?: string,
+        variable = "value",
+    ): Promise<Record<string, any>> {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+            documentLocale,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const result: Record<string, any> = {};
+        for (const name of names) {
+            const idx = await resolvePathToNodeIdx(name);
+            result[name] = stateVariables[idx].stateValues[variable];
+        }
+        return result;
+    }
+
+    describe("boolean words", () => {
+        const doenetML = `
+        <boolean name="t">true</boolean>
+        <boolean name="f">false</boolean>
+        <booleanInput name="bi" prefill="true" />
+        <text name="tt" extend="$t.text" />
+        <text name="ft" extend="$f.text" />
+        <text name="bit" extend="$bi.text" />
+        `;
+        const names = ["tt", "ft", "bit"];
+
+        it("renders English by default", async () => {
+            expect(await values(doenetML, names)).toEqual({
+                tt: "true",
+                ft: "false",
+                bit: "true",
+            });
+        });
+
+        it("renders the document's words when it declares a language", async () => {
+            expect(await values(doenetML, names, "es")).toEqual({
+                tt: "verdadero",
+                ft: "falso",
+                bit: "verdadero",
+            });
+        });
+
+        it("keeps `true`/`false` as the value, which is syntax rather than prose", async () => {
+            // The whole split: the word moved, the value did not. An `<award>`
+            // comparing against `true`, and saved state holding it, are
+            // unaffected by the document's language.
+            const spelled = await values(
+                `<boolean name="t">true</boolean>
+                 <boolean name="f">false</boolean>`,
+                ["t", "f"],
+                "es",
+            );
+            expect(spelled).toEqual({ t: true, f: false });
+        });
+
+        it("reads either spelling back through `text`", async () => {
+            // `$b.text` is writable, and what comes back depends on where it
+            // came from: a reader hands back the word they saw, an author's own
+            // DoenetML hands back the syntax. Both have to land.
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+                <boolean name="b">false</boolean>
+                <text name="w" extend="$b.text" />
+                <updateValue name="toSpanish" target="$b.text" newValue="verdadero" type="text" />
+                <updateValue name="toEnglish" target="$b.text" newValue="false" type="text" />
+                `,
+                documentLocale: "es",
+            });
+
+            await core.requestAction({
+                actionName: "updateValue",
+                componentIdx: await resolvePathToNodeIdx("toSpanish"),
+                args: {},
+            });
+            let stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("b")].stateValues
+                    .value,
+            ).eq(true);
+
+            await core.requestAction({
+                actionName: "updateValue",
+                componentIdx: await resolvePathToNodeIdx("toEnglish"),
+                args: {},
+            });
+            stateVariables = await core.returnAllStateVariables(false, true);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("b")].stateValues
+                    .value,
+            ).eq(false);
+        });
+
+        it("still rejects a word with whitespace around it", async () => {
+            // The comparison this replaced lower-cased and nothing else, so
+            // `" true "` named no boolean and the write was refused. Accepting
+            // more spellings must not quietly accept sloppier ones too.
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+                <boolean name="b">false</boolean>
+                <updateValue name="pad" target="$b.text" newValue=" true " type="text" />
+                `,
+            });
+            await core.requestAction({
+                actionName: "updateValue",
+                componentIdx: await resolvePathToNodeIdx("pad"),
+                args: {},
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("b")].stateValues
+                    .value,
+            ).eq(false);
+        });
+
+        it("follows a `<booleanInput>` as the reader toggles it", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+                <booleanInput name="bi" />
+                <text name="w" extend="$bi.text" />
+                `,
+                documentLocale: "es",
+            });
+
+            let stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("w")].stateValues
+                    .value,
+            ).eq("falso");
+
+            await updateBooleanInputValue({
+                boolean: true,
+                componentIdx: await resolvePathToNodeIdx("bi"),
+                core,
+            });
+            stateVariables = await core.returnAllStateVariables(false, true);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("w")].stateValues
+                    .value,
+            ).eq("verdadero");
+        });
+    });
+
+    describe("default submit labels", () => {
+        const doenetML = `
+        <answer name="a">42</answer>
+        <text name="withCorrectness" extend="$a.submitLabel" />
+        <text name="withoutCorrectness" extend="$a.submitLabelNoCorrectness" />
+        `;
+        const names = ["withCorrectness", "withoutCorrectness"];
+
+        it("renders English by default", async () => {
+            expect(await values(doenetML, names)).toEqual({
+                withCorrectness: "Check Work",
+                withoutCorrectness: "Submit Response",
+            });
+        });
+
+        it("renders the document's words when it declares a language", async () => {
+            expect(await values(doenetML, names, "es")).toEqual({
+                withCorrectness: "Revisar",
+                withoutCorrectness: "Enviar respuesta",
+            });
+        });
+
+        it("passes an authored label through verbatim, in every language", async () => {
+            // The author chose these words for their document. Translating
+            // them would be Doenet overwriting content it did not write.
+            const authored = `
+            <answer name="a" submitLabel="¿Listo?" submitLabelNoCorrectness="Entregar">42</answer>
+            <text name="withCorrectness" extend="$a.submitLabel" />
+            <text name="withoutCorrectness" extend="$a.submitLabelNoCorrectness" />
+            `;
+            const expected = {
+                withCorrectness: "¿Listo?",
+                withoutCorrectness: "Entregar",
+            };
+            expect(await values(authored, names)).toEqual(expected);
+            expect(await values(authored, names, "es")).toEqual(expected);
+        });
+
+        it("passes an authored label through even when it is the English default", async () => {
+            // `usedDefault` is what separates "unspecified" from "specified,
+            // and happens to match the default" — a plain value comparison
+            // would translate this one, against the author's explicit choice.
+            const authored = `
+            <answer name="a" submitLabel="Check Work">42</answer>
+            <text name="withCorrectness" extend="$a.submitLabel" />
+            `;
+            expect(
+                (await values(authored, ["withCorrectness"], "es"))
+                    .withCorrectness,
+            ).eq("Check Work");
+        });
+
+        it("keeps the pre-localization value out of an author's reach", async () => {
+            // The attribute writes to `submitLabelPreLocalize` so the derived
+            // definition can tell an unspecified attribute from a specified
+            // one. That is plumbing: `$a.submitLabel` is the label, and the
+            // raw value behind it is not a property an author can reference.
+            const doc = `
+            <answer name="a">42</answer>
+            <text name="raw" extend="$a.submitLabelPreLocalize" />
+            `;
+            expect((await values(doc, ["raw"])).raw).eq("");
+        });
+
+        it("labels a section-wide button too", async () => {
+            const section = `
+            <section name="s" sectionWideCheckWork>
+              <answer name="a">42</answer>
+            </section>
+            <text name="withCorrectness" extend="$s.submitLabel" />
+            `;
+            expect(
+                (await values(section, ["withCorrectness"])).withCorrectness,
+            ).eq("Check Work");
+            expect(
+                (await values(section, ["withCorrectness"], "es"))
+                    .withCorrectness,
+            ).eq("Revisar");
+        });
+
+        it("reads the root document's own `lang` for its own button", async () => {
+            // An ancestor dependency skips the component it runs on, so
+            // without `<document>` re-taking these the root would label its own
+            // button against the host's locale rather than the one it declares.
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `<document lang="es" sectionWideCheckWork>
+                  <answer name="a">42</answer>
+                </document>`,
+                documentLocale: "en",
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const documentIdx = await resolvePathToNodeIdx("_document1");
+            expect(stateVariables[documentIdx].stateValues.submitLabel).eq(
+                "Revisar",
+            );
+        });
+
+        it("gives a nested <document> its own language, and its contents with it", async () => {
+            // The ancestor lookup finds the *nearest* document, so an answer
+            // inside the inner one labels against the inner one's language
+            // while one outside keeps the outer's — and the inner document's
+            // own button, which the lookup cannot see itself with, follows the
+            // `lang` it declares rather than the one it is nested in.
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `<document>
+                  <answer name="outerAnswer">42</answer>
+                  <section>
+                    <document name="inner" lang="es" sectionWideCheckWork>
+                      <answer name="innerAnswer">42</answer>
+                    </document>
+                  </section>
+                </document>`,
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const labelOf = async (name: string) =>
+                stateVariables[await resolvePathToNodeIdx(name)].stateValues
+                    .submitLabel;
+            expect(await labelOf("outerAnswer")).eq("Check Work");
+            expect(await labelOf("inner")).eq("Revisar");
+            expect(await labelOf("innerAnswer")).eq("Revisar");
+        });
+    });
+
+    describe("<intComma>", () => {
+        const doenetML = `
+        <intComma name="whole">25236501</intComma>
+        <intComma name="fraction">25236501.35</intComma>
+        <intComma name="trailing">1000.50</intComma>
+        <intComma name="small">999</intComma>
+        <intComma name="padded">007</intComma>
+        <intComma name="prose">not a number</intComma>
+        `;
+        const names = [
+            "whole",
+            "fraction",
+            "trailing",
+            "small",
+            "padded",
+            "prose",
+        ];
+
+        it("renders English by default", async () => {
+            expect(await values(doenetML, names)).toEqual({
+                whole: "25,236,501",
+                fraction: "25,236,501.35",
+                // Not "1,000.5": the component groups, it does not round.
+                trailing: "1,000.50",
+                small: "999",
+                // Not "7": it does not drop digits either.
+                padded: "007",
+                prose: "not a number",
+            });
+        });
+
+        it("groups by the document's own conventions", async () => {
+            expect(await values(doenetML, names, "es")).toEqual({
+                whole: "25.236.501",
+                fraction: "25.236.501,35",
+                trailing: "1.000,50",
+                small: "999",
+                padded: "007",
+                prose: "not a number",
+            });
+        });
+
+        it("groups in twos where the locale does", async () => {
+            expect(
+                (
+                    await values(
+                        `<intComma name="n">1234567</intComma>`,
+                        ["n"],
+                        "hi-IN",
+                    )
+                ).n,
+            ).eq("12,34,567");
+        });
+    });
+
+    describe("<pluralize>", () => {
+        it("pluralizes in English", async () => {
+            expect(
+                (await values(`<pluralize name="p">cat</pluralize>`, ["p"])).p,
+            ).eq("cats");
+        });
+
+        it("leaves the text alone elsewhere, and says so", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `<pluralize name="p">gato</pluralize>`,
+                documentLocale: "es",
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("p")].stateValues
+                    .value,
+            ).eq("gato");
+
+            const warnings = getDiagnosticsByType(core).warnings;
+            expect(
+                warnings.some((warning) => warning.code === "doenet-w0111"),
+            ).eq(true);
+            expect(
+                warnings.some((warning) =>
+                    warning.message.includes(
+                        "can only pluralize English, so its text is left unchanged in a document written in es",
+                    ),
+                ),
+            ).eq(true);
+        });
+
+        it("uses an authored `pluralForm` in any language", async () => {
+            // The remedy the warning recommends has to work, or recommending
+            // it is worse than saying nothing: an author who supplied their
+            // own language's plural asked for something that needs no English
+            // model, and `basedOnNumber` picks between the two by arithmetic.
+            const doenetML = `
+            <pluralize name="many" pluralForm="lápices">lápiz</pluralize>
+            <pluralize name="three" pluralForm="lápices" basedOnNumber="3">lápiz</pluralize>
+            <pluralize name="one" pluralForm="lápices" basedOnNumber="1">lápiz</pluralize>
+            `;
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML,
+                documentLocale: "es",
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const valueOf = async (name: string) =>
+                stateVariables[await resolvePathToNodeIdx(name)].stateValues
+                    .value;
+            expect(await valueOf("many")).eq("lápices");
+            expect(await valueOf("three")).eq("lápices");
+            expect(await valueOf("one")).eq("lápiz");
+
+            // Nothing was left undone, so nothing is warned about.
+            expect(
+                getDiagnosticsByType(core).warnings.some(
+                    (warning) => warning.code === "doenet-w0111",
+                ),
+            ).eq(false);
+        });
+
+        it("counts every dialect of English as English", async () => {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `<pluralize name="p">cat</pluralize>`,
+                documentLocale: "en-GB",
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("p")].stateValues
+                    .value,
+            ).eq("cats");
+            expect(
+                getDiagnosticsByType(core).warnings.some(
+                    (warning) => warning.code === "doenet-w0111",
+                ),
+            ).eq(false);
+        });
+    });
+
+    describe("<piecewiseFunction> conditions", () => {
+        const doenetML = `
+        <piecewiseFunction name="pf">
+          <function domain="(3,4)">1/x-1</function>
+          <function domain="(4,5)">1/x-1</function>
+        </piecewiseFunction>
+        <text name="l" extend="$pf.latex" />
+        `;
+
+        it("renders English by default", async () => {
+            const latex = (await values(doenetML, ["l"])).l;
+            expect(latex).toContain("\\text{ or }");
+            expect(latex).not.toContain("\\text{ o }");
+        });
+
+        it("joins the intervals in the document's language", async () => {
+            const latex = (await values(doenetML, ["l"], "es")).l;
+            expect(latex).toContain("\\text{ o }");
+            expect(latex).not.toContain("\\text{ or }");
+        });
+
+        // "if" and "otherwise" sit in the same rendered expression as the "or",
+        // so a document that translated one and not the others would come out
+        // written half in each language.
+        const withOtherwise = `
+        <piecewiseFunction name="pf">
+          <function domain="(0,Infinity)">x^2</function>
+          <function>-x^2</function>
+        </piecewiseFunction>
+        <text name="l" extend="$pf.latex" />
+        `;
+
+        it("writes `if` and `otherwise` in English by default", async () => {
+            const latex = (await values(withOtherwise, ["l"])).l;
+            expect(latex).toContain("\\text{if }");
+            expect(latex).toContain("\\text{otherwise}");
+        });
+
+        it("writes `if` and `otherwise` in the document's language", async () => {
+            const latex = (await values(withOtherwise, ["l"], "es")).l;
+            expect(latex).toContain("\\text{si }");
+            expect(latex).toContain("\\text{en otro caso}");
+            expect(latex).not.toContain("\\text{if }");
+            expect(latex).not.toContain("\\text{otherwise}");
+        });
+    });
+});

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -3,6 +3,10 @@ import sha1 from "crypto-js/sha1";
 import Base64 from "crypto-js/enc-base64";
 import stringify from "json-stringify-deterministic";
 import { codedDiagnostic } from "./diagnostics";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "./contentLocale";
 
 function returnScoredContainerAncestorDependency(...variableNames) {
     return {
@@ -61,15 +65,13 @@ export function returnStandardAnswerAttributes() {
             createComponentOfType: "boolean",
             createStateVariable: "colorCorrectnessPreliminary",
             defaultValue: true,
-            public: true,
             groupName: "answer-grading",
             // The runtime stores the raw attribute value under
             // `colorCorrectnessPreliminary` so a derived `colorCorrectness`
-            // state def can combine it with the ancestor's setting. Authors
-            // should see only the derived `colorCorrectness` property, so
-            // hide the plumbing-named state var from the schema while
-            // keeping the attribute itself author-facing. See #1089.
-            stateVarExcludeFromSchema: true,
+            // state def can combine it with the ancestor's setting. That raw
+            // variable is plumbing, so it is not public: the attribute stays
+            // author-facing, and `$a.colorCorrectnessPreliminary` is not a
+            // reference anyone can write. See #1089.
             description:
                 "Whether to color-code the response based on its correctness.",
         },
@@ -86,10 +88,13 @@ export function returnStandardAnswerAttributes() {
 
         submitLabel: {
             createComponentOfType: "text",
-            createStateVariable: "submitLabel",
+            createStateVariable: "submitLabelPreLocalize",
+            // The default is English here only so that authors see the words
+            // in the schema; `returnSubmitLabelStateVariableDefinitions`
+            // ignores this value when the attribute is unspecified and takes
+            // the label from the document's own language instead. An authored
+            // value is never translated — see the note there.
             defaultValue: "Check Work",
-            public: true,
-            forRenderer: true,
             groupName: "answer-grading",
             description:
                 "Label for the submit button when correctness is shown.",
@@ -97,10 +102,9 @@ export function returnStandardAnswerAttributes() {
 
         submitLabelNoCorrectness: {
             createComponentOfType: "text",
-            createStateVariable: "submitLabelNoCorrectness",
+            createStateVariable: "submitLabelNoCorrectnessPreLocalize",
+            // See the note on `submitLabel`.
             defaultValue: "Submit Response",
-            public: true,
-            forRenderer: true,
             groupName: "answer-grading",
             description:
                 "Label for the submit button when correctness is not shown.",
@@ -128,12 +132,105 @@ export function returnStandardAnswerAttributes() {
     };
 }
 
+/**
+ * `submitLabel` and `submitLabelNoCorrectness`, with their defaults in the
+ * document's language.
+ *
+ * Only the *default* is translated. An author who writes
+ * `submitLabel="Ready?"` gets "Ready?" in every locale: those are their words,
+ * chosen for their document, and Doenet translating them would be a surprise
+ * at best and wrong at worst. So the attribute value passes through verbatim
+ * and only an unspecified one — which `usedDefault` is the only way to
+ * distinguish from an author who typed the English default on purpose —
+ * reaches the catalog.
+ *
+ * Shared by `<answer>` and by every container with a section-wide check-work
+ * button, which declare the same two attributes from different tables
+ * (`returnStandardAnswerAttributes` and `returnScoredSectionAttributes`) but
+ * resolve them identically.
+ *
+ * @param button How the schema should name the button these label — a section
+ *   labels a section-wide one, an `<answer>` its own.
+ * @param ownLocale Read the component's *own* `locale` as well as the
+ *   enclosing document's. Only `<document>` has one; see
+ *   `returnContentLocaleDependencies`.
+ */
+export function returnSubmitLabelStateVariableDefinitions({
+    ownLocale = false,
+    button = "the submit button",
+} = {}) {
+    return {
+        submitLabel: submitLabelDefinition({
+            name: "submitLabel",
+            translatedDefault: (t) => t("answer-submit-label"),
+            description: `Label for ${button} when correctness is shown.`,
+            ownLocale,
+        }),
+        submitLabelNoCorrectness: submitLabelDefinition({
+            name: "submitLabelNoCorrectness",
+            translatedDefault: (t) => t("answer-submit-label-no-correctness"),
+            description: `Label for ${button} when correctness is not shown.`,
+            ownLocale,
+        }),
+    };
+}
+
+/**
+ * One submit label: the authored value if there is one, otherwise
+ * `translatedDefault`.
+ *
+ * The default arrives as a function of the translator rather than as a key,
+ * because `lint:i18n` reads call sites literally — `t(key)` is invisible to
+ * it, so the catalog entry would read as an orphan and a typo would surface
+ * only at runtime.
+ */
+function submitLabelDefinition({
+    name,
+    translatedDefault,
+    description,
+    ownLocale,
+}) {
+    const authored = `${name}PreLocalize`;
+    return {
+        description,
+        public: true,
+        shadowingInstructions: {
+            createComponentOfType: "text",
+        },
+        forRenderer: true,
+        returnDependencies: () => ({
+            [authored]: {
+                dependencyType: "stateVariable",
+                variableName: authored,
+            },
+            ...returnContentLocaleDependencies({ ownLocale }),
+        }),
+        definition({ dependencyValues, usedDefault }) {
+            const label = usedDefault[authored]
+                ? translatedDefault(contentTranslator(dependencyValues))
+                : dependencyValues[authored];
+            return { setValue: { [name]: label } };
+        },
+    };
+}
+
 // Note: depends on `creditAchievedIfSubmit` state variable
 // and having the original `disabled` attribute be renamed to `disabledOriginal`.
 export function returnStandardAnswerStateVariableDefinition() {
     const stateVariableDefinitions = {};
 
+    Object.assign(
+        stateVariableDefinitions,
+        returnSubmitLabelStateVariableDefinitions(),
+    );
+
     stateVariableDefinitions.showCorrectness = {
+        description:
+            "Whether correctness is shown for the submitted response, after combining the attribute with hand-grading, any enclosing section's setting, and the activity-wide flag.",
+        public: true,
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
         forRenderer: true,
         returnDependencies: () => ({
             showCorrectnessPreliminary: {
@@ -172,6 +269,12 @@ export function returnStandardAnswerStateVariableDefinition() {
     };
 
     stateVariableDefinitions.colorCorrectness = {
+        description:
+            "Whether the response is color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all.",
+        public: true,
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
         forRenderer: true,
         returnDependencies: () => ({
             colorCorrectnessPreliminary: {

--- a/packages/doenetml-worker-javascript/src/utils/booleanWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/booleanWords.js
@@ -1,0 +1,42 @@
+/**
+ * The words `true` and `false` are shown as, and reading one back.
+ *
+ * A boolean has two spellings in a translated document and they do different
+ * jobs. The *value* is `true`/`false`: that is DoenetML syntax, it is what an
+ * author writes, what `<award>` compares against, and what saved state holds,
+ * and it stays English in every language. The *display* is prose — a reader
+ * reads it in the sentence it sits in — so it follows `documentLocale`.
+ *
+ * Which means anything that reads a boolean back out of text has to accept
+ * both: `$b.text` bound to a `<textInput>` will be handed whichever spelling
+ * the reader saw, while an author's own `<updateValue newValue="true">`
+ * arrives in the syntax spelling. {@link booleanFromWord} takes either, which
+ * is the whole reason it exists rather than a `text === "true"` at each site.
+ */
+
+/** The word `value` displays in the translator's language. */
+export function booleanWord(value, t) {
+    return value ? t("boolean-true") : t("boolean-false");
+}
+
+/**
+ * The boolean `text` names, or `undefined` if it names neither.
+ *
+ * Accepts the English syntax spelling always, and the translated spelling as
+ * well — case-insensitively on both, and only case-insensitively, which is
+ * exactly what the English-only comparison here did before.
+ */
+export function booleanFromWord(text, t) {
+    const word = normalize(text);
+    if (word === "true" || word === normalize(booleanWord(true, t))) {
+        return true;
+    }
+    if (word === "false" || word === normalize(booleanWord(false, t))) {
+        return false;
+    }
+    return undefined;
+}
+
+function normalize(text) {
+    return String(text).toLowerCase();
+}

--- a/packages/doenetml-worker-javascript/src/utils/contentLocale.js
+++ b/packages/doenetml-worker-javascript/src/utils/contentLocale.js
@@ -1,0 +1,102 @@
+import { DEFAULT_LOCALE } from "@doenet/i18n";
+
+/**
+ * The document's language, for the state variables that compute *content*.
+ *
+ * Content answers to `documentLocale`, not to the reader's UI language: an
+ * author can interpolate `$b.text` or `$answer.submitLabel` into their own
+ * prose, so the words have to be in the language the activity is written in.
+ * That language is the resolved `locale` of the `<document>` the component
+ * sits in — a nested `<document lang="de">` differs from the one around it, so
+ * an ancestor dependency is the only thing that can answer it.
+ *
+ * This is the same wiring `@doenet/utils`' style descriptions use
+ * (`styleDescriptionDefinitions.ts`), lifted here for the components that need
+ * it without needing the style pipeline. The two are deliberately not shared:
+ * `@doenet/utils` cannot import from the worker, and hoisting this there would
+ * put the worker's dependency vocabulary in a package that has no core.
+ *
+ * Bind the translator to `t` (or `translate`) and pass it a literal key —
+ * `lint:i18n` reads call sites textually, and anything else is invisible to it.
+ * There is no example written out here for the same reason: the scan does not
+ * skip comments, so an illustration would register as a real use of whatever
+ * key it named. `packages/i18n/README.md` is not scanned, and has one.
+ */
+export function returnContentLocaleDependencies({ ownLocale = false } = {}) {
+    return {
+        // For `<document>` itself, whose own `lang` is the language of its own
+        // content. The ancestor lookup below deliberately excludes the
+        // component it runs on — that is what lets a nested `<document>`
+        // detect that it is nested — so without this a root
+        // `<document lang="es">` would resolve its own prose against the
+        // host's locale instead of the one it declares.
+        //
+        // Off by default: a `stateVariable` dependency on a variable the
+        // component doesn't have is an error, not an empty value, and only
+        // `<document>` has `locale`.
+        ...(ownLocale
+            ? {
+                  contentLocaleSelf: {
+                      dependencyType: "stateVariable",
+                      variableName: "locale",
+                  },
+              }
+            : {}),
+        contentLocaleDocument: {
+            dependencyType: "ancestor",
+            componentType: "document",
+            variableNames: ["locale"],
+        },
+        // The host's locale, for a component with no `<document>` above it —
+        // which happens in tests and in a fragment rendered on its own. Without
+        // it `contentLocale` would have no tag to hand `Intl`, and a number
+        // would be grouped in English inside a Spanish document merely because
+        // the ancestor lookup came up empty.
+        contentHostLocale: {
+            dependencyType: "locale",
+        },
+        getContentTranslator: {
+            dependencyType: "translator",
+        },
+    };
+}
+
+/**
+ * The BCP-47 tag this component's content is written in.
+ *
+ * Always a non-empty tag: a component with no `<document>` above it falls back
+ * to the host's, and a host that supplied none falls back to English.
+ */
+export function contentLocale(dependencyValues) {
+    return (
+        dependencyValues.contentLocaleSelf ||
+        dependencyValues.contentLocaleDocument?.stateValues.locale ||
+        dependencyValues.contentHostLocale ||
+        // A host that supplies an empty tag, which is not a locale but is also
+        // not a reason for a state variable to throw.
+        DEFAULT_LOCALE
+    );
+}
+
+/**
+ * Whether this component's content is written in English.
+ *
+ * For the handful of things that are English-language *processing* rather than
+ * English text — `<pluralize>`'s part-of-speech model is the one today — and
+ * so have to know whether they apply at all, rather than which words to use.
+ *
+ * The primary subtag alone: `en-GB` and `en-US` are both English for this
+ * purpose, and no dialect of English is not.
+ */
+export function isEnglishContent(dependencyValues) {
+    return (
+        contentLocale(dependencyValues).split(/[-_]/)[0].toLowerCase() === "en"
+    );
+}
+
+/** The translator for {@link contentLocale}. */
+export function contentTranslator(dependencyValues) {
+    return dependencyValues.getContentTranslator(
+        contentLocale(dependencyValues),
+    );
+}

--- a/packages/doenetml-worker-javascript/src/utils/scoredSection.js
+++ b/packages/doenetml-worker-javascript/src/utils/scoredSection.js
@@ -1,4 +1,5 @@
 import { codedDiagnostic } from "./diagnostics";
+import { returnSubmitLabelStateVariableDefinitions } from "./answer";
 
 /**
  * Attributes implementing a "scored section": score aggregation plus the
@@ -83,20 +84,21 @@ export function returnScoredSectionAttributes() {
         },
         submitLabel: {
             createComponentOfType: "text",
-            createStateVariable: "submitLabel",
+            createStateVariable: "submitLabelPreLocalize",
+            // See the note in `returnStandardAnswerAttributes`: this default
+            // is shown to authors, but an unspecified attribute resolves to
+            // the label in the document's own language rather than to this
+            // English.
             defaultValue: "Check Work",
-            public: true,
-            forRenderer: true,
             groupName: "scoring",
             description:
                 "Label for the section-wide submit button when correctness is shown.",
         },
         submitLabelNoCorrectness: {
             createComponentOfType: "text",
-            createStateVariable: "submitLabelNoCorrectness",
+            createStateVariable: "submitLabelNoCorrectnessPreLocalize",
+            // See the note on `submitLabel`.
             defaultValue: "Submit Response",
-            public: true,
-            forRenderer: true,
             groupName: "scoring",
             description:
                 "Label for the section-wide submit button when correctness is not shown.",
@@ -131,6 +133,15 @@ export function returnScoredSectionAttributes() {
  */
 export function returnScoredSectionStateVariableDefinition() {
     const stateVariableDefinitions = {};
+
+    // The section-wide button carries the same two labels an `<answer>` does,
+    // and resolves them the same way.
+    Object.assign(
+        stateVariableDefinitions,
+        returnSubmitLabelStateVariableDefinitions({
+            button: "the section-wide submit button",
+        }),
+    );
 
     stateVariableDefinitions.scoredDescendants = {
         returnDependencies: () => ({
@@ -332,6 +343,12 @@ export function returnScoredSectionStateVariableDefinition() {
     };
 
     stateVariableDefinitions.showCorrectness = {
+        description:
+            "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag.",
+        public: true,
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
         forRenderer: true,
         returnDependencies: () => ({
             showCorrectnessPreliminary: {
@@ -364,6 +381,12 @@ export function returnScoredSectionStateVariableDefinition() {
     };
 
     stateVariableDefinitions.colorCorrectness = {
+        description:
+            "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all.",
+        public: true,
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
         forRenderer: true,
         returnDependencies: () => ({
             colorCorrectnessPreliminary: {

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -163,6 +163,25 @@ factory for the matching translator.
 Those state variables stay **computed, never essential**, so a locale change
 recomputes them and no English is written into saved state.
 
+The wiring is packaged as `returnContentLocaleDependencies` /
+`contentTranslator` in the worker's `utils/contentLocale.js`. Bind the
+translator to `t` and pass a literal key, or `lint:i18n` cannot see the use:
+
+```js
+returnDependencies: () => ({
+    value: { dependencyType: "stateVariable", variableName: "value" },
+    ...returnContentLocaleDependencies(),
+}),
+definition({ dependencyValues }) {
+    const t = contentTranslator(dependencyValues);
+    return { setValue: { text: t("some-key") } };
+},
+```
+
+An ancestor dependency skips the component it runs on, which is what lets a
+nested `<document>` detect that it is nested — so `<document>` itself passes
+`{ ownLocale: true }` to read the language it declares rather than the host's.
+
 ### Composition, not substitution
 
 `@doenet/utils/style/styleDescriptions.ts` is the worked example of a phrase
@@ -438,9 +457,17 @@ select expressions are left untouched, so the output is a working catalog.
 
 Math-context numbers keep `.` as the decimal separator regardless of locale,
 until the deferred math-notation phase decides otherwise; changing it would
-alter answers, not just their presentation. Only prose counts localize, via
-Fluent's `Intl.NumberFormat` integration — which is why `TranslationArgs`
-accepts a real `number` rather than a pre-formatted string.
+alter answers, not just their presentation. `MATH_NOTATION_LOCALE` in
+`src/intl.ts` is where that policy is written down, so a number formatted in
+English is a decision with a name rather than an omission.
+
+Prose numbers do localize. Inside a message, that happens for free: Fluent
+formats a placeable with `Intl.NumberFormat`, which is why `TranslationArgs`
+accepts a real `number` rather than a pre-formatted string. Outside one —
+`<intComma>`, whose whole output is a number and which has no sentence around
+it — use `formatDecimalString`, which re-punctuates an already-rendered decimal
+under the locale's grouping and separator without adding, removing, or rounding
+a digit.
 
 ## Bidi isolation
 

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -181,5 +181,6 @@
     "doenet-w0107": "children-invalid",
     "doenet-w0108": "deprecated-attribute-renamed",
     "doenet-w0109": "deprecated-attribute-renamed-conflict",
-    "doenet-w0110": "deprecated-attribute-ignored"
+    "doenet-w0110": "deprecated-attribute-ignored",
+    "doenet-w0111": "pluralize-english-only"
 }

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -208,3 +208,55 @@ style-text =
 
 # What `backgroundColor` answers when nothing is drawn behind the text.
 style-background-none = none
+
+
+## Boolean words
+##
+## What a `<boolean>` or `<booleanInput>` *displays*.
+##
+## Not what it parses or serializes. `true` and `false` are DoenetML syntax —
+## an author writes them in the source, `<award>` compares against them, and
+## saved state stores them — so they stay English everywhere, in every
+## language, exactly as `<` stays `<`. Only the word the reader sees moves.
+##
+## The consequence is that a value has two spellings in a translated document,
+## and both have to be accepted where one is read back in: see
+## `booleanFromWord` in the worker.
+
+boolean-true = true
+boolean-false = false
+
+
+## Answer buttons
+##
+## The default text on an answer's submit button. Only the *default* is
+## translated: an author who writes `submitLabel="Ready?"` gets "Ready?" in
+## every locale, because they chose those words for their document and a
+## translation of it is not Doenet's to make.
+
+# Shown when the answer will report whether the response was right.
+answer-submit-label = Check Work
+
+# Shown when it will not — the reader submits, and is told nothing more.
+answer-submit-label-no-correctness = Submit Response
+
+
+## Piecewise functions
+##
+## `<piecewiseFunction>` renders each branch's domain as mathematics and writes
+## these three words around it: "if 1 < x < 2 or 4 < x < 5", and "otherwise"
+## for the branch that catches what the others leave. The inequalities are
+## notation and stay as they are; these are prose, and are read aloud as prose.
+##
+## `or` is the only conjunction the core composes into content. Everything else
+## that reads as "a, b, and c" is a diagnostic, and those are joined by
+## `Intl.ListFormat` at the moment the reader's language is known rather than
+## by a catalog word (see `DiagnosticListArg`).
+
+piecewise-condition-or = or
+
+# Introduces the domain a branch applies on; the mathematics follows it.
+piecewise-condition-if = if
+
+# The last branch, which applies wherever none of the earlier ones do.
+piecewise-condition-otherwise = otherwise

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -715,3 +715,19 @@ deprecated-attribute-renamed-conflict =
     }
 
 deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` on `<{ $component }>` is deprecated and ignored.
+
+
+## Language coverage
+
+# `<pluralize>` runs an English part-of-speech model over its text and puts the
+# nouns in the plural. There is no equivalent for an arbitrary language — a
+# correct plural needs that language's own morphology, and often its
+# dictionary — so in a document written in anything else the word is left as
+# the author typed it, and this says so rather than silently doing nothing.
+#
+# Raised only when there is nothing else to fall back on: a `pluralForm` is the
+# author supplying their own language's plural, and that is honored in every
+# language, which is why this can recommend it.
+#
+# $locale is the document's language tag, as declared.
+pluralize-english-only = `<pluralize>` can only pluralize English, so its text is left unchanged in a document written in { $locale }. Write the plural form directly, or set it with the `pluralForm` attribute.

--- a/packages/i18n/locales/es/content.ftl
+++ b/packages/i18n/locales/es/content.ftl
@@ -197,3 +197,25 @@ style-text =
     }
 
 style-background-none = ninguno
+
+
+## Palabras booleanas
+##
+## `true` y `false` siguen siendo sintaxis de DoenetML y no se traducen; aquí
+## solo se traduce la palabra que lee quien usa el documento.
+
+boolean-true = verdadero
+boolean-false = falso
+
+
+## Botones de respuesta
+
+answer-submit-label = Revisar
+answer-submit-label-no-correctness = Enviar respuesta
+
+
+## Funciones definidas a trozos
+
+piecewise-condition-or = o
+piecewise-condition-if = si
+piecewise-condition-otherwise = en otro caso

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -571,3 +571,9 @@ deprecated-attribute-renamed-conflict =
     }
 
 deprecated-attribute-ignored = [deprecation] El atributo `{ $attribute }` de `<{ $component }>` está obsoleto y se ignora.
+
+
+## Cobertura de idiomas
+
+# $locale es la etiqueta de idioma del documento, tal como se declaró.
+pluralize-english-only = `<pluralize>` solo puede pluralizar en inglés, así que su texto queda sin cambios en un documento escrito en { $locale }. Escribe el plural directamente o indícalo con el atributo `pluralForm`.

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -34,6 +34,7 @@
  */
 import { DEFAULT_LOCALE } from "./catalogs";
 import type { MessageKey } from "./generated/messageKeys";
+import { listFormatFor } from "./intl";
 import { createTranslator, type Translator } from "./translator";
 
 /**
@@ -194,6 +195,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0108": "deprecated-attribute-renamed",
     "doenet-w0109": "deprecated-attribute-renamed-conflict",
     "doenet-w0110": "deprecated-attribute-ignored",
+    "doenet-w0111": "pluralize-english-only",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",
@@ -325,37 +327,6 @@ function asListArg(value: unknown): DiagnosticListArg | undefined {
         return Array.isArray(candidate.list) ? candidate : undefined;
     }
     return undefined;
-}
-
-const LIST_TYPES: readonly string[] = ["conjunction", "disjunction", "unit"];
-
-/**
- * An `Intl.ListFormat` for `locale`, falling back to English for a tag `Intl`
- * refuses.
- *
- * Nothing upstream promises a well-formed tag. `normalizeLocaleTag` leaves an
- * unparseable one alone on purpose, and negotiation keeps it so the host's own
- * catalog can still be found, so a host that supplies its catalogs under
- * `en_US` — the POSIX spelling, and the usual way to get this wrong — reaches
- * a constructor that throws `RangeError`. Joining that list in English is a
- * cosmetic loss; throwing would take the diagnostic down, and with it the core
- * result it arrived on.
- *
- * The `type` is checked rather than passed on for the same reason: an
- * unrecognized one throws too, and would throw again out of the fallback.
- */
-function listFormatFor(locale: string, type: unknown): Intl.ListFormat {
-    const options: Intl.ListFormatOptions = {
-        style: "long",
-        type: LIST_TYPES.includes(type as string)
-            ? (type as DiagnosticListArg["type"])
-            : "conjunction",
-    };
-    try {
-        return new Intl.ListFormat(locale, options);
-    } catch {
-        return new Intl.ListFormat(DEFAULT_LOCALE, options);
-    }
 }
 
 /**

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -113,6 +113,13 @@ export type MessageKey =
     | "style-unfilled"
     | "style-text"
     | "style-background-none"
+    | "boolean-true"
+    | "boolean-false"
+    | "answer-submit-label"
+    | "answer-submit-label-no-correctness"
+    | "piecewise-condition-or"
+    | "piecewise-condition-if"
+    | "piecewise-condition-otherwise"
     | "line-segment-attributes-ignored-with-endpoints"
     | "line-segment-attributes-ignored-with-endpoint-and-midpoint"
     | "line-segment-midpoint-offset-without-midpoint"
@@ -295,7 +302,8 @@ export type MessageKey =
     | "external-doenetml-type-mismatch"
     | "deprecated-attribute-renamed"
     | "deprecated-attribute-renamed-conflict"
-    | "deprecated-attribute-ignored";
+    | "deprecated-attribute-ignored"
+    | "pluralize-english-only";
 
 /** Every key in the English catalogs, in catalog order. */
 export const MESSAGE_KEYS: readonly MessageKey[] = [
@@ -405,6 +413,13 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "style-unfilled",
     "style-text",
     "style-background-none",
+    "boolean-true",
+    "boolean-false",
+    "answer-submit-label",
+    "answer-submit-label-no-correctness",
+    "piecewise-condition-or",
+    "piecewise-condition-if",
+    "piecewise-condition-otherwise",
     "line-segment-attributes-ignored-with-endpoints",
     "line-segment-attributes-ignored-with-endpoint-and-midpoint",
     "line-segment-midpoint-offset-without-midpoint",
@@ -588,4 +603,5 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "deprecated-attribute-renamed",
     "deprecated-attribute-renamed-conflict",
     "deprecated-attribute-ignored",
+    "pluralize-english-only",
 ];

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -47,6 +47,14 @@ export {
     type LocaleData,
 } from "./localeData";
 
+export {
+    MATH_NOTATION_LOCALE,
+    formatDecimalString,
+    intlLocale,
+    listFormatFor,
+    type ListType,
+} from "./intl";
+
 // `DIAGNOSTIC_CODE_PATTERN` is deliberately not here: it is the rule
 // `lint:i18n` holds new codes to, not something anything at runtime should be
 // parsing a code with. The lint imports it from `./diagnostics` directly.

--- a/packages/i18n/src/intl.ts
+++ b/packages/i18n/src/intl.ts
@@ -1,0 +1,262 @@
+import { DEFAULT_LOCALE } from "./catalogs";
+
+/**
+ * The `Intl` side of localization: the conventions that come from CLDR rather
+ * than from a catalog.
+ *
+ * Nothing here needs a translation to be written. A locale's thousands
+ * separator, decimal point, and list punctuation ship with every JavaScript
+ * runtime, so these work for locales Doenet has no catalog for at all — which
+ * is most of them. Anything that needs a *word* belongs in an FTL file
+ * instead.
+ */
+
+/**
+ * The tag to hand `Intl`, which is not always the tag a catalog is filed
+ * under.
+ *
+ * A locale tag does two jobs: it keys the catalog, and it names the language
+ * `Intl` formats in. They come apart for a tag `Intl` refuses — `en_US`, the
+ * POSIX spelling, is the usual way a host gets one wrong, and
+ * `normalizeLocaleTag` passes it through untouched because rewriting it would
+ * stop the host's own catalog from being found.
+ *
+ * Every `Intl` constructor throws `RangeError` on such a tag. That must not
+ * reach a state-variable definition: a mis-tagged locale should cost the
+ * host's number conventions — which were never available for that tag anyway
+ * — and not the document.
+ */
+export function intlLocale(locale: string): string {
+    try {
+        // Throws `RangeError` for a structurally invalid tag — the same tags,
+        // and the same error, every `Intl` constructor rejects.
+        Intl.getCanonicalLocales(locale);
+        return locale;
+    } catch {
+        return DEFAULT_LOCALE;
+    }
+}
+
+/**
+ * The locale numbers *inside mathematics* are formatted under, regardless of
+ * the document's language.
+ *
+ * A decimal point is notation, not prose. `1.5` is a `<number>`'s value as
+ * much as `x^2` is a `<math>`'s, it round-trips through `math-expressions` and
+ * through authored DoenetML, and it is compared against a student's typed
+ * response. Rendering it as `1,5` in a Spanish document would change what the
+ * grader compares and what `$n.text` interpolates into an author's own
+ * expression — while leaving the input side, which parses `.` either way,
+ * behind.
+ *
+ * European decimal commas are a real and wanted feature; they are a
+ * *math-notation* feature, and they have to arrive on both sides at once.
+ * Until then this constant is where the policy is written down, so that a
+ * number formatted in English is a decision with a name rather than an
+ * omission — see {@link formatDecimalString} for the other half, the numbers
+ * that are prose and do follow the document.
+ *
+ * It has no callers, and that is what it records: no math number in the core
+ * passes through an `Intl` formatter at all, so there is no site to pass a
+ * locale to. It is here for the phase that adds those sites, which should
+ * reach for this rather than reopen the question.
+ */
+export const MATH_NOTATION_LOCALE = DEFAULT_LOCALE;
+
+/** A decimal literal: an optional sign, digits, and optional fraction digits. */
+const DECIMAL_LITERAL = /^(-?\d+)(?:\.(\d+))?$/;
+
+/**
+ * Re-punctuate an already-rendered decimal number under `locale`'s
+ * conventions: the integer part regrouped, the decimal separator swapped.
+ * `"1234567.50"` becomes `"1.234.567,50"` in German.
+ *
+ * Re-punctuates rather than re-formats, and the distinction is the point.
+ * Every digit the caller wrote survives — same count, same order, same values
+ * — because the fraction digits are carried across rather than reformatted:
+ * handing the whole literal to `Intl.NumberFormat` under its default options
+ * would round to three fraction digits and drop a trailing zero, so
+ * `"1000.50"` would come back `"1,000.5"` — a different number of significant
+ * figures than the author asked for, in English, where nothing was supposed to
+ * change at all. (`maximumFractionDigits` lifts the rounding, but stops at a
+ * hundred digits; carrying the fraction across has no ceiling.)
+ *
+ * Carried across, but not verbatim: a locale that counts in its own digits
+ * gets the fraction in those digits too, or the two halves of one number would
+ * be written in two different scripts (`"২,৫২,৩৬,৫০১.35"`).
+ *
+ * A string that is not a decimal literal is returned unchanged — there is
+ * nothing to regroup, and a caller that has extracted the number itself
+ * shouldn't have to check twice.
+ */
+export function formatDecimalString(locale: string, value: string): string {
+    const match = DECIMAL_LITERAL.exec(value);
+    if (match === null) {
+        return value;
+    }
+    const [, integerPart, fractionPart] = match;
+    const tag = intlLocale(locale);
+    const grouped = groupIntegerPart(tag, integerPart);
+    if (fractionPart === undefined) {
+        return grouped;
+    }
+    return `${grouped}${decimalSeparator(tag)}${localizeDigits(tag, fractionPart)}`;
+}
+
+/**
+ * An integer literal under `tag`'s grouping, with every digit it was written
+ * with still in it.
+ *
+ * The separators are placed by hand, against a pattern read out of `Intl`,
+ * rather than by handing the literal to a formatter. A formatter shown the
+ * value gets two things wrong that this component cannot afford: it normalizes
+ * a leading zero away, so `<intComma>007</intComma>` would stop rendering
+ * `007`, and it overflows to `∞` past `Number.MAX_VALUE`, so an integer of
+ * some three hundred digits would stop rendering at all. Neither is a
+ * formatting question — where a locale puts its separators depends on how many
+ * digits a number has, not on which ones or on how many of them fit in a
+ * double — so only the pattern is asked for.
+ */
+function groupIntegerPart(tag: string, integerPart: string): string {
+    const negative = integerPart.startsWith("-");
+    const { prefix, suffix, separator, primary, secondary } = numberPattern(
+        tag,
+        negative,
+    );
+    const digits = Array.from(
+        localizeDigits(tag, integerPart.slice(negative ? 1 : 0)),
+    );
+    const groups = [];
+    let size = primary;
+    let end = digits.length;
+    while (end > size) {
+        groups.unshift(digits.slice(end - size, end).join(""));
+        end -= size;
+        size = secondary;
+    }
+    groups.unshift(digits.slice(0, end).join(""));
+    return prefix + groups.join(separator) + suffix;
+}
+
+/**
+ * Long enough to expose a locale's secondary grouping, which is not always its
+ * primary one: India groups the lowest three digits and then in twos
+ * (`12,34,567`).
+ */
+const GROUPING_PROBE = "1111111111111111";
+
+/**
+ * How `tag` writes a signed integer: what goes outside the digits, what goes
+ * between their groups, and how long a group is counting from the right.
+ *
+ * Read off a formatted probe rather than tabled, so that this follows CLDR
+ * wherever CLDR goes. `prefix` and `suffix` are whatever the formatter puts
+ * around the digits — a minus sign, which is not always `-`, and the bidi
+ * marks Arabic and Hebrew wrap a negative number in.
+ */
+function numberPattern(tag: string, negative: boolean) {
+    const parts = new Intl.NumberFormat(tag, {
+        // `true` is `"always"`. The probe is long enough that `"auto"` would
+        // group it too, so this changes nothing here and only states what is
+        // being asked for: where a group boundary falls, not whether some
+        // particular number is given any.
+        //
+        // That second question is answered by {@link groupIntegerPart}, which
+        // groups from a thousand up in every locale — what `<intComma>` has
+        // always done, and not what CLDR would do left alone: Spanish,
+        // Italian, Polish, Hungarian, Bulgarian, Slovenian, Latvian, Estonian
+        // and European Portuguese all suppress the separator in a bare
+        // four-digit number, though German does not.
+        useGrouping: true,
+        maximumFractionDigits: 0,
+        // The string overload: `Intl.NumberFormat` reads a decimal string
+        // exactly. TypeScript's `lib.es5` signature predates it, hence the cast.
+    }).formatToParts(
+        ((negative ? "-" : "") + GROUPING_PROBE) as unknown as number,
+    );
+    const groups: number[] = [];
+    let prefix = "";
+    let suffix = "";
+    let separator = "";
+    for (const part of parts) {
+        if (part.type === "integer") {
+            groups.push(Array.from(part.value).length);
+            suffix = "";
+        } else if (part.type === "group") {
+            separator = part.value;
+        } else if (groups.length === 0) {
+            prefix += part.value;
+        } else {
+            suffix += part.value;
+        }
+    }
+    const primary = groups[groups.length - 1];
+    return {
+        prefix,
+        suffix,
+        separator,
+        primary,
+        secondary: groups[groups.length - 2] ?? primary,
+    };
+}
+
+/**
+ * The character `locale` writes between a number's whole and fractional parts.
+ *
+ * Read out of `Intl` rather than tabled, and defaulted to `"."` for a locale
+ * whose formatter somehow reports no decimal part at all — a missing
+ * separator would silently concatenate the two halves into a different number.
+ */
+function decimalSeparator(tag: string): string {
+    return (
+        new Intl.NumberFormat(tag)
+            .formatToParts(1.1)
+            .find((part) => part.type === "decimal")?.value ?? "."
+    );
+}
+
+/**
+ * ASCII `digits` rewritten in the digits `tag` counts in.
+ *
+ * Bengali, Persian, Nepali and Burmese — among others — format numbers in
+ * their own digits by default, so the integer part comes back out of
+ * `Intl.NumberFormat` transliterated while a fraction copied across as text
+ * would not be. One number written half in one script and half in another is
+ * wrong in a way neither half is.
+ *
+ * The digits are read out of the formatter one at a time rather than derived
+ * from the code point of its zero: most numbering systems are a contiguous
+ * run, but `hanidec` (〇一二三…) is not, and a tag can name it (`zh-u-nu-hanidec`).
+ */
+function localizeDigits(tag: string, digits: string): string {
+    const format = new Intl.NumberFormat(tag, { useGrouping: false });
+    if (format.format(0) === "0") {
+        // Latin digits, which is nearly every locale: nothing to rewrite.
+        return digits;
+    }
+    const localDigits = Array.from({ length: 10 }, (_, digit) =>
+        format.format(digit),
+    );
+    return Array.from(digits, (digit) => localDigits[Number(digit)]).join("");
+}
+
+/** The list joins `Intl.ListFormat` can produce. */
+export type ListType = "conjunction" | "disjunction" | "unit";
+
+const LIST_TYPES: readonly string[] = ["conjunction", "disjunction", "unit"];
+
+/**
+ * An `Intl.ListFormat` for `locale`.
+ *
+ * The `type` is checked rather than passed on, for the same reason
+ * {@link intlLocale} checks the tag: an unrecognized one throws, and would
+ * throw again out of any fallback built on it.
+ */
+export function listFormatFor(locale: string, type: unknown): Intl.ListFormat {
+    return new Intl.ListFormat(intlLocale(locale), {
+        style: "long",
+        type: LIST_TYPES.includes(type as string)
+            ? (type as ListType)
+            : "conjunction",
+    });
+}

--- a/packages/i18n/src/translator.ts
+++ b/packages/i18n/src/translator.ts
@@ -1,6 +1,7 @@
 import { FluentBundle, FluentResource } from "@fluent/bundle";
 
 import { DEFAULT_LOCALE, EN_CATALOG_SOURCE } from "./catalogs";
+import { intlLocale } from "./intl";
 
 /**
  * Arguments substituted into a message's placeables (`{ $count }`).
@@ -81,41 +82,21 @@ function lookupPattern(bundle: FluentBundle, key: string) {
     return message.attributes[attribute] ?? null;
 }
 
-/**
- * The tag a bundle should hand to `Intl`, which is not always the tag its
- * catalog is filed under.
- *
- * A locale tag does two jobs here: it keys the catalog, and it names the
- * language `Intl` counts and formats in. They come apart for a tag `Intl`
- * refuses — `en_US`, the POSIX spelling, is the usual way a host gets one
- * wrong, and `normalizeLocaleTag` passes it through untouched because
- * rewriting it would stop the host's own catalog from being found.
- *
- * Fluent builds its `Intl.PluralRules` from `bundle.locales`, and unlike its
- * number formatting it does not degrade when that constructor throws: the
- * `RangeError` is recorded as a formatting error and the whole message
- * resolves to `{???}`. So a bundle formats under English whenever its tag is
- * one `Intl` cannot parse. That loses the locale's counting and number
- * conventions — which were never available for such a tag anyway — and keeps
- * the host's own words, which are the part that was really asked for.
- */
-function intlFormattingLocale(locale: string): string {
-    try {
-        // Throws `RangeError` for a structurally invalid tag — the same tags,
-        // and the same error, every `Intl` constructor rejects.
-        Intl.getCanonicalLocales(locale);
-        return locale;
-    } catch {
-        return DEFAULT_LOCALE;
-    }
-}
-
 /** A locale's catalog, with the tag it was filed under. */
 type ChainLink = {
     /**
      * The tag as the caller wrote it, which is what {@link Translator.localeOf}
      * reports and what an error is attributed to — not necessarily the tag the
-     * bundle formats under. See {@link intlFormattingLocale}.
+     * bundle formats under. See {@link intlLocale}.
+     *
+     * Fluent builds its `Intl.PluralRules` from `bundle.locales`, and unlike
+     * its number formatting it does not degrade when that constructor throws:
+     * the `RangeError` is recorded as a formatting error and the whole message
+     * resolves to `{???}`. So a bundle formats under English whenever its tag
+     * is one `Intl` cannot parse. That loses the locale's counting and number
+     * conventions — which were never available for such a tag anyway — and
+     * keeps the host's own words, which are the part that was really asked
+     * for.
      */
     locale: string;
     bundle: FluentBundle;
@@ -127,7 +108,7 @@ function createChainLink(
     useIsolating: boolean,
     onError: CreateTranslatorOptions["onError"],
 ): ChainLink {
-    const bundle = new FluentBundle(intlFormattingLocale(locale), {
+    const bundle = new FluentBundle(intlLocale(locale), {
         useIsolating,
     });
     const errors = bundle.addResource(new FluentResource(source));

--- a/packages/i18n/test/intl.test.ts
+++ b/packages/i18n/test/intl.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    MATH_NOTATION_LOCALE,
+    formatDecimalString,
+    intlLocale,
+    listFormatFor,
+} from "../src/intl";
+
+describe("intlLocale", () => {
+    it("passes a well-formed tag through", () => {
+        expect(intlLocale("es-MX")).toBe("es-MX");
+    });
+
+    it("falls back to English for a tag Intl refuses", () => {
+        // The POSIX spelling, which `normalizeLocaleTag` deliberately leaves
+        // alone so the host's own catalog can still be found by it.
+        expect(intlLocale("en_US")).toBe("en");
+        expect(intlLocale("")).toBe("en");
+    });
+});
+
+describe("formatDecimalString", () => {
+    it("leaves English exactly as it was", () => {
+        expect(formatDecimalString("en", "25236501.35")).toBe("25,236,501.35");
+        expect(formatDecimalString("en", "999")).toBe("999");
+        expect(formatDecimalString("en", "-1234")).toBe("-1,234");
+    });
+
+    it("uses the locale's separators", () => {
+        expect(formatDecimalString("de", "1234567.5")).toBe("1.234.567,5");
+        expect(formatDecimalString("es", "1234567.5")).toBe("1.234.567,5");
+        // India groups in twos above the first thousand.
+        expect(formatDecimalString("hi-IN", "1234567")).toBe("12,34,567");
+    });
+
+    it("groups a bare four-digit number, which some locales otherwise would not", () => {
+        // `<intComma>` has grouped from a thousand up since it was written, but
+        // CLDR's default is to leave four digits alone in Spanish, Italian,
+        // Polish, Hungarian, Bulgarian, Slovenian, Latvian, Estonian and
+        // European Portuguese — though not in German. Placing the separators
+        // by hand is what keeps this uniform: `groupIntegerPart` asks the
+        // locale where a boundary falls and then groups everything above a
+        // thousand, rather than asking it whether to group at all.
+        expect(formatDecimalString("es", "1234")).toBe("1.234");
+        expect(formatDecimalString("it", "1234")).toBe("1.234");
+        expect(formatDecimalString("pt-PT", "1234")).toBe("1 234");
+        expect(formatDecimalString("de", "1234")).toBe("1.234");
+    });
+
+    it("counts digits that are not one code unit each", () => {
+        // Adlam's digits are astral, so a group of three is six code units.
+        // Both the group size read off the pattern and the split of the value
+        // into digits are counted in code points; either one measured in code
+        // units would group this in halves and cut a surrogate pair.
+        expect(formatDecimalString("ff-Adlm", "1234567")).toBe(
+            "\u{1e951}\u{2e41}\u{1e952}\u{1e953}\u{1e954}\u{2e41}\u{1e955}\u{1e956}\u{1e957}",
+        );
+        expect(formatDecimalString("ff-Adlm", "0001234")).toBe(
+            "\u{1e950}\u{2e41}\u{1e950}\u{1e950}\u{1e951}\u{2e41}\u{1e952}\u{1e953}\u{1e954}",
+        );
+    });
+
+    it("keeps every digit the caller wrote", () => {
+        // Trailing zeros and precision are the reason the fraction is carried
+        // as text: handing the whole literal to `Intl` would round it to three
+        // fraction digits and drop the zero, and lifting that with
+        // `maximumFractionDigits` runs into a hundred-digit ceiling.
+        expect(formatDecimalString("en", "1000.50")).toBe("1,000.50");
+        expect(
+            formatDecimalString("en", "1234.1234567890123456789012345678901"),
+        ).toBe("1,234.1234567890123456789012345678901");
+        expect(
+            formatDecimalString("en", "123456789012345678901234567890"),
+        ).toBe("123,456,789,012,345,678,901,234,567,890");
+    });
+
+    it("groups a leading zero rather than dropping it", () => {
+        expect(formatDecimalString("en", "0001234")).toBe("0,001,234");
+        expect(formatDecimalString("en", "-0001234")).toBe("-0,001,234");
+        // A short zero-padded run comes back exactly as it went in, which is
+        // what `<intComma>` did before it grouped through `Intl` at all.
+        expect(formatDecimalString("en", "007")).toBe("007");
+        expect(
+            formatDecimalString("en", "0000000000000000000000000001234"),
+        ).toBe("0,000,000,000,000,000,000,000,000,001,234");
+    });
+
+    it("groups an integer too big to be a double", () => {
+        // `Intl.NumberFormat` answers `∞` above `Number.MAX_VALUE`, so the
+        // separators are placed against a pattern rather than by handing it
+        // the value. Four hundred digits is well past that; the regex loop
+        // this replaced had no ceiling, and neither does this.
+        const digits = "1234567890".repeat(40);
+        const grouped = formatDecimalString("en", digits);
+        expect(grouped.replace(/,/g, "")).toBe(digits);
+        expect(grouped.split(",").map((group) => group.length)).toEqual([
+            1,
+            ...Array(133).fill(3),
+        ]);
+        // A number whose *value* is zero, which the leading-zero handling
+        // makes just as long.
+        const zeros = "0".repeat(400);
+        expect(formatDecimalString("en", zeros).replace(/,/g, "")).toBe(zeros);
+        // Secondary grouping and non-Latin digits come off the same pattern.
+        const hindi = formatDecimalString("hi-IN", digits).split(",");
+        expect(hindi.at(-1)).toHaveLength(3);
+        expect(hindi.at(-2)).toHaveLength(2);
+        expect(formatDecimalString("bn", digits)).not.toContain("∞");
+    });
+
+    it("writes a negative the way the locale writes one", () => {
+        // Not always an ASCII hyphen, and not always only a sign: Persian
+        // negates with U+2212 and Arabic prefixes a bidi mark.
+        expect(formatDecimalString("fa", "-1234")).toBe("‎−۱٬۲۳۴");
+        expect(formatDecimalString("ar-EG", "-1234")).toBe("؜-١٬٢٣٤");
+    });
+
+    it("keeps a leading zero in the locale's own digits", () => {
+        // Written back after grouping, so it has to be the digit the locale
+        // counts in rather than an ASCII `0` spliced into a Bengali number.
+        expect(formatDecimalString("bn", "0001234")).toBe("০০,০১,২৩৪");
+    });
+
+    it("writes both halves of a number in the same digits", () => {
+        // Bengali and Persian count in their own digits, so an integer part
+        // regrouped by `Intl` comes back transliterated. A fraction copied
+        // across as ASCII would make one number out of two scripts.
+        expect(formatDecimalString("bn", "25236501.35")).toBe("২,৫২,৩৬,৫০১.৩৫");
+        expect(formatDecimalString("fa", "1000.50")).toBe("۱٬۰۰۰٫۵۰");
+    });
+
+    it("returns anything that is not a decimal literal unchanged", () => {
+        expect(formatDecimalString("en", "twelve")).toBe("twelve");
+        expect(formatDecimalString("en", "1e5")).toBe("1e5");
+        expect(formatDecimalString("en", "")).toBe("");
+    });
+
+    it("formats under English for a tag Intl refuses, rather than throwing", () => {
+        expect(formatDecimalString("en_US", "1234.5")).toBe("1,234.5");
+    });
+});
+
+describe("listFormatFor", () => {
+    it("joins in the locale's own conventions", () => {
+        expect(listFormatFor("en", "conjunction").format(["a", "b"])).toBe(
+            "a and b",
+        );
+        expect(listFormatFor("es", "disjunction").format(["a", "b"])).toBe(
+            "a o b",
+        );
+    });
+
+    it("treats an unrecognized type as a conjunction rather than throwing", () => {
+        expect(listFormatFor("en", "nonsense").format(["a", "b"])).toBe(
+            "a and b",
+        );
+        expect(listFormatFor("en", undefined).format(["a", "b"])).toBe(
+            "a and b",
+        );
+    });
+});
+
+describe("MATH_NOTATION_LOCALE", () => {
+    it("is English, and says so where the policy is written down", () => {
+        // A decimal point inside mathematics round-trips through authored
+        // DoenetML and is compared against a student's typed response, so it
+        // stays a point until the input side can read a comma too. The
+        // constant exists so that is a decision with a name.
+        expect(MATH_NOTATION_LOCALE).toBe("en");
+    });
+});

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -3838,20 +3838,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -3889,6 +3875,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -3899,6 +3897,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -4774,20 +4784,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -4825,6 +4821,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -4835,6 +4843,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -5710,20 +5730,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -5761,6 +5767,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -5771,6 +5789,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -6643,20 +6673,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -6694,6 +6710,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -6704,6 +6732,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -11164,7 +11204,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 },
                 {
                     "name": "value",
@@ -11518,7 +11558,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -11866,7 +11906,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -12214,7 +12254,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -12562,7 +12602,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -12910,7 +12950,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -13450,7 +13490,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -13990,7 +14030,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -14557,7 +14597,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -44438,20 +44478,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -44545,6 +44571,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -44555,6 +44593,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -45578,20 +45628,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -45685,6 +45721,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -45695,6 +45743,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -46718,20 +46778,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -46825,6 +46871,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -46835,6 +46893,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -47858,20 +47928,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -47965,6 +48021,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -47975,6 +48043,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -49005,20 +49085,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -49112,6 +49178,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -49122,6 +49200,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -50145,20 +50235,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -50252,6 +50328,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -50262,6 +50350,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -51292,20 +51392,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -51399,6 +51485,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -51409,6 +51507,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -52439,20 +52549,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -52546,6 +52642,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -52556,6 +52664,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -53586,20 +53706,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -53693,6 +53799,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -53703,6 +53821,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -54733,20 +54863,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -54840,6 +54956,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -54850,6 +54978,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -55873,20 +56013,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -55980,6 +56106,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -55990,6 +56128,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -57013,20 +57163,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -57120,6 +57256,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -57130,6 +57278,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -58153,20 +58313,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -58260,6 +58406,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -58270,6 +58428,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -59293,20 +59463,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -59400,6 +59556,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -59410,6 +59578,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -60433,20 +60613,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -60540,6 +60706,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -60550,6 +60728,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -61573,20 +61763,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -61680,6 +61856,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -61690,6 +61878,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -62719,20 +62919,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -62819,6 +63005,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -62829,6 +63027,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -63851,20 +64061,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -63951,6 +64147,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -63961,6 +64169,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -64983,20 +65203,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -65083,6 +65289,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -65093,6 +65311,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -65332,20 +65562,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -65383,6 +65599,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -65393,6 +65621,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -65608,20 +65848,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -65659,6 +65885,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -65669,6 +65907,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -66544,20 +66794,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -66595,6 +66831,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -66605,6 +66853,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -75205,20 +75465,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -75256,6 +75502,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -75266,6 +75524,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -76141,20 +76411,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -76192,6 +76448,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -76202,6 +76470,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -82172,20 +82452,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -82223,6 +82489,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -82233,6 +82511,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "creditAchieved",
@@ -83812,20 +84102,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -83863,6 +84139,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -83873,6 +84161,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -84490,7 +84790,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -99362,20 +99662,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
                     "isArray": false,
@@ -99601,6 +99887,30 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is not shown."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the submitted response, after combining the attribute with hand-grading, any enclosing section's setting, and the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the response is color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "creditAchieved",
@@ -101062,7 +101372,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -103113,7 +103423,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The current value rendered as a text string (\"true\" or \"false\")."
+                    "description": "The current value rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -126799,7 +127109,7 @@
                     "name": "value",
                     "type": "intComma",
                     "isArray": false,
-                    "description": "The numeric value with thousands separators."
+                    "description": "The numeric value, grouped as the document's language groups digits."
                 }
             ]
         },
@@ -142811,7 +143121,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ]
         },
@@ -144342,7 +144652,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 },
                 {
                     "name": "numMatches",
@@ -148394,20 +148704,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
                     "isArray": false,
@@ -148458,6 +148754,30 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is not shown."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the submitted response, after combining the attribute with hand-grading, any enclosing section's setting, and the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the response is color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "creditAchieved",
@@ -149535,20 +149855,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -149635,6 +149941,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -149645,6 +149963,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -2503,22 +2503,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -2557,6 +2541,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -2567,6 +2563,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -3039,22 +3047,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -3093,6 +3085,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -3103,6 +3107,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -3575,22 +3591,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -3629,6 +3629,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -3639,6 +3651,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -4312,22 +4336,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -4366,6 +4374,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -4376,6 +4396,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -7565,7 +7597,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 },
                 {
                     "name": "value",
@@ -7960,7 +7992,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -8349,7 +8381,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -8738,7 +8770,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -9127,7 +9159,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -9516,7 +9548,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -9969,7 +10001,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -10422,7 +10454,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -10905,7 +10937,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -37735,22 +37767,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -37845,6 +37861,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -37855,6 +37883,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -38498,22 +38538,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -38608,6 +38632,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -38618,6 +38654,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -39261,22 +39309,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -39371,6 +39403,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -39381,6 +39425,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -40024,22 +40080,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -40134,6 +40174,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -40144,6 +40196,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -40796,22 +40860,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -40906,6 +40954,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -40916,6 +40976,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -41559,22 +41631,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -41669,6 +41725,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -41679,6 +41747,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -42331,22 +42411,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -42441,6 +42505,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -42451,6 +42527,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -43103,22 +43191,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -43213,6 +43285,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -43223,6 +43307,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -43875,22 +43971,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -43985,6 +44065,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -43995,6 +44087,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -44647,22 +44751,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -44757,6 +44845,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -44767,6 +44867,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -45410,22 +45522,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -45520,6 +45616,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -45530,6 +45638,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -46173,22 +46293,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -46283,6 +46387,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -46293,6 +46409,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -46936,22 +47064,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -47046,6 +47158,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -47056,6 +47180,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -47699,22 +47835,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -47809,6 +47929,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -47819,6 +47951,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -48462,22 +48606,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -48572,6 +48700,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -48582,6 +48722,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -49225,22 +49377,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -49335,6 +49471,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -49345,6 +49493,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -49992,22 +50152,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -50095,6 +50239,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -50105,6 +50261,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -50742,22 +50910,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -50845,6 +50997,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -50855,6 +51019,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -51492,22 +51668,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -51595,6 +51755,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -51605,6 +51777,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -51888,22 +52072,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -51942,6 +52110,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -51952,6 +52132,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -52211,22 +52403,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -52265,6 +52441,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -52275,6 +52463,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -52746,22 +52946,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -52800,6 +52984,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -52810,6 +53006,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -60647,22 +60855,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -60701,6 +60893,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -60711,6 +60915,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -61183,22 +61399,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -61237,6 +61437,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -61247,6 +61459,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -64758,22 +64982,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -64812,6 +65020,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -64822,6 +65042,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "creditAchieved",
@@ -65913,22 +66145,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -65967,6 +66183,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -65977,6 +66205,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",
@@ -66470,7 +66710,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -80808,22 +81048,6 @@
                     "groupName": "answer-grading"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "answer-grading"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "answer-grading"
-                },
-                {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
                     "isArray": false,
@@ -81054,6 +81278,30 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is not shown."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the submitted response, after combining the attribute with hand-grading, any enclosing section's setting, and the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the response is color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "creditAchieved",
@@ -82276,7 +82524,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": false,
@@ -84136,7 +84384,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The current value rendered as a text string (\"true\" or \"false\")."
+                    "description": "The current value rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -103462,14 +103710,14 @@
                     "name": "value",
                     "type": "intComma",
                     "isArray": false,
-                    "description": "The numeric value with thousands separators."
+                    "description": "The numeric value, grouped as the document's language groups digits."
                 }
             ],
             "top": true,
             "acceptsStringChildren": true,
             "takesIndex": false,
             "docsSlug": "intComma",
-            "summary": "Renders a numeric value with thousands separators (e.g. 1,000,000)",
+            "summary": "Renders a numeric value with the thousands separators of the document's language (e.g. 1,000,000)",
             "layoutCategory": "inline"
         },
         {
@@ -103961,7 +104209,7 @@
             "acceptsStringChildren": true,
             "takesIndex": false,
             "docsSlug": "pluralize",
-            "summary": "Renders a word in its singular or plural form based on a count",
+            "summary": "Renders a word in its singular or plural form based on a count (English only)",
             "layoutCategory": "inline"
         },
         {
@@ -114418,7 +114666,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 }
             ],
             "top": true,
@@ -115711,7 +115959,7 @@
                     "name": "text",
                     "type": "text",
                     "isArray": false,
-                    "description": "The boolean rendered as a text string (\"true\" or \"false\")."
+                    "description": "The boolean rendered as a text string (\"true\" or \"false\", in the document's language)."
                 },
                 {
                     "name": "numMatches",
@@ -118701,22 +118949,6 @@
                     "groupName": "answer-grading"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "answer-grading"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "answer-grading"
-                },
-                {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
                     "isArray": false,
@@ -118769,6 +119001,30 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the submit button when correctness is not shown."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the submitted response, after combining the attribute with hand-grading, any enclosing section's setting, and the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the response is color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "creditAchieved",
@@ -119470,22 +119726,6 @@
                     "groupName": "scoring"
                 },
                 {
-                    "name": "submitLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
-                    "name": "submitLabelNoCorrectness",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the section-wide submit button when correctness is not shown.",
-                    "fromAttribute": true,
-                    "groupName": "scoring"
-                },
-                {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
                     "isArray": false,
@@ -119573,6 +119813,18 @@
                     "description": "The DoenetML source code that produced this component."
                 },
                 {
+                    "name": "submitLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is shown."
+                },
+                {
+                    "name": "submitLabelNoCorrectness",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the section-wide submit button when correctness is not shown."
+                },
+                {
                     "name": "numSubmissions",
                     "type": "integer",
                     "isArray": false,
@@ -119583,6 +119835,18 @@
                     "type": "integer",
                     "isArray": false,
                     "description": "Remaining number of section-wide submissions before the maximum is reached."
+                },
+                {
+                    "name": "showCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether correctness is shown for the answers this section contains, after combining the attribute with any enclosing section's setting and with the activity-wide flag."
+                },
+                {
+                    "name": "colorCorrectness",
+                    "type": "boolean",
+                    "isArray": false,
+                    "description": "Whether the answers this section contains are color-coded by correctness, after combining the attribute with any enclosing section's setting and with whether correctness is shown at all."
                 },
                 {
                     "name": "aggregateScores",

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -414,9 +414,13 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             // Phase 1 miss and should be extracted instead of listed.
             const KNOWN_UNTRANSLATED = [
                 // `submitLabel` / `submitLabelNoCorrectness` — the check-work
-                // button's resting label. Public authorable attributes, so
-                // translating the default also needs a rule for not
-                // overwriting a label the author wrote.
+                // button's resting label. These *are* translated as of #1519,
+                // but against `documentLocale`, and this sweep only
+                // pseudo-localizes `uiLocale`: the pseudo-locale is derived
+                // from the English chrome catalog and the content side has no
+                // equivalent, so a `documentLocale` of `en-XA` negotiates
+                // straight back to English. Deleting these two entries needs a
+                // pseudo content catalog first, not another extraction.
                 // (doenetml-worker-javascript/src/utils/answer.js)
                 /Check Work/g,
                 /Submit Response/g,


### PR DESCRIPTION
Closes #1519. Part of #861 (i18n Phase 4).

**#1564, which this was stacked on, has merged.** This is rebased onto `main` and is a single commit — the whole diff is this PR.

The families #1519 lists of words a component generates as *content* rather than as a message about content. Everything here answers to `documentLocale`, and English comes out character-for-character as before.

Not the last English the worker composes into a document, though — a sweep of the whole worker turned up four groups outside #1519's scope, none of them touched here: a section's auto-generated name and the `"<name> <number>: <title>"` frame around it (`SectioningComponent.js`), `<hint>`'s default "Hint" and `<solution>`'s "Solution"/"Answer", `<table>`/`<figure>`'s "Table 1"/"Figure 1", and `<paginator>`'s "Previous"/"Next"/"Page" defaults — which are structurally the same problem as `submitLabel` and would resolve the same way. Chemistry is a fifth and larger one: `[Invalid Chemical Symbol]`, and English nomenclature and element data that are a translation problem rather than a string-literal one. These want a Phase 5 issue rather than a bigger Phase 4.

## Booleans

`<boolean>` and `<booleanInput>` render "verdadero"/"falso" in a Spanish document. The **value** is untouched — `true`/`false` are DoenetML syntax, what an author writes, what `<award>` compares against, and what saved state holds — so only `text` moved. `text` is computed, never essential, so nothing localized is written into saved state and a document saved in one language reopens correctly in another.

That split means a boolean now has two spellings and both have to be accepted where one is read back in (`$b.text` bound to an input hands back the word the reader saw; an author's own `<updateValue newValue="true">` hands back the syntax). `booleanFromWord` takes either, which is why it exists rather than a `text === "true"` at each site. It lower-cases and does nothing else, exactly as the English-only comparison it replaced did, so `" true "` still names no boolean and is still refused — there is a test for that, because the alternative is a boolean that flips on whitespace it used to ignore.

## Default submit labels

An answer's button says "Revisar" instead of "Check Work"; likewise a section-wide check-work button. Only the *default* is translated — `submitLabel="Ready?"` is the author's own wording and passes through verbatim in every language, **including when it happens to match the English default**. `usedDefault` is the only thing that can tell those two apart, so the attribute stores its raw value beside the resolved one: the attribute writes a `…PreLocalize` state variable, and a state definition resolves the author-facing name from it.

That raw variable is **not public**, which is the same shape `showCorrectness` has used all along. Not public is the stronger statement than hiding the companion variable from the schema with `stateVarExcludeFromSchema`, which is what `colorCorrectness` used to do: that left `$a.colorCorrectnessPreliminary` resolving, a reference no author should be able to write. The schema output is identical either way, since a non-public state variable produces no property to hide.

`colorCorrectness` is moved onto the same footing here (it predates this PR, #1089), and the resolved values behind both correctness settings are now **public in their own right** — `$a.showCorrectness`, `$a.colorCorrectness` and their section equivalents report the value after any enclosing section's setting, hand-grading and the activity-wide flag are taken into account. Previously neither resolved name worked, while `$a.colorCorrectnessPreliminary` did. Those are the schema additions in this PR: `showCorrectness` and `colorCorrectness` properties on the 33 elements that carry the attributes. Nothing is removed. `stateVarExcludeFromSchema` now has no users, though the mechanism and its test remain.

`<document>` re-takes the two definitions with `ownLocale: true`: an ancestor dependency skips the component it runs on (that is what lets a nested `<document>` detect that it is nested), so a root `<document lang="es">` would otherwise label its own button against the host's locale. Tested for the root and for a `<document lang="es">` nested inside an English one, where the inner document, the answer inside it, and the answer outside it each get the language they sit in.

## `<intComma>`

Groups by the document's conventions — `25.236.501,35` in Spanish or German, `12,34,567` in Hindi.

It **re-punctuates rather than re-formats**: `formatDecimalString` carries the fraction digits across rather than reformatting them, because handing the whole literal to `Intl.NumberFormat` *under its default options* rounds to three fraction digits and drops a trailing zero — `"1000.50"` would come back `"1,000.5"` in English, where nothing was supposed to change. (`maximumFractionDigits` lifts the rounding but stops at 100 digits; carrying the fraction has no ceiling.)

Carried across, but not verbatim. Bengali, Persian, Nepali and Burmese count in their own digits, so both halves are transliterated into them — otherwise one number ends up written half in one script and half in another (`"২,৫২,৩৬,৫০১.35"`). Grouping is also uniform where CLDR is not: Spanish, Italian, Polish, Hungarian, Bulgarian, Slovenian, Latvian, Estonian and European Portuguese all leave a bare four-digit number ungrouped, though German does not, and `<intComma>` has grouped from a thousand up since it was written. Placing the separators by hand is what keeps that true — the locale is asked where a boundary falls, never whether this number gets one.

English is byte-identical, including a leading-zero run, because the separators are placed against a **pattern** read out of `Intl` — its group separator, its minus sign, its bidi marks, and how long a group is counting from the right — rather than by handing `Intl` the value. A formatter shown the value gets two things wrong. It normalizes a leading zero away, so `<intComma>007</intComma>` would render `7`. And it overflows to `∞` above `Number.MAX_VALUE`, so an integer of about 309 digits would stop rendering at all — where the old regex loop had no ceiling. Neither is a formatting question: where a locale puts its separators depends on how many digits a number has, not on which ones or on how many of them fit in a double.

So `0001234` still groups as `0,001,234`, `<intComma>007</intComma>` still renders `007`, and a 400-digit integer groups the whole way across. Checked four ways, three of them differentially:

- The whole `<intComma>` definition against the pre-PR regex loop, in English, over **266,927 inputs** — every code point below U+0300, structural cases (negatives, exponents, prose, a bare `.`, a trailing `.`, Arabic-Indic and astral digits), every all-zero string up to 500 digits signed and unsigned, zeros-then-digits for every combination up to 70 + 70, every length up to 1,200, 250,000 random literals weighted towards leading zeros and long fractions, and inputs up to 100,000 characters: **zero divergences.**
- `formatDecimalString` against an implementation that hands the decimal *string* to `Intl` directly — exact, but only where `Intl` is: **every one of the 242 locales this ICU has number data for**, at every length from 1 to 45 digits, signed and unsigned (21,780 comparisons), plus 267 locale/numbering-system pairs (`hanidec`, astral-digit `adlm`, `fullwide`, `nkoo`, India's secondary grouping, Arabic and Persian negatives) out to the 308 digits `Intl` can still represent (29,370 comparisons): **zero divergences.**
- Where `Intl` cannot be the oracle — leading zeros, and integers past `Number.MAX_VALUE` — 42,780 checks against two independent ones: leading zeros re-derived by formatting the same number with its zeros written as ones and mapping them back, and 309-to-5,000-digit integers checked digit-for-digit against their localized digits with the rightmost 300 grouped as `Intl` groups 300. **Zero divergences.**
- Mutation-tested: 19 mutants of `intl.ts` (grouping sizes read off the wrong end of the probe, a four-digit probe, code-unit instead of code-point digit counting, a hardcoded separator or decimal point, a dropped bidi prefix, an unanchored literal pattern, no tag validation) — **16 killed, 3 survivors, all three inert rather than untested**: shortening the probe from 16 digits to 8, `useGrouping: true` → `"auto"` (the probe is long enough that every locale groups it either way — what makes a four-digit number group is the placement loop, not this option), and dropping the `suffix` accumulator, which is empty in all 300 locale/numbering-system pairs checked and is kept only for symmetry with the bidi `prefix` that is not.

Only three locale grouping shapes exist across all 242: `3-3-3…`, India's `…2-2-3`, and one locale that groups in twos throughout. The 16-digit probe reveals all three.

## `<pluralize>` and `<lorem>`

`<pluralize>` runs an English part-of-speech model and cannot generalize — a correct plural elsewhere needs that language's morphology and often its dictionary. Outside English the model does not run.

`pluralForm` still does: that is the author supplying their own language's plural, and `basedOnNumber` chooses between the two forms by arithmetic, neither of which needs a model. Only a `<pluralize>` with no plural to fall back on passes its text through and raises `doenet-w0111` — which is what makes the warning's own advice ("set it with the `pluralForm` attribute") true.

`<lorem>` stays Latin in every language and needs no warning: nothing was asked for that wasn't delivered.

## Numbers in mathematics

`MATH_NOTATION_LOCALE` is where the policy is written down, so English formatting is a decision with a name rather than an omission. A decimal comma is real and wanted, but it has to arrive on the input side at the same time — until then it would change what a grader compares, not just how it looks.

It has no callers, and its doc comment says so: `Intl.NumberFormat` and `toLocaleString` appear nowhere in the worker, the viewer or `@doenet/utils`, so no math number reaches a locale-aware formatter and there is no site to pass a locale to. It is there for the phase that adds those sites.

## One scope correction

The issue lists "~12 worker files hand-roll `" and "` / `" or "`". **They are not in the tree.** The words the core composes into content itself are the three `<piecewiseFunction>` writes around a branch's domain — `\text{if } x < 1 \text{ or } x > 2`, and `\text{otherwise}` for the branch that catches what the others leave — and all three are localized here, since translating the conjunction alone would render one expression half in each language. Everything else that reads as "a, b, and c" is a *diagnostic*, and diagnostics were given `Intl.ListFormat` joining in Phase 3 via `DiagnosticListArg`.

`Intl.ListFormat` also turned out to be the wrong tool for `<asList>`: its `type: "unit"` is CLDR's measurement-unit list, so Russian and Japanese come back space-separated (`"a b c"`) and Chinese with no separator at all (`"abc"`). `<asList>` keeps its comma.

Relatedly, `listFormatFor` moves out of `diagnostics.ts` into a shared `intl.ts`, alongside the invalid-tag check `translator.ts` was keeping its own copy of.

## Documentation

The reference pages for the three components whose rendered output changes are updated: `intComma` (grouping follows the document's language, digits are regrouped and never rounded), `pluralize` (English-only, with `pluralForm` as the cross-language route), and `boolean` (`text` localizes, `value` does not).

The `KNOWN_UNTRANSLATED` list in the pseudo-locale sweep (`i18n.cy.js`) keeps its `Check Work` / `Submit Response` entries, with a corrected reason: those labels *are* translated now, but against `documentLocale`, and the sweep pseudo-localizes only `uiLocale` — the pseudo-locale is derived from the chrome catalog and the content side has no equivalent, so a `documentLocale` of `en-XA` negotiates straight back to English. Deleting those entries needs a pseudo content catalog, not another extraction.

## Verification

- `lint:i18n`: 297 keys, 184/184 codes covered, **2 constructions still holding a literal** — unchanged, still the deferred `<curve>` pair (#1560)
- New: 24 worker tests (`contentWordsLocale.test.ts`) and 17 `@doenet/i18n` tests (`intl.test.ts`), each item asserted in both `en` and `es`
- Green: worker suites matching `answer` / `boolean` / `booleanInput` / `contentWordsLocale` / `mathdisplay` / `piecewisefunction` / `document` / `sectioning` / `text` / `problem` / `pluralize` / `lorem` / `diagnostics` / `baseComponent` / `list` — 41 files, 691 passing, 11 skipped; `@doenet/i18n` 157; `@doenet/lsp` 46 (1 skipped); `@doenet/lsp-tools` 626; `@doenet/static-assets` 42; `@doenet/doenetml` 88
- Language-server bundle guard re-run after a rebuild: 1044 KiB of 1128 KiB, no message catalogs
- `doenet-schema.json` / `doenet-relaxng-schema.json` regenerated, and `build:schema` re-run afterwards is a no-op. No element or attribute is gained or lost; the properties gained are `showCorrectness` and `colorCorrectness` on the 33 elements carrying those attributes, described above. What moves: the `submitLabel` / `submitLabelNoCorrectness` property entries on the 33 elements that carry them lose `fromAttribute: true` and `groupName` and change position, because they are now defined as state variables rather than derived from a same-named attribute — the attribute keeps its own `groupName`, which is where the docs pipeline reads a property's group from anyway, and `fromAttribute` has no consumer. Plus the description changes this PR makes: `text` on the 14 components that inherit it from `<boolean>` (`<boolean>`, `<booleanInput>`, `<not>`, `<and>`, `<or>`, `<xor>`, `<iff>`, `<implies>`, `<isInteger>`, `<isNumber>`, `<isBetween>`, `<when>`, `<hasSameFactoring>`, `<matchesPattern>`), `<pluralize>`'s summary, and `<intComma>`'s summary and `value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





