### PR TITLE
Keep a periodic group's name as the value an award compares against

### DIFF
--- a/.changeset/chemistry-names-follow-document-language.md
+++ b/.changeset/chemistry-names-follow-document-language.md
@@ -6,9 +6,9 @@
 "doenet-vscode-extension": patch
 ---
 
-Write the names the chemistry components generate in the document's language: all 118 element names, the periodic group names, the name an ion takes, and the message shown where a symbol names nothing.
+Write the names the chemistry components generate in the document's language: all 118 element names, the name an ion takes, and the message shown where a symbol names nothing.
 
-Symbols, formulas, and anything an author's `<award>` compares against by value are unchanged. Only what is displayed as prose moves.
+Symbols, formulas, and anything an author's `<award>` compares against by value are unchanged. Only what is displayed as prose moves. An element's periodic group, its phase at STP and its metal category read as words but are compared as values — `$atom.groupName = Noble Gas` — so they stay as the atom database spells them in every language.
 
 An ion's name is now looked up rather than derived. English builds an anion's name by stripping a trailing "ine" and adding "ide", with a small table for the words that rule does not fit — that is English morphology, and no other language derives its anion names that way. Each language supplies its own names instead. A transition metal's oxidation state keeps its Roman numeral, which is international, but where it sits and how it is punctuated is now the catalog's to say.
 

--- a/packages/doenetml-worker-javascript/src/components/chemistry/Atom.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/Atom.js
@@ -14,7 +14,7 @@ import {
     contentTranslator,
     returnContentLocaleDependencies,
 } from "../../utils/contentLocale";
-import { elementName, periodicGroupName } from "../../utils/chemistryWords";
+import { elementName } from "../../utils/chemistryWords";
 
 export default class Atom extends InlineComponent {
     static componentType = "atom";
@@ -344,6 +344,12 @@ export default class Atom extends InlineComponent {
             },
         };
 
+        // Not translated, unlike `name` above, and for the same reason
+        // `phaseAtSTP` and `metalCategory` are not: this is an enumerated
+        // category an author compares against — `$atom.groupName = Noble Gas`
+        // — rather than prose the reader is meant to read as a sentence. A
+        // name that changed with the document's language would break that
+        // award silently (#1577).
         stateVariableDefinitions.groupName = {
             description:
                 'The descriptive name of the element\'s periodic group (e.g. "Alkali metals").',
@@ -356,16 +362,12 @@ export default class Atom extends InlineComponent {
                     dependencyType: "stateVariable",
                     variableName: "dataForAtom",
                 },
-                ...returnContentLocaleDependencies(),
             }),
             definition({ dependencyValues }) {
                 let groupName;
 
                 if (dependencyValues.dataForAtom) {
-                    groupName = periodicGroupName(
-                        contentTranslator(dependencyValues),
-                        dependencyValues.dataForAtom["Group Name"],
-                    );
+                    groupName = dependencyValues.dataForAtom["Group Name"];
                 } else {
                     groupName = null;
                 }

--- a/packages/doenetml-worker-javascript/src/components/chemistry/Ion.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/Ion.js
@@ -13,7 +13,6 @@ import {
     anionName,
     elementName,
     englishAnionName,
-    periodicGroupName,
     withOxidationState,
 } from "../../utils/chemistryWords";
 
@@ -357,6 +356,8 @@ export default class Ion extends InlineComponent {
             },
         };
 
