### PR TITLE
Give the language server's schema checks diagnostic codes

### DIFF
--- a/.changeset/i18n-schema-violation-codes.md
+++ b/.changeset/i18n-schema-violation-codes.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Give the language server's schema checks stable diagnostic codes, so the squiggles the editor draws under an unrecognized element, a misplaced one, an unknown attribute, or a value outside its enumeration can be translated and cited.
+
+These were the last author-facing diagnostics composing their English at the point they were raised, with no name a bug report could quote or a host could filter on. Each now carries a code and the values that fill its message in, alongside the English it has always shown, and the same sentences are in the message catalogs for translators.
+
+The check for a name that does not start with a letter shares its code with the parser's identical check rather than taking a second name for one mistake, which also lets the editor collapse the two reports into one entry.
+
+Every message reads exactly as it did before.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26530,7 +26530,9 @@
                 "mdast-util-to-markdown": "^2.1.2",
                 "mdast-util-to-string": "^4.0.0"
             },
-            "devDependencies": {}
+            "devDependencies": {
+                "@doenet/i18n": "*"
+            }
         },
         "packages/memory-benchmark": {
             "name": "@doenet/memory-benchmark",

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -304,6 +304,34 @@ migrate and no code to name; they spread `diagnosticCodeFrom` to pass along
 whatever their source carried. `lint:i18n` counts those as migrated too, since
 there is nothing further to do to them.
 
+### Producers that cannot read the catalog
+
+`@doenet/parser` and `@doenet/lsp-tools` raise author-facing diagnostics and
+neither can render one. Both are bundled into the DoenetML language server,
+which `@doenet/codemirror` embeds verbatim and starts as a blob worker, so
+every byte sits on the editor's critical path before the first cursor-help
+request can be answered — and the server has no locale to render in anyway.
+Reaching the catalog from there pulls in `EN_CATALOG_SOURCE`, every English
+namespace joined, plus the Fluent runtime to read it;
+`packages/lsp/scripts/check-server-bundle.mjs` fails outright if either
+arrives, rather than budgeting for it (see [Bundling](#bundling)).
+
+So these two pass the English **alongside** the code instead of rendering it —
+`codedDastError` in `packages/parser/src/coded-dast-error.ts`,
+`codedLspDiagnostic` in `packages/lsp-tools/src/coded-lsp-diagnostic.ts`. The
+message lives in two places, and each package holds the two together with a
+test: `test/coded-dast-errors.test.ts` and `test/coded-schema-violations.test.ts`
+run their producer over a corpus of broken DoenetML and assert every coded
+diagnostic renders, through the catalog, to exactly the string the producer
+wrote. A message edited on one side and not the other fails there, as does a
+missing or misnamed argument — one the catalog reads and the producer doesn't
+pass renders as `{$name}`, which no hand-written English will match.
+
+`@doenet/i18n` is a **devDependency** in both: `import type` in `src/`, so
+every code is still checked against the registry at compile time, and the real
+package only in that test. Their `dependencies` stay free of it and the bundle
+guard stays green.
+
 ### Codes
 
 A code is a permanent name — what a bug report cites, what a host reading

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -182,5 +182,10 @@
     "doenet-w0108": "deprecated-attribute-renamed",
     "doenet-w0109": "deprecated-attribute-renamed-conflict",
     "doenet-w0110": "deprecated-attribute-ignored",
-    "doenet-w0111": "pluralize-english-only"
+    "doenet-w0111": "pluralize-english-only",
+    "doenet-w0112": "schema-element-unrecognized",
+    "doenet-w0113": "schema-element-not-allowed-at-root",
+    "doenet-w0114": "schema-element-not-allowed-inside",
+    "doenet-w0115": "schema-attribute-unrecognized",
+    "doenet-w0116": "schema-attribute-value-not-allowed"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -731,3 +731,44 @@ deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` on `<{ $
 #
 # $locale is the document's language tag, as declared.
 pluralize-english-only = `<pluralize>` can only pluralize English, so its text is left unchanged in a document written in { $locale }. Write the plural form directly, or set it with the `pluralForm` attribute.
+
+
+## Checking against the schema
+
+# What the editor draws a squiggle under: the language server's own check of
+# the document against the DoenetML schema, run on every keystroke and
+# answered before anything is evaluated. A beginner meets these first, and
+# usually only these, because a document that does not pass them rarely gets
+# as far as producing a diagnostic from the core.
+#
+# `@doenet/lsp-tools` writes its English beside the code rather than rendering
+# it from here, for the same reason `@doenet/parser` does: it is inside the
+# language-server bundle, which `@doenet/codemirror` embeds verbatim and
+# starts as a blob worker, and a catalog on the editor's critical path is what
+# `packages/lsp/scripts/check-server-bundle.mjs` exists to reject. The two
+# copies are held together by a test in that package, which runs the checker
+# over a corpus and asserts every coded violation renders to exactly what the
+# checker wrote — so a message edited here without its counterpart fails
+# there.
+#
+# $tag, $parent and $attribute quote the author's own source back at them and
+# stay exactly as written; the angle brackets and backticks around them are
+# punctuation this catalog supplies, not part of the name.
+
+schema-element-unrecognized = Element `<{ $tag }>` is not a recognized Doenet element.
+
+schema-element-not-allowed-at-root = Element `<{ $tag }>` is not allowed at the root of the document.
+
+schema-element-not-allowed-inside = Element `<{ $tag }>` is not allowed inside of `<{ $parent }>`.
+
+schema-attribute-unrecognized = Element `<{ $tag }>` doesn't have an attribute called `{ $attribute }`.
+
+# $allowed is the attribute's permitted values, each already in double quotes
+# and joined for the reader's language. $isList says whether the attribute
+# takes several of them at once: one situation, two sentences, because the
+# reader has to be told they are choosing a whole list rather than a value.
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Attribute `{ $attribute }` of element `<{ $tag }>` must be a list whose items are each one of: { $allowed }
+       *[other] Attribute `{ $attribute }` of element `<{ $tag }>` must be one of: { $allowed }
+    }

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -577,3 +577,27 @@ deprecated-attribute-ignored = [deprecation] El atributo `{ $attribute }` de `<{
 
 # $locale es la etiqueta de idioma del documento, tal como se declaró.
 pluralize-english-only = `<pluralize>` solo puede pluralizar en inglés, así que su texto queda sin cambios en un documento escrito en { $locale }. Escribe el plural directamente o indícalo con el atributo `pluralForm`.
+
+
+## Comprobación del esquema
+
+# $tag, $parent y $attribute reproducen lo que escribió quien redacta el
+# documento y se dejan tal cual; los signos `<`, `>` y las comillas invertidas
+# que los rodean son puntuación de este catálogo, no parte del nombre.
+
+schema-element-unrecognized = El elemento `<{ $tag }>` no es un elemento de Doenet reconocido.
+
+schema-element-not-allowed-at-root = El elemento `<{ $tag }>` no se permite en la raíz del documento.
+
+schema-element-not-allowed-inside = El elemento `<{ $tag }>` no se permite dentro de `<{ $parent }>`.
+
+schema-attribute-unrecognized = El elemento `<{ $tag }>` no tiene ningún atributo llamado `{ $attribute }`.
+
+# $allowed son los valores admitidos, cada uno ya entre comillas dobles y
+# enumerados según el idioma de quien lee. $isList indica si el atributo acepta
+# varios a la vez.
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] El atributo `{ $attribute }` del elemento `<{ $tag }>` debe ser una lista en la que cada elemento sea uno de: { $allowed }
+       *[other] El atributo `{ $attribute }` del elemento `<{ $tag }>` debe ser uno de: { $allowed }
+    }

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -196,6 +196,11 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0109": "deprecated-attribute-renamed-conflict",
     "doenet-w0110": "deprecated-attribute-ignored",
     "doenet-w0111": "pluralize-english-only",
+    "doenet-w0112": "schema-element-unrecognized",
+    "doenet-w0113": "schema-element-not-allowed-at-root",
+    "doenet-w0114": "schema-element-not-allowed-inside",
+    "doenet-w0115": "schema-attribute-unrecognized",
+    "doenet-w0116": "schema-attribute-value-not-allowed",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -303,7 +303,12 @@ export type MessageKey =
     | "deprecated-attribute-renamed"
     | "deprecated-attribute-renamed-conflict"
     | "deprecated-attribute-ignored"
-    | "pluralize-english-only";
+    | "pluralize-english-only"
+    | "schema-element-unrecognized"
+    | "schema-element-not-allowed-at-root"
+    | "schema-element-not-allowed-inside"
+    | "schema-attribute-unrecognized"
+    | "schema-attribute-value-not-allowed";
 
 /** Every key in the English catalogs, in catalog order. */
 export const MESSAGE_KEYS: readonly MessageKey[] = [
@@ -604,4 +609,9 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "deprecated-attribute-renamed-conflict",
     "deprecated-attribute-ignored",
     "pluralize-english-only",
+    "schema-element-unrecognized",
+    "schema-element-not-allowed-at-root",
+    "schema-element-not-allowed-inside",
+    "schema-attribute-unrecognized",
+    "schema-attribute-value-not-allowed",
 ];

--- a/packages/lsp-tools/package.json
+++ b/packages/lsp-tools/package.json
@@ -39,11 +39,14 @@
             "dependencies": [
                 "../static-assets:build",
                 "../parser:build",
-                "../utils:build"
+                "../utils:build",
+                "../i18n:build"
             ]
         }
     },
-    "devDependencies": {},
+    "devDependencies": {
+        "@doenet/i18n": "*"
+    },
     "dependencies": {
         "@doenet/utils": "*",
         "mdast-util-to-markdown": "^2.1.2",

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -14,6 +14,7 @@ import {
     visit,
 } from "@doenet/parser";
 import { AutoCompleter } from "..";
+import { codedLspDiagnostic } from "../../coded-lsp-diagnostic";
 
 /**
  * Get a list of places where the schema is violated.
@@ -60,16 +61,18 @@ export async function getSchemaViolations(
             if (name === "UNKNOWN_NAME") {
                 // No further checking for unknown elements.
                 const range = this.sourceObj.getElementTagRanges(node);
-                return {
+                return codedLspDiagnostic({
+                    code: "doenet-w0112",
+                    message: `Element \`<${node.name}>\` is not a recognized Doenet element.`,
+                    args: { tag: node.name },
                     range: {
                         start: this.sourceObj.offsetToLSPPosition(
                             range[0].start,
                         ),
                         end: this.sourceObj.offsetToLSPPosition(range[0].end),
                     },
-                    message: `Element \`<${node.name}>\` is not a recognized Doenet element.`,
                     severity: DiagnosticSeverity.Warning,
-                };
+                });
             }
 
             const schema = this.schemaElementsByName[name];
