### PR TITLE
fix: keep section child render indices aligned with active children

### DIFF
--- a/.changeset/section-child-render-indices.md
+++ b/.changeset/section-child-render-indices.md
@@ -8,4 +8,4 @@
 
 Sections: fix children silently disappearing when a section contains a `<stylePalette>`, `<styleDefinition>`, or `<feedbackDefinition>`.
 
-Each of those configuration children shifted the section's rendered-child indices by one, so that many children fell off the end of the section and were never rendered. A section holding both a `<stylePalette>` and a `<styleDefinition>` lost its last two children.
+Each of those configuration children shifted the section's rendered-child indices by one, dropping an equal number of children off the end of the section. A section holding both a `<stylePalette>` and a `<styleDefinition>` lost its last two children.

--- a/.changeset/section-child-render-indices.md
+++ b/.changeset/section-child-render-indices.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Sections: fix children silently disappearing when a section contains a `<stylePalette>`, `<styleDefinition>`, or `<feedbackDefinition>`.
+
+Each of those configuration children shifted the section's rendered-child indices by one, so that many children fell off the end of the section and were never rendered. A section holding both a `<stylePalette>` and a `<styleDefinition>` lost its last two children.

--- a/.changeset/section-child-render-indices.md
+++ b/.changeset/section-child-render-indices.md
@@ -8,4 +8,4 @@
 
 Sections: fix children silently disappearing when a section contains a `<stylePalette>`, `<styleDefinition>`, or `<feedbackDefinition>`.
 
-Each of those configuration children shifted the section's rendered-child indices by one, dropping an equal number of children off the end of the section. A section holding both a `<stylePalette>` and a `<styleDefinition>` lost its last two children.
+Each of those configuration children shifted the section's rendered-child indices by one, so content at the end of the section was silently dropped — one child for each configuration child present.

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -42,9 +42,8 @@ import { codedDiagnostic } from "../../utils/diagnostics";
  *
  * `configurationChildren` are the children that configure the section — its
  * styles and its answer feedback — rather than render inside it. They keep
