### PR TITLE
Speak the editor's chrome in the reader's language

### DIFF
--- a/.changeset/editor-chrome-locale.md
+++ b/.changeset/editor-chrome-locale.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Render the editor's own chrome in the reader's language.
+
+The viewer chrome was translated; the editor's was not, so a reader who set `uiLocale="es"` — or opened a document declaring `<document lang="es">` — got a Spanish document inside an English editor. It showed worst in the Diagnostics panel, where a translated message sat beside an untranslated `Line #2`.
+
+The footer, the diagnostics and responses panels, the variant picker, the accessibility button and the update button all follow the same language now, and that language is the one the viewer resolved rather than the one the surrounding host chrome uses — so the two halves of the editor can never disagree. Spanish translations ship with it.

--- a/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
+++ b/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
@@ -1,11 +1,27 @@
 import React from "react";
 import { IoAccessibility } from "react-icons/io5";
+import { useT } from "../utils/i18n";
 
 /**
- * Returns the tooltip text for the accessibility status button.
- * The message varies by accessibility severity and whether the report is open.
+ * The arguments both of the button's sentences are selected on: which of the
+ * three things it has to say, how many of them, and whether clicking opens the
+ * report or closes it.
+ *
+ * The tooltip and the label both branch on this, and both used to build their
+ * English with an `if` per branch and an interpolated verb — `Click to
+ * ${action} accessibility report` — with the plural spelled by hand
+ * (`violation${count === 1 ? "" : "s"}`). None of that is reachable from a
+ * catalog, and none of it is how every language works, so the branch and the
+ * count go to Fluent as arguments and the sentences are selected there
+ * (#1580).
  */
