### PR TITLE
Keep the whole check-work widget in one language

### DIFF
--- a/.changeset/check-work-button-one-language.md
+++ b/.changeset/check-work-button-one-language.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Keep the whole check-work widget in one language.
+
+The button rested on a label in the document's language and then reported "Correct", "37% Credit" or "Response Saved" in the reader's, so an activity declaring `lang="es"` read with `uiLocale="en"` said "Revisar" and then "Correct" on the same control.
+
+The button, its verdict, the attempts-remaining message beside it and the validation state announced on the input now all follow the document. An author can name that button from their own prose — "Pulsa el botón $ans.submitLabel" — and a sentence that names the button has to name what the button actually says, so the label, the prose pointing at it, and the verdict are all one language.
+
+Nothing changes when the reader's language and the document's agree. Where they differ the whole widget is now the document's — including when an activity declares no language at all, which counts as English: a reader who set `uiLocale="es"` used to see a Spanish "Correcto" beside an English "Check Work", and now sees the control wholly in English. One language on one control is the trade.
+
+Error boxes still follow the reader: a diagnostic is addressed to whoever is looking at the screen, and no authored prose ever refers to one.

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -49,7 +49,11 @@ import {
     CORE_START_FAILED_MESSAGE,
 } from "./coreWorkerBoot";
 import type { ResolvedTheme } from "../utils/theme";