+        // English in every language, as `<atom>`'s copy is: an enumerated
+        // category an author compares against, not prose (#1577).
         stateVariableDefinitions.groupName = {
             description:
                 "The descriptive name of the underlying element's periodic group.",
@@ -369,16 +370,12 @@ export default class Ion extends InlineComponent {
                     dependencyType: "stateVariable",
                     variableName: "dataForAtom",
                 },
-                ...returnContentLocaleDependencies(),
             }),
             definition({ dependencyValues }) {
                 let groupName;
 
                 if (dependencyValues.dataForAtom) {
-                    groupName = periodicGroupName(
-                        contentTranslator(dependencyValues),
-                        dependencyValues.dataForAtom["Group Name"],
-                    );
+                    groupName = dependencyValues.dataForAtom["Group Name"];
                 } else {
                     groupName = null;
                 }

--- a/packages/doenetml-worker-javascript/src/test/chemistry/chemistryWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/chemistry/chemistryWordsLocale.test.ts
@@ -6,7 +6,6 @@ import {
     elementName,
     elementWordsCoverage,
     englishAnionName,
-    periodicGroupName,
 } from "../../utils/chemistryWords";
 import { atomDatabase } from "@doenet/static-assets/atom-database";
 
@@ -14,14 +13,19 @@ vi.mock("hyperformula");
 
 /**
  * i18n Phase 4 (#1573): the names the chemistry components generate — the 118
- * element names, the periodic group names, the name an ion derives from its
- * element's, and the message shown where a symbol names nothing.
+ * element names, the name an ion derives from its element's, and the message
+ * shown where a symbol names nothing.
  *
  * Two things are checked throughout, and the second matters as much as the
  * first: that the document's language reaches these definitions at all, and
  * that English comes out character-for-character as it did before, so that
  * every other assertion in this repo stays true of a document that declares no
  * language.
+ *
+ * The other half of the line is checked here too (#1577): the values an author
+ * compares against — an element's periodic group, its phase at STP and its
+ * metal category — stay as the atom database spells them no matter what
+ * language the document declares.
  */
 describe("chemistry words follow the document locale @group4", () => {
     async function values(
@@ -89,8 +93,7 @@ describe("chemistry words follow the document locale @group4", () => {
             // word anywhere in the vocabulary would silently change what a
             // document that declares no language renders. Only a handful of
             // these are spelled out above, so the rest are pinned here against
-            // the database column, the group column, and the derivation the
-            // anion names replaced.
+            // the database column and the derivation the anion names replaced.
             const covered = new Set(elementWordsCoverage());
             const rows = atomDatabase as Record<string, string>[];
             expect(rows.length).eq(118);
@@ -106,18 +109,16 @@ describe("chemistry words follow the document locale @group4", () => {
                 .map((row) => {
                     const symbol = unquoted(row.Symbol);
                     const name = unquoted(row.Name);
-                    const group = unquoted(row["Group Name"] ?? "");
                     return {
                         symbol,
                         got: [
                             elementName(t, symbol, "no fallback"),
                             anionName(t, symbol, englishAnionName(name)),
-                            periodicGroupName(t, group),
                         ],
                         // What each printed before the words moved: the
-                        // database's own name, the English "-ine" → "-ide"
-                        // derivation over it, and the database's own group.
-                        expected: [name, englishAnionName(name), group],
+                        // database's own name, and the English "-ine" → "-ide"
+                        // derivation over it.
+                        expected: [name, englishAnionName(name)],
                     };
                 })
                 .filter(({ got, expected }) =>
@@ -127,7 +128,14 @@ describe("chemistry words follow the document locale @group4", () => {
         });
     });
 
-    describe("periodic group names", () => {
+    // #1577. These three read as words, and were the ones held back when the
+    // element names moved. They are what an author's `<award>` compares
+    // against — `$atom.groupName = Noble Gas` — so a name that changed with
+    // the document's language would break that award at the moment the
+    // document declared one. The line is drawn at what is compared, and these
+    // tests are what says where it is: the same value in every language, and
+    // the same value from an `<ion>` as from an `<atom>`.
+    describe("the values an award compares against", () => {
         const doenetML = `
         <atom name="na" symbol="Na" />
         <atom name="cl" symbol="Cl" />
@@ -136,37 +144,59 @@ describe("chemistry words follow the document locale @group4", () => {
         `;
         const names = ["na", "cl", "he", "h"];
 
-        it("renders English by default", async () => {
-            expect(await values(doenetML, names, "groupName")).toEqual({
-                na: "Alkali Metal",
-                cl: "Halogen",
-                he: "Noble Gas",
-                // Hydrogen belongs to no named group.
-                h: "",
-            });
+        const groups = {
+            na: "Alkali Metal",
+            cl: "Halogen",
+            he: "Noble Gas",
+            // Hydrogen belongs to no named group.
+            h: "",
+        };
+
+        it("names a periodic group the same in every language", async () => {
+            expect(await values(doenetML, names, "groupName")).toEqual(groups);
+            expect(await values(doenetML, names, "groupName", "es")).toEqual(
+                groups,
+            );
         });
 
-        it("renders the document's names when it declares a language", async () => {
-            expect(await values(doenetML, names, "groupName", "es")).toEqual({
-                na: "Metal alcalino",
-                cl: "Halógeno",
-                he: "Gas noble",
-                h: "",
-            });
-        });
-
-        it("names an ion's group too, and not only an atom's", async () => {
-            // `<ion>` carries its own copy of this definition. A document
-            // showing both would otherwise report the same group in two
-            // languages at once.
+        it("gives an ion the same group as an atom, in every language", async () => {
+            // `<ion>` carries its own copy of this definition, so it can drift
+            // from `<atom>`'s on its own.
             const both = `
             <atom name="a" symbol="Fe" />
             <ion name="i" symbol="Fe" charge="2" />
             `;
-            expect(await values(both, ["a", "i"], "groupName", "es")).toEqual({
-                a: "Metal de transición",
-                i: "Metal de transición",
-            });
+            for (const locale of [undefined, "es"]) {
+                expect(
+                    await values(both, ["a", "i"], "groupName", locale),
+                ).toEqual({
+                    a: "Transition Metal",
+                    i: "Transition Metal",
+                });
+            }
+        });
+
+        it("reports a phase at STP the same in every language", async () => {
+            const phases = { na: "Solid", cl: "Gas", he: "Gas", h: "Gas" };
+            expect(await values(doenetML, names, "phaseAtSTP")).toEqual(phases);
+            expect(await values(doenetML, names, "phaseAtSTP", "es")).toEqual(
+                phases,
+            );
+        });
+
+        it("reports a metal category the same in every language", async () => {
+            const both = `
+            <atom name="na" symbol="Na" />
+            <atom name="cl" symbol="Cl" />
+            <ion name="i" symbol="Na" charge="1" />
+            `;
+            const categories = { na: "Metal", cl: "Non Metal", i: "Metal" };
+            expect(
+                await values(both, ["na", "cl", "i"], "metalCategory"),
+            ).toEqual(categories);
+            expect(
+                await values(both, ["na", "cl", "i"], "metalCategory", "es"),
+            ).toEqual(categories);
         });
     });
 
@@ -265,11 +295,14 @@ describe("chemistry words follow the document locale @group4", () => {
             fe: "Hierro",
             cl: "Cloruro",
         });
-        expect((await values(doenetML, ["fe"], "groupName")).fe).eq(
-            "Metal de transición",
-        );
         expect((await values(doenetML, ["bad"], "text")).bad).eq(
             "[Símbolo químico no válido]",
+        );
+        // And the author's own route to a language does not reach the values
+        // either, which is the half of #1577 a host-declared locale cannot
+        // check on its own.
+        expect((await values(doenetML, ["fe"], "groupName")).fe).eq(
+            "Transition Metal",
         );
     });
 });

--- a/packages/doenetml-worker-javascript/src/utils/chemistryWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/chemistryWords.js
@@ -1,18 +1,26 @@
 /**
- * The words the chemistry components generate: element names, periodic group
- * names, and the name an ion derives from its element's.
+ * The words the chemistry components generate: element names and the name an
+ * ion derives from its element's.
  *
- * These reach the reader as `$atom.name`, `$ion.name` and `$atom.groupName`,
- * so they are *content* and follow the document's language rather than the
- * reader's UI language.
+ * These reach the reader as `$atom.name` and `$ion.name`, so they are
+ * *content* and follow the document's language rather than the reader's UI
+ * language.
  *
- * ## Symbols are not words
+ * ## Symbols are not words, and neither are categories
  *
  * `H`, `He`, `Fe` are international and are never translated, and neither is
  * anything else an author's `<award>` compares against by value. Only what is
  * *displayed as prose* is here. Element names are keyed **by symbol**, which
  * is both the stable identifier and the key the atom database is already read
  * through.
+ *
+ * An element's periodic group, its phase at STP and its metal category are
+ * deliberately absent. They read as words, but an author writes
+ * `<award><when>$atom.groupName = Noble Gas</when></award>`, and a name that
+ * changed with the document's language would break that award silently, at the
+ * moment the document declared a language. The line is drawn at what is
+ * compared rather than at what looks like prose, so all three stay as the atom
+ * database spells them (#1577).
  *
  * ## Ion names are data, not a rule
  *
@@ -175,39 +183,6 @@ const ELEMENT_ANION_NAME_WORDS = {
 };
 
 /**
- * The periodic group names the atom database uses, keyed by the English value
- * in the `Group Name` column. An element with no group has an empty value,
- * which is not a word and passes through as it is.
- */
-const GROUP_NAME_WORDS = {
-    "Alkali Metal": (t) =>
-        t("periodic-group-name.alkali-metal", undefined, "Alkali Metal"),
-    "Alkaline Earth Metal": (t) =>
-        t(
-            "periodic-group-name.alkaline-earth-metal",
-            undefined,
-            "Alkaline Earth Metal",
-        ),
-    Chalcogen: (t) =>
-        t("periodic-group-name.chalcogen", undefined, "Chalcogen"),
-    Halogen: (t) => t("periodic-group-name.halogen", undefined, "Halogen"),
-    "Noble Gas": (t) =>
-        t("periodic-group-name.noble-gas", undefined, "Noble Gas"),
-    "Rare Earth Metal": (t) =>
-        t(
-            "periodic-group-name.rare-earth-metal",
-            undefined,
-            "Rare Earth Metal",
-        ),
-    "Transition Metal": (t) =>
-        t(
-            "periodic-group-name.transition-metal",
-            undefined,
-            "Transition Metal",
-        ),
-};
-
-/**
  * The oxidation state a transition metal's ion name carries, as a Roman
  * numeral. IUPAC notation, so the numerals themselves are international.
  */
@@ -283,12 +258,6 @@ export function withOxidationState(t, name, charge) {
         { name, numeral },
         `${name} (${numeral})`,
     );
-}
-
-/** The name of the periodic group `group`, in `t`'s language. */
-export function periodicGroupName(t, group) {
-    const word = GROUP_NAME_WORDS[group];
-    return word === undefined ? group : word(t);
 }
 
 /** Which symbols {@link elementName} can name. For tests. */

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -376,6 +376,11 @@ piecewise-condition-otherwise = otherwise
 ##
 ## Element names are keyed by symbol, which is the identifier the atom database
 ## is read through and is itself never translated.
+##
+## An element's periodic group, its phase at STP and its metal category are not
+## here. They are enumerated values an author's `<award>` compares against —
+## `$atom.groupName = Noble Gas` — and translating one would break that
+## comparison the moment a document declared a language (#1577).
 
 element-name =
     .h = Hydrogen
@@ -524,18 +529,6 @@ element-anion-name =
 # it sits and how it is punctuated is not, which is why this is a message and
 # not a suffix the code appends.
 ion-name-oxidation-state = { $name } ({ $numeral })
-
-# The descriptive names of the periodic groups, as `$atom.groupName` reports
-# them. An element belonging to no named group reports an empty value, which
-# is not a word and has no entry.
-periodic-group-name =
-    .alkali-metal = Alkali Metal
-    .alkaline-earth-metal = Alkaline Earth Metal
-    .chalcogen = Chalcogen
-    .halogen = Halogen
-    .noble-gas = Noble Gas
-    .rare-earth-metal = Rare Earth Metal
-    .transition-metal = Transition Metal
 
 # Shown in place of a chemical symbol or formula that names nothing. Rendered
 # into mathematics as well as into text, so the brackets around it are added by

--- a/packages/i18n/locales/es/content.ftl
+++ b/packages/i18n/locales/es/content.ftl
@@ -425,14 +425,5 @@ element-anion-name =
 
 ion-name-oxidation-state = { $name } ({ $numeral })
 
-periodic-group-name =
-    .alkali-metal = Metal alcalino
-    .alkaline-earth-metal = Metal alcalinotérreo
-    .chalcogen = Calcógeno
-    .halogen = Halógeno
-    .noble-gas = Gas noble
-    .rare-earth-metal = Metal de tierras raras
-    .transition-metal = Metal de transición
-
 chemistry-invalid-symbol = Símbolo químico no válido
 chemistry-invalid-ionic-compound = Compuesto iónico no válido

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -286,13 +286,6 @@ export type MessageKey =
     | "element-anion-name.at"
     | "element-anion-name.ts"
     | "ion-name-oxidation-state"
-    | "periodic-group-name.alkali-metal"
-    | "periodic-group-name.alkaline-earth-metal"
-    | "periodic-group-name.chalcogen"
-    | "periodic-group-name.halogen"
-    | "periodic-group-name.noble-gas"
-    | "periodic-group-name.rare-earth-metal"
-    | "periodic-group-name.transition-metal"
     | "chemistry-invalid-symbol"
     | "chemistry-invalid-ionic-compound"
     | "line-segment-attributes-ignored-with-endpoints"
@@ -766,13 +759,6 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "element-anion-name.at",
     "element-anion-name.ts",
     "ion-name-oxidation-state",
-    "periodic-group-name.alkali-metal",
-    "periodic-group-name.alkaline-earth-metal",
-    "periodic-group-name.chalcogen",
-    "periodic-group-name.halogen",
-    "periodic-group-name.noble-gas",
-    "periodic-group-name.rare-earth-metal",
-    "periodic-group-name.transition-metal",
     "chemistry-invalid-symbol",
     "chemistry-invalid-ionic-compound",
     "line-segment-attributes-ignored-with-endpoints",


### PR DESCRIPTION
Bottom of the stack: #1576 has merged, so this is a single commit on `main`.

Closes #1577.

## The decision

#1576 moved `$atom.groupName` into the catalogs with the element names, and left `$atom.phaseAtSTP` and `$atom.metalCategory` behind. That drew a line nothing in the code explained: all three are enumerated category values read from the same three columns of `atom-database.csv`.

This draws it at **what is compared** rather than at what looks like prose, which is option 2 of the three the issue weighed. `groupName` goes back to the value the database holds, beside the other two.

The case against translating them is one an author can hit without knowing anything about i18n:

```xml
<answer><award><when>$atom.groupName = Noble Gas</when></award></answer>
```

That award works today. Translating the state variable breaks it the moment the document declares a language — silently, with no diagnostic, in one locale only. `<boolean>` resolved the same hazard in #1519 by keeping `true`/`false` as the value and translating only the displayed word, and that split is available here only if the comparison target and the display text become two different state variables (option 3). They are not two things today, and inventing a second name for each of the three is more surface than the prose is worth.

## What changed

- `Atom.js` and `Ion.js` report `groupName` straight from the `Group Name` column again, with no content-locale dependency.
- `periodicGroupName` and its seven-entry vocabulary come out of `utils/chemistryWords.js`; the seven `periodic-group-name.*` messages come out of both catalogs. The module's doc comment now says why the three are absent rather than leaving it to be inferred.
- The changeset from #1576 drops "the periodic group names" from what moved and states the rule instead. Both changesets ship in the same release, so what a reader sees in the changelog is the net effect.

## Tests

`chemistryWordsLocale.test.ts`'s "periodic group names" block becomes "the values an award compares against": the same value in English and in Spanish, for `groupName`, `phaseAtSTP` and `metalCategory`, and the same value from an `<ion>` as from an `<atom>` — which is worth its own assertion because `<ion>` carries its own copies of `groupName` and `metalCategory` and can drift.

The `<document lang="es">` test gains the other half. A host-declared locale cannot show that an author's own route to a language does not reach these either, and that is the route an author would actually take.

The 118-element coverage test drops its group-name column, since there is nothing left to compare.

Regression: the chemistry suite, `@doenet/i18n` (157), `lint:i18n` (470 keys across 2 locales, 297 call sites), and `build:schema` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
