### PR TITLE
fix: skip non-rendering children when picking a list item's first child

### DIFF
--- a/.changeset/list-item-first-visible-child.md
+++ b/.changeset/list-item-first-visible-child.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-List items: fix a leading `<setup>` or `<variantControl>` breaking the layout of a `<part>` or `<task>`.
+List items: fix a leading child that renders nothing breaking the layout of a `<part>` or `<task>`.
 
-A list item aligns its hanging number against its first visible child. `<setup>` and `<variantControl>` render nothing, but were still eligible to be chosen, so the child that actually renders first kept its top margin and never reported the alignment it needs. A `<part>` starting with a `<setup>` followed by a `<graph>` (or image, video, tabular, spreadsheet, or block `<choiceInput>`) put its number at the bottom of that content instead of the top.
+A list item aligns its hanging number against its first visible child. Children that render nothing — `<setup>`, `<variantControl>`, `<animateFromSequence>`, `<solveEquations>` and the like — were still eligible to be chosen, so the child that actually rendered first kept its top margin and never reported the alignment it needs. A `<part>` starting with a `<setup>` followed by a `<graph>` (or image, video, tabular, spreadsheet, or block `<choiceInput>`) put its number at the bottom of that content instead of the top.

--- a/.changeset/list-item-first-visible-child.md
+++ b/.changeset/list-item-first-visible-child.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+List items: fix a leading `<setup>` or `<variantControl>` breaking the layout of a `<part>` or `<task>`.
+
+A list item aligns its hanging number against its first visible child. `<setup>` and `<variantControl>` render nothing, but were still eligible to be chosen, so the child that actually renders first kept its top margin and never reported the alignment it needs. A `<part>` starting with a `<setup>` followed by a `<graph>` (or image, video, tabular, spreadsheet, or block `<choiceInput>`) put its number at the bottom of that content instead of the top.

--- a/.changeset/list-item-first-visible-child.md
+++ b/.changeset/list-item-first-visible-child.md
@@ -9,3 +9,5 @@
 List items: fix a leading child that renders nothing breaking the layout of a `<part>` or `<task>`.
 
 A list item aligns its hanging number against its first visible child. Children that render nothing — `<setup>`, `<variantControl>`, `<animateFromSequence>`, `<solveEquations>` and the like — were still eligible to be chosen, so the child that actually rendered first kept its top margin and never reported the alignment it needs. A `<part>` starting with a `<setup>` followed by a `<graph>` (or image, video, tabular, spreadsheet, or block `<choiceInput>`) put its number at the bottom of that content instead of the top.
+
+Also, a section no longer hides its `<setup>` and `<variantControl>` along with its content. Hiding a `<setup>` hid everything defined inside it, which stripped hidden pieces out of the text of those definitions — so text defined in the `<setup>` of an unrevealed `<cascade>` step came back incomplete.

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -41,7 +41,7 @@ import { codedDiagnostic } from "../../utils/diagnostics";
  * rendered children off the end of the section.
  *
  * `configurationChildren` are the children that configure the section — its
- * styles, its answer feedback, its variants, and its non-rendered setup —
+ * styles, its answer feedback, its variants, and its `<setup>` definitions —
  * rather than render inside it. None of these component types has a
  * `rendererType`. They keep their slot in `allChildren` so the positions stay
  * aligned, and `nonConfigurationChildEntries()` filters them back out.
