### PR TITLE
Render the in-document error box in the reader's language

### DIFF
--- a/.changeset/error-box-follows-reader-language.md
+++ b/.changeset/error-box-follows-reader-language.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Render the red error box inside a document in the reader's language, instead of leaving it English beside a Diagnostics panel that was already translated.
+
+The same error reported in two places used to read in two languages: the panel showed the reader's, the box in the document showed the English the worker wrote. The box now renders from the same code and arguments the panel does, so the two agree.
+
+The line the error was found on follows the reader too. It is a message with a line number in it rather than a sentence the worker assembles, so a translation can put the number where its own language wants it.
+
+An error that has no code yet still shows the English it arrived with, unchanged.

--- a/packages/doenetml-worker-javascript/src/components/abstract/Error.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Error.js
@@ -76,6 +76,17 @@ export default class ErrorComponent extends BlockComponent {
             }),
         };
 
+        // Where in the source the error was found, said twice from one
+        // reading of the position so the two cannot drift.
+        //
+        // `rangeMessage` is the English sentence, and it is public, so
+        // `$err.rangeMessage` keeps working and it is what the renderer falls
+        // back to. `rangeArgs` is that same location taken apart, which is
+        // what lets `_error.tsx` say it in the reader's language.
+        //
+        // The line numbers are strings on purpose. Fluent formats a numeric
+        // argument through `Intl.NumberFormat`, which would group line 1234 as
+        // "1,234" — a line number is an identifier, not a quantity.
         stateVariableDefinitions.rangeMessage = {
             description:
                 "A message describing where in the source document the error was found.",
@@ -84,39 +95,12 @@ export default class ErrorComponent extends BlockComponent {
             shadowingInstructions: {
                 createComponentOfType: "text",
             },
-            returnDependencies: () => ({
-                position: {
-                    dependencyType: "position",
+            additionalStateVariablesDefined: [
+                {
+                    variableName: "rangeArgs",
+                    forRenderer: true,
                 },
-            }),
-            definition({ dependencyValues }) {
-                let rangeMessage = "";
-
-                let position = dependencyValues.position;
-                if (position?.start.line !== undefined) {
-                    rangeMessage =
-                        "Found on " + printDoenetMLrange(position) + ".";
-                }
-
-                return { setValue: { rangeMessage } };
-            },
-        };
-
-        // The same location as `rangeMessage`, taken apart so the renderer can
-        // say it in the reader's language instead of showing the sentence
-        // assembled here.
-        //
-        // `rangeMessage` stays as it is rather than being replaced: it is a
-        // public state variable, so `$err.rangeMessage` is an author-facing
-        // string that has to keep working, and it is the fallback if the
-        // catalog somehow can't answer. What changed is that the renderer no
-        // longer *reads* it.
-        //
-        // The line numbers are strings on purpose. Fluent formats a numeric
-        // argument through `Intl.NumberFormat`, which would group line 1234 as
-        // "1,234" — a line number is an identifier, not a quantity.
-        stateVariableDefinitions.rangeArgs = {
-            forRenderer: true,
+            ],
             returnDependencies: () => ({
                 position: {
                     dependencyType: "position",
@@ -125,11 +109,13 @@ export default class ErrorComponent extends BlockComponent {
             definition({ dependencyValues }) {
                 let position = dependencyValues.position;
                 if (position?.start.line === undefined) {
-                    return { setValue: { rangeArgs: null } };
+                    return { setValue: { rangeMessage: "", rangeArgs: null } };
                 }
 
                 return {
                     setValue: {
+                        rangeMessage:
+                            "Found on " + printDoenetMLrange(position) + ".",
                         rangeArgs: {
                             // Which sentence to select, as a key rather than a
                             // phrase, so a translation can reorder the whole

--- a/packages/doenetml-worker-javascript/src/components/abstract/Error.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Error.js
@@ -44,6 +44,38 @@ export default class ErrorComponent extends BlockComponent {
             definition: () => ({ setValue: { hidden: false } }),
         };
 
+        // The code naming the diagnostic this error came from, and the
+        // arguments filling that code's message in. `convertToErrorComponent`
+        // and its relatives put both on the component's `state` (#1556); these
+        // are what read them back, and `forRenderer` is what carries them to
+        // `_error.tsx`, which renders the message in the reader's language
+        // rather than showing the English the worker wrote. Not `public`:
+        // `message` is the author-facing form of this, and these are the
+        // plumbing behind it.
+        //
+        // An error that arrived with no code — anything not yet migrated to
+        // the catalogs (#1518) — leaves both `null`, and the renderer falls
+        // back to `message` exactly as before.
+        stateVariableDefinitions.code = {
+            forRenderer: true,
+            hasEssential: true,
+            defaultValue: null,
+            returnDependencies: () => ({}),
+            definition: () => ({
+                useEssentialOrDefaultValue: { code: true },
+            }),
+        };
+
+        stateVariableDefinitions.args = {
+            forRenderer: true,
+            hasEssential: true,
+            defaultValue: null,
+            returnDependencies: () => ({}),
+            definition: () => ({
+                useEssentialOrDefaultValue: { args: true },
+            }),
+        };
+
         stateVariableDefinitions.rangeMessage = {
             description:
                 "A message describing where in the source document the error was found.",
@@ -67,6 +99,50 @@ export default class ErrorComponent extends BlockComponent {
                 }
 
                 return { setValue: { rangeMessage } };
+            },
+        };
+
+        // The same location as `rangeMessage`, taken apart so the renderer can
+        // say it in the reader's language instead of showing the sentence
+        // assembled here.
+        //
+        // `rangeMessage` stays as it is rather than being replaced: it is a
+        // public state variable, so `$err.rangeMessage` is an author-facing
+        // string that has to keep working, and it is the fallback if the
+        // catalog somehow can't answer. What changed is that the renderer no
+        // longer *reads* it.
+        //
+        // The line numbers are strings on purpose. Fluent formats a numeric
+        // argument through `Intl.NumberFormat`, which would group line 1234 as
+        // "1,234" — a line number is an identifier, not a quantity.
+        stateVariableDefinitions.rangeArgs = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                position: {
+                    dependencyType: "position",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let position = dependencyValues.position;
+                if (position?.start.line === undefined) {
+                    return { setValue: { rangeArgs: null } };
+                }
+
+                return {
+                    setValue: {
+                        rangeArgs: {
+                            // Which sentence to select, as a key rather than a
+                            // phrase, so a translation can reorder the whole
+                            // of it.
+                            span:
+                                position.start.line === position.end.line
+                                    ? "line"
+                                    : "lines",
+                            startLine: String(position.start.line),
+                            endLine: String(position.end.line),
+                        },
+                    },
+                };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/errorRendererState.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/errorRendererState.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+/**
+ * The red box an error is rendered as, in the reader's language.
+ *
+ * `_error` has carried the code and arguments of the diagnostic it came from
+ * since #1556, but only on its `state`, where the renderer could not see them
+ * — so the box showed the English the worker wrote while the Diagnostics panel
+ * beside it showed the reader's language (#1568). These are the state
+ * variables that close that gap; `_error.tsx` renders `message` through them
+ * and falls back to the English when there is nothing to render from.
+ *
+ * The rendering itself is a Cypress test
+ * (`packages/doenetml/test/cypress/component/DoenetViewer.errorLocale.cy.tsx`).
+ * What is checked here is that the worker hands over everything that test
+ * needs, since a value missing here is invisible from the other side.
+ */
+describe("the error component carries its diagnostic to the renderer @group4", () => {
+    it("exposes the code and arguments a coded error arrived with", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<p name="bad" bogusAttribute="x">Unhappy</p>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const error = stateVariables[await resolvePathToNodeIdx("bad")];
+
+        expect(error.componentType).eq("_error");
+        expect(error.stateValues.code).eq("doenet-e0004");
+        expect(error.stateValues.args).eqls({
+            attribute: "bogusAttribute",
+            componentType: "p",
+        });
+        // The English is still there: it is what the renderer falls back to
+        // when the reader's catalogs have no answer for the code.
+        expect(error.stateValues.message).eq(
+            'Invalid attribute "bogusAttribute" for a component of type `<p>`.',
+        );
+    });
+
+    it("leaves an uncoded error with nothing but its English", async () => {
+        // `<select>`'s `errorMessage` is the family `utils/dast/errors.ts`
+        // names as still holding a finished English string with no code behind
+        // it (#1518). Both slots have to stay empty rather than take some
+        // invented value the formatter would then try to resolve — the
+        // renderer shows this English, exactly as it does today.
+        const { core } = await createTestCore({
+            doenetML: `
+<variantControl variantNames="uno dos" />
+<select numToSelect="1">
+  <option selectForVariants="uno"><p>x</p></option>
+</select>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const errors = Object.values(stateVariables).filter(
+            (component: any) => component.componentType === "_error",
+        ) as any[];
+
+        expect(errors.length).eq(1);
+        expect(errors[0].stateValues.code).eq(null);
+        expect(errors[0].stateValues.args).eq(null);
+        expect(errors[0].stateValues.showMessage).eq(true);
+        expect(errors[0].stateValues.message).eq(
+            "Some variants are specified for select but no options are specified for possible variant name: dos.",
+        );
+    });
+
+    it("takes the source location apart instead of only spelling it out", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<p name="bad" bogusAttribute="x">Unhappy</p>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const error = stateVariables[await resolvePathToNodeIdx("bad")];
+
+        // The English sentence stays: `rangeMessage` is public, so
+        // `$err.rangeMessage` has to keep working, and it is the fallback.
+        expect(error.stateValues.rangeMessage).eq("Found on line 2.");
+        // Line numbers as strings, so Fluent does not group line 1234 as
+        // "1,234" on its way through `Intl.NumberFormat`.
+        expect(error.stateValues.rangeArgs).eqls({
+            span: "line",
+            startLine: "2",
+            endLine: "2",
+        });
+    });
+
+    it("says when an error spans more than one line", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<p name="bad"
+   bogusAttribute="x"
+>Unhappy</p>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const error = stateVariables[await resolvePathToNodeIdx("bad")];
+
+        expect(error.stateValues.rangeMessage).eq("Found on lines 2–4.");
+        expect(error.stateValues.rangeArgs).eqls({
+            span: "lines",
+            startLine: "2",
+            endLine: "4",
+        });
+    });
+});

--- a/packages/doenetml-worker-javascript/src/utils/dast/errors.ts
+++ b/packages/doenetml-worker-javascript/src/utils/dast/errors.ts
@@ -74,12 +74,11 @@ export function errorComponentState(
  * their own (the `_error` they wrap already did), so nothing is lost today
  * beyond the rendered text, which is English either way.
  *
- * The extra `state` keys are inert. Serialized `state` becomes the created
- * component's `essentialState` wholesale, and only keys naming a state
- * variable that asked for an essential value are ever read back — `_error`
- * has neither a `code` nor an `args` variable. Making them `forRenderer`
- * later is what would let the rendered error text be localized too; today
- * only the diagnostic is.
+ * Serialized `state` becomes the created component's `essentialState`
+ * wholesale, and `_error` declares `code` and `args` as `forRenderer` state
+ * variables that take their essential value from it. That is how the red box
+ * in the document reads in the same language as the Diagnostics panel beside
+ * it (#1568).
  */
 export function convertToErrorComponent(
     component: UnflattenedComponent | SerializedComponent,

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -2287,7 +2287,10 @@ export function DocViewer({
                         the props alone: only here is the authored
                         `<document lang>` known, so only here can the chrome
                         follow the language the content was written in. */}
-                    <I18nProvider translate={translate}>
+                    <I18nProvider
+                        translate={translate}
+                        locale={effectiveUiLocale}
+                    >
                         {documentRenderer}
                     </I18nProvider>
                 </DocContext.Provider>

--- a/packages/doenetml/src/Viewer/renderers/_error.tsx
+++ b/packages/doenetml/src/Viewer/renderers/_error.tsx
@@ -49,8 +49,8 @@ export default React.memo(function Error(props: UseDoenetRendererProps) {
         // for: the English travels on the record as the fallback.
         const message = formatDiagnostic({
             message: SVs.message,
-            ...(SVs.code == null ? {} : { code: SVs.code }),
-            ...(SVs.args == null ? {} : { args: SVs.args }),
+            code: SVs.code,
+            args: SVs.args,
         });
         let rangeMessage = null;
         if (SVs.rangeMessage) {

--- a/packages/doenetml/src/Viewer/renderers/_error.tsx
+++ b/packages/doenetml/src/Viewer/renderers/_error.tsx
@@ -26,11 +26,12 @@ export default React.memo(function Error(props: UseDoenetRendererProps) {
     let { id, SVs, children } = useDoenetRenderer<ErrorSVs>(props);
 
     const t = useT();
+    const uiLocale = useUiLocale();
     // The same formatter the Diagnostics panel renders with, over the same
     // translator: one diagnostic now reads the same in both places, where this
     // box used to show the English the worker wrote beside a panel showing the
     // reader's language.
-    const formatDiagnostic = useDiagnosticFormatter(t, useUiLocale());
+    const formatDiagnostic = useDiagnosticFormatter(t, uiLocale);
 
     let displayedMessage = null;
 
@@ -52,9 +53,11 @@ export default React.memo(function Error(props: UseDoenetRendererProps) {
             code: SVs.code,
             args: SVs.args,
         });
-        let rangeMessage = null;
+        // Named apart from `SVs.rangeMessage`, which is the English sentence
+        // this falls back to.
+        let locationLine = null;
         if (SVs.rangeMessage) {
-            rangeMessage = (
+            locationLine = (
                 <>
                     <br />
                     <em>
@@ -72,7 +75,7 @@ export default React.memo(function Error(props: UseDoenetRendererProps) {
         displayedMessage = (
             <div style={errorStyle}>
                 <b>{t("error-heading", undefined, "Error")}</b>: {message}
-                {rangeMessage}
+                {locationLine}
             </div>
         );
     }

--- a/packages/doenetml/src/Viewer/renderers/_error.tsx
+++ b/packages/doenetml/src/Viewer/renderers/_error.tsx
@@ -1,20 +1,36 @@
 import React from "react";
+import type { DiagnosticArgs, DiagnosticCode } from "@doenet/i18n";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { useT } from "../../utils/i18n";
+import { useT, useUiLocale } from "../../utils/i18n";
+import { useDiagnosticFormatter } from "../../utils/diagnostics";
 
 interface ErrorSVs {
     hidden: boolean;
     showMessage: boolean;
     rangeMessage?: string;
+    /** `{span, startLine, endLine}`, or `null` when the source position is unknown. */
+    rangeArgs?: {
+        span: "line" | "lines";
+        startLine: string;
+        endLine: string;
+    } | null;
     message: string;
+    /** The diagnostic this error came from, when it has migrated to the catalogs. */
+    code?: DiagnosticCode | null;
+    args?: DiagnosticArgs | null;
 }
 
 export default React.memo(function Error(props: UseDoenetRendererProps) {
     let { id, SVs, children } = useDoenetRenderer<ErrorSVs>(props);
 
     const t = useT();
+    // The same formatter the Diagnostics panel renders with, over the same
+    // translator: one diagnostic now reads the same in both places, where this
+    // box used to show the English the worker wrote beside a panel showing the
+    // reader's language.
+    const formatDiagnostic = useDiagnosticFormatter(t, useUiLocale());
 
     let displayedMessage = null;
 
@@ -27,18 +43,35 @@ export default React.memo(function Error(props: UseDoenetRendererProps) {
             borderStyle: "solid",
             borderColor: "var(--mainRed)",
         };
+        // An error with no code — anything not yet migrated (#1518) — has
+        // nothing to render from, and the formatter hands `message` straight
+        // back. So does one whose code the negotiated catalogs don't answer
+        // for: the English travels on the record as the fallback.
+        const message = formatDiagnostic({
+            message: SVs.message,
+            ...(SVs.code == null ? {} : { code: SVs.code }),
+            ...(SVs.args == null ? {} : { args: SVs.args }),
+        });
         let rangeMessage = null;
         if (SVs.rangeMessage) {
             rangeMessage = (
                 <>
                     <br />
-                    <em>{SVs.rangeMessage}</em>
+                    <em>
+                        {SVs.rangeArgs
+                            ? t(
+                                  "error-found-at",
+                                  SVs.rangeArgs,
+                                  SVs.rangeMessage,
+                              )
+                            : SVs.rangeMessage}
+                    </em>
                 </>
             );
         }
         displayedMessage = (
             <div style={errorStyle}>
-                <b>{t("error-heading", undefined, "Error")}</b>: {SVs.message}
+                <b>{t("error-heading", undefined, "Error")}</b>: {message}
                 {rangeMessage}
             </div>
         );

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -246,11 +246,8 @@ export function DoenetViewer({
     // Chrome outside the document — the virtual keyboard, the variant
     // selector — has only the props to go on. `DocViewer` mounts a nested
     // provider that also accounts for an authored `<document lang>`.
-    const translateChrome = useHostChromeTranslator(
-        uiLocale,
-        documentLocale,
-        localeResources,
-    );
+    const { translate: translateChrome, locale: hostUiLocale } =
+        useHostChromeTranslator(uiLocale, documentLocale, localeResources);
 
     // Start off hidden and then unhide once the viewer is visible.
     // This is needed to delay the initialization of JSXgraph
@@ -399,7 +396,10 @@ export function DoenetViewer({
                         }
                     }}
                 >
-                    <I18nProvider translate={translateChrome}>
+                    <I18nProvider
+                        translate={translateChrome}
+                        locale={hostUiLocale}
+                    >
                         <WrapWithKeyboard
                             addVirtualKeyboard={addVirtualKeyboard}
                             externalVirtualKeyboardProvided={
@@ -566,11 +566,8 @@ export const DoenetEditor = React.forwardRef<
     const resolvedTheme = useResolvedTheme(darkMode);
     // As in `DoenetViewer`: props only here, authored `<document lang>` in the
     // nested provider `DocViewer` mounts.
-    const translateChrome = useHostChromeTranslator(
-        uiLocale,
-        documentLocale,
-        localeResources,
-    );
+    const { translate: translateChrome, locale: hostUiLocale } =
+        useHostChromeTranslator(uiLocale, documentLocale, localeResources);
 
     const normalizedShowDiagnostics =
         showDiagnostics ?? showErrorsWarnings ?? true;
@@ -656,7 +653,10 @@ export const DoenetEditor = React.forwardRef<
                 useExistingMathJax={useExistingMathjax}
             >
                 <div data-theme={resolvedTheme} style={{ display: "contents" }}>
-                    <I18nProvider translate={translateChrome}>
+                    <I18nProvider
+                        translate={translateChrome}
+                        locale={hostUiLocale}
+                    >
                         <WrapWithKeyboard
                             addVirtualKeyboard={addVirtualKeyboard}
                             externalVirtualKeyboardProvided={

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -4,19 +4,28 @@ import {
     localeResourceKey,
     resolveDocumentLocale,
     resolveUiLocale,
+    DEFAULT_LOCALE,
     EN_CHROME_TRANSLATOR,
     type Translator,
 } from "@doenet/i18n";
 
 /**
- * The translator the viewer chrome renders with.
+ * The language the chrome renders in, and the translator that does it.
+ *
+ * The tag travels beside the translator because a renderer that has to format
+ * something *outside* Fluent — `Intl.ListFormat`, in the diagnostic formatter
+ * `_error.tsx` builds — needs to know which language to format it in, and a
+ * `Translator` alone cannot say.
  *
  * Defaults to English rather than to a throwing or empty translator:
  * `@doenet/doenetml` exports its renderers individually, so one can be mounted
  * by a host that never set up a locale. Those hosts should keep seeing exactly
  * what they see today.
  */
-const I18nContext = createContext<Translator>(EN_CHROME_TRANSLATOR);
+const I18nContext = createContext<{ translate: Translator; locale: string }>({
+    translate: EN_CHROME_TRANSLATOR,
+    locale: DEFAULT_LOCALE,
+});
 
 /**
  * Build the chrome translator for a resolved UI locale.
@@ -47,6 +56,10 @@ export function useChromeTranslator(
  * resolves the same pair of rules again against the language it parsed out of
  * the source, and mounts a nested provider with the result.
  *
+ * Returns the resolved tag alongside the translator, because that is what
+ * {@link I18nProvider} publishes and the caller has no other way to recover it
+ * — the resolution happens in here.
+ *
  * @param uiLocale The `uiLocale` prop, if the host set one.
  * @param documentLocale The `documentLocale` prop, if the host set one.
  * @param localeResources Host-supplied catalogs as locale → FTL source.
@@ -55,14 +68,12 @@ export function useHostChromeTranslator(
     uiLocale: string | null | undefined,
     documentLocale: string | null | undefined,
     localeResources?: Record<string, string> | null,
-): Translator {
-    return useChromeTranslator(
-        resolveUiLocale(
-            uiLocale,
-            resolveDocumentLocale(undefined, documentLocale),
-        ),
-        localeResources,
+): { translate: Translator; locale: string } {
+    const locale = resolveUiLocale(
+        uiLocale,
+        resolveDocumentLocale(undefined, documentLocale),
     );
+    return { translate: useChromeTranslator(locale, localeResources), locale };
 }
 
 /**
@@ -76,15 +87,19 @@ export function useHostChromeTranslator(
  */
 export function I18nProvider({
     translate,
+    locale,
     children,
 }: {
     translate: Translator;
+    /** The resolved `uiLocale` `translate` was built for. */
+    locale: string;
     children: React.ReactNode;
 }) {
+    // Memoized so a re-render of the provider's parent doesn't hand every
+    // consumer a new object and re-render the whole document with it.
+    const value = useMemo(() => ({ translate, locale }), [translate, locale]);
     return (
-        <I18nContext.Provider value={translate}>
-            {children}
-        </I18nContext.Provider>
+        <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
     );
 }
 
@@ -97,5 +112,16 @@ export function I18nProvider({
  * fallback is what renders if a catalog is somehow missing it.
  */
 export function useT(): Translator {
-    return useContext(I18nContext);
+    return useContext(I18nContext).translate;
+}
+
+/**
+ * The language the chrome is rendering in.
+ *
+ * For a renderer that has to format something `Fluent` isn't formatting —
+ * today, the diagnostic formatter `_error.tsx` builds, which joins list
+ * arguments with `Intl.ListFormat`.
+ */
+export function useUiLocale(): string {
+    return useContext(I18nContext).locale;
 }

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -73,7 +73,8 @@ export function useHostChromeTranslator(
         uiLocale,
         resolveDocumentLocale(undefined, documentLocale),
     );
-    return { translate: useChromeTranslator(locale, localeResources), locale };
+    const translate = useChromeTranslator(locale, localeResources);
+    return { translate, locale };
 }
 
 /**

--- a/packages/doenetml/test/cypress/component/DoenetViewer.errorLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.errorLocale.cy.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+
+// The red error box rendered *inside* the document used to stay English while
+// the same diagnostic in the Diagnostics panel was translated — same error,
+// same reader, two languages (Doenet/DoenetML#1568). `_error` has carried the
+// diagnostic's code and arguments since #1556, but not as `forRenderer`, so
+// the renderer had nothing but the English sentence the worker wrote.
+//
+// What is asserted here is the rendering itself, which is the half a worker
+// test cannot see: that the box reads in the reader's language, that the
+// "found on line" line under it does too, and that an error with no code
+// still shows the English it arrived with.
+
+const VIEWER_TIMEOUT = 30_000;
+
+/** The box `_error.tsx` draws, identified by the border color it alone uses. */
+const ERROR_BOX = "[style*='mainRed']";
+
+/** Assert some error box on the page contains `text`. */
+function errorBoxContains(text: string) {
+    return cy.contains(ERROR_BOX, text, { timeout: VIEWER_TIMEOUT });
+}
+
+describe("the in-document error box follows the reader's language", () => {
+    it("renders a coded error in Spanish, location line and all", () => {
+        // Line 2 on purpose: the location line is a separate message with a
+        // line number in it, and a translation has to be free to reorder the
+        // whole sentence around that number.
+        cy.mount(
+            <DoenetViewer
+                doenetML={"\n<abc></abc>"}
+                uiLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        errorBoxContains("Tipo de componente no válido");
+        errorBoxContains("Encontrado en la línea 2");
+        // The English it replaced is gone rather than shown beside it.
+        cy.get("body").should("not.contain.text", "Invalid component type");
+        cy.get("body").should("not.contain.text", "Found on line");
+    });
+
+    it("renders the same error in English when no locale is set", () => {
+        cy.mount(
+            <DoenetViewer
+                doenetML={"\n<abc></abc>"}
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        errorBoxContains("Invalid component type");
+        errorBoxContains("Found on line 2");
+    });
+
+    it("says so when the error spans more than one line", () => {
+        cy.mount(
+            <DoenetViewer
+                doenetML={"\n<abc\n></abc>"}
+                uiLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        errorBoxContains("Encontrado en las líneas 2 a 3");
+    });
+
+    it("falls back to the English an uncoded error arrived with", () => {
+        // `<select>`'s `errorMessage` still holds a finished English string
+        // with no code behind it (#1518). It has to keep rendering exactly as
+        // it does today; only the heading and the location line, which the
+        // viewer owns, follow the reader.
+        cy.mount(
+            <DoenetViewer
+                doenetML={
+                    '\n<variantControl variantNames="uno dos" />\n<select numToSelect="1">\n  <option selectForVariants="uno"><p>x</p></option>\n</select>'
+                }
+                uiLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        errorBoxContains("Some variants are specified for select");
+        errorBoxContains("Encontrado en");
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetViewer.errorLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.errorLocale.cy.tsx
@@ -12,7 +12,8 @@ import { DoenetViewer } from "../../../src/doenetml-inline-worker";
 // "found on line" line under it does too, and that an error with no code
 // still shows the English it arrived with.
 
-const VIEWER_TIMEOUT = 30_000;
+/** Long enough for the inline worker to boot and compile the document. */
+const VIEWER_TIMEOUT = 15_000;
 
 /** The box `_error.tsx` draws, identified by the border color it alone uses. */
 const ERROR_BOX = "[style*='mainRed']";

--- a/packages/i18n/locales/en/chrome.ftl
+++ b/packages/i18n/locales/en/chrome.ftl
@@ -154,6 +154,18 @@ viewer-initializing = Initializing...
 # placeholder left where a renderer chunk failed to load.
 error-heading = Error
 
+# Follows the error's own message inside that box, saying where in the source
+# the error was found. $span selects the sentence — one line or a range of
+# them — as a key rather than a phrase, so a translation is free to reorder the
+# whole of it. $startLine and $endLine are line numbers, and arrive as text
+# rather than as numbers so that line 1234 is not grouped as "1,234": a line
+# number is an identifier, not a quantity.
+error-found-at =
+    { $span ->
+        [line] Found on line { $startLine }.
+       *[lines] Found on lines { $startLine }–{ $endLine }.
+    }
+
 # Banner above a document that compiled with at least one error in it.
 document-contains-errors = This document contains errors!
 

--- a/packages/i18n/locales/es/chrome.ftl
+++ b/packages/i18n/locales/es/chrome.ftl
@@ -111,6 +111,14 @@ viewer-initializing = Inicializando...
 
 error-heading = Error
 
+# $startLine y $endLine son números de línea y llegan como texto, no como
+# números, para que no se agrupen los millares.
+error-found-at =
+    { $span ->
+        [line] Encontrado en la línea { $startLine }.
+       *[lines] Encontrado en las líneas { $startLine } a { $endLine }.
+    }
+
 document-contains-errors = ¡Este documento contiene errores!
 
 something-went-wrong = Algo salió mal.

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -307,11 +307,18 @@ export type DiagnosticArgValue =
  */
 export type DiagnosticArgs = Record<string, DiagnosticArgValue>;
 
-/** The parts of a diagnostic record this module needs. */
+/**
+ * The parts of a diagnostic record this module needs.
+ *
+ * `null` is accepted beside `undefined` for both optional halves, because some
+ * of what gets formatted arrives as component state rather than as a record a
+ * caller assembled — a state variable defaults to `null`, not to absent — and
+ * either way it means "nothing to render from, use the English".
+ */
 export type FormattableDiagnostic = {
     message: string;
-    code?: string;
-    args?: DiagnosticArgs;
+    code?: string | null;
+    args?: DiagnosticArgs | null;
 };
 
 /**
@@ -353,12 +360,12 @@ function asListArg(value: unknown): DiagnosticListArg | undefined {
  * `"false"`, which is the form a Fluent selector would compare against anyway.
  */
 function lowerArgs(
-    args: DiagnosticArgs | undefined,
+    args: DiagnosticArgs | null | undefined,
     locale: string,
 ): Record<string, string | number> | undefined {
     // `null` as well as `undefined`: an untyped call site can pass one as
     // easily as leave the property off, and `Object.entries(null)` throws.
-    if (args === undefined || args === null) {
+    if (args == null) {
         return undefined;
     }
     const lowered: Record<string, string | number> = {};
@@ -408,7 +415,7 @@ export function createDiagnosticFormatter(
 ): DiagnosticFormatter {
     return (diagnostic) => {
         const { code } = diagnostic;
-        if (code === undefined || !isDiagnosticCode(code)) {
+        if (code == null || !isDiagnosticCode(code)) {
             return diagnostic.message;
         }
         const key = DIAGNOSTIC_CODES[code];

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -57,6 +57,7 @@ export type MessageKey =
     | "math-input-invalid-expression"
     | "viewer-initializing"
     | "error-heading"
+    | "error-found-at"
     | "document-contains-errors"
     | "something-went-wrong"
     | "renderer-load-failed"
@@ -362,6 +363,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "math-input-invalid-expression",
     "viewer-initializing",
     "error-heading",
+    "error-found-at",
     "document-contains-errors",
     "something-went-wrong",
     "renderer-load-failed",


### PR DESCRIPTION
**#1569, which this was stacked on, has merged.** This is rebased onto `main` — the whole diff is this PR. (#1571 is stacked on top of this one.)

Closes #1568. Part of #861 — the tail of what #1518 tracked as Phase 3, closed once the codes were all in place.

## What changed

The red error box rendered inside the document now reads in the reader's language, so it agrees with the Diagnostics panel beside it instead of showing the English the worker wrote.

**`_error` hands the diagnostic to the renderer.** The code and arguments have been on the component's `state` since #1556, where nothing could see them. They are now state variables with `forRenderer`, and `_error.tsx` renders `message` through the same `createDiagnosticFormatter` `DocViewer` builds for the panel, over the same translator — so one diagnostic cannot come out two ways.

**The location line is a message, not a sentence the worker assembles.** `rangeArgs` carries `{span, startLine, endLine}` and the catalog selects between "Found on line 7." and "Found on lines 7–9.", so a translation can put the number where its own language wants it. The line numbers travel as **strings**: Fluent puts a numeric argument through `Intl.NumberFormat`, which would render line 1234 as "1,234", and a line number is an identifier rather than a quantity.

`rangeMessage` keeps composing its English. It is a *public* state variable, so `$err.rangeMessage` has to keep working, and it is the fallback if the catalog somehow can't answer. What changed is that the renderer no longer reads it. Both come out of one definition — `rangeArgs` is an `additionalStateVariablesDefined` of `rangeMessage` — so the sentence and the arguments behind it read the position once and cannot disagree about it.

**`I18nProvider` publishes the resolved locale beside the translator.** A renderer that formats something outside Fluent — `Intl.ListFormat`, for a diagnostic with a list argument — needs to know which language, and a `Translator` alone cannot say. `useT()` is unchanged for its ~60 existing call sites; `useUiLocale()` is the new half.

`FormattableDiagnostic` in `@doenet/i18n` accepts `null` for `code` and `args` beside `undefined`. That is the form they take as component state — a state variable defaults to `null`, not to absent — and the formatter already treated both as "nothing to render from"; saying so in the type is what lets `_error.tsx` hand its state variables straight over.

## What did not change

An error with no code renders the English it arrived with, exactly as before — `<select>`'s `errorMessage` is the family that still has none, and it is one of the cases under test. With no locale configured, every box reads as it did.

## Verification

Before:

| Surface | Spanish reader |
| --- | --- |
| Diagnostics panel | `Línea #2 · Tipo de componente no válido: <abc>` |
| In-document box | ``Error: Invalid component type: `<abc>` `` / `Found on line 2.` |

After, both say `Tipo de componente no válido: <abc>` / `Encontrado en la línea 2.`

- **New** `DoenetViewer.errorLocale.cy.tsx` (4 passing, whole spec in 2 s): a coded error in Spanish with its location line; the same error in English with no locale set; the multi-line variant (`Encontrado en las líneas 2 a 3`); and an uncoded error still showing its English. The negative assertions matter as much — the English is *gone*, not rendered beside the translation.
- **New** `errorRendererState.test.ts` (4 passing): the worker hands over everything that spec needs, since a value missing there is invisible from the renderer's side.
- `packages/test-cypress` after a full `build -> preview -> cypress run`: `errorsAndWarnings/errors` 1, `DocViewer/i18n` 21, `DocViewer/documentLang` 5
- `@doenet/doenetml` vitest 88, `@doenet/i18n` 157, `lint:i18n` 303 keys across 2 locales (189/189 codes; the burn-down is unchanged, since this adds no diagnostic construction)
- `npm run build:schema -w packages/static-assets` produces no diff — the new state variables are plumbing, not `public`
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)