-function getAccessibilityStatusTitle({
+type AccessibilityStatus = {
+    status: "violations" | "advisories" | "clean";
+    count: number;
+    action: "open" | "close";
+};
+
+function accessibilityStatus({
     accessibilityLevel1Count,
     accessibilityLevel2Count,
     isAccessibilityReportOpen,
@@ -13,42 +29,45 @@ function getAccessibilityStatusTitle({
     accessibilityLevel1Count: number;
     accessibilityLevel2Count: number;
     isAccessibilityReportOpen: boolean;
-}) {
+}): AccessibilityStatus {
     const action = isAccessibilityReportOpen ? "close" : "open";
 
     if (accessibilityLevel1Count > 0) {
+        return {
+            status: "violations",
+            count: accessibilityLevel1Count,
+            action,
+        };
+    }
+    if (accessibilityLevel2Count > 0) {
+        return {
+            status: "advisories",
+            count: accessibilityLevel2Count,
+            action,
+        };
+    }
+    return { status: "clean", count: 0, action };
+}
+
+/** The English the catalog falls back to, for the tooltip. */
+function englishTitle({ status, action }: AccessibilityStatus) {
+    if (status === "violations") {
         return `WCAG AA accessibility violation identified. Click to ${action} accessibility report.`;
     }
-
-    if (accessibilityLevel2Count > 0) {
+    if (status === "advisories") {
         return `Click to ${action} accessibility report. No WCAG AA violations were found, but additional accessibility recommendations are available.`;
     }
-
     return `Click to ${action} accessibility report. No accessibility issues were found.`;
 }
 
-/**
- * Returns an accessible label that includes diagnostic counts and toggle action.
- */
-function getAccessibilityStatusAriaLabel({
-    accessibilityLevel1Count,
-    accessibilityLevel2Count,
-    isAccessibilityReportOpen,
-}: {
-    accessibilityLevel1Count: number;
-    accessibilityLevel2Count: number;
-    isAccessibilityReportOpen: boolean;
-}) {
-    const action = isAccessibilityReportOpen ? "close" : "open";
-
-    if (accessibilityLevel1Count > 0) {
-        return `WCAG AA accessibility violation identified. ${accessibilityLevel1Count} WCAG AA violation${accessibilityLevel1Count === 1 ? "" : "s"} found. Click to ${action} accessibility report.`;
+/** The English the catalog falls back to, for the accessible name. */
+function englishLabel({ status, count, action }: AccessibilityStatus) {
+    if (status === "violations") {
+        return `WCAG AA accessibility violation identified. ${count} WCAG AA violation${count === 1 ? "" : "s"} found. Click to ${action} accessibility report.`;
     }
-
-    if (accessibilityLevel2Count > 0) {
-        return `No WCAG AA violations identified. ${accessibilityLevel2Count} additional accessibility recommendation${accessibilityLevel2Count === 1 ? "" : "s"} found. Click to ${action} accessibility report.`;
+    if (status === "advisories") {
+        return `No WCAG AA violations identified. ${count} additional accessibility recommendation${count === 1 ? "" : "s"} found. Click to ${action} accessibility report.`;
     }
-
     return `No WCAG AA violations identified. Click to ${action} accessibility report.`;
 }
 
@@ -66,6 +85,13 @@ export function AccessibilityStatusButton({
     isAccessibilityReportOpen: boolean;
     onToggle: () => void;
 }) {
+    const t = useT();
+    const args = accessibilityStatus({
+        accessibilityLevel1Count,
+        accessibilityLevel2Count,
+        isAccessibilityReportOpen,
+    });
+
     return (
         <button
             type="button"
@@ -75,21 +101,22 @@ export function AccessibilityStatusButton({
                     : "no-level-1-issues"
             }`}
             onClick={onToggle}
-            title={getAccessibilityStatusTitle({
-                accessibilityLevel1Count,
-                accessibilityLevel2Count,
-                isAccessibilityReportOpen,
-            })}
-            aria-label={getAccessibilityStatusAriaLabel({
-                accessibilityLevel1Count,
-                accessibilityLevel2Count,
-                isAccessibilityReportOpen,
-            })}
+            title={t("editor-accessibility-title", args, englishTitle(args))}
+            aria-label={t(
+                "editor-accessibility-label",
+                args,
+                englishLabel(args),
+            )}
         >
             {accessibilityLevel1Count > 0 ? (
                 <>
                     <IoAccessibility />
-                    <span>WCAG</span>
+                    {/* The name of the standard, not a word — it stays as it
+                        is in every language, the way the `es` catalog already
+                        leaves it in `accessibility-heading-level-1`. */}
+                    <span>
+                        {t("editor-accessibility-badge", undefined, "WCAG")}
+                    </span>
                 </>
             ) : (
                 <IoAccessibility />

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -16,6 +16,9 @@ import {
 import { renderDiagnosticMarkdownHtml } from "@doenet/utils/diagnostics/renderDiagnosticMarkdownHtml";
 import type { HelpContent } from "@doenet/lsp-tools";
 import { ContextHelpPanel } from "./contextHelp/ContextHelpPanel";
+import { useT } from "../utils/i18n";
+import { fillSlots, slot } from "./slots";
+import type { Translator } from "@doenet/i18n";
 
 type SubmittedResponse = {
     answerId: string;
@@ -28,13 +31,24 @@ type SubmittedResponse = {
 export type DiagnosticsTabId =
     "errors" | "warnings" | "info" | "accessibility" | "responses" | "help";
 
-/** Human-readable label for diagnostic source line, when position exists. */
-function diagnosticLocationLabel(diagnostic: {
-    position?: { start: { line: number } };
-}) {
-    return diagnostic.position
-        ? `Line #${diagnostic.position.start.line}`
-        : null;
+/**
+ * Human-readable label for diagnostic source line, when position exists.
+ *
+ * The line arrives as text rather than as a number, so Fluent hands it to no
+ * `Intl.NumberFormat`: it identifies the line, and line 1234 is "#1234" rather
+ * than "#1,234". Same rule `rangeArgs` follows for the error box.
+ */
+function diagnosticLocationLabel(
+    t: Translator,
+    diagnostic: {
+        position?: { start: { line: number } };
+    },
+) {
+    if (!diagnostic.position) {
+        return null;
+    }
+    const line = String(diagnostic.position.start.line);
+    return t("editor-diagnostic-line", { line }, `Line #${line}`);
 }
 
 /** Stable identity for diagnostic list rendering keys. */
@@ -93,6 +107,7 @@ function DiagnosticList({
     icon: ReactElement;
     iconClassName: string;
 }) {
+    const t = useT();
     if (diagnostics.length === 0) {
         return <>{emptyMessage}</>;
     }
@@ -102,7 +117,7 @@ function DiagnosticList({
     return (
         <ul className="diagnostic-list">
             {diagnostics.map((diagnostic, i) => {
-                const location = diagnosticLocationLabel(diagnostic);
+                const location = diagnosticLocationLabel(t, diagnostic);
                 const identity = diagnosticIdentityKey(diagnostic);
                 const currentCount =
                     diagnosticIdentityCounts.get(identity) ?? 0;
@@ -140,6 +155,35 @@ function DiagnosticList({
                 );
             })}
         </ul>
+    );
+}
+
+/** The name of the standard, which no locale translates. */
+const WCAG_AA = "WCAG AA";
+
+const WCAG_URL = "https://www.w3.org/WAI/standards-guidelines/wcag/";
+
+/**
+ * "Accessibility violations (WCAG AA)", with the standard's name linked.
+ *
+ * The heading is one message rather than two halves with a link between them,
+ * so its wording and the brackets around the name are the catalog's while the
+ * link stays the code's — see {@link fillSlots} for the mechanism and why the
+ * argument is a marker rather than the name itself.
+ */
+function AccessibilityViolationsHeading() {
+    const t = useT();
+    return fillSlots(
+        t(
+            "editor-accessibility-violations-heading",
+            { standard: slot(0) },
+            `Accessibility violations (${slot(0)})`,
+        ),
+        [
+            <a href={WCAG_URL} target="_blank">
+                {WCAG_AA}
+            </a>,
+        ],
     );
 }
 
@@ -204,6 +248,7 @@ export function DiagnosticsResponseTabContents({
     helpContent: HelpContent;
     docsURL: string;
 }) {
+    const t = useT();
     const panels = useRef<HTMLDivElement>(null);
     const lastScrolledToBottom = useRef(true);
 
@@ -290,7 +335,15 @@ export function DiagnosticsResponseTabContents({
                             >
                                 <DiagnosticList
                                     diagnostics={errors}
-                                    emptyMessage={<h3>No Errors</h3>}
+                                    emptyMessage={
+                                        <h3>
+                                            {t(
+                                                "editor-no-errors",
+                                                undefined,
+                                                "No Errors",
+                                            )}
+                                        </h3>
+                                    }
                                     testPrefix="Error"
                                     icon={<BsXOctagonFill />}
                                     iconClassName="is-error"
@@ -305,7 +358,15 @@ export function DiagnosticsResponseTabContents({
                             >
                                 <DiagnosticList
                                     diagnostics={warnings}
-                                    emptyMessage={<h3>No Warnings</h3>}
+                                    emptyMessage={
+                                        <h3>
+                                            {t(
+                                                "editor-no-warnings",
+                                                undefined,
+                                                "No Warnings",
+                                            )}
+                                        </h3>
+                                    }
                                     testPrefix="Warning"
                                     icon={<BsExclamationTriangleFill />}
                                     iconClassName="is-warning"
@@ -320,12 +381,24 @@ export function DiagnosticsResponseTabContents({
                             >
                                 <AnnotationToggle
                                     checked={showInfoAnnotations}
-                                    label="Show info diagnostics in editor"
+                                    label={t(
+                                        "editor-show-info-annotations",
+                                        undefined,
+                                        "Show info diagnostics in editor",
+                                    )}
                                     onChange={setShowInfoAnnotations}
                                 />
                                 <DiagnosticList
                                     diagnostics={infos}
-                                    emptyMessage={<h3>No Info Diagnostics</h3>}
+                                    emptyMessage={
+                                        <h3>
+                                            {t(
+                                                "editor-no-info",
+                                                undefined,
+                                                "No Info Diagnostics",
+                                            )}
+                                        </h3>
+                                    }
                                     testPrefix="Info"
                                     icon={<BsInfoCircleFill />}
                                     iconClassName="is-info"
@@ -340,7 +413,11 @@ export function DiagnosticsResponseTabContents({
                             >
                                 <AnnotationToggle
                                     checked={showAccessibilityAnnotations}
-                                    label="Show accessibility diagnostics in editor"
+                                    label={t(
+                                        "editor-show-accessibility-annotations",
+                                        undefined,
+                                        "Show accessibility diagnostics in editor",
+                                    )}
                                     onChange={setShowAccessibilityAnnotations}
                                 />
                                 <p className="accessibility-report-intro">
@@ -349,26 +426,30 @@ export function DiagnosticsResponseTabContents({
                                         target="_blank"
                                         rel="noreferrer"
                                     >
-                                        Learn how Doenet approaches
-                                        accessibility
+                                        {t(
+                                            "editor-accessibility-learn-more",
+                                            undefined,
+                                            "Learn how Doenet approaches accessibility",
+                                        )}
                                     </a>
                                 </p>
                                 <section className="accessibility-report-section">
                                     <div className="accessibility-report-heading critical">
                                         <h3>
-                                            Accessibility violations (
-                                            <a
-                                                href="https://www.w3.org/WAI/standards-guidelines/wcag/"
-                                                target="_blank"
-                                            >
-                                                WCAG AA
-                                            </a>
-                                            )
+                                            <AccessibilityViolationsHeading />
                                         </h3>
                                     </div>
                                     <DiagnosticList
                                         diagnostics={level1Accessibility}
-                                        emptyMessage={<p>None found</p>}
+                                        emptyMessage={
+                                            <p>
+                                                {t(
+                                                    "editor-none-found",
+                                                    undefined,
+                                                    "None found",
+                                                )}
+                                            </p>
+                                        }
                                         testPrefix="WCAG AA Accessibility Violation"
                                         icon={<IoAccessibility />}
                                         iconClassName="is-accessibility-critical"
@@ -376,11 +457,25 @@ export function DiagnosticsResponseTabContents({
                                 </section>
                                 <section className="accessibility-report-section">
                                     <div className="accessibility-report-heading advisory">
-                                        <h3>Other accessibility issues</h3>
+                                        <h3>
+                                            {t(
+                                                "editor-accessibility-other-heading",
+                                                undefined,
+                                                "Other accessibility issues",
+                                            )}
+                                        </h3>
                                     </div>
                                     <DiagnosticList
                                         diagnostics={level2Accessibility}
-                                        emptyMessage={<p>None found</p>}
+                                        emptyMessage={
+                                            <p>
+                                                {t(
+                                                    "editor-none-found",
+                                                    undefined,
+                                                    "None found",
+                                                )}
+                                            </p>
+                                        }
                                         testPrefix="Accessibility alert"
                                         icon={<IoAccessibility />}
                                         iconClassName="is-accessibility-advisory"
@@ -395,21 +490,45 @@ export function DiagnosticsResponseTabContents({
                                 className="diagnostic-panel"
                             >
                                 {submittedResponses.length == 0 ? (
-                                    <h3>No submitted responses yet</h3>
+                                    <h3>
+                                        {t(
+                                            "editor-no-responses",
+                                            undefined,
+                                            "No submitted responses yet",
+                                        )}
+                                    </h3>
                                 ) : (
                                     <div style={{ minWidth: "fit-content" }}>
                                         <table>
                                             <thead>
                                                 <tr>
                                                     <th scope="col">
-                                                        Answer Id
+                                                        {t(
+                                                            "editor-response-answer-id",
+                                                            undefined,
+                                                            "Answer Id",
+                                                        )}
                                                     </th>
                                                     <th scope="col">
-                                                        Response
+                                                        {t(
+                                                            "editor-response-response",
+                                                            undefined,
+                                                            "Response",
+                                                        )}
                                                     </th>
-                                                    <th scope="col">Credit</th>
                                                     <th scope="col">
-                                                        Submitted
+                                                        {t(
+                                                            "editor-response-credit",
+                                                            undefined,
+                                                            "Credit",
+                                                        )}
+                                                    </th>
+                                                    <th scope="col">
+                                                        {t(
+                                                            "editor-response-submitted",
+                                                            undefined,
+                                                            "Submitted",
+                                                        )}
                                                     </th>
                                                 </tr>
                                             </thead>

--- a/packages/doenetml/src/EditorViewer/EditorFooter.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorFooter.tsx
@@ -25,6 +25,7 @@ import { IoAccessibility, IoAccessibilityOutline } from "react-icons/io5";
 import classNames from "classnames";
 import type { DiagnosticsTabId } from "./DiagnosticsResponseTabs";
 import type { DiagnosticsSummary } from "./diagnostics";
+import { useT } from "../utils/i18n";
 
 /**
  * Tab trigger with icon + optional count badge used by the editor footer to
@@ -32,6 +33,10 @@ import type { DiagnosticsSummary } from "./diagnostics";
  * footer so an active+selected click can close the panel rather than re-select.
  * Pass `inlineLabel` to render a short text label next to the icon (used by
  * the help tab); otherwise pass `count` to render a numeric badge.
+ *
+ * The accessible name joins the label to its count through the catalog rather
+ * than through a template literal: the separator is punctuation, and which
+ * punctuation is a translation decision (#1580).
  */
 function TabTrigger({
     id,
@@ -50,11 +55,20 @@ function TabTrigger({
     iconClassName?: string;
     onActivate: (tabId: DiagnosticsTabId) => void;
 }) {
+    const t = useT();
     return (
         <Tab
             id={id}
             title={label}
-            aria-label={count === undefined ? label : `${label}: ${count}`}
+            aria-label={
+                count === undefined
+                    ? label
+                    : t(
+                          "editor-tab-with-count",
+                          { label, count },
+                          `${label}: ${count}`,
+                      )
+            }
             className="diagnostic-tab-trigger"
             data-test={`footer-tab-${id}`}
             onClick={() => onActivate(id)}
@@ -122,8 +136,12 @@ export function EditorFooter({
     } = diagnosticsSummary;
     const accessibilityCount =
         accessibilityLevel1Count + accessibilityLevel2Count;
-
     const anyTabs = showDiagnostics || showResponses || showHelp;
+
+    const t = useT();
+    // The menu button's tooltip and its accessible name are the same words, so
+    // they are the same message resolved once.
+    const editorOptions = t("editor-options", undefined, "Editor options");
 
     return (
         <div
@@ -133,7 +151,11 @@ export function EditorFooter({
         >
             <div
                 className="doenetml-version"
-                title={`DoenetML version ${DOENETML_VERSION}`}
+                title={t(
+                    "editor-version-title",
+                    { version: DOENETML_VERSION },
+                    `DoenetML version ${DOENETML_VERSION}`,
+                )}
             >
                 v{DOENETML_VERSION}
             </div>
@@ -150,8 +172,16 @@ export function EditorFooter({
                                 id="help"
                                 icon={<BsCodeSlash />}
                                 iconClassName="is-help"
-                                label="Context-sensitive help"
-                                inlineLabel="Context"
+                                label={t(
+                                    "editor-tab-help",
+                                    undefined,
+                                    "Context-sensitive help",
+                                )}
+                                inlineLabel={t(
+                                    "editor-tab-help-short",
+                                    undefined,
+                                    "Context",
+                                )}
                                 onActivate={activateTab}
                             />
                         )}
@@ -174,7 +204,11 @@ export function EditorFooter({
                                 iconClassName={
                                     errorsCount > 0 ? "is-error" : undefined
                                 }
-                                label="Errors"
+                                label={t(
+                                    "editor-tab-errors",
+                                    undefined,
+                                    "Errors",
+                                )}
                                 count={errorsCount}
                                 onActivate={activateTab}
                             />
@@ -192,7 +226,11 @@ export function EditorFooter({
                                 iconClassName={
                                     warningsCount > 0 ? "is-warning" : undefined
                                 }
-                                label="Warnings"
+                                label={t(
+                                    "editor-tab-warnings",
+                                    undefined,
+                                    "Warnings",
+                                )}
                                 count={warningsCount}
                                 onActivate={activateTab}
                             />
@@ -210,7 +248,7 @@ export function EditorFooter({
                                 iconClassName={
                                     infosCount > 0 ? "is-info" : undefined
                                 }
-                                label="Info"
+                                label={t("editor-tab-info", undefined, "Info")}
                                 count={infosCount}
                                 onActivate={activateTab}
                             />
@@ -232,7 +270,11 @@ export function EditorFooter({
                                           ? "is-accessibility-advisory"
                                           : undefined
                                 }
-                                label="Accessibility"
+                                label={t(
+                                    "editor-tab-accessibility",
+                                    undefined,
+                                    "Accessibility",
+                                )}
                                 count={accessibilityCount}
                                 onActivate={activateTab}
                             />
@@ -258,7 +300,11 @@ export function EditorFooter({
                                         ? "is-responses"
                                         : undefined
                                 }
-                                label="Submitted responses"
+                                label={t(
+                                    "editor-tab-responses",
+                                    undefined,
+                                    "Submitted responses",
+                                )}
                                 count={submittedResponsesCount}
                                 onActivate={activateTab}
                             />
@@ -270,8 +316,8 @@ export function EditorFooter({
                 <MenuProvider>
                     <MenuButton
                         className="footer-menu-button"
-                        title="Editor options"
-                        aria-label="Editor options"
+                        title={editorOptions}
+                        aria-label={editorOptions}
                         data-test="footer-menu-button"
                     >
                         <BsThreeDotsVertical />
@@ -289,7 +335,11 @@ export function EditorFooter({
                             }}
                             data-test="footer-menu-format-doenetml"
                         >
-                            Format as DoenetML
+                            {t(
+                                "editor-format-as-doenetml",
+                                undefined,
+                                "Format as DoenetML",
+                            )}
                         </MenuItem>
                         <MenuItem
                             className="footer-menu-item"
@@ -303,7 +353,11 @@ export function EditorFooter({
                             }}
                             data-test="footer-menu-format-xml"
                         >
-                            Format as XML
+                            {t(
+                                "editor-format-as-xml",
+                                undefined,
+                                "Format as XML",
+                            )}
                         </MenuItem>
                     </Menu>
                 </MenuProvider>

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -41,7 +41,7 @@ import { EditorSelection, type Extension } from "@codemirror/state";
 import type { Completion } from "@codemirror/autocomplete";
 import { doenetGlobalConfig } from "../global-config";
 import type { DiagnosticArgs } from "@doenet/i18n";
-import { useChromeTranslator, useUiLocale } from "../utils/i18n";
+import { I18nProvider, useChromeTranslator, useUiLocale } from "../utils/i18n";
 import { useDiagnosticFormatter } from "../utils/diagnostics";
 import type {
     DiagnosticPresentation,
@@ -263,7 +263,12 @@ export const EditorViewer = React.forwardRef<
 
     const [codeChanged, setCodeChanged] = useState(false);
     const [documentInteracted, setDocumentInteracted] = useState(false);
-    const [updateWord, setUpdateWord] = useState("Reset");
+    // Which of the two states the button is in, not the word it shows. The
+    // word is translated at render, so a language change mid-session cannot
+    // leave the previous language's word sitting in state (#1580).
+    const [updateAction, setUpdateAction] = useState<"reset" | "update">(
+        "reset",
+    );
 
     const codeChangedRef = useRef(false); //To keep value up to date in the code mirror function
     codeChangedRef.current = codeChanged;
@@ -513,26 +518,27 @@ export const EditorViewer = React.forwardRef<
         setReceivedDiagnosticsFromViewer(true);
     }
 
-    // Everything the editor says about a diagnostic — the tooltip over a
-    // squiggle and the lint panel behind it — in the reader's language.
+    // The language the whole editor speaks — the footer, the diagnostics
+    // panel, the variant picker, the hover over a squiggle, all of it.
     //
     // That language is whichever one the viewer below resolved, not the one
-    // the editor's own chrome uses: the records in the Diagnostics tab were
+    // the surrounding host chrome uses. The panel lists diagnostics that were
     // rendered down there, where an authored `<document lang>` is known, and
-    // the hover renders the same diagnostics a second time. Until the source
-    // has been parsed there is nothing to report, so the props-only answer the
-    // surrounding chrome uses stands in.
+    // the hover renders the same diagnostics a second time — so binding only
+    // those to it would leave "Line #2" in English beside a Spanish message.
+    // One scope for the editor, decided once (#1580): a footer in one language
+    // above a panel in another reads worse than either choice on its own.
+    //
+    // Until the source has been parsed there is nothing to report, so the
+    // props-only answer the surrounding chrome uses stands in.
     const [viewerUiLocale, setViewerUiLocale] = useState<string | null>(null);
     const hostUiLocale = useUiLocale();
-    const diagnosticLocale = viewerUiLocale ?? hostUiLocale;
+    const editorLocale = viewerUiLocale ?? hostUiLocale;
     // Bound to `translate` on purpose: `lint:i18n` only recognizes call sites
     // through a translator named `t` or `translate`, so the keys reached below
     // would otherwise read as orphans.
-    const translate = useChromeTranslator(diagnosticLocale, localeResources);
-    const formatDiagnostic = useDiagnosticFormatter(
-        translate,
-        diagnosticLocale,
-    );
+    const translate = useChromeTranslator(editorLocale, localeResources);
+    const formatDiagnostic = useDiagnosticFormatter(translate, editorLocale);
 
     const accessibilityHeadings = useMemo(
         () => ({
@@ -704,7 +710,7 @@ export const EditorViewer = React.forwardRef<
                 if (data.verb !== "experienced" && data.verb !== "isVisible") {
                     setDocumentInteracted(true);
                     if (!codeChangedRef.current) {
-                        setUpdateWord("Reset");
+                        setUpdateAction("reset");
                     }
                 }
                 if (data.verb === "submitted") {
@@ -790,7 +796,7 @@ export const EditorViewer = React.forwardRef<
 
             if (!codeChangedRef.current) {
                 setCodeChanged(true);
-                setUpdateWord("Update");
+                setUpdateAction("update");
             }
 
             immediateDoenetmlChangeCallbackRef.current?.(value);
@@ -1309,7 +1315,7 @@ export const EditorViewer = React.forwardRef<
                 readOnly={readOnly}
                 codeChanged={codeChanged}
                 documentInteracted={documentInteracted}
-                updateWord={updateWord}
+                updateAction={updateAction}
                 onUpdateViewer={updateViewer}
                 variants={variants}
                 setVariants={setVariants}
@@ -1376,19 +1382,27 @@ export const EditorViewer = React.forwardRef<
     const viewerFirst = viewerLocation === "left" || viewerLocation === "top";
 
     return (
-        <div data-theme={darkMode} style={{ display: "contents" }}>
-            <ResizablePanelPair
-                panelA={viewerFirst ? viewerPanel : editorPanel}
-                panelB={viewerFirst ? editorPanel : viewerPanel}
-                preferredDirection={
-                    viewerLocation === "bottom" || viewerLocation === "top"
-                        ? "vertical"
-                        : "horizontal"
-                }
-                width={width}
-                height={height}
-                border={border}
-            />
-        </div>
+        // A third provider, between the one `doenetml.tsx` mounts from the
+        // props and the one `DocViewer` mounts once it has parsed the source.
+        // Everything the editor draws reads `editorLocale` from here; the
+        // viewer nests its own inside and wins for the document itself, which
+        // is the same split as before — the two only ever differ while the
+        // first parse is still in flight.
+        <I18nProvider translate={translate} locale={editorLocale}>
+            <div data-theme={darkMode} style={{ display: "contents" }}>
+                <ResizablePanelPair
+                    panelA={viewerFirst ? viewerPanel : editorPanel}
+                    panelB={viewerFirst ? editorPanel : viewerPanel}
+                    preferredDirection={
+                        viewerLocation === "bottom" || viewerLocation === "top"
+                            ? "vertical"
+                            : "horizontal"
+                    }
+                    width={width}
+                    height={height}
+                    border={border}
+                />
+            </div>
+        </I18nProvider>
     );
 });

--- a/packages/doenetml/src/EditorViewer/VariantSelect.tsx
+++ b/packages/doenetml/src/EditorViewer/VariantSelect.tsx
@@ -2,6 +2,7 @@ import * as Ariakit from "@ariakit/react";
 import React, { useEffect, useState } from "react";
 import { BsCaretDownFill, BsCaretUpFill } from "react-icons/bs";
 import type { ResolvedTheme } from "../utils/theme";
+import { useT } from "../utils/i18n";
 import "./variant-select.css";
 
 export default function VariantSelect({
@@ -15,6 +16,7 @@ export default function VariantSelect({
     onChange: (index: number) => void;
     syncIndex?: number;
 }) {
+    const t = useT();
     const [index, setIndex] = useState(0);
     const [inputValue, setInputValue] = useState("");
     const value = array[index] ?? "";
@@ -58,7 +60,7 @@ export default function VariantSelect({
                     >
                         <Ariakit.Select
                             className="doenet-ui-button button select-button"
-                            title="Variant"
+                            title={t("editor-variant", undefined, "Variant")}
                         />
                         <Ariakit.SelectPopover
                             gutter={4}
@@ -69,7 +71,11 @@ export default function VariantSelect({
                             <div className="combobox-wrapper">
                                 <Ariakit.Combobox
                                     autoSelect
-                                    placeholder="Filter..."
+                                    placeholder={t(
+                                        "editor-variant-filter",
+                                        undefined,
+                                        "Filter...",
+                                    )}
                                     className="combobox"
                                 />
                             </div>
@@ -88,7 +94,11 @@ export default function VariantSelect({
                 </Ariakit.ComboboxProvider>
             </div>
             <Ariakit.Button
-                title="Select next variant"
+                title={t(
+                    "editor-variant-next",
+                    undefined,
+                    "Select next variant",
+                )}
                 data-test="Next Variant"
                 className="doenet-ui-button button prev-next-button"
                 disabled={index == array.length - 1}
@@ -102,7 +112,11 @@ export default function VariantSelect({
                 <BsCaretDownFill />
             </Ariakit.Button>
             <Ariakit.Button
-                title="Select previous variant"
+                title={t(
+                    "editor-variant-previous",
+                    undefined,
+                    "Select previous variant",
+                )}
                 data-test="Previous Variant"
                 className="doenet-ui-button button prev-next-button"
                 disabled={index < 1}

--- a/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
+++ b/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
@@ -8,6 +8,7 @@ import VariantSelect from "./VariantSelect";
 import type { ResolvedTheme } from "../utils/theme";
 import { setVariantIndex } from "../utils/variants";
 import type { VariantsState } from "../utils/variants";
+import { useT } from "../utils/i18n";
 
 /**
  * Header controls above the viewer: update/reset, variant selection, and accessibility status.
@@ -17,7 +18,7 @@ export function ViewerControlsBar({
     readOnly,
     codeChanged,
     documentInteracted,
-    updateWord,
+    updateAction,
     onUpdateViewer,
     variants,
     setVariants,
@@ -32,7 +33,8 @@ export function ViewerControlsBar({
     readOnly: boolean;
     codeChanged: boolean;
     documentInteracted: boolean;
-    updateWord: string;
+    /** Which of the two things the button does, not the word it shows. */
+    updateAction: "reset" | "update";
     onUpdateViewer: () => void;
     variants: VariantsState;
     setVariants: React.Dispatch<React.SetStateAction<VariantsState>>;
@@ -43,19 +45,37 @@ export function ViewerControlsBar({
     onToggleAccessibilityReport: () => void;
     darkMode: ResolvedTheme;
 }) {
+    const t = useT();
+    // Translated at render rather than carried in state, so that a language
+    // change mid-session cannot leave the previous language's word on the
+    // button (#1580).
+    const updateWord = t(
+        "editor-update-viewer",
+        { action: updateAction },
+        updateAction === "reset" ? "Reset" : "Update",
+    );
+    // The shortcut is a branch of the tooltip rather than text appended to it:
+    // where a key combination sits in a sentence is not the same in every
+    // language.
+    const shortcut = !codeChanged
+        ? "none"
+        : isMacPlatform()
+          ? "cmd+s"
+          : "ctrl+s";
+
     return (
         <div className="viewer-controls" id={`${id}-viewer-controls`}>
             {!readOnly && (
                 <UiButton
                     data-test="Viewer Update Button"
                     disabled={!codeChanged && !documentInteracted}
-                    title={
-                        codeChanged
-                            ? isMacPlatform()
-                                ? `${updateWord} Viewer cmd+s`
-                                : `${updateWord} Viewer ctrl+s`
-                            : `${updateWord} Viewer`
-                    }
+                    title={t(
+                        "editor-update-viewer-title",
+                        { word: updateWord, shortcut },
+                        shortcut === "none"
+                            ? `${updateWord} Viewer`
+                            : `${updateWord} Viewer ${shortcut}`,
+                    )}
                     onClick={onUpdateViewer}
                 >
                     <RxUpdate /> {updateWord}{" "}

--- a/packages/doenetml/src/EditorViewer/slots.test.tsx
+++ b/packages/doenetml/src/EditorViewer/slots.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { fillSlots, slot } from "./slots";
+
+/**
+ * The four properties the marker shape exists for — a fragment can repeat, a
+ * translation can reorder the fragments or drop one, and a marker cannot be
+ * found by accident inside the surrounding prose. Each is a claim `slots.tsx`
+ * makes in prose and nothing else checks: the Cypress specs that use it assert
+ * on what the `en` and `es` catalogs happen to say today, which is one
+ * well-behaved translation of each message (#1580).
+ */
+describe("fillSlots", () => {
+    /** What a caller would render, as HTML, so the markup is visible. */
+    function render(text: string, nodes: readonly React.ReactNode[]) {
+        return renderToStaticMarkup(<>{fillSlots(text, nodes)}</>);
+    }
+
+    it("puts each node where its marker sits", () => {
+        expect(
+            render(`Inside ${slot(0)} — try ${slot(1)}.`, [
+                <code>{"<p>"}</code>,
+                <em>these</em>,
+            ]),
+        ).eq("Inside <code>&lt;p&gt;</code> — try <em>these</em>.");
+    });
+
+    it("follows a translation that reorders the fragments", () => {
+        expect(render(`${slot(1)} before ${slot(0)}`, ["A", "B"])).eq(
+            "B before A",
+        );
+    });
+
+    it("repeats a fragment a translation names twice", () => {
+        expect(render(`${slot(0)} and ${slot(0)}`, [<code>x</code>])).eq(
+            "<code>x</code> and <code>x</code>",
+        );
+    });
+
+    it("renders without a fragment a translation dropped", () => {
+        // The sentence survives; only the fragment is missing. This is the
+        // failure mode the marker shape is chosen to make survivable.
+        expect(render("Nothing goes here.", [<code>x</code>])).eq(
+            "Nothing goes here.",
+        );
+    });
+
+    it("renders nothing in place of a marker with no node behind it", () => {
+        expect(render(`before ${slot(3)} after`, [<code>x</code>])).eq(
+            "before  after",
+        );
+    });
+
+    it("leaves prose that looks like a fragment alone", () => {
+        // A bare `$m` in the surrounding words is not a marker, which is the
+        // reason the marker is a delimited index rather than the fragment's
+        // own text.
+        expect(render(`$m is $m: ${slot(0)}`, [<code>$m</code>])).eq(
+            "$m is $m: <code>$m</code>",
+        );
+    });
+});

--- a/packages/doenetml/src/EditorViewer/slots.tsx
+++ b/packages/doenetml/src/EditorViewer/slots.tsx
@@ -1,0 +1,56 @@
+/**
+ * Sentences that have marked-up fragments inside them.
+ *
+ * Some of what the editor says is not a label but a sentence with something
+ * rendered in the middle of it — a linked standard name in the accessibility
+ * heading, an element name in `<code>` in the context-help panel. Splitting
+ * such a sentence at the markup would hand a translator two or three fragments
+ * and no sentence, and would fix English's word order in the JSX. So the whole
+ * sentence is one message and each fragment is an argument; what the argument
+ * carries is a marker, and the marker is swapped for the React node after
+ * Fluent has formatted the sentence (#1580).
+ *
+ * The marker is a NUL-delimited index rather than the fragment's own text, so a
+ * fragment can repeat, can be reordered by a translation, and can be a
+ * substring of the surrounding prose without being found by accident. NUL
+ * cannot appear in an FTL source or in anything the editor formats.
+ *
+ * A translation that drops a placeable renders without that fragment rather
+ * than losing the sentence, and one that leaves a marker unmatched — which only
+ * a hand-edited catalog could do — renders nothing in its place.
+ *
+ * @module
+ */
+import React from "react";
+
+/** The delimiter around a marker's index. */
+const SLOT = "\u0000";
+
+/** Matches one marker, capturing the index inside it. */
+const SLOT_PATTERN = new RegExp(`${SLOT}(\\d+)${SLOT}`);
+
+/** The value to pass as the argument standing in for node `index`. */
+export function slot(index: number): string {
+    return `${SLOT}${index}${SLOT}`;
+}
+
+/**
+ * A formatted message with its {@link slot} markers replaced by `nodes`.
+ *
+ * @param text What the translator returned, with markers still in it.
+ * @param nodes The fragments, indexed as they were passed to {@link slot}.
+ */
+export function fillSlots(
+    text: string,
+    nodes: readonly React.ReactNode[],
+): React.ReactNode {
+    // A capturing split alternates literal text and captured indices, so the
+    // odd positions are the markers.
+    return text
+        .split(SLOT_PATTERN)
+        .map((piece, ind) => (
+            <React.Fragment key={ind}>
+                {ind % 2 === 0 ? piece : nodes[Number(piece)]}
+            </React.Fragment>
+        ));
+}

--- a/packages/doenetml/test/cypress/component/DoenetEditor.chromeLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.chromeLocale.cy.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+
+// The editor chrome had no `useT()` in it at all, so a reader who asked for
+// Spanish got a Spanish document inside an English editor — worst in the
+// Diagnostics panel, where "Line #2" sat in English beside a translated
+// message (Doenet/DoenetML#1580).
+//
+// What is asserted here is the decision as much as the strings: the *whole*
+// editor binds to one language, and that language is the one the viewer below
+// resolved — including when the author declared it in the source and the host
+// said nothing.
+
+const VIEWER_TIMEOUT = 15_000;
+
+function mountEditor(props: Record<string, unknown>) {
+    cy.mount(
+        <div style={{ height: "600px", width: "900px" }}>
+            <DoenetEditor
+                height="600px"
+                width="900px"
+                addVirtualKeyboard={false}
+                {...(props as any)}
+            />
+        </div>,
+    );
+}
+
+describe("the editor chrome follows the reader's language", () => {
+    it("renders the footer, the panel and the controls in Spanish", () => {
+        mountEditor({
+            doenetML: `<p>Hola</p>`,
+            uiLocale: "es",
+            initialOpenTab: "errors",
+        });
+
+        // The footer's tabs.
+        cy.get('[data-test="footer-tab-errors"]', {
+            timeout: VIEWER_TIMEOUT,
+        }).should("have.attr", "title", "Errores");
+        cy.get('[data-test="footer-tab-warnings"]').should(
+            "have.attr",
+            "title",
+            "Advertencias",
+        );
+        // The panel behind them.
+        cy.contains("Sin errores");
+        // And the controls above the viewer.
+        cy.get('[data-test="Viewer Update Button"]').should(
+            "contain.text",
+            "Reiniciar",
+        );
+    });
+
+    it("says where a diagnostic was found in the same language as the diagnostic", () => {
+        // The line this was filed for: a translated message on the same line
+        // as an untranslated label.
+        mountEditor({
+            doenetML: `<p>ok</p>\n<abc />`,
+            uiLocale: "es",
+            initialOpenTab: "errors",
+        });
+
+        cy.contains("Línea n.º 2", { timeout: VIEWER_TIMEOUT });
+        cy.get("body").should("not.contain.text", "Line #2");
+    });
+
+    it("takes the language from a `<document lang>` the host never mentioned", () => {
+        // The editor chrome sits under the provider built from the props
+        // alone, which never sees an authored language. Binding it to what the
+        // viewer resolved is what makes this work.
+        mountEditor({
+            doenetML: `<document lang="es"><p>Hola</p></document>`,
+            initialOpenTab: "errors",
+        });
+
+        cy.contains("Sin errores", { timeout: VIEWER_TIMEOUT });
+        cy.get('[data-test="footer-tab-errors"]').should(
+            "have.attr",
+            "title",
+            "Errores",
+        );
+    });
+
+    it("keeps the link inside the heading a translation writes around it", () => {
+        // The one sentence in this panel with markup in the middle of it. The
+        // linked name goes to the catalog as a marker rather than as its own
+        // text, so what is checked is that the sentence came back translated
+        // *and* that the anchor landed back inside it.
+        mountEditor({
+            doenetML: `<p>Hola</p>`,
+            uiLocale: "es",
+            initialOpenTab: "accessibility",
+        });
+
+        cy.contains("h3", "Infracciones de accesibilidad", {
+            timeout: VIEWER_TIMEOUT,
+        }).within(() => {
+            cy.get("a").should("have.text", "WCAG AA");
+        });
+        cy.contains("h3", "Infracciones de accesibilidad (WCAG AA)");
+    });
+
+    it("renders it in English when nothing asks for another language", () => {
+        mountEditor({
+            doenetML: `<p>hello</p>`,
+            initialOpenTab: "errors",
+        });
+
+        cy.contains("No Errors", { timeout: VIEWER_TIMEOUT });
+        cy.get('[data-test="footer-tab-errors"]').should(
+            "have.attr",
+            "title",
+            "Errors",
+        );
+        cy.get('[data-test="Viewer Update Button"]').should(
+            "contain.text",
+            "Reset",
+        );
+    });
+
+    it("translates the update button when the word changes, not when it is stored", () => {
+        // The word travels through React state, so localizing it means storing
+        // which of the two states the button is in and translating at render.
+        mountEditor({
+            doenetML: `<p>Hola</p>`,
+            uiLocale: "es",
+            initialOpenTab: "errors",
+        });
+
+        cy.get('[data-test="Viewer Update Button"]', {
+            timeout: VIEWER_TIMEOUT,
+        }).should("contain.text", "Reiniciar");
+
+        cy.get(".cm-content").type("x");
+
+        cy.get('[data-test="Viewer Update Button"]').should(
+            "contain.text",
+            "Actualizar",
+        );
+        cy.get('[data-test="Viewer Update Button"]')
+            .invoke("attr", "title")
+            .should("match", /^Actualizar el visor (cmd|ctrl)\+s$/);
+    });
+});

--- a/packages/i18n/locales/en/editor.ftl
+++ b/packages/i18n/locales/en/editor.ftl
@@ -1,9 +1,166 @@
-# Editor and language-server surfaces: formatter labels, completion detail
-# text, hover help. Selected by `uiLocale`.
+# Editor and language-server surfaces: the footer, the diagnostics panel, the
+# variant picker and the accessibility button. Selected by `uiLocale`.
 #
-# Intentionally empty in i18n Phase 0 (#1515). A later phase moves the editor
-# strings into this file; note that the LSP ships bundled with its DoenetML
-# version, so these catalogs are version-correct rather than always-latest.
+# The editor binds to *one* language, and it is the one the viewer below it
+# resolved rather than the one the surrounding host chrome uses: the panel
+# lists diagnostics rendered down there, where an authored `<document lang>` is
+# known, and a footer in one language above a panel in another reads worse than
+# either choice on its own (#1580).
+#
+# The LSP ships bundled with its DoenetML version, so these catalogs are
+# version-correct rather than always-latest.
 #
 # Message ids are lower-kebab-case Fluent identifiers, optionally with a
 # single `.attribute` suffix (`format-document`).
+
+
+## The viewer's controls
+##
+## `editor-update-viewer` names the button that recompiles the document. Its
+## word depends on whether the source changed or only the document's state
+## did, which is a distinction the code makes and a `$action` says: the button
+## is otherwise identical, and splitting it into two messages would let the two
+## drift.
+##
+## The keyboard hint is a separate branch rather than text appended after the
+## title, because where a shortcut sits in a sentence is not the same in every
+## language. `$shortcut` is a key combination and stays as written.
+##
+## The tooltip takes the word as `$word` rather than referencing the message
+## above it: a message reference resolves only inside its own bundle, so a
+## locale that translated the tooltip but not the word would render the
+## reference literally instead of falling back to English. This is the shape
+## `paginator-page-status` already uses.
+
+editor-update-viewer =
+    { $action ->
+        [reset] Reset
+       *[update] Update
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Viewer
+       *[other] { $word } Viewer { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variant
+editor-variant-filter = Filter...
+editor-variant-next = Select next variant
+editor-variant-previous = Select previous variant
+
+
+## The accessibility status button
+##
+## `WCAG AA` is the name of the standard and is not translated, the way
+## `accessibility-heading-level-1` already leaves it.
+##
+## The tooltip and the label are separate messages rather than one with an
+## extra clause: the label counts the violations and the tooltip does not, and
+## a screen reader and a hover are different audiences.
+##
+## `$action` is whether clicking opens or closes the report — an interpolated
+## English verb before this, which no locale could reach and which no language
+## has to place where English does.
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA accessibility violation identified. Click to { $action ->
+            [close] close
+           *[open] open
+        } accessibility report.
+        [advisories] Click to { $action ->
+            [close] close
+           *[open] open
+        } accessibility report. No WCAG AA violations were found, but additional accessibility recommendations are available.
+       *[clean] Click to { $action ->
+            [close] close
+           *[open] open
+        } accessibility report. No accessibility issues were found.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA accessibility violation identified. { $count ->
+            [one] { $count } WCAG AA violation
+           *[other] { $count } WCAG AA violations
+        } found. Click to { $action ->
+            [close] close
+           *[open] open
+        } accessibility report.
+        [advisories] No WCAG AA violations identified. { $count ->
+            [one] { $count } additional accessibility recommendation
+           *[other] { $count } additional accessibility recommendations
+        } found. Click to { $action ->
+            [close] close
+           *[open] open
+        } accessibility report.
+       *[clean] No WCAG AA violations identified. Click to { $action ->
+            [close] close
+           *[open] open
+        } accessibility report.
+    }
+
+# The word on the button itself, beside the icon, when there are violations.
+editor-accessibility-badge = WCAG
+
+
+## The footer
+##
+## `$version` is a version number and stays as written.
+
+editor-version-title = DoenetML version { $version }
+
+editor-tab-help = Context-sensitive help
+# The word beside the icon on that tab, which has room for one word.
+editor-tab-help-short = Context
+editor-tab-errors = Errors
+editor-tab-warnings = Warnings
+editor-tab-info = Info
+editor-tab-accessibility = Accessibility
+editor-tab-responses = Submitted responses
+
+# A tab's accessible name when it carries a count: "Errors: 3".
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Editor options
+editor-format-as-doenetml = Format as DoenetML
+editor-format-as-xml = Format as XML
+
+
+## The diagnostics panel
+
+# Where in the source a diagnostic was found. `$line` arrives as text, not as a
+# number: it identifies the line, so line 1234 is "#1234" and not "#1,234".
+editor-diagnostic-line = Line #{ $line }
+
+editor-no-errors = No Errors
+editor-no-warnings = No Warnings
+editor-no-info = No Info Diagnostics
+
+editor-show-info-annotations = Show info diagnostics in editor
+editor-show-accessibility-annotations = Show accessibility diagnostics in editor
+
+# Links into the documentation, which has no translated pages yet. The words
+# move; where they point does not (#1580).
+editor-accessibility-learn-more = Learn how Doenet approaches accessibility
+
+# The heading over the WCAG AA failures. The standard's name is a link, so it
+# arrives as an argument rather than being written into the sentence — the
+# brackets around it are this catalog's punctuation, and the link is the code's.
+editor-accessibility-violations-heading = Accessibility violations ({ $standard })
+
+editor-accessibility-other-heading = Other accessibility issues
+editor-none-found = None found
+
+
+## Submitted responses
+
+editor-no-responses = No submitted responses yet
+editor-response-answer-id = Answer Id
+editor-response-response = Response
+editor-response-credit = Credit
+editor-response-submitted = Submitted

--- a/packages/i18n/locales/es/editor.ftl
+++ b/packages/i18n/locales/es/editor.ftl
@@ -1,0 +1,117 @@
+# Superficies del editor: el pie, el panel de diagnósticos, el selector de
+# variantes y el botón de accesibilidad. Se selecciona con `uiLocale`.
+#
+# `WCAG AA` es el nombre de la norma y no se traduce.
+
+
+## Los controles del visor
+
+editor-update-viewer =
+    { $action ->
+        [reset] Reiniciar
+       *[update] Actualizar
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } el visor
+       *[other] { $word } el visor { $shortcut }
+    }
+
+
+## El selector de variantes
+
+editor-variant = Variante
+editor-variant-filter = Filtrar...
+editor-variant-next = Seleccionar la variante siguiente
+editor-variant-previous = Seleccionar la variante anterior
+
+
+## El botón de estado de accesibilidad
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Se detectó una infracción de accesibilidad WCAG AA. Pulse para { $action ->
+            [close] cerrar
+           *[open] abrir
+        } el informe de accesibilidad.
+        [advisories] Pulse para { $action ->
+            [close] cerrar
+           *[open] abrir
+        } el informe de accesibilidad. No se detectaron infracciones WCAG AA, pero hay recomendaciones adicionales de accesibilidad.
+       *[clean] Pulse para { $action ->
+            [close] cerrar
+           *[open] abrir
+        } el informe de accesibilidad. No se detectó ningún problema de accesibilidad.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Se detectó una infracción de accesibilidad WCAG AA. Se { $count ->
+            [one] encontró { $count } infracción WCAG AA
+           *[other] encontraron { $count } infracciones WCAG AA
+        }. Pulse para { $action ->
+            [close] cerrar
+           *[open] abrir
+        } el informe de accesibilidad.
+        [advisories] No se detectaron infracciones WCAG AA. Se { $count ->
+            [one] encontró { $count } recomendación adicional de accesibilidad
+           *[other] encontraron { $count } recomendaciones adicionales de accesibilidad
+        }. Pulse para { $action ->
+            [close] cerrar
+           *[open] abrir
+        } el informe de accesibilidad.
+       *[clean] No se detectaron infracciones WCAG AA. Pulse para { $action ->
+            [close] cerrar
+           *[open] abrir
+        } el informe de accesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## El pie
+
+editor-version-title = Versión de DoenetML { $version }
+
+editor-tab-help = Ayuda contextual
+editor-tab-help-short = Contexto
+editor-tab-errors = Errores
+editor-tab-warnings = Advertencias
+editor-tab-info = Información
+editor-tab-accessibility = Accesibilidad
+editor-tab-responses = Respuestas enviadas
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opciones del editor
+editor-format-as-doenetml = Formatear como DoenetML
+editor-format-as-xml = Formatear como XML
+
+
+## El panel de diagnósticos
+
+editor-diagnostic-line = Línea n.º { $line }
+
+editor-no-errors = Sin errores
+editor-no-warnings = Sin advertencias
+editor-no-info = Sin diagnósticos informativos
+
+editor-show-info-annotations = Mostrar los diagnósticos informativos en el editor
+editor-show-accessibility-annotations = Mostrar los diagnósticos de accesibilidad en el editor
+
+editor-accessibility-learn-more = Descubra cómo Doenet aborda la accesibilidad
+
+editor-accessibility-violations-heading = Infracciones de accesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Otros problemas de accesibilidad
+editor-none-found = No se encontró ninguno
+
+
+## Respuestas enviadas
+
+editor-no-responses = Todavía no hay respuestas enviadas
+editor-response-answer-id = Id. de respuesta
+editor-response-response = Respuesta
+editor-response-credit = Puntuación
+editor-response-submitted = Enviada

--- a/packages/i18n/src/bundled.ts
+++ b/packages/i18n/src/bundled.ts
@@ -1,6 +1,7 @@
 import esChrome from "../locales/es/chrome.ftl?raw";
 import esContent from "../locales/es/content.ftl?raw";
 import esDiagnostics from "../locales/es/diagnostics.ftl?raw";
+import esEditor from "../locales/es/editor.ftl?raw";
 
 import { DEFAULT_LOCALE, EN_CATALOGS } from "./catalogs";
 import {
@@ -30,6 +31,7 @@ const BUNDLED_TRANSLATIONS: Record<string, Catalogs> = {
         chrome: esChrome,
         content: esContent,
         diagnostics: esDiagnostics,
+        editor: esEditor,
     },
 };
 

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -498,7 +498,43 @@ export type MessageKey =
     | "select-prime-numbers-values-excluded-combination"
     | "select-prime-numbers-excluded-too-many-combinations"
     | "select-random-combination-fluke"
-    | "select-random-value-fluke";
+    | "select-random-value-fluke"
+    | "editor-update-viewer"
+    | "editor-update-viewer-title"
+    | "editor-variant"
+    | "editor-variant-filter"
+    | "editor-variant-next"
+    | "editor-variant-previous"
+    | "editor-accessibility-title"
+    | "editor-accessibility-label"
+    | "editor-accessibility-badge"
+    | "editor-version-title"
+    | "editor-tab-help"
+    | "editor-tab-help-short"
+    | "editor-tab-errors"
+    | "editor-tab-warnings"
+    | "editor-tab-info"
+    | "editor-tab-accessibility"
+    | "editor-tab-responses"
+    | "editor-tab-with-count"
+    | "editor-options"
+    | "editor-format-as-doenetml"
+    | "editor-format-as-xml"
+    | "editor-diagnostic-line"
+    | "editor-no-errors"
+    | "editor-no-warnings"
+    | "editor-no-info"
+    | "editor-show-info-annotations"
+    | "editor-show-accessibility-annotations"
+    | "editor-accessibility-learn-more"
+    | "editor-accessibility-violations-heading"
+    | "editor-accessibility-other-heading"
+    | "editor-none-found"
+    | "editor-no-responses"
+    | "editor-response-answer-id"
+    | "editor-response-response"
+    | "editor-response-credit"
+    | "editor-response-submitted";
 
 /** Every key in the English catalogs, in catalog order. */
 export const MESSAGE_KEYS: readonly MessageKey[] = [
@@ -994,4 +1030,40 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "select-prime-numbers-excluded-too-many-combinations",
     "select-random-combination-fluke",
     "select-random-value-fluke",
+    "editor-update-viewer",
+    "editor-update-viewer-title",
+    "editor-variant",
+    "editor-variant-filter",
+    "editor-variant-next",
+    "editor-variant-previous",
+    "editor-accessibility-title",
+    "editor-accessibility-label",
+    "editor-accessibility-badge",
+    "editor-version-title",
+    "editor-tab-help",
+    "editor-tab-help-short",
+    "editor-tab-errors",
+    "editor-tab-warnings",
+    "editor-tab-info",
+    "editor-tab-accessibility",
+    "editor-tab-responses",
+    "editor-tab-with-count",
+    "editor-options",
+    "editor-format-as-doenetml",
+    "editor-format-as-xml",
+    "editor-diagnostic-line",
+    "editor-no-errors",
+    "editor-no-warnings",
+    "editor-no-info",
+    "editor-show-info-annotations",
+    "editor-show-accessibility-annotations",
+    "editor-accessibility-learn-more",
+    "editor-accessibility-violations-heading",
+    "editor-accessibility-other-heading",
+    "editor-none-found",
+    "editor-no-responses",
+    "editor-response-answer-id",
+    "editor-response-response",
+    "editor-response-credit",
+    "editor-response-submitted",
 ];

--- a/packages/i18n/src/namespaces.ts
+++ b/packages/i18n/src/namespaces.ts
@@ -27,10 +27,20 @@ export type CatalogNamespace = (typeof CATALOG_NAMESPACES)[number];
  */
 export const WORKER_NAMESPACES: readonly CatalogNamespace[] = ["content"];
 
-/** Namespaces the main-thread viewer/editor chrome needs. */
+/**
+ * Namespaces the main-thread viewer/editor chrome needs.
+ *
+ * `editor` is here rather than in a list of its own because the editor chrome
+ * has no load context separate from the viewer's: `DoenetEditor` and
+ * `DoenetViewer` are two exports of one main-thread bundle, and the editor's
+ * strings would ride along in it whichever list named them. A namespace earns
+ * its own list by being *droppable* — `content` is, because the worker is a
+ * separate bundle that draws nothing — and this one is not.
+ */
 export const CHROME_NAMESPACES: readonly CatalogNamespace[] = [
     "chrome",
     "diagnostics",
+    "editor",
 ];
 
 export type Catalogs = Partial<Record<CatalogNamespace, string>>;

--- a/packages/i18n/test/catalogs.test.ts
+++ b/packages/i18n/test/catalogs.test.ts
@@ -50,14 +50,13 @@ describe("bundled English catalogs", () => {
         );
     });
 
-    it("still defines no keys in the namespaces later phases populate", () => {
-        // The orphan check in `lint:i18n` is only meaningful while every key
-        // that exists is one some call site actually uses. A key appearing
-        // here before its phase moves the strings would be a key nothing
-        // references.
-        for (const namespace of ["editor"] as const) {
-            expect(extractKeys(EN_CATALOGS[namespace]), namespace).toEqual([]);
-        }
+    it("defines the editor chrome Phase 4 extracted", () => {
+        // The last namespace to be populated: `editor.ftl` sat empty from
+        // Phase 0 until the editor's own chrome moved into it (#1580).
+        const editorKeys = extractKeys(EN_CATALOGS.editor);
+        expect(editorKeys).toContain("editor-tab-errors");
+        expect(editorKeys).toContain("editor-diagnostic-line");
+        expect(editorKeys).toContain("editor-accessibility-label");
     });
 });
 


### PR DESCRIPTION
Based on `main`, now that #1585 has merged. This PR is one commit.

Part of #1580 — the context-help panel follows in the next PR, which closes it.

## What was English

#1543 translated the viewer chrome. The editor's was never done, and it is easy to miss because nothing about it looks unfinished: it simply had no `useT()` in it at all. A reader who set `uiLocale="es"`, or opened a document declaring `<document lang="es">`, got a Spanish document inside an English editor. It showed worst in the Diagnostics panel:

> `Line #2 · Tipo de componente no válido: <abc>`

The message half was localized; `Line #2` was a literal.

This covers the footer, the diagnostics and responses panels, the variant picker, the accessibility button and the update button — about forty strings across six files. The context-help panel is the same size again and lands separately.

## Three decisions

### One language for the whole editor

Not the ambient one. `I18nProvider` is mounted twice: an outer one from the host's props, which never sees an authored `<document lang>`, and an inner one in `DocViewer`, which does. `EditorViewer` renders `DocViewer` as a child, so the editor chrome sat under the outer one, and plain `useT()` would have left `Line #2` in English beside a Spanish message for any document that declared its own language.

#1571 already built the answer for the hover tooltips: `DocViewer` reports the tag it resolved, and `EditorViewer` derives `viewerUiLocale ?? hostUiLocale`. The open question was whether the *rest* of the editor should follow it too. It should: those are host chrome by one argument, but an editor split across two languages is worse than either choice, and the footer sits directly above the panel it would disagree with. So `diagnosticLocale` becomes `editorLocale` and a third `I18nProvider` publishes it to everything the editor draws. The viewer nests its own inside and still wins for the document itself, which is the same split as before — the two only differ while the first parse is in flight.

### The composed and pluralized strings

`AccessibilityStatusButton` built six sentences with a hand-rolled English plural and an interpolated English verb:

```js
`WCAG AA accessibility violation identified. ${count} WCAG AA violation${count === 1 ? "" : "s"} found. Click to ${action} accessibility report.`
```

Which of the three things it has to say, how many, and whether clicking opens or closes are arguments now; Fluent selects the sentence. Those arguments are one `AccessibilityStatus` type with literal unions, so the two English fallbacks branch on the same closed set the catalog selects on. `editor-tab-with-count` does the same for `Errors: 3`, whose separator is punctuation rather than code.

### One sentence with markup inside it

The heading over the WCAG AA failures is not a label — it is a sentence with a link in the middle of it. It stays one message: the linked name goes to the catalog as a marker, and `EditorViewer/slots.tsx` swaps the marker for the anchor once Fluent has formatted the sentence. So a translation owns the wording, the brackets and where the link sits, and one that drops the placeable renders the heading without the link rather than losing the heading.

The marker is a NUL-delimited index rather than the name's own text, which is what lets a fragment repeat, be reordered by a translation, and not be found by accident inside the surrounding prose. There is one such sentence here; the context-help panel in #1587 is mostly sentences of this shape and uses the same two functions, which is why they live one directory up rather than beside that panel.

### `updateWord` was English in React state

`useState("Reset")`, set to `"Reset"` / `"Update"` from two places, rendered by `ViewerControlsBar`. It is `updateAction` holding `"reset"` or `"update"` now, translated at render — otherwise a language change mid-session would leave the previous language's word sitting in state. The keyboard hint is a branch of the tooltip rather than text appended to it, since where a shortcut sits in a sentence is not the same in every language.

## The catalog

`editor.ftl` was reserved in Phase 0 (#1515) and has been empty since. It is populated, with `es` alongside, and joins the namespaces the chrome loads.

That last part deserves a sentence, because the namespace split is by load context and this looks like it breaks it. It does not: `DoenetEditor` and `DoenetViewer` are two exports of one main-thread bundle, so the editor's strings ride along in it whichever list names them. A namespace earns its own list by being *droppable* — `content` is, because the worker is a separate bundle that draws nothing — and this one is not. `bundled.ts`'s own note applies: at roughly a kilobyte gzipped, paying for it unconditionally costs less than the machinery to avoid it.

The pseudo-locale now covers the editor too, since it is derived from the bundled English chrome.

## Tests

`DoenetEditor.chromeLocale.cy.tsx`, six tests: the footer, panel and controls in Spanish; `Línea n.º 2` with no `Line #2` left beside it; the language taken from a `<document lang>` the host never mentioned, which is the case the locale decision exists for; the violations heading translated with the anchor landed back inside it; English when nothing asks for anything else; and the update button changing from `Reiniciar` to `Actualizar` on a keystroke, with the shortcut in the tooltip.

`slots.test.tsx`, six tests, holds the properties the marker shape was chosen for: a fragment reordered, repeated or dropped by a translation, a marker with no node behind it, and prose that looks like a fragment but is not. Those are claims the module makes in prose, and the specs that render through it only ever see one well-behaved translation of each message — `en` and `es`, both of which put the fragment exactly where English does.

`catalogs.test.ts`'s "still defines no keys in the namespaces later phases populate" becomes "defines the editor chrome Phase 4 extracted" — `editor` was the last namespace that guard was watching.

Regression: the other editor component specs including `DoenetEditor.refreshKeyboardShortcut` (4) and `DoenetEditor.contextHelp` (7), `@doenet/i18n` (157), and `lint:i18n` (528 keys across 2 locales, 334 call sites). The existing `Update Viewer cmd+s` assertion in `DoenetEditor.refreshKeyboardShortcut.cy.tsx` is untouched and still green, which is the English-is-byte-identical check for the one string that had a test.

## Not in scope

`Learn how Doenet approaches accessibility` links into `docs-nextra`, which has no localized pages. The words move; where the link points does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





