### PR TITLE
Render the editor's diagnostic tooltips in the reader's language

### DIFF
--- a/.changeset/editor-diagnostic-hover-locale.md
+++ b/.changeset/editor-diagnostic-hover-locale.md
@@ -14,4 +14,6 @@ The lint panel and what a screen reader announces follow the same text, so no su
 
 A language that arrives after the editor is already up — a host switching it, or a `<document lang>` the viewer has only just parsed — redraws the squiggles that are already marked, rather than leaving them in the previous language until the next edit.
 
+Also fixes squiggles disappearing when the editor re-renders. Re-rendering `<DoenetEditor>` reconfigures the CodeMirror instance behind it, which used to discard every diagnostic on screen — and nothing brought them back until the language server next published. The editor now carries the lint state in its own configuration, so what is marked stays marked.
+
 With no locale configured anywhere, every tooltip reads exactly as it did before.

--- a/.changeset/editor-diagnostic-hover-locale.md
+++ b/.changeset/editor-diagnostic-hover-locale.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Show the editor's diagnostic tooltips in the reader's language: the message, the severity heading above it, and the accessibility headings.
+
+Hovering a squiggle was the last place a diagnostic stayed English no matter who was reading. The checks the language server runs as you type — an unrecognized element, one in a parent that doesn't accept it, an unknown attribute, a value outside its enumeration — now read in the same language as the Diagnostics tab beside them.
+
+The lint panel and what a screen reader announces follow the same text, so no surface of one diagnostic disagrees with another.
+
+With no locale configured, every tooltip reads exactly as it did before.

--- a/.changeset/editor-diagnostic-hover-locale.md
+++ b/.changeset/editor-diagnostic-hover-locale.md
@@ -12,4 +12,6 @@ Hovering a squiggle was the last place a diagnostic stayed English no matter who
 
 The lint panel and what a screen reader announces follow the same text, so no surface of one diagnostic disagrees with another. A document that declares its own language is read in that language here too, the same as everywhere else the reader's language is left unset.
 
+A language that arrives after the editor is already up — a host switching it, or a `<document lang>` the viewer has only just parsed — redraws the squiggles that are already marked, rather than leaving them in the previous language until the next edit.
+
 With no locale configured anywhere, every tooltip reads exactly as it did before.

--- a/.changeset/editor-diagnostic-hover-locale.md
+++ b/.changeset/editor-diagnostic-hover-locale.md
@@ -10,6 +10,6 @@ Show the editor's diagnostic tooltips in the reader's language: the message, the
 
 Hovering a squiggle was the last place a diagnostic stayed English no matter who was reading. The checks the language server runs as you type — an unrecognized element, one in a parent that doesn't accept it, an unknown attribute, a value outside its enumeration — now read in the same language as the Diagnostics tab beside them.
 
-The lint panel and what a screen reader announces follow the same text, so no surface of one diagnostic disagrees with another.
+The lint panel and what a screen reader announces follow the same text, so no surface of one diagnostic disagrees with another. A document that declares its own language is read in that language here too, the same as everywhere else the reader's language is left unset.
 
-With no locale configured, every tooltip reads exactly as it did before.
+With no locale configured anywhere, every tooltip reads exactly as it did before.

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -7,6 +7,7 @@ import { tabExtension } from "./extensions/tab";
 import { autoCloseTagExtension } from "./extensions/auto-close-tag";
 import {
     lspPlugin,
+    redrawDiagnostics,
     uniqueLanguageServerInstance,
     type DiagnosticPresentation,
 } from "./extensions/lsp/plugin";
