### PR TITLE
Write the context-help panel in the reader's language

### DIFF
--- a/.changeset/context-help-panel-locale.md
+++ b/.changeset/context-help-panel-locale.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Render the editor's context-help panel in the reader's language.
+
+The panel that explains whatever the cursor is on was the last English surface left inside the editor. Its labels, its placeholder, and the sentences it writes about a reference — "`$m` is a reference to `<point>` (line 4)" — now come from the catalogs, with Spanish alongside.
+
+Those sentences stay whole rather than being split at the markup inside them, so a translation decides where each quoted name sits and how the sentence is punctuated around it. Element names, attribute names and `styleNumber` stay as written, and the descriptions the panel shows still come from the schema, which is generated from the documentation and is not translated.

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -6,6 +6,9 @@ import type {
     FunctionNamesBreakdownPayload,
     HelpContent,
 } from "@doenet/lsp-tools";
+import type { Translator } from "@doenet/i18n";
+import { useT } from "../../utils/i18n";
+import { fillSlots, slot } from "../slots";
 import "./context-help-panel.css";
 
 /**
@@ -71,6 +74,7 @@ function renderElementName(
 const REFERENCES_DOC_PATH = "concepts/references";
 
 function ReferencesDocLink({ docsBase }: { docsBase: string }) {
+    const t = useT();
     return (
         <a
             className="help-docs-link"
@@ -78,9 +82,38 @@ function ReferencesDocLink({ docsBase }: { docsBase: string }) {
             target="_blank"
             rel="noreferrer noopener"
         >
-            Learn about references →
+            {t(
+                "help-learn-about-references",
+                undefined,
+                "Learn about references \u2192",
+            )}
         </a>
     );
+}
+
+/** The footer link to an element's or attribute's own reference page. */
+function ReferencePageLink({ href }: { href: string }) {
+    const t = useT();
+    return (
+        <a
+            className="help-docs-link"
+            href={href}
+            target="_blank"
+            rel="noreferrer noopener"
+        >
+            {t("help-reference-page", undefined, "Reference page \u2192")}
+        </a>
+    );
+}
+
+/**
+ * A line number as the catalog wants it: text, so Fluent hands it to no
+ * `Intl.NumberFormat` and line 1234 stays "1234"; and `"none"` when there is
+ * no position, so a sentence without one is a branch rather than an empty
+ * parenthesis.
+ */
+function lineArg(line: number | undefined): string {
+    return line === undefined ? "none" : String(line);
 }
 
 export function ContextHelpPanel({
@@ -90,6 +123,7 @@ export function ContextHelpPanel({
     content: HelpContent;
     docsURL: string;
 }) {
+    const t = useT();
     // Tolerate a trailing slash on the consumer-supplied `docsURL` so that
     // e.g. "https://docs.doenet.org/" doesn't produce "//reference/..." URLs.
     const docsBase = docsURL.replace(/\/+$/, "");
@@ -99,8 +133,14 @@ export function ContextHelpPanel({
             return (
                 <div className="help-panel help-panel-empty">
                     <p className="help-placeholder">
-                        Place cursor on a tag name, attribute, or{" "}
-                        <code>$ref.property</code> for documentation.
+                        {fillSlots(
+                            t(
+                                "help-placeholder",
+                                { ref: slot(0) },
+                                `Place cursor on a tag name, attribute, or ${slot(0)} for documentation.`,
+                            ),
+                            [<code>$ref.property</code>],
+                        )}
                     </p>
                 </div>
             );
@@ -109,8 +149,14 @@ export function ContextHelpPanel({
             return (
                 <div className="help-panel help-panel-empty">
                     <p className="help-placeholder">
-                        Help for multi-part references like <code>$a.b.c</code>{" "}
-                        is not yet supported.
+                        {fillSlots(
+                            t(
+                                "help-unsupported-ref-chain",
+                                { example: slot(0) },
+                                `Help for multi-part references like ${slot(0)} is not yet supported.`,
+                            ),
+                            [<code>$a.b.c</code>],
+                        )}
                     </p>
                 </div>
             );
@@ -120,15 +166,18 @@ export function ContextHelpPanel({
             const ref = <code>{`$${displayPath}`}</code>;
             // `notFound`/`multiple` are authoritative resolver verdicts;
             // `indeterminate` hedges so an incomplete-view miss is never
-            // presented as a definite "no referent".
-            const sentence =
-                reason === "notFound" ? (
-                    <>No referent found for reference: {ref}.</>
-                ) : reason === "multiple" ? (
-                    <>Multiple referents found for reference: {ref}.</>
-                ) : (
-                    <>A referent for {ref} could not be determined.</>
-                );
+            // presented as a definite "no referent". Which one it is selects
+            // the sentence in the catalog rather than in the JSX.
+            const english =
+                reason === "notFound"
+                    ? `No referent found for reference: ${slot(0)}.`
+                    : reason === "multiple"
+                      ? `Multiple referents found for reference: ${slot(0)}.`
+                      : `A referent for ${slot(0)} could not be determined.`;
+            const sentence = fillSlots(
+                t("help-unresolved-ref", { reason, ref: slot(0) }, english),
+                [ref],
+            );
             return (
                 <div className="help-panel">
                     <p className="help-ref-sentence">{sentence}</p>
@@ -140,32 +189,53 @@ export function ContextHelpPanel({
         case "suggestions": {
             const { context, suggested, totalAllowed, acceptsStringChildren } =
                 content;
-            const location =
-                "elementName" in context ? (
-                    <>
-                        Inside <code>{`<${context.elementName}>`}</code>
-                    </>
-                ) : (
-                    "At the top level"
-                );
+            // Narrowed here rather than re-tested below, so the element name
+            // never needs a cast to be read.
+            const containerName =
+                "elementName" in context ? context.elementName : null;
             // Four cases the header line discriminates:
             //   - nothing allowed at all → "<x> — nothing goes here."
             //   - text only             → "<x> — type text here."
             //   - components only       → "<x> — things to try:" (today)
             //   - text + components     → "<x> — type text here, or try:"
-            const headerSuffix =
+            const allowed =
                 totalAllowed === 0
                     ? acceptsStringChildren
-                        ? " — type text here."
-                        : " — nothing goes here."
+                        ? "text"
+                        : "none"
                     : acceptsStringChildren
-                      ? " — type text here, or try:"
-                      : " — things to try:";
+                      ? "text-and-components"
+                      : "components";
+            const englishSuffix = {
+                text: " — type text here.",
+                none: " — nothing goes here.",
+                "text-and-components": " — type text here, or try:",
+                components: " — things to try:",
+            }[allowed];
             return (
                 <div className="help-panel">
                     <p className="help-suggestions-header">
-                        {location}
-                        {headerSuffix}
+                        {fillSlots(
+                            t(
+                                "help-suggestions-header",
+                                {
+                                    location:
+                                        containerName === null
+                                            ? "top"
+                                            : "inside",
+                                    element: slot(0),
+                                    allowed,
+                                },
+                                (containerName === null
+                                    ? "At the top level"
+                                    : `Inside ${slot(0)}`) + englishSuffix,
+                            ),
+                            [
+                                containerName === null ? null : (
+                                    <code>{`<${containerName}>`}</code>
+                                ),
+                            ],
+                        )}
                     </p>
                     {suggested.length > 0 && (
                         <ul className="help-suggestions-list">
@@ -181,8 +251,26 @@ export function ContextHelpPanel({
                                     )}
                                     {s.summary && (
                                         <span className="help-suggestion-summary">
-                                            {" — "}
-                                            {renderInlineMarkdown(s.summary)}
+                                            {/* The name is already rendered
+                                                beside this, so it is empty
+                                                here: what is wanted is the
+                                                separator the same message puts
+                                                between the two. */}
+                                            {fillSlots(
+                                                t(
+                                                    "help-name-summary",
+                                                    {
+                                                        name: "",
+                                                        summary: slot(0),
+                                                    },
+                                                    ` — ${slot(0)}`,
+                                                ),
+                                                [
+                                                    renderInlineMarkdown(
+                                                        s.summary,
+                                                    ),
+                                                ],
+                                            )}
                                         </span>
                                     )}
                                 </li>
@@ -191,8 +279,17 @@ export function ContextHelpPanel({
                     )}
                     {totalAllowed > 0 && (
                         <p className="help-suggestions-footer">
-                            Press <code>Ctrl+Space</code> to see all{" "}
-                            {totalAllowed} components.
+                            {fillSlots(
+                                t(
+                                    "help-suggestions-footer",
+                                    {
+                                        shortcut: slot(0),
+                                        total: totalAllowed,
+                                    },
+                                    `Press ${slot(0)} to see all ${totalAllowed} components.`,
+                                ),
+                                [<code>Ctrl+Space</code>],
+                            )}
                         </p>
                     )}
                 </div>
@@ -206,25 +303,28 @@ export function ContextHelpPanel({
             return (
                 <div className="help-panel">
                     <p className="help-element-title">
-                        {renderElementName(
-                            content.elementName,
-                            content.docsSlug,
-                            docsBase,
+                        {fillSlots(
+                            t(
+                                "help-name-summary",
+                                { name: slot(0), summary: slot(1) },
+                                `${slot(0)} — ${slot(1)}`,
+                            ),
+                            [
+                                renderElementName(
+                                    content.elementName,
+                                    content.docsSlug,
+                                    docsBase,
+                                ),
+                                renderInlineMarkdown(content.summary),
+                            ],
                         )}
-                        {" — "}
-                        {renderInlineMarkdown(content.summary)}
                     </p>
                     {content.styleBreakdown &&
-                        renderStyleBreakdown(content.styleBreakdown)}
+                        renderStyleBreakdown(t, content.styleBreakdown)}
                     {content.docsSlug && (
-                        <a
-                            className="help-docs-link"
+                        <ReferencePageLink
                             href={`${docsBase}/reference/${content.docsSlug}`}
-                            target="_blank"
-                            rel="noreferrer noopener"
-                        >
-                            Reference page →
-                        </a>
+                        />
                     )}
                 </div>
             );
@@ -238,18 +338,43 @@ export function ContextHelpPanel({
             return (
                 <div className="help-panel">
                     <p className="help-ref-sentence">
-                        <code>{`$${displayPath}`}</code> is a reference to{" "}
-                        <code>{`<${targetElementName}>`}</code>
-                        {line !== undefined ? ` (line ${line})` : ""}.
+                        {fillSlots(
+                            t(
+                                "help-ref-is-reference",
+                                {
+                                    ref: slot(0),
+                                    target: slot(1),
+                                    line: lineArg(line),
+                                },
+                                line === undefined
+                                    ? `${slot(0)} is a reference to ${slot(1)}.`
+                                    : `${slot(0)} is a reference to ${slot(1)} (line ${line}).`,
+                            ),
+                            [
+                                <code>{`$${displayPath}`}</code>,
+                                <code>{`<${targetElementName}>`}</code>,
+                            ],
+                        )}
                     </p>
                     {derivedFrom && (
                         <p className="help-ref-derived">
-                            Introduced by{" "}
-                            <code>{`<${derivedFrom.ownerElementName}>`}</code>
-                            {derivedFrom.ownerLine !== undefined
-                                ? ` on line ${derivedFrom.ownerLine}`
-                                : ""}{" "}
-                            as <code>{derivedFrom.role}</code>.
+                            {fillSlots(
+                                t(
+                                    "help-ref-derived-from",
+                                    {
+                                        owner: slot(0),
+                                        role: slot(1),
+                                        line: lineArg(derivedFrom.ownerLine),
+                                    },
+                                    derivedFrom.ownerLine === undefined
+                                        ? `Introduced by ${slot(0)} as ${slot(1)}.`
+                                        : `Introduced by ${slot(0)} on line ${derivedFrom.ownerLine} as ${slot(1)}.`,
+                                ),
+                                [
+                                    <code>{`<${derivedFrom.ownerElementName}>`}</code>,
+                                    <code>{derivedFrom.role}</code>,
+                                ],
+                            )}
                         </p>
                     )}
                     <ReferencesDocLink docsBase={docsBase} />
@@ -274,7 +399,9 @@ export function ContextHelpPanel({
                 <div className="help-panel">
                     <div className="help-title">
                         {renderElementName(elementName, docsSlug, docsBase)}
-                        <span className="help-kind-label">attribute</span>
+                        <span className="help-kind-label">
+                            {t("help-kind-attribute", undefined, "attribute")}
+                        </span>
                         <span className="help-attribute-name">
                             {attributeName}
                         </span>
@@ -294,7 +421,7 @@ export function ContextHelpPanel({
                         ) && (
                             <div className="help-detail">
                                 <span className="help-detail-label">
-                                    Default:
+                                    {t("help-default", undefined, "Default:")}
                                 </span>
                                 <div className="help-values-list">
                                     <span className="help-value-item">
@@ -309,25 +436,45 @@ export function ContextHelpPanel({
                         // value (#1198).
                         <div className="help-detail">
                             <span className="help-detail-label">
-                                Active default:
+                                {t(
+                                    "help-active-default",
+                                    undefined,
+                                    "Active default:",
+                                )}
                             </span>
                             <div className="help-values-list">
                                 {renderActiveDefaultValue(activeDefault)}
                                 <span className="help-detail-annotation">
-                                    {` (styleNumber ${activeDefault.styleNumber})`}
+                                    {t(
+                                        "help-style-number-annotation",
+                                        {
+                                            styleNumber: String(
+                                                activeDefault.styleNumber,
+                                            ),
+                                        },
+                                        ` (styleNumber ${activeDefault.styleNumber})`,
+                                    )}
                                 </span>
                             </div>
                         </div>
                     )}
-                    {styleBreakdown && renderStyleBreakdown(styleBreakdown)}
+                    {styleBreakdown && renderStyleBreakdown(t, styleBreakdown)}
                     {functionNamesBreakdown &&
-                        renderFunctionNamesBreakdown(functionNamesBreakdown)}
+                        renderFunctionNamesBreakdown(t, functionNamesBreakdown)}
                     {allowedValues && allowedValues.length > 0 && (
                         <div className="help-detail help-allowed-values">
                             <span className="help-detail-label">
-                                {allowedValuesArePerItem
-                                    ? "Allowed values (one per item):"
-                                    : "Allowed values:"}
+                                {t(
+                                    "help-allowed-values",
+                                    {
+                                        perItem: allowedValuesArePerItem
+                                            ? "true"
+                                            : "false",
+                                    },
+                                    allowedValuesArePerItem
+                                        ? "Allowed values (one per item):"
+                                        : "Allowed values:",
+                                )}
                             </span>
                             <dl className="help-allowed-values-list">
                                 {allowedValues.map(
@@ -348,14 +495,9 @@ export function ContextHelpPanel({
                         </div>
                     )}
                     {docsSlug && (
-                        <a
-                            className="help-docs-link"
+                        <ReferencePageLink
                             href={`${docsBase}/reference/${docsSlug}`}
-                            target="_blank"
-                            rel="noreferrer noopener"
-                        >
-                            Reference page →
-                        </a>
+                        />
                     )}
                 </div>
             );
@@ -367,12 +509,16 @@ export function ContextHelpPanel({
             return (
                 <div className="help-panel">
                     <div className="help-title">
-                        <span className="help-kind-label">snippet</span>
+                        <span className="help-kind-label">
+                            {t("help-kind-snippet", undefined, "snippet")}
+                        </span>
                         <span className="help-snippet-name">{snippetKey}</span>
                     </div>
                     <p className="help-description">{description}</p>
                     <div className="help-detail">
-                        <span className="help-detail-label">Inserts:</span>
+                        <span className="help-detail-label">
+                            {t("help-inserts", undefined, "Inserts:")}
+                        </span>
                         <span className="help-detail-value">{`<${elementName}>`}</span>
                     </div>
                     <pre className="help-snippet-preview">
@@ -399,7 +545,13 @@ export function ContextHelpPanel({
                 <div className="help-panel">
                     <div className="help-title">
                         {renderElementName(elementName, docsSlug, docsBase)}
-                        <span className="help-kind-label">array entry</span>
+                        <span className="help-kind-label">
+                            {t(
+                                "help-kind-array-entry",
+                                undefined,
+                                "array entry",
+                            )}
+                        </span>
                         <span className="help-property-name">
                             {displayTail}
                         </span>
@@ -410,9 +562,13 @@ export function ContextHelpPanel({
                     {aliasPath.length > 0 && (
                         <div className="help-detail">
                             <span className="help-detail-label">
-                                {aliasPath.length === 1
-                                    ? "Coordinate:"
-                                    : "Coordinates:"}
+                                {t(
+                                    "help-coordinates",
+                                    { count: aliasPath.length },
+                                    aliasPath.length === 1
+                                        ? "Coordinate:"
+                                        : "Coordinates:",
+                                )}
                             </span>
                             <span className="help-detail-value">
                                 {aliasPath.join(", ")}
@@ -421,21 +577,18 @@ export function ContextHelpPanel({
                     )}
                     {leafType && (
                         <div className="help-detail">
-                            <span className="help-detail-label">Type:</span>
+                            <span className="help-detail-label">
+                                {t("help-type", undefined, "Type:")}
+                            </span>
                             <span className="help-detail-value">
                                 {`<${leafType}>`}
                             </span>
                         </div>
                     )}
                     {docsSlug && (
-                        <a
-                            className="help-docs-link"
+                        <ReferencePageLink
                             href={`${docsBase}/reference/${docsSlug}`}
-                            target="_blank"
-                            rel="noreferrer noopener"
-                        >
-                            Reference page →
-                        </a>
+                        />
                     )}
                 </div>
             );
@@ -458,17 +611,34 @@ export function ContextHelpPanel({
             return (
                 <div className="help-panel">
                     <p className="help-ref-sentence">
-                        <code>{`$${displayPath}`}</code> is a reference to the{" "}
-                        <code>{propertyName}</code> property of{" "}
-                        <code>{`<${elementName}>`}</code>
-                        {line !== undefined ? ` (line ${line})` : ""}.
+                        {fillSlots(
+                            t(
+                                "help-property-is-reference",
+                                {
+                                    ref: slot(0),
+                                    property: slot(1),
+                                    element: slot(2),
+                                    line: lineArg(line),
+                                },
+                                line === undefined
+                                    ? `${slot(0)} is a reference to the ${slot(1)} property of ${slot(2)}.`
+                                    : `${slot(0)} is a reference to the ${slot(1)} property of ${slot(2)} (line ${line}).`,
+                            ),
+                            [
+                                <code>{`$${displayPath}`}</code>,
+                                <code>{propertyName}</code>,
+                                <code>{`<${elementName}>`}</code>,
+                            ],
+                        )}
                     </p>
                     <p className="help-description">
                         {renderInlineMarkdown(description)}
                     </p>
                     {type !== undefined && (
                         <div className="help-detail">
-                            <span className="help-detail-label">Type:</span>
+                            <span className="help-detail-label">
+                                {t("help-type", undefined, "Type:")}
+                            </span>
                             <span className="help-detail-value">
                                 {`<${type}>`}
                                 {isArray ? "[]" : ""}
@@ -539,18 +709,25 @@ function renderBreakdownValue(entry: {
  * when to mount it; this helper just keeps the markup in one place so the
  * two trigger sites can't drift in layout or class names.
  */
-function renderStyleBreakdown(breakdown: {
-    styleNumber: number;
-    entries: Array<{
-        key: string;
-        value: string | number | boolean;
-        colorWord?: string;
-    }>;
-}): React.ReactNode {
+function renderStyleBreakdown(
+    t: Translator,
+    breakdown: {
+        styleNumber: number;
+        entries: Array<{
+            key: string;
+            value: string | number | boolean;
+            colorWord?: string;
+        }>;
+    },
+): React.ReactNode {
     return (
         <div className="help-detail help-style-breakdown">
             <span className="help-detail-label">
-                {`Resolved style (styleNumber ${breakdown.styleNumber}):`}
+                {t(
+                    "help-resolved-style",
+                    { styleNumber: String(breakdown.styleNumber) },
+                    `Resolved style (styleNumber ${breakdown.styleNumber}):`,
+                )}
             </span>
             <dl className="help-style-breakdown-list">
                 {breakdown.entries.map((entry) => (
@@ -600,34 +777,62 @@ function renderLabeledChipList(
  * author that the other two attributes are inactive.
  */
 function renderFunctionNamesBreakdown(
+    t: Translator,
     breakdown: FunctionNamesBreakdownPayload,
 ): React.ReactNode {
     const isReset = breakdown.reset !== undefined;
     return (
         <div className="help-detail help-function-names-breakdown">
-            {renderLabeledChipList("Resolved function names:", breakdown.names)}
+            {renderLabeledChipList(
+                t(
+                    "help-resolved-function-names",
+                    undefined,
+                    "Resolved function names:",
+                ),
+                breakdown.names,
+            )}
             {isReset ? (
                 <>
                     {renderLabeledChipList(
-                        "Reset list on this input:",
+                        t(
+                            "help-reset-list",
+                            undefined,
+                            "Reset list on this input:",
+                        ),
                         breakdown.reset!,
                     )}
                     <span className="help-detail-annotation">
-                        {
-                            "resetFunctionNames overrides additionalFunctionNames and removedFunctionNames."
-                        }
+                        {/* The three attribute names are identifiers, so they
+                            are arguments rather than words in the sentence. */}
+                        {t(
+                            "help-reset-overrides",
+                            {
+                                reset: "resetFunctionNames",
+                                additional: "additionalFunctionNames",
+                                removed: "removedFunctionNames",
+                            },
+                            "resetFunctionNames overrides additionalFunctionNames and removedFunctionNames.",
+                        )}
                     </span>
                 </>
             ) : (
                 <>
                     {breakdown.added.length > 0 &&
                         renderLabeledChipList(
-                            "Added on this input:",
+                            t(
+                                "help-added-on-input",
+                                undefined,
+                                "Added on this input:",
+                            ),
                             breakdown.added,
                         )}
                     {breakdown.removed.length > 0 &&
                         renderLabeledChipList(
-                            "Removed on this input:",
+                            t(
+                                "help-removed-on-input",
+                                undefined,
+                                "Removed on this input:",
+                            ),
                             breakdown.removed,
                         )}
                 </>

--- a/packages/doenetml/test/cypress/component/DoenetEditor.contextHelpLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.contextHelpLocale.cy.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+
+// The context-help panel had no `useT()` in it, so it stayed English inside an
+// otherwise Spanish editor (Doenet/DoenetML#1580). Most of it is sentences
+// with something in `<code>` in the middle — "`$m` is a reference to
+// `<math>`" — which are one message each with the fragments as arguments, put
+// back as React nodes after Fluent has formatted the sentence. What is
+// asserted here is that the sentence comes out whole: the words translated,
+// the fragments still marked up, and no marker left in the text.
+
+const EDITOR_VIEWPORT = { height: "500px", width: "900px" };
+
+function mountHelp(doenetML: string, uiLocale?: string) {
+    cy.mount(
+        <div style={EDITOR_VIEWPORT}>
+            <DoenetEditor
+                doenetML={doenetML}
+                initialOpenTab="help"
+                addVirtualKeyboard={false}
+                {...(uiLocale ? { uiLocale } : {})}
+            />
+        </div>,
+    );
+}
+
+function focusEditorAtEnd() {
+    cy.get(".cm-content")
+        .should("be.visible")
+        .click()
+        .type("{ctrl+end}", { force: true });
+}
+
+describe("the context-help panel follows the reader's language", () => {
+    it("translates the placeholder and keeps its code fragment marked up", () => {
+        mountHelp("", "es");
+
+        cy.get(".help-placeholder", { timeout: 15_000 }).should(
+            "contain.text",
+            "Coloque el cursor",
+        );
+        // The fragment is still a `<code>` rather than plain text folded into
+        // the sentence, and the marker standing in for it is gone.
+        cy.get(".help-placeholder code").should("have.text", "$ref.property");
+        cy.get(".help-placeholder")
+            .invoke("text")
+            .should("not.contain", "\u0000");
+    });
+
+    it("translates a reference sentence around the names it quotes", () => {
+        // Driven from the autocomplete popup, the way the English spec beside
+        // this one reaches `refName` help.
+        mountHelp(`<math name="m">x</math>\n`, "es");
+        focusEditorAtEnd();
+        cy.get(".cm-content").type("$", { force: true });
+        cy.get(".cm-tooltip-autocomplete", { timeout: 15_000 }).should(
+            "be.visible",
+        );
+        cy.get(".cm-tooltip-autocomplete .cm-completionLabel")
+            .contains("m")
+            .trigger("mouseover");
+
+        cy.get(".help-ref-sentence")
+            .invoke("text")
+            .should("match", /\$m\s+es una referencia a\s+<math>/);
+        // The names inside the sentence are identifiers, still in `<code>`,
+        // and still spelled the way the author wrote them.
+        cy.get(".help-ref-sentence code").should("contain.text", "$m");
+    });
+
+    it("translates an attribute's detail labels", () => {
+        mountHelp("", "es");
+        focusEditorAtEnd();
+        cy.get(".cm-content").type("<math simplify", { force: true });
+        cy.get(".cm-content").type("{esc}", { force: true });
+
+        cy.get(".help-attribute-name", { timeout: 15_000 }).should(
+            "have.text",
+            "simplify",
+        );
+        cy.get(".help-kind-label").should("have.text", "atributo");
+        cy.get(".help-detail-label").should("contain.text", "Valor");
+        cy.get(".help-panel").should("not.contain.text", "Allowed values");
+    });
+
+    it("renders the same English as before when nothing asks for another language", () => {
+        mountHelp("", undefined);
+
+        cy.get(".help-placeholder", { timeout: 15_000 })
+            .invoke("text")
+            .should(
+                "eq",
+                "Place cursor on a tag name, attribute, or $ref.property for documentation.",
+            );
+    });
+});

--- a/packages/i18n/locales/en/editor.ftl
+++ b/packages/i18n/locales/en/editor.ftl
@@ -1,5 +1,6 @@
 # Editor and language-server surfaces: the footer, the diagnostics panel, the
-# variant picker and the accessibility button. Selected by `uiLocale`.
+# variant picker, the accessibility button, and the context-help panel beside
+# them. Selected by `uiLocale`.
 #
 # The editor binds to *one* language, and it is the one the viewer below it
 # resolved rather than the one the surrounding host chrome uses: the panel
@@ -164,3 +165,122 @@ editor-response-answer-id = Answer Id
 editor-response-response = Response
 editor-response-credit = Credit
 editor-response-submitted = Submitted
+
+
+## The context-help panel
+##
+## The panel beside the diagnostics, which explains whatever the cursor is on.
+## It is the last of the surfaces the header above names.
+##
+## Several of these sentences have marked-up fragments in them — an element
+## name in `<code>`, a link, a rendered piece of inline markdown. Those arrive
+## as arguments and are put back as React nodes after the message is formatted,
+## so a translation owns the whole sentence including where each fragment sits
+## and the punctuation around it. A translation that drops one simply renders
+## without it rather than losing the sentence.
+##
+## Element names, attribute names and `styleNumber` are DoenetML identifiers
+## and stay as written. The descriptions and summaries the panel shows come
+## from the schema, which is generated from the documentation and is not
+## translated, and the values it resolves — a color's derived word, a
+## function name, a type — come from the language server in the same state.
+## What is here is the panel's own prose around them (#1580).
+
+help-placeholder = Place cursor on a tag name, attribute, or { $ref } for documentation.
+
+help-unsupported-ref-chain = Help for multi-part references like { $example } is not yet supported.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] No referent found for reference: { $ref }.
+        [multiple] Multiple referents found for reference: { $ref }.
+       *[indeterminate] A referent for { $ref } could not be determined.
+    }
+
+# Both links end in an arrow, which is direction rather than punctuation and is
+# the same in every language this ships in — but it is inside the message, so a
+# language written right to left can turn it around.
+help-learn-about-references = Learn about references →
+help-reference-page = Reference page →
+
+# What can go where the cursor is. Two selectors joined: where the cursor sits,
+# and what the schema allows there.
+help-suggestions-header =
+    { $location ->
+        [inside] Inside { $element }
+       *[top] At the top level
+    }{ $allowed ->
+        [none] { " — nothing goes here." }
+        [text] { " — type text here." }
+        [text-and-components] { " — type text here, or try:" }
+       *[components] { " — things to try:" }
+    }
+
+# `$shortcut` is a key combination and stays as written. `$total` is a real
+# count, so a language that agrees a noun with it can select on it.
+help-suggestions-footer = Press { $shortcut } to see all { $total } components.
+
+# An element's name joined to its one-line summary. `$name` is empty where the
+# panel has already printed the name beside this — a suggestion in the list —
+# and only the separator is wanted, so the message has to read as punctuation
+# on its own.
+help-name-summary = { $name } — { $summary }
+
+# `$line` is text, not a number: it identifies a line, so line 1234 is "1234"
+# and not "1,234". `none` is how a position that is not known selects a
+# sentence without one rather than substituting an empty parenthesis.
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } is a reference to { $target }.
+       *[other] { $ref } is a reference to { $target } (line { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Introduced by { $owner } as { $role }.
+       *[other] Introduced by { $owner } on line { $line } as { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } is a reference to the { $property } property of { $element }.
+       *[other] { $ref } is a reference to the { $property } property of { $element } (line { $line }).
+    }
+
+# The badge on the title row saying what kind of thing the panel is explaining.
+help-kind-attribute = attribute
+help-kind-snippet = snippet
+help-kind-array-entry = array entry
+
+help-default = Default:
+help-active-default = Active default:
+
+# Appended after the active default's value. `styleNumber` is the attribute's
+# own name and stays as written; the space and brackets around it do not.
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Allowed values (one per item):
+       *[other] Allowed values:
+    }
+
+help-inserts = Inserts:
+
+help-coordinates =
+    { $count ->
+        [one] Coordinate:
+       *[other] Coordinates:
+    }
+
+help-type = Type:
+
+help-resolved-style = Resolved style (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Resolved function names:
+help-reset-list = Reset list on this input:
+help-added-on-input = Added on this input:
+help-removed-on-input = Removed on this input:
+
+# The three names are attributes an author writes, so they stay as written.
+help-reset-overrides = { $reset } overrides { $additional } and { $removed }.

--- a/packages/i18n/locales/es/editor.ftl
+++ b/packages/i18n/locales/es/editor.ftl
@@ -1,5 +1,6 @@
 # Superficies del editor: el pie, el panel de diagnósticos, el selector de
-# variantes y el botón de accesibilidad. Se selecciona con `uiLocale`.
+# variantes, el botón de accesibilidad y el panel de ayuda contextual.
+# Se selecciona con `uiLocale`.
 #
 # `WCAG AA` es el nombre de la norma y no se traduce.
 
@@ -115,3 +116,91 @@ editor-response-answer-id = Id. de respuesta
 editor-response-response = Respuesta
 editor-response-credit = Puntuación
 editor-response-submitted = Enviada
+
+
+## El panel de ayuda contextual
+##
+## Los fragmentos con formato — un nombre de elemento en `<code>`, un enlace —
+## llegan como argumentos y se vuelven a insertar después de formatear el
+## mensaje, de modo que la traducción decide dónde va cada uno.
+
+help-placeholder = Coloque el cursor sobre el nombre de una etiqueta, un atributo o { $ref } para ver la documentación.
+
+help-unsupported-ref-chain = Todavía no hay ayuda para las referencias de varias partes como { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] No se encontró ningún referente para la referencia: { $ref }.
+        [multiple] Se encontraron varios referentes para la referencia: { $ref }.
+       *[indeterminate] No se pudo determinar un referente para { $ref }.
+    }
+
+help-learn-about-references = Más información sobre las referencias →
+help-reference-page = Página de referencia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Dentro de { $element }
+       *[top] En el nivel superior
+    }{ $allowed ->
+        [none] { " — aquí no va nada." }
+        [text] { " — escriba texto aquí." }
+        [text-and-components] { " — escriba texto aquí o pruebe con:" }
+       *[components] { " — puede probar con:" }
+    }
+
+help-suggestions-footer = Pulse { $shortcut } para ver los { $total } componentes.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } es una referencia a { $target }.
+       *[other] { $ref } es una referencia a { $target } (línea { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Introducida por { $owner } como { $role }.
+       *[other] Introducida por { $owner } en la línea { $line } como { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } es una referencia a la propiedad { $property } de { $element }.
+       *[other] { $ref } es una referencia a la propiedad { $property } de { $element } (línea { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = fragmento
+help-kind-array-entry = entrada de arreglo
+
+help-default = Valor predeterminado:
+help-active-default = Valor predeterminado activo:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valores admitidos (uno por elemento):
+       *[other] Valores admitidos:
+    }
+
+help-inserts = Inserta:
+
+help-coordinates =
+    { $count ->
+        [one] Coordenada:
+       *[other] Coordenadas:
+    }
+
+help-type = Tipo:
+
+help-resolved-style = Estilo resuelto (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nombres de función resueltos:
+help-reset-list = Lista restablecida en esta entrada:
+help-added-on-input = Añadidos en esta entrada:
+help-removed-on-input = Eliminados en esta entrada:
+
+help-reset-overrides = { $reset } prevalece sobre { $additional } y { $removed }.

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -534,7 +534,34 @@ export type MessageKey =
     | "editor-response-answer-id"
     | "editor-response-response"
     | "editor-response-credit"
-    | "editor-response-submitted";
+    | "editor-response-submitted"
+    | "help-placeholder"
+    | "help-unsupported-ref-chain"
+    | "help-unresolved-ref"
+    | "help-learn-about-references"
+    | "help-reference-page"
+    | "help-suggestions-header"
+    | "help-suggestions-footer"
+    | "help-name-summary"
+    | "help-ref-is-reference"
+    | "help-ref-derived-from"
+    | "help-property-is-reference"
+    | "help-kind-attribute"
+    | "help-kind-snippet"
+    | "help-kind-array-entry"
+    | "help-default"
+    | "help-active-default"
+    | "help-style-number-annotation"
+    | "help-allowed-values"
+    | "help-inserts"
+    | "help-coordinates"
+    | "help-type"
+    | "help-resolved-style"
+    | "help-resolved-function-names"
+    | "help-reset-list"
+    | "help-added-on-input"
+    | "help-removed-on-input"
+    | "help-reset-overrides";
 
 /** Every key in the English catalogs, in catalog order. */
 export const MESSAGE_KEYS: readonly MessageKey[] = [
@@ -1066,4 +1093,31 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "editor-response-response",
     "editor-response-credit",
     "editor-response-submitted",
+    "help-placeholder",
+    "help-unsupported-ref-chain",
+    "help-unresolved-ref",
+    "help-learn-about-references",
+    "help-reference-page",
+    "help-suggestions-header",
+    "help-suggestions-footer",
+    "help-name-summary",
+    "help-ref-is-reference",
+    "help-ref-derived-from",
+    "help-property-is-reference",
+    "help-kind-attribute",
+    "help-kind-snippet",
+    "help-kind-array-entry",
+    "help-default",
+    "help-active-default",
+    "help-style-number-annotation",
+    "help-allowed-values",
+    "help-inserts",
+    "help-coordinates",
+    "help-type",
+    "help-resolved-style",
+    "help-resolved-function-names",
+    "help-reset-list",
+    "help-added-on-input",
+    "help-removed-on-input",
+    "help-reset-overrides",
 ];


### PR DESCRIPTION
Based on `main`, now that #1586 has merged. This PR is one commit, and the last of the five.

Closes #1580.

## What was English

The context-help panel — the tab beside Diagnostics that explains whatever the cursor is on — was the last English surface inside the editor. About thirty strings, and most of them are not labels.

They are sentences with markup in the middle of them:

```jsx
<code>{`$${displayPath}`}</code> is a reference to{" "}
<code>{`<${targetElementName}>`}</code>
{line !== undefined ? ` (line ${line})` : ""}.
```

Splitting that at the markup would hand a translator three fragments and no sentence, and would fix English's word order in the JSX.

## Sentences with holes in them

Each sentence is one message; each marked-up fragment is an argument carrying a marker; the marker is swapped for its React node once Fluent has formatted the sentence. `EditorViewer/slots.tsx` is the whole mechanism, about twenty lines, and #1586 added it for the one sentence of that shape in the diagnostics panel. Ten more arrive here, which is what it was written for.

The marker is a NUL-delimited index rather than the fragment's own text, which matters for three reasons: a fragment can repeat, a translation can reorder them, and a marker cannot be found by accident inside the surrounding prose the way a bare `"$m"` could. NUL cannot appear in an FTL source or in anything this panel formats. A translation that drops a placeable renders without that fragment rather than losing the sentence.

## Everything else that was composed in code

- Whether a line number is known **selects a sentence** rather than appending ` (line N)`, so a language that puts the position first can.
- The four things that can go where the cursor sits — nothing, text, components, both — select the header's suffix, which was a nested ternary building ` — type text here, or try:`.
- `Coordinate:` / `Coordinates:` is a Fluent selector on the count rather than `aliasPath.length === 1`.
- `Allowed values (one per item):` likewise.
- Line numbers are passed as text, so Fluent hands them to no `Intl.NumberFormat` and line 1234 stays `1234`.
- The `Reference page →` footer link was written out three times; it is one component now.

## What stays as written

Element names, attribute names, `styleNumber`, and the three function-name attributes in `resetFunctionNames overrides …` are DoenetML identifiers, so they are arguments rather than words.

The descriptions and summaries the panel shows come from the schema, which is generated from the documentation. Translating those is the documentation question the issue put out of scope. The values the panel resolves are in the same position: a color's derived word, a function name, a type all arrive from the language server as they are, and what moves here is the panel's own prose around them. The catalog's section header says so, so a later reader does not take the untranslated word for an oversight.

## Tests

`DoenetEditor.contextHelpLocale.cy.tsx`, four tests: the placeholder in Spanish with its `<code>` fragment still marked up and no marker left in the text; a reference sentence translated around the names it quotes, with the names still in `<code>` and still spelled as the author wrote them; an attribute's detail labels; and the English one, asserted as an exact string rather than a substring, since "unchanged" is the claim.

Regression: the existing `DoenetEditor.contextHelp.cy.tsx` (7 tests, untouched), the editor chrome spec from #1586 (6) and `DoenetEditor.refreshKeyboardShortcut` (4) stay green, `@doenet/i18n` passes (157), and `lint:i18n` reports 555 keys across 2 locales and 363 call sites with no orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