-import { I18nProvider, useChromeTranslator } from "../utils/i18n";
+import {
+    ContentI18nProvider,
+    I18nProvider,
+    useChromeTranslator,
+} from "../utils/i18n";
 import {
     localizeDiagnostics,
     useDiagnosticFormatter,
@@ -568,6 +572,14 @@ export function DocViewer({
     // `translate`, so a key reached from here would otherwise read as an
     // orphan.
     const translate = useChromeTranslator(effectiveUiLocale, localeResources);
+    // The same catalogs negotiated against the *content's* language, for a
+    // control the core already writes part of — see `useContentT`. Built from
+    // `effectiveDocumentLocale`, the tag the core itself was handed, so the
+    // words this renders and the words the worker computed cannot disagree.
+    const translateContent = useChromeTranslator(
+        effectiveDocumentLocale,
+        localeResources,
+    );
     const formatDiagnostic = useDiagnosticFormatter(
         translate,
         effectiveUiLocale,
@@ -2315,7 +2327,9 @@ export function DocViewer({
                         translate={translate}
                         locale={effectiveUiLocale}
                     >
-                        {documentRenderer}
+                        <ContentI18nProvider translate={translateContent}>
+                            {documentRenderer}
+                        </ContentI18nProvider>
                     </I18nProvider>
                 </DocContext.Provider>
             </div>

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -11,7 +11,7 @@ import {
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { DynamicMath } from "./utils/DynamicMath";
 import { DescriptionPopover } from "./utils/Description";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface AnswerSVs {
     [key: string]: any;
@@ -40,7 +40,9 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
         callAction,
     } = useDoenetRenderer<AnswerSVs>(props);
 
-    const t = useT();
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     const { showAnswerResponseButton, answerResponseCounts } =
         useContext(DocContext) || {};
@@ -104,7 +106,7 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
         submitActionWithPending,
         SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton,
         isPending,
-        t,
+        tContent,
     );
 
     if (checkWorkComponent) {

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -19,7 +19,7 @@ import {
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface BooleanInputSVs {
     [key: string]: any;
@@ -44,7 +44,9 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, ignoreUpdate, callAction } =
         useDoenetRenderer<BooleanInputSVs>(props);
 
-    const t = useT();
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     // @ts-ignore
     BooleanInput.baseStateVariable = "value";
@@ -501,7 +503,7 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
         submitActionWithPending,
         SVs.forceFullCheckWorkButton,
         isPending,
-        t,
+        tContent,
     );
 
     let input;

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -21,7 +21,7 @@ import { DescriptionPopover } from "./utils/Description";
 import { addValidationStateToShortDescription } from "./utils/validationState";
 import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 // type guard
 const isMultiValue = <T,>(
@@ -77,7 +77,10 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
     let { id, SVs, actions, children, ignoreUpdate, callAction } =
         useDoenetRenderer<ChoiceInputSVs>(props);
 
-    const t = useT();
+    // The check-work button and the validation state announced on the input
+    // both follow the document's language, not the reader's — see
+    // `useContentT`.
+    const tContent = useContentT();
 
     const { darkMode } = useContext(DocContext) || {};
 
@@ -239,7 +242,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         submitActionWithPending,
         fullCheckWork,
         isPending,
-        t,
+        tContent,
     );
 
     const inlineSelectComponents = useMemo(
@@ -281,7 +284,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             shortDescription = addValidationStateToShortDescription(
                 validationState,
                 shortDescription,
-                t,
+                tContent,
             );
         }
 

--- a/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
@@ -9,7 +9,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface ContainerBlockSVs {
     [key: string]: any;
@@ -23,7 +23,9 @@ export default React.memo(function Container(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, callAction } =
         useDoenetRenderer<ContainerBlockSVs>(props);
 
-    const t = useT();
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     const ref = useRef(null);
 
@@ -51,7 +53,7 @@ export default React.memo(function Container(props: UseDoenetRendererProps) {
             submitActionWithPending,
             true,
             isPending,
-            t,
+            tContent,
         );
 
         if (checkWorkComponent) {

--- a/packages/doenetml/src/Viewer/renderers/containerInline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerInline.tsx
@@ -8,7 +8,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface ContainerInlineSVs {
     [key: string]: any;
@@ -23,7 +23,9 @@ export default React.memo(function ContainerInline(
     let { id, SVs, children, actions, callAction } =
         useDoenetRenderer<ContainerInlineSVs>(props);
 
-    const t = useT();
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     if (SVs.hidden) {
         return null;
@@ -47,7 +49,7 @@ export default React.memo(function ContainerInline(
             submitActionWithPending,
             true,
             isPending,
-            t,
+            tContent,
         );
     }
 

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -13,7 +13,7 @@ import {
 import { addValidationStateToShortDescription } from "./utils/validationState";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface FractionInputSVs {
     [key: string]: any;
@@ -36,7 +36,10 @@ export default React.memo(function FractionInput(
     let { id, SVs, actions, children, callAction } =
         useDoenetRenderer<FractionInputSVs>(props);
 
-    const t = useT();
+    // The check-work button and the validation state announced on the input
+    // both follow the document's language, not the reader's — see
+    // `useContentT`.
+    const tContent = useContentT();
 
     // need to use a ref for validation state as handlePressEnter
     // does not update to current values
@@ -65,7 +68,7 @@ export default React.memo(function FractionInput(
         submitActionWithPending,
         SVs.forceFullCheckWorkButton,
         isPending,
-        t,
+        tContent,
     );
 
     let label: React.ReactNode = SVs.label;
@@ -93,7 +96,7 @@ export default React.memo(function FractionInput(
         shortDescription = addValidationStateToShortDescription(
             validationState.current,
             shortDescription,
-            t,
+            tContent,
         );
     }
 

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -9,7 +9,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface ListSVs {
     [key: string]: any;
@@ -26,7 +26,9 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, callAction } =
         useDoenetRenderer<ListSVs>(props);
 
-    const t = useT();
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     const ref = useRef(null);
 
@@ -54,7 +56,7 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
             submitActionWithPending,
             true,
             isPending,
-            t,
+            tContent,
         );
     }
 

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -38,7 +38,7 @@ import {
     POINTER_DRAG_THRESHOLD,
 } from "./utils/graph";
 import { JXGObject } from "./jsxgraph-distrib/types";
-import { useT } from "../../utils/i18n";
+import { useContentT, useT } from "../../utils/i18n";
 
 const PREVIEW_UPDATE_DELAY_MS = 500;
 const PARSE_ERROR_PLACEHOLDER_LATEX = "\uff3f";
@@ -418,7 +418,10 @@ export default function MathInput(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, ignoreUpdate, callAction } =
         useDoenetRenderer<MathInputSVs>(props);
 
-    const t = useT();
+    // The check-work button and the validation state announced on the input
+    // both follow the document's language, not the reader's — see
+    // `useContentT`.
+    const tContent = useContentT();
 
     // @ts-ignore
     MathInput.baseStateVariable = "rawRendererValue";
@@ -1072,7 +1075,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
             shortDescription = addValidationStateToShortDescription(
                 validationState.current,
                 shortDescription,
-                t,
+                tContent,
             );
         }
     }
@@ -1297,7 +1300,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         submitActionWithPending,
         SVs.forceFullCheckWorkButton,
         isPending,
-        t,
+        tContent,
     );
 
     const labelComponent = hasLabel ? (

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
@@ -15,7 +15,7 @@ import {
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT, useT } from "../../utils/i18n";
 
 interface MatrixInputSVs {
     [key: string]: any;
@@ -39,6 +39,10 @@ export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
         useDoenetRenderer<MatrixInputSVs>(props);
 
     const t = useT();
+
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     // need to use a ref for validation state as handlePressEnter
     // does not update to current values
@@ -78,7 +82,7 @@ export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
         submitActionWithPending,
         SVs.forceFullCheckWorkButton,
         isPending,
-        t,
+        tContent,
     );
 
     let matrixInputs = [];

--- a/packages/doenetml/src/Viewer/renderers/p.tsx
+++ b/packages/doenetml/src/Viewer/renderers/p.tsx
@@ -10,7 +10,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface PSVs {
     [key: string]: any;
@@ -24,7 +24,9 @@ export default React.memo(function P(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, callAction } =
         useDoenetRenderer<PSVs>(props);
 
-    const t = useT();
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     const ref = useRef(null);
 
@@ -52,7 +54,7 @@ export default React.memo(function P(props: UseDoenetRendererProps) {
             submitActionWithPending,
             true,
             isPending,
-            t,
+            tContent,
         );
     }
 

--- a/packages/doenetml/src/Viewer/renderers/pretzel.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pretzel.tsx
@@ -11,7 +11,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT, useT } from "../../utils/i18n";
 
 interface PretzelSVs {
     [key: string]: any;
@@ -35,6 +35,10 @@ export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
     } = useDoenetRenderer<PretzelSVs>(props);
 
     const t = useT();
+
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     const ref = useRef(null);
 
@@ -140,7 +144,7 @@ export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
         submitActionWithPending,
         true,
         isPending,
-        t,
+        tContent,
     );
 
     return (

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -21,7 +21,7 @@ import {
 import { cesc } from "@doenet/utils";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { DocContext } from "../DocViewer";
-import { useT } from "../../utils/i18n";
+import { useContentT, useT } from "../../utils/i18n";
 import { clickToToggleLabel } from "./utils/disclosure";
 
 interface SectionSVs {
@@ -51,6 +51,10 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         useDoenetRenderer<SectionSVs>(props);
 
     const t = useT();
+
+    // The check-work button follows the document's language, not the
+    // reader's — see `useContentT`.
+    const tContent = useContentT();
 
     const { darkMode } = useContext(DocContext) || {};
 
@@ -452,7 +456,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         submitActionWithPending,
         true,
         isPending,
-        t,
+        tContent,
     );
 
     if (checkWorkComponent) {

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -20,7 +20,7 @@ import "./textInput.css";
 import { DescriptionPopover } from "./utils/Description";
 import { addValidationStateToShortDescription } from "./utils/validationState";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useT } from "../../utils/i18n";
+import { useContentT } from "../../utils/i18n";
 
 interface TextInputSVs {
     [key: string]: any;
@@ -49,7 +49,10 @@ export default function TextInput(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, ignoreUpdate, callAction } =
         useDoenetRenderer<TextInputSVs>(props);
 
-    const t = useT();
+    // The check-work button and the validation state announced on the input
+    // both follow the document's language, not the reader's — see
+    // `useContentT`.
+    const tContent = useContentT();
 
     let width = sizeToCSS(SVs.width);
     let height = sizeToCSS(SVs.height); // only for TextArea
@@ -617,7 +620,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
         submitActionWithPending,
         SVs.forceFullCheckWorkButton,
         isPending,
-        t,
+        tContent,
     );
 
     let input;
@@ -658,7 +661,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
         shortDescription = addValidationStateToShortDescription(
             validationState,
             shortDescription,
-            t,
+            tContent,
         );
     }
 

--- a/packages/doenetml/src/Viewer/renderers/utils/checkWork.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/checkWork.tsx
@@ -48,8 +48,15 @@ export function calculateValidationState(
  * - showText: if true, then the button includes text like "Submit" or "Correct"
  *   in addition to the symbols
  * - isPending: if true, shows pending/checking state with spinner
- * - t: chrome translator from `useT()`. Passed in rather than read from
- *   context here because this is a plain function that several renderers call
+ * - t: translator for the *document's* language, from `useContentT()` — not
+ *   the reader's. The resting label is `SVs.submitLabel`, which the core
+ *   computed against `documentLocale` because authored prose can name it
+ *   ("Pulsa el botón $ans.submitLabel"), so everything else written here has
+ *   to answer to the same tag: the verdict, the status only a screen reader
+ *   hears, and the message line beside the button, which sits next to
+ *   `submitLabel` in one hidden span or one joined sentence. See `useContentT`
+ *   for the whole argument. Passed in rather than read from context here
+ *   because this is a plain function that several renderers call
  *   conditionally, so it cannot itself use a hook.
  */
 export function createCheckWorkComponent(

--- a/packages/doenetml/src/Viewer/renderers/utils/validationState.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/validationState.ts
@@ -5,7 +5,13 @@ import type { Translator } from "@doenet/i18n";
  *
  * @param validationState - one of "correct", "incorrect", "partialcorrect", or "unvalidated"
  * @param shortDescription - the existing short description
- * @param t - chrome translator from `useT()`
+ * @param t - translator for the *document's* language, from `useContentT()`.
+ *   This suffix and the check-work button beside it announce the same verdict
+ *   about the same response, so they are one control and answer to one tag
+ *   (see `useContentT`). Being addressed to a screen reader does not put it on
+ *   `uiLocale`: the button's own `aria-live` region is addressed there too and
+ *   follows the document. Splitting them would land only on screen-reader
+ *   users, who are the only ones who hear both.
  * @returns updated short description with validation state appended if applicable
  */
 export function addValidationStateToShortDescription(

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -126,3 +126,82 @@ export function useT(): Translator {
 export function useUiLocale(): string {
     return useContext(I18nContext).locale;
 }
+
+/**
+ * The translator for the *document's* language, as opposed to the reader's.
+ *
+ * Defaults to English for the same reason {@link I18nContext} does: a renderer
+ * mounted outside any provider should keep rendering what it renders today.
+ */
+const ContentI18nContext = createContext<Translator>(EN_CHROME_TRANSLATOR);
+
+/**
+ * Publish the document-language translator to every {@link useContentT} below.
+ *
+ * Mounted by `DocViewer` beside {@link I18nProvider}, from the same
+ * `effectiveDocumentLocale` the core was handed — so a word this renders and a
+ * word the worker computed cannot disagree.
+ *
+ * Needs no `useMemo` where {@link I18nProvider} does: what it publishes is the
+ * translator itself, which `useChromeTranslator` already memoizes, rather than
+ * an object rebuilt on every render.
+ */
+export function ContentI18nProvider({
+    translate,
+    children,
+}: {
+    translate: Translator;
+    children: React.ReactNode;
+}) {
+    return (
+        <ContentI18nContext.Provider value={translate}>
+            {children}
+        </ContentI18nContext.Provider>
+    );
+}
+
+/**
+ * A translator bound to the document's language — usually *not* the one to
+ * reach for. Almost everything a renderer draws is chrome and belongs on
+ * {@link useT}; this is for a control the core already writes part of, where
+ * following the reader would put one widget in two languages.
+ *
+ * The check-work button is the case it exists for, and the reason is a chain
+ * of two links rather than taste. Its resting label is `submitLabel`, a
+ * *content* state variable: an author can write `submitLabel="Comprueba"`, and
+ * can interpolate `$ans.submitLabel` into their own prose — "Pulsa el botón
+ * $ans.submitLabel" — so its value cannot depend on who is reading, and the
+ * worker that computes it is never told `uiLocale`. Everything the button says
+ * afterwards ("Correct", "37% Credit", "no attempts remaining") therefore has
+ * to answer to the same tag, or the sentence pointing at the button stops
+ * naming what the button says.
+ *
+ * What answers to it is the whole control, not each string weighed alone. The
+ * button's visually hidden span carries `submitLabel` verbatim beside the
+ * status only a screen reader hears ("Checking answer"), so putting that
+ * announcement in the reader's language would leave one span bilingual; the
+ * `Max credit available: 80%; 1 attempt remaining` line renders as a single
+ * joined sentence immediately after the button and splits no better.
+ *
+ * This is deliberately *not* the rule for everything drawn inside the
+ * document. What a *neighbouring* element says is weighed on its own, and
+ * mostly comes out the other way: the in-document error box follows the reader
+ * (#1570), and so does the validation state appended to an input's accessible
+ * description, because both are addressed to whoever is looking at the screen
+ * and no authored prose ever refers to them. The test is whether the author's
+ * own document talks about the words — not where they appear.
+ *
+ * The catalogs are the same ones {@link useT} resolves against; only the
+ * negotiated locale differs. The keys stay in `chrome.ftl` because namespaces
+ * split by *load context*, and these are drawn on the main thread — moving
+ * them to `content` would ship them to the worker, which never draws them.
+ *
+ * Bind it as `tContent`, and reach its keys through a helper whose own
+ * parameter is named `t` (`createCheckWorkComponent`). `lint:i18n` only sees
+ * call sites through a translator named `t` or `translate`, so a key called
+ * straight off `tContent` would read as an orphan; the name also keeps `t`
+ * meaning the reader's translator in every renderer.
+ */
+export function useContentT(): Translator {
+    return useContext(ContentI18nContext);
+}

--- a/packages/doenetml/test/cypress/component/DoenetViewer.checkWorkLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.checkWorkLocale.cy.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+
+// The check-work button is written half by the core and half by the renderer.
+// Its resting label is `submitLabel`, a *content* state variable in the
+// document's language; everything it said once pressed came from the chrome
+// catalog, in the reader's. A `lang="es"` document read with `uiLocale="en"`
+// therefore said "Revisar" and then "Correct" on one control.
+//
+// The whole control follows the document now, because an author can point at
+// that label by name — "Pulsa el botón $ans.submitLabel" — and a sentence that
+// names the button has to name what the button actually says. That chain is
+// what these pin: the prose, the resting label and the verdict are one
+// language, whatever the reader asked for.
+
+const VIEWER_TIMEOUT = 15_000;
+
+const ANSWER = `<answer name="ans">x</answer>`;
+
+/**
+ * The button, which carries both halves of the text under test.
+ *
+ * By class rather than by id: an `<answer>` delegates its button to whichever
+ * input it created, so the id belongs to that generated input rather than to
+ * the name the author wrote.
+ */
+const CHECK_WORK = ".check-work";
+
+describe("the check-work button speaks the document's language", () => {
+    it("stays Spanish through a submit, for an English reader", () => {
+        // The reported case: the two locales deliberately disagree.
+        cy.mount(
+            <DoenetViewer
+                doenetML={`<document lang="es">${ANSWER}</document>`}
+                uiLocale="en"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get(CHECK_WORK, { timeout: VIEWER_TIMEOUT }).should(
+            "contain.text",
+            "Revisar",
+        );
+        cy.get(CHECK_WORK).click();
+        cy.get(CHECK_WORK).should("contain.text", "Incorrecto");
+    });
+
+    it("names the button the same way the author's prose does", () => {
+        // The reason the whole control moved rather than only half of it. An
+        // author who writes "the button labeled $ans.submitLabel" is naming
+        // the button; if the two disagreed the student would be told to press
+        // something that isn't there.
+        cy.mount(
+            <DoenetViewer
+                doenetML={`<document lang="es"><answer name="ans">x</answer><p name="prose">$ans.submitLabel</p></document>`}
+                uiLocale="en"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get("#prose", { timeout: VIEWER_TIMEOUT })
+            .invoke("text")
+            .then((prose) => {
+                expect(prose.trim()).to.eq("Revisar");
+                cy.get(CHECK_WORK).should("contain.text", prose.trim());
+            });
+    });
+
+    it("keeps an authored label and the prose naming it in step", () => {
+        // The author's own words are already immune to both locales; what
+        // matters is that the button and the sentence still agree.
+        cy.mount(
+            <DoenetViewer
+                doenetML={`<document lang="es"><answer name="ans" submitLabel="¿Listo?">x</answer><p name="prose">$ans.submitLabel</p></document>`}
+                uiLocale="en"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get("#prose", { timeout: VIEWER_TIMEOUT }).should(
+            "have.text",
+            "¿Listo?",
+        );
+        cy.get(CHECK_WORK).should("contain.text", "¿Listo?");
+    });
+
+    it("renders the same English as before when nothing declares a language", () => {
+        cy.mount(<DoenetViewer doenetML={ANSWER} addVirtualKeyboard={false} />);
+
+        cy.get(CHECK_WORK, { timeout: VIEWER_TIMEOUT }).should(
+            "contain.text",
+            "Check Work",
+        );
+        cy.get(CHECK_WORK).click();
+        cy.get(CHECK_WORK).should("contain.text", "Incorrect");
+    });
+
+    it("keeps the button English when only the reader declares a language", () => {
+        // The trade, on its most common path, pinned so it is not rediscovered
+        // as a bug. An activity that declares nothing counts as English, so a
+        // reader who set `uiLocale` alone used to get a Spanish verdict beside
+        // the worker's English "Check Work" and now gets the control wholly in
+        // English. Chrome no authored prose can name — the disclosure label —
+        // still follows the reader, which is what makes this a choice rather
+        // than the setting being ignored.
+        cy.mount(
+            <DoenetViewer
+                doenetML={`${ANSWER}<solution name="sol"><p>respuesta</p></solution>`}
+                uiLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get(CHECK_WORK, { timeout: VIEWER_TIMEOUT }).should(
+            "contain.text",
+            "Check Work",
+        );
+        cy.get("#sol_button").should("contain.text", "(clic para abrir)");
+
+        cy.get(CHECK_WORK).click();
+        cy.get(CHECK_WORK).should("contain.text", "Incorrect");
+    });
+
+    it("follows the host's documentLocale when the document declares none", () => {
+        // The content language is the host's `documentLocale` prop, overridden
+        // by an authored `<document lang>` and only then falling back to
+        // English — so an activity that declares nothing still follows
+        // whatever the host configured rather than stranding on English.
+        cy.mount(
+            <DoenetViewer
+                doenetML={ANSWER}
+                documentLocale="es"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get(CHECK_WORK, { timeout: VIEWER_TIMEOUT }).should(
+            "contain.text",
+            "Revisar",
+        );
+        cy.get(CHECK_WORK).click();
+        cy.get(CHECK_WORK).should("contain.text", "Incorrecto");
+    });
+
+    it("leaves the error box in the reader's language", () => {
+        // The other half of the split, and the reason this is not "everything
+        // inside the document follows the document". A diagnostic is addressed
+        // to whoever is looking at the screen, and no authored prose ever
+        // names it, so it still follows `uiLocale` (Doenet/DoenetML#1570).
+        cy.mount(
+            <DoenetViewer
+                doenetML={`<document lang="es">\n<abc></abc></document>`}
+                uiLocale="en"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.contains("Invalid component type", { timeout: VIEWER_TIMEOUT });
+        cy.get("body").should("not.contain.text", "Tipo de componente");
+    });
+
+    it("announces the verdict once, in one language", () => {
+        // `mathInput`, `textInput`, `fractionInput` and `choiceInput` append
+        // the validation state to the input's accessible description, and the
+        // button beside it announces the same verdict through its own
+        // `aria-live` region. A screen-reader user hears both, and is the only
+        // one who does — so this is the reader most exposed to a split, and the
+        // two have to agree.
+        cy.mount(
+            <DoenetViewer
+                doenetML={`<document lang="es"><answer name="ans"><textInput name="ti" /><award>hola</award></answer></document>`}
+                uiLocale="en"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get("#ti_input", { timeout: VIEWER_TIMEOUT }).type("mal");
+        cy.get(CHECK_WORK).click();
+
+        cy.get(CHECK_WORK).should("contain.text", "Incorrecto");
+        cy.get("#ti_input").should("have.attr", "aria-label", "(Incorrecto)");
+    });
+});

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -15,12 +15,22 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
     /**
      * A section-wide check-work button, which gives a stable `#prob_button`
      * to assert on without resolving the answer's input index, plus the
-     * attempts-remaining message.
+     * attempts-remaining message beside it.
+     *
+     * Both of those follow the *document's* language, not the reader's: an
+     * author can name the button from their own prose ("press
+     * $ans.submitLabel"), so the button, the sentence pointing at it and the
+     * status beside it are one language whatever the reader asked for.
+     * `uiLocale` is probed through `<solution>`'s disclosure label instead,
+     * which nothing in the document refers to.
      */
     const problem = `
     <problem sectionWideCheckWork maxNumAttempts="2" name="prob">
       <p><answer name="ans"><textInput name="ti" /><award>hello</award></answer></p>
     </problem>`;
+
+    /** A disclosure label, which does follow the reader. */
+    const solution = `<solution name="sol"><p>respuesta</p></solution>`;
 
     function submitWrongAnswer() {
         cy.get("#ti_input").type("wrong");
@@ -48,7 +58,17 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
     });
 
     it("translates chrome for a host-supplied uiLocale", () => {
-        render({ doenetML: problem, uiLocale: "es" });
+        render({ doenetML: solution, uiLocale: "es" });
+
+        cy.get("#sol_button").should("contain.text", "(clic para abrir)");
+    });
+
+    it("translates the check-work widget for the document's language", () => {
+        // The whole widget follows the document, so a `documentLocale` with no
+        // `uiLocale` moves it. The plural form is the target language's, not a
+        // translation of English's: Spanish puts the verb first and inflects
+        // it.
+        render({ doenetML: problem, documentLocale: "es" });
 
         cy.get("[data-test=attempts-remaining]").should(
             "contain.text",
@@ -58,8 +78,6 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         submitWrongAnswer();
 
         cy.get("#prob_button").should("contain.text", "Incorrecto");
-        // The plural form is the target language's, not a translation of
-        // English's: Spanish puts the verb first and inflects it.
         cy.get("[data-test=attempts-remaining]").should(
             "contain.text",
             "queda 1 intento",
@@ -82,49 +100,44 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         // A Spanish-speaking student may work a French problem: the chrome
         // answers to the reader, the content to the author.
         render({
-            doenetML: `<document lang="fr">${problem}</document>`,
+            doenetML: `<document lang="fr">${solution}</document>`,
             uiLocale: "es",
         });
 
         cy.get(".doenet-viewer").should("have.attr", "lang", "fr");
-        cy.get("[data-test=attempts-remaining]").should(
-            "contain.text",
-            "quedan 2 intentos",
-        );
+        cy.get("#sol_button").should("contain.text", "(clic para abrir)");
     });
 
     it("negotiates a regional tag down to the locale that exists", () => {
-        render({ doenetML: problem, uiLocale: "es-MX" });
+        render({ doenetML: solution, uiLocale: "es-MX" });
 
-        cy.get("[data-test=attempts-remaining]").should(
-            "contain.text",
-            "quedan 2 intentos",
-        );
+        cy.get("#sol_button").should("contain.text", "(clic para abrir)");
     });
 
     it("keeps English for a locale nothing is translated into", () => {
-        render({ doenetML: problem, uiLocale: "fr" });
+        render({ doenetML: solution, uiLocale: "fr" });
 
-        cy.get("[data-test=attempts-remaining]").should(
-            "contain.text",
-            "2 attempts remaining",
-        );
+        cy.get("#sol_button").should("contain.text", "(click to open)");
     });
 
     it("retranslates in place when uiLocale changes", () => {
-        // `uiLocale` is main-thread only: no core rebuild, so the submitted
-        // response survives the switch.
-        render({ doenetML: problem });
+        // `uiLocale` is main-thread only: no core rebuild, so whatever the
+        // reader had typed survives the switch. Probed on a disclosure label
+        // rather than the check-work button, which follows the document and so
+        // does not move when the reader's language does.
+        render({ doenetML: `${solution}${problem}` });
 
         submitWrongAnswer();
-        cy.get("#prob_button").should("contain.text", "Incorrect");
+        cy.get("#sol_button").should("contain.text", "(click to open)");
 
         cy.window().then((win) => {
             win.postMessage({ uiLocale: "es" }, "*");
         });
 
-        cy.get("#prob_button").should("contain.text", "Incorrecto");
+        cy.get("#sol_button").should("contain.text", "(clic para abrir)");
         cy.get("#ti_input").should("have.value", "wrong");
+        // The button did not follow: it answers to the document.
+        cy.get("#prob_button").should("contain.text", "Incorrect");
     });
 
     it("translates disclosure panels", () => {
@@ -313,7 +326,15 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         // Anything still plain ASCII is a string that was never extracted —
         // the class of bug no key-based lint can see.
         it("accents extracted chrome", () => {
-            render({ doenetML: problem, uiLocale: "en-XA" });
+            // Both locales: the viewer draws from two now. The check-work
+            // widget follows the document, and its renderer-side strings
+            // resolve through the same chrome catalog the pseudo-locale is
+            // derived from, so they accent when `documentLocale` does.
+            render({
+                doenetML: problem,
+                uiLocale: "en-XA",
+                documentLocale: "en-XA",
+            });
 
             cy.get("[data-test=attempts-remaining]")
                 .invoke("text")
@@ -407,20 +428,25 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             // into that string's guard, so the list is a deferral made
             // executable rather than a note in a PR description.
             //
-            // Every entry so far is a string the *worker* computes, which is
-            // the honest result of running this sweep: the renderers really
-            // are extracted, and what is left belongs to the content locale,
-            // a later phase. A renderer-side string appearing here would be a
-            // Phase 1 miss and should be extracted instead of listed.
+            // Every entry is a string the *worker* computes, which is the
+            // honest result of running this sweep: the renderers really are
+            // extracted, and what is left belongs to the content locale. A
+            // renderer-side string appearing here would be a miss and should
+            // be extracted instead of listed.
+            //
+            // The sweep drives both locales at `en-XA`, so a string is only
+            // left in English if the *worker* produced it: `createTranslator-
+            // FromLocaleData` has no pseudo-locale, and the content catalogs
+            // have no `en-XA`, so a content locale of `en-XA` negotiates
+            // straight back to English. Renderer-side strings accent either
+            // way, whichever locale they answer to.
             const KNOWN_UNTRANSLATED = [
                 // `submitLabel` / `submitLabelNoCorrectness` — the check-work
-                // button's resting label. These *are* translated as of #1519,
-                // but against `documentLocale`, and this sweep only
-                // pseudo-localizes `uiLocale`: the pseudo-locale is derived
-                // from the English chrome catalog and the content side has no
-                // equivalent, so a `documentLocale` of `en-XA` negotiates
-                // straight back to English. Deleting these two entries needs a
-                // pseudo content catalog first, not another extraction.
+                // button's resting label, computed by the worker. The rest of
+                // that widget follows the document too but is drawn by the
+                // renderer from the chrome catalog, so it accents and this
+                // sweep guards it. Deleting these two entries needs a pseudo
+                // content catalog, not another extraction.
                 // (doenetml-worker-javascript/src/utils/answer.js)
                 /Check Work/g,
                 /Submit Response/g,
@@ -543,7 +569,11 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             }
 
             it("finds no hard-coded English in the chrome as first rendered", () => {
-                render({ doenetML: chromeFixture, uiLocale: "en-XA" });
+                render({
+                    doenetML: chromeFixture,
+                    uiLocale: "en-XA",
+                    documentLocale: "en-XA",
+                });
 
                 // Wait for a string only the catalogs can produce, so the
                 // sweep cannot race the first paint.
@@ -558,7 +588,11 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
                 // Validation states, the attempts counter and the feedback a
                 // submission reveals are chrome that does not exist until the
                 // reader acts, so the first sweep cannot see them.
-                render({ doenetML: chromeFixture, uiLocale: "en-XA" });
+                render({
+                    doenetML: chromeFixture,
+                    uiLocale: "en-XA",
+                    documentLocale: "en-XA",
+                });
 
                 cy.get("[data-test=attempts-remaining]").should(
                     "contain.text",


### PR DESCRIPTION
Based on `main`. One commit.

Fixes the bilingual check-work button reported after #1587 landed.

> **Note on the branch name.** It is `i18n-check-work-ui-locale`, from a first attempt that took the opposite direction. The branch cannot be renamed without closing the PR; the commit and everything below describe what this actually does.

## What was wrong

The widget draws from two sources, and only one string came from the first:

| Source | Strings |
| --- | --- |
| `documentLocale` (content) | `SVs.submitLabel` / `submitLabelNoCorrectness` — the resting label |
| `uiLocale` (chrome) | `Correct`, `Incorrect`, `N% Credit`, `N% Correct`, `N %`, `Checking…`, `Submitting…`, `Response Saved`, `N attempts remaining`, `Max credit available`, and the two screen-reader-only statuses `Checking answer` / `Submitting answer` |

So `<document lang="es">` read with `uiLocale="en"` said **Revisar**, then **Correct** on the same control. With the two settings equal — or `uiLocale` omitted, which defaults to `documentLocale` — the disagreement is invisible, which is why it surfaced only in that configuration.

## Why the document, and not the reader

The button is not simply "inside the document" — so is the error box, and that still follows the reader. What decides it is that **an author can name this control from their own prose**:

```xml
<p>Pulsa el botón $ans.submitLabel para continuar.</p>
```

A sentence that names the button has to name what the button actually says. And `$ans.submitLabel` cannot follow the reader:

- `LocaleData` carries exactly one tag to the worker, and says so explicitly — the worker is never told `uiLocale`, because everything it renders is either content or a code the main thread formats.
- That tag is fixed for a core's lifetime (`LocaleDependency`): changing it rebuilds the core. Making `uiLocale` reach the worker would turn every language switch into a rebuild and discard the reader's submitted work — there is an e2e test pinning that it currently does not.

So the label is pinned to the document, and everything the control says has to be pinned with it. The alternative — everything including the state variable following the reader — was implemented first and abandoned for exactly these two reasons.

### What counts as "the control"

The unit is the control, not each string weighed alone, and two of the strings that moved would come out the other way if they were weighed alone:

- **The screen-reader-only status** (`Checking answer`) is not named by any prose — but it lives in the button's visually hidden span *beside `submitLabel` itself*, which is the author's word and cannot move. Leaving it on `uiLocale` would make that one span bilingual.
- **`Max credit available: 80%; 1 attempt remaining`** renders as a single joined sentence immediately after the button. `Revisar (2 attempts remaining)` would have been worse than the bug being fixed, and the two halves of that sentence cannot split from each other in any case.

Anything drawn on a *neighbouring* element is still weighed on its own, and mostly comes out the other way — see Behavior below.

**One adjacent case this deliberately does not touch.** A disclosure panel's `(click to open)` is appended inside the same button as the panel's title, and that title is core-computed against `documentLocale` too (#1575) — structurally the same shape as the attempts-remaining line, so the control rule would move it as well. It is left on `uiLocale` here, and the e2e spec now uses it as its probe for reader-following chrome. That is scope, not a claim that it is settled: the bug being fixed is the check-work button, no disclosure behavior changes in this PR, and if the rule should reach `<solution>` it should get its own change and its own evidence — at which point the probe moves again.

## How

`useContentT()` publishes a translator bound to `effectiveDocumentLocale`, mounted by `DocViewer` beside the existing one. The thirteen renderers that draw a check-work button bind it as **`tContent`**; `t` keeps meaning the reader's translator in every renderer, so nothing else a renderer draws moves by accident. Four of the thirteen have such strings of their own and still call `useT()` for them: `mathInput`'s preview, `matrixInput`'s add-row, `pretzel`'s answer heading, `section`'s disclosure label.

The validation state that `mathInput`, `textInput`, `fractionInput` and `choiceInput` append to an input's accessible description takes `tContent` too. That suffix and the button beside it announce the same verdict about the same response, so they are one control by the rule above. Being addressed to a screen reader does not put a string on `uiLocale` here — the button's own `aria-live` region is addressed there too and follows the document — and a screen-reader user is the only reader who hears *both*, so a split would land on them alone.

The `tContent` name is also what keeps `lint:i18n` honest: it only recognizes call sites through a translator named `t` or `translate`, and `createCheckWorkComponent` names its parameter `t`, so every key stays visible to the catalog scan while no renderer can reach a chrome key through the document's translator by mistake.

No catalog entries move and no keys are added. The keys stay in `chrome.ftl` because namespaces split by *load context*, and these are drawn on the main thread — putting them in `content` would ship them to the worker, which never draws them. **No worker changes at all.**

## Behavior

- Reader and document agree — including a `<document lang>` or `documentLocale` with no `uiLocale`, since the chrome then follows the content: **unchanged**.
- They disagree: the widget is wholly the document's language instead of split, and the prose naming it agrees with it.
- **`uiLocale` alone, on an activity that declares no language, is a disagreement** — and the one place this is a visible loss rather than a fix. Undeclared content resolves to English (`effectiveDocumentLocale = declaredLocale ?? DEFAULT_LOCALE`), so a reader who set `uiLocale="es"` used to get a Spanish "Correcto" beside the worker's English "Check Work" and now gets the control wholly in English. That is the trade being made — one language on one control, at the cost of a verdict that used to be translated on a common path. `<solution>`'s disclosure label still follows `uiLocale` on that same page, so the setting is honored rather than ignored. Pinned by a test, so it stays a decision.
- An author's own `submitLabel`: verbatim in every language, as before.
- Error boxes: still the reader's language (#1570). A diagnostic is addressed to whoever is looking at the screen, and no authored prose ever refers to one.

## Tests

`DoenetViewer.checkWorkLocale.cy.tsx`, eight tests. The one carrying the argument reads `$ans.submitLabel` out of the rendered prose and asserts the button contains *that same string*, rather than comparing both to a literal — so it fails if they ever diverge, whatever they say. One pins the split from the other side — the error box, in the reader's language on a document that is not — and one pins that the input's accessible description and the button announce the same verdict in the same language, which is what a screen-reader user hears twice. One pins the trade above — `uiLocale="es"` on an undeclared document leaves the button English while the disclosure label beside it turns Spanish — so it is recorded rather than rediscovered as a bug report.

`test-cypress/.../i18n.cy.js` used the attempts-remaining message as its worked probe for reader-following chrome, which it no longer is. Six assertions move to `<solution>`'s disclosure label, which this PR leaves on `uiLocale`, and the retranslate-in-place test gains an assertion that a `uiLocale` change now leaves the check-work button alone.

The pseudo-locale sweep — the guard that catches strings no key-based lint can see — now drives **both** locales at `en-XA`. That makes it stricter than before: the widget's renderer-side strings resolve through the chrome catalog, which has a pseudo-locale, so they are now swept. `KNOWN_UNTRANSLATED` still tolerates `Check Work` / `Submit Response`, which the *worker* computes and which have no pseudo content catalog; its comment is rewritten to say precisely that.

Verified locally: the component spec (8), and via build → preview → run the `i18n.cy.js` e2e spec plus the `textInput` / `fractionInput` / `choiceInput` tag specs whose accessible descriptions this touches — **57 passing across the four**. Plus `lint:i18n` and `tsc`. No worker suites run, because no worker file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