@@ -82,18 +85,22 @@ export async function getSchemaViolations(
                 }
                 if (!schema.top) {
                     const range = this.sourceObj.getElementTagRanges(node);
-                    ret.push({
-                        range: {
-                            start: this.sourceObj.offsetToLSPPosition(
-                                range[0].start,
-                            ),
-                            end: this.sourceObj.offsetToLSPPosition(
-                                range[0].end,
-                            ),
-                        },
-                        message: `Element \`<${name}>\` is not allowed at the root of the document.`,
-                        severity: DiagnosticSeverity.Warning,
-                    });
+                    ret.push(
+                        codedLspDiagnostic({
+                            code: "doenet-w0113",
+                            message: `Element \`<${name}>\` is not allowed at the root of the document.`,
+                            args: { tag: name },
+                            range: {
+                                start: this.sourceObj.offsetToLSPPosition(
+                                    range[0].start,
+                                ),
+                                end: this.sourceObj.offsetToLSPPosition(
+                                    range[0].end,
+                                ),
+                            },
+                            severity: DiagnosticSeverity.Warning,
+                        }),
+                    );
                 }
             } else {
                 const parentName = this.normalizeElementName(parent.name);
@@ -110,18 +117,22 @@ export async function getSchemaViolations(
                     !this.isAllowedChild(parentName, name, grandparentName)
                 ) {
                     const range = this.sourceObj.getElementTagRanges(node);
-                    ret.push({
-                        range: {
-                            start: this.sourceObj.offsetToLSPPosition(
-                                range[0].start,
-                            ),
-                            end: this.sourceObj.offsetToLSPPosition(
-                                range[0].end,
-                            ),
-                        },
-                        message: `Element \`<${name}>\` is not allowed inside of \`<${parentName}>\`.`,
-                        severity: DiagnosticSeverity.Warning,
-                    });
+                    ret.push(
+                        codedLspDiagnostic({
+                            code: "doenet-w0114",
+                            message: `Element \`<${name}>\` is not allowed inside of \`<${parentName}>\`.`,
+                            args: { tag: name, parent: parentName },
+                            range: {
+                                start: this.sourceObj.offsetToLSPPosition(
+                                    range[0].start,
+                                ),
+                                end: this.sourceObj.offsetToLSPPosition(
+                                    range[0].end,
+                                ),
+                            },
+                            severity: DiagnosticSeverity.Warning,
+                        }),
+                    );
                 }
             }
 
