### PR TITLE
Name tables, figures and paginator controls in the document's language

### DIFF
--- a/.changeset/table-figure-paginator-words-locale.md
+++ b/.changeset/table-figure-paginator-words-locale.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Write the words a `<table>`, a `<figure>`, and a `<paginatorControls>` name themselves with in the document's language.
+
+"Table 2" and "Figure 3" are one message each rather than a word with a number stuck on the end, so a language that orders or punctuates them differently can say so.
+
+The paginator's "Page 3 of 5" is now composed as a whole sentence in the document's language. It used to be half worker and half renderer — the word came from the document, the "of" joining the counts was English written into the viewer and unreachable — so a translated activity read "Página 3 of 5".
+
+`previousLabel`, `nextLabel`, and `pageLabel` follow the document when the author leaves them unset, and pass through untouched when the author writes them — including when what they wrote is the English default.
+
+A document that declares no language reads exactly as it did before.

--- a/packages/doenetml-worker-javascript/src/components/Figure.js
+++ b/packages/doenetml-worker-javascript/src/components/Figure.js
@@ -1,4 +1,8 @@
 import BlockComponent from "./abstract/BlockComponent";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 export default class Figure extends BlockComponent {
     constructor(args) {
@@ -80,7 +84,7 @@ export default class Figure extends BlockComponent {
             ],
             mustEvaluate: true, // must evaluate to make sure all counters are accounted for
             returnDependencies({ stateValues }) {
-                let dependencies = {};
+                let dependencies = { ...returnContentLocaleDependencies() };
 
                 if (stateValues.number) {
                     dependencies.figureCounter = {
@@ -91,16 +95,26 @@ export default class Figure extends BlockComponent {
                 return dependencies;
             },
             definition({ dependencyValues }) {
+                const t = contentTranslator(dependencyValues);
+
                 if (dependencyValues.figureCounter === undefined) {
                     return {
                         setValue: {
                             figureEnumeration: null,
-                            figureName: "Figure",
+                            figureName: t(
+                                "figure-name",
+                                { parts: "unnumbered" },
+                                "Figure",
+                            ),
                         },
                     };
                 }
                 let figureEnumeration = String(dependencyValues.figureCounter);
-                let figureName = "Figure " + figureEnumeration;
+                let figureName = t(
+                    "figure-name",
+                    { parts: "numbered", enumeration: figureEnumeration },
+                    `Figure ${figureEnumeration}`,
+                );
                 return {
                     setValue: { figureEnumeration, figureName },
                 };

--- a/packages/doenetml-worker-javascript/src/components/Paginator.js
+++ b/packages/doenetml-worker-javascript/src/components/Paginator.js
@@ -1,4 +1,9 @@
 import BlockComponent from "./abstract/BlockComponent";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+    returnLocalizedDefaultStateVariableDefinition,
+} from "../utils/contentLocale";
 
 export class Paginator extends BlockComponent {
     constructor(args) {
@@ -248,29 +253,27 @@ export class PaginatorControls extends BlockComponent {
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
 
+        // The three labels land on `…PreLocalize` state variables and are
+        // re-taken below, where an unspecified attribute is replaced by the
+        // default in the document's language. The English `defaultValue`s here
+        // are what authors see in the schema; they are never read.
         attributes.previousLabel = {
             description: 'Label for the "previous page" button.',
             createComponentOfType: "text",
-            createStateVariable: "previousLabel",
+            createStateVariable: "previousLabelPreLocalize",
             defaultValue: "Previous",
-            forRenderer: true,
-            public: true,
         };
         attributes.nextLabel = {
             description: 'Label for the "next page" button.',
             createComponentOfType: "text",
-            createStateVariable: "nextLabel",
+            createStateVariable: "nextLabelPreLocalize",
             defaultValue: "Next",
-            forRenderer: true,
-            public: true,
         };
         attributes.pageLabel = {
             description: "Label format for the current page indicator.",
             createComponentOfType: "text",
-            createStateVariable: "pageLabel",
+            createStateVariable: "pageLabelPreLocalize",
             defaultValue: "Page",
-            forRenderer: true,
-            public: true,
         };
         attributes.paginator = {
             createReferences: true,
@@ -283,6 +286,24 @@ export class PaginatorControls extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(stateVariableDefinitions, {
+            previousLabel: returnLocalizedDefaultStateVariableDefinition({
+                name: "previousLabel",
+                translatedDefault: (t) => t("paginator-previous"),
+                description: 'Label for the "previous page" button.',
+            }),
+            nextLabel: returnLocalizedDefaultStateVariableDefinition({
+                name: "nextLabel",
+                translatedDefault: (t) => t("paginator-next"),
+                description: 'Label for the "next page" button.',
+            }),
+            pageLabel: returnLocalizedDefaultStateVariableDefinition({
+                name: "pageLabel",
+                translatedDefault: (t) => t("paginator-page"),
+                description: "Label format for the current page indicator.",
+            }),
+        });
 
         stateVariableDefinitions.paginatorComponentIdx = {
             additionalStateVariablesDefined: ["unresolvedPath"],
@@ -377,6 +398,50 @@ export class PaginatorControls extends BlockComponent {
                 } else {
                     return { setValue: { numPages: 1 } };
                 }
+            },
+        };
+
+        // The whole status line between the two buttons — "Page 3 of 5" —
+        // rather than the renderer setting the word joining the counts. It
+        // belongs here because `pageLabel` does: the label may be the author's
+        // own wording, in the document's language, and a renderer composing
+        // around it would join it with a word in the reader's instead.
+        //
+        // The counts are stringified so that page 1000 is not grouped as
+        // "1,000": a page number identifies a page rather than counting.
+        stateVariableDefinitions.pageStatus = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                pageLabel: {
+                    dependencyType: "stateVariable",
+                    variableName: "pageLabel",
+                },
+                currentPage: {
+                    dependencyType: "stateVariable",
+                    variableName: "currentPage",
+                },
+                numPages: {
+                    dependencyType: "stateVariable",
+                    variableName: "numPages",
+                },
+                ...returnContentLocaleDependencies(),
+            }),
+            definition({ dependencyValues }) {
+                const t = contentTranslator(dependencyValues);
+                const args = {
+                    pageLabel: dependencyValues.pageLabel,
+                    currentPage: String(dependencyValues.currentPage),
+                    numPages: String(dependencyValues.numPages),
+                };
+                return {
+                    setValue: {
+                        pageStatus: t(
+                            "paginator-page-status",
+                            args,
+                            `${args.pageLabel} ${args.currentPage} of ${args.numPages}`,
+                        ),
+                    },
+                };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/Table.js
+++ b/packages/doenetml-worker-javascript/src/components/Table.js
@@ -1,4 +1,8 @@
 import BlockComponent from "./abstract/BlockComponent";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 export default class Table extends BlockComponent {
     constructor(args) {
@@ -75,7 +79,7 @@ export default class Table extends BlockComponent {
             ],
             mustEvaluate: true, // must evaluate to make sure all counters are accounted for
             returnDependencies({ stateValues }) {
-                let dependencies = {};
+                let dependencies = { ...returnContentLocaleDependencies() };
 
                 if (stateValues.number) {
                     dependencies.tableCounter = {
@@ -86,16 +90,26 @@ export default class Table extends BlockComponent {
                 return dependencies;
             },
             definition({ dependencyValues }) {
+                const t = contentTranslator(dependencyValues);
+
                 if (dependencyValues.tableCounter === undefined) {
                     return {
                         setValue: {
                             tableEnumeration: null,
-                            tableName: "Table",
+                            tableName: t(
+                                "table-name",
+                                { parts: "unnumbered" },
+                                "Table",
+                            ),
                         },
                     };
                 }
                 let tableEnumeration = String(dependencyValues.tableCounter);
-                let tableName = "Table " + tableEnumeration;
+                let tableName = t(
+                    "table-name",
+                    { parts: "numbered", enumeration: tableEnumeration },
+                    `Table ${tableEnumeration}`,
+                );
                 return {
                     setValue: { tableEnumeration, tableName },
                 };

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+
+vi.mock("hyperformula");
+
+/**
+ * i18n Phase 4 (#1572): the words a `<table>`, a `<figure>`, and a
+ * `<paginatorControls>` name themselves with.
+ *
+ * Two things are checked throughout, and the second matters as much as the
+ * first: that the document's language reaches these definitions at all, and
+ * that English comes out character-for-character as it did before, so that
+ * every other assertion in this repo stays true of a document that declares no
+ * language.
+ */
+describe("container words follow the document locale @group4", () => {
+    async function values(
+        doenetML: string,
+        names: string[],
+        variable: string,
+        documentLocale?: string,
+    ): Promise<Record<string, any>> {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+            documentLocale,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const result: Record<string, any> = {};
+        for (const name of names) {
+            const idx = await resolvePathToNodeIdx(name);
+            result[name] = stateVariables[idx].stateValues[variable];
+        }
+        return result;
+    }
+
+    describe("<table>", () => {
+        const doenetML = `
+        <table name="first"><tabular><row><cell>1</cell></row></tabular></table>
+        <table name="second"><tabular><row><cell>2</cell></row></tabular></table>
+        <table name="unnumbered" number="false"><tabular><row><cell>3</cell></row></tabular></table>
+        `;
+        const names = ["first", "second", "unnumbered"];
+
+        it("renders English by default", async () => {
+            expect(await values(doenetML, names, "tableName")).toEqual({
+                first: "Table 1",
+                second: "Table 2",
+                unnumbered: "Table",
+            });
+        });
+
+        it("renders the document's words when it declares a language", async () => {
+            expect(await values(doenetML, names, "tableName", "es")).toEqual({
+                first: "Tabla 1",
+                second: "Tabla 2",
+                unnumbered: "Tabla",
+            });
+        });
+
+        it("leaves the enumeration alone, which is the number and not the name", async () => {
+            // `$table.tableEnumeration` is what a cross-reference points at.
+            // The name around it moved; the identifier did not.
+            expect(
+                await values(doenetML, ["second"], "tableEnumeration", "es"),
+            ).toEqual({ second: "2" });
+        });
+    });
+
+    describe("<figure>", () => {
+        const doenetML = `
+        <figure name="first"><image source="doenet:a" /></figure>
+        <figure name="second"><image source="doenet:b" /></figure>
+        <figure name="unnumbered" number="false"><image source="doenet:c" /></figure>
+        `;
+        const names = ["first", "second", "unnumbered"];
+
+        it("renders English by default", async () => {
+            expect(await values(doenetML, names, "figureName")).toEqual({
+                first: "Figure 1",
+                second: "Figure 2",
+                unnumbered: "Figure",
+            });
+        });
+
+        it("renders the document's words when it declares a language", async () => {
+            expect(await values(doenetML, names, "figureName", "es")).toEqual({
+                first: "Figura 1",
+                second: "Figura 2",
+                unnumbered: "Figura",
+            });
+        });
+    });
+
+    describe("<paginatorControls>", () => {
+        const doenetML = `
+        <paginatorControls name="pc" paginator="$pgn" />
+        <paginator name="pgn">
+          <section name="s1"><p>one</p></section>
+          <section name="s2"><p>two</p></section>
+          <section name="s3"><p>three</p></section>
+        </paginator>
+        `;
+        const names = ["pc"];
+
+        async function labels(documentLocale?: string) {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML,
+                documentLocale,
+            });
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            const { stateValues } =
+                stateVariables[await resolvePathToNodeIdx("pc")];
+            return {
+                previousLabel: stateValues.previousLabel,
+                nextLabel: stateValues.nextLabel,
+                pageLabel: stateValues.pageLabel,
+                pageStatus: stateValues.pageStatus,
+            };
+        }
+
+        it("renders English by default", async () => {
+            expect(await labels()).toEqual({
+                previousLabel: "Previous",
+                nextLabel: "Next",
+                pageLabel: "Page",
+                pageStatus: "Page 1 of 3",
+            });
+        });
+
+        it("renders the document's words when it declares a language", async () => {
+            expect(await labels("es")).toEqual({
+                previousLabel: "Anterior",
+                nextLabel: "Siguiente",
+                pageLabel: "Página",
+                pageStatus: "Página 1 de 3",
+            });
+        });
+
+        it("passes authored labels through verbatim, in every language", async () => {
+            // The author chose these words for their document. Translating
+            // them would be Doenet overwriting content it did not write.
+            const authored = `
+            <paginatorControls name="pc" paginator="$pgn"
+                previousLabel="Atrás" nextLabel="Adelante" pageLabel="Hoja" />
+            <paginator name="pgn">
+              <section name="s1"><p>one</p></section>
+              <section name="s2"><p>two</p></section>
+            </paginator>
+            `;
+            for (const locale of [undefined, "es"]) {
+                expect(
+                    await values(authored, names, "previousLabel", locale),
+                ).toEqual({ pc: "Atrás" });
+                expect(
+                    await values(authored, names, "nextLabel", locale),
+                ).toEqual({ pc: "Adelante" });
+            }
+        });
+
+        it("passes an authored label through even when it is the English default", async () => {
+            // `usedDefault` is what separates "unspecified" from "specified,
+            // and happens to match the default" — a plain value comparison
+            // would translate this one, against the author's explicit choice.
+            const authored = `
+            <paginatorControls name="pc" paginator="$pgn" nextLabel="Next" />
+            <paginator name="pgn"><section name="s1"><p>one</p></section></paginator>
+            `;
+            expect(await values(authored, names, "nextLabel", "es")).toEqual({
+                pc: "Next",
+            });
+        });
+
+        it("keeps the whole page status in one language, around the author's own word", async () => {
+            // The status is composed in the worker precisely so this holds: an
+            // authored `pageLabel` sits inside a sentence in the document's
+            // language rather than one in the reader's.
+            const authored = `
+            <paginatorControls name="pc" paginator="$pgn" pageLabel="Hoja" />
+            <paginator name="pgn">
+              <section name="s1"><p>one</p></section>
+              <section name="s2"><p>two</p></section>
+            </paginator>
+            `;
+            expect(await values(authored, names, "pageStatus", "es")).toEqual({
+                pc: "Hoja 1 de 2",
+            });
+        });
+
+        it("keeps the pre-localization value out of an author's reach", async () => {
+            // The attribute writes to `nextLabelPreLocalize` so the derived
+            // definition can tell an unspecified attribute from a specified
+            // one. That is plumbing: `$pc.nextLabel` is the label, and the raw
+            // value behind it is not a property an author can reference.
+            const doc = `
+            <paginatorControls name="pc" paginator="$pgn" nextLabel="Onward" />
+            <paginator name="pgn"><section name="s1"><p>one</p></section></paginator>
+            <text name="raw" extend="$pc.nextLabelPreLocalize" />
+            `;
+            expect(await values(doc, ["raw"], "value")).toEqual({ raw: "" });
+        });
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
@@ -202,4 +202,46 @@ describe("container words follow the document locale @group4", () => {
             expect(await values(doc, ["raw"], "value")).toEqual({ raw: "" });
         });
     });
+
+    describe("a `<document lang>` written by the author", () => {
+        // Everything above reaches the language through the host. `lang` on
+        // the document is the author's own route to it, and it is answered by
+        // an ancestor lookup that excludes the component it runs on — so a
+        // word a `<document>` computes about *itself* needs `ownLocale`. None
+        // of these three is ever a document, and these pin that each reads the
+        // language the root declares rather than the host's English.
+        const inDocument = (body: string) =>
+            `<document lang="es">${body}</document>`;
+
+        it("names a table in the language the root declares", async () => {
+            const doenetML = inDocument(
+                `<table name="t"><tabular><row><cell>1</cell></row></tabular></table>`,
+            );
+            expect((await values(doenetML, ["t"], "tableName")).t).eq(
+                "Tabla 1",
+            );
+        });
+
+        it("names a figure in the language the root declares", async () => {
+            const doenetML = inDocument(
+                `<figure name="f"><image source="doenet:a" /></figure>`,
+            );
+            expect((await values(doenetML, ["f"], "figureName")).f).eq(
+                "Figura 1",
+            );
+        });
+
+        it("writes the paginator's status in the language the root declares", async () => {
+            const doenetML = inDocument(`
+            <paginatorControls name="pc" paginator="$pgn" />
+            <paginator name="pgn"><section name="s1"><p>one</p></section></paginator>
+            `);
+            expect((await values(doenetML, ["pc"], "pageStatus")).pc).eq(
+                "Página 1 de 1",
+            );
+            expect((await values(doenetML, ["pc"], "previousLabel")).pc).eq(
+                "Anterior",
+            );
+        });
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
@@ -197,9 +197,15 @@ describe("container words follow the document locale @group4", () => {
             const doc = `
             <paginatorControls name="pc" paginator="$pgn" nextLabel="Onward" />
             <paginator name="pgn"><section name="s1"><p>one</p></section></paginator>
+            <text name="label" extend="$pc.nextLabel" />
             <text name="raw" extend="$pc.nextLabelPreLocalize" />
             `;
-            expect(await values(doc, ["raw"], "value")).toEqual({ raw: "" });
+            // `label` is the control: an empty `raw` says something about
+            // reachability only if a reference that should resolve does.
+            expect(await values(doc, ["label", "raw"], "value")).toEqual({
+                label: "Onward",
+                raw: "",
+            });
         });
     });
 

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -3,10 +3,7 @@ import sha1 from "crypto-js/sha1";
 import Base64 from "crypto-js/enc-base64";
 import stringify from "json-stringify-deterministic";
 import { codedDiagnostic } from "./diagnostics";
-import {
-    contentTranslator,
-    returnContentLocaleDependencies,
-} from "./contentLocale";
+import { returnLocalizedDefaultStateVariableDefinition } from "./contentLocale";
 
 function returnScoredContainerAncestorDependency(...variableNames) {
     return {
@@ -136,13 +133,9 @@ export function returnStandardAnswerAttributes() {
  * `submitLabel` and `submitLabelNoCorrectness`, with their defaults in the
  * document's language.
  *
- * Only the *default* is translated. An author who writes
- * `submitLabel="Ready?"` gets "Ready?" in every locale: those are their words,
- * chosen for their document, and Doenet translating them would be a surprise
- * at best and wrong at worst. So the attribute value passes through verbatim
- * and only an unspecified one — which `usedDefault` is the only way to
- * distinguish from an author who typed the English default on purpose —
- * reaches the catalog.
+ * Only the *default* is translated; see
+ * `returnLocalizedDefaultStateVariableDefinition`, which every
+ * author-overridable label in the worker resolves through.
  *
  * Shared by `<answer>` and by every container with a section-wide check-work
  * button, which declare the same two attributes from different tables
@@ -160,57 +153,21 @@ export function returnSubmitLabelStateVariableDefinitions({
     button = "the submit button",
 } = {}) {
     return {
-        submitLabel: submitLabelDefinition({
+        submitLabel: returnLocalizedDefaultStateVariableDefinition({
             name: "submitLabel",
             translatedDefault: (t) => t("answer-submit-label"),
             description: `Label for ${button} when correctness is shown.`,
             ownLocale,
         }),
-        submitLabelNoCorrectness: submitLabelDefinition({
-            name: "submitLabelNoCorrectness",
-            translatedDefault: (t) => t("answer-submit-label-no-correctness"),
-            description: `Label for ${button} when correctness is not shown.`,
-            ownLocale,
-        }),
-    };
-}
-
-/**
- * One submit label: the authored value if there is one, otherwise
- * `translatedDefault`.
- *
- * The default arrives as a function of the translator rather than as a key,
- * because `lint:i18n` reads call sites literally — `t(key)` is invisible to
- * it, so the catalog entry would read as an orphan and a typo would surface
- * only at runtime.
- */
-function submitLabelDefinition({
-    name,
-    translatedDefault,
-    description,
-    ownLocale,
-}) {
-    const authored = `${name}PreLocalize`;
-    return {
-        description,
-        public: true,
-        shadowingInstructions: {
-            createComponentOfType: "text",
-        },
-        forRenderer: true,
-        returnDependencies: () => ({
-            [authored]: {
-                dependencyType: "stateVariable",
-                variableName: authored,
+        submitLabelNoCorrectness: returnLocalizedDefaultStateVariableDefinition(
+            {
+                name: "submitLabelNoCorrectness",
+                translatedDefault: (t) =>
+                    t("answer-submit-label-no-correctness"),
+                description: `Label for ${button} when correctness is not shown.`,
+                ownLocale,
             },
-            ...returnContentLocaleDependencies({ ownLocale }),
-        }),
-        definition({ dependencyValues, usedDefault }) {
-            const label = usedDefault[authored]
-                ? translatedDefault(contentTranslator(dependencyValues))
-                : dependencyValues[authored];
-            return { setValue: { [name]: label } };
-        },
+        ),
     };
 }
 

--- a/packages/doenetml-worker-javascript/src/utils/contentLocale.js
+++ b/packages/doenetml-worker-javascript/src/utils/contentLocale.js
@@ -100,3 +100,56 @@ export function contentTranslator(dependencyValues) {
         contentLocale(dependencyValues),
     );
 }
+
+/**
+ * A state variable holding an author-overridable label: the attribute's value
+ * if the author wrote one, otherwise the default in the document's language.
+ *
+ * Only the *default* is translated. An author who writes `nextLabel="Onward"`
+ * gets "Onward" in every locale — those are their words, chosen for their
+ * document — so the attribute value passes through verbatim, and only an
+ * unspecified one reaches the catalog. `usedDefault` is the only thing that
+ * tells an unspecified attribute apart from an author who typed the English
+ * default on purpose, which is why the attribute has to land on a separate
+ * `…PreLocalize` state variable and be re-taken here.
+ *
+ * The attribute declaration keeps its English `defaultValue` so that authors
+ * see the words in the schema; the value is never read, because this
+ * definition replaces it whenever `usedDefault` is set.
+ *
+ * @param name The state variable authors and renderers see.
+ * @param translatedDefault The default, as a function of the translator rather
+ *   than as a key: `lint:i18n` reads call sites literally, so a key passed as
+ *   data would read as an orphan in the catalog and a typo would surface only
+ *   at runtime.
+ * @param ownLocale Read the component's *own* `locale` as well as the
+ *   enclosing document's; see {@link returnContentLocaleDependencies}.
+ */
+export function returnLocalizedDefaultStateVariableDefinition({
+    name,
+    translatedDefault,
+    description,
+    createComponentOfType = "text",
+    ownLocale = false,
+}) {
+    const authored = `${name}PreLocalize`;
+    return {
+        description,
+        public: true,
+        shadowingInstructions: { createComponentOfType },
+        forRenderer: true,
+        returnDependencies: () => ({
+            [authored]: {
+                dependencyType: "stateVariable",
+                variableName: authored,
+            },
+            ...returnContentLocaleDependencies({ ownLocale }),
+        }),
+        definition({ dependencyValues, usedDefault }) {
+            const value = usedDefault[authored]
+                ? translatedDefault(contentTranslator(dependencyValues))
+                : dependencyValues[authored];
+            return { setValue: { [name]: value } };
+        },
+    };
+}

--- a/packages/doenetml-worker-javascript/src/utils/contentLocale.js
+++ b/packages/doenetml-worker-javascript/src/utils/contentLocale.js
@@ -129,14 +129,13 @@ export function returnLocalizedDefaultStateVariableDefinition({
     name,
     translatedDefault,
     description,
-    createComponentOfType = "text",
     ownLocale = false,
 }) {
     const authored = `${name}PreLocalize`;
     return {
         description,
         public: true,
-        shadowingInstructions: { createComponentOfType },
+        shadowingInstructions: { createComponentOfType: "text" },
         forRenderer: true,
         returnDependencies: () => ({
             [authored]: {

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -68,7 +68,10 @@ export default defineConfig({
                                 // turns every multi-byte character in the
                                 // bundle — the Spanish message catalogs, among
                                 // others — into mojibake before it reaches the
-                                // Blob the worker is built from.
+                                // Blob the worker is built from. The same
+                                // plugin in ../doenetml-iframe/cypress.config.ts
+                                // decodes its bundle this way; keep the two in
+                                // step.
                                 return `
                                     const __bin = atob(${JSON.stringify(b64)});
                                     const __bytes = new Uint8Array(__bin.length);

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -63,7 +63,18 @@ export default defineConfig({
                                 );
                                 const b64 =
                                     Buffer.from(content).toString("base64");
-                                return `export default atob(${JSON.stringify(b64)});`;
+                                // Decode base64 → bytes → UTF-8 at runtime.
+                                // `atob` alone yields a Latin-1 string, which
+                                // turns every multi-byte character in the
+                                // bundle — the Spanish message catalogs, among
+                                // others — into mojibake before it reaches the
+                                // Blob the worker is built from.
+                                return `
+                                    const __bin = atob(${JSON.stringify(b64)});
+                                    const __bytes = new Uint8Array(__bin.length);
+                                    for (let i = 0; i < __bin.length; i++) __bytes[i] = __bin.charCodeAt(i);
+                                    export default new TextDecoder("utf-8").decode(__bytes);
+                                `;
                             }
                         },
                     },

--- a/packages/doenetml/src/Viewer/renderers/paginatorControls.tsx
+++ b/packages/doenetml/src/Viewer/renderers/paginatorControls.tsx
@@ -11,7 +11,7 @@ interface PaginatorControlsSVs {
     disabledDirectly: boolean;
     nextLabel: string;
     numPages: number;
-    pageLabel: string;
+    pageStatus: string;
     previousLabel: string;
 }
 
@@ -40,7 +40,10 @@ export default React.memo(function PaginatorControls(
                     value={SVs.previousLabel}
                 />
             </div>
-            {" " + SVs.pageLabel} {SVs.currentPage} of {SVs.numPages + " "}
+            {/* The whole status is composed in the worker, in the document's
+                language, so that the author's own `pageLabel` and the words
+                around it are never in two different languages. */}
+            {" " + SVs.pageStatus + " "}
             <div id={id} style={{ display: "inline-block", margin: "12px 0" }}>
                 <Button
                     id={id + "_next"}

--- a/packages/doenetml/test/cypress/component/DoenetViewer.paginatorLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.paginatorLocale.cy.tsx
@@ -10,14 +10,6 @@ import { DoenetViewer } from "../../../src/doenetml-inline-worker";
 
 const VIEWER_TIMEOUT = 15_000;
 
-// Non-ASCII from the worker cannot be asserted here. Cypress serves this spec
-// through a Vite dev server, and the dev server's `?raw` import of the worker
-// bundle — which is where the message catalogs live — hands back Latin-1, so
-// "Página" arrives as "PÃ¡gina". The shipped bundles are UTF-8 and correct;
-// it is the harness that mis-decodes. So the assertions below turn on the
-// ASCII parts of the Spanish ("de", "Anterior", "Hoja"), and the exact
-// accented output is pinned by the worker's own tests, which run in Node.
-
 const DOENETML = `
 <paginatorControls name="pc" paginator="$pgn" />
 <paginator name="pgn">
@@ -37,7 +29,7 @@ describe("the paginator's controls follow the document's language", () => {
             />,
         );
 
-        cy.contains("1 de 3", { timeout: VIEWER_TIMEOUT });
+        cy.contains("Página 1 de 3", { timeout: VIEWER_TIMEOUT });
         cy.get("#pc_previous").should("have.text", "Anterior");
         cy.get("#pc_next").should("have.text", "Siguiente");
         // The English half-sentence is gone rather than shown beside it.

--- a/packages/doenetml/test/cypress/component/DoenetViewer.paginatorLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.paginatorLocale.cy.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+
+// "Page 3 of 5" used to be assembled in this renderer: the word came from the
+// worker via `pageLabel`, the word joining the counts was English written into
+// the JSX, and nothing could reach it (Doenet/DoenetML#1572). The whole status
+// is now one message composed in the worker, so what is asserted here is the
+// half a worker test cannot see — that the sentence the reader actually gets
+// is in one language from end to end.
+
+const VIEWER_TIMEOUT = 30_000;
+
+// Non-ASCII from the worker cannot be asserted here. Cypress serves this spec
+// through a Vite dev server, and the dev server's `?raw` import of the worker
+// bundle — which is where the message catalogs live — hands back Latin-1, so
+// "Página" arrives as "PÃ¡gina". The shipped bundles are UTF-8 and correct;
+// it is the harness that mis-decodes. So the assertions below turn on the
+// ASCII parts of the Spanish ("de", "Anterior", "Hoja"), and the exact
+// accented output is pinned by the worker's own tests, which run in Node.
+
+const DOENETML = `
+<paginatorControls name="pc" paginator="$pgn" />
+<paginator name="pgn">
+  <section><p>one</p></section>
+  <section><p>two</p></section>
+  <section><p>three</p></section>
+</paginator>
+`;
+
+describe("the paginator's controls follow the document's language", () => {
+    it("renders the status and both buttons in Spanish", () => {
+        cy.mount(
+            <DoenetViewer
+                doenetML={DOENETML}
+                documentLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.contains("1 de 3", { timeout: VIEWER_TIMEOUT });
+        cy.get("#pc_previous").should("have.text", "Anterior");
+        cy.get("#pc_next").should("have.text", "Siguiente");
+        // The English half-sentence is gone rather than shown beside it.
+        cy.get("body").should("not.contain.text", "1 of 3");
+    });
+
+    it("renders it in English when the document declares no language", () => {
+        cy.mount(
+            <DoenetViewer doenetML={DOENETML} addVirtualKeyboard={false} />,
+        );
+
+        cy.contains("Page 1 of 3", { timeout: VIEWER_TIMEOUT });
+        cy.get("#pc_previous").should("have.text", "Previous");
+        cy.get("#pc_next").should("have.text", "Next");
+    });
+
+    it("keeps an authored label inside the translated sentence", () => {
+        // The author's own word, in a sentence the catalog supplies the rest
+        // of — the case that made composing this in the worker necessary.
+        cy.mount(
+            <DoenetViewer
+                doenetML={DOENETML.replace(
+                    'name="pc"',
+                    'name="pc" pageLabel="Hoja"',
+                )}
+                documentLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.contains("Hoja 1 de 3", { timeout: VIEWER_TIMEOUT });
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetViewer.paginatorLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.paginatorLocale.cy.tsx
@@ -8,7 +8,7 @@ import { DoenetViewer } from "../../../src/doenetml-inline-worker";
 // half a worker test cannot see — that the sentence the reader actually gets
 // is in one language from end to end.
 
-const VIEWER_TIMEOUT = 30_000;
+const VIEWER_TIMEOUT = 15_000;
 
 // Non-ASCII from the worker cannot be asserted here. Cypress serves this spec
 // through a Vite dev server, and the dev server's `?raw` import of the worker

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -241,6 +241,52 @@ answer-submit-label = Check Work
 answer-submit-label-no-correctness = Submit Response
 
 
+## Tables and figures
+##
+## The name a `<table>` or `<figure>` gives itself, which the renderer sets in
+## bold at the head of the title or caption: "Table 2", "Figure 3". An
+## unnumbered one is named by the bare word.
+##
+## The word and the number are one message rather than a word the code
+## concatenates a number onto, so that a language which orders or punctuates
+## them differently can say so.
+##
+## `$enumeration` arrives as text rather than as a number: it identifies the
+## table, so the thousandth one is "Table 1000" and not "Table 1,000".
+
+table-name =
+    { $parts ->
+        [numbered] Table { $enumeration }
+       *[unnumbered] Table
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figure { $enumeration }
+       *[unnumbered] Figure
+    }
+
+
+## Paginator controls
+##
+## The strip of controls that steps through a `<paginator>`'s pages. All three
+## words are author-overridable attributes, so only the default is translated.
+
+paginator-previous = Previous
+paginator-next = Next
+paginator-page = Page
+
+# The status between the two buttons: "Page 3 of 5".
+#
+# Composed in the worker rather than in the renderer so that the whole of it is
+# in one language: `$pageLabel` is the `pageLabel` attribute, which an author
+# may have written themselves, and the words joining it to the counts have to
+# sit beside it in the same tongue.
+#
+# The two counts arrive as text, for the same reason `$enumeration` does above.
+paginator-page-status = { $pageLabel } { $currentPage } of { $numPages }
+
+
 ## Piecewise functions
 ##
 ## `<piecewiseFunction>` renders each branch's domain as mathematics and writes

--- a/packages/i18n/locales/es/content.ftl
+++ b/packages/i18n/locales/es/content.ftl
@@ -214,6 +214,30 @@ answer-submit-label = Revisar
 answer-submit-label-no-correctness = Enviar respuesta
 
 
+## Tablas y figuras
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figura { $enumeration }
+       *[unnumbered] Figura
+    }
+
+
+## Controles de paginación
+
+paginator-previous = Anterior
+paginator-next = Siguiente
+paginator-page = Página
+
+paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
+
+
 ## Funciones definidas a trozos
 
 piecewise-condition-or = o

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -124,6 +124,12 @@ export type MessageKey =
     | "boolean-false"
     | "answer-submit-label"
     | "answer-submit-label-no-correctness"
+    | "table-name"
+    | "figure-name"
+    | "paginator-previous"
+    | "paginator-next"
+    | "paginator-page"
+    | "paginator-page-status"
     | "piecewise-condition-or"
     | "piecewise-condition-if"
     | "piecewise-condition-otherwise"
@@ -436,6 +442,12 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "boolean-false",
     "answer-submit-label",
     "answer-submit-label-no-correctness",
+    "table-name",
+    "figure-name",
+    "paginator-previous",
+    "paginator-next",
+    "paginator-page",
+    "paginator-page-status",
     "piecewise-condition-or",
     "piecewise-condition-if",
     "piecewise-condition-otherwise",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -79055,27 +79055,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "previousLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the \"previous page\" button.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "nextLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the \"next page\" button.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "pageLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label format for the current page indicator.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "hidden",
                     "type": "boolean",
                     "isArray": false,
@@ -79104,6 +79083,24 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "previousLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the \"previous page\" button."
+                },
+                {
+                    "name": "nextLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the \"next page\" button."
+                },
+                {
+                    "name": "pageLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label format for the current page indicator."
                 },
                 {
                     "name": "disabledDirectly",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -62771,27 +62771,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "previousLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the \"previous page\" button.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "nextLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label for the \"next page\" button.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "pageLabel",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "Label format for the current page indicator.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "hidden",
                     "type": "boolean",
                     "isArray": false,
@@ -62820,6 +62799,24 @@
                     "type": "text",
                     "isArray": false,
                     "description": "The DoenetML source code that produced this component."
+                },
+                {
+                    "name": "previousLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the \"previous page\" button."
+                },
+                {
+                    "name": "nextLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label for the \"next page\" button."
+                },
+                {
+                    "name": "pageLabel",
+                    "type": "text",
+                    "isArray": false,
+                    "description": "Label format for the current page indicator."
                 },
                 {
                     "name": "disabledDirectly",


### PR DESCRIPTION
Base of a three-PR stack: #1575 and #1576 sit on top of this one.

Closes part of #1572 — the `<table>`, `<figure>` and `<paginator>` groups. The section/hint/solution group follows in the next PR.

## What was English

Three components wrote their own words and no locale could reach them:

- `Table.js` — `"Table"`, and `"Table " + tableEnumeration`
- `Figure.js` — `"Figure"`, and `"Figure " + figureEnumeration`
- `Paginator.js` — `previousLabel` / `nextLabel` / `pageLabel` defaulting to `"Previous"` / `"Next"` / `"Page"`

## The composition, not just the words

`"Table " + enumeration` bakes English order and spacing into the code. `table-name` and `figure-name` are one message each with a `$parts` selector, so a language that puts the number first, or wants different spacing, writes that in the catalog rather than needing a code change.

The paginator is the case that actually broke. `paginatorControls.tsx` rendered:

```jsx
{" " + SVs.pageLabel} {SVs.currentPage} of {SVs.numPages + " "}
```

Half the sentence came from the worker in the document's language, and the "of" was English in the renderer with nothing able to reach it — a Spanish activity read **"Página 3 of 5"**. The whole status is now one `paginator-page-status` message computed in the worker, so it is in one language end to end, including around an author's own `pageLabel`. The renderer prints the finished string.

The counts are passed as text, not numbers: a page number identifies a page rather than counting one, so page 1000 stays "1000" and is not grouped as "1,000". Same for `$enumeration`.

## Only the default translates

All three paginator labels are author-overridable, so they move to the `…PreLocalize` shape #1566 built for `submitLabel`: the attribute lands on a private state variable, and the public one takes the authored value or — when `usedDefault` says the attribute was never written — the catalog's. That distinction is the whole point; a value comparison would translate `nextLabel="Next"`, against the author's explicit choice.

Since these are that pattern's third, fourth and fifth users, the mechanics move from `utils/answer.js` into `returnLocalizedDefaultStateVariableDefinition` in `utils/contentLocale.js`, beside the rest of the content-locale wiring. `answer.js` calls it and keeps its own doc comment. No behaviour change there.

`<table>` and `<figure>` need none of this — nothing overrides their names — so they just ask the translator.

## Schema

The three labels now record the way `submitLabel` already does after #1566: still offered as attributes (autocomplete unaffected), no longer carrying `fromAttribute` as properties. `npm run build:schema -w @doenet/static-assets` regenerated, diff is those three entries moving.

## Tests

- `containerWordsLocale.test.ts` — 14 tests: English byte-identical, Spanish, numbered and unnumbered, an authored label passed through in both languages, an authored label that *equals* the English default, an authored `pageLabel` inside the translated sentence, `nextLabelPreLocalize` staying unreachable from DoenetML while `$pc.nextLabel` beside it resolves, and each of the three reading a `<document lang="es">` on the root.
- That last group is the trap #1566 hit: the language is reached through an `ancestor` dependency, which excludes the component it runs on, so a word a `<document>` computes about *itself* needs `ownLocale`. A `<table>`, a `<figure>` and a `<paginatorControls>` are never that document, and now there are tests saying the lookup reaches them.
- `DoenetViewer.paginatorLocale.cy.tsx` — 3 tests for the rendering itself, which is the half a worker test cannot see: the Spanish status, the English one, and an authored `pageLabel` inside the translated sentence.
- Regression: `paginator.test.ts`, `answer.test.ts` (185 passed), `contentWordsLocale.test.ts`, `@doenet/i18n` (157), and the `paginator.cy.js` e2e spec.

## Not in scope

`<table>` and `<figure>` name themselves in the document's language now, but their renderers still write the `": "` that joins that name to an authored title or caption — `{tableName}: {title}` in `table.tsx`, the same for a caption in `figure.tsx`. It is the shape the paginator's "of" had, and the shape `section-title-prefix`'s `-title` branches fixed for a section, but moving it needs a decision about whether the separator becomes bold along with the name, which changes the markup of every existing table and figure. Filed as #1582.

## One thing found along the way

The Cypress **component** harness could not assert non-ASCII text the worker produced: "Página" arrived as "PÃ¡gina". The cause is in `packages/doenetml/cypress.config.ts`, which inlines the worker bundle — where the catalogs live — by base64-encoding it and calling `atob` in the browser. `atob` returns a Latin-1 string, so every multi-byte character in the bundle was mojibake before the Blob the worker is built from ever saw it.

Fixed here by decoding through `TextDecoder`, which is what the same plugin in `@doenet/doenetml-iframe` already does — the two copies now say so in a comment, so they are kept in step. The paginator spec now asserts the accented Spanish it actually renders; reverting the config change fails that assertion, and nothing else in the package's component suite is disturbed — all 48 of its tests pass, the three new ones included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