@@ -71,15 +71,18 @@ function returnSectionChildDependencies() {
  * `activeChildren`. Takes the `dependencyValues` produced by
  * `returnSectionChildDependencies()`.
  *
- * Configuration children are neither rendered nor hidden: they are not content,
- * and a section's styles, feedback, and variants stay in effect even when its
- * content is hidden. Filtering them here also keeps them out of
- * `firstVisibleChild` — a list item delegates its inline first-line rendering
- * and its number's alignment to that child, so choosing one that renders
- * nothing strands the child that actually renders first. Their positions are
- * still consumed from `allChildren`, so the positions of the children around
- * them stay aligned with `activeChildren`. String children have no
- * `componentIdx`, so they are never dropped.
+ * Configuration children are neither rendered nor hidden. Leaving them out of
+ * `childIndicesToRender` also keeps them out of `firstVisibleChild` — a list
+ * item delegates its inline first-line rendering and its number's alignment to
+ * that child, so choosing one that renders nothing strands the child that
+ * actually renders first. Leaving them out of `childrenToHide` is a visual
+ * no-op, since none of them renders in the first place, and it is what keeps a
+ * section's styles, feedback, variants, and `<setup>` definitions in effect
+ * even when its content is hidden.
+ *
+ * Their positions are still consumed from `allChildren`, so the positions of
+ * the children around them stay aligned with `activeChildren`. String children
+ * have no `componentIdx`, so they are never dropped.
  */
 function nonConfigurationChildEntries(dependencyValues) {
     const configurationChildIndices = new Set(

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -41,9 +41,10 @@ import { codedDiagnostic } from "../../utils/diagnostics";
  * rendered children off the end of the section.
  *
  * `configurationChildren` are the children that configure the section — its
- * styles and its answer feedback — rather than render inside it. They keep
- * their slot in `allChildren` so the positions stay aligned, and
- * `nonConfigurationChildEntries()` filters them back out.
+ * styles, its answer feedback, its variants, and its non-rendered setup —
+ * rather than render inside it. None of these component types has a
+ * `rendererType`. They keep their slot in `allChildren` so the positions stay
+ * aligned, and `nonConfigurationChildEntries()` filters them back out.
  */
 function returnSectionChildDependencies() {
     return {
@@ -57,6 +58,8 @@ function returnSectionChildDependencies() {
                 "styleDefinitions",
                 "stylePalettes",
                 "feedbackDefinitions",
+                "setups",
+                "variantControls",
             ],
         },
     };
@@ -69,10 +72,14 @@ function returnSectionChildDependencies() {
  * `returnSectionChildDependencies()`.
  *
  * Configuration children are neither rendered nor hidden: they are not content,
- * and a section's styles and feedback stay in effect even when its content is
- * hidden. Their positions are still consumed from `allChildren`, so the
- * positions of the children around them stay aligned with `activeChildren`.
- * String children have no `componentIdx`, so they are never dropped.
+ * and a section's styles, feedback, and variants stay in effect even when its
+ * content is hidden. Filtering them here also keeps them out of
+ * `firstVisibleChild` — a list item delegates its inline first-line rendering
+ * and its number's alignment to that child, so choosing one that renders
+ * nothing strands the child that actually renders first. Their positions are
+ * still consumed from `allChildren`, so the positions of the children around
+ * them stay aligned with `activeChildren`. String children have no
+ * `componentIdx`, so they are never dropped.
  */
 function nonConfigurationChildEntries(dependencyValues) {
     const configurationChildIndices = new Set(

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -72,8 +72,9 @@ function returnSectionChildDependencies() {
  * `returnSectionChildDependencies()`.
  *
  * Configuration children are neither rendered nor hidden. Leaving them out of
- * `childIndicesToRender` costs nothing, since a child with no `rendererType`
- * only ever reached the renderer as an empty slot. Leaving them out of
+ * `childIndicesToRender` costs nothing, and shifts nothing: a child with no
+ * `rendererType` is dropped again when the renderer's child list is built, so
+ * it never occupied a position in that list to begin with. Leaving them out of
  * `childrenToHide` is what keeps a section's styles, feedback, variants, and
  * `<setup>` definitions usable while its content is hidden: `hidden` is
  * inherited by every descendant, and a hidden child is dropped from its

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -72,13 +72,13 @@ function returnSectionChildDependencies() {
  * `returnSectionChildDependencies()`.
  *
  * Configuration children are neither rendered nor hidden. Leaving them out of
- * `childIndicesToRender` also keeps them out of `firstVisibleChild` — a list
- * item delegates its inline first-line rendering and its number's alignment to
- * that child, so choosing one that renders nothing strands the child that
- * actually renders first. Leaving them out of `childrenToHide` is a visual
- * no-op, since none of them renders in the first place, and it is what keeps a
- * section's styles, feedback, variants, and `<setup>` definitions in effect
- * even when its content is hidden.
+ * `childIndicesToRender` costs nothing, since a child with no `rendererType`
+ * only ever reached the renderer as an empty slot. Leaving them out of
+ * `childrenToHide` is likewise inert on screen — nothing reads the `hidden` of
+ * a component that never renders, nor of anything nested inside one — and it
+ * has the benefit of keeping a section's styles, feedback, variants, and
+ * `<setup>` definitions independent of whether its content is currently
+ * revealed.
  *
  * Their positions are still consumed from `allChildren`, so the positions of
  * the children around them stay aligned with `activeChildren`. String children
@@ -93,6 +93,29 @@ function nonConfigurationChildEntries(dependencyValues) {
 
     return [...dependencyValues.allChildren.entries()].filter(
         ([, child]) => !configurationChildIndices.has(child.componentIdx),
+    );
+}
+
+/**
+ * Whether a child puts anything on the screen: a non-blank string always does,
+ * a component only if its class declares a `rendererType`.
+ *
+ * A list item delegates its inline first-line rendering, and the alignment of
+ * its hanging number, to `firstVisibleChild`, so a child that renders nothing
+ * must never be picked as that child — doing so strands the child that
+ * actually renders first, which then keeps its top margin and never gets to
+ * report the alignment it needs. `<setup>` and `<variantControl>` are the
+ * common offenders and are already excluded as configuration children; this
+ * covers the rest (`<animateFromSequence>`, `<solveEquations>`, …).
+ */
+function childRendersSomething(child, componentInfoObjects) {
+    if (typeof child !== "object") {
+        return child.trim() !== "";
+    }
+
+    return Boolean(
+        componentInfoObjects.allComponentClasses[child.componentType]
+            ?.rendererType,
     );
 }
 
@@ -528,8 +551,9 @@ export class SectioningComponent extends BlockComponent {
             }),
             definition({ dependencyValues, componentInfoObjects }) {
                 const childIndicesToRender = [];
-                // Tracks first non-hidden rendered child (including non-blank strings)
-                // so list-item sections can delegate alignment behavior to that child.
+                // Tracks the first non-hidden child that actually puts something
+                // on the screen (see `childRendersSomething()`), so list-item
+                // sections can delegate alignment behavior to that child.
                 let firstVisibleChild = null;
 
                 let allTitleChildNames = dependencyValues.titleChildren.map(
@@ -550,40 +574,36 @@ export class SectioningComponent extends BlockComponent {
                         continue;
                     }
 
-                    if (dependencyValues.asList) {
-                        // if asList, then only include titleChild, sections, introduction, and conclusion
-                        if (
-                            child.componentIdx ===
-                                dependencyValues.titleChildName ||
-                            componentInfoObjects.isInheritedComponentType({
-                                inheritedComponentType: child.componentType,
-                                baseComponentType: "_sectioningComponent",
-                            }) ||
-                            ["introduction", "conclusion"].includes(
-                                child.componentType,
-                            )
-                        ) {
-                            childIndicesToRender.push(ind);
-                            if (
-                                firstVisibleChild === null &&
-                                !dependencyValues.hideChildren
-                            ) {
-                                firstVisibleChild = child;
-                            }
-                        }
-                    } else if (
-                        typeof child !== "object" ||
-                        !allTitleChildNames.includes(child.componentIdx) ||
-                        child.componentIdx === dependencyValues.titleChildName
+                    const renderChild = dependencyValues.asList
+                        ? // if asList, then only include titleChild, sections, introduction, and conclusion
+                          child.componentIdx ===
+                              dependencyValues.titleChildName ||
+                          componentInfoObjects.isInheritedComponentType({
+                              inheritedComponentType: child.componentType,
+                              baseComponentType: "_sectioningComponent",
+                          }) ||
+                          ["introduction", "conclusion"].includes(
+                              child.componentType,
+                          )
+                        : // otherwise, include everything but the title children
+                          // that lost out to `titleChildName`
+                          typeof child !== "object" ||
+                          !allTitleChildNames.includes(child.componentIdx) ||
+                          child.componentIdx ===
+                              dependencyValues.titleChildName;
+
+                    if (!renderChild) {
+                        continue;
+                    }
+
+                    childIndicesToRender.push(ind);
+
+                    if (
+                        firstVisibleChild === null &&
+                        !dependencyValues.hideChildren &&
+                        childRendersSomething(child, componentInfoObjects)
                     ) {
-                        childIndicesToRender.push(ind);
-                        if (
-                            firstVisibleChild === null &&
-                            !dependencyValues.hideChildren &&
-                            (typeof child === "object" || child.trim() !== "")
-                        ) {
-                            firstVisibleChild = child;
-                        }
+                        firstVisibleChild = child;
                     }
                 }
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -74,11 +74,11 @@ function returnSectionChildDependencies() {
  * Configuration children are neither rendered nor hidden. Leaving them out of
  * `childIndicesToRender` costs nothing, since a child with no `rendererType`
  * only ever reached the renderer as an empty slot. Leaving them out of
- * `childrenToHide` is likewise inert on screen — nothing reads the `hidden` of
- * a component that never renders, nor of anything nested inside one — and it
- * has the benefit of keeping a section's styles, feedback, variants, and
- * `<setup>` definitions independent of whether its content is currently
- * revealed.
+ * `childrenToHide` is what keeps a section's styles, feedback, variants, and
+ * `<setup>` definitions usable while its content is hidden: `hidden` is
+ * inherited by every descendant, and a hidden child is dropped from its
+ * parent's `text`, so hiding a `<setup>` used to hollow out the text of what it
+ * defined for as long as the section stayed unrevealed.
  *
  * Their positions are still consumed from `allChildren`, so the positions of
  * the children around them stay aligned with `activeChildren`. String children
@@ -107,6 +107,12 @@ function nonConfigurationChildEntries(dependencyValues) {
  * report the alignment it needs. `<setup>` and `<variantControl>` are the
  * common offenders and are already excluded as configuration children; this
  * covers the rest (`<animateFromSequence>`, `<solveEquations>`, …).
+ *
+ * Composites are not a loophole even though none of them declares a
+ * `rendererType`: a composite is replaced by its replacements in
+ * `activeChildren` unless the parent names its component type in a child group
+ * (see `findChildGroup()`), and `<setup>` — which really does render nothing —
+ * is the only composite a section names.
  */
 function childRendersSomething(child, componentInfoObjects) {
     if (typeof child !== "object") {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1562,7 +1562,9 @@ describe("Cascade tag tests @group4", async () => {
   <section boxed name="section2">
     <title name="title2">Second part</title>
     <variantControl name="vc2" numVariants="2" />
-    <setup name="setup2"><number name="n2">7</number></setup>
+    <setup name="setup2">
+      <p name="prompt2">Add <number name="n2">7</number></p>
+    </setup>
     <p name="p2">What is 3+4?</p>
     <answer name="ans">7</answer>
   </section>
@@ -1575,9 +1577,11 @@ describe("Cascade tag tests @group4", async () => {
 
         // `<setup>` and `<variantControl>` are configuration children, so
         // `section2` leaves them out of `childrenToHide` even though it is
-        // hidden until `section1` is answered. Neither renders, so not hiding
-        // them changes nothing on screen; it just keeps the definitions inside
-        // a `<setup>` independent of whether the section has been revealed.
+        // hidden until `section1` is answered. Neither renders, so this changes
+        // nothing on screen; what it does is keep the definitions inside a
+        // `<setup>` usable while the section is unrevealed. Hiding the `<setup>`
+        // hid everything under it, and a hidden child drops out of its parent's
+        // `text`, so `prompt2.text` was missing its `<number>`.
         expect(section2.stateValues.childrenToHide).eqls([
             await resolvePathToNodeIdx("p2"),
             await resolvePathToNodeIdx("section2.ans"),
@@ -1589,6 +1593,10 @@ describe("Cascade tag tests @group4", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("n2")].stateValues.hidden,
         ).eq(false);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("prompt2")].stateValues
+                .text,
+        ).eq("Add 7");
     });
 
     it("boxAll boxes only immediate section children", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1550,6 +1550,47 @@ describe("Cascade tag tests @group4", async () => {
         ]);
     });
 
+    it("do not hide the setup or variant control of a hidden section", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <section boxed name="section1">
+    <title>First part</title>
+    What is 1+1? <answer name="ans">2</answer>
+  </section>
+
+  <section boxed name="section2">
+    <title name="title2">Second part</title>
+    <variantControl name="vc2" numVariants="2" />
+    <setup name="setup2"><number name="n2">7</number></setup>
+    <p name="p2">What is 3+4?</p>
+    <answer name="ans">7</answer>
+  </section>
+</cascade>
+  `,
+        });
+
+        const stateVariables = await getStateVariables(core);
+        const section2 = stateVariables[await resolvePathToNodeIdx("section2")];
+
+        // `<setup>` and `<variantControl>` are configuration children, so
+        // `section2` leaves them out of `childrenToHide` even though it is
+        // hidden until `section1` is answered. Neither renders, so not hiding
+        // them changes nothing on screen; it just keeps the definitions inside
+        // a `<setup>` independent of whether the section has been revealed.
+        expect(section2.stateValues.childrenToHide).eqls([
+            await resolvePathToNodeIdx("p2"),
+            await resolvePathToNodeIdx("section2.ans"),
+        ]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("setup2")].stateValues
+                .hidden,
+        ).eq(false);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("n2")].stateValues.hidden,
+        ).eq(false);
+    });
+
     it("boxAll boxes only immediate section children", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1700,79 +1700,109 @@ describe("Sectioning tag tests @group3", async () => {
         ]);
     });
 
-    // A list item delegates its inline first-line rendering to `firstVisibleChild`.
-    // A `<setup>` renders nothing, so it must not be picked as that child; if it
-    // is, the actually-first child keeps its top margin and never reports the
-    // alignment the section uses to place the hanging number.
-    it("does not delegate list-item rendering to a leading <setup>", async () => {
+    /**
+     * A list item delegates its inline first-line rendering, and the alignment
+     * of its hanging number, to its first visible child. A child that renders
+     * nothing must never be picked as that child; if it is, the child that
+     * actually renders first keeps its top margin and never reports the
+     * alignment the section uses to place the number.
+     *
+     * `doenetML` must define two `<part>`s: `pa`, which opens with the
+     * non-rendering child under test, and the control `pb`, which does not.
+     * The child that should be picked in each is named `ca` and `cb`
+     * respectively; both parts must reach the same result.
+     */
+    async function test_first_visible_child_skips_non_rendering_child({
+        doenetML,
+        componentType,
+        alignment,
+    }: {
+        doenetML: string;
+        componentType: string;
+        alignment: string;
+    }) {
         const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        for (const [partName, childName] of [
+            ["pa", "ca"],
+            ["pb", "cb"],
+        ]) {
+            const part =
+                stateVariables[await resolvePathToNodeIdx(partName)]
+                    .stateValues;
+            const child =
+                stateVariables[await resolvePathToNodeIdx(childName)]
+                    .stateValues;
+
+            expect(part.firstVisibleChild.componentType, partName).eq(
+                componentType,
+            );
+            expect(part.firstChildListItemAlignment, partName).eq(alignment);
+            // Checked separately from the alignment because a non-rendering
+            // child can report the same alignment by coincidence: only this
+            // tells the two apart when the expected alignment is `baseline`.
+            expect(child.renderInlineForListItem, childName).eq(true);
+        }
+    }
+
+    // A `<graph>` declares `flex-start` to opt out of baseline alignment, so
+    // the number sits at the top of the graph rather than at its bottom.
+    it("does not delegate list-item rendering to a leading <setup>", async () => {
+        await test_first_visible_child_skips_non_rendering_child({
             doenetML: `
 <problem>
   <part name="pa">
     <setup><number name="n">5</number></setup>
-    <graph name="ga" size="small"><point>(1,2)</point></graph>
+    <graph name="ca" size="small"><point>(1,2)</point></graph>
   </part>
   <part name="pb">
-    <graph name="gb" size="small"><point>(1,2)</point></graph>
+    <graph name="cb" size="small"><point>(1,2)</point></graph>
   </part>
 </problem>`,
+            componentType: "graph",
+            alignment: "flex-start",
         });
-
-        const stateVariables = await core.returnAllStateVariables(false, true);
-
-        // `pb` is the control: the part with the `<setup>` must resolve to the
-        // same first visible child and the same alignment as the part without
-        // one. A graph opts out of baseline alignment, so the number sits at
-        // the top of the graph rather than at its bottom.
-        for (const [partName, graphName] of [
-            ["pa", "ga"],
-            ["pb", "gb"],
-        ]) {
-            const part =
-                stateVariables[await resolvePathToNodeIdx(partName)]
-                    .stateValues;
-            const graph =
-                stateVariables[await resolvePathToNodeIdx(graphName)]
-                    .stateValues;
-
-            expect(part.firstVisibleChild.componentType, partName).eq("graph");
-            expect(part.firstChildListItemAlignment, partName).eq("flex-start");
-            expect(graph.renderInlineForListItem, graphName).eq(true);
-        }
     });
 
     it("does not delegate list-item rendering to a leading <variantControl>", async () => {
-        const { core, resolvePathToNodeIdx } = await createTestCore({
+        await test_first_visible_child_skips_non_rendering_child({
             doenetML: `
 <problem>
   <part name="pa">
     <variantControl numVariants="2" />
-    <p name="pap">First</p>
+    <p name="ca">First</p>
   </part>
   <part name="pb">
-    <p name="pbp">Second</p>
+    <p name="cb">Second</p>
   </part>
 </problem>`,
+            componentType: "p",
+            alignment: "baseline",
         });
+    });
 
-        const stateVariables = await core.returnAllStateVariables(false, true);
-
-        // A `<p>` and a `<variantControl>` would both report `baseline`
-        // alignment, so the alignment cannot tell them apart here. What does is
-        // whether the `<p>` is the child asked to render inline.
-        for (const [partName, pName] of [
-            ["pa", "pap"],
-            ["pb", "pbp"],
-        ]) {
-            const part =
-                stateVariables[await resolvePathToNodeIdx(partName)]
-                    .stateValues;
-            const p =
-                stateVariables[await resolvePathToNodeIdx(pName)].stateValues;
-
-            expect(part.firstVisibleChild.componentType, partName).eq("p");
-            expect(p.renderInlineForListItem, pName).eq(true);
-        }
+    // `<setup>` and `<variantControl>` are excluded as configuration children;
+    // every other component with no `rendererType` is caught by the general
+    // check, for which `<animateFromSequence>` stands in here.
+    it("does not delegate list-item rendering to any leading child that renders nothing", async () => {
+        await test_first_visible_child_skips_non_rendering_child({
+            doenetML: `
+<problem>
+  <part name="pa">
+    <animateFromSequence target="$Pa.x" from="1" to="5" />
+    <graph name="ca" size="small"><point name="Pa">(1,2)</point></graph>
+  </part>
+  <part name="pb">
+    <graph name="cb" size="small"><point name="Pb">(1,2)</point></graph>
+  </part>
+</problem>`,
+            componentType: "graph",
+            alignment: "flex-start",
+        });
     });
 });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1719,32 +1719,26 @@ describe("Sectioning tag tests @group3", async () => {
         });
 
         const stateVariables = await core.returnAllStateVariables(false, true);
-        const withSetup =
-            stateVariables[await resolvePathToNodeIdx("pa")].stateValues;
-        const withoutSetup =
-            stateVariables[await resolvePathToNodeIdx("pb")].stateValues;
 
-        expect(withSetup.firstVisibleChild.componentType).eq("graph");
+        // `pb` is the control: the part with the `<setup>` must resolve to the
+        // same first visible child and the same alignment as the part without
+        // one. A graph opts out of baseline alignment, so the number sits at
+        // the top of the graph rather than at its bottom.
+        for (const [partName, graphName] of [
+            ["pa", "ga"],
+            ["pb", "gb"],
+        ]) {
+            const part =
+                stateVariables[await resolvePathToNodeIdx(partName)]
+                    .stateValues;
+            const graph =
+                stateVariables[await resolvePathToNodeIdx(graphName)]
+                    .stateValues;
 
-        // A graph opts out of baseline alignment; the `<setup>` must not mask
-        // that and drop the number to the bottom of the graph.
-        expect(withoutSetup.firstChildListItemAlignment).eq("flex-start");
-        expect(withSetup.firstChildListItemAlignment).eq(
-            withoutSetup.firstChildListItemAlignment,
-        );
-
-        const graphWithSetup =
-            stateVariables[await resolvePathToNodeIdx("ga")].stateValues;
-        const graphWithoutSetup =
-            stateVariables[await resolvePathToNodeIdx("gb")].stateValues;
-
-        expect(graphWithoutSetup.renderInlineForListItem).eq(true);
-        expect(graphWithSetup.renderInlineForListItem).eq(
-            graphWithoutSetup.renderInlineForListItem,
-        );
-        expect(graphWithSetup.listItemInlineAlignment).eq(
-            graphWithoutSetup.listItemInlineAlignment,
-        );
+            expect(part.firstVisibleChild.componentType, partName).eq("graph");
+            expect(part.firstChildListItemAlignment, partName).eq("flex-start");
+            expect(graph.renderInlineForListItem, graphName).eq(true);
+        }
     });
 
     it("does not delegate list-item rendering to a leading <variantControl>", async () => {
@@ -1762,20 +1756,23 @@ describe("Sectioning tag tests @group3", async () => {
         });
 
         const stateVariables = await core.returnAllStateVariables(false, true);
-        expect(
-            stateVariables[await resolvePathToNodeIdx("pa")].stateValues
-                .firstVisibleChild.componentType,
-        ).eq("p");
 
-        const withVariantControl =
-            stateVariables[await resolvePathToNodeIdx("pap")].stateValues;
-        const without =
-            stateVariables[await resolvePathToNodeIdx("pbp")].stateValues;
+        // A `<p>` and a `<variantControl>` would both report `baseline`
+        // alignment, so the alignment cannot tell them apart here. What does is
+        // whether the `<p>` is the child asked to render inline.
+        for (const [partName, pName] of [
+            ["pa", "pap"],
+            ["pb", "pbp"],
+        ]) {
+            const part =
+                stateVariables[await resolvePathToNodeIdx(partName)]
+                    .stateValues;
+            const p =
+                stateVariables[await resolvePathToNodeIdx(pName)].stateValues;
 
-        expect(without.renderInlineForListItem).eq(true);
-        expect(withVariantControl.renderInlineForListItem).eq(
-            without.renderInlineForListItem,
-        );
+            expect(part.firstVisibleChild.componentType, partName).eq("p");
+            expect(p.renderInlineForListItem, pName).eq(true);
+        }
     });
 });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -1699,6 +1699,84 @@ describe("Sectioning tag tests @group3", async () => {
             await resolvePathToNodeIdx("p3"),
         ]);
     });
+
+    // A list item delegates its inline first-line rendering to `firstVisibleChild`.
+    // A `<setup>` renders nothing, so it must not be picked as that child; if it
+    // is, the actually-first child keeps its top margin and never reports the
+    // alignment the section uses to place the hanging number.
+    it("does not delegate list-item rendering to a leading <setup>", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<problem>
+  <part name="pa">
+    <setup><number name="n">5</number></setup>
+    <graph name="ga" size="small"><point>(1,2)</point></graph>
+  </part>
+  <part name="pb">
+    <graph name="gb" size="small"><point>(1,2)</point></graph>
+  </part>
+</problem>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const withSetup =
+            stateVariables[await resolvePathToNodeIdx("pa")].stateValues;
+        const withoutSetup =
+            stateVariables[await resolvePathToNodeIdx("pb")].stateValues;
+
+        expect(withSetup.firstVisibleChild.componentType).eq("graph");
+
+        // A graph opts out of baseline alignment; the `<setup>` must not mask
+        // that and drop the number to the bottom of the graph.
+        expect(withoutSetup.firstChildListItemAlignment).eq("flex-start");
+        expect(withSetup.firstChildListItemAlignment).eq(
+            withoutSetup.firstChildListItemAlignment,
+        );
+
+        const graphWithSetup =
+            stateVariables[await resolvePathToNodeIdx("ga")].stateValues;
+        const graphWithoutSetup =
+            stateVariables[await resolvePathToNodeIdx("gb")].stateValues;
+
+        expect(graphWithoutSetup.renderInlineForListItem).eq(true);
+        expect(graphWithSetup.renderInlineForListItem).eq(
+            graphWithoutSetup.renderInlineForListItem,
+        );
+        expect(graphWithSetup.listItemInlineAlignment).eq(
+            graphWithoutSetup.listItemInlineAlignment,
+        );
+    });
+
+    it("does not delegate list-item rendering to a leading <variantControl>", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<problem>
+  <part name="pa">
+    <variantControl numVariants="2" />
+    <p name="pap">First</p>
+  </part>
+  <part name="pb">
+    <p name="pbp">Second</p>
+  </part>
+</problem>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pa")].stateValues
+                .firstVisibleChild.componentType,
+        ).eq("p");
+
+        const withVariantControl =
+            stateVariables[await resolvePathToNodeIdx("pap")].stateValues;
+        const without =
+            stateVariables[await resolvePathToNodeIdx("pbp")].stateValues;
+
+        expect(without.renderInlineForListItem).eq(true);
+        expect(withVariantControl.renderInlineForListItem).eq(
+            without.renderInlineForListItem,
+        );
+    });
 });
 
 describe("Section heading color accessibility diagnostics @group3", async () => {


### PR DESCRIPTION
## Problem

A list item (`<part>`, `<task>`, or anything under `asList`) delegates two things to its `firstVisibleChild`: inline rendering of its first line (`childrenToRenderInlineForListItem`, which suppresses that child's top margin) and the alignment used to place the hanging number (`firstChildListItemAlignment` → the grid's `align-items`).

Any child was eligible to be picked as `firstVisibleChild`, including children that render nothing at all — a component whose class has no `rendererType`. A list item opening with one therefore delegated to a child that never renders, and the child that actually renders first got neither the margin suppression nor a chance to report its alignment.

`<setup>` and `<variantControl>` are the everyday cases, but they are not the only ones: `<animateFromSequence>`, `<solveEquations>`, `<dataFrame>`, `<periodicSet>` and others also declare `rendererType = undefined` and are perfectly ordinary things to put at the top of a part.

```
<problem>
  <part name="pa">
    <setup><number name="n">5</number></setup>
    <graph name="ga" size="small"><point>(1,2)</point></graph>
  </part>
  <part name="pb">
    <graph name="gb" size="small"><point>(1,2)</point></graph>
  </part>
</problem>
```

| | `pa` (leading `<setup>`) | `pb` |
| --- | --- | --- |
| `firstVisibleChild` | `setup` | `graph` |
| `firstChildListItemAlignment` | `baseline` | `flex-start` |
| graph's `renderInlineForListItem` | `false` | `true` |
| graph's `listItemInlineAlignment` | `none` | `flex-start` |

`<graph>` declares `listItemInlineAlignment: "flex-start"` to opt out of baseline alignment, and `pb` honors it — "2." sits at the top of the graph. In `pa` the signal never reaches the section, so it falls back to `align-items: baseline`; a graph has no text baseline, the browser synthesizes one at its bottom margin edge, and "1." drops to the bottom of the graph. Two adjacent parts with identical graphs, numbers at opposite ends.

The same applies to the other first children that opt out of baseline: `<image>`, `<video>`, `<tabular>`, `<spreadsheet>`, and a block `<choiceInput>`.

With a plain text first child the damage is milder — the grid's baseline alignment moves the number down along with the text, so the number stays on the text's line and the only residue is a stray `1em` top margin above that list item.

## Fix

Two parts, both in `SectioningComponent.js`:

**1. A general rule for picking `firstVisibleChild`.** A new `childRendersSomething()` helper gates the choice: a string qualifies if it is non-blank (as before), a component only if its class declares a `rendererType`. That covers every non-rendering component, not just the two obvious ones. The surrounding loop is restructured so the "should this child render" test and the `firstVisibleChild` update each appear once, instead of being duplicated across the `asList` and non-`asList` branches.

**2. `<setup>` and `<variantControl>` join the configuration-children exclusion** added in #1578 for `<styleDefinition>`, `<stylePalette>`, and `<feedbackDefinition>`. They belong there on their own terms — they configure the section rather than appear in it — and the classification reaches two other consumers of that shared helper:

- **`childIndicesToRender`** — no visible change, and no shift either: a child with no `rendererType` is dropped again when the renderer's child list is built, so it never occupied a position in that list to begin with. Now it is simply not handed over.
- **`childrenToHide`** — a hidden section (an unrevealed `<cascade>` step, say) no longer lists its `<setup>` or `<variantControl>` among the children it hides. Nothing is drawn differently, but this one *is* observable, and it is a second fix rather than a wash. `hidden` is inherited by every descendant, so hiding the `<setup>` hid everything defined inside it — and a hidden child is dropped from its parent's `text`. Text defined inside the `<setup>` of an unrevealed section therefore came back with pieces missing: `<setup><p name="prompt">Add <number>7</number></p></setup>` gave `$prompt.text` as `"Add "` until the section was revealed, and `"Add 7"` afterwards. Now it is `"Add 7"` throughout. A test in `cascade.test.ts` pins this down.

  This does not weaken `<cascade>`. The contents of a `<setup>` are never rendered whether or not they are hidden, so nothing new appears on screen; and a reference from a revealed step to something defined in a later step's `<setup>` already rendered in full, because the reference's copy takes its visibility from where the copy lives, not from the source. The old truncation was not containment — it dropped only *component* children from `text` while string children came through — it was an author's definition being silently corrupted for as long as the step stayed unrevealed.

## Tests

Three regression tests in `sectioning.test.ts` share one helper. Each renders a list item that opens with a non-rendering child alongside a control that does not, and asserts the same three outcomes for both — the first visible child's component type, the resulting alignment, and that the intended child is the one asked to render inline:

- a leading `<setup>` before a `<graph>` — resolves to the graph, `flex-start`
- a leading `<variantControl>` before a `<p>` — resolves to the `<p>`, `baseline`. Alignment cannot tell a `<p>` from a `<variantControl>` here, so `renderInlineForListItem` is what separates them.
- a leading `<animateFromSequence>` before a `<graph>` — the general case, caught by `childRendersSomething()` rather than by the configuration-children list.

One test in `cascade.test.ts` for the `childrenToHide` consequence described above: a hidden section hides only its `<p>` and its `<answer>`; its `<setup>` and the `<number>` defined inside that setup stay `hidden: false`; and the `<p>` wrapping that number reports its full text.

All four fail against `main` (`expected 'setup' to equal 'graph'`, `expected 'variantControl' to equal 'p'`, `expected 'animateFromSequence' to equal 'graph'`, and the setup and variant control showing up in `childrenToHide`).

Also re-ran `sectioning`, `problem`, `solution`, `cascade`, `document`, `hint`, `stylePalette`, `styledefinition`, `feedback`, and the `variants` suite locally — all green. Regenerating the schema produces no diff: the change touches only child-dependency and child-selection logic, not any attribute or state variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



