### PR TITLE
Punctuate a table's title and a figure's caption from the catalog

### DIFF
--- a/.changeset/table-figure-caption-separator-locale.md
+++ b/.changeset/table-figure-caption-separator-locale.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Punctuate a table's title and a figure's caption from the document's language.
+
+`<table>` and `<figure>` already named themselves in the document's language, but the `": "` joining that name to the authored title or caption was written into the renderer, so a Spanish activity read **`Figura 2`: pie de foto** — the name from one language and the punctuation from another. The separator is part of the name the catalog composes now, so a language that joins the two differently can say so.
+
+The English text is unchanged. The separator is emphasized along with the name it belongs to, so `<strong>Figure 2</strong>: caption` becomes `<strong>Figure 2: </strong>caption`.

--- a/packages/doenetml-prototype/src/renderers/doenet/table.tsx
+++ b/packages/doenetml-prototype/src/renderers/doenet/table.tsx
@@ -42,16 +42,12 @@ export const Table: BasicComponentWithPassthroughChildren<TableData> = ({
             id={htmlId}
         >
             <Header depth={node.data.props.divisionDepth}>
-                <span className="title-prefix">
-                    {displayName ? (
-                        <>
-                            {displayName}
-                            {title ? ":" : ""}{" "}
-                        </>
-                    ) : (
-                        ""
-                    )}
-                </span>
+                {/* `titlePrefix` already ends in whatever separates it from
+                    the title, in the document's language, so nothing is added
+                    here (#1582). An untitled table therefore no longer trails
+                    the space this used to print unconditionally, which nothing
+                    followed. */}
+                <span className="title-prefix">{displayName}</span>
                 <span className="title">{title}</span>
             </Header>
             <div className="content">{children}</div>

--- a/packages/doenetml-worker-javascript/src/components/Figure.js
+++ b/packages/doenetml-worker-javascript/src/components/Figure.js
@@ -3,6 +3,7 @@ import {
     contentTranslator,
     returnContentLocaleDependencies,
 } from "../utils/contentLocale";
+import { composeFigureName } from "../utils/containerWords";
 
 export default class Figure extends BlockComponent {
     constructor(args) {
@@ -81,10 +82,23 @@ export default class Figure extends BlockComponent {
                     description:
                         "The full display name of the figure (e.g., 'Figure 3').",
                 },
+                {
+                    // The name with the separator joining it to an authored
+                    // `<caption>` — "Figure 3: ". See `tableNamePrefix` in
+                    // `Table.js`; same reason, same shape (#1582).
+                    variableName: "figureNamePrefix",
+                    forRenderer: true,
+                },
             ],
             mustEvaluate: true, // must evaluate to make sure all counters are accounted for
             returnDependencies({ stateValues }) {
-                let dependencies = { ...returnContentLocaleDependencies() };
+                let dependencies = {
+                    captionChild: {
+                        dependencyType: "child",
+                        childGroups: ["captions"],
+                    },
+                    ...returnContentLocaleDependencies(),
+                };
 
                 if (stateValues.number) {
                     dependencies.figureCounter = {
@@ -95,28 +109,23 @@ export default class Figure extends BlockComponent {
                 return dependencies;
             },
             definition({ dependencyValues }) {
-                const t = contentTranslator(dependencyValues);
+                const figureEnumeration =
+                    dependencyValues.figureCounter === undefined
+                        ? null
+                        : String(dependencyValues.figureCounter);
 
-                if (dependencyValues.figureCounter === undefined) {
-                    return {
-                        setValue: {
-                            figureEnumeration: null,
-                            figureName: t(
-                                "figure-name",
-                                { parts: "unnumbered" },
-                                "Figure",
-                            ),
-                        },
-                    };
-                }
-                let figureEnumeration = String(dependencyValues.figureCounter);
-                let figureName = t(
-                    "figure-name",
-                    { parts: "numbered", enumeration: figureEnumeration },
-                    `Figure ${figureEnumeration}`,
-                );
+                const { figureName, figureNamePrefix } = composeFigureName({
+                    t: contentTranslator(dependencyValues),
+                    enumeration: figureEnumeration,
+                    haveCaptionChild: dependencyValues.captionChild.length > 0,
+                });
+
                 return {
-                    setValue: { figureEnumeration, figureName },
+                    setValue: {
+                        figureEnumeration,
+                        figureName,
+                        figureNamePrefix,
+                    },
                 };
             },
         };

--- a/packages/doenetml-worker-javascript/src/components/Table.js
+++ b/packages/doenetml-worker-javascript/src/components/Table.js
@@ -3,6 +3,7 @@ import {
     contentTranslator,
     returnContentLocaleDependencies,
 } from "../utils/contentLocale";
+import { composeTableName } from "../utils/containerWords";
 
 export default class Table extends BlockComponent {
     constructor(args) {
@@ -76,10 +77,27 @@ export default class Table extends BlockComponent {
                     description:
                         "The full display name of the table (e.g., 'Table 2').",
                 },
+                {
+                    // The same name with the separator that joins it to an
+                    // authored `<title>` — "Table 2: ". Not public and not a
+                    // cross-reference label: `tableName` above is what an
+                    // author references and what an `<xref>` shows, and
+                    // neither wants punctuation. This exists so that the
+                    // separator is the catalog's to choose rather than a
+                    // literal in the renderer (#1582).
+                    variableName: "tableNamePrefix",
+                    forRenderer: true,
+                },
             ],
             mustEvaluate: true, // must evaluate to make sure all counters are accounted for
             returnDependencies({ stateValues }) {
-                let dependencies = { ...returnContentLocaleDependencies() };
+                let dependencies = {
+                    titleChild: {
+                        dependencyType: "child",
+                        childGroups: ["titles"],
+                    },
+                    ...returnContentLocaleDependencies(),
+                };
 
                 if (stateValues.number) {
                     dependencies.tableCounter = {
@@ -90,28 +108,19 @@ export default class Table extends BlockComponent {
                 return dependencies;
             },
             definition({ dependencyValues }) {
-                const t = contentTranslator(dependencyValues);
+                const tableEnumeration =
+                    dependencyValues.tableCounter === undefined
+                        ? null
+                        : String(dependencyValues.tableCounter);
 
-                if (dependencyValues.tableCounter === undefined) {
-                    return {
-                        setValue: {
-                            tableEnumeration: null,
-                            tableName: t(
-                                "table-name",
-                                { parts: "unnumbered" },
-                                "Table",
-                            ),
-                        },
-                    };
-                }
-                let tableEnumeration = String(dependencyValues.tableCounter);
-                let tableName = t(
-                    "table-name",
-                    { parts: "numbered", enumeration: tableEnumeration },
-                    `Table ${tableEnumeration}`,
-                );
+                const { tableName, tableNamePrefix } = composeTableName({
+                    t: contentTranslator(dependencyValues),
+                    enumeration: tableEnumeration,
+                    haveTitleChild: dependencyValues.titleChild.length > 0,
+                });
+
                 return {
-                    setValue: { tableEnumeration, tableName },
+                    setValue: { tableEnumeration, tableName, tableNamePrefix },
                 };
             },
         };

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/containerWordsLocale.test.ts
@@ -64,6 +64,44 @@ describe("container words follow the document locale @group4", () => {
                 await values(doenetML, ["second"], "tableEnumeration", "es"),
             ).toEqual({ second: "2" });
         });
+
+        // #1582. The separator joining the name to an authored `<title>` was a
+        // `": "` in the renderer's JSX, so a Spanish document rendered a
+        // Spanish name with English punctuation and no locale could reach it.
+        // It is part of the name the worker composes now.
+        describe("the separator before an authored title", () => {
+            const titled = `
+            <table name="t"><title>Results</title><tabular><row><cell>1</cell></row></tabular></table>
+            <table name="untitled"><tabular><row><cell>2</cell></row></tabular></table>
+            <table name="bare" number="false"><title>Results</title><tabular><row><cell>3</cell></row></tabular></table>
+            `;
+
+            it("ends the renderer's prefix with it when a title follows", async () => {
+                expect(
+                    await values(titled, ["t", "bare"], "tableNamePrefix"),
+                ).toEqual({ t: "Table 1: ", bare: "Table: " });
+            });
+
+            it("leaves the prefix bare when nothing follows", async () => {
+                expect(
+                    await values(titled, ["untitled"], "tableNamePrefix"),
+                ).toEqual({ untitled: "Table 2" });
+            });
+
+            it("comes from the document's catalog, not from the renderer", async () => {
+                expect(
+                    await values(titled, ["t"], "tableNamePrefix", "es"),
+                ).toEqual({ t: "Tabla 1: " });
+            });
+
+            it("stays out of the name an author and a cross-reference read", async () => {
+                // `$table.tableName` and an `<xref>`'s label want the name
+                // alone; punctuation there would show up in both.
+                expect(await values(titled, ["t"], "tableName", "es")).toEqual({
+                    t: "Tabla 1",
+                });
+            });
+        });
     });
 
     describe("<figure>", () => {
@@ -87,6 +125,36 @@ describe("container words follow the document locale @group4", () => {
                 first: "Figura 1",
                 second: "Figura 2",
                 unnumbered: "Figura",
+            });
+        });
+
+        // The caption's half of #1582; see `<table>` above.
+        describe("the separator before an authored caption", () => {
+            const captioned = `
+            <figure name="f"><image source="doenet:a" /><caption>A picture</caption></figure>
+            <figure name="uncaptioned"><image source="doenet:b" /></figure>
+            `;
+
+            it("ends the renderer's prefix with it when a caption follows", async () => {
+                expect(
+                    await values(
+                        captioned,
+                        ["f", "uncaptioned"],
+                        "figureNamePrefix",
+                    ),
+                ).toEqual({ f: "Figure 1: ", uncaptioned: "Figure 2" });
+            });
+
+            it("comes from the document's catalog, not from the renderer", async () => {
+                expect(
+                    await values(captioned, ["f"], "figureNamePrefix", "es"),
+                ).toEqual({ f: "Figura 1: " });
+            });
+
+            it("stays out of the name an author and a cross-reference read", async () => {
+                expect(
+                    await values(captioned, ["f"], "figureName", "es"),
+                ).toEqual({ f: "Figura 1" });
             });
         });
     });

--- a/packages/doenetml-worker-javascript/src/utils/containerWords.js
+++ b/packages/doenetml-worker-javascript/src/utils/containerWords.js
@@ -1,0 +1,115 @@
+/**
+ * The name a `<table>` or `<figure>` gives itself — "Table 2", "Figure 3" —
+ * and the same name with the separator that joins it to the authored title or
+ * caption.
+ *
+ * Both reach the reader, so they are *content* and follow the document's
+ * language rather than the reader's UI language.
+ *
+ * ## Two values, one message
+ *
+ * The bare name is what `$table.tableName` reports and what a cross-reference
+ * labels itself with, so it cannot carry punctuation. The renderer needs the
+ * name *plus* its separator, because that separator is a translation decision
+ * and it used to be a literal `": "` written into the JSX, where no locale
+ * could reach it (#1582).
+ *
+ * They come out of one catalog message, selected on which pieces are present,
+ * rather than out of a message and a suffix the code appends: a language that
+ * orders or punctuates the join differently has to be able to say so in one
+ * place, and two places could drift.
+ *
+ * The title or caption itself is not an argument. It is arbitrary marked-up
+ * content the renderer prints after this string, so the branches that expect
+ * one end in the separator — the same shape `composeTitlePrefix` uses for a
+ * section.
+ *
+ * ## Written out one call per word
+ *
+ * `lint:i18n` reads translator call sites textually and only sees a key
+ * spelled as a string literal, so `<table>`'s composer and `<figure>`'s are
+ * two functions rather than one taking the message key as data.
+ *
+ * They are near-identical below, and that is deliberate rather than
+ * unfinished. Four things differ — the message key, the English word, the name
+ * `$parts` gives the branch that ends in a separator (`title` for a table's
+ * child element, `caption` for a figure's), and the two result properties —
+ * and the key has to stay a literal, so the only factoring left passes a bound
+ * translator down to a shared body. That trades two functions a reader can
+ * follow straight through for a callback plus two wrappers that are longer
+ * than what they replace, and it hides the `t` call from the branch that
+ * chooses its arguments. `sectionWords.js` makes the same trade for the same
+ * reason. A third container joining these two would be the point to revisit
+ * it.
+ */
+
+/**
+ * What a `<table>` calls itself, bare and with its separator.
+ *
+ * @param t The document's translator.
+ * @param enumeration The table's number as text, or `null` for an unnumbered
+ *   table.
+ * @param haveTitleChild Whether an authored `<title>` follows the name.
+ * @returns `{ tableName, tableNamePrefix }` — the bare name, and the name the
+ *   renderer prints before the title.
+ */
+export function composeTableName({ t, enumeration, haveTitleChild }) {
+    const numbered = enumeration !== null;
+    const englishName = numbered ? `Table ${enumeration}` : "Table";
+    const args = { enumeration: enumeration ?? "" };
+
+    const tableName = t(
+        "table-name",
+        { ...args, parts: numbered ? "numbered" : "unnumbered" },
+        englishName,
+    );
+
+    if (!haveTitleChild) {
+        // Nothing follows, so there is nothing to separate from. The prefix is
+        // still the bare name rather than absent, because the prototype's
+        // renderer prints it unconditionally.
+        return { tableName, tableNamePrefix: tableName };
+    }
+
+    const tableNamePrefix = t(
+        "table-name",
+        { ...args, parts: numbered ? "numbered-title" : "unnumbered-title" },
+        `${englishName}: `,
+    );
+    return { tableName, tableNamePrefix };
+}
+
+/**
+ * What a `<figure>` calls itself, bare and with its separator.
+ *
+ * @param t The document's translator.
+ * @param enumeration The figure's number as text, or `null` for an unnumbered
+ *   figure.
+ * @param haveCaptionChild Whether an authored `<caption>` follows the name.
+ * @returns `{ figureName, figureNamePrefix }` — see {@link composeTableName}.
+ */
+export function composeFigureName({ t, enumeration, haveCaptionChild }) {
+    const numbered = enumeration !== null;
+    const englishName = numbered ? `Figure ${enumeration}` : "Figure";
+    const args = { enumeration: enumeration ?? "" };
+
+    const figureName = t(
+        "figure-name",
+        { ...args, parts: numbered ? "numbered" : "unnumbered" },
+        englishName,
+    );
+
+    if (!haveCaptionChild) {
+        return { figureName, figureNamePrefix: figureName };
+    }
+
+    const figureNamePrefix = t(
+        "figure-name",
+        {
+            ...args,
+            parts: numbered ? "numbered-caption" : "unnumbered-caption",
+        },
+        `${englishName}: `,
+    );
+    return { figureName, figureNamePrefix };
+}

--- a/packages/doenetml-worker/src/jsRustConversions/table.ts
+++ b/packages/doenetml-worker/src/jsRustConversions/table.ts
@@ -11,6 +11,13 @@ import type { FlatDastElement } from "../CoreWorker";
  * the same role as `titlePrefix` does for sections.  `tableEnumeration` (the
  * bare number, e.g. "2") becomes both `codeNumber` and the ident fields for
  * cross-reference resolution.
+ *
+ * `titlePrefix` takes the *other* name the core composes, `tableNamePrefix`,
+ * which carries the separator joining it to an authored title ("Table 2: ").
+ * That is what makes it a title prefix rather than a label: the renderer
+ * prints it and the title after it and adds no punctuation of its own, so the
+ * separator is the catalog's to choose (#1582). A cross-reference label wants
+ * the bare name, which is why the two are different values.
  */
 export function tableJsToRust(
     props: Record<string, any>,
@@ -25,7 +32,7 @@ export function tableJsToRust(
     props.codeNumber = props.tableEnumeration ?? "";
     props.titlePrefix = props.suppressTableNameInTitle
         ? ""
-        : (props.tableName ?? "");
+        : (props.tableNamePrefix ?? "");
     props.divisionType = "table";
     // XXX: this is wrong; should be an actual depth to get the headings correct for accessibility.
     props.divisionDepth = 3;
@@ -51,4 +58,5 @@ export function tableJsToRust(
     delete props.tableEnumeration;
     delete props.titleChildName;
     delete props.tableName;
+    delete props.tableNamePrefix;
 }

--- a/packages/doenetml/src/Viewer/renderers/figure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/figure.tsx
@@ -10,6 +10,7 @@ interface FigureSVs {
     hidden: boolean;
     captionChildName?: any;
     figureName: string;
+    figureNamePrefix: string;
     suppressFigureNameInCaption: boolean;
 }
 
@@ -55,16 +56,22 @@ export default React.memo(function Figure(props: UseDoenetRendererProps) {
     }
 
     if (!SVs.suppressFigureNameInCaption) {
-        let figureName = <strong>{SVs.figureName}</strong>;
-        if (captionChild) {
-            caption = (
-                <div>
-                    {figureName}: {captionChild}
-                </div>
-            );
-        } else {
-            caption = <div>{figureName}</div>;
-        }
+        // The separator belongs to the name the worker composed, not to this
+        // JSX — see the same change in `table.tsx` (#1582). Which of the two
+        // names to print is decided here rather than taken from the worker's
+        // answer alone, because a caption child can exist without this
+        // renderer finding a node for it, and a dangling ": " would show.
+        const figureName = (
+            <strong>
+                {captionChild ? SVs.figureNamePrefix : SVs.figureName}
+            </strong>
+        );
+        caption = (
+            <div>
+                {figureName}
+                {captionChild}
+            </div>
+        );
     } else {
         if (captionChild) {
             caption = <div>{captionChild}</div>;

--- a/packages/doenetml/src/Viewer/renderers/table.tsx
+++ b/packages/doenetml/src/Viewer/renderers/table.tsx
@@ -9,6 +9,7 @@ interface TableSVs {
     hidden: boolean;
     suppressTableNameInTitle: boolean;
     tableName: string;
+    tableNamePrefix: string;
     title: string;
     titleChildName: string;
 }
@@ -60,16 +61,25 @@ export default React.memo(function Table(props: UseDoenetRendererProps) {
     }
 
     if (!SVs.suppressTableNameInTitle) {
-        let tableName = <strong>{SVs.tableName}</strong>;
-        if (title) {
-            title = (
-                <>
-                    {tableName}: {title}
-                </>
-            );
-        } else {
-            title = tableName;
-        }
+        // The separator between the name and the title is part of the name the
+        // worker composed, not a `": "` written here: it is a translation
+        // decision, and it used to be unreachable from any catalog (#1582).
+        // It falls inside the `<strong>` as a result, which is the trade the
+        // issue named and settled. Which of the two names to print is decided
+        // here rather than taken from the worker's answer alone, because a
+        // title child can exist without this renderer finding a node for it,
+        // and a dangling ": " would show.
+        const tableName = (
+            <strong>{title ? SVs.tableNamePrefix : SVs.tableName}</strong>
+        );
+        title = title ? (
+            <>
+                {tableName}
+                {title}
+            </>
+        ) : (
+            tableName
+        );
     }
 
     heading = <div id={id + "_title"}>{title}</div>;

--- a/packages/doenetml/test/cypress/component/DoenetViewer.captionSeparatorLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.captionSeparatorLocale.cy.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+
+// A table's and a figure's name came from the worker in the document's
+// language, and the `": "` joining it to the authored title or caption was
+// written into these renderers, where no catalog could reach it
+// (Doenet/DoenetML#1582). The whole prefix is one message now, so what is
+// asserted here is what a worker test cannot see: the text the reader gets,
+// and the markup the separator ended up inside.
+
+const VIEWER_TIMEOUT = 15_000;
+
+// The figure is "Figure 2" rather than "Figure 1": tables and figures share
+// the sectioning counter, so the table above it takes the first number.
+const DOENETML = `
+<table name="t">
+  <title>Resultados</title>
+  <tabular><row><cell>1</cell></row></tabular>
+</table>
+<figure name="f">
+  <image source="doenet:a" />
+  <caption>Una imagen</caption>
+</figure>
+`;
+
+describe("a table's and a figure's caption separator follows the document's language", () => {
+    it("punctuates the join from the catalog in Spanish", () => {
+        cy.mount(
+            <DoenetViewer
+                doenetML={DOENETML}
+                documentLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.contains("Tabla 1: Resultados", { timeout: VIEWER_TIMEOUT });
+        cy.contains("Figura 2: Una imagen");
+    });
+
+    it("renders the same text as before when the document declares no language", () => {
+        cy.mount(
+            <DoenetViewer doenetML={DOENETML} addVirtualKeyboard={false} />,
+        );
+
+        cy.contains("Table 1: Resultados", { timeout: VIEWER_TIMEOUT });
+        cy.contains("Figure 2: Una imagen");
+    });
+
+    it("puts the separator inside the bold name", () => {
+        // The decision #1582 needed: the separator is part of the name the
+        // catalog composes, so it is emphasized with it rather than sitting
+        // between two nodes. Pinned because it is the one thing about every
+        // existing document's markup that this changed.
+        cy.mount(
+            <DoenetViewer doenetML={DOENETML} addVirtualKeyboard={false} />,
+        );
+
+        cy.contains("strong", "Table 1", { timeout: VIEWER_TIMEOUT }).should(
+            "have.text",
+            "Table 1: ",
+        );
+        cy.contains("strong", "Figure 2").should("have.text", "Figure 2: ");
+    });
+
+    it("leaves the name bare when nothing follows it", () => {
+        cy.mount(
+            <DoenetViewer
+                doenetML={`<table name="t"><tabular><row><cell>1</cell></row></tabular></table>`}
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.contains("strong", "Table 1", { timeout: VIEWER_TIMEOUT }).should(
+            "have.text",
+            "Table 1",
+        );
+    });
+});

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -313,16 +313,27 @@ hint-title = Hint
 ##
 ## `$enumeration` arrives as text rather than as a number: it identifies the
 ## table, so the thousandth one is "Table 1000" and not "Table 1,000".
+##
+## The `-title` and `-caption` branches end in the separator joining the name
+## to the authored title or caption, which the renderer used to write as a
+## literal `": "` of its own. That child is arbitrary marked-up content
+## rendered after this string rather than an argument passed into it, so where
+## it sits is the one thing a translation cannot reorder — the same shape
+## `section-title-prefix` has.
 
 table-name =
     { $parts ->
         [numbered] Table { $enumeration }
+        [numbered-title] Table { $enumeration }{ ": " }
+        [unnumbered-title] Table{ ": " }
        *[unnumbered] Table
     }
 
 figure-name =
     { $parts ->
         [numbered] Figure { $enumeration }
+        [numbered-caption] Figure { $enumeration }{ ": " }
+        [unnumbered-caption] Figure{ ": " }
        *[unnumbered] Figure
     }
 

--- a/packages/i18n/locales/es/content.ftl
+++ b/packages/i18n/locales/es/content.ftl
@@ -258,12 +258,16 @@ hint-title = Pista
 table-name =
     { $parts ->
         [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
        *[unnumbered] Tabla
     }
 
 figure-name =
     { $parts ->
         [numbered] Figura { $enumeration }
+        [numbered-caption] Figura { $enumeration }{ ": " }
+        [unnumbered-caption] Figura{ ": " }
        *[unnumbered] Figura
     }
 


### PR DESCRIPTION
Based on `main`, now that #1583 has merged. This PR is one commit.

Closes #1582.

## What was English

#1574 made `<table>` and `<figure>` name themselves in the document's language. The `": "` joining that name to the authored title or caption stayed in the renderer:

```jsx
let tableName = <strong>{SVs.tableName}</strong>;
if (title) {
    title = <>{tableName}: {title}</>;
}
```

So a Spanish activity rendered **`Tabla 2`: pie de foto** — the name from the catalog and the punctuation from English, with no locale able to reach the second half. `<section>`'s renderer prints `{titlePrefix}{title}` and adds nothing; these two were the last doing it the old way.

## The bolding decision

The issue held this back because it is not only a message: the name is bold and the separator is not, so moving the separator into the catalog either bolds it too or splits the message across two nodes.

**The separator is bold.** `<strong>Table 2: </strong>caption` rather than `<strong>Table 2</strong>: caption`. That is the whole visible change to every existing document, and it buys the thing the split would not: the catalog owns the entire join, so a language that puts the number after the word, or the title before the name, or uses ` : ` with a space either side, says so in one place. A message split across two nodes can repunctuate the join but never reorder it.

## Two values, one message

`tableName` stays the bare name. It is public — `$table.tableName` — and it is what an `<xref>` labels itself with, and neither wants punctuation. A second `forRenderer` state variable, `tableNamePrefix`, carries the name plus its separator, the way `titlePrefix` does for a section.

Both come out of one `table-name` message selected on which pieces are present, rather than out of a message plus a suffix the code appends, so the two cannot drift:

```
table-name =
    { $parts ->
        [numbered] Table { $enumeration }
        [numbered-title] Table { $enumeration }{ ": " }
        [unnumbered-title] Table{ ": " }
       *[unnumbered] Table
    }
```

The `-title` and `-caption` branches end in the separator because the child is arbitrary marked-up content rendered after this string rather than an argument passed into it — the same shape `section-title-prefix` has, and the one thing a translation cannot reorder here.

`utils/containerWords.js` holds the two composers, beside `sectionWords.js`.

The renderer still decides for itself which of the two names to print, rather than taking the worker's `haveTitleChild` answer as final: a title or caption child can exist without the renderer finding a node for it, and in that case the bare name is what should show. The prefix falls back to the bare name when nothing follows, because the prototype's renderer prints it unconditionally.

## Also the prototype

`jsRustConversions/table.ts` built the prototype renderer's `titlePrefix` from the bare name, and `doenetml-prototype`'s `table.tsx` added its own `":"`. Same bug, same fix: the conversion takes `tableNamePrefix` and the renderer adds nothing. The cross-reference label still takes the bare name, which is why the two are different values.

`<figure>` has no rust conversion, so it is unaffected there.

One rendered difference falls out of that renderer: it printed a space after the name unconditionally, so an untitled table's prefix span was `"Table 2 "`. It is `"Table 2"` now — nothing follows it either way, and the comment there says so.

## On the two composers being near-identical

`composeTableName` and `composeFigureName` are the same twenty lines twice, and the file's doc comment says why that is the intended shape rather than unfinished work: the message key has to stay a string literal for `lint:i18n` to see it, so the only factoring left passes a bound translator into a shared body — which comes out longer than the two functions it replaces and hides the `t` call from the branch choosing its arguments. `sectionWords.js` makes the same trade. A third container joining these two would be the point to revisit it.

## Tests

`containerWordsLocale.test.ts` gains a block per component: the prefix ends in the separator when a title or caption follows, stays bare when nothing does, comes from the document's catalog in Spanish, and the bare name an author reads stays free of punctuation.

`DoenetViewer.captionSeparatorLocale.cy.tsx` is the half a worker test cannot see — the text the reader gets (`Tabla 1: Resultados`, `Figura 2: Una imagen`), the same text in English, and the markup the separator ended up inside, pinned because it is what changed for every existing document.

Regression: `containerWordsLocale`, the chemistry and section suites, `lint:i18n` (470 keys, 297 call sites), the caption-separator component spec (4), and `build:schema` produces no diff — the new state variables are `forRenderer` only, so the schema does not see them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