@@ -94,11 +95,10 @@ const CodeMirror = React.memo(function CodeMirror({
      * why it deliberately doesn't. Omit it and the tooltip shows the English
      * the producer wrote, exactly as before.
      *
-     * Hand over one object for the life of the editor: a new one rebuilds the
-     * extensions, which reopens the document on the language server. Both
-     * members are called lazily — the message as a batch of diagnostics
-     * arrives, the heading as a tooltip is drawn — so a host whose language
-     * can change answers differently rather than replacing this.
+     * Replace it whenever its answers change — when the reader's language
+     * does. That neither reconfigures the editor nor reopens the document on
+     * the language server; the diagnostics already on screen are simply drawn
+     * again through the new answers.
      */
     diagnosticPresentation?: DiagnosticPresentation;
 }) {
@@ -129,6 +129,38 @@ const CodeMirror = React.memo(function CodeMirror({
         };
     }, [languageServerRef]);
 
+    // The editor view, kept here as well as mirrored into the caller's
+    // `editorViewRef`, so the redraw below has something to aim at whether or
+    // not the caller asked for one.
+    const viewRef = React.useRef<EditorView | null>(null);
+
+    // The presentation the host most recently supplied, read through a ref so
+    // the extension set never sees it. A new extension set reconfigures the
+    // editor and reopens the document on the language server, discarding any
+    // tooltip open at the time — far too much to pay for the reader changing
+    // language. This indirection is what lets that be a plain prop.
+    const presentationRef = React.useRef(diagnosticPresentation);
+    presentationRef.current = diagnosticPresentation;
+    const stablePresentation = React.useMemo<DiagnosticPresentation>(
+        () => ({
+            formatMessage: (diagnostic) =>
+                presentationRef.current?.formatMessage?.(diagnostic) ??
+                diagnostic.message,
+            severityHeading: (severity) =>
+                presentationRef.current?.severityHeading?.(severity),
+        }),
+        [],
+    );
+
+    // Messages and headings are built when their batch of diagnostics
+    // arrives, so a host that starts answering differently has to say so for
+    // what is already drawn to follow.
+    React.useEffect(() => {
+        if (viewRef.current) {
+            redrawDiagnostics(viewRef.current);
+        }
+    }, [diagnosticPresentation]);
+
     const extensions: Extension[] = React.useMemo(() => {
         const extensions: Extension[] = [
             syntaxHighlightingExtension(darkMode),
@@ -141,7 +173,7 @@ const CodeMirror = React.memo(function CodeMirror({
             extensions.push(tabExtension);
             extensions.push(autoCloseTagExtension);
             extensions.push(
-                lspPlugin(documentId, doenetWorkerUrl, diagnosticPresentation),
+                lspPlugin(documentId, doenetWorkerUrl, stablePresentation),
             );
             extensions.push(completionIconTheme(darkMode));
         } else {
@@ -154,7 +186,7 @@ const CodeMirror = React.memo(function CodeMirror({
         ariaLabel,
         doenetWorkerUrl,
         darkMode,
-        diagnosticPresentation,
+        stablePresentation,
     ]);
 
     return (
@@ -198,6 +230,7 @@ const CodeMirror = React.memo(function CodeMirror({
                 onBlur={onBlur}
                 onFocus={onFocus}
                 onCreateEditor={(view) => {
+                    viewRef.current = view;
                     if (editorViewRef) {
                         editorViewRef.current = view;
                     }

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -96,9 +96,9 @@ const CodeMirror = React.memo(function CodeMirror({
      * the producer wrote, exactly as before.
      *
      * Replace it whenever its answers change — when the reader's language
-     * does. That neither reconfigures the editor nor reopens the document on
-     * the language server; the diagnostics already on screen are simply drawn
-     * again through the new answers.
+     * does. A new one leaves the extension set alone, so the document stays
+     * open on the language server; the diagnostics already on screen are
+     * simply drawn again through the new answers.
      */
     diagnosticPresentation?: DiagnosticPresentation;
 }) {
@@ -135,10 +135,10 @@ const CodeMirror = React.memo(function CodeMirror({
     const viewRef = React.useRef<EditorView | null>(null);
 
     // The presentation the host most recently supplied, read through a ref so
-    // the extension set never sees it. A new extension set reconfigures the
-    // editor and reopens the document on the language server, discarding any
-    // tooltip open at the time — far too much to pay for the reader changing
-    // language. This indirection is what lets that be a plain prop.
+    // the extension set never sees it. A new extension set builds a new LSP
+    // plugin, which closes the document on the language server and reopens it
+    // — far too much to pay for the reader changing language. This
+    // indirection is what lets that be a plain prop.
     const presentationRef = React.useRef(diagnosticPresentation);
     presentationRef.current = diagnosticPresentation;
     const stablePresentation = React.useMemo<DiagnosticPresentation>(

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -8,6 +8,7 @@ import { autoCloseTagExtension } from "./extensions/auto-close-tag";
 import {
     lspPlugin,
     uniqueLanguageServerInstance,
+    type DiagnosticPresentation,
 } from "./extensions/lsp/plugin";
 import {
     colorTheme,
@@ -32,6 +33,7 @@ const CodeMirror = React.memo(function CodeMirror({
     ariaLabel = "DoenetML code editor",
     doenetWorkerUrl,
     darkMode = "light",
+    diagnosticPresentation,
 }: {
     value: string;
     onChange?: (str: string) => void;
@@ -83,6 +85,19 @@ const CodeMirror = React.memo(function CodeMirror({
      * autocomplete icon colors all switch to dark-mode-verified variants.
      */
     darkMode?: ThemeMode;
+    /**
+     * How the reader wants a diagnostic said: a message formatter and the
+     * severity headings, both already in their language.
+     *
+     * This package renders the squiggles and their tooltips but has no
+     * catalogs to render them *from* — see {@link DiagnosticPresentation} for
+     * why it deliberately doesn't. Omit it and the tooltip shows the English
+     * the producer wrote, exactly as before.
+     *
+     * Memoize it: a new object each render rebuilds the editor's extensions,
+     * which reopens the document on the language server.
+     */
+    diagnosticPresentation?: DiagnosticPresentation;
 }) {
     // Only one language server runs for all documents, so we specify a document id to keep different instances different.
     const [documentId, _] = React.useState(() =>
@@ -122,13 +137,22 @@ const CodeMirror = React.memo(function CodeMirror({
         if (!readOnly) {
             extensions.push(tabExtension);
             extensions.push(autoCloseTagExtension);
-            extensions.push(lspPlugin(documentId, doenetWorkerUrl));
+            extensions.push(
+                lspPlugin(documentId, doenetWorkerUrl, diagnosticPresentation),
+            );
             extensions.push(completionIconTheme(darkMode));
         } else {
             extensions.push(EditorState.readOnly.of(true));
         }
         return extensions;
-    }, [documentId, readOnly, ariaLabel, doenetWorkerUrl, darkMode]);
+    }, [
+        documentId,
+        readOnly,
+        ariaLabel,
+        doenetWorkerUrl,
+        darkMode,
+        diagnosticPresentation,
+    ]);
 
     return (
         <div

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -86,16 +86,18 @@ const CodeMirror = React.memo(function CodeMirror({
      */
     darkMode?: ThemeMode;
     /**
-     * How the reader wants a diagnostic said: a message formatter and the
-     * severity headings, both already in their language.
+     * How the reader wants a diagnostic said: a message formatter and a
+     * source of severity headings, both answering in their language.
      *
      * This package renders the squiggles and their tooltips but has no
      * catalogs to render them *from* — see {@link DiagnosticPresentation} for
      * why it deliberately doesn't. Omit it and the tooltip shows the English
      * the producer wrote, exactly as before.
      *
-     * Memoize it: a new object each render rebuilds the editor's extensions,
-     * which reopens the document on the language server.
+     * Hand over one object for the life of the editor: a new one rebuilds the
+     * extensions, which reopens the document on the language server. Both
+     * members are called as a tooltip is drawn, so a host whose language can
+     * change answers differently rather than replacing this.
      */
     diagnosticPresentation?: DiagnosticPresentation;
 }) {

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -96,8 +96,9 @@ const CodeMirror = React.memo(function CodeMirror({
      *
      * Hand over one object for the life of the editor: a new one rebuilds the
      * extensions, which reopens the document on the language server. Both
-     * members are called as a tooltip is drawn, so a host whose language can
-     * change answers differently rather than replacing this.
+     * members are called lazily — the message as a batch of diagnostics
+     * arrives, the heading as a tooltip is drawn — so a host whose language
+     * can change answers differently rather than replacing this.
      */
     diagnosticPresentation?: DiagnosticPresentation;
 }) {

--- a/packages/codemirror/src/extensions/lsp/index.ts
+++ b/packages/codemirror/src/extensions/lsp/index.ts
@@ -1,1 +1,5 @@
-export { lspPlugin, uniqueLanguageServerInstance } from "./plugin";
+export {
+    lspPlugin,
+    uniqueLanguageServerInstance,
+    type DiagnosticPresentation,
+} from "./plugin";

--- a/packages/codemirror/src/extensions/lsp/index.ts
+++ b/packages/codemirror/src/extensions/lsp/index.ts
@@ -2,4 +2,5 @@ export {
     lspPlugin,
     uniqueLanguageServerInstance,
     type DiagnosticPresentation,
+    type SeverityHeadingKey,
 } from "./plugin";

--- a/packages/codemirror/src/extensions/lsp/plugin.ts
+++ b/packages/codemirror/src/extensions/lsp/plugin.ts
@@ -102,13 +102,6 @@ function escapeHtml(str: string): string {
         .replace(/'/g, "&#39;");
 }
 
-const lspDiagnosticToName = {
-    [LSPDiagnosticSeverity.Error]: "Error",
-    [LSPDiagnosticSeverity.Warning]: "Warning",
-    [LSPDiagnosticSeverity.Information]: "Info",
-    [LSPDiagnosticSeverity.Hint]: "Hint",
-};
-
 /**
  * How the host wants a diagnostic said, for the tooltip this plugin draws.
  *
@@ -119,11 +112,16 @@ const lspDiagnosticToName = {
  * the Fluent runtime in here to answer a question the viewer has already
  * answered would put both on the editor's critical path — the growth
  * `packages/lsp/scripts/check-server-bundle.mjs` exists to catch. So the seam
- * is two plain values, and `@doenet/doenetml` supplies them from the same
- * translator its Diagnostics panel renders with.
+ * is two questions the host answers, and `@doenet/doenetml` answers them from
+ * the same translator its Diagnostics panel renders with.
  *
  * Both are optional, and omitting them leaves the tooltip exactly as it was:
  * the English the producer wrote, under an English severity heading.
+ *
+ * Both are also *functions*, called at the moment a tooltip is drawn. That
+ * lets a host whose language can change keep handing over one object for the
+ * life of the editor: this value is part of the extension set, and replacing
+ * it reconfigures the editor and reopens the document on the language server.
  */
 export type DiagnosticPresentation = {
     /**
@@ -140,24 +138,35 @@ export type DiagnosticPresentation = {
         args?: unknown;
     }) => string;
     /**
-     * The tooltip heading for a diagnostic that names no `source` of its own.
+     * The tooltip heading for a diagnostic that names no `source` of its own,
+     * or `undefined` to keep the English one.
      *
-     * Keyed by LSP severity rather than by the CodeMirror severity the
-     * tooltip is styled with, because those are not the same set — `Hint` and
+     * Asked by LSP severity rather than by the CodeMirror severity the tooltip
+     * is styled with, because those are not the same set — `Hint` and
      * `Information` both style as `info` and are two different words.
      */
-    severityHeadings?: Partial<
-        Record<"error" | "warning" | "information" | "hint", string>
-    >;
+    severityHeading?: (severity: SeverityHeadingKey) => string | undefined;
 };
 
-/** The `severityHeadings` key an LSP severity is looked up under. */
+/** The heading a diagnostic is filed under when it names no `source`. */
+export type SeverityHeadingKey = "error" | "warning" | "information" | "hint";
+
+/** The {@link SeverityHeadingKey} an LSP severity is asked for under. */
 const lspSeverityToHeadingKey = {
     [LSPDiagnosticSeverity.Error]: "error",
     [LSPDiagnosticSeverity.Warning]: "warning",
     [LSPDiagnosticSeverity.Information]: "information",
     [LSPDiagnosticSeverity.Hint]: "hint",
-} as const;
+} as const satisfies Record<LSPDiagnosticSeverity, SeverityHeadingKey>;
+
+/** Shown when the host offers no translation of a heading. */
+const EN_SEVERITY_HEADINGS: Record<SeverityHeadingKey, string> = {
+    error: "Error",
+    warning: "Warning",
+    information: "Info",
+    hint: "Hint",
+};
+
 const lspSeverityToCmSeverity = {
     [LSPDiagnosticSeverity.Error]: "error",
     [LSPDiagnosticSeverity.Warning]: "warning",
@@ -165,6 +174,16 @@ const lspSeverityToCmSeverity = {
     [LSPDiagnosticSeverity.Hint]: "info",
 } as const;
 
+/**
+ * Which style the tooltip heading takes: an accessibility level, or the
+ * diagnostic's severity.
+ *
+ * `code` and `markClass` are what actually classify a diagnostic, and
+ * `toAdditionalDiagnosticsForLsp` in `@doenet/doenetml` sets both at the call
+ * site that sets `source`. Matching the English `source` as well is what
+ * classifies a diagnostic from a host that sets only that; a translated
+ * heading no longer matches there and does not need to.
+ */
 function getDiagnosticHeadingClass({
     code,
     source,
@@ -339,13 +358,12 @@ export class LSPPlugin implements PluginValue {
                     // over the severity word, as it always has. It arrives
                     // already translated, because the host that set it is the
                     // one that knows the reader's language.
+                    const headingKey =
+                        lspSeverityToHeadingKey[severity!] ?? "information";
                     const heading =
                         source ??
-                        this.presentation.severityHeadings?.[
-                            lspSeverityToHeadingKey[severity!]
-                        ] ??
-                        lspDiagnosticToName[severity!] ??
-                        "Info";
+                        this.presentation.severityHeading?.(headingKey) ??
+                        EN_SEVERITY_HEADINGS[headingKey];
                     const headingClass = getDiagnosticHeadingClass({
                         code,
                         source,

--- a/packages/codemirror/src/extensions/lsp/plugin.ts
+++ b/packages/codemirror/src/extensions/lsp/plugin.ts
@@ -118,10 +118,14 @@ function escapeHtml(str: string): string {
  * Both are optional, and omitting them leaves the tooltip exactly as it was:
  * the English the producer wrote, under an English severity heading.
  *
- * Both are also *functions*, called at the moment a tooltip is drawn. That
- * lets a host whose language can change keep handing over one object for the
- * life of the editor: this value is part of the extension set, and replacing
- * it reconfigures the editor and reopens the document on the language server.
+ * Both are *functions*, and neither is called before there is something to
+ * say: `formatMessage` as a batch of diagnostics is turned into CodeMirror's
+ * own, `severityHeading` as a tooltip is drawn. That lets a host whose
+ * language can change keep handing over one object for the life of the
+ * editor — this value is part of the extension set, and replacing it
+ * reconfigures the editor and reopens the document on the language server.
+ * Messages already on screen were rendered when their batch arrived, so a
+ * host that changes language republishes its diagnostics to redraw them.
  */
 export type DiagnosticPresentation = {
     /**
@@ -338,11 +342,8 @@ export class LSPPlugin implements PluginValue {
             const shownMessage =
                 this.presentation.formatMessage?.({
                     message,
-                    ...(code === undefined ? {} : { code }),
-                    ...((data as { args?: unknown } | undefined)?.args ===
-                    undefined
-                        ? {}
-                        : { args: (data as { args?: unknown }).args }),
+                    code,
+                    args: (data as { args?: unknown } | undefined)?.args,
                 }) ?? message;
 
             diagnostics.push({

--- a/packages/codemirror/src/extensions/lsp/plugin.ts
+++ b/packages/codemirror/src/extensions/lsp/plugin.ts
@@ -108,6 +108,56 @@ const lspDiagnosticToName = {
     [LSPDiagnosticSeverity.Information]: "Info",
     [LSPDiagnosticSeverity.Hint]: "Hint",
 };
+
+/**
+ * How the host wants a diagnostic said, for the tooltip this plugin draws.
+ *
+ * Everything the reader sees in that tooltip arrives already in their
+ * language, or not at all: this package renders it and does not translate it.
+ * That is deliberate. `@doenet/codemirror` embeds the built language server as
+ * a string and starts it as a blob worker, and pulling a message catalog and
+ * the Fluent runtime in here to answer a question the viewer has already
+ * answered would put both on the editor's critical path — the growth
+ * `packages/lsp/scripts/check-server-bundle.mjs` exists to catch. So the seam
+ * is two plain values, and `@doenet/doenetml` supplies them from the same
+ * translator its Diagnostics panel renders with.
+ *
+ * Both are optional, and omitting them leaves the tooltip exactly as it was:
+ * the English the producer wrote, under an English severity heading.
+ */
+export type DiagnosticPresentation = {
+    /**
+     * Render a diagnostic's message.
+     *
+     * A diagnostic that has migrated to the catalogs carries a stable `code`
+     * and the arguments filling its message in; `message` is the producer's
+     * English, which is the fallback and what an unmigrated diagnostic has
+     * instead. Returning `message` unchanged is always valid.
+     */
+    formatMessage?: (diagnostic: {
+        message: string;
+        code?: string | number;
+        args?: unknown;
+    }) => string;
+    /**
+     * The tooltip heading for a diagnostic that names no `source` of its own.
+     *
+     * Keyed by LSP severity rather than by the CodeMirror severity the
+     * tooltip is styled with, because those are not the same set — `Hint` and
+     * `Information` both style as `info` and are two different words.
+     */
+    severityHeadings?: Partial<
+        Record<"error" | "warning" | "information" | "hint", string>
+    >;
+};
+
+/** The `severityHeadings` key an LSP severity is looked up under. */
+const lspSeverityToHeadingKey = {
+    [LSPDiagnosticSeverity.Error]: "error",
+    [LSPDiagnosticSeverity.Warning]: "warning",
+    [LSPDiagnosticSeverity.Information]: "information",
+    [LSPDiagnosticSeverity.Hint]: "hint",
+} as const;
 const lspSeverityToCmSeverity = {
     [LSPDiagnosticSeverity.Error]: "error",
     [LSPDiagnosticSeverity.Warning]: "warning",
@@ -175,10 +225,12 @@ export class LSPPlugin implements PluginValue {
     reopenLatch: ReopenLatch | null = null;
     view?: EditorView;
     unsubscribeDiagnostics?: () => void;
+    presentation: DiagnosticPresentation;
 
-    constructor(documentId: string) {
+    constructor(documentId: string, presentation: DiagnosticPresentation = {}) {
         this.documentId = documentId;
         this.uri = `file:///${documentId}.doenet`;
+        this.presentation = presentation;
     }
 
     update(update: ViewUpdate): void {
@@ -247,7 +299,7 @@ export class LSPPlugin implements PluginValue {
         for (const diagnostic of this.diagnostics as Array<
             LSPDiagnostic & { markClass?: string }
         >) {
-            const { range, message, severity, source, markClass, code } =
+            const { range, message, severity, source, markClass, code, data } =
                 diagnostic;
             const cmSeverity = lspSeverityToCmSeverity[severity!] ?? "info";
             const offsets = getValidDiagnosticOffsets(
@@ -259,16 +311,41 @@ export class LSPPlugin implements PluginValue {
             }
             const { from, to } = offsets;
 
+            // Rendered once here rather than inside `renderMessage`, because
+            // the same text is also the `message` CodeMirror puts in the lint
+            // panel and reads out to a screen reader. The tooltip and the
+            // panel showing one diagnostic in two languages would be the same
+            // bug in a smaller place.
+            const shownMessage =
+                this.presentation.formatMessage?.({
+                    message,
+                    ...(code === undefined ? {} : { code }),
+                    ...((data as { args?: unknown } | undefined)?.args ===
+                    undefined
+                        ? {}
+                        : { args: (data as { args?: unknown }).args }),
+                }) ?? message;
+
             diagnostics.push({
                 from,
                 to,
                 severity: cmSeverity,
-                message,
+                message: shownMessage,
                 ...(markClass ? { markClass } : {}),
                 renderMessage: () => {
                     const div = document.createElement("div");
+                    // A `source` is the producer's own label for the kind of
+                    // diagnostic — the accessibility levels use it — and wins
+                    // over the severity word, as it always has. It arrives
+                    // already translated, because the host that set it is the
+                    // one that knows the reader's language.
                     const heading =
-                        source ?? lspDiagnosticToName[severity!] ?? "Info";
+                        source ??
+                        this.presentation.severityHeadings?.[
+                            lspSeverityToHeadingKey[severity!]
+                        ] ??
+                        lspDiagnosticToName[severity!] ??
+                        "Info";
                     const headingClass = getDiagnosticHeadingClass({
                         code,
                         source,
@@ -281,7 +358,7 @@ export class LSPPlugin implements PluginValue {
                         "heading " + headingClass
                     }">${escapeHtml(
                         heading,
-                    )}</h4><div class="cm-lint-body">${renderDiagnosticMarkdownHtml(message)}</div>
+                    )}</h4><div class="cm-lint-body">${renderDiagnosticMarkdownHtml(shownMessage)}</div>
                             </div>`;
                     return div.firstChild as HTMLElement;
                 },
@@ -713,13 +790,17 @@ export class LSPPlugin implements PluginValue {
     };
 }
 
-export const lspPlugin = (documentId: string, doenetWorkerUrl?: string) => {
+export const lspPlugin = (
+    documentId: string,
+    doenetWorkerUrl?: string,
+    presentation?: DiagnosticPresentation,
+) => {
     // The LSP is a process-wide singleton.  The first plugin instance to fire
     // the worker locks in `doenetWorkerUrl`; later instances pass theirs but
     // the singleton ignores subsequent values.  In practice every editor on a
     // page reads the URL from the same `doenetGlobalConfig`, so this is fine.
     uniqueLanguageServerInstance.setDoenetWorkerUrl(doenetWorkerUrl);
-    const plugin = new LSPPlugin(documentId);
+    const plugin = new LSPPlugin(documentId, presentation);
     return [
         ViewPlugin.define((view) => {
             plugin.view = view;

--- a/packages/codemirror/src/extensions/lsp/plugin.ts
+++ b/packages/codemirror/src/extensions/lsp/plugin.ts
@@ -118,14 +118,11 @@ function escapeHtml(str: string): string {
  * Both are optional, and omitting them leaves the tooltip exactly as it was:
  * the English the producer wrote, under an English severity heading.
  *
- * Both are *functions*, and neither is called before there is something to
- * say: `formatMessage` as a batch of diagnostics is turned into CodeMirror's
- * own, `severityHeading` as a tooltip is drawn. That lets a host whose
- * language can change keep handing over one object for the life of the
- * editor — this value is part of the extension set, and replacing it
- * reconfigures the editor and reopens the document on the language server.
- * Messages already on screen were rendered when their batch arrived, so a
- * host that changes language republishes its diagnostics to redraw them.
+ * A host whose reader's language changes hands over a new one. `CodeMirror`
+ * keeps this out of the extension set and reads it through a ref, so a
+ * replacement neither reconfigures the editor nor reopens the document on the
+ * language server; it redraws the diagnostics already on screen through the
+ * new answers ({@link redrawDiagnostics}).
  */
 export type DiagnosticPresentation = {
     /**
@@ -239,6 +236,27 @@ type ExtendedCompletion = Completion & {
 // One language server is shared across all plugin instances
 export const uniqueLanguageServerInstance = new LSP();
 
+/**
+ * The plugin drawing diagnostics in a given editor, so
+ * {@link redrawDiagnostics} can reach it. An editor with no language server
+ * (a read-only one) has no entry, and an entry drops with its view.
+ */
+const lspPluginsByView = new WeakMap<EditorView, LSPPlugin>();
+
+/**
+ * Render the diagnostics already on screen again, through whatever the
+ * editor's {@link DiagnosticPresentation} now answers.
+ *
+ * Nothing is re-fetched: the last batch the language server published is
+ * still held, and only the words are built from it again. This is what makes
+ * a language change reach messages and headings that were drawn in the
+ * previous one — they were rendered when their batch arrived, so without it
+ * they would keep reading in that language until the next edit.
+ */
+export function redrawDiagnostics(view: EditorView) {
+    lspPluginsByView.get(view)?.redrawDiagnostics();
+}
+
 export class LSPPlugin implements PluginValue {
     documentId: string;
     uri: string = "";
@@ -310,8 +328,26 @@ export class LSPPlugin implements PluginValue {
     }
 
     destroy() {
+        // Only if this plugin is still the one registered: a reconfigured
+        // editor creates the replacement before destroying this, and the
+        // registration for that view now belongs to it.
+        if (this.view && lspPluginsByView.get(this.view) === this) {
+            lspPluginsByView.delete(this.view);
+        }
         this.unsubscribeDiagnostics?.();
         uniqueLanguageServerInstance.closeDocument(this.uri).catch(() => {});
+    }
+
+    /**
+     * Say the last published batch again. A no-op before one has arrived,
+     * so a host that hands over its presentation at mount doesn't clear the
+     * (empty) diagnostic set for nothing.
+     */
+    redrawDiagnostics() {
+        if (this.diagnostics.length === 0) {
+            return;
+        }
+        this.processDiagnostics();
     }
 
     processDiagnostics() {
@@ -823,6 +859,7 @@ export const lspPlugin = (
     return [
         ViewPlugin.define((view) => {
             plugin.view = view;
+            lspPluginsByView.set(view, plugin);
             plugin.unsubscribeDiagnostics =
                 uniqueLanguageServerInstance.onDiagnostics(
                     plugin.uri,

--- a/packages/codemirror/src/extensions/lsp/plugin.ts
+++ b/packages/codemirror/src/extensions/lsp/plugin.ts
@@ -43,6 +43,7 @@ import {
 } from "vscode-languageserver-protocol/browser";
 import { Text, Transaction } from "@codemirror/state";
 import {
+    linter,
     setDiagnostics,
     Diagnostic as CodeMirrorDiagnostic,
 } from "@codemirror/lint";
@@ -120,9 +121,9 @@ function escapeHtml(str: string): string {
  *
  * A host whose reader's language changes hands over a new one. `CodeMirror`
  * keeps this out of the extension set and reads it through a ref, so a
- * replacement neither reconfigures the editor nor reopens the document on the
- * language server; it redraws the diagnostics already on screen through the
- * new answers ({@link redrawDiagnostics}).
+ * replacement leaves the language server's copy of the document open and
+ * redraws the diagnostics already on screen through the new answers
+ * ({@link redrawDiagnostics}).
  */
 export type DiagnosticPresentation = {
     /**
@@ -328,9 +329,9 @@ export class LSPPlugin implements PluginValue {
     }
 
     destroy() {
-        // Only if this plugin is still the one registered: a reconfigured
-        // editor creates the replacement before destroying this, and the
-        // registration for that view now belongs to it.
+        // Only if this plugin is still the one registered, so that a
+        // replacement which has already claimed the view keeps its
+        // registration.
         if (this.view && lspPluginsByView.get(this.view) === this) {
             lspPluginsByView.delete(this.view);
         }
@@ -857,6 +858,18 @@ export const lspPlugin = (
     uniqueLanguageServerInstance.setDoenetWorkerUrl(doenetWorkerUrl);
     const plugin = new LSPPlugin(documentId, presentation);
     return [
+        // Hold the lint state — the squiggles, the panel and the tooltip over
+        // them — in the editor's own configuration. `setDiagnostics` will
+        // otherwise append it the first time it is called, and appended
+        // configuration is discarded by the next `StateEffect.reconfigure`,
+        // which `@uiw/react-codemirror` dispatches whenever `<CodeMirror>`
+        // re-renders. Every diagnostic on screen would vanish there, with
+        // nothing to bring it back until the language server next published.
+        //
+        // `null` as the source is how `@codemirror/lint` spells "configure
+        // linting, but I supply the diagnostics myself" — which the LSP
+        // plugin below does, out of what the server publishes.
+        linter(null),
         ViewPlugin.define((view) => {
             plugin.view = view;
             lspPluginsByView.set(view, plugin);

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./CodeMirror";
 export type { ThemeMode } from "./extensions/theme";
+export type { DiagnosticPresentation } from "./extensions/lsp/plugin";
 export type { LSP } from "./extensions/lsp/worker";
 export { EditorView } from "@uiw/react-codemirror";

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -1,5 +1,8 @@
 export * from "./CodeMirror";
 export type { ThemeMode } from "./extensions/theme";
-export type { DiagnosticPresentation } from "./extensions/lsp/plugin";
+export type {
+    DiagnosticPresentation,
+    SeverityHeadingKey,
+} from "./extensions/lsp/plugin";
 export type { LSP } from "./extensions/lsp/worker";
 export { EditorView } from "@uiw/react-codemirror";

--- a/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
+++ b/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
@@ -58,6 +58,33 @@ const DiagnosticsTestHarness = ({
     );
 };
 
+/**
+ * Harness for a host whose answers change while the editor is up — the reader
+ * picked another language. The presentation is a fresh object on every render,
+ * as it is for a host building it from a rebuilt translator.
+ */
+const SwitchablePresentationHarness = () => {
+    const [word, setWord] = React.useState("first");
+
+    return (
+        <div style={{ height: "400px", width: "600px" }}>
+            <button
+                data-cy="switch-presentation"
+                onClick={() => setWord("second")}
+            >
+                switch
+            </button>
+            <CodeMirror
+                value="<graph invalid-attr='x' />"
+                diagnosticPresentation={{
+                    formatMessage: ({ message }) => `${word}: ${message}`,
+                    severityHeading: () => word,
+                }}
+            />
+        </div>
+    );
+};
+
 describe("CodeMirror LSP Diagnostics DOM Rendering", () => {
     const mountEditor = (initialValue: string) => {
         cy.mount(<DiagnosticsTestHarness initialValue={initialValue} />);
@@ -218,6 +245,35 @@ describe("CodeMirror LSP Diagnostics DOM Rendering", () => {
         cy.get(".cm-lint-tooltip .cm-lint-body").should(
             "contain.text",
             '[doenet-w0115] {"tag":"graph","attribute":"invalid-attr"}',
+        );
+    });
+
+    it("says a diagnostic again when the presentation starts answering differently", () => {
+        // The reader changed language while the editor was up. The message and
+        // the heading were built when the batch arrived, so nothing about the
+        // document has changed and the language server will not publish again
+        // on its own — replacing the presentation is what has to redraw them.
+        //
+        // The harness deliberately passes a *new object every render*, which
+        // is what a host formatting through a rebuilt translator hands over.
+        cy.mount(<SwitchablePresentationHarness />);
+        cy.get(".cm-line").should("exist");
+        waitForDiagnosticDom();
+
+        hoverLintRange(".cm-lintRange-warning");
+        cy.get(".cm-lint-tooltip .heading").should("have.text", "first");
+        cy.get(".cm-lint-tooltip .cm-lint-body").should(
+            "contain.text",
+            "first: Element",
+        );
+
+        cy.get("[data-cy=switch-presentation]").click();
+
+        hoverLintRange(".cm-lintRange-warning");
+        cy.get(".cm-lint-tooltip .heading").should("have.text", "second");
+        cy.get(".cm-lint-tooltip .cm-lint-body").should(
+            "contain.text",
+            "second: Element",
         );
     });
 

--- a/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
+++ b/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from "react";
 import { CodeMirror } from "../../../src/CodeMirror";
+import type { DiagnosticPresentation } from "../../../src/extensions/lsp/plugin";
 import type { Diagnostic } from "vscode-languageserver-protocol/browser";
 
 type LspInstance =
@@ -26,7 +27,13 @@ type WindowWithLspRef = Window & {
 /**
  * Test harness component that exposes languageServerRef for test control
  */
-const DiagnosticsTestHarness = ({ initialValue }: { initialValue: string }) => {
+const DiagnosticsTestHarness = ({
+    initialValue,
+    diagnosticPresentation,
+}: {
+    initialValue: string;
+    diagnosticPresentation?: DiagnosticPresentation;
+}) => {
     const lspRef = useRef<LspRef | null>(null);
 
     React.useEffect(() => {
@@ -42,7 +49,11 @@ const DiagnosticsTestHarness = ({ initialValue }: { initialValue: string }) => {
 
     return (
         <div style={{ height: "400px", width: "600px" }}>
-            <CodeMirror value={initialValue} languageServerRef={lspRef} />
+            <CodeMirror
+                value={initialValue}
+                languageServerRef={lspRef}
+                diagnosticPresentation={diagnosticPresentation}
+            />
         </div>
     );
 };
@@ -179,6 +190,51 @@ describe("CodeMirror LSP Diagnostics DOM Rendering", () => {
             ".cm-lintRange-error",
             "The tag <math> has no closing tag",
         );
+    });
+
+    it("says a diagnostic the way `diagnosticPresentation` asks for", () => {
+        // This package draws the tooltip and holds no catalogs, so a host that
+        // knows the reader's language supplies the words: the message through
+        // `formatMessage`, given the diagnostic's code and arguments, and the
+        // heading through `severityHeading`, asked by LSP severity.
+        cy.mount(
+            <DiagnosticsTestHarness
+                initialValue="<graph invalid-attr='x' />"
+                diagnosticPresentation={{
+                    formatMessage: ({ code, args }) =>
+                        `[${code}] ${JSON.stringify(args)}`,
+                    severityHeading: (severity) => `heading:${severity}`,
+                }}
+            />,
+        );
+        cy.get(".cm-line").should("exist");
+        waitForDiagnosticDom();
+
+        hoverLintRange(".cm-lintRange-warning");
+        cy.get(".cm-lint-tooltip .heading").should(
+            "have.text",
+            "heading:warning",
+        );
+        cy.get(".cm-lint-tooltip .cm-lint-body").should(
+            "contain.text",
+            '[doenet-w0115] {"tag":"graph","attribute":"invalid-attr"}',
+        );
+    });
+
+    it("keeps the English heading when the presentation offers none", () => {
+        cy.mount(
+            <DiagnosticsTestHarness
+                initialValue="<graph invalid-attr='x' />"
+                diagnosticPresentation={{
+                    formatMessage: ({ message }) => message,
+                }}
+            />,
+        );
+        cy.get(".cm-line").should("exist");
+        waitForDiagnosticDom();
+
+        hoverLintRange(".cm-lintRange-warning");
+        cy.get(".cm-lint-tooltip .heading").should("have.text", "Warning");
     });
 
     it("displays additional diagnostics sent via sendAdditionalDiagnostics", () => {

--- a/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
+++ b/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
@@ -85,6 +85,25 @@ const SwitchablePresentationHarness = () => {
     );
 };
 
+/**
+ * Harness for a host that re-renders the editor for a reason of its own,
+ * without changing anything the editor is configured from. The inline
+ * `onFocus` is a fresh identity each render, which is what gets the re-render
+ * past `React.memo`.
+ */
+const RerenderingHarness = () => {
+    const [count, setCount] = React.useState(0);
+
+    return (
+        <div style={{ height: "400px", width: "600px" }}>
+            <button data-cy="rerender" onClick={() => setCount(count + 1)}>
+                re-render ({count})
+            </button>
+            <CodeMirror value="<graph invalid-attr='x' />" onFocus={() => {}} />
+        </div>
+    );
+};
+
 describe("CodeMirror LSP Diagnostics DOM Rendering", () => {
     const mountEditor = (initialValue: string) => {
         cy.mount(<DiagnosticsTestHarness initialValue={initialValue} />);
@@ -274,6 +293,25 @@ describe("CodeMirror LSP Diagnostics DOM Rendering", () => {
         cy.get(".cm-lint-tooltip .cm-lint-body").should(
             "contain.text",
             "second: Element",
+        );
+    });
+
+    it("keeps the squiggles when the host re-renders the editor", () => {
+        // `@uiw/react-codemirror` reconfigures the editor whenever
+        // `<CodeMirror>` re-renders, and a reconfigure discards appended
+        // configuration — which is how `setDiagnostics` installs the lint
+        // state unless the editor already carries it. The LSP extension set
+        // carries it, so what is marked stays marked.
+        cy.mount(<RerenderingHarness />);
+        cy.get(".cm-line").should("exist");
+        waitForDiagnosticDom();
+
+        cy.get("[data-cy=rerender]").click();
+
+        hoverLintRange(".cm-lintRange-warning");
+        cy.get(".cm-lint-tooltip .cm-lint-body").should(
+            "contain.text",
+            "doesn't have an attribute called invalid-attr",
         );
     });
 

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -39,6 +39,7 @@ import type { HelpContent } from "@doenet/lsp-tools";
 import { EditorSelection } from "@codemirror/state";
 import type { Completion } from "@codemirror/autocomplete";
 import { doenetGlobalConfig } from "../global-config";
+import type { DiagnosticArgs } from "@doenet/i18n";
 import { useChromeTranslator, useUiLocale } from "../utils/i18n";
 import { useDiagnosticFormatter } from "../utils/diagnostics";
 import type {
@@ -551,8 +552,10 @@ export const EditorViewer = React.forwardRef<
     // the editor and reopens the document on the language server — which
     // discards any tooltip open at the time. The language can change while the
     // editor is up (the viewer resolves it once it has parsed the source), and
-    // both members below are called at the moment a tooltip is drawn, so they
-    // see whichever language is in effect then.
+    // both members below are called lazily — the heading as a tooltip is
+    // drawn, the message as a batch of diagnostics is turned into
+    // CodeMirror's own — so each answers in whichever language is in effect
+    // by then.
     const presentationRef = useRef({ formatDiagnostic, severityHeadings });
     presentationRef.current = { formatDiagnostic, severityHeadings };
 
@@ -565,8 +568,8 @@ export const EditorViewer = React.forwardRef<
                     // code is always a string, and anything else names no
                     // catalog message, so it is dropped rather than coerced
                     // into a lookup that cannot succeed.
-                    ...(typeof code === "string" ? { code } : {}),
-                    ...(args === undefined ? {} : { args: args as never }),
+                    code: typeof code === "string" ? code : undefined,
+                    args: args as DiagnosticArgs | undefined,
                 }),
             severityHeading: (severity) =>
                 presentationRef.current.severityHeadings[severity],
@@ -574,6 +577,11 @@ export const EditorViewer = React.forwardRef<
         [],
     );
 
+    // Sending these is also what carries a language change out to the
+    // squiggles: the server republishes on receiving them, and the plugin
+    // renders every message again through `diagnosticPresentation`. That
+    // happens without asking, because `accessibilityHeadings` is rebuilt
+    // whenever the translator behind it is.
     useEffect(() => {
         const additionalDiagnostics = toAdditionalDiagnosticsForLsp({
             diagnostics: [...initialDiagnostics, ...diagnostics],

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -551,8 +551,8 @@ export const EditorViewer = React.forwardRef<
     // severity word. Rebuilt whenever the translator behind it is, which is
     // how a language settled after the editor was already up reaches the
     // tooltips — `CodeMirror` reads this through a ref and redraws the
-    // diagnostics on screen rather than reconfiguring the editor, so a new
-    // object costs nothing beyond that redraw.
+    // diagnostics on screen rather than rebuilding its extension set, so a
+    // new object costs nothing beyond that redraw.
     const diagnosticPresentation = useMemo<DiagnosticPresentation>(
         () => ({
             formatMessage: ({ message, code, args }) =>

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -39,9 +39,12 @@ import type { HelpContent } from "@doenet/lsp-tools";
 import { EditorSelection } from "@codemirror/state";
 import type { Completion } from "@codemirror/autocomplete";
 import { doenetGlobalConfig } from "../global-config";
-import { useT, useUiLocale } from "../utils/i18n";
+import { useChromeTranslator, useUiLocale } from "../utils/i18n";
 import { useDiagnosticFormatter } from "../utils/diagnostics";
-import type { DiagnosticPresentation } from "@doenet/codemirror";
+import type {
+    DiagnosticPresentation,
+    SeverityHeadingKey,
+} from "@doenet/codemirror";
 
 const HELP_NONE: HelpContent = { kind: "none" };
 
@@ -489,13 +492,25 @@ export const EditorViewer = React.forwardRef<
     }
 
     // Everything the editor says about a diagnostic — the tooltip over a
-    // squiggle and the lint panel behind it — in the reader's language. The
-    // editor's chrome answers to `uiLocale` alone, so this is the same
-    // translator the Diagnostics tab beside it renders with; the squiggles and
-    // the tab cannot disagree.
-    const translate = useT();
-    const editorUiLocale = useUiLocale();
-    const formatDiagnostic = useDiagnosticFormatter(translate, editorUiLocale);
+    // squiggle and the lint panel behind it — in the reader's language.
+    //
+    // That language is whichever one the viewer below resolved, not the one
+    // the editor's own chrome uses: the records in the Diagnostics tab were
+    // rendered down there, where an authored `<document lang>` is known, and
+    // the hover renders the same diagnostics a second time. Until the source
+    // has been parsed there is nothing to report, so the props-only answer the
+    // surrounding chrome uses stands in.
+    const [viewerUiLocale, setViewerUiLocale] = useState<string | null>(null);
+    const hostUiLocale = useUiLocale();
+    const diagnosticLocale = viewerUiLocale ?? hostUiLocale;
+    // Bound to `translate` on purpose: `lint:i18n` only recognizes call sites
+    // through a translator named `t` or `translate`, so the keys reached below
+    // would otherwise read as orphans.
+    const translate = useChromeTranslator(diagnosticLocale, localeResources);
+    const formatDiagnostic = useDiagnosticFormatter(
+        translate,
+        diagnosticLocale,
+    );
 
     const accessibilityHeadings = useMemo(
         () => ({
@@ -513,12 +528,38 @@ export const EditorViewer = React.forwardRef<
         [translate],
     );
 
-    // Memoized because a new object here rebuilds the editor's extensions,
-    // which closes and reopens the document on the language server.
-    const diagnosticPresentation: DiagnosticPresentation = useMemo(
+    const severityHeadings = useMemo<Record<SeverityHeadingKey, string>>(
+        () => ({
+            error: translate("diagnostic-heading-error", undefined, "Error"),
+            warning: translate(
+                "diagnostic-heading-warning",
+                undefined,
+                "Warning",
+            ),
+            information: translate(
+                "diagnostic-heading-information",
+                undefined,
+                "Info",
+            ),
+            hint: translate("diagnostic-heading-hint", undefined, "Hint"),
+        }),
+        [translate],
+    );
+
+    // Read through a ref so the object handed to the editor never changes
+    // identity: it is part of the extension set, and replacing it reconfigures
+    // the editor and reopens the document on the language server — which
+    // discards any tooltip open at the time. The language can change while the
+    // editor is up (the viewer resolves it once it has parsed the source), and
+    // both members below are called at the moment a tooltip is drawn, so they
+    // see whichever language is in effect then.
+    const presentationRef = useRef({ formatDiagnostic, severityHeadings });
+    presentationRef.current = { formatDiagnostic, severityHeadings };
+
+    const diagnosticPresentation = useMemo<DiagnosticPresentation>(
         () => ({
             formatMessage: ({ message, code, args }) =>
-                formatDiagnostic({
+                presentationRef.current.formatDiagnostic({
                     message,
                     // The LSP allows a numeric `code`; a Doenet diagnostic
                     // code is always a string, and anything else names no
@@ -527,26 +568,10 @@ export const EditorViewer = React.forwardRef<
                     ...(typeof code === "string" ? { code } : {}),
                     ...(args === undefined ? {} : { args: args as never }),
                 }),
-            severityHeadings: {
-                error: translate(
-                    "diagnostic-heading-error",
-                    undefined,
-                    "Error",
-                ),
-                warning: translate(
-                    "diagnostic-heading-warning",
-                    undefined,
-                    "Warning",
-                ),
-                information: translate(
-                    "diagnostic-heading-information",
-                    undefined,
-                    "Info",
-                ),
-                hint: translate("diagnostic-heading-hint", undefined, "Hint"),
-            },
+            severityHeading: (severity) =>
+                presentationRef.current.severityHeadings[severity],
         }),
-        [formatDiagnostic, translate],
+        [],
     );
 
     useEffect(() => {
@@ -1257,6 +1282,7 @@ export const EditorViewer = React.forwardRef<
                     documentLocale={documentLocale}
                     uiLocale={uiLocale}
                     localeResources={localeResources}
+                    resolvedUiLocaleCallback={setViewerUiLocale}
                     styleOverrides={styleOverrides}
                     showAnswerResponseButton={showAnswerResponseButton}
                     answerResponseCounts={answerResponseCounts}

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -547,22 +547,16 @@ export const EditorViewer = React.forwardRef<
         [translate],
     );
 
-    // Read through a ref so the object handed to the editor never changes
-    // identity: it is part of the extension set, and replacing it reconfigures
-    // the editor and reopens the document on the language server — which
-    // discards any tooltip open at the time. The language can change while the
-    // editor is up (the viewer resolves it once it has parsed the source), and
-    // both members below are called lazily — the heading as a tooltip is
-    // drawn, the message as a batch of diagnostics is turned into
-    // CodeMirror's own — so each answers in whichever language is in effect
-    // by then.
-    const presentationRef = useRef({ formatDiagnostic, severityHeadings });
-    presentationRef.current = { formatDiagnostic, severityHeadings };
-
+    // What the editor says about a diagnostic: the message and, above it, the
+    // severity word. Rebuilt whenever the translator behind it is, which is
+    // how a language settled after the editor was already up reaches the
+    // tooltips — `CodeMirror` reads this through a ref and redraws the
+    // diagnostics on screen rather than reconfiguring the editor, so a new
+    // object costs nothing beyond that redraw.
     const diagnosticPresentation = useMemo<DiagnosticPresentation>(
         () => ({
             formatMessage: ({ message, code, args }) =>
-                presentationRef.current.formatDiagnostic({
+                formatDiagnostic({
                     message,
                     // The LSP allows a numeric `code`; a Doenet diagnostic
                     // code is always a string, and anything else names no
@@ -571,17 +565,15 @@ export const EditorViewer = React.forwardRef<
                     code: typeof code === "string" ? code : undefined,
                     args: args as DiagnosticArgs | undefined,
                 }),
-            severityHeading: (severity) =>
-                presentationRef.current.severityHeadings[severity],
+            severityHeading: (severity) => severityHeadings[severity],
         }),
-        [],
+        [formatDiagnostic, severityHeadings],
     );
 
-    // Sending these is also what carries a language change out to the
-    // squiggles: the server republishes on receiving them, and the plugin
-    // renders every message again through `diagnosticPresentation`. That
-    // happens without asking, because `accessibilityHeadings` is rebuilt
-    // whenever the translator behind it is.
+    // The accessibility headings travel to the language server rather than
+    // being asked for at draw time, because they arrive as each diagnostic's
+    // `source`. So a language change has to resend them, which the dependency
+    // on `accessibilityHeadings` below does.
     useEffect(() => {
         const additionalDiagnostics = toAdditionalDiagnosticsForLsp({
             diagnostics: [...initialDiagnostics, ...diagnostics],

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -39,6 +39,9 @@ import type { HelpContent } from "@doenet/lsp-tools";
 import { EditorSelection } from "@codemirror/state";
 import type { Completion } from "@codemirror/autocomplete";
 import { doenetGlobalConfig } from "../global-config";
+import { useT, useUiLocale } from "../utils/i18n";
+import { useDiagnosticFormatter } from "../utils/diagnostics";
+import type { DiagnosticPresentation } from "@doenet/codemirror";
 
 const HELP_NONE: HelpContent = { kind: "none" };
 
@@ -485,11 +488,73 @@ export const EditorViewer = React.forwardRef<
         setReceivedDiagnosticsFromViewer(true);
     }
 
+    // Everything the editor says about a diagnostic — the tooltip over a
+    // squiggle and the lint panel behind it — in the reader's language. The
+    // editor's chrome answers to `uiLocale` alone, so this is the same
+    // translator the Diagnostics tab beside it renders with; the squiggles and
+    // the tab cannot disagree.
+    const translate = useT();
+    const editorUiLocale = useUiLocale();
+    const formatDiagnostic = useDiagnosticFormatter(translate, editorUiLocale);
+
+    const accessibilityHeadings = useMemo(
+        () => ({
+            level1: translate(
+                "accessibility-heading-level-1",
+                undefined,
+                "WCAG AA Accessibility Violation",
+            ),
+            level2: translate(
+                "accessibility-heading-level-2",
+                undefined,
+                "Accessibility alert",
+            ),
+        }),
+        [translate],
+    );
+
+    // Memoized because a new object here rebuilds the editor's extensions,
+    // which closes and reopens the document on the language server.
+    const diagnosticPresentation: DiagnosticPresentation = useMemo(
+        () => ({
+            formatMessage: ({ message, code, args }) =>
+                formatDiagnostic({
+                    message,
+                    // The LSP allows a numeric `code`; a Doenet diagnostic
+                    // code is always a string, and anything else names no
+                    // catalog message, so it is dropped rather than coerced
+                    // into a lookup that cannot succeed.
+                    ...(typeof code === "string" ? { code } : {}),
+                    ...(args === undefined ? {} : { args: args as never }),
+                }),
+            severityHeadings: {
+                error: translate(
+                    "diagnostic-heading-error",
+                    undefined,
+                    "Error",
+                ),
+                warning: translate(
+                    "diagnostic-heading-warning",
+                    undefined,
+                    "Warning",
+                ),
+                information: translate(
+                    "diagnostic-heading-information",
+                    undefined,
+                    "Info",
+                ),
+                hint: translate("diagnostic-heading-hint", undefined, "Hint"),
+            },
+        }),
+        [formatDiagnostic, translate],
+    );
+
     useEffect(() => {
         const additionalDiagnostics = toAdditionalDiagnosticsForLsp({
             diagnostics: [...initialDiagnostics, ...diagnostics],
             showInfoAnnotations,
             showAccessibilityAnnotations,
+            accessibilityHeadings,
         });
 
         lspRef.current?.lsp.sendAdditionalDiagnostics(
@@ -501,6 +566,7 @@ export const EditorViewer = React.forwardRef<
         diagnostics,
         showInfoAnnotations,
         showAccessibilityAnnotations,
+        accessibilityHeadings,
     ]);
 
     const {
@@ -974,6 +1040,7 @@ export const EditorViewer = React.forwardRef<
             editorViewRef={editorViewRef}
             doenetWorkerUrl={doenetGlobalConfig.doenetWorkerUrl}
             darkMode={darkMode}
+            diagnosticPresentation={diagnosticPresentation}
         />
     );
 

--- a/packages/doenetml/src/EditorViewer/diagnostics.test.ts
+++ b/packages/doenetml/src/EditorViewer/diagnostics.test.ts
@@ -188,4 +188,45 @@ describe("toAdditionalDiagnosticsForLsp", () => {
         expect(out).toHaveLength(1);
         expect(out[0].message).toBe("W");
     });
+    it("shows the accessibility heading in the reader's language, keeping the keys that classify it", () => {
+        // `source` is reader-facing text, so it follows `uiLocale`. Nothing
+        // may key on the English of it: `getDiagnosticHeadingClass` in
+        // `@doenet/codemirror` also matches `code` and `markClass`, and those
+        // are what still say which level this is once the words change.
+        const accessibility: DiagnosticRecord = {
+            type: "accessibility",
+            level: 1,
+            message: "A",
+            position: dastPos(1, 1, 1, 2),
+        };
+        const [lsp] = toAdditionalDiagnosticsForLsp({
+            diagnostics: [accessibility],
+            showInfoAnnotations: false,
+            showAccessibilityAnnotations: true,
+            accessibilityHeadings: {
+                level1: "Incumplimiento de accesibilidad WCAG AA",
+                level2: "Aviso de accesibilidad",
+            },
+        });
+        expect(lsp.source).toBe("Incumplimiento de accesibilidad WCAG AA");
+        expect(lsp.code).toBe("accessibility-level-1");
+        expect(lsp.markClass).toContain(
+            "cm-doenet-accessibility-diagnostic-level-1",
+        );
+    });
+
+    it("keeps the English headings for a caller that offers no translation", () => {
+        const accessibility: DiagnosticRecord = {
+            type: "accessibility",
+            level: 2,
+            message: "A",
+            position: dastPos(1, 1, 1, 2),
+        };
+        const [lsp] = toAdditionalDiagnosticsForLsp({
+            diagnostics: [accessibility],
+            showInfoAnnotations: false,
+            showAccessibilityAnnotations: true,
+        });
+        expect(lsp.source).toBe("Accessibility alert");
+    });
 });

--- a/packages/doenetml/src/EditorViewer/diagnostics.ts
+++ b/packages/doenetml/src/EditorViewer/diagnostics.ts
@@ -64,10 +64,32 @@ const DIAGNOSTIC_TYPE_TO_LSP_SEVERITY: Record<
 };
 
 /**
+ * The heading the editor's tooltip shows over an accessibility diagnostic.
+ *
+ * `source` is the LSP's slot for the producer's own label for a *kind* of
+ * diagnostic, and the CodeMirror tooltip shows it in place of the severity
+ * word. It is therefore reader-facing text, and the viewer is where the
+ * reader's language is known — the language server has no locale.
+ *
+ * Defaulted to the English these have always been, so a caller that has no
+ * translator to offer (the unit tests, and any host embedding this directly)
+ * gets exactly what it got before.
+ */
+export type AccessibilityHeadings = { level1: string; level2: string };
+
+const EN_ACCESSIBILITY_HEADINGS: AccessibilityHeadings = {
+    level1: "WCAG AA Accessibility Violation",
+    level2: "Accessibility alert",
+};
+
+/**
  * Converts a single editor diagnostic into an LSP-compatible diagnostic.
  * Accessibility diagnostics are surfaced as warnings with custom source/markClass.
  */
-function toLspDiagnostic(diagnostic: DiagnosticRecord): EditorLspDiagnostic {
+function toLspDiagnostic(
+    diagnostic: DiagnosticRecord,
+    accessibilityHeadings: AccessibilityHeadings,
+): EditorLspDiagnostic {
     const range = dastPositionToLspRange(diagnostic.position!);
 
     if (isAccessibilityRecord(diagnostic)) {
@@ -76,10 +98,14 @@ function toLspDiagnostic(diagnostic: DiagnosticRecord): EditorLspDiagnostic {
             severity: DiagnosticSeverity.Warning,
             range,
             code: `accessibility-level-${diagnostic.level}`,
+            // Translated, which is why `getDiagnosticHeadingClass` in
+            // `@doenet/codemirror` must not be the only thing keying on the
+            // English: it matches `code` and `markClass` first, and both are
+            // set right here.
             source:
                 diagnostic.level === 1
-                    ? "WCAG AA Accessibility Violation"
-                    : "Accessibility alert",
+                    ? accessibilityHeadings.level1
+                    : accessibilityHeadings.level2,
             markClass: `cm-doenet-accessibility-diagnostic cm-doenet-accessibility-diagnostic-level-${diagnostic.level}`,
         };
     }
@@ -117,10 +143,12 @@ export function toAdditionalDiagnosticsForLsp({
     diagnostics,
     showInfoAnnotations,
     showAccessibilityAnnotations,
+    accessibilityHeadings = EN_ACCESSIBILITY_HEADINGS,
 }: {
     diagnostics: DiagnosticRecord[];
     showInfoAnnotations: boolean;
     showAccessibilityAnnotations: boolean;
+    accessibilityHeadings?: AccessibilityHeadings;
 }): EditorLspDiagnostic[] {
     return diagnostics
         .filter((diagnostic) => {
@@ -146,7 +174,9 @@ export function toAdditionalDiagnosticsForLsp({
 
             return false;
         })
-        .map(toLspDiagnostic);
+        .map((diagnostic) =>
+            toLspDiagnostic(diagnostic, accessibilityHeadings),
+        );
 }
 
 /**

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -129,6 +129,7 @@ export function DocViewer({
     documentLocale,
     uiLocale,
     localeResources,
+    resolvedUiLocaleCallback,
     styleOverrides,
     showAnswerResponseButton = false,
     answerResponseCounts = {},
@@ -184,6 +185,17 @@ export function DocViewer({
      * are handed to it at creation.
      */
     localeResources?: Record<string, string> | null;
+    /**
+     * Report the language this viewer renders its chrome and its diagnostics
+     * in, whenever it changes.
+     *
+     * Only here is an authored `<document lang>` known, and it is what
+     * `uiLocale` falls back to — so a host that wraps this viewer cannot
+     * resolve the same tag from its own props. The editor needs it: it renders
+     * the same diagnostics again in its hover tooltips, and the two must not
+     * come out in different languages.
+     */
+    resolvedUiLocaleCallback?: (uiLocale: string) => void;
     styleOverrides?: ReaderStyleOverrides | null;
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -567,6 +579,10 @@ export function DocViewer({
     // has to be rendered in the language in effect now.
     const formatDiagnosticRef = useRef(formatDiagnostic);
     formatDiagnosticRef.current = formatDiagnostic;
+
+    useEffect(() => {
+        resolvedUiLocaleCallback?.(effectiveUiLocale);
+    }, [effectiveUiLocale, resolvedUiLocaleCallback]);
 
     /**
      * Store a batch of diagnostics, rendered in the chrome's language, and

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -12,10 +12,10 @@ import {
 /**
  * The language the chrome renders in, and the translator that does it.
  *
- * The tag travels beside the translator because a renderer that has to format
- * something *outside* Fluent — `Intl.ListFormat`, in the diagnostic formatter
- * `_error.tsx` builds — needs to know which language to format it in, and a
- * `Translator` alone cannot say.
+ * The tag travels beside the translator because a consumer that has to format
+ * something *outside* Fluent — `Intl.ListFormat`, in the diagnostic formatters
+ * the error box and the editor's hover tooltips build — needs to know which
+ * language to format it in, and a `Translator` alone cannot say.
  *
  * Defaults to English rather than to a throwing or empty translator:
  * `@doenet/doenetml` exports its renderers individually, so one can be mounted
@@ -119,9 +119,9 @@ export function useT(): Translator {
 /**
  * The language the chrome is rendering in.
  *
- * For a renderer that has to format something `Fluent` isn't formatting —
- * today, the diagnostic formatter `_error.tsx` builds, which joins list
- * arguments with `Intl.ListFormat`.
+ * For a consumer that has to format something Fluent isn't formatting — today,
+ * the diagnostic formatters in `_error.tsx` and `EditorViewer`, which join
+ * list arguments with `Intl.ListFormat`.
  */
 export function useUiLocale(): string {
     return useContext(I18nContext).locale;

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+
+// The tooltip over a squiggle in the editor is the last place a diagnostic
+// was still English regardless of who was reading (Doenet/DoenetML#1569's
+// "not in scope"). The language server that produces these has no locale and
+// renders nothing; the viewer supplies the formatter and the headings, and
+// this asserts they arrive.
+//
+// `<abc></abc>` is squiggled by the language server's own schema check — the
+// family that gained codes in #1569 — and that is the copy under test: it has
+// no worker counterpart to be translated on its behalf, so before this it
+// stayed English no matter what.
+
+const EDITOR_TIMEOUT = 30_000;
+
+function Editor({ uiLocale }: { uiLocale?: string }) {
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <DoenetEditor
+                doenetML={"<abc></abc>"}
+                addVirtualKeyboard={false}
+                initialOpenTab={null}
+                {...(uiLocale === undefined ? {} : { uiLocale })}
+            />
+        </div>
+    );
+}
+
+/**
+ * Hover the first squiggle and yield the tooltip it opens.
+ *
+ * CodeMirror's hover tooltip tracks the pointer's coordinates and opens only
+ * once it has been still for `hoverTime`, so a bare `mouseover` on the marked
+ * text never opens it — the move has to land on the editor's content at the
+ * squiggle's own position, and then wait.
+ */
+function hoverFirstSquiggle() {
+    cy.get(".cm-lintRange", { timeout: EDITOR_TIMEOUT })
+        .first()
+        .then(($mark) => {
+            const box = $mark[0].getBoundingClientRect();
+            const clientX = box.left + box.width / 2;
+            const clientY = box.top + box.height / 2;
+            cy.get(".cm-content").trigger("mousemove", {
+                clientX,
+                clientY,
+                force: true,
+            });
+        });
+    return cy.get(".cm-lint-tooltip", { timeout: EDITOR_TIMEOUT });
+}
+
+describe("the editor's diagnostic tooltip follows the reader's language", () => {
+    it("renders a schema violation and its heading in Spanish", () => {
+        cy.mount(<Editor uiLocale="es" />);
+
+        hoverFirstSquiggle().should(
+            "contain.text",
+            "no es un elemento de Doenet reconocido",
+        );
+        cy.get(".cm-lint-tooltip .heading").should(
+            "contain.text",
+            "Advertencia",
+        );
+        cy.get(".cm-lint-tooltip").should(
+            "not.contain.text",
+            "is not a recognized Doenet element",
+        );
+    });
+
+    it("renders the same violation in English when no locale is set", () => {
+        cy.mount(<Editor />);
+
+        hoverFirstSquiggle().should(
+            "contain.text",
+            "is not a recognized Doenet element",
+        );
+        cy.get(".cm-lint-tooltip .heading").should("contain.text", "Warning");
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
@@ -12,13 +12,20 @@ import { DoenetEditor } from "../../../src/doenetml-inline-worker";
 // no worker counterpart to be translated on its behalf, so before this it
 // stayed English no matter what.
 
-const EDITOR_TIMEOUT = 30_000;
+/** Long enough for the language server to start and answer the first check. */
+const EDITOR_TIMEOUT = 15_000;
 
-function Editor({ uiLocale }: { uiLocale?: string }) {
+function Editor({
+    uiLocale,
+    doenetML = "<abc></abc>",
+}: {
+    uiLocale?: string;
+    doenetML?: string;
+}) {
     return (
         <div style={{ height: "500px", width: "900px" }}>
             <DoenetEditor
-                doenetML={"<abc></abc>"}
+                doenetML={doenetML}
                 addVirtualKeyboard={false}
                 initialOpenTab={null}
                 {...(uiLocale === undefined ? {} : { uiLocale })}
@@ -66,6 +73,36 @@ describe("the editor's diagnostic tooltip follows the reader's language", () => 
         cy.get(".cm-lint-tooltip").should(
             "not.contain.text",
             "is not a recognized Doenet element",
+        );
+    });
+
+    it("follows an authored `<document lang>` when the host sets no locale", () => {
+        // The language the tooltip needs is the one the *viewer* resolved:
+        // `uiLocale` falls back to the content's language, and only the viewer
+        // has parsed the source far enough to know it. Getting this from the
+        // editor's own props instead would put the hover in English while the
+        // Diagnostics tab beside it, whose records the viewer rendered, is in
+        // Spanish.
+        cy.viewport(1000, 600);
+        cy.mount(
+            <Editor doenetML={'<document lang="es"><abc></abc></document>'} />,
+        );
+
+        // Wait for the viewer to render before hovering. It is what parses the
+        // source, and replacing the diagnostics with their Spanish rendering
+        // closes any tooltip open at the time — the same as any other edit
+        // does. Its red error box is the signal that it has resolved Spanish.
+        cy.contains("[style*='mainRed']", "Tipo de componente no válido", {
+            timeout: EDITOR_TIMEOUT,
+        });
+
+        hoverFirstSquiggle().should(
+            "contain.text",
+            "no es un elemento de Doenet reconocido",
+        );
+        cy.get(".cm-lint-tooltip .heading").should(
+            "contain.text",
+            "Advertencia",
         );
     });
 

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
@@ -58,6 +58,42 @@ function hoverFirstSquiggle() {
     return cy.get(".cm-lint-tooltip", { timeout: EDITOR_TIMEOUT });
 }
 
+/**
+ * Move the pointer off the squiggle, so the next `hoverFirstSquiggle` is a
+ * fresh arrival there rather than a move to where the pointer already is.
+ */
+function unhover() {
+    cy.get(".cm-content").trigger("mousemove", {
+        clientX: 0,
+        clientY: 0,
+        force: true,
+    });
+    cy.get(".cm-lint-tooltip").should("not.exist");
+}
+
+/** An editor whose reader picks a language after it is already up. */
+function EditorWithLanguageSwitch() {
+    const [uiLocale, setUiLocale] = React.useState<string | undefined>(
+        undefined,
+    );
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <button
+                data-cy="switch-to-spanish"
+                onClick={() => setUiLocale("es")}
+            >
+                español
+            </button>
+            <DoenetEditor
+                doenetML="<abc></abc>"
+                addVirtualKeyboard={false}
+                initialOpenTab={null}
+                {...(uiLocale === undefined ? {} : { uiLocale })}
+            />
+        </div>
+    );
+}
+
 describe("the editor's diagnostic tooltip follows the reader's language", () => {
     it("renders a schema violation and its heading in Spanish", () => {
         cy.mount(<Editor uiLocale="es" />);
@@ -114,5 +150,36 @@ describe("the editor's diagnostic tooltip follows the reader's language", () => 
             "is not a recognized Doenet element",
         );
         cy.get(".cm-lint-tooltip .heading").should("contain.text", "Warning");
+    });
+
+    it("follows a language chosen after the editor is already up", () => {
+        // A tooltip's words are built when its batch of diagnostics arrives,
+        // not when it is drawn, so a squiggle that has already been checked
+        // would keep reading in the old language until the next edit unless
+        // something says otherwise. What says so is `EditorViewer` handing
+        // `CodeMirror` a presentation built from the new translator, which
+        // redraws the diagnostics on screen without reconfiguring the editor.
+        cy.mount(<EditorWithLanguageSwitch />);
+
+        hoverFirstSquiggle().should(
+            "contain.text",
+            "is not a recognized Doenet element",
+        );
+        unhover();
+
+        cy.get("[data-cy=switch-to-spanish]").click();
+
+        hoverFirstSquiggle().should(
+            "contain.text",
+            "no es un elemento de Doenet reconocido",
+        );
+        cy.get(".cm-lint-tooltip .heading").should(
+            "contain.text",
+            "Advertencia",
+        );
+        cy.get(".cm-lint-tooltip").should(
+            "not.contain.text",
+            "is not a recognized Doenet element",
+        );
     });
 });

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -332,6 +332,14 @@ every code is still checked against the registry at compile time, and the real
 package only in that test. Their `dependencies` stay free of it and the bundle
 guard stays green.
 
+The same boundary runs through `@doenet/codemirror`, which draws the tooltip
+over a squiggle: it embeds that server and so carries no catalogs either. It
+takes a `diagnosticPresentation` instead — a message formatter and a source of
+severity headings, supplied by `EditorViewer` from the translator the
+Diagnostics tab renders with. The language is the one the **viewer** resolved,
+since only there is an authored `<document lang>` known, and the hover and the
+tab are showing the same records.
+
 ### Codes
 
 A code is a permanent name — what a bug report cites, what a host reading

--- a/packages/i18n/locales/en/chrome.ftl
+++ b/packages/i18n/locales/en/chrome.ftl
@@ -169,6 +169,22 @@ error-found-at =
 # Banner above a document that compiled with at least one error in it.
 document-contains-errors = This document contains errors!
 
+# Headings of the tooltip the editor shows over a squiggle, naming what kind
+# of diagnostic it is. `-information` and `-hint` are styled identically but
+# are two different words; `-hint` is unreachable today, since nothing Doenet
+# raises is an LSP hint, and is here so the set is complete.
+diagnostic-heading-error = Error
+diagnostic-heading-warning = Warning
+diagnostic-heading-information = Info
+diagnostic-heading-hint = Hint
+
+# Headings of the same tooltip over an accessibility diagnostic, which says
+# what kind of problem it is rather than how severe. Level 1 is a failure
+# against the WCAG AA success criteria; level 2 is Doenet's own advice, which
+# no standard requires.
+accessibility-heading-level-1 = WCAG AA Accessibility Violation
+accessibility-heading-level-2 = Accessibility alert
+
 # Shown in place of the document when a renderer threw and the error boundary
 # caught it.
 something-went-wrong = Something went wrong.

--- a/packages/i18n/locales/es/chrome.ftl
+++ b/packages/i18n/locales/es/chrome.ftl
@@ -121,6 +121,16 @@ error-found-at =
 
 document-contains-errors = ¡Este documento contiene errores!
 
+# Encabezados del globo que muestra el editor sobre un subrayado.
+diagnostic-heading-error = Error
+diagnostic-heading-warning = Advertencia
+diagnostic-heading-information = Información
+diagnostic-heading-hint = Sugerencia
+
+# «WCAG AA» es el nombre propio de la norma y no se traduce.
+accessibility-heading-level-1 = Incumplimiento de accesibilidad WCAG AA
+accessibility-heading-level-2 = Aviso de accesibilidad
+
 something-went-wrong = Algo salió mal.
 
 # Follows `error-heading` and a colon, so it begins in lower case, as in

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -59,6 +59,12 @@ export type MessageKey =
     | "error-heading"
     | "error-found-at"
     | "document-contains-errors"
+    | "diagnostic-heading-error"
+    | "diagnostic-heading-warning"
+    | "diagnostic-heading-information"
+    | "diagnostic-heading-hint"
+    | "accessibility-heading-level-1"
+    | "accessibility-heading-level-2"
     | "something-went-wrong"
     | "renderer-load-failed"
     | "core-start-failed"
@@ -365,6 +371,12 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "error-heading",
     "error-found-at",
     "document-contains-errors",
+    "diagnostic-heading-error",
+    "diagnostic-heading-warning",
+    "diagnostic-heading-information",
+    "diagnostic-heading-hint",
+    "accessibility-heading-level-1",
+    "accessibility-heading-level-2",
     "something-went-wrong",
     "renderer-load-failed",
     "core-start-failed",


### PR DESCRIPTION
Rebased onto `main` now that #1570 has merged — the diff is this PR's five commits alone. (#1569, which this stack started from, has also merged.)

Closes the **"Not in scope"** note on #1569. Part of #861 — the tail of what #1518 tracked as Phase 3, closed once the codes were all in place.

## What changed

#1569 gave the language server's schema checks stable codes, which made them *translatable*; nothing rendered them. This is the render side. Hovering a squiggle was the last place a diagnostic stayed English no matter who was reading — the parser's errors only escaped it because the worker re-surfaces them and the dedupe keeps that already-translated copy, and the schema checks have no worker counterpart to do that for them.

Three things in the tooltip now follow the reader's language: the **message**, the **severity heading** above it, and the **accessibility headings** that replace that heading for a WCAG or advisory diagnostic.

Which language that is comes from the **viewer**, not from the editor's own props. `uiLocale` falls back to the content's language, and only the viewer has parsed the source far enough to know what an authored `<document lang>` says — so `DocViewer` reports the tag it settled on (`resolvedUiLocaleCallback`) and `EditorViewer` renders diagnostics in it. Without that, a document declaring `lang="es"` to a host that configures nothing would put the hover in English beside the same diagnostics listed in Spanish, which is the disagreement this is here to close.

## The seam

`@doenet/codemirror` takes the rendering but **not** the catalogs. It embeds the built language server as a string and starts it as a blob worker, so pulling the Fluent runtime and a catalog in here — to answer a question the viewer has already answered — would put both on the editor's critical path, which is the growth `check-server-bundle.mjs` exists to catch. `dependencies` there is still `{}`.

Instead there is an optional `diagnosticPresentation` prop, two questions the host answers:

```ts
export type DiagnosticPresentation = {
    formatMessage?: (d: { message: string; code?: string | number; args?: unknown }) => string;
    severityHeading?: (severity: SeverityHeadingKey) => string | undefined;
};
```

Omit it and the tooltip is byte-identical to before. `EditorViewer` fills it from a translator bound to the language the viewer resolved — the same language the diagnostics listed in the Diagnostics tab were rendered in — so one diagnostic cannot read two ways across the two surfaces. (The tab's own chrome around them, its labels and empty states, is still English: the editor chrome has never been translated, which is #1580.)

It is an **ordinary prop**: hand over a new one whenever its answers change. `CodeMirror` holds it in a ref rather than in the extension set, so a replacement leaves the extension set alone — the language server's copy of the document is never closed and reopened — and the diagnostics already marked are simply drawn again through the new answers, with no round trip to the server. `EditorViewer` therefore builds one from whichever translator is current, and a language that arrives after the editor is up reaches the squiggles the same way it reaches everything else.

Two details worth a look:

- The message is formatted **once**, when a batch of diagnostics is turned into CodeMirror's own, not inside `renderMessage`. The same text is what CodeMirror puts in the lint panel and reads out to a screen reader; one diagnostic in two languages across those surfaces would be the same bug in a smaller place. That is also why replacing the presentation has to redraw — nothing about the document changed, so the server would not publish again on its own.
- The severity headings are asked for by **LSP** severity, not by the CodeMirror severity the tooltip is styled with: `Hint` and `Information` both style as `info` and are two different words.

## A bug this uncovered: squiggles lost on any re-render

`setDiagnostics` installs CodeMirror's lint state through `StateEffect.appendConfig` the first time it is called, and appended configuration is discarded by the next `StateEffect.reconfigure`. `@uiw/react-codemirror` dispatches one on **every** re-render of `<CodeMirror>`, because the `onChange` and `onUpdate` it watches are built inline. So every diagnostic on screen was thrown away whenever the editor re-rendered, with nothing to bring it back until the language server next published.

The LSP extension set now carries the lint state itself, through `linter(null)` — `@codemirror/lint`'s spelling of "configure linting, I supply the diagnostics myself" — so a reconfigure leaves what is marked marked.

This is also what makes the redraw above mean what it says. Before the fix, replacing the presentation was *restoring* the squiggles a reconfigure had just destroyed rather than repainting them, and the new component test for the redraw could not tell those apart.

## The accessibility headings

Those travel as LSP `source`, which the tooltip shows in place of the severity word — reader-facing text, so it is translated in `toAdditionalDiagnosticsForLsp`, where the reader's language is known. They reach the tooltip through the language server rather than through `diagnosticPresentation`, so a language change has to resend them; that is what the `accessibilityHeadings` dependency on that effect is for.

`getDiagnosticHeadingClass` in `@doenet/codemirror` used to be able to fall back on matching the English of it; it matches `code` and `markClass` first, and both are set at the very same call site, so the classification survives the words changing. There is a unit test asserting exactly that pair.

## Still English after this

The **VS Code extension**. It talks to the same language server, but VS Code renders `message` itself and the extension has no locale plumbing — a separate piece of work, and the codes this depends on are already on the wire for whenever it happens. Context-sensitive help (the `editor` catalog, still empty) is likewise its own phase.

## Verification

- **New** `DoenetEditor.diagnosticHoverLocale.cy.tsx` (4 passing): hovering the squiggle under `<abc></abc>` shows `no es un elemento de Doenet reconocido` under an `Advertencia` heading, and the English is *gone*; the same document declaring `lang="es"` with no `uiLocale` set reads the same way (that one fails against the editor's own props); with neither, the hover reads as it always did; and a reader who switches to Spanish while the editor is up sees the squiggle already on screen say so.
- **New** `@doenet/codemirror` component tests in `diagnostics.cy.tsx`: a presentation that rewrites the message and the heading is what the tooltip shows, one that offers no heading keeps the English, replacing the presentation redraws what is already marked, and a re-render that changes nothing the editor is configured from leaves the squiggles alone. The last two are the regression pins — drop the redraw effect and the tooltip keeps saying `first`; drop `linter(null)` and the squiggle is gone entirely.
- **New** unit tests in `diagnostics.test.ts` for the translated `source` and the English default.
- `packages/doenetml` component specs 45, `@doenet/codemirror` component specs 73 (`diagnostics` 10)
- `packages/test-cypress` after a full `build -> preview -> cypress run`: `DocViewer/i18n` 21, `DocViewer/documentLang` 5, `errorsAndWarnings/errors` 1, `EditorViewer/*` 36 (`editorViewer` 5, `editorViewerAccessibilityReport` 17, `contextSensitiveHelp` 8, `editorViewerClickToNavigate` 4, `autocompletion` 2)
- `@doenet/doenetml` vitest 90, `@doenet/lsp` 46 (1 skipped), `@doenet/lsp-tools` 635, `@doenet/i18n` 157, `lint:i18n` 309 keys across 2 locales
- `npm run check:size -w @doenet/lsp`: 1045 KiB of 1128 KiB, no message catalogs
- `npm run check:size -w @doenet/standalone`: within budget, core inlined exactly once
- `npm run build:schema -w packages/static-assets` produces no diff
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)




