### PR TITLE
Name sections, hints and solutions in the document's language

### DIFF
--- a/.changeset/section-words-follow-document-language.md
+++ b/.changeset/section-words-follow-document-language.md
@@ -14,4 +14,6 @@ The word is keyed by the element an author writes rather than by an internal cla
 
 An unnumbered block such as `<proof>`, asked to include its number, used to render the word "null" where the number would have gone. It now renders no number, which is what it has.
 
-Apart from that, a document that declares no language reads exactly as it did before.
+A block whose `renameTo` is empty likewise renders no name, rather than the space and colon that used to be written around the word that isn't there.
+
+Apart from those, a document that declares no language reads exactly as it did before.

--- a/.changeset/section-words-follow-document-language.md
+++ b/.changeset/section-words-follow-document-language.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Write the word a sectional block calls itself in the document's language: section, example, problem, part, proof, solution, answer, hint, and the rest.
+
+The heading a section builds around that word moves with it. "Section 2: Limits" used to be assembled by concatenation — the word, a space, the number, then a colon or a period before the title — which is English order and English punctuation written into the code. It is now one message per shape, so a translation can order and punctuate each one on its own terms.
+
+The word is keyed by the element an author writes rather than by an internal class name, so `<subsection>` and `<subsubsection>` share the word for section, and a block whose name the author set with `renameTo` keeps their word in every language.
+
+A document that declares no language reads exactly as it did before.

--- a/.changeset/section-words-follow-document-language.md
+++ b/.changeset/section-words-follow-document-language.md
@@ -12,4 +12,6 @@ The heading a section builds around that word moves with it. "Section 2: Limits"
 
 The word is keyed by the element an author writes rather than by an internal class name, so `<subsection>` and `<subsubsection>` share the word for section, and a block whose name the author set with `renameTo` keeps their word in every language.
 
-A document that declares no language reads exactly as it did before.
+An unnumbered block such as `<proof>`, asked to include its number, used to render the word "null" where the number would have gone. It now renders no number, which is what it has.
+
+Apart from that, a document that declares no language reads exactly as it did before.

--- a/.changeset/section-words-follow-document-language.md
+++ b/.changeset/section-words-follow-document-language.md
@@ -14,6 +14,6 @@ The word is keyed by the element an author writes rather than by an internal cla
 
 An unnumbered block such as `<proof>`, asked to include its number, used to render the word "null" where the number would have gone. It now renders no number, which is what it has.
 
-A block whose `renameTo` is empty, or is nothing but spaces, likewise renders no name, rather than the space and colon that used to be written around the word that isn't there.
+A block whose `renameTo` is empty, or is nothing but blank space, likewise renders no name, rather than the space and colon that used to be written around the word that isn't there.
 
 Apart from those, a document that declares no language reads exactly as it did before.

--- a/.changeset/section-words-follow-document-language.md
+++ b/.changeset/section-words-follow-document-language.md
@@ -14,6 +14,6 @@ The word is keyed by the element an author writes rather than by an internal cla
 
 An unnumbered block such as `<proof>`, asked to include its number, used to render the word "null" where the number would have gone. It now renders no number, which is what it has.
 
-A block whose `renameTo` is empty likewise renders no name, rather than the space and colon that used to be written around the word that isn't there.
+A block whose `renameTo` is empty, or is nothing but spaces, likewise renders no name, rather than the space and colon that used to be written around the word that isn't there.
 
 Apart from those, a document that declares no language reads exactly as it did before.