- * their slot in `allChildren`, so the positions stay aligned, but are filtered
- * out of the rendered and hidden sets by
- * `configurationChildComponentIndices()`.
+ * their slot in `allChildren` so the positions stay aligned, and
+ * `nonConfigurationChildEntries()` filters them back out.
  */
 function returnSectionChildDependencies() {
     return {
@@ -64,16 +63,26 @@ function returnSectionChildDependencies() {
 }
 
 /**
- * The `componentIdx` of each child returned by the `configurationChildren`
- * dependency of `returnSectionChildDependencies()`, as a set for filtering
- * those children out of `allChildren`. String children have no `componentIdx`,
- * so they can never match.
+ * The `[position, child]` entries of a section's children that are not
+ * configuration children, where `position` is the child's index in
+ * `activeChildren`. Takes the `dependencyValues` produced by
+ * `returnSectionChildDependencies()`.
+ *
+ * Configuration children are neither rendered nor hidden: they are not content,
+ * and a section's styles and feedback stay in effect even when its content is
+ * hidden. Their positions are still consumed from `allChildren`, so the
+ * positions of the children around them stay aligned with `activeChildren`.
+ * String children have no `componentIdx`, so they are never dropped.
  */
-function configurationChildComponentIndices(dependencyValues) {
-    return new Set(
+function nonConfigurationChildEntries(dependencyValues) {
+    const configurationChildIndices = new Set(
         dependencyValues.configurationChildren.map(
             (child) => child.componentIdx,
         ),
+    );
+
+    return [...dependencyValues.allChildren.entries()].filter(
+        ([, child]) => !configurationChildIndices.has(child.componentIdx),
     );
 }
 
@@ -517,20 +526,9 @@ export class SectioningComponent extends BlockComponent {
                     (x) => x.componentIdx,
                 );
 
-                const configurationChildIndices =
-                    configurationChildComponentIndices(dependencyValues);
-
-                for (let [
-                    ind,
-                    child,
-                ] of dependencyValues.allChildren.entries()) {
-                    // The configuration children are never rendered, but their
-                    // slots must still be counted so that `ind` remains a
-                    // position in `activeChildren`.
-                    if (configurationChildIndices.has(child.componentIdx)) {
-                        continue;
-                    }
-
+                for (let [ind, child] of nonConfigurationChildEntries(
+                    dependencyValues,
+                )) {
                     // If `hideChildren` is set, string children should also be hidden.
                     // However, string children cannot be hidden via the `childrenToHide`
                     // state variable as it is based on component indices.
@@ -601,16 +599,9 @@ export class SectioningComponent extends BlockComponent {
             definition({ dependencyValues }) {
                 const childrenToHide = [];
 
-                const configurationChildIndices =
-                    configurationChildComponentIndices(dependencyValues);
-
-                for (let child of dependencyValues.allChildren) {
-                    // A section's styles and feedback stay in effect even when
-                    // its content is hidden.
-                    if (configurationChildIndices.has(child.componentIdx)) {
-                        continue;
-                    }
-
+                for (let [, child] of nonConfigurationChildEntries(
+                    dependencyValues,
+                )) {
                     if (child.componentType === "cascadeMessage") {
                         // For <cascadeMessage>, the logic is inverted.
                         // It is hidden when `hideChildren` is `false`!

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -444,10 +444,11 @@ export class SectioningComponent extends BlockComponent {
                     childGroups: ["titles"],
                 },
                 // `childIndicesToRender` is consumed as indices into
-                // `activeChildren`, so this dependency has to cover *every*
-                // child group. Listing groups individually would silently
-                // shift every index past a child in an omitted group (e.g. a
-                // `<styleDefinition>`), dropping rendered children off the end.
+                // `activeChildren` (see `returnActiveChildrenIndicesToRender`),
+                // so it must be computed from the complete child list.
+                // Enumerating child groups here would silently drop any group
+                // left off the list (e.g. `styleDefinitions`), shifting every
+                // later index down and pushing rendered children off the end.
                 allChildren: {
                     dependencyType: "child",
                     includeAllChildren: true,
@@ -496,10 +497,9 @@ export class SectioningComponent extends BlockComponent {
                     ind,
                     child,
                 ] of dependencyValues.allChildren.entries()) {
-                    if (
-                        typeof child === "object" &&
-                        definitionChildIndices.has(child.componentIdx)
-                    ) {
+                    // Skip the configuration children. (String children have no
+                    // `componentIdx`, so they can never match.)
+                    if (definitionChildIndices.has(child.componentIdx)) {
                         continue;
                     }
 
@@ -560,6 +560,10 @@ export class SectioningComponent extends BlockComponent {
 
         stateVariableDefinitions.childrenToHide = {
             returnDependencies: () => ({
+                // Unlike `childIndicesToRender`, this variable reports component
+                // indices rather than positions, so omitting a child group here
+                // cannot shift anything. The style/feedback definition groups
+                // are left out because they are never rendered to begin with.
                 allChildren: {
                     dependencyType: "child",
                     childGroups: [
@@ -783,7 +787,9 @@ export class SectioningComponent extends BlockComponent {
             ],
             forRenderer: true,
             returnDependencies: () => ({
-                // Must match the child list `childIndicesToRender` indexes into.
+                // `childIndicesToRender` holds indices into `activeChildren`,
+                // and is used below to index into this list, so this dependency
+                // must cover every child too.
                 allChildren: {
                     dependencyType: "child",
                     includeAllChildren: true,

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -27,6 +27,56 @@ import {
 } from "../../utils/sectionTitleColors";
 import { codedDiagnostic } from "../../utils/diagnostics";
 
+/**
+ * The `child` dependencies shared by the state variables that split a section's
+ * children into the ones it renders (or hides) and the ones that merely
+ * configure it.
+ *
+ * `allChildren` deliberately uses `includeAllChildren` rather than a list of
+ * child groups. `childIndicesToRender` is consumed as *positions* in
+ * `activeChildren` (see `returnActiveChildrenIndicesToRender`), and
+ * `includeAllChildren` is the only form whose indices are by construction those
+ * positions. Enumerating child groups instead would silently drop any group
+ * left off the list, shifting every later position down and pushing that many
+ * rendered children off the end of the section.
+ *
+ * `configurationChildren` are the children that configure the section — its
+ * styles and its answer feedback — rather than render inside it. They keep
+ * their slot in `allChildren`, so the positions stay aligned, but are filtered
+ * out of the rendered and hidden sets by
+ * `configurationChildComponentIndices()`.
+ */
+function returnSectionChildDependencies() {
+    return {
+        allChildren: {
+            dependencyType: "child",
+            includeAllChildren: true,
+        },
+        configurationChildren: {
+            dependencyType: "child",
+            childGroups: [
+                "styleDefinitions",
+                "stylePalettes",
+                "feedbackDefinitions",
+            ],
+        },
+    };
+}
+
+/**
+ * The `componentIdx` of each child returned by the `configurationChildren`
+ * dependency of `returnSectionChildDependencies()`, as a set for filtering
+ * those children out of `allChildren`. String children have no `componentIdx`,
+ * so they can never match.
+ */
+function configurationChildComponentIndices(dependencyValues) {
+    return new Set(
+        dependencyValues.configurationChildren.map(
+            (child) => child.componentIdx,
+        ),
+    );
+}
+
 export class SectioningComponent extends BlockComponent {
     constructor(args) {
         super(args);
@@ -443,27 +493,7 @@ export class SectioningComponent extends BlockComponent {
                     dependencyType: "child",
                     childGroups: ["titles"],
                 },
-                // `childIndicesToRender` is consumed as indices into
-                // `activeChildren` (see `returnActiveChildrenIndicesToRender`),
-                // so it must be computed from the complete child list.
-                // Enumerating child groups here would silently drop any group
-                // left off the list (e.g. `styleDefinitions`), shifting every
-                // later index down and pushing rendered children off the end.
-                allChildren: {
-                    dependencyType: "child",
-                    includeAllChildren: true,
-                },
-                // Children that configure the section rather than render in
-                // it. They keep their place in `allChildren` (so the indices
-                // stay aligned) but are never rendered themselves.
-                definitionChildren: {
-                    dependencyType: "child",
-                    childGroups: [
-                        "styleDefinitions",
-                        "stylePalettes",
-                        "feedbackDefinitions",
-                    ],
-                },
+                ...returnSectionChildDependencies(),
                 titleChildName: {
                     dependencyType: "stateVariable",
                     variableName: "titleChildName",
@@ -487,19 +517,17 @@ export class SectioningComponent extends BlockComponent {
                     (x) => x.componentIdx,
                 );
 
-                const definitionChildIndices = new Set(
-                    dependencyValues.definitionChildren.map(
-                        (x) => x.componentIdx,
-                    ),
-                );
+                const configurationChildIndices =
+                    configurationChildComponentIndices(dependencyValues);
 
                 for (let [
                     ind,
                     child,
                 ] of dependencyValues.allChildren.entries()) {
-                    // Skip the configuration children. (String children have no
-                    // `componentIdx`, so they can never match.)
-                    if (definitionChildIndices.has(child.componentIdx)) {
+                    // The configuration children are never rendered, but their
+                    // slots must still be counted so that `ind` remains a
+                    // position in `activeChildren`.
+                    if (configurationChildIndices.has(child.componentIdx)) {
                         continue;
                     }
 
@@ -560,20 +588,7 @@ export class SectioningComponent extends BlockComponent {
 
         stateVariableDefinitions.childrenToHide = {
             returnDependencies: () => ({
-                // Unlike `childIndicesToRender`, this variable reports component
-                // indices rather than positions, so omitting a child group here
-                // cannot shift anything. The style/feedback definition groups
-                // are left out because they are never rendered to begin with.
-                allChildren: {
-                    dependencyType: "child",
-                    childGroups: [
-                        "anything",
-                        "variantControls",
-                        "titles",
-                        "setups",
-                        "cascadeMessages",
-                    ],
-                },
+                ...returnSectionChildDependencies(),
                 titleChildName: {
                     dependencyType: "stateVariable",
                     variableName: "titleChildName",
@@ -586,7 +601,16 @@ export class SectioningComponent extends BlockComponent {
             definition({ dependencyValues }) {
                 const childrenToHide = [];
 
+                const configurationChildIndices =
+                    configurationChildComponentIndices(dependencyValues);
+
                 for (let child of dependencyValues.allChildren) {
+                    // A section's styles and feedback stay in effect even when
+                    // its content is hidden.
+                    if (configurationChildIndices.has(child.componentIdx)) {
+                        continue;
+                    }
+
                     if (child.componentType === "cascadeMessage") {
                         // For <cascadeMessage>, the logic is inverted.
                         // It is hidden when `hideChildren` is `false`!
@@ -787,9 +811,11 @@ export class SectioningComponent extends BlockComponent {
             ],
             forRenderer: true,
             returnDependencies: () => ({
-                // `childIndicesToRender` holds indices into `activeChildren`,
-                // and is used below to index into this list, so this dependency
-                // must cover every child too.
+                // `childIndicesToRender` is looked up in this list below, so it
+                // must be the same complete child list that produced those
+                // positions (see `returnSectionChildDependencies`). The
+                // configuration children are already excluded from
+                // `childIndicesToRender`, so they need not be identified here.
                 allChildren: {
                     dependencyType: "child",
                     includeAllChildren: true,

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -443,14 +443,24 @@ export class SectioningComponent extends BlockComponent {
                     dependencyType: "child",
                     childGroups: ["titles"],
                 },
+                // `childIndicesToRender` is consumed as indices into
+                // `activeChildren`, so this dependency has to cover *every*
+                // child group. Listing groups individually would silently
+                // shift every index past a child in an omitted group (e.g. a
+                // `<styleDefinition>`), dropping rendered children off the end.
                 allChildren: {
                     dependencyType: "child",
+                    includeAllChildren: true,
+                },
+                // Children that configure the section rather than render in
+                // it. They keep their place in `allChildren` (so the indices
+                // stay aligned) but are never rendered themselves.
+                definitionChildren: {
+                    dependencyType: "child",
                     childGroups: [
-                        "anything",
-                        "variantControls",
-                        "titles",
-                        "setups",
-                        "cascadeMessages",
+                        "styleDefinitions",
+                        "stylePalettes",
+                        "feedbackDefinitions",
                     ],
                 },
                 titleChildName: {
@@ -476,10 +486,23 @@ export class SectioningComponent extends BlockComponent {
                     (x) => x.componentIdx,
                 );
 
+                const definitionChildIndices = new Set(
+                    dependencyValues.definitionChildren.map(
+                        (x) => x.componentIdx,
+                    ),
+                );
+
                 for (let [
                     ind,
                     child,
                 ] of dependencyValues.allChildren.entries()) {
+                    if (
+                        typeof child === "object" &&
+                        definitionChildIndices.has(child.componentIdx)
+                    ) {
+                        continue;
+                    }
+
                     // If `hideChildren` is set, string children should also be hidden.
                     // However, string children cannot be hidden via the `childrenToHide`
                     // state variable as it is based on component indices.
@@ -760,15 +783,10 @@ export class SectioningComponent extends BlockComponent {
             ],
             forRenderer: true,
             returnDependencies: () => ({
+                // Must match the child list `childIndicesToRender` indexes into.
                 allChildren: {
                     dependencyType: "child",
-                    childGroups: [
-                        "anything",
-                        "variantControls",
-                        "titles",
-                        "setups",
-                        "cascadeMessages",
-                    ],
+                    includeAllChildren: true,
                 },
                 asList: {
                     dependencyType: "stateVariable",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1504,6 +1504,51 @@ describe("Cascade tag tests @group4", async () => {
         expect(stateVariables[section2Idx].stateValues.childrenToHide).eqls([]);
     });
 
+    it("do not render or hide the configuration children of a section", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <section boxed name="section1">
+    <title>First part</title>
+    What is 1+1? <answer name="ans">2</answer>
+  </section>
+
+  <section boxed name="section2">
+    <title name="title2">Second part</title>
+    <stylePalette name="palette2" palette="okabeito" />
+    <styleDefinition name="styleDef2" styleNumber="2" lineOpacity="1" />
+    <p name="p2">What is 3+4?</p>
+    <answer name="ans">7</answer>
+  </section>
+</cascade>
+  `,
+        });
+
+        const stateVariables = await getStateVariables(core);
+        const section2Idx = await resolvePathToNodeIdx("section2");
+        const section2 = stateVariables[section2Idx];
+
+        // `childIndicesToRender` holds positions in `activeChildren`, so resolve
+        // it back to components rather than assert on the positions themselves.
+        const renderedChildIndices = section2.stateValues.childIndicesToRender
+            .map((ind: number) => section2.activeChildren[ind])
+            .filter((child: any) => typeof child === "object")
+            .map((child: any) => child.componentIdx);
+
+        expect(renderedChildIndices).eqls([
+            await resolvePathToNodeIdx("title2"),
+            await resolvePathToNodeIdx("p2"),
+            await resolvePathToNodeIdx("section2.ans"),
+        ]);
+
+        // `section2` is hidden because `section1` has not been answered yet.
+        // Its title stays visible and its style children are left alone.
+        expect(section2.stateValues.childrenToHide).eqls([
+            await resolvePathToNodeIdx("p2"),
+            await resolvePathToNodeIdx("section2.ans"),
+        ]);
+    });
+
     it("boxAll boxes only immediate section children", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1530,12 +1530,13 @@ describe("Cascade tag tests @group4", async () => {
 
         // `childIndicesToRender` holds positions in `activeChildren`, so resolve
         // it back to components rather than assert on the positions themselves.
-        const renderedChildIndices = section2.stateValues.childIndicesToRender
-            .map((ind: number) => section2.activeChildren[ind])
-            .filter((child: any) => typeof child === "object")
-            .map((child: any) => child.componentIdx);
+        const renderedChildComponentIndices =
+            section2.stateValues.childIndicesToRender
+                .map((ind: number) => section2.activeChildren[ind])
+                .filter((child: any) => typeof child === "object")
+                .map((child: any) => child.componentIdx);
 
-        expect(renderedChildIndices).eqls([
+        expect(renderedChildComponentIndices).eqls([
             await resolvePathToNodeIdx("title2"),
             await resolvePathToNodeIdx("p2"),
             await resolvePathToNodeIdx("section2.ans"),

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1807,6 +1807,76 @@ describe("Section heading color accessibility diagnostics @group3", async () => 
         expect(sectionState.titleColorDarkMode).eq("#3a3a3a");
     });
 
+    // The section's `childIndicesToRender` indexes into `activeChildren`, so it
+    // must be computed from a child list that includes *every* child. When it
+    // was built from a partial list of child groups, each configuration child
+    // (`<stylePalette>`, `<styleDefinition>`, `<feedbackDefinition>`) shifted
+    // the indices by one and silently dropped that many children off the end.
+    async function renderedChildrenOfSection(
+        core: PublicDoenetMLCore,
+        sectionIdx: number,
+    ) {
+        return core
+            .core!.rendererState[sectionIdx].childrenInstructions.filter(
+                (child: any) => child !== null && typeof child === "object",
+            )
+            .map((child: any) => child.componentIdx);
+    }
+
+    it("renders all children of a section that configures its own style", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<section name="sec">
+  <stylePalette palette="grumpynarwhal" />
+  <styleDefinition styleNumber="2" lineOpacity="1" />
+
+  <graph name="g1">
+    <vector name="v">(3,4)</vector>
+  </graph>
+
+  <graph name="g2" copy="$g1">
+    <circle filled center="(5,2)" />
+  </graph>
+</section>`,
+        });
+
+        expect(
+            await renderedChildrenOfSection(
+                core,
+                await resolvePathToNodeIdx("sec"),
+            ),
+        ).eqls([
+            await resolvePathToNodeIdx("g1"),
+            await resolvePathToNodeIdx("g2"),
+        ]);
+    });
+
+    it("renders all children of a section that defines feedback and styles", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<section name="sec">
+  <stylePalette palette="okabeito" />
+  <styleDefinition styleNumber="2" lineOpacity="1" />
+  <feedbackDefinition code="lostPI" text="You lost pi" />
+
+  <p name="p1">First</p>
+  <p name="p2">Second</p>
+  <p name="p3">Third</p>
+</section>`,
+        });
+
+        expect(
+            await renderedChildrenOfSection(
+                core,
+                await resolvePathToNodeIdx("sec"),
+            ),
+        ).eqls([
+            await resolvePathToNodeIdx("p1"),
+            await resolvePathToNodeIdx("p2"),
+            await resolvePathToNodeIdx("p3"),
+        ]);
+    });
+
     it("does not emit diagnostics for translucent heading colors that remain accessible after compositing", async () => {
         const { core } = await createTestCore({
             doenetML: `<section name="sec" boxed notStartedColor="rgba(0,0,0,0.5)">

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1622,12 +1622,14 @@ describe("Sectioning tag tests @group3", async () => {
         ).eq(true);
     });
 
-    // `childIndicesToRender` is consumed as indices into `activeChildren`, so it
-    // must be computed from a child list that includes *every* child. When it
-    // was built from a partial list of child groups, each configuration child
-    // (`<stylePalette>`, `<styleDefinition>`, `<feedbackDefinition>`) shifted
-    // the indices by one and silently dropped that many children off the end.
-    function renderedChildrenOfSection(
+    /**
+     * The component indices of the children a section actually handed to the
+     * renderer. Read from the renderer instructions rather than from
+     * `childIndicesToRender` so that the tests below assert the outcome the
+     * reader sees. Instruction slots that are strings (whitespace between the
+     * children) or `null` (a child that was not rendered) are dropped.
+     */
+    function renderedChildComponentIndices(
         core: PublicDoenetMLCore,
         sectionIdx: number,
     ) {
@@ -1637,6 +1639,12 @@ describe("Sectioning tag tests @group3", async () => {
             )
             .map((child: any) => child.componentIdx);
     }
+
+    // The two tests below cover the bug where `childIndicesToRender`, which is
+    // consumed as positions in `activeChildren`, was computed from a child list
+    // that left out the `<stylePalette>`, `<styleDefinition>`, and
+    // `<feedbackDefinition>` groups. Each such child shifted the positions down
+    // by one and silently dropped a child off the end of the section.
 
     it("renders all children of a section that configures its own style", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
@@ -1656,7 +1664,10 @@ describe("Sectioning tag tests @group3", async () => {
         });
 
         expect(
-            renderedChildrenOfSection(core, await resolvePathToNodeIdx("sec")),
+            renderedChildComponentIndices(
+                core,
+                await resolvePathToNodeIdx("sec"),
+            ),
         ).eqls([
             await resolvePathToNodeIdx("g1"),
             await resolvePathToNodeIdx("g2"),
@@ -1678,7 +1689,10 @@ describe("Sectioning tag tests @group3", async () => {
         });
 
         expect(
-            renderedChildrenOfSection(core, await resolvePathToNodeIdx("sec")),
+            renderedChildComponentIndices(
+                core,
+                await resolvePathToNodeIdx("sec"),
+            ),
         ).eqls([
             await resolvePathToNodeIdx("p1"),
             await resolvePathToNodeIdx("p2"),

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1555,6 +1555,18 @@ describe("Sectioning tag tests @group3", async () => {
             <p>Welcome to section 4</p>
         </introduction>
     </section>
+
+    <section name="sec5">
+      <stylePalette palette="okabeito" />
+      <styleDefinition styleNumber="2" lineOpacity="1" />
+      <introduction name="intro5">
+        <p>Welcome to section 5</p>
+      </introduction>
+      <p>Some content</p>
+      <conclusion name="concl5">
+        <p>Thanks for reading section 5</p>
+      </conclusion>
+    </section>
     `,
         });
 
@@ -1595,6 +1607,83 @@ describe("Sectioning tag tests @group3", async () => {
             stateVariables[await resolvePathToNodeIdx("sec4")].stateValues
                 .endsWithConclusion,
         ).eq(false);
+
+        // `startsWithIntroduction`/`endsWithConclusion` look up
+        // `childIndicesToRender` in their own child list, so the two must be
+        // derived from the same (complete) list of children. The unrendered
+        // configuration children of `sec5` occupy slots in that list.
+        expect(
+            stateVariables[await resolvePathToNodeIdx("sec5")].stateValues
+                .startsWithIntroduction,
+        ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("sec5")].stateValues
+                .endsWithConclusion,
+        ).eq(true);
+    });
+
+    // `childIndicesToRender` is consumed as indices into `activeChildren`, so it
+    // must be computed from a child list that includes *every* child. When it
+    // was built from a partial list of child groups, each configuration child
+    // (`<stylePalette>`, `<styleDefinition>`, `<feedbackDefinition>`) shifted
+    // the indices by one and silently dropped that many children off the end.
+    function renderedChildrenOfSection(
+        core: PublicDoenetMLCore,
+        sectionIdx: number,
+    ) {
+        return core
+            .core!.rendererState[sectionIdx].childrenInstructions.filter(
+                (child: any) => child !== null && typeof child === "object",
+            )
+            .map((child: any) => child.componentIdx);
+    }
+
+    it("renders all children of a section that configures its own style", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<section name="sec">
+  <stylePalette palette="grumpynarwhal" />
+  <styleDefinition styleNumber="2" lineOpacity="1" />
+
+  <graph name="g1">
+    <vector name="v">(3,4)</vector>
+  </graph>
+
+  <graph name="g2" copy="$g1">
+    <circle filled center="(5,2)" />
+  </graph>
+</section>`,
+        });
+
+        expect(
+            renderedChildrenOfSection(core, await resolvePathToNodeIdx("sec")),
+        ).eqls([
+            await resolvePathToNodeIdx("g1"),
+            await resolvePathToNodeIdx("g2"),
+        ]);
+    });
+
+    it("renders all children of a section that defines feedback and styles", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<section name="sec">
+  <stylePalette palette="okabeito" />
+  <styleDefinition styleNumber="2" lineOpacity="1" />
+  <feedbackDefinition code="lostPI" text="You lost pi" />
+
+  <p name="p1">First</p>
+  <p name="p2">Second</p>
+  <p name="p3">Third</p>
+</section>`,
+        });
+
+        expect(
+            renderedChildrenOfSection(core, await resolvePathToNodeIdx("sec")),
+        ).eqls([
+            await resolvePathToNodeIdx("p1"),
+            await resolvePathToNodeIdx("p2"),
+            await resolvePathToNodeIdx("p3"),
+        ]);
     });
 });
 
@@ -1805,76 +1894,6 @@ describe("Section heading color accessibility diagnostics @group3", async () => 
 
         expect(sectionState.titleColor).eq("var(--mainGray)");
         expect(sectionState.titleColorDarkMode).eq("#3a3a3a");
-    });
-
-    // The section's `childIndicesToRender` indexes into `activeChildren`, so it
-    // must be computed from a child list that includes *every* child. When it
-    // was built from a partial list of child groups, each configuration child
-    // (`<stylePalette>`, `<styleDefinition>`, `<feedbackDefinition>`) shifted
-    // the indices by one and silently dropped that many children off the end.
-    async function renderedChildrenOfSection(
-        core: PublicDoenetMLCore,
-        sectionIdx: number,
-    ) {
-        return core
-            .core!.rendererState[sectionIdx].childrenInstructions.filter(
-                (child: any) => child !== null && typeof child === "object",
-            )
-            .map((child: any) => child.componentIdx);
-    }
-
-    it("renders all children of a section that configures its own style", async () => {
-        const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `
-<section name="sec">
-  <stylePalette palette="grumpynarwhal" />
-  <styleDefinition styleNumber="2" lineOpacity="1" />
-
-  <graph name="g1">
-    <vector name="v">(3,4)</vector>
-  </graph>
-
-  <graph name="g2" copy="$g1">
-    <circle filled center="(5,2)" />
-  </graph>
-</section>`,
-        });
-
-        expect(
-            await renderedChildrenOfSection(
-                core,
-                await resolvePathToNodeIdx("sec"),
-            ),
-        ).eqls([
-            await resolvePathToNodeIdx("g1"),
-            await resolvePathToNodeIdx("g2"),
-        ]);
-    });
-
-    it("renders all children of a section that defines feedback and styles", async () => {
-        const { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `
-<section name="sec">
-  <stylePalette palette="okabeito" />
-  <styleDefinition styleNumber="2" lineOpacity="1" />
-  <feedbackDefinition code="lostPI" text="You lost pi" />
-
-  <p name="p1">First</p>
-  <p name="p2">Second</p>
-  <p name="p3">Third</p>
-</section>`,
-        });
-
-        expect(
-            await renderedChildrenOfSection(
-                core,
-                await resolvePathToNodeIdx("sec"),
-            ),
-        ).eqls([
-            await resolvePathToNodeIdx("p1"),
-            await resolvePathToNodeIdx("p2"),
-            await resolvePathToNodeIdx("p3"),
-        ]);
     });
 
     it("does not emit diagnostics for translucent heading colors that remain accessible after compositing", async () => {


### PR DESCRIPTION
## Problem

Children of a `<section>` silently vanish from the rendered document when the section also contains a `<stylePalette>`, `<styleDefinition>`, or `<feedbackDefinition>`. Reported case:

```
<section>
  <stylePalette palette="grumpynarwhal" />
  <styleDefinition styleNumber="2" lineOpacity="1" />

  <graph name="g1">
    <vector name="v">(3,4)</vector>
  </graph>

  <graph copy="$g1">
    <circle filled center="(5,2)" />
  </graph>
</section>
```

The second graph never appears. Removing any one of the `<section>`, the `<stylePalette>`, or the `<styleDefinition>` brings it back.

## Cause

`SectioningComponent`'s `childIndicesToRender` is consumed by `returnActiveChildrenIndicesToRender` as **indices into `activeChildren`**, but it was computed from a `child` dependency that listed only five of the section's eight child groups:

```js
childGroups: ["anything", "variantControls", "titles", "setups", "cascadeMessages"]
```

`styleDefinitions`, `stylePalettes`, and `feedbackDefinitions` were missing. Each child is matched to exactly one group, so a child of one of those types shortens the dependency list by one and shifts every later index down by one — that many children then fall off the end and are never handed to the renderer.

In the example above the section has nine active children, but `childIndicesToRender` came out as `[0…6]`, dropping `activeChildren[7]` (the copied graph) and `[8]`. `initializeRenderedComponentInstruction` pushed `null` in the graph's place, and neither it nor its descendants ever reached the renderer:

```
before:  ["\n  ", null, "\n  ", null, "\n\n  ", graph, "\n\n  ", null,  null]
after:   ["\n  ", null, "\n  ", null, "\n\n  ", graph, "\n\n  ", graph, "\n"]
```

That also explains the three "delete any one and it works" cases. Removing the `<section>` moves the content to `<document>`, which extends `BaseComponent` and has no `childIndicesToRender` at all. Removing either style tag leaves a shift of only one, which swallowed just a trailing whitespace string.

This is a latent bug in the index computation rather than anything specific to style palettes; adding the `stylePalettes` group simply made a one-child shift reachable in a second way, so two configuration children could stack up and eat a real child.

## Fix

A shared `returnSectionChildDependencies()` helper now supplies both `child` dependencies used to split a section's children into the ones it renders (or hides) and the ones that merely configure it:

- `allChildren` uses `includeAllChildren: true`, whose indices are by construction the keys of `activeChildren`. The list can no longer drift as child groups are added.
- `configurationChildren` picks out the style/feedback children, which `nonConfigurationChildEntries()` filters back out while keeping the `[position, child]` pairs of everything else. They stay excluded from the rendered set and from `firstVisibleChild` exactly as before, while the surrounding indices stay aligned.

`childIndicesToRender` and `childrenToHide` both iterate `nonConfigurationChildEntries()`. `childrenToHide` reports component indices rather than positions, so it was never affected by the shift — but it enumerated the complement of the same three groups by hand, which is the same stale-list hazard one step removed: a newly added child group would silently stop being hidden. Its behavior is unchanged; it just no longer maintains its own list.

`startsWithIntroduction`/`endsWithConclusion` looks `childIndicesToRender` up in its own child list, so it takes the same complete `allChildren` dependency. It does not need `configurationChildren`, since those children are already excluded from `childIndicesToRender`.

The doc comment on the helper records why `includeAllChildren` is required rather than a group list, so the next person to touch these dependencies does not reintroduce the shift.

## Tests

In `sectioning.test.ts`:

- Two regression tests assert the outcome — which children actually reach the renderer, via `rendererState[section].childrenInstructions` — rather than the internal index list:
    - the reported case (`<stylePalette>` + `<styleDefinition>` + a graph copied by a second graph)
    - a broader case adding `<feedbackDefinition>` with three `<p>` children
- The existing "starts with introduction / ends with conclusion" test gains a section that carries a `<stylePalette>` and a `<styleDefinition>` alongside its `<introduction>` and `<conclusion>`. This pins the two positionally-indexed dependencies to each other: reverting either one back to a partial group list makes the test fail.

In `cascade.test.ts`:

- A section inside a `<cascade>` — the only place `hideChildren` is ever set — carries a `<stylePalette>` and a `<styleDefinition>`. The test asserts both which children are rendered and that `childrenToHide` covers the section's content but not its title or its configuration children.

The three new tests all fail on `main` and pass with the fix.

Also re-ran `sectioning`, `cascade`, `stylePalette`, `styledefinition`, `styleOverride`, `styleDescriptionLocale`, `document`, `feedback`, `problem`, `solution`, and `hint` locally — all green. `npm run build:schema -w packages/static-assets` leaves the generated schema unchanged.

## Not fixed here

`<setup>` and `<variantControl>` were already in the old dependency list, so they never triggered the index shift — but they are also not rendered, and they can still be picked as a list item's `firstVisibleChild`, which incorrectly turns on the list-item first-child alignment adjustment. That is a separate pre-existing issue and is left alone here.

`<cascade>` overrides `childrenToHide` with a deliberately different child set of its own, and is likewise left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