@@ -157,18 +168,32 @@ export async function getSchemaViolations(
                 if (attrName === "name") {
                     const value = toXml(attr.children);
                     if (!value.charAt(0).match(/[a-zA-Z]/)) {
-                        ret.push({
-                            range: {
-                                start: this.sourceObj.offsetToLSPPosition(
-                                    attr.position?.start.offset || 0,
-                                ),
-                                end: this.sourceObj.offsetToLSPPosition(
-                                    attr.position?.end.offset || 0,
-                                ),
-                            },
-                            message: `Invalid attribute name='${value}'. Names must start with a letter.`,
-                            severity: DiagnosticSeverity.Error,
-                        });
+                        // The parser's own name check raises this same
+                        // sentence, from `enforce-valid-names.ts`, and a code
+                        // names a situation rather than the producer that
+                        // spotted it — so this is `doenet-e0025` and not a
+                        // second name for it. Sharing it is also what lets
+                        // `dedupeLspDiagnostics` collapse the two reports of
+                        // one mistake once they stop being the same string.
+                        // The parser's message branches on which rule the name
+                        // broke; this check only looks at the first character,
+                        // so it always takes the `start` branch.
+                        ret.push(
+                            codedLspDiagnostic({
+                                code: "doenet-e0025",
+                                message: `Invalid attribute name='${value}'. Names must start with a letter.`,
+                                args: { name: value, reason: "start" },
+                                range: {
+                                    start: this.sourceObj.offsetToLSPPosition(
+                                        attr.position?.start.offset || 0,
+                                    ),
+                                    end: this.sourceObj.offsetToLSPPosition(
+                                        attr.position?.end.offset || 0,
+                                    ),
+                                },
+                                severity: DiagnosticSeverity.Error,
+                            }),
+                        );
                     }
                 }
 
@@ -186,18 +211,22 @@ export async function getSchemaViolations(
                 }
 
                 if (attrName === "UNKNOWN_NAME") {
-                    ret.push({
-                        range: {
-                            start: this.sourceObj.offsetToLSPPosition(
-                                attr.position?.start.offset || 0,
-                            ),
-                            end: this.sourceObj.offsetToLSPPosition(
-                                attr.position?.end.offset || 0,
-                            ),
-                        },
-                        message: `Element \`<${name}>\` doesn't have an attribute called \`${attr.name}\`.`,
-                        severity: DiagnosticSeverity.Warning,
-                    });
+                    ret.push(
+                        codedLspDiagnostic({
+                            code: "doenet-w0115",
+                            message: `Element \`<${name}>\` doesn't have an attribute called \`${attr.name}\`.`,
+                            args: { tag: name, attribute: attr.name },
+                            range: {
+                                start: this.sourceObj.offsetToLSPPosition(
+                                    attr.position?.start.offset || 0,
+                                ),
+                                end: this.sourceObj.offsetToLSPPosition(
+                                    attr.position?.end.offset || 0,
+                                ),
+                            },
+                            severity: DiagnosticSeverity.Warning,
+                        }),
+                    );
                 } else if (
                     !this.isAllowedAttribute(
                         name,
@@ -206,18 +235,22 @@ export async function getSchemaViolations(
                         perInstanceAllowlist ?? undefined,
                     )
                 ) {
-                    ret.push({
-                        range: {
-                            start: this.sourceObj.offsetToLSPPosition(
-                                attr.position?.start.offset || 0,
-                            ),
-                            end: this.sourceObj.offsetToLSPPosition(
-                                attr.position?.end.offset || 0,
-                            ),
-                        },
-                        message: `Element \`<${name}>\` doesn't have an attribute called \`${attrName}\`.`,
-                        severity: DiagnosticSeverity.Warning,
-                    });
+                    ret.push(
+                        codedLspDiagnostic({
+                            code: "doenet-w0115",
+                            message: `Element \`<${name}>\` doesn't have an attribute called \`${attrName}\`.`,
+                            args: { tag: name, attribute: attrName },
+                            range: {
+                                start: this.sourceObj.offsetToLSPPosition(
+                                    attr.position?.start.offset || 0,
+                                ),
+                                end: this.sourceObj.offsetToLSPPosition(
+                                    attr.position?.end.offset || 0,
+                                ),
+                            },
+                            severity: DiagnosticSeverity.Warning,
+                        }),
+                    );
                 } else {
                     // If there are no macros/functions in the attribute value and the list of allowed values is non-empty,
                     // check that the value is in the list of allowed values.
@@ -252,23 +285,48 @@ export async function getSchemaViolations(
                                 ),
                         );
                         if (invalidTokens.length > 0) {
-                            const allowedList = [...allowedValues.correctCase]
-                                .map((v) => `"${v}"`)
-                                .join(", ");
-                            ret.push({
-                                range: {
-                                    start: this.sourceObj.offsetToLSPPosition(
-                                        range.start,
-                                    ),
-                                    end: this.sourceObj.offsetToLSPPosition(
-                                        range.end,
-                                    ),
-                                },
-                                message: allowedValues.isList
-                                    ? `Attribute \`${attrName}\` of element \`<${name}>\` must be a list whose items are each one of: ${allowedList}`
-                                    : `Attribute \`${attrName}\` of element \`<${name}>\` must be one of: ${allowedList}`,
-                                severity: DiagnosticSeverity.Warning,
-                            });
+                            // Quoted here, joined here, and *also* handed over
+                            // as a list. The English below has to be the
+                            // finished sentence, but the catalog joins the
+                            // same values itself with `Intl.ListFormat`, so
+                            // that a language which does not enumerate with a
+                            // bare comma is not stuck with English
+                            // punctuation. `type: "unit"` is the bare
+                            // enumeration rather than an "a, b, and c"
+                            // conjunction, which is what `", "` already means
+                            // here — the two agree in English, which is what
+                            // the round-trip test checks.
+                            const allowed = [...allowedValues.correctCase].map(
+                                (v) => `"${v}"`,
+                            );
+                            const allowedList = allowed.join(", ");
+                            const isList = Boolean(allowedValues.isList);
+                            ret.push(
+                                codedLspDiagnostic({
+                                    code: "doenet-w0116",
+                                    message: isList
+                                        ? `Attribute \`${attrName}\` of element \`<${name}>\` must be a list whose items are each one of: ${allowedList}`
+                                        : `Attribute \`${attrName}\` of element \`<${name}>\` must be one of: ${allowedList}`,
+                                    args: {
+                                        tag: name,
+                                        attribute: attrName,
+                                        isList,
+                                        allowed: {
+                                            list: allowed,
+                                            type: "unit",
+                                        },
+                                    },
+                                    range: {
+                                        start: this.sourceObj.offsetToLSPPosition(
+                                            range.start,
+                                        ),
+                                        end: this.sourceObj.offsetToLSPPosition(
+                                            range.end,
+                                        ),
+                                    },
+                                    severity: DiagnosticSeverity.Warning,
+                                }),
+                            );
                         }
                     }
                 }

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -1,15 +1,10 @@
-import { RowCol } from "../../doenet-source-object";
-import type { CompletionItem, Diagnostic } from "vscode-languageserver/browser";
-import {
-    CompletionItemKind,
-    DiagnosticSeverity,
-} from "vscode-languageserver/browser";
+import type { Diagnostic } from "vscode-languageserver/browser";
+import { DiagnosticSeverity } from "vscode-languageserver/browser";
 import {
     DastAttribute,
     DastElement,
     DastNodes,
     DastRoot,
-    showCursor,
     toXml,
     visit,
 } from "@doenet/parser";

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -29,6 +29,30 @@ export async function getSchemaViolations(
     this: AutoCompleter,
 ): Promise<Diagnostic[]> {
     await this._refreshModuleInstanceAttributes();
+
+    /** An LSP range from a pair of source offsets. */
+    const offsetRange = (start: number, end: number) => ({
+        start: this.sourceObj.offsetToLSPPosition(start),
+        end: this.sourceObj.offsetToLSPPosition(end),
+    });
+
+    /** The opening tag, which is what an element-level violation points at. */
+    const elementTagRange = (node: DastElement) => {
+        const [openTag] = this.sourceObj.getElementTagRanges(node);
+        return offsetRange(openTag.start, openTag.end);
+    };
+
+    /**
+     * The whole `name="value"` pair, which is what an attribute-level
+     * violation points at. A pair the parser gave no position falls back to
+     * the top of the document rather than dropping the violation.
+     */
+    const attributeRange = (attr: DastAttribute) =>
+        offsetRange(
+            attr.position?.start.offset || 0,
+            attr.position?.end.offset || 0,
+        );
+
     /**
      * Get all pairs of elements and their parent.
      */
@@ -60,17 +84,11 @@ export async function getSchemaViolations(
 
             if (name === "UNKNOWN_NAME") {
                 // No further checking for unknown elements.
-                const range = this.sourceObj.getElementTagRanges(node);
                 return codedLspDiagnostic({
                     code: "doenet-w0112",
                     message: `Element \`<${node.name}>\` is not a recognized Doenet element.`,
                     args: { tag: node.name },
-                    range: {
-                        start: this.sourceObj.offsetToLSPPosition(
-                            range[0].start,
-                        ),
-                        end: this.sourceObj.offsetToLSPPosition(range[0].end),
-                    },
+                    range: elementTagRange(node),
                     severity: DiagnosticSeverity.Warning,
                 });
             }
@@ -84,20 +102,12 @@ export async function getSchemaViolations(
                     return [];
                 }
                 if (!schema.top) {
-                    const range = this.sourceObj.getElementTagRanges(node);
                     ret.push(
                         codedLspDiagnostic({
                             code: "doenet-w0113",
                             message: `Element \`<${name}>\` is not allowed at the root of the document.`,
                             args: { tag: name },
-                            range: {
-                                start: this.sourceObj.offsetToLSPPosition(
-                                    range[0].start,
-                                ),
-                                end: this.sourceObj.offsetToLSPPosition(
-                                    range[0].end,
-                                ),
-                            },
+                            range: elementTagRange(node),
                             severity: DiagnosticSeverity.Warning,
                         }),
                     );
@@ -116,20 +126,12 @@ export async function getSchemaViolations(
                     parentName !== "UNKNOWN_NAME" &&
                     !this.isAllowedChild(parentName, name, grandparentName)
                 ) {
-                    const range = this.sourceObj.getElementTagRanges(node);
                     ret.push(
                         codedLspDiagnostic({
                             code: "doenet-w0114",
                             message: `Element \`<${name}>\` is not allowed inside of \`<${parentName}>\`.`,
                             args: { tag: name, parent: parentName },
-                            range: {
-                                start: this.sourceObj.offsetToLSPPosition(
-                                    range[0].start,
-                                ),
-                                end: this.sourceObj.offsetToLSPPosition(
-                                    range[0].end,
-                                ),
-                            },
+                            range: elementTagRange(node),
                             severity: DiagnosticSeverity.Warning,
                         }),
                     );
@@ -168,29 +170,21 @@ export async function getSchemaViolations(
                 if (attrName === "name") {
                     const value = toXml(attr.children);
                     if (!value.charAt(0).match(/[a-zA-Z]/)) {
-                        // The parser's own name check raises this same
-                        // sentence, from `enforce-valid-names.ts`, and a code
-                        // names a situation rather than the producer that
-                        // spotted it — so this is `doenet-e0025` and not a
-                        // second name for it. Sharing it is also what lets
-                        // `dedupeLspDiagnostics` collapse the two reports of
-                        // one mistake once they stop being the same string.
-                        // The parser's message branches on which rule the name
-                        // broke; this check only looks at the first character,
-                        // so it always takes the `start` branch.
+                        // `doenet-e0025` is the parser's own name check, in
+                        // `enforce-valid-names.ts`, raising this same
+                        // sentence. A code names a situation, so both reports
+                        // of one mistake share it, which is what lets
+                        // `dedupeLspDiagnostics` collapse them into a single
+                        // hover entry once they stop being the same string.
+                        // That message branches on which rule the name broke;
+                        // this check reads only the first character, so it is
+                        // always the `start` branch.
                         ret.push(
                             codedLspDiagnostic({
                                 code: "doenet-e0025",
                                 message: `Invalid attribute name='${value}'. Names must start with a letter.`,
                                 args: { name: value, reason: "start" },
-                                range: {
-                                    start: this.sourceObj.offsetToLSPPosition(
-                                        attr.position?.start.offset || 0,
-                                    ),
-                                    end: this.sourceObj.offsetToLSPPosition(
-                                        attr.position?.end.offset || 0,
-                                    ),
-                                },
+                                range: attributeRange(attr),
                                 severity: DiagnosticSeverity.Error,
                             }),
                         );
@@ -210,24 +204,8 @@ export async function getSchemaViolations(
                     continue;
                 }
 
-                if (attrName === "UNKNOWN_NAME") {
-                    ret.push(
-                        codedLspDiagnostic({
-                            code: "doenet-w0115",
-                            message: `Element \`<${name}>\` doesn't have an attribute called \`${attr.name}\`.`,
-                            args: { tag: name, attribute: attr.name },
-                            range: {
-                                start: this.sourceObj.offsetToLSPPosition(
-                                    attr.position?.start.offset || 0,
-                                ),
-                                end: this.sourceObj.offsetToLSPPosition(
-                                    attr.position?.end.offset || 0,
-                                ),
-                            },
-                            severity: DiagnosticSeverity.Warning,
-                        }),
-                    );
-                } else if (
+                if (
+                    attrName === "UNKNOWN_NAME" ||
                     !this.isAllowedAttribute(
                         name,
                         attrName,
@@ -235,99 +213,83 @@ export async function getSchemaViolations(
                         perInstanceAllowlist ?? undefined,
                     )
                 ) {
+                    // A name no element anywhere declares normalizes to
+                    // `UNKNOWN_NAME`, so the author's own spelling is what
+                    // gets quoted back; one that exists on some other element
+                    // is quoted in the schema's casing.
+                    const attribute =
+                        attrName === "UNKNOWN_NAME" ? attr.name : attrName;
                     ret.push(
                         codedLspDiagnostic({
                             code: "doenet-w0115",
-                            message: `Element \`<${name}>\` doesn't have an attribute called \`${attrName}\`.`,
-                            args: { tag: name, attribute: attrName },
-                            range: {
-                                start: this.sourceObj.offsetToLSPPosition(
-                                    attr.position?.start.offset || 0,
-                                ),
-                                end: this.sourceObj.offsetToLSPPosition(
-                                    attr.position?.end.offset || 0,
-                                ),
-                            },
+                            message: `Element \`<${name}>\` doesn't have an attribute called \`${attribute}\`.`,
+                            args: { tag: name, attribute },
+                            range: attributeRange(attr),
                             severity: DiagnosticSeverity.Warning,
                         }),
                     );
-                } else {
-                    // If there are no macros/functions in the attribute value and the list of allowed values is non-empty,
-                    // check that the value is in the list of allowed values.
-                    // Pass the direct parent so the alias-aware path picks
-                    // up alias-specific enumerations (#1092).
-                    const allowedValues = this.getAttributeAllowedValues(
-                        name,
-                        attrName,
-                        directParentName,
+                    continue;
+                }
+
+                // If there are no macros/functions in the attribute value and the list of allowed values is non-empty,
+                // check that the value is in the list of allowed values.
+                // Pass the direct parent so the alias-aware path picks
+                // up alias-specific enumerations (#1092).
+                const allowedValues = this.getAttributeAllowedValues(
+                    name,
+                    attrName,
+                    directParentName,
+                );
+                if (!hasMacroOrFunctionChild(attr.children) && allowedValues) {
+                    // Attributes specified without a value are considered to have a value of "true".
+                    const attrValue =
+                        attr.children.length === 0
+                            ? "true"
+                            : toXml(attr.children);
+                    const valueRange = getAttributeValueRange(attr);
+                    // List-valued attributes constrain each item, so split
+                    // the authored value on whitespace and flag any token
+                    // that isn't allowed. Scalar attributes validate the
+                    // whole value as before.
+                    const tokensToCheck = allowedValues.isList
+                        ? attrValue.split(/\s+/).filter((t) => t.length > 0)
+                        : [attrValue];
+                    const invalidTokens = tokensToCheck.filter(
+                        (token) =>
+                            !allowedValues.lowerCase.has(token.toLowerCase()),
                     );
-                    if (
-                        !hasMacroOrFunctionChild(attr.children) &&
-                        allowedValues
-                    ) {
-                        // Attributes specified without a value are considered to have a value of "true".
-                        const attrValue =
-                            attr.children.length === 0
-                                ? "true"
-                                : toXml(attr.children);
-                        const range = getAttributeValueRange(attr);
-                        // List-valued attributes constrain each item, so split
-                        // the authored value on whitespace and flag any token
-                        // that isn't allowed. Scalar attributes validate the
-                        // whole value as before.
-                        const tokensToCheck = allowedValues.isList
-                            ? attrValue.split(/\s+/).filter((t) => t.length > 0)
-                            : [attrValue];
-                        const invalidTokens = tokensToCheck.filter(
-                            (token) =>
-                                !allowedValues.lowerCase.has(
-                                    token.toLowerCase(),
-                                ),
+                    if (invalidTokens.length > 0) {
+                        // The permitted values go over quoted and unjoined as
+                        // well as spelled into the English sentence, so the
+                        // catalog can enumerate them with `Intl.ListFormat` in
+                        // a language that does not separate a list with a bare
+                        // comma. `type: "unit"` is that bare enumeration,
+                        // which in English is the `", "` used just below — the
+                        // agreement the round-trip test checks.
+                        const allowed = [...allowedValues.correctCase].map(
+                            (v) => `"${v}"`,
                         );
-                        if (invalidTokens.length > 0) {
-                            // Quoted here, joined here, and *also* handed over
-                            // as a list. The English below has to be the
-                            // finished sentence, but the catalog joins the
-                            // same values itself with `Intl.ListFormat`, so
-                            // that a language which does not enumerate with a
-                            // bare comma is not stuck with English
-                            // punctuation. `type: "unit"` is the bare
-                            // enumeration rather than an "a, b, and c"
-                            // conjunction, which is what `", "` already means
-                            // here — the two agree in English, which is what
-                            // the round-trip test checks.
-                            const allowed = [...allowedValues.correctCase].map(
-                                (v) => `"${v}"`,
-                            );
-                            const allowedList = allowed.join(", ");
-                            const isList = Boolean(allowedValues.isList);
-                            ret.push(
-                                codedLspDiagnostic({
-                                    code: "doenet-w0116",
-                                    message: isList
-                                        ? `Attribute \`${attrName}\` of element \`<${name}>\` must be a list whose items are each one of: ${allowedList}`
-                                        : `Attribute \`${attrName}\` of element \`<${name}>\` must be one of: ${allowedList}`,
-                                    args: {
-                                        tag: name,
-                                        attribute: attrName,
-                                        isList,
-                                        allowed: {
-                                            list: allowed,
-                                            type: "unit",
-                                        },
-                                    },
-                                    range: {
-                                        start: this.sourceObj.offsetToLSPPosition(
-                                            range.start,
-                                        ),
-                                        end: this.sourceObj.offsetToLSPPosition(
-                                            range.end,
-                                        ),
-                                    },
-                                    severity: DiagnosticSeverity.Warning,
-                                }),
-                            );
-                        }
+                        const allowedList = allowed.join(", ");
+                        const isList = Boolean(allowedValues.isList);
+                        ret.push(
+                            codedLspDiagnostic({
+                                code: "doenet-w0116",
+                                message: isList
+                                    ? `Attribute \`${attrName}\` of element \`<${name}>\` must be a list whose items are each one of: ${allowedList}`
+                                    : `Attribute \`${attrName}\` of element \`<${name}>\` must be one of: ${allowedList}`,
+                                args: {
+                                    tag: name,
+                                    attribute: attrName,
+                                    isList,
+                                    allowed: { list: allowed, type: "unit" },
+                                },
+                                range: offsetRange(
+                                    valueRange.start,
+                                    valueRange.end,
+                                ),
+                                severity: DiagnosticSeverity.Warning,
+                            }),
+                        );
                     }
                 }
             }

--- a/packages/lsp-tools/src/coded-lsp-diagnostic.ts
+++ b/packages/lsp-tools/src/coded-lsp-diagnostic.ts
@@ -41,8 +41,8 @@ import type {
  * the rendered message, so it is how two renderings of one diagnostic
  * recognize each other once they stop being the same string.
  *
- * `args` is omitted rather than set to `undefined` when there is nothing to
- * fill in, so a coded diagnostic serializes across the LSP connection as the
+ * A diagnostic with nothing to fill in gets no `data` at all, rather than one
+ * holding an absent `args`, so it serializes across the LSP connection as the
  * same JSON an uncoded one does apart from what it is actually carrying.
  */
 export function codedLspDiagnostic({

--- a/packages/lsp-tools/src/coded-lsp-diagnostic.ts
+++ b/packages/lsp-tools/src/coded-lsp-diagnostic.ts
@@ -1,0 +1,69 @@
+import type { DiagnosticArgs, DiagnosticCode } from "@doenet/i18n";
+import type {
+    Diagnostic,
+    DiagnosticSeverity,
+    Range,
+} from "vscode-languageserver/browser";
+
+/**
+ * Build an LSP diagnostic that names what went wrong, as well as saying it.
+ *
+ * The language server's counterpart to `codedDastError` in `@doenet/parser`,
+ * and it makes the same trade for the same reason: the caller passes the
+ * English `message` instead of having it rendered from the catalog.
+ *
+ * ## Why the English is written at the call site and not read from the catalog
+ *
+ * `@doenet/lsp-tools` is bundled into the language server, and
+ * `@doenet/codemirror` embeds that built IIFE verbatim to start it as a blob
+ * worker — so every byte is on the editor's critical path before the first
+ * cursor-help request can be answered. Rendering from the catalog reaches
+ * `EN_CATALOG_SOURCE`, every English namespace joined, plus the Fluent runtime
+ * to read it, all for a bundle that renders no messages and has no locale to
+ * render them in. `packages/lsp/scripts/check-server-bundle.mjs` fails
+ * outright if either arrives rather than budgeting for it.
+ *
+ * So the English lives in two places, and the risk that they drift is real. It
+ * is held down by `test/coded-schema-violations.test.ts`, which runs the
+ * checker over a corpus of broken DoenetML and asserts that every coded
+ * violation it produces renders, through the catalog, to exactly the string
+ * the checker wrote. That test is where `@doenet/i18n` is a genuine (dev)
+ * dependency; nothing in `src/` imports anything but its types.
+ *
+ * ## Where the code and arguments go
+ *
+ * `code` is the LSP's own field for the stable name of a diagnostic, and the
+ * one a client reads to show or to link it (#1548). The arguments have no such
+ * field, so they ride in `data` — the LSP's slot for payload a client hands
+ * back later — under the same `{ args }` shape `validate.ts` uses for the
+ * parser's errors and `toAdditionalDiagnosticsForLsp` uses for the worker's.
+ * `dedupeLspDiagnostics` reads both: code plus arguments is what determines
+ * the rendered message, so it is how two renderings of one diagnostic
+ * recognize each other once they stop being the same string.
+ *
+ * `args` is omitted rather than set to `undefined` when there is nothing to
+ * fill in, so a coded diagnostic serializes across the LSP connection as the
+ * same JSON an uncoded one does apart from what it is actually carrying.
+ */
+export function codedLspDiagnostic({
+    code,
+    message,
+    args,
+    range,
+    severity,
+}: {
+    code: DiagnosticCode;
+    /** The English rendering of `code` with `args` applied. */
+    message: string;
+    args?: DiagnosticArgs;
+    range: Range;
+    severity: DiagnosticSeverity;
+}): Diagnostic {
+    return {
+        range,
+        message,
+        severity,
+        code,
+        ...(args === undefined ? {} : { data: { args } }),
+    };
+}

--- a/packages/lsp-tools/test/coded-schema-violations.test.ts
+++ b/packages/lsp-tools/test/coded-schema-violations.test.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import type { Diagnostic } from "vscode-languageserver/browser";
+import { formatEnglishDiagnostic, isDiagnosticCode } from "@doenet/i18n";
+import { doenetSchema } from "@doenet/static-assets/schema";
+
+import { AutoCompleter } from "../src";
+
+/**
+ * The schema checker writes its own English and names it with a code; the
+ * catalog in `@doenet/i18n` holds the same sentence for translators. These
+ * tests are what stop the two from drifting.
+ *
+ * The checker cannot render its messages from the catalog the way the worker
+ * does, because `@doenet/lsp` bundles it and a catalog on the editor's
+ * critical path is what `packages/lsp/scripts/check-server-bundle.mjs` exists
+ * to reject — see the header of `src/coded-lsp-diagnostic.ts`. So
+ * `@doenet/i18n` is a devDependency, used here and nowhere in `src/`, and the
+ * guarantee it buys is checked rather than assumed: run the checker over
+ * broken DoenetML, and assert that every coded violation it produces renders,
+ * through the catalog, to exactly the string the checker wrote.
+ *
+ * A message edited on one side and not the other fails here. So does a missing
+ * or misnamed argument: an argument the catalog reads and the checker does not
+ * pass renders as `{$name}`, which no hand-written English will match. And so
+ * does a list joined one way in the sentence and another in the catalog, which
+ * is the failure the `type: "unit"` on the allowed-values argument avoids.
+ *
+ * Run against the real DoenetML schema rather than a fixture, so the snippets
+ * below are documents an author could actually type — which is the only way
+ * the "every code is reachable" assertion at the end means anything.
+ */
+
+const REPO_SRC = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "src",
+);
+
+/** Every `code: "doenet-…"` literal in `src`, which is every code the checker can raise. */
+function codesNamedInSource(): Set<string> {
+    const codes = new Set<string>();
+    const walk = (dir: string) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                walk(full);
+            } else if (entry.name.endsWith(".ts")) {
+                for (const match of fs
+                    .readFileSync(full, "utf-8")
+                    .matchAll(/code:\s*"(doenet-[a-z]\d+)"/g)) {
+                    codes.add(match[1]);
+                }
+            }
+        }
+    };
+    walk(REPO_SRC);
+    return codes;
+}
+
+function violations(source: string): Promise<Diagnostic[]> {
+    return new AutoCompleter(
+        source,
+        doenetSchema.elements,
+    ).getSchemaViolations();
+}
+
+/**
+ * Broken DoenetML, one snippet per shape of violation.
+ *
+ * Named by what the author did wrong rather than by code: which code a snippet
+ * produces is the checker's business, and `doenet-auto-schema-check.test.ts`
+ * already pins the exact messages and ranges.
+ */
+const BROKEN_DOENETML: Record<string, string> = {
+    "a tag that is not a Doenet element": `<abc></abc>`,
+    "an element that cannot stand at the root": `<li>an item</li>`,
+    "an element in a parent that does not accept it": `<p><section /></p>`,
+    "an attribute the element does not have": `<p bogus="1">hi</p>`,
+    "a name that does not start with a letter": `<p name="1st">hi</p>`,
+    "a value outside the attribute's enumeration": `<p hide="maybe">hi</p>`,
+    "a list value outside the attribute's enumeration": `<sideBySide valigns="top sideways" />`,
+};
+
+describe("Coded schema violations render to the English the checker wrote", () => {
+    const exercised = new Set<string>();
+
+    /** Assert every coded violation round-trips, and record which codes were seen. */
+    function expectRoundTrip(diagnostics: Diagnostic[]) {
+        const coded = diagnostics.filter((d) => d.code !== undefined);
+        expect(coded.length).toBeGreaterThan(0);
+        for (const diagnostic of coded) {
+            const code = String(diagnostic.code);
+            expect(isDiagnosticCode(code)).toBe(true);
+            exercised.add(code);
+            const args = (diagnostic.data as { args?: never } | undefined)
+                ?.args;
+            expect(
+                formatEnglishDiagnostic(code as never, args),
+                `${code} rendered from the catalog does not match the English the checker wrote`,
+            ).toBe(diagnostic.message);
+        }
+    }
+
+    for (const [name, source] of Object.entries(BROKEN_DOENETML)) {
+        it(name, async () => {
+            expectRoundTrip(await violations(source));
+        });
+    }
+
+    it("an attribute name the schema has never heard of", async () => {
+        // The other half of `schema-attribute-unrecognized`: a name that is
+        // not an attribute of *any* element takes the `UNKNOWN_NAME` branch
+        // and reports the author's own spelling, where a name that exists
+        // elsewhere is reported normalized. One code, two call sites, and the
+        // arguments differ — so both are exercised.
+        expectRoundTrip(
+            await violations(`<p thisIsNotAnAttributeAnywhere="1">hi</p>`),
+        );
+    });
+
+    it("exercises every code the checker can raise", () => {
+        expect(
+            [...codesNamedInSource()].filter((code) => !exercised.has(code)),
+            "add a snippet above for each of these",
+        ).toEqual([]);
+    });
+});

--- a/packages/lsp-tools/test/coded-schema-violations.test.ts
+++ b/packages/lsp-tools/test/coded-schema-violations.test.ts
@@ -115,8 +115,8 @@ describe("Coded schema violations render to the English the checker wrote", () =
         // The other half of `schema-attribute-unrecognized`: a name that is
         // not an attribute of *any* element takes the `UNKNOWN_NAME` branch
         // and reports the author's own spelling, where a name that exists
-        // elsewhere is reported normalized. One code, two call sites, and the
-        // arguments differ — so both are exercised.
+        // elsewhere is reported normalized. One code, one call site, two
+        // spellings of `$attribute` — so both are exercised.
         expectRoundTrip(
             await violations(`<p thisIsNotAnAttributeAnywhere="1">hi</p>`),
         );

--- a/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
@@ -101,6 +101,12 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0113",
+              "data": {
+                "args": {
+                  "tag": "c",
+                },
+              },
               "message": "Element \`<c>\` is not allowed at the root of the document.",
               "range": {
                 "end": {
@@ -123,6 +129,12 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0113",
+              "data": {
+                "args": {
+                  "tag": "c",
+                },
+              },
               "message": "Element \`<c>\` is not allowed at the root of the document.",
               "range": {
                 "end": {
@@ -145,6 +157,13 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0114",
+              "data": {
+                "args": {
+                  "parent": "b",
+                  "tag": "c",
+                },
+              },
               "message": "Element \`<c>\` is not allowed inside of \`<b>\`.",
               "range": {
                 "end": {
@@ -172,6 +191,12 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0112",
+              "data": {
+                "args": {
+                  "tag": "e",
+                },
+              },
               "message": "Element \`<e>\` is not a recognized Doenet element.",
               "range": {
                 "end": {
@@ -207,6 +232,12 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0113",
+              "data": {
+                "args": {
+                  "tag": "c",
+                },
+              },
               "message": "Element \`<c>\` is not allowed at the root of the document.",
               "range": {
                 "end": {
@@ -229,6 +260,13 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0114",
+              "data": {
+                "args": {
+                  "parent": "b",
+                  "tag": "c",
+                },
+              },
               "message": "Element \`<c>\` is not allowed inside of \`<b>\`.",
               "range": {
                 "end": {
@@ -260,6 +298,13 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0115",
+              "data": {
+                "args": {
+                  "attribute": "food",
+                  "tag": "b",
+                },
+              },
               "message": "Element \`<b>\` doesn't have an attribute called \`food\`.",
               "range": {
                 "end": {
@@ -286,6 +331,13 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0115",
+              "data": {
+                "args": {
+                  "attribute": "foo",
+                  "tag": "a",
+                },
+              },
               "message": "Element \`<a>\` doesn't have an attribute called \`foo\`.",
               "range": {
                 "end": {
@@ -353,6 +405,21 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
+              "code": "doenet-w0116",
+              "data": {
+                "args": {
+                  "allowed": {
+                    "list": [
+                      ""true"",
+                      ""false"",
+                    ],
+                    "type": "unit",
+                  },
+                  "attribute": "foo",
+                  "isList": false,
+                  "tag": "b",
+                },
+              },
               "message": "Attribute \`foo\` of element \`<b>\` must be one of: "true", "false"",
               "range": {
                 "end": {
@@ -393,23 +460,38 @@ describe("AutoCompleter", () => {
             autoCompleter = new AutoCompleter(source, schema.elements);
             expect(await autoCompleter.getSchemaViolations())
                 .toMatchInlineSnapshot(`
-              [
-                {
-                  "message": "Attribute \`xyx\` of element \`<a>\` must be one of: "a", "B"",
-                  "range": {
-                    "end": {
-                      "character": 10,
-                      "line": 0,
-                    },
-                    "start": {
-                      "character": 7,
-                      "line": 0,
-                    },
+          [
+            {
+              "code": "doenet-w0116",
+              "data": {
+                "args": {
+                  "allowed": {
+                    "list": [
+                      ""a"",
+                      ""B"",
+                    ],
+                    "type": "unit",
                   },
-                  "severity": 2,
+                  "attribute": "xyx",
+                  "isList": false,
+                  "tag": "a",
                 },
-              ]
-            `);
+              },
+              "message": "Attribute \`xyx\` of element \`<a>\` must be one of: "a", "B"",
+              "range": {
+                "end": {
+                  "character": 10,
+                  "line": 0,
+                },
+                "start": {
+                  "character": 7,
+                  "line": 0,
+                },
+              },
+              "severity": 2,
+            },
+          ]
+        `);
         },
     );
 
@@ -489,7 +571,23 @@ describe("AutoCompleter", () => {
             .toMatchInlineSnapshot(`
           [
             {
-              "message": "Attribute \`modeOneSided\` of element \`<b>\` must be one of: \"none\", \"full\", \"true\"",
+              "code": "doenet-w0116",
+              "data": {
+                "args": {
+                  "allowed": {
+                    "list": [
+                      ""none"",
+                      ""full"",
+                      ""true"",
+                    ],
+                    "type": "unit",
+                  },
+                  "attribute": "modeOneSided",
+                  "isList": false,
+                  "tag": "b",
+                },
+              },
+              "message": "Attribute \`modeOneSided\` of element \`<b>\` must be one of: "none", "full", "true"",
               "range": {
                 "end": {
                   "character": 23,

--- a/packages/lsp/test/language-server.test.ts
+++ b/packages/lsp/test/language-server.test.ts
@@ -68,6 +68,13 @@ describe("Doenet Language Server", async () => {
           {
             "diagnostics": [
               {
+                "code": "doenet-w0115",
+                "data": {
+                  "args": {
+                    "attribute": "xxx",
+                    "tag": "graph",
+                  },
+                },
                 "message": "Element \`<graph>\` doesn't have an attribute called \`xxx\`.",
                 "range": {
                   "end": {


### PR DESCRIPTION
**#1566, which this was stacked on, has merged.** This is rebased onto `main`.

Closes #1567. Part of #861 — the tail of what #1518 tracked as Phase 3, closed once the codes were all in place.

## What changed

The schema violations `@doenet/lsp-tools` raises are what the editor draws a squiggle and a hover from, and they were the last author-facing diagnostic family composing their English at the call site with no code on them. Each now carries a stable code and the values that fill its message in, and the same sentences are in the catalogs for translators.

`codedLspDiagnostic` (`packages/lsp-tools/src/coded-lsp-diagnostic.ts`) is the direct counterpart of `codedDastError` from #1564, and makes the same trade for the same reason: the caller passes the English **alongside** the code rather than having it rendered, because this package is inside the language-server bundle that `@doenet/codemirror` embeds and starts as a blob worker. `@doenet/i18n` enters as a **devDependency** — `import type` in `src/`, the real package only in the round-trip test — so `dependencies` stays free of it and no catalog reaches the bundle. `check:size` reports **1045 KiB of 1128 KiB, no message catalogs**.

`test/coded-schema-violations.test.ts` is what stops the two copies drifting: it runs the checker over broken DoenetML **against the real DoenetML schema** and asserts every coded violation renders, through the catalog, to exactly the string the checker wrote. A message edited on one side and not the other fails there; so does an argument the catalog reads and the checker doesn't pass, which renders as `{$name}`.

## The two decisions the issue asked to make

**A prefix of their own, or the existing sequence?** The existing sequence. A code names a *situation*, not the producer that spotted it, and #1564 already put the parser's codes in the same ranges as the worker's; a per-producer prefix would fragment the ranges while answering a question (`who raised this?`) that no consumer asks. Five new codes, `doenet-w0112`–`doenet-w0116`.

**Six sentences, six codes?** Five. Two of them collapse:

- The allowed-values message becomes one code with a Fluent selector on `$isList`, following `name-attribute-invalid`'s `$reason` precedent in the same catalog — one situation, two sentences, because the reader has to be told whether they are choosing a whole list.
- The "Invalid attribute name='…'. Names must start with a letter." check turns out to be *the parser's own message*, already coded as `doenet-e0025` by #1564. It reuses that code rather than taking a second name for one mistake. That is also a small win for #1555: `dedupeLspDiagnostics` keys on code + arguments, so the two reports of that mistake now collapse into one hover entry even once they stop being the same string.

The two unknown-attribute reports — a name the schema has never heard of, and one that exists elsewhere but not here — differ only in which spelling they quote back, so they raise `doenet-w0115` from one call site with the spelling picked where they differ. Three local helpers name the ranges a violation can point at (`offsetRange`, `elementTagRange`, `attributeRange`), which the six call sites had been spelling out in full. The file also loses four imports (`RowCol`, `CompletionItem`, `CompletionItemKind`, `showCursor`) that nothing in it had referenced.

The allowed-values list is handed over as a list (`{ list, type: "unit" }`) rather than a pre-joined string, so a language that does not enumerate with a bare comma isn't stuck with English punctuation. The producer still joins it with `", "` for the English it writes, and `type: "unit"` is exactly that join in English — which is what the round-trip test checks.

## What did not change

Every message reads exactly as it did before, in every existing test. The inline snapshots in `doenet-auto-schema-check.test.ts` gained `code` and `data.args` and nothing else.

## Not in scope

Rendering these in the editor's hover in the reader's language — that is #1571, stacked on top of this. The parser's copies get translated today only because the worker re-surfaces them as runtime diagnostics and `DocViewer` re-renders those before the dedupe keeps them; schema violations have no worker counterpart, so translating them at display time needs the CodeMirror LSP plugin to render through a formatter, which is a change in a different package. This PR is what makes that possible — before it there was nothing to render *from*.

## Verification

- `lint:i18n`: 302 keys across 2 locales, 258 coded call sites covering **189/189** codes; 164/166 constructions migrated, 2 still holding a literal (unchanged — the deferred `<curve>` pair)
- `@doenet/lsp-tools` 635, including `coded-schema-violations` 9
- `@doenet/i18n` 157, `@doenet/lsp` 46 (1 skipped)
- `npm run build -w @doenet/lsp` then `npm run check:size -w @doenet/lsp`: 1045 KiB of 1128 KiB, no message catalogs
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)