--- a/packages/doenetml-worker-javascript/src/components/Hint.js
+++ b/packages/doenetml-worker-javascript/src/components/Hint.js
@@ -176,7 +176,11 @@ export default class Hint extends BlockComponent {
                     // Only the default is translated: an authored `<title>` is
                     // the author's own words, in every language.
                     const t = contentTranslator(dependencyValues);
-                    return { setValue: { title: t("hint-title") } };
+                    return {
+                        setValue: {
+                            title: t("hint-title", undefined, "Hint"),
+                        },
+                    };
                 } else {
                     return {
                         setValue: {

--- a/packages/doenetml-worker-javascript/src/components/Hint.js
+++ b/packages/doenetml-worker-javascript/src/components/Hint.js
@@ -1,4 +1,8 @@
 import BlockComponent from "./abstract/BlockComponent";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
 
 export default class Hint extends BlockComponent {
     constructor(args) {
@@ -165,10 +169,14 @@ export default class Hint extends BlockComponent {
                     childGroups: ["titles"],
                     variableNames: ["text"],
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition({ dependencyValues }) {
                 if (dependencyValues.titleChild.length === 0) {
-                    return { setValue: { title: "Hint" } };
+                    // Only the default is translated: an authored `<title>` is
+                    // the author's own words, in every language.
+                    const t = contentTranslator(dependencyValues);
+                    return { setValue: { title: t("hint-title") } };
                 } else {
                     return {
                         setValue: {

--- a/packages/doenetml-worker-javascript/src/components/Sectioning.js
+++ b/packages/doenetml-worker-javascript/src/components/Sectioning.js
@@ -26,9 +26,8 @@ export class Section extends SectioningComponentNumberWithSiblings {
     }
 }
 
-// A subsection is called a section, at every depth. That used to be an
-// override here; it is now an entry in `utils/sectionWords.js`, alongside every
-// other block's word, mapping all three element names onto one catalog key.
+// A subsection is called a section, at every depth: all three element names
+// map onto one catalog key in `utils/sectionWords.js`.
 export class Subsection extends Section {
     static componentType = "subsection";
 

--- a/packages/doenetml-worker-javascript/src/components/Sectioning.js
+++ b/packages/doenetml-worker-javascript/src/components/Sectioning.js
@@ -26,6 +26,9 @@ export class Section extends SectioningComponentNumberWithSiblings {
     }
 }
 
+// A subsection is called a section, at every depth. That used to be an
+// override here; it is now an entry in `utils/sectionWords.js`, alongside every
+// other block's word, mapping all three element names onto one catalog key.
 export class Subsection extends Section {
     static componentType = "subsection";
 
@@ -33,15 +36,6 @@ export class Subsection extends Section {
         summary:
             "A sectional component nested one heading level deeper than `<section>`",
     };
-    static returnStateVariableDefinitions() {
-        let stateVariableDefinitions = super.returnStateVariableDefinitions();
-
-        stateVariableDefinitions.sectionName.definition = () => ({
-            setValue: { sectionName: "Section" },
-        });
-
-        return stateVariableDefinitions;
-    }
 }
 export class Subsubsection extends Section {
     static componentType = "subsubsection";
@@ -50,15 +44,6 @@ export class Subsubsection extends Section {
         summary:
             "A sectional component nested one heading level deeper than `<subsection>`",
     };
-    static returnStateVariableDefinitions() {
-        let stateVariableDefinitions = super.returnStateVariableDefinitions();
-
-        stateVariableDefinitions.sectionName.definition = () => ({
-            setValue: { sectionName: "Section" },
-        });
-
-        return stateVariableDefinitions;
-    }
 }
 
 export class Paragraphs extends SectioningComponentNumberWithSiblings {

--- a/packages/doenetml-worker-javascript/src/components/Solution.js
+++ b/packages/doenetml-worker-javascript/src/components/Solution.js
@@ -1,4 +1,9 @@
 import BlockComponent from "./abstract/BlockComponent";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../utils/contentLocale";
+import { sectionNameWord } from "../utils/sectionWords";
 
 export class Solution extends BlockComponent {
     constructor(args) {
@@ -40,6 +45,10 @@ export class Solution extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        // `<givenAnswer>` inherits this whole set, and its own component type
+        // is what picks its word out of the catalog — so it needs no override.
+        let componentClass = this;
 
         stateVariableDefinitions.hide = {
             description: "Whether the solution is currently hidden.",
@@ -232,8 +241,16 @@ export class Solution extends BlockComponent {
 
         stateVariableDefinitions.sectionName = {
             forRenderer: true,
-            returnDependencies: () => ({}),
-            definition: () => ({ setValue: { sectionName: "Solution" } }),
+            returnDependencies: () => returnContentLocaleDependencies(),
+            definition: ({ dependencyValues }) => ({
+                setValue: {
+                    sectionName: sectionNameWord(
+                        contentTranslator(dependencyValues),
+                        componentClass.componentType,
+                        componentClass.name,
+                    ),
+                },
+            }),
         };
 
         return stateVariableDefinitions;
@@ -353,14 +370,4 @@ export class GivenAnswer extends Solution {
         summary:
             'A sectional component that renders an expandable block labeled "Answer"',
     };
-
-    static returnStateVariableDefinitions() {
-        let stateVariableDefinitions = super.returnStateVariableDefinitions();
-
-        stateVariableDefinitions.sectionName.definition = () => ({
-            setValue: { sectionName: "Answer" },
-        });
-
-        return stateVariableDefinitions;
-    }
 }

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -26,6 +26,11 @@ import {
     addSectionTitleColorContrastDiagnostic,
 } from "../../utils/sectionTitleColors";
 import { codedDiagnostic } from "../../utils/diagnostics";
+import {
+    contentTranslator,
+    returnContentLocaleDependencies,
+} from "../../utils/contentLocale";
+import { composeTitlePrefix, sectionNameWord } from "../../utils/sectionWords";
 
 /**
  * The `child` dependencies shared by the state variables that split a section's
@@ -480,18 +485,28 @@ export class SectioningComponent extends BlockComponent {
                     attributeName: "renameTo",
                     variableNames: ["value"],
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition: ({ dependencyValues }) => {
                 if (dependencyValues.renameToAttr) {
+                    // The author named this block themselves. Their word
+                    // passes through in every language.
                     return {
                         setValue: {
                             sectionName:
                                 dependencyValues.renameToAttr.stateValues.value,
                         },
                     };
-                } else {
-                    return { setValue: { sectionName: componentClass.name } };
                 }
+                return {
+                    setValue: {
+                        sectionName: sectionNameWord(
+                            contentTranslator(dependencyValues),
+                            componentClass.componentType,
+                            componentClass.name,
+                        ),
+                    },
+                };
             },
         };
 
@@ -940,9 +955,9 @@ export class SectioningComponent extends BlockComponent {
                     dependencyType: "stateVariable",
                     variableName: "noAutoTitle",
                 },
+                ...returnContentLocaleDependencies(),
             }),
             definition({ dependencyValues }) {
-                let titlePrefix = "";
                 let title = "";
 
                 const haveTitleChild = dependencyValues.titleChild.length > 0;
@@ -960,28 +975,18 @@ export class SectioningComponent extends BlockComponent {
                         dependencyValues.includeAutoNameIfNoTitle &&
                         !dependencyValues.noAutoTitle);
 
-                if (includeAutoNumber) {
-                    if (includeAutoName) {
-                        titlePrefix = dependencyValues.sectionName + " ";
-                    }
-                    titlePrefix += dependencyValues.sectionNumber;
-                } else {
-                    if (includeAutoName) {
-                        titlePrefix = dependencyValues.sectionName;
-                    }
-                }
+                const titlePrefix = composeTitlePrefix({
+                    t: contentTranslator(dependencyValues),
+                    includeAutoName,
+                    includeAutoNumber,
+                    haveTitleChild,
+                    sectionName: dependencyValues.sectionName,
+                    sectionNumber: dependencyValues.sectionNumber,
+                });
 
                 if (!haveTitleChild) {
                     title = titlePrefix;
                 } else {
-                    if (titlePrefix) {
-                        if (dependencyValues.includeAutoName) {
-                            titlePrefix += ": ";
-                        } else {
-                            titlePrefix += ". ";
-                        }
-                    }
-
                     title =
                         dependencyValues.titleChild[
                             dependencyValues.titleChild.length - 1

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { createTestCore } from "../utils/test-core";
 import * as ComponentTypes from "../../ComponentTypes";
-import { sectionWordsCoverage } from "../../utils/sectionWords";
+import {
+    composeTitlePrefix,
+    sectionWordsCoverage,
+} from "../../utils/sectionWords";
 
 vi.mock("hyperformula");
 
@@ -184,6 +187,59 @@ describe("section words follow the document locale @group4", () => {
                 both: "Sección 2: ",
                 numbered: "3. ",
             });
+        });
+
+        it("renders no number for a section that has none", async () => {
+            // `<proof>` is unnumbered. Asked for its number anyway, the
+            // concatenation that built this used to render the string "null".
+            const doenetML = `
+            <proof name="bare" includeAutoNumber><p>a</p></proof>
+            <proof name="titled" includeAutoNumber><title>Limits</title><p>b</p></proof>
+            `;
+            expect(
+                await values(doenetML, ["bare", "titled"], "titlePrefix"),
+            ).toEqual({ bare: "Proof", titled: "" });
+        });
+
+        it("hands the catalog its number as text", () => {
+            // A section rendered as a list item numbers itself by counting its
+            // siblings, so `sectionNumber` reaches this as a number. Fluent
+            // formats a numeric argument through `Intl`, which would group the
+            // thousandth item as "1,000" in English and "1.000" in Spanish —
+            // an identifier reformatted as though it were a quantity.
+            let passed: Record<string, unknown> | undefined;
+            composeTitlePrefix({
+                t: (
+                    _key: string,
+                    args: Record<string, unknown>,
+                    english: string,
+                ) => {
+                    passed = args;
+                    return english;
+                },
+                includeAutoName: true,
+                includeAutoNumber: true,
+                haveTitleChild: false,
+                sectionName: "Problems",
+                sectionNumber: 1000,
+            });
+            expect(passed?.sectionNumber).eq("1000");
+        });
+
+        it("takes the language from a `<document lang>` on the root", async () => {
+            // Everything else here declares the language through the host.
+            // `lang` on the document is the author's own route to it, and it
+            // is answered by an ancestor lookup that excludes the component it
+            // runs on — a `<section>` is never that document, so the lookup
+            // reaches it.
+            const doenetML = `<document lang="es">
+              <section name="s"><p>a</p></section>
+              <hint name="h"><p>b</p></hint>
+            </document>`;
+            const svs = await stateValuesOf(doenetML, ["s", "h"]);
+            expect(svs.s.sectionName).eq("Sección");
+            expect(svs.s.titlePrefix).eq("Sección 1");
+            expect(svs.h.title).eq("Pista");
         });
 
         it("gives a nested <document> its own language, and its sections with it", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
@@ -251,20 +251,30 @@ describe("section words follow the document locale @group4", () => {
         });
 
         it("renders no name for a section renamed to blank space", async () => {
-            // A name of nothing but spaces shows the reader no word either,
-            // and the punctuation around one would read as the same mistake.
-            // The name the author wrote still reaches `sectionName` as they
-            // wrote it; it is the heading that leaves the piece out.
+            // A name of nothing but blank space shows the reader no word
+            // either, and the punctuation around one would read as the same
+            // mistake. The name the author wrote still reaches `sectionName`
+            // as they wrote it; it is the heading that leaves the piece out.
+            //
+            // A tab and a non-breaking space are as blank to a reader as a
+            // space is, and are what a copy-and-paste tends to leave behind,
+            // so all three are read the same way.
             const doenetML = `
             <problems name="bare" renameTo="   " includeAutoName><p>a</p></problems>
             <problems name="titled" renameTo="   " includeAutoName includeAutoNumber="false"><title>Limits</title><p>b</p></problems>
+            <problems name="tab" renameTo="\t" includeAutoName><p>c</p></problems>
+            <problems name="nbsp" renameTo="\u00a0" includeAutoName><p>d</p></problems>
             `;
             expect(
-                await values(doenetML, ["bare", "titled"], "titlePrefix"),
-            ).toEqual({ bare: "1", titled: "" });
+                await values(
+                    doenetML,
+                    ["bare", "titled", "tab", "nbsp"],
+                    "titlePrefix",
+                ),
+            ).toEqual({ bare: "1", titled: "", tab: "3", nbsp: "4" });
             expect(
-                (await values(doenetML, ["bare"], "sectionName")).bare,
-            ).toEqual("   ");
+                await values(doenetML, ["bare", "nbsp"], "sectionName"),
+            ).toEqual({ bare: "   ", nbsp: "\u00a0" });
         });
 
         it("numbers a list item by counting, which arrives as a number", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
@@ -250,6 +250,23 @@ describe("section words follow the document locale @group4", () => {
             });
         });
 
+        it("renders no name for a section renamed to blank space", async () => {
+            // A name of nothing but spaces shows the reader no word either,
+            // and the punctuation around one would read as the same mistake.
+            // The name the author wrote still reaches `sectionName` as they
+            // wrote it; it is the heading that leaves the piece out.
+            const doenetML = `
+            <problems name="bare" renameTo="   " includeAutoName><p>a</p></problems>
+            <problems name="titled" renameTo="   " includeAutoName includeAutoNumber="false"><title>Limits</title><p>b</p></problems>
+            `;
+            expect(
+                await values(doenetML, ["bare", "titled"], "titlePrefix"),
+            ).toEqual({ bare: "1", titled: "" });
+            expect(
+                (await values(doenetML, ["bare"], "sectionName")).bare,
+            ).toEqual("   ");
+        });
+
         it("numbers a list item by counting, which arrives as a number", async () => {
             // The premise of the test below: a section rendered as a list item
             // takes its number from `countAmongSiblings`, and that reaches
@@ -285,37 +302,6 @@ describe("section words follow the document locale @group4", () => {
                 sectionNumber: 1000,
             });
             expect(passed?.sectionNumber).eq("1000");
-        });
-
-        it("takes the language from a `<document lang>` on the root", async () => {
-            // Everything else here declares the language through the host.
-            // `lang` on the document is the author's own route to it, and it
-            // is answered by an ancestor lookup that excludes the component it
-            // runs on — a `<section>` is never that document, so the lookup
-            // reaches it.
-            const doenetML = `<document lang="es">
-              <section name="s"><p>a</p></section>
-              <hint name="h"><p>b</p></hint>
-            </document>`;
-            const svs = await stateValuesOf(doenetML, ["s", "h"]);
-            expect(svs.s.sectionName).eq("Sección");
-            expect(svs.s.titlePrefix).eq("Sección 1");
-            expect(svs.h.title).eq("Pista");
-        });
-
-        it("gives a nested <document> its own language, and its sections with it", async () => {
-            // The ancestor lookup finds the *nearest* document, so a section
-            // inside the inner one is named in the inner one's language while
-            // one outside keeps the outer's.
-            const nested = `<document>
-              <section name="outer"><p>a</p></section>
-              <document name="inner" lang="es">
-                <section name="innerSection"><p>b</p></section>
-              </document>
-            </document>`;
-            const svs = await stateValuesOf(nested, ["outer", "innerSection"]);
-            expect(svs.outer.sectionName).eq("Section");
-            expect(svs.innerSection.sectionName).eq("Sección");
         });
 
         it("keeps the section number out of the catalog's hands", async () => {
@@ -382,6 +368,41 @@ describe("section words follow the document locale @group4", () => {
                     "Try this",
                 );
             }
+        });
+    });
+
+    describe("a `<document lang>` written by the author", () => {
+        // Everything above reaches the language through the host. `lang` on
+        // the document is the author's own route to it, and it is answered by
+        // an ancestor lookup that excludes the component it runs on — so a
+        // word a `<document>` computes about *itself* needs `ownLocale`.
+        // Neither a `<section>` nor a `<hint>` is ever that document, and
+        // these pin that the lookup reaches them.
+
+        it("names a section and a hint in the language the root declares", async () => {
+            const doenetML = `<document lang="es">
+              <section name="s"><p>a</p></section>
+              <hint name="h"><p>b</p></hint>
+            </document>`;
+            const svs = await stateValuesOf(doenetML, ["s", "h"]);
+            expect(svs.s.sectionName).eq("Sección");
+            expect(svs.s.titlePrefix).eq("Sección 1");
+            expect(svs.h.title).eq("Pista");
+        });
+
+        it("gives a nested <document> its own language, and its sections with it", async () => {
+            // The ancestor lookup finds the *nearest* document, so a section
+            // inside the inner one is named in the inner one's language while
+            // one outside keeps the outer's.
+            const nested = `<document>
+              <section name="outer"><p>a</p></section>
+              <document name="inner" lang="es">
+                <section name="innerSection"><p>b</p></section>
+              </document>
+            </document>`;
+            const svs = await stateValuesOf(nested, ["outer", "innerSection"]);
+            expect(svs.outer.sectionName).eq("Section");
+            expect(svs.innerSection.sectionName).eq("Sección");
         });
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+import * as ComponentTypes from "../../ComponentTypes";
+import { sectionWordsCoverage } from "../../utils/sectionWords";
+
+vi.mock("hyperformula");
+
+/**
+ * i18n Phase 4 (#1572): the word a sectional block calls itself, the heading
+ * it builds around that word, and the two blocks whose default heading is a
+ * word of its own — `<hint>` and `<solution>`.
+ *
+ * Two things are checked throughout, and the second matters as much as the
+ * first: that the document's language reaches these definitions at all, and
+ * that English comes out character-for-character as it did before, so that
+ * every other assertion in this repo stays true of a document that declares no
+ * language.
+ */
+describe("section words follow the document locale @group4", () => {
+    async function stateValuesOf(
+        doenetML: string,
+        names: string[],
+        documentLocale?: string,
+    ): Promise<Record<string, any>> {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+            documentLocale,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const result: Record<string, any> = {};
+        for (const name of names) {
+            result[name] =
+                stateVariables[await resolvePathToNodeIdx(name)].stateValues;
+        }
+        return result;
+    }
+
+    async function values(
+        doenetML: string,
+        names: string[],
+        variable: string,
+        documentLocale?: string,
+    ): Promise<Record<string, any>> {
+        const all = await stateValuesOf(doenetML, names, documentLocale);
+        return Object.fromEntries(
+            Object.entries(all).map(([name, sv]) => [name, sv[variable]]),
+        );
+    }
+
+    describe("the word a block calls itself", () => {
+        const doenetML = `
+        <section name="s"><p>a</p></section>
+        <subsection name="sub"><p>b</p></subsection>
+        <example name="ex"><p>c</p></example>
+        <problem name="pr"><p>d</p></problem>
+        <part name="pa"><p>e</p></part>
+        <proof name="pf"><p>f</p></proof>
+        `;
+        const names = ["s", "sub", "ex", "pr", "pa", "pf"];
+
+        it("renders English by default", async () => {
+            expect(await values(doenetML, names, "sectionName")).toEqual({
+                s: "Section",
+                // A subsection is called a section, at every depth.
+                sub: "Section",
+                ex: "Example",
+                pr: "Problem",
+                pa: "Part",
+                pf: "Proof",
+            });
+        });
+
+        it("renders the document's words when it declares a language", async () => {
+            expect(await values(doenetML, names, "sectionName", "es")).toEqual({
+                s: "Sección",
+                sub: "Sección",
+                ex: "Ejemplo",
+                pr: "Problema",
+                pa: "Parte",
+                pf: "Demostración",
+            });
+        });
+
+        it("passes an author's `renameTo` through verbatim, in every language", async () => {
+            // The author named this block themselves. Translating their word
+            // would be Doenet overwriting content it did not write.
+            // `<section>` and its siblings drop `renameTo`; the plain
+            // sectioning components keep it.
+            const renamed = `<problems name="s" renameTo="Lección"><p>a</p></problems>`;
+            for (const locale of [undefined, "es"]) {
+                expect(
+                    (await values(renamed, ["s"], "sectionName", locale)).s,
+                ).eq("Lección");
+            }
+        });
+
+        it("names every authorable sectional block", async () => {
+            // A new sectional component that nobody adds to the vocabulary
+            // would silently keep its JavaScript class name, in every
+            // language, and nothing else would notice.
+            const all = ComponentTypes.allComponentClasses() as Record<
+                string,
+                any
+            >;
+            const namesItself: string[] = [];
+            for (const [componentType, componentClass] of Object.entries(all)) {
+                if (
+                    componentType.startsWith("_") ||
+                    componentClass.excludeFromSchema
+                ) {
+                    continue;
+                }
+                if (
+                    componentClass.returnStateVariableDefinitions?.()
+                        ?.sectionName !== undefined
+                ) {
+                    namesItself.push(componentType);
+                }
+            }
+
+            // The scan is the load-bearing half, so check it found something
+            // before trusting that it found nothing missing.
+            expect(namesItself).toContain("section");
+            expect(namesItself).toContain("solution");
+            expect(namesItself).toContain("givenAnswer");
+
+            const covered = new Set(sectionWordsCoverage());
+            expect(namesItself.filter((type) => !covered.has(type))).toEqual(
+                [],
+            );
+        });
+    });
+
+    describe("the heading a section builds", () => {
+        it("renders English by default", async () => {
+            const doenetML = `
+            <section name="plain"><p>a</p></section>
+            <section name="titled"><title>Limits</title><p>b</p></section>
+            <section name="numbered" includeAutoNumber includeAutoName="false">
+              <title>Limits</title><p>c</p>
+            </section>
+            <section name="named" includeAutoName includeAutoNumber="false">
+              <title>Limits</title><p>d</p>
+            </section>
+            <section name="both" includeAutoName includeAutoNumber>
+              <title>Limits</title><p>e</p>
+            </section>
+            <section name="bare" noAutoTitle><p>f</p></section>
+            `;
+            const names = [
+                "plain",
+                "titled",
+                "numbered",
+                "named",
+                "both",
+                "bare",
+            ];
+            expect(await values(doenetML, names, "titlePrefix")).toEqual({
+                plain: "Section 1",
+                // An authored title suppresses both auto pieces unless they
+                // were asked for explicitly.
+                titled: "",
+                // A bare number separates its title with a period, not a colon.
+                numbered: "3. ",
+                named: "Section: ",
+                both: "Section 5: ",
+                bare: "",
+            });
+        });
+
+        it("renders the document's heading when it declares a language", async () => {
+            const doenetML = `
+            <section name="plain"><p>a</p></section>
+            <section name="both" includeAutoName includeAutoNumber>
+              <title>Límites</title><p>b</p>
+            </section>
+            <section name="numbered" includeAutoNumber includeAutoName="false">
+              <title>Límites</title><p>c</p>
+            </section>
+            `;
+            const names = ["plain", "both", "numbered"];
+            expect(await values(doenetML, names, "titlePrefix", "es")).toEqual({
+                plain: "Sección 1",
+                both: "Sección 2: ",
+                numbered: "3. ",
+            });
+        });
+
+        it("gives a nested <document> its own language, and its sections with it", async () => {
+            // The ancestor lookup finds the *nearest* document, so a section
+            // inside the inner one is named in the inner one's language while
+            // one outside keeps the outer's.
+            const nested = `<document>
+              <section name="outer"><p>a</p></section>
+              <document name="inner" lang="es">
+                <section name="innerSection"><p>b</p></section>
+              </document>
+            </document>`;
+            const svs = await stateValuesOf(nested, ["outer", "innerSection"]);
+            expect(svs.outer.sectionName).eq("Section");
+            expect(svs.innerSection.sectionName).eq("Sección");
+        });
+
+        it("keeps the section number out of the catalog's hands", async () => {
+            // `sectionNumber` is built from counters and is an identifier, not
+            // a quantity — a deep enumeration must not be reformatted.
+            const deep = `
+            <section name="a"><subsection name="b" includeParentNumber>
+              <p>x</p>
+            </subsection></section>
+            `;
+            expect((await values(deep, ["b"], "sectionNumber", "es")).b).eq(
+                "1.1",
+            );
+        });
+    });
+
+    describe("<solution> and <givenAnswer>", () => {
+        const doenetML = `
+        <problem><solution name="sol"><p>a</p></solution>
+        <givenAnswer name="ga"><p>b</p></givenAnswer></problem>
+        `;
+        const names = ["sol", "ga"];
+
+        it("renders English by default", async () => {
+            expect(await values(doenetML, names, "sectionName")).toEqual({
+                sol: "Solution",
+                ga: "Answer",
+            });
+        });
+
+        it("renders the document's words when it declares a language", async () => {
+            expect(await values(doenetML, names, "sectionName", "es")).toEqual({
+                sol: "Solución",
+                ga: "Respuesta",
+            });
+        });
+    });
+
+    describe("<hint>", () => {
+        it("renders English by default", async () => {
+            expect(
+                (await values(`<hint name="h"><p>a</p></hint>`, ["h"], "title"))
+                    .h,
+            ).eq("Hint");
+        });
+
+        it("renders the document's word when it declares a language", async () => {
+            expect(
+                (
+                    await values(
+                        `<hint name="h"><p>a</p></hint>`,
+                        ["h"],
+                        "title",
+                        "es",
+                    )
+                ).h,
+            ).eq("Pista");
+        });
+
+        it("passes an authored title through verbatim, in every language", async () => {
+            const authored = `<hint name="h"><title>Try this</title><p>a</p></hint>`;
+            for (const locale of [undefined, "es"]) {
+                expect((await values(authored, ["h"], "title", locale)).h).eq(
+                    "Try this",
+                );
+            }
+        });
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
@@ -201,12 +201,24 @@ describe("section words follow the document locale @group4", () => {
             ).toEqual({ bare: "Proof", titled: "" });
         });
 
+        it("numbers a list item by counting, which arrives as a number", async () => {
+            // The premise of the test below: a section rendered as a list item
+            // takes its number from `countAmongSiblings`, and that reaches
+            // `composeTitlePrefix` as a real number rather than as text.
+            const listed = `<problems asList>
+              <problems name="a" includeAutoName includeAutoNumber><p>x</p></problems>
+              <problems name="b" includeAutoName includeAutoNumber><p>y</p></problems>
+            </problems>`;
+            const svs = await stateValuesOf(listed, ["b"]);
+            expect(typeof svs.b.sectionNumber).eq("number");
+            expect(svs.b.titlePrefix).eq("Problems 2");
+        });
+
         it("hands the catalog its number as text", () => {
-            // A section rendered as a list item numbers itself by counting its
-            // siblings, so `sectionNumber` reaches this as a number. Fluent
-            // formats a numeric argument through `Intl`, which would group the
-            // thousandth item as "1,000" in English and "1.000" in Spanish —
-            // an identifier reformatted as though it were a quantity.
+            // Fluent formats a numeric argument through `Intl`, which would
+            // group the thousandth list item as "1,000" in English — and the
+            // ten-thousandth as "10.000" in Spanish — reformatting an
+            // identifier as though it were a quantity.
             let passed: Record<string, unknown> | undefined;
             composeTitlePrefix({
                 t: (

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectionWordsLocale.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
+import { createTranslator } from "@doenet/i18n";
 import { createTestCore } from "../utils/test-core";
 import * as ComponentTypes from "../../ComponentTypes";
 import {
     composeTitlePrefix,
+    sectionNameWord,
     sectionWordsCoverage,
 } from "../../utils/sectionWords";
 
@@ -97,15 +99,19 @@ describe("section words follow the document locale @group4", () => {
             }
         });
 
-        it("names every authorable sectional block", async () => {
-            // A new sectional component that nobody adds to the vocabulary
-            // would silently keep its JavaScript class name, in every
-            // language, and nothing else would notice.
+        it("names every authorable sectional block, with the word it had", async () => {
+            // Two failures at once. A new sectional component that nobody adds
+            // to the vocabulary would silently keep its JavaScript class name,
+            // in every language; and a wrong English word anywhere in the
+            // vocabulary would silently change what a document that declares
+            // no language renders. Only six of these types are spelled out
+            // above, so the rest are pinned here against the class name the
+            // word replaced.
             const all = ComponentTypes.allComponentClasses() as Record<
                 string,
                 any
             >;
-            const namesItself: string[] = [];
+            const namesItself: [string, string][] = [];
             for (const [componentType, componentClass] of Object.entries(all)) {
                 if (
                     componentType.startsWith("_") ||
@@ -117,20 +123,37 @@ describe("section words follow the document locale @group4", () => {
                     componentClass.returnStateVariableDefinitions?.()
                         ?.sectionName !== undefined
                 ) {
-                    namesItself.push(componentType);
+                    namesItself.push([componentType, componentClass.name]);
                 }
             }
+            const types = namesItself.map(([type]) => type);
 
             // The scan is the load-bearing half, so check it found something
             // before trusting that it found nothing missing.
-            expect(namesItself).toContain("section");
-            expect(namesItself).toContain("solution");
-            expect(namesItself).toContain("givenAnswer");
+            expect(types).toContain("section");
+            expect(types).toContain("solution");
+            expect(types).toContain("givenAnswer");
 
             const covered = new Set(sectionWordsCoverage());
-            expect(namesItself.filter((type) => !covered.has(type))).toEqual(
-                [],
-            );
+            expect(types.filter((type) => !covered.has(type))).toEqual([]);
+
+            // The three element names whose word was never their class name:
+            // a subsection at either depth is called a section, and
+            // `<givenAnswer>` is called an answer.
+            const renamed: Record<string, string> = {
+                subsection: "Section",
+                subsubsection: "Section",
+                givenAnswer: "Answer",
+            };
+            const t = createTranslator([], {});
+            const wrongInEnglish = namesItself
+                .map(([type, className]) => ({
+                    type,
+                    word: sectionNameWord(t, type, className),
+                    expected: renamed[type] ?? className,
+                }))
+                .filter(({ word, expected }) => word !== expected);
+            expect(wrongInEnglish).toEqual([]);
         });
     });
 
@@ -199,6 +222,32 @@ describe("section words follow the document locale @group4", () => {
             expect(
                 await values(doenetML, ["bare", "titled"], "titlePrefix"),
             ).toEqual({ bare: "Proof", titled: "" });
+        });
+
+        it("renders no name for a section renamed to nothing", async () => {
+            // `renameTo=""` leaves the block with no word, so the heading is
+            // built as though no name had been asked for — without the space
+            // and punctuation that would sit around one. The concatenation
+            // that built this wrote them anyway: " 1", and a bare ": " where
+            // the heading was the name alone.
+            const doenetML = `
+            <problems name="bare" renameTo="" includeAutoName><p>a</p></problems>
+            <problems name="titled" renameTo="" includeAutoName includeAutoNumber="false"><title>Limits</title><p>b</p></problems>
+            <problems name="numbered" renameTo="" includeAutoName includeAutoNumber><title>Limits</title><p>c</p></problems>
+            `;
+            expect(
+                await values(
+                    doenetML,
+                    ["bare", "titled", "numbered"],
+                    "titlePrefix",
+                ),
+            ).toEqual({
+                bare: "1",
+                titled: "",
+                // Only the number is left, and it is punctuated the way a
+                // bare number is.
+                numbered: "3. ",
+            });
         });
 
         it("numbers a list item by counting, which arrives as a number", async () => {

--- a/packages/doenetml-worker-javascript/src/utils/sectionWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/sectionWords.js
@@ -132,7 +132,12 @@ export function composeTitlePrefix({
         {
             parts,
             sectionName: sectionName ?? "",
-            sectionNumber: sectionNumber ?? "",
+            // As text, because Fluent hands a numeric argument to `Intl` — and
+            // a section rendered as a list item numbers itself by counting its
+            // siblings, so this arrives as a number there. The number
+            // identifies the section; the thousandth item is "1000", not
+            // "1,000" in English or "1.000" in Spanish.
+            sectionNumber: withNumber ? String(sectionNumber) : "",
         },
         english,
     );

--- a/packages/doenetml-worker-javascript/src/utils/sectionWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/sectionWords.js
@@ -52,9 +52,8 @@ const SECTION_NAME_WORDS = {
     question: (t) => t("section-name.question", undefined, "Question"),
     section: (t) => t("section-name.section", undefined, "Section"),
     solution: (t) => t("section-name.solution", undefined, "Solution"),
-    // A subsection is called a section, at every depth. Three element names,
-    // one word — so they share a key rather than asking a translator to
-    // translate "Section" three times and keep the three in step.
+    // A subsection is called a section, at every depth: three element names,
+    // one word, one key for a translator to keep.
     subsection: (t) => t("section-name.section", undefined, "Section"),
     subsubsection: (t) => t("section-name.section", undefined, "Section"),
     task: (t) => t("section-name.task", undefined, "Task"),

--- a/packages/doenetml-worker-javascript/src/utils/sectionWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/sectionWords.js
@@ -1,9 +1,10 @@
 /**
  * The word a sectional block calls itself: "Section", "Example", "Solution".
  *
- * These reach the reader in two ways — as `$section.sectionName`, and inside
- * the heading `titlePrefix` composes — so they are *content*, translated
- * against the document's language rather than the reader's UI language.
+ * These reach the reader inside the heading `titlePrefix` composes, and — for
+ * `<solution>` and `<givenAnswer>` — as the word on the block's own control,
+ * so they are *content*, translated against the document's language rather
+ * than the reader's UI language.
  *
  * ## Keyed by component type, not by class name
  *
@@ -29,8 +30,8 @@
  * runtime, in one language, in one element. So each entry names its key, the
  * way `@doenet/utils`' style vocabulary does.
  *
- * The English beside each key is the fallback a locale that lacks the message
- * degrades to, and is also the word this replaced.
+ * The English beside each key is the last-resort fallback the vocabularies all
+ * carry, and is the word this replaced.
  */
 const SECTION_NAME_WORDS = {
     activity: (t) => t("section-name.activity", undefined, "Activity"),
@@ -135,8 +136,9 @@ export function composeTitlePrefix({
             // As text, because Fluent hands a numeric argument to `Intl` — and
             // a section rendered as a list item numbers itself by counting its
             // siblings, so this arrives as a number there. The number
-            // identifies the section; the thousandth item is "1000", not
-            // "1,000" in English or "1.000" in Spanish.
+            // identifies the section, so it is not grouped: the thousandth
+            // item is "1000" rather than English's "1,000", and the
+            // ten-thousandth "10000" rather than Spanish's "10.000".
             sectionNumber: withNumber ? String(sectionNumber) : "",
         },
         english,

--- a/packages/doenetml-worker-javascript/src/utils/sectionWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/sectionWords.js
@@ -1,0 +1,139 @@
+/**
+ * The word a sectional block calls itself: "Section", "Example", "Solution".
+ *
+ * These reach the reader in two ways — as `$section.sectionName`, and inside
+ * the heading `titlePrefix` composes — so they are *content*, translated
+ * against the document's language rather than the reader's UI language.
+ *
+ * ## Keyed by component type, not by class name
+ *
+ * `sectionName` used to be `componentClass.name`, the JavaScript class name.
+ * That is the same string as the element an author writes only by convention:
+ * it is not the authoring vocabulary, it is not stable under a bundler that
+ * renames classes, and `<subsection>` already had to override it because the
+ * word it wants is "Section". The table below keys on `componentType`, which
+ * is the element name itself and is the thing the schema, the parser and the
+ * documentation all agree on.
+ *
+ * A component type the table does not list keeps its class name, untranslated
+ * — which is what an internal component with no reader-facing name wants, and
+ * is why `sectionWordsCoverage` exists to make sure a new *authorable* one is
+ * not left there by accident.
+ *
+ * ## Written out one call per word
+ *
+ * `lint:i18n` reads translator call sites textually and only sees a key
+ * spelled as a string literal. A table built from a list of keys, or a key
+ * assembled from `componentType`, would be invisible to it: the catalog
+ * entries would be reported as orphans and a typo would surface only at
+ * runtime, in one language, in one element. So each entry names its key, the
+ * way `@doenet/utils`' style vocabulary does.
+ *
+ * The English beside each key is the fallback a locale that lacks the message
+ * degrades to, and is also the word this replaced.
+ */
+const SECTION_NAME_WORDS = {
+    activity: (t) => t("section-name.activity", undefined, "Activity"),
+    aside: (t) => t("section-name.aside", undefined, "Aside"),
+    cascade: (t) => t("section-name.cascade", undefined, "Cascade"),
+    definition: (t) => t("section-name.definition", undefined, "Definition"),
+    example: (t) => t("section-name.example", undefined, "Example"),
+    exercise: (t) => t("section-name.exercise", undefined, "Exercise"),
+    exercises: (t) => t("section-name.exercises", undefined, "Exercises"),
+    givenAnswer: (t) => t("section-name.given-answer", undefined, "Answer"),
+    note: (t) => t("section-name.note", undefined, "Note"),
+    objectives: (t) => t("section-name.objectives", undefined, "Objectives"),
+    paragraphs: (t) => t("section-name.paragraphs", undefined, "Paragraphs"),
+    part: (t) => t("section-name.part", undefined, "Part"),
+    problem: (t) => t("section-name.problem", undefined, "Problem"),
+    problems: (t) => t("section-name.problems", undefined, "Problems"),
+    proof: (t) => t("section-name.proof", undefined, "Proof"),
+    question: (t) => t("section-name.question", undefined, "Question"),
+    section: (t) => t("section-name.section", undefined, "Section"),
+    solution: (t) => t("section-name.solution", undefined, "Solution"),
+    // A subsection is called a section, at every depth. Three element names,
+    // one word — so they share a key rather than asking a translator to
+    // translate "Section" three times and keep the three in step.
+    subsection: (t) => t("section-name.section", undefined, "Section"),
+    subsubsection: (t) => t("section-name.section", undefined, "Section"),
+    task: (t) => t("section-name.task", undefined, "Task"),
+    theorem: (t) => t("section-name.theorem", undefined, "Theorem"),
+};
+
+/**
+ * The word `componentType` names itself with, in `t`'s language.
+ *
+ * @param fallback What to use for a component type the catalog has never named
+ *   — the class name, which is what this computed before.
+ */
+export function sectionNameWord(t, componentType, fallback) {
+    const word = SECTION_NAME_WORDS[componentType];
+    return word === undefined ? fallback : word(t);
+}
+
+/** Which component types {@link sectionNameWord} can name. For tests. */
+export function sectionWordsCoverage() {
+    return Object.keys(SECTION_NAME_WORDS);
+}
+
+/**
+ * The heading a section builds for itself: "Example 2", "Section 1.3: Limits".
+ *
+ * The English this replaced was three `+=` in a row — the name, a space, the
+ * number, then `": "` or `". "` before a `<title>` child — which is English
+ * word order and English punctuation written into the code. A language that
+ * puts the number first, or separates a title differently, could not express
+ * that by translating a word.
+ *
+ * So the pieces go to the catalog as arguments, and which pieces are present
+ * goes with them as `$parts`. An absent piece selects a different branch
+ * rather than substituting an empty string, which is what lets each
+ * combination be ordered and punctuated on its own terms.
+ *
+ * The `-title` branches end in the separator because the title child is
+ * rendered after this string rather than passed into it — it is arbitrary
+ * marked-up content, not text. That is the one thing a translation cannot
+ * reorder here.
+ *
+ * @param haveTitleChild Whether an authored `<title>` follows this prefix.
+ */
+export function composeTitlePrefix({
+    t,
+    includeAutoName,
+    includeAutoNumber,
+    haveTitleChild,
+    sectionName,
+    sectionNumber,
+}) {
+    // An unnumbered section has no number to include, whatever was asked for.
+    const withNumber = includeAutoNumber && sectionNumber != null;
+
+    if (!includeAutoName && !withNumber) {
+        return "";
+    }
+
+    const parts = [
+        ...(includeAutoName ? ["name"] : []),
+        ...(withNumber ? ["number"] : []),
+        ...(haveTitleChild ? ["title"] : []),
+    ].join("-");
+
+    // English, for a locale whose catalog has never seen this message. Built
+    // the same way the branches above are, so the two cannot drift.
+    const separator = haveTitleChild ? (includeAutoName ? ": " : ". ") : "";
+    const english =
+        (includeAutoName ? sectionName : "") +
+        (includeAutoName && withNumber ? " " : "") +
+        (withNumber ? sectionNumber : "") +
+        separator;
+
+    return t(
+        "section-title-prefix",
+        {
+            parts,
+            sectionName: sectionName ?? "",
+            sectionNumber: sectionNumber ?? "",
+        },
+        english,
+    );
+}

--- a/packages/doenetml-worker-javascript/src/utils/sectionWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/sectionWords.js
@@ -107,11 +107,11 @@ export function composeTitlePrefix({
     sectionNumber,
 }) {
     // An unnumbered section has no number to include, whatever was asked for,
-    // and a block the author renamed to nothing has no name — either way the
-    // piece is absent rather than empty, so it selects a branch that leaves
-    // out the space and punctuation around it.
+    // and a block the author renamed to nothing — or to blank space — has no
+    // word to show. Either way the piece is absent rather than empty, so it
+    // selects a branch that leaves out the space and punctuation around it.
     const withNumber = includeAutoNumber && sectionNumber != null;
-    const withName = Boolean(includeAutoName && sectionName);
+    const withName = Boolean(includeAutoName && sectionName?.trim());
 
     if (!withName && !withNumber) {
         return "";

--- a/packages/doenetml-worker-javascript/src/utils/sectionWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/sectionWords.js
@@ -106,25 +106,29 @@ export function composeTitlePrefix({
     sectionName,
     sectionNumber,
 }) {
-    // An unnumbered section has no number to include, whatever was asked for.
+    // An unnumbered section has no number to include, whatever was asked for,
+    // and a block the author renamed to nothing has no name — either way the
+    // piece is absent rather than empty, so it selects a branch that leaves
+    // out the space and punctuation around it.
     const withNumber = includeAutoNumber && sectionNumber != null;
+    const withName = Boolean(includeAutoName && sectionName);
 
-    if (!includeAutoName && !withNumber) {
+    if (!withName && !withNumber) {
         return "";
     }
 
     const parts = [
-        ...(includeAutoName ? ["name"] : []),
+        ...(withName ? ["name"] : []),
         ...(withNumber ? ["number"] : []),
         ...(haveTitleChild ? ["title"] : []),
     ].join("-");
 
     // English, for a locale whose catalog has never seen this message. Built
     // the same way the branches above are, so the two cannot drift.
-    const separator = haveTitleChild ? (includeAutoName ? ": " : ". ") : "";
+    const separator = haveTitleChild ? (withName ? ": " : ". ") : "";
     const english =
-        (includeAutoName ? sectionName : "") +
-        (includeAutoName && withNumber ? " " : "") +
+        (withName ? sectionName : "") +
+        (withName && withNumber ? " " : "") +
         (withNumber ? sectionNumber : "") +
         separator;
 

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -241,6 +241,66 @@ answer-submit-label = Check Work
 answer-submit-label-no-correctness = Submit Response
 
 
+## Sectional blocks
+##
+## The word a sectional block calls itself, which the reader sees as its
+## heading and an author can read back as `$section.sectionName`. Keyed by the
+## element the author writes, so `<subsection>` and `<subsubsection>` share
+## `.section` — they are all called a section.
+##
+## An author who writes `renameTo` has named the block themselves, and that
+## name passes through in every language.
+
+section-name =
+    .activity = Activity
+    .aside = Aside
+    .cascade = Cascade
+    .definition = Definition
+    .example = Example
+    .exercise = Exercise
+    .exercises = Exercises
+    .given-answer = Answer
+    .note = Note
+    .objectives = Objectives
+    .paragraphs = Paragraphs
+    .part = Part
+    .problem = Problem
+    .problems = Problems
+    .proof = Proof
+    .question = Question
+    .section = Section
+    .solution = Solution
+    .task = Task
+    .theorem = Theorem
+
+# The heading a section builds for itself: "Example 2", "Section 1.3: Limits".
+#
+# `$parts` names which pieces are present and whether a `<title>` follows, so
+# that a translation orders and punctuates each combination on its own terms
+# rather than substituting into an English frame. English puts the word first
+# and separates a title with a colon — or with a period when the heading is a
+# bare number — and none of that is a given.
+#
+# The `-title` variants end in the separator, because what follows them is the
+# title child, rendered separately. Fluent trims trailing whitespace, so the
+# separator is written as a string literal to keep its space.
+#
+# `$sectionNumber` is already text ("2", "1.3"), never a number: it is an
+# identifier made of counters, and it is not the catalog's to reformat.
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+# The heading a `<hint>` shows when the author gave it no `<title>`.
+hint-title = Hint
+
+
 ## Tables and figures
 ##
 ## The name a `<table>` or `<figure>` gives itself, which the renderer sets in

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -243,10 +243,10 @@ answer-submit-label-no-correctness = Submit Response
 
 ## Sectional blocks
 ##
-## The word a sectional block calls itself, which the reader sees as its
-## heading and an author can read back as `$section.sectionName`. Keyed by the
-## element the author writes, so `<subsection>` and `<subsubsection>` share
-## `.section` — they are all called a section.
+## The word a sectional block calls itself, which the reader sees in its
+## heading and on a `<solution>`'s reveal control. Keyed by the element the
+## author writes, so `<subsection>` and `<subsubsection>` share `.section` —
+## they are all called a section.
 ##
 ## An author who writes `renameTo` has named the block themselves, and that
 ## name passes through in every language.

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -285,8 +285,8 @@ section-name =
 # title child, rendered separately. Fluent trims trailing whitespace, so the
 # separator is written as a string literal to keep its space.
 #
-# `$sectionNumber` is already text ("2", "1.3"), never a number: it is an
-# identifier made of counters, and it is not the catalog's to reformat.
+# `$sectionNumber` arrives as text ("2", "1.3") rather than as a number: it is
+# an identifier made of counters, and it is not the catalog's to reformat.
 section-title-prefix =
     { $parts ->
         [name] { $sectionName }

--- a/packages/i18n/locales/es/content.ftl
+++ b/packages/i18n/locales/es/content.ftl
@@ -214,6 +214,45 @@ answer-submit-label = Revisar
 answer-submit-label-no-correctness = Enviar respuesta
 
 
+## Bloques seccionales
+
+section-name =
+    .activity = Actividad
+    .aside = Nota al margen
+    .cascade = Cascada
+    .definition = Definición
+    .example = Ejemplo
+    .exercise = Ejercicio
+    .exercises = Ejercicios
+    .given-answer = Respuesta
+    .note = Nota
+    .objectives = Objetivos
+    .paragraphs = Párrafos
+    .part = Parte
+    .problem = Problema
+    .problems = Problemas
+    .proof = Demostración
+    .question = Pregunta
+    .section = Sección
+    .solution = Solución
+    .task = Tarea
+    .theorem = Teorema
+
+# El español separa el título con un punto tras un número solo, igual que el
+# inglés, y con dos puntos cuando la palabra encabeza.
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Pista
+
+
 ## Tablas y figuras
 
 table-name =

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -124,6 +124,28 @@ export type MessageKey =
     | "boolean-false"
     | "answer-submit-label"
     | "answer-submit-label-no-correctness"
+    | "section-name.activity"
+    | "section-name.aside"
+    | "section-name.cascade"
+    | "section-name.definition"
+    | "section-name.example"
+    | "section-name.exercise"
+    | "section-name.exercises"
+    | "section-name.given-answer"
+    | "section-name.note"
+    | "section-name.objectives"
+    | "section-name.paragraphs"
+    | "section-name.part"
+    | "section-name.problem"
+    | "section-name.problems"
+    | "section-name.proof"
+    | "section-name.question"
+    | "section-name.section"
+    | "section-name.solution"
+    | "section-name.task"
+    | "section-name.theorem"
+    | "section-title-prefix"
+    | "hint-title"
     | "table-name"
     | "figure-name"
     | "paginator-previous"
@@ -442,6 +464,28 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "boolean-false",
     "answer-submit-label",
     "answer-submit-label-no-correctness",
+    "section-name.activity",
+    "section-name.aside",
+    "section-name.cascade",
+    "section-name.definition",
+    "section-name.example",
+    "section-name.exercise",
+    "section-name.exercises",
+    "section-name.given-answer",
+    "section-name.note",
+    "section-name.objectives",
+    "section-name.paragraphs",
+    "section-name.part",
+    "section-name.problem",
+    "section-name.problems",
+    "section-name.proof",
+    "section-name.question",
+    "section-name.section",
+    "section-name.solution",
+    "section-name.task",
+    "section-name.theorem",
+    "section-title-prefix",
+    "hint-title",
     "table-name",
     "figure-name",
     "paginator-previous",


### PR DESCRIPTION
**#1574, which this was stacked on, has merged.** This is rebased onto `main` — the whole diff is this PR. (#1576 is stacked on top of this one.)

Closes #1572 — this is the section, hint and solution half; the table, figure and paginator half merged as #1574.

## The word

`sectionName` was `componentClass.name`: the JavaScript class name, arriving at the reader as "Section", "Example", "Problem", "Part", "Proof" — in the heading a section builds, and on the control a `<solution>` is revealed by. It is not public, so an author never reads it back. The vocabulary moves to `utils/sectionWords.js` and is keyed by **`componentType`** rather than by class name, because:

- it is the element an author writes, and what the schema, parser and docs all agree on;
- it does not depend on a bundler leaving class names alone;
- `<subsection>` and `<subsubsection>` already had to override the class name to get the word "Section", and now just map onto the same catalog key. Both overrides in `Sectioning.js` are gone.
- `<givenAnswer>` picks up "Answer" from its own component type, so `GivenAnswer`'s override of `<solution>`'s definition is gone too.

Each entry is written out as its own literal `t("section-name.…")` call, the way `@doenet/utils`' style vocabulary is, because `lint:i18n` only sees a key spelled as a string literal — a key built from `componentType` would be invisible to it and every entry would read as an orphan.

A component type the table doesn't list keeps its class name, untranslated. That is right for the two `excludeFromSchema` internals, and **wrong** for anything authorable, so there is a test for it — see below.

## The heading

This is the half with design in it. `titlePrefix` was built by concatenation:

```js
if (includeAutoNumber) {
    if (includeAutoName) { titlePrefix = sectionName + " "; }
    titlePrefix += sectionNumber;
} else if (includeAutoName) { titlePrefix = sectionName; }
// …then ": " or ". " before an authored <title>
```

English word order, English spacing, English punctuation — none of it reachable by a translation. `composeTitlePrefix` hands the catalog the pieces plus a `$parts` argument naming which are present, so each of the six shapes is ordered and punctuated in the catalog rather than in the code. An absent piece is a different branch, never an empty placeable.

The one thing a translation still cannot move is the `<title>` child: it is rendered after this string because it is marked-up content, not text. So the `-title` branches end in the separator. Fluent trims trailing whitespace, so those are written as string literals to keep the space — there's a comment saying so.

`$sectionNumber` is stringified before it goes to the catalog. It is built from counters and identifies the section; it is not a quantity for the catalog to reformat, and "1.3" must not become anything else. The stringifying is load-bearing rather than defensive: a section rendered as a list item numbers itself by counting its siblings, so it arrives as a real number there, and Fluent hands a numeric argument to `Intl` — which would have made the thousandth list item "Problems 1,000" in English. Spanish groups only from five digits, so its ten-thousandth would have read "Problemas 10.000"; German's thousandth already would.

## Two behaviour changes

Both are a piece that isn't there no longer being written out as though it were, and nothing asserted either old output.

An unnumbered section (`<proof>`) asked to `includeAutoNumber` used to render the string **"null"** — `titlePrefix += dependencyValues.sectionNumber` with `sectionNumber === null`. It now renders no number, which is what it has.

A block with `renameTo=""` has no word, and the concatenation wrote the space and punctuation around it anyway: a heading that was the name alone came out as a bare **": "** before its title, and one with a number as **" 1"**. A name that is nothing but blank space — spaces, a tab, the non-breaking space a copy-and-paste leaves behind — reads the same way to a reader and came out the same way: **"   : "**. Either is now an absent piece, the way an absent number is. The name the author wrote still reaches `sectionName` as they wrote it; it is the heading that leaves the piece out.

## Defaults only

`<hint>`'s "Hint" and `<solution>`'s "Solution" are defaults an authored `<title>` already overrides, and the branch that picks the default is right there — no `usedDefault` needed, unlike the attribute-backed labels in #1574. An author's `renameTo` likewise passes through in every language.

## Tests

`sectionWordsLocale.test.ts`, 19 tests: the word in English and Spanish across six element types, `renameTo` passing through in both, all six heading shapes byte-identical in English and translated in Spanish, an unnumbered section asked for a number rendering none, a block renamed to nothing and one renamed to blank space (spaces, a tab, a non-breaking space) rendering no name, a list item's number really arriving as a number and then reaching the catalog as text, a `<document lang="es">` on the root naming its own sections and hint, a nested one naming its own while the outer keeps English, `sectionNumber` unreformatted, `<solution>`/`<givenAnswer>`, and `<hint>` with and without an authored title.

The root-`lang` one covers the trap #1566 hit: the language is reached through an `ancestor` dependency, which excludes the component it runs on, so a word a `<document>` computes about *itself* needs `ownLocale`. A `<section>` and a `<hint>` are never that document, and the test says the lookup reaches them.

The last one in the first group is the guard worth calling out: it walks the component registry, collects every authorable component that computes a `sectionName`, asserts the scan actually found some (so it can't pass vacuously), and then checks two things about each. That it has a word at all — a new sectional element cannot quietly keep its class name. And that the word, in English, is the class name it replaced, with the three documented exceptions (`<subsection>` and `<subsubsection>` are called a section, `<givenAnswer>` an answer) named in the test. Six of the twenty-two types are spelled out by hand above; a wrong English word in any of the other sixteen would otherwise have changed what an untranslated document renders with nothing to catch it.

Regression: `sectioning`, `problem` and `hint` (55 passed), plus the locale suites. E2E: `sectioning.cy.js`, `hint.cy.js`, `problem.cy.js` — 38 passing.

`npm run build:schema -w @doenet/static-assets` produces no diff: nothing here is public that wasn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







