### PR TITLE
Name a pattern's placeholders so one can appear twice

### DIFF
--- a/.changeset/matches-pattern-named-parameters.md
+++ b/.changeset/matches-pattern-named-parameters.md
@@ -8,7 +8,7 @@
 
 `parameters` names the variables in `pattern` that stand for a subexpression instead of themselves. A name repeated in the pattern has to match the same subexpression each time, which is what the blanks written `()` cannot say — each of those matches independently of the others. So `pattern="sin(a)^2+cos(a)^2" parameters="a"` accepts `sin(x)^2+cos(x)^2` and turns down `sin(x)^2+cos(y)^2`.
 
-`patternMatches` comes back in the order the parameters were named, and a parameter that does not occur in the pattern holds its place there as a blank, so an author's `$m.patternMatches[2]` keeps meaning the second name they wrote.
+`patternMatches` comes back in the order the parameters were named, and a parameter that does not occur in the pattern holds its place there as a blank, so an author's `$m.patternMatches[2]` keeps meaning the second name they wrote. A name listed twice is one placeholder and takes one place in that list.
 
 Specifying `parameters` also makes `()` a literal blank rather than a placeholder — a pattern cannot ask for both kinds at once, and a pattern that wants a literal blank matched needs `matchExpressionWithBlanks` as before. A parameter must be a variable: a plain symbol, a subscripted or primed one, or a function name. Anything else is ignored with a warning.
 

--- a/.changeset/matches-pattern-named-parameters.md
+++ b/.changeset/matches-pattern-named-parameters.md
@@ -8,7 +8,7 @@
 
 `parameters` names the variables in `pattern` that stand for a subexpression instead of themselves. A name repeated in the pattern has to match the same subexpression each time, which is what the blanks written `()` cannot say — each of those matches independently of the others. So `pattern="sin(a)^2+cos(a)^2" parameters="a"` accepts `sin(x)^2+cos(x)^2` and turns down `sin(x)^2+cos(y)^2`.
 
-`patternMatches` comes back in the order the parameters were named, and a parameter that does not occur in the pattern holds its place there as a blank, so an author's `$m.patternMatches[2]` keeps meaning the second name they wrote. A name listed twice is one placeholder and takes one place in that list.
+`patternMatches` comes back in the order the parameters were named, and a parameter that does not occur in the pattern holds its place there as a blank and warns, so an author's `$m.patternMatches[2]` keeps meaning the second name they wrote. A name listed twice is one placeholder and takes one place in that list.
 
 Specifying `parameters` also makes `()` a literal blank rather than a placeholder — a pattern cannot ask for both kinds at once, and a pattern that wants a literal blank matched needs `matchExpressionWithBlanks` as before. A parameter must be a variable: a plain symbol, a subscripted or primed one, or a function name. Anything else is ignored with a warning.
 

--- a/.changeset/matches-pattern-named-parameters.md
+++ b/.changeset/matches-pattern-named-parameters.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+`<matchesPattern>`: add a `parameters` attribute, so a pattern can require the same subexpression in more than one place.
+
+`parameters` names the variables in `pattern` that stand for a subexpression instead of themselves. A name repeated in the pattern has to match the same subexpression each time, which is what the blanks written `()` cannot say — each of those matches independently of the others. So `pattern="sin(a)^2+cos(a)^2" parameters="a"` accepts `sin(x)^2+cos(x)^2` and turns down `sin(x)^2+cos(y)^2`.
+
+`patternMatches` comes back in the order the parameters were named, and a parameter that does not occur in the pattern holds its place there as a blank, so an author's `$m.patternMatches[2]` keeps meaning the second name they wrote.
+
+Specifying `parameters` also makes `()` a literal blank rather than a placeholder — a pattern cannot ask for both kinds at once, and a pattern that wants a literal blank matched needs `matchExpressionWithBlanks` as before. A parameter must be a variable: a plain symbol, a subscripted or primed one, or a function name. Anything else is ignored with a warning.
+
+Leaving `parameters` off changes nothing.
+
+Closes #1315.

--- a/.changeset/matches-pattern-named-parameters.md
+++ b/.changeset/matches-pattern-named-parameters.md
@@ -10,7 +10,7 @@
 
 `patternMatches` comes back in the order the parameters were named, and a parameter that does not occur in the pattern holds its place there as a blank and warns, so an author's `$m.patternMatches[2]` keeps meaning the second name they wrote. A name listed twice is one placeholder and takes one place in that list.
 
-Specifying `parameters` also makes `()` a literal blank rather than a placeholder — a pattern cannot ask for both kinds at once, and a pattern that wants a literal blank matched needs `matchExpressionWithBlanks` as before. A parameter must be a variable: a plain symbol, a subscripted or primed one, or a function name. Anything else is ignored with a warning.
+Specifying `parameters` also makes `()` a literal blank rather than a placeholder — a pattern cannot ask for both kinds at once, and a pattern that wants a literal blank matched needs `matchExpressionWithBlanks` as before. `parameters` is a list of variable names, the same kind `<function variables>` and `<solveEquations variables>` take, so a plain symbol or a subscripted one is a parameter and anything else is ignored with a warning. A function name counts, which makes `pattern="f(x)+f(y)" parameters="f"` match `sin(x)+sin(y)` and not `sin(x)+cos(y)`.
 
 Leaving `parameters` off changes nothing.
 

--- a/packages/docs-nextra/pages/reference/matchesPattern.mdx
+++ b/packages/docs-nextra/pages/reference/matchesPattern.mdx
@@ -52,7 +52,7 @@ attributes to `<matchesPattern>{:dn}`.
 
 ```doenet-editor-horiz
 <answer name="ans1">
-<mathInput name="mi"><label>Enter an equation in slope-intercept form, <m>y = mx + b</m>, where <m>b \neq 0</m></label></mathInput>
+<mathInput name="mi"><label>Enter an equation in slope-intercept form, <m>y = mx + b</m>, where <m>b</m> must not be omitted</label></mathInput>
   <award>
       <when>
         <matchesPattern 
@@ -79,6 +79,7 @@ In this example, the following conditions must be met:
 
 * a $y$ by itself on one side, and an $x$ on the other, and no other variables can be present
 * the $x$ value must have a numerical coefficient, or no coefficient
+* a constant term must be written, even if it is $0$ — `y = 3x + 0` is accepted but `y = 3x` is not
 * switching the order of terms on the right-hand side is acceptable
 
 The attribute `requireNumericMatches` ensures that the user only enters numerical values for the

--- a/packages/docs-nextra/pages/reference/matchesPattern.mdx
+++ b/packages/docs-nextra/pages/reference/matchesPattern.mdx
@@ -11,11 +11,15 @@ import { ComponentDisplay, AttrPropDisplay } from "../../components"
 component that returns the boolean value of `true` or `false` depending on whether the enclosed 
 math (often a referenced `<mathInput/>{:dn}`) conforms to the specified `pattern` template.
 
+The `pattern` attribute is required. Write the pattern the way you would write the expression
+itself, and list in `parameters` the variables that stand in for whatever the student writes
+there. Everything in the pattern that is not named in `parameters` has to appear literally.
+
 <AttrPropDisplay name='matchesPattern'/>
 
 ## Examples
 
-### Example: Default case
+### Example: Check the form of an equation
 
 
 ```doenet-editor-horiz
@@ -24,22 +28,20 @@ math (often a referenced `<mathInput/>{:dn}`) conforms to the specified `pattern
   <m>y = ax^2 + bx + c</m>)</label></mathInput></p>
 
 <p>Format correct: </p>
-<matchesPattern pattern="y = () + () + ()" >
+<matchesPattern pattern="y = a + b + c" parameters="a b c">
   $mi
 </matchesPattern>    
 ```
 
 
-
 The `<matchesPattern>{:dn}` component is used to check that the user has supplied an 
-equation in the requested format. The `pattern` attribute is required. If used without 
-additional attributes as shown above, a rather liberal comparison occurs. 
+equation in the requested format. Here `a`, `b` and `c` are placeholders, each matching a term
+of whatever the student writes; only the `y` and the shape of the equation are fixed. Used
+without additional attributes as shown above, a rather liberal comparison occurs.
 
-* there must be two operands on one side, and none on the other
+* there must be three terms on one side, and none on the other
 * one side must contain only $y$ (RHS or LHS are acceptable)
-* the operands may be `+` or `-`
-
-
+* the terms may be added or subtracted
 
 These requirements may be tightened, if desired, by applying additional 
 attributes to `<matchesPattern>{:dn}`.
@@ -54,7 +56,8 @@ attributes to `<matchesPattern>{:dn}`.
   <award>
       <when>
         <matchesPattern 
-          pattern="y = ()x + ()" 
+          pattern="y = m x + b" 
+          parameters="m b"
           requireNumericMatches>
             $mi
         </matchesPattern> 
@@ -63,7 +66,8 @@ attributes to `<matchesPattern>{:dn}`.
   <award>
     <when>
       <matchesPattern 
-        pattern="y = x + ()" 
+        pattern="y = x + b" 
+        parameters="b"
         requireNumericMatches>
           $mi
       </matchesPattern>  
@@ -77,6 +81,50 @@ In this example, the following conditions must be met:
 * the $x$ value must have a numerical coefficient, or no coefficient
 * switching the order of terms on the right-hand side is acceptable
 
-The attribute `requireNumericMatches` ensures that the user only enters numerical coefficients
-into the `( )` spaces (rather than an `x`, for example.). Multiple `<award>` conditions are used to
+The attribute `requireNumericMatches` ensures that the user only enters numerical values for the
+parameters `m` and `b` (rather than an `x`, for example). Multiple `<award>` conditions are used to
 ensure that the case where $x$ does not have a coefficient are allowed.
+
+
+### Example: Require the same expression in more than one place
+
+
+```doenet-editor-horiz
+<p><mathInput name="mi"><label>Write the left-hand side of the Pythagorean identity,
+  <m>\sin(u)^2 + \cos(u)^2 = 1</m>, using any variable you like for <m>u</m>.</label></mathInput></p>
+
+<p>Format correct: </p>
+<matchesPattern name="mp" pattern="sin(u)^2 + cos(u)^2" parameters="u">
+  $mi
+</matchesPattern>
+
+<p>Matched <m>u = <math extend="$mp.patternMatch1" /></m></p>
+```
+
+Naming `u` once and using it twice is what makes this work: a parameter that occurs more than once
+in the pattern has to match the *same* expression at every occurrence. So `sin(x)^2 + cos(x)^2`
+matches and `sin(x)^2 + cos(y)^2` does not.
+
+A few things to know when using `parameters`:
+
+* The matches come back in the order the parameters were named, so the first entry of
+  `patternMatches` is always what the first name in `parameters` matched. A parameter that does
+  not occur in the pattern keeps its place in that list and reports a blank.
+* A name listed in `parameters` is a placeholder at *every* place it occurs in the pattern, so it
+  cannot also be matched literally there. Choose names that are not the ones you want matched
+  exactly.
+* A parameter must be a variable — a plain symbol such as `u`, a subscripted or primed one such as
+  `x_1` or `f'`, or a function name. A function name is a useful case in its own right:
+  `pattern="f(x) + f(y)" parameters="f"` matches `sin(x) + sin(y)` but not `sin(x) + cos(y)`.
+
+
+### Blanks as placeholders
+
+If `parameters` is left off, then blanks — written `( )` — are the placeholders instead:
+`pattern="y = () + () + ()"` behaves like the first example above. Each blank matches
+independently of the others, so there is no way to say "and the same expression here," which is
+what `parameters` is for.
+
+Specifying `parameters` turns this off: a `( )` is then matched as a literal blank, and a pattern
+containing one only matches an expression that has a blank of its own, which additionally requires
+`matchExpressionWithBlanks`.

--- a/packages/docs-nextra/pages/reference/matchesPattern.mdx
+++ b/packages/docs-nextra/pages/reference/matchesPattern.mdx
@@ -109,12 +109,13 @@ A few things to know when using `parameters`:
 
 * The matches come back in the order the parameters were named, so the first entry of
   `patternMatches` is always what the first name in `parameters` matched. A parameter that does
-  not occur in the pattern keeps its place in that list and reports a blank.
+  not occur in the pattern keeps its place in that list and reports a blank, with a warning.
 * A name listed in `parameters` is a placeholder at *every* place it occurs in the pattern, so it
   cannot also be matched literally there. Choose names that are not the ones you want matched
   exactly.
 * A parameter must be a variable — a plain symbol such as `u`, a subscripted or primed one such as
-  `x_1` or `f'`, or a function name. A function name is a useful case in its own right:
+  `x_1` or `f'`, or a function name. Anything else, such as a number or a compound expression, is
+  ignored with a warning. A function name is a useful case in its own right:
   `pattern="f(x) + f(y)" parameters="f"` matches `sin(x) + sin(y)` but not `sin(x) + cos(y)`.
 
 

--- a/packages/docs-nextra/pages/reference/matchesPattern.mdx
+++ b/packages/docs-nextra/pages/reference/matchesPattern.mdx
@@ -114,10 +114,11 @@ A few things to know when using `parameters`:
 * A name listed in `parameters` is a placeholder at *every* place it occurs in the pattern, so it
   cannot also be matched literally there. Choose names that are not the ones you want matched
   exactly.
-* A parameter must be a variable — a plain symbol such as `u`, a subscripted or primed one such as
-  `x_1` or `f'`, or a function name. Anything else, such as a number or a compound expression, is
-  ignored with a warning. A function name is a useful case in its own right:
-  `pattern="f(x) + f(y)" parameters="f"` matches `sin(x) + sin(y)` but not `sin(x) + cos(y)`.
+* A parameter must be a variable name — a plain symbol such as `u`, or a subscripted one such as
+  `x_1` — the same names every other attribute that takes a list of variables accepts. Anything
+  else, such as a number or a compound expression, is ignored with a warning. A function name
+  counts, and is a useful case in its own right: `pattern="f(x) + f(y)" parameters="f"` matches
+  `sin(x) + sin(y)` but not `sin(x) + cos(y)`.
 
 
 ## Blanks as placeholders

--- a/packages/docs-nextra/pages/reference/matchesPattern.mdx
+++ b/packages/docs-nextra/pages/reference/matchesPattern.mdx
@@ -98,7 +98,7 @@ ensure that the case where $x$ does not have a coefficient are allowed.
   $mi
 </matchesPattern>
 
-<p>Matched <m>u = <math extend="$mp.patternMatch1" /></m></p>
+<p>Matched <m>u = $mp.patternMatch1</m></p>
 ```
 
 Naming `u` once and using it twice is what makes this work: a parameter that occurs more than once
@@ -118,7 +118,7 @@ A few things to know when using `parameters`:
   `pattern="f(x) + f(y)" parameters="f"` matches `sin(x) + sin(y)` but not `sin(x) + cos(y)`.
 
 
-### Blanks as placeholders
+## Blanks as placeholders
 
 If `parameters` is left off, then blanks — written `( )` — are the placeholders instead:
 `pattern="y = () + () + ()"` behaves like the first example above. Each blank matches

--- a/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
+++ b/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
@@ -52,6 +52,33 @@ function parameterKey(tree) {
     return null;
 }
 
+/**
+ * Rebuild `tree` with every node that `placeholderFor` names replaced by the
+ * placeholder it returns, leaving the nodes it returns `undefined` for as they
+ * were.
+ *
+ * A node is offered before its children, so a parameter such as `x_1` is
+ * replaced whole rather than through the `x` inside it. The head of an operator
+ * node is left alone, since it names the operation rather than an operand — the
+ * function of an `["apply", "f", "x"]` is its second entry, so a function name
+ * is still reached.
+ */
+function replacePlaceholders(tree, placeholderFor) {
+    let placeholder = placeholderFor(tree);
+    if (placeholder !== undefined) {
+        return placeholder;
+    }
+    if (Array.isArray(tree)) {
+        return [
+            tree[0],
+            ...tree
+                .slice(1)
+                .map((subTree) => replacePlaceholders(subTree, placeholderFor)),
+        ];
+    }
+    return tree;
+}
+
 export default class MatchesPattern extends BooleanComponent {
     static componentType = "matchesPattern";
 
@@ -232,26 +259,20 @@ export default class MatchesPattern extends BooleanComponent {
                 if (!dependencyValues.parametersAttr) {
                     // Without `parameters`, the blanks are the placeholders,
                     // and each one matches independently of the others.
-                    function replaceBlanks(tree) {
-                        if (tree === BLANK) {
-                            let newVar = nextPatternVariable();
-                            patternVariables.push(newVar);
-                            return newVar;
-                        } else if (Array.isArray(tree)) {
-                            return [
-                                tree[0],
-                                ...tree.slice(1).map(replaceBlanks),
-                            ];
-                        } else {
-                            return tree;
-                        }
-                    }
+                    let pattern = replacePlaceholders(
+                        patternExpression.tree,
+                        (node) => {
+                            if (node !== BLANK) {
+                                return undefined;
+                            }
+                            let placeholder = nextPatternVariable();
+                            patternVariables.push(placeholder);
+                            return placeholder;
+                        },
+                    );
 
                     return {
-                        setValue: {
-                            pattern: replaceBlanks(patternExpression.tree),
-                            patternVariables,
-                        },
+                        setValue: { pattern, patternVariables },
                     };
                 }
 
@@ -301,25 +322,16 @@ export default class MatchesPattern extends BooleanComponent {
 
                 let substituted = new Set();
 
-                function replaceParameters(tree) {
-                    // The node is checked before its children, so that a
-                    // parameter such as `x_1` is replaced whole rather than
-                    // through the `x` inside it.
-                    let placeholder = substitutions.get(parameterKey(tree));
-                    if (placeholder !== undefined) {
-                        substituted.add(placeholder);
+                let pattern = replacePlaceholders(
+                    patternExpression.tree,
+                    (node) => {
+                        let placeholder = substitutions.get(parameterKey(node));
+                        if (placeholder !== undefined) {
+                            substituted.add(placeholder);
+                        }
                         return placeholder;
-                    } else if (Array.isArray(tree)) {
-                        return [
-                            tree[0],
-                            ...tree.slice(1).map(replaceParameters),
-                        ];
-                    } else {
-                        return tree;
-                    }
-                }
-
-                let pattern = replaceParameters(patternExpression.tree);
+                    },
+                );
 
                 let absent = [...parametersByPlaceholder]
                     .filter(([placeholder]) => !substituted.has(placeholder))
@@ -468,9 +480,10 @@ export default class MatchesPattern extends BooleanComponent {
                         // A parameter that does not occur in the pattern is
                         // never bound. It keeps its place in the list so that
                         // `patternMatches` always lines up with the order the
-                        // parameters were named in, and reports a blank.
-                        // `??`, as a placeholder can legitimately be bound to
-                        // `0` via `allowImplicitIdentities`.
+                        // parameters were named in, and reports a blank. Only
+                        // an absent binding becomes that blank: a placeholder
+                        // that `allowImplicitIdentities` bound to `0` is a
+                        // match like any other.
                         allPatternMatches =
                             dependencyValues.patternVariables.map((v) =>
                                 me.fromAst(matchResult[v] ?? BLANK),

--- a/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
+++ b/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
@@ -1,38 +1,29 @@
 import BooleanComponent from "./Boolean";
 import { numberToLetters } from "@doenet/utils";
 import { codedDiagnostic } from "../utils/diagnostics";
+import { isValidVariable } from "../utils/math";
 import me from "math-expressions";
 
 const BLANK = "\uff3f";
 
 /**
- * A string key for `tree` when `tree` is something a parameter is allowed to
- * be, and `undefined` when it is not. Two trees get the same key exactly when
- * they are the same parameter.
+ * A string key for `tree` when `tree` names a variable, and `undefined` when it
+ * does not. Two trees get the same key exactly when they are the same variable.
  *
  * Both the parameter list and every node of the pattern are keyed this way, so
- * recognizing a parameter in the pattern is a map lookup.
- *
- * A parameter names a variable: a bare symbol, or one dressed with a subscript
- * (`x_1` → `["_", "x", 1]`) or a prime (`f'` → `["prime", "f"]`). A blank is a
- * string too, and is refused so that it stays literal once `parameters` is
- * given. Numbers and compound expressions get no key.
+ * recognizing a parameter in the pattern is a map lookup. The test is
+ * `isValidVariable`, the one `<_variableNameList>` already applied to the
+ * `parameters` attribute, so a pattern node is measured against the rule that
+ * decided which parameters were accepted.
  *
  * The `s`/`t` prefixes keep a subscripted parameter from colliding with a
  * symbol whose name happens to be that subtree's JSON.
  */
 function parameterKey(tree) {
-    if (typeof tree === "string") {
-        return tree === BLANK ? undefined : "s" + tree;
+    if (!isValidVariable({ tree })) {
+        return undefined;
     }
-    if (
-        Array.isArray(tree) &&
-        ((tree[0] === "_" && tree.length === 3) || tree[0] === "prime") &&
-        parameterKey(tree[1]) !== undefined
-    ) {
-        return "t" + JSON.stringify(tree);
-    }
-    return undefined;
+    return typeof tree === "string" ? "s" + tree : "t" + JSON.stringify(tree);
 }
 
 /**
@@ -80,7 +71,7 @@ export default class MatchesPattern extends BooleanComponent {
             highlighted: true,
         };
         attributes.parameters = {
-            createComponentOfType: "mathList",
+            createComponentOfType: "_variableNameList",
             description:
                 "Variables in the pattern that act as placeholders. Repeating one in the pattern requires the same subexpression at each occurrence. When specified, blanks in the pattern are matched literally.",
             highlighted: true,
@@ -216,7 +207,7 @@ export default class MatchesPattern extends BooleanComponent {
                 parametersAttr: {
                     dependencyType: "attributeComponent",
                     attributeName: "parameters",
-                    variableNames: ["maths"],
+                    variableNames: ["variables"],
                 },
             }),
             definition({ dependencyValues }) {
@@ -274,16 +265,14 @@ export default class MatchesPattern extends BooleanComponent {
                     dependencyValues.parametersAttr.position || undefined;
                 let sendDiagnostics = [];
 
-                // A set, so that a parameter listed twice is reported once.
-                let rejected = new Set();
                 let substitutions = new Map(); // parameter key -> placeholder
                 let parametersByPlaceholder = new Map(); // placeholder -> text
 
                 for (let parameter of dependencyValues.parametersAttr
-                    .stateValues.maths) {
+                    .stateValues.variables) {
                     let key = parameterKey(parameter.tree);
                     if (key === undefined) {
-                        rejected.add(parameter.toString());
+                        // not a variable; `<_variableNameList>` said so
                         continue;
                     }
                     if (substitutions.has(key)) {
@@ -297,17 +286,6 @@ export default class MatchesPattern extends BooleanComponent {
                         parameter.toString(),
                     );
                     patternVariables.push(placeholder);
-                }
-
-                if (rejected.size > 0) {
-                    sendDiagnostics.push(
-                        codedDiagnostic({
-                            type: "warning",
-                            code: "doenet-w0117",
-                            args: { parameters: [...rejected] },
-                            position,
-                        }),
-                    );
                 }
 
                 let substituted = new Set();
@@ -331,7 +309,7 @@ export default class MatchesPattern extends BooleanComponent {
                     sendDiagnostics.push(
                         codedDiagnostic({
                             type: "warning",
-                            code: "doenet-w0118",
+                            code: "doenet-w0117",
                             args: { parameters: absent },
                             position,
                         }),

--- a/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
+++ b/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
@@ -6,17 +6,20 @@ import me from "math-expressions";
 const BLANK = "\uff3f";
 
 /**
- * A string key standing for `tree` as a parameter, or `undefined` if `tree`
- * cannot be one. Both the list of parameters and every node of the pattern are
- * keyed this way, so recognizing a parameter in the pattern is a map lookup.
+ * A string key for `tree` when `tree` is something a parameter is allowed to
+ * be, and `undefined` when it is not. Two trees get the same key exactly when
+ * they are the same parameter.
+ *
+ * Both the parameter list and every node of the pattern are keyed this way, so
+ * recognizing a parameter in the pattern is a map lookup.
  *
  * A parameter names a variable: a bare symbol, or one dressed with a subscript
  * (`x_1` → `["_", "x", 1]`) or a prime (`f'` → `["prime", "f"]`). A blank is a
- * string as well, and is keyed out by name so that it stays literal once
- * `parameters` is given. Numbers and compound expressions have no key.
+ * string too, and is refused so that it stays literal once `parameters` is
+ * given. Numbers and compound expressions get no key.
  *
- * The prefixes keep a subscripted parameter from colliding with a symbol whose
- * name happens to be that subtree's JSON.
+ * The `s`/`t` prefixes keep a subscripted parameter from colliding with a
+ * symbol whose name happens to be that subtree's JSON.
  */
 function parameterKey(tree) {
     if (typeof tree === "string") {

--- a/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
+++ b/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
@@ -8,21 +8,12 @@ const BLANK = "\uff3f";
 /**
  * A string key standing for `tree` as a parameter, or `undefined` if `tree`
  * cannot be one. Both the list of parameters and every node of the pattern are
- * keyed this way, so recognizing a parameter in the pattern is a map lookup
- * rather than a deep comparison at every node.
+ * keyed this way, so recognizing a parameter in the pattern is a map lookup.
  *
- * A parameter has to name a variable: a bare symbol, or one dressed with a
- * subscript (`x_1` → `["_", "x", 1]`) or a prime (`f'` → `["prime", "f"]`).
- * A parameter is found in the pattern by syntactic equality, so only names
- * qualify. A number such as `2` occurs in a pattern as an exponent or an index
- * as readily as it does as a coefficient, and turning all of them into one
- * placeholder is nothing the author asked for; a compound expression such as
- * `x+1` would go unrecognized in a pattern that spells it `1+x`, even though
- * `allowPermutations` makes those interchangeable everywhere else here.
- *
- * A blank is a string, so it has to be turned away by name: accepting one
- * would make every blank in the pattern a single shared placeholder, which is
- * the opposite of what blanks mean when `parameters` is absent.
+ * A parameter names a variable: a bare symbol, or one dressed with a subscript
+ * (`x_1` → `["_", "x", 1]`) or a prime (`f'` → `["prime", "f"]`). A blank is a
+ * string as well, and is keyed out by name so that it stays literal once
+ * `parameters` is given. Numbers and compound expressions have no key.
  *
  * The prefixes keep a subscripted parameter from colliding with a symbol whose
  * name happens to be that subtree's JSON.
@@ -232,8 +223,8 @@ export default class MatchesPattern extends BooleanComponent {
                 let ind = 26 * 27 + 1; // starts with variable AAA
 
                 // A placeholder is given a name the pattern does not already
-                // use, so that a parameter — `e` or `pi` as readily as `a` —
-                // can never be confused with a literal the pattern matches.
+                // use, so that a variable the pattern matches literally is
+                // never mistaken for a placeholder.
                 function nextPatternVariable() {
                     let newVar = numberToLetters(ind);
                     ind++;
@@ -265,10 +256,9 @@ export default class MatchesPattern extends BooleanComponent {
                 }
 
                 // With `parameters`, the named parameters are the
-                // placeholders and blanks stay literal. An empty list is still
-                // a list: it says the pattern has no placeholders at all,
-                // which is the reading that holds steady when the list comes
-                // from a reference that happens to be empty.
+                // placeholders and blanks stay literal. An empty list still
+                // counts as specified: it says the pattern has no
+                // placeholders at all.
                 let position =
                     dependencyValues.parametersAttr.position || undefined;
                 let sendDiagnostics = [];
@@ -470,9 +460,9 @@ export default class MatchesPattern extends BooleanComponent {
                         // never bound. It keeps its place in the list so that
                         // `patternMatches` always lines up with the order the
                         // parameters were named in, and reports a blank. Only
-                        // an absent binding becomes that blank: a placeholder
-                        // that `allowImplicitIdentities` bound to `0` is a
-                        // match like any other.
+                        // an absent binding becomes that blank:
+                        // `allowImplicitIdentities` can bind a placeholder to
+                        // `0`, which is a match like any other.
                         allPatternMatches =
                             dependencyValues.patternVariables.map((v) =>
                                 me.fromAst(matchResult[v] ?? BLANK),

--- a/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
+++ b/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
@@ -6,9 +6,13 @@ import me from "math-expressions";
 const BLANK = "\uff3f";
 
 /**
- * Whether `tree` names a variable: a bare symbol, or one dressed with a
- * subscript (`x_1` → `["_", "x", 1]`) or a prime (`f'` → `["prime", "f"]`).
+ * A string key standing for `tree` as a parameter, or `undefined` if `tree`
+ * cannot be one. Both the list of parameters and every node of the pattern are
+ * keyed this way, so recognizing a parameter in the pattern is a map lookup
+ * rather than a deep comparison at every node.
  *
+ * A parameter has to name a variable: a bare symbol, or one dressed with a
+ * subscript (`x_1` → `["_", "x", 1]`) or a prime (`f'` → `["prime", "f"]`).
  * A parameter is found in the pattern by syntactic equality, so only names
  * qualify. A number such as `2` occurs in a pattern as an exponent or an index
  * as readily as it does as a coefficient, and turning all of them into one
@@ -19,37 +23,22 @@ const BLANK = "\uff3f";
  * A blank is a string, so it has to be turned away by name: accepting one
  * would make every blank in the pattern a single shared placeholder, which is
  * the opposite of what blanks mean when `parameters` is absent.
- */
-function isVariableTree(tree) {
-    if (typeof tree === "string") {
-        return tree !== BLANK;
-    }
-    if (Array.isArray(tree)) {
-        if (tree[0] === "_" && tree.length === 3) {
-            return isVariableTree(tree[1]);
-        }
-        if (tree[0] === "prime") {
-            return isVariableTree(tree[1]);
-        }
-    }
-    return false;
-}
-
-/**
- * A string key for a parameter subtree, so that recognizing one in the pattern
- * is a map lookup rather than a deep comparison at every node.
  *
  * The prefixes keep a subscripted parameter from colliding with a symbol whose
  * name happens to be that subtree's JSON.
  */
 function parameterKey(tree) {
     if (typeof tree === "string") {
-        return "s" + tree;
+        return tree === BLANK ? undefined : "s" + tree;
     }
-    if (Array.isArray(tree)) {
+    if (
+        Array.isArray(tree) &&
+        ((tree[0] === "_" && tree.length === 3) || tree[0] === "prime") &&
+        parameterKey(tree[1]) !== undefined
+    ) {
         return "t" + JSON.stringify(tree);
     }
-    return null;
+    return undefined;
 }
 
 /**
@@ -242,10 +231,9 @@ export default class MatchesPattern extends BooleanComponent {
 
                 let ind = 26 * 27 + 1; // starts with variable AAA
 
-                // A placeholder is given a name the pattern cannot already
-                // contain, so a parameter called `e` or `pi`, or one that
-                // collides with math-expressions' own bookkeeping keys, can
-                // never be confused with a literal in the pattern.
+                // A placeholder is given a name the pattern does not already
+                // use, so that a parameter — `e` or `pi` as readily as `a` —
+                // can never be confused with a literal the pattern matches.
                 function nextPatternVariable() {
                     let newVar = numberToLetters(ind);
                     ind++;
@@ -285,17 +273,18 @@ export default class MatchesPattern extends BooleanComponent {
                     dependencyValues.parametersAttr.position || undefined;
                 let sendDiagnostics = [];
 
-                let rejected = [];
+                // A set, so that a parameter listed twice is reported once.
+                let rejected = new Set();
                 let substitutions = new Map(); // parameter key -> placeholder
                 let parametersByPlaceholder = new Map(); // placeholder -> text
 
                 for (let parameter of dependencyValues.parametersAttr
                     .stateValues.maths) {
-                    if (!isVariableTree(parameter.tree)) {
-                        rejected.push(parameter.toString());
+                    let key = parameterKey(parameter.tree);
+                    if (key === undefined) {
+                        rejected.add(parameter.toString());
                         continue;
                     }
-                    let key = parameterKey(parameter.tree);
                     if (substitutions.has(key)) {
                         // the same parameter listed twice is one placeholder
                         continue;
@@ -309,12 +298,12 @@ export default class MatchesPattern extends BooleanComponent {
                     patternVariables.push(placeholder);
                 }
 
-                if (rejected.length > 0) {
+                if (rejected.size > 0) {
                     sendDiagnostics.push(
                         codedDiagnostic({
                             type: "warning",
                             code: "doenet-w0117",
-                            args: { parameters: rejected },
+                            args: { parameters: [...rejected] },
                             position,
                         }),
                     );

--- a/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
+++ b/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
@@ -1,6 +1,56 @@
 import BooleanComponent from "./Boolean";
 import { numberToLetters } from "@doenet/utils";
+import { codedDiagnostic } from "../utils/diagnostics";
 import me from "math-expressions";
+
+const BLANK = "\uff3f";
+
+/**
+ * Whether `tree` names a variable: a bare symbol, or one dressed with a
+ * subscript (`x_1` → `["_", "x", 1]`) or a prime (`f'` → `["prime", "f"]`).
+ *
+ * A parameter is found in the pattern by syntactic equality, so only names
+ * qualify. A number such as `2` occurs in a pattern as an exponent or an index
+ * as readily as it does as a coefficient, and turning all of them into one
+ * placeholder is nothing the author asked for; a compound expression such as
+ * `x+1` would go unrecognized in a pattern that spells it `1+x`, even though
+ * `allowPermutations` makes those interchangeable everywhere else here.
+ *
+ * A blank is a string, so it has to be turned away by name: accepting one
+ * would make every blank in the pattern a single shared placeholder, which is
+ * the opposite of what blanks mean when `parameters` is absent.
+ */
+function isVariableTree(tree) {
+    if (typeof tree === "string") {
+        return tree !== BLANK;
+    }
+    if (Array.isArray(tree)) {
+        if (tree[0] === "_" && tree.length === 3) {
+            return isVariableTree(tree[1]);
+        }
+        if (tree[0] === "prime") {
+            return isVariableTree(tree[1]);
+        }
+    }
+    return false;
+}
+
+/**
+ * A string key for a parameter subtree, so that recognizing one in the pattern
+ * is a map lookup rather than a deep comparison at every node.
+ *
+ * The prefixes keep a subscripted parameter from colliding with a symbol whose
+ * name happens to be that subtree's JSON.
+ */
+function parameterKey(tree) {
+    if (typeof tree === "string") {
+        return "s" + tree;
+    }
+    if (Array.isArray(tree)) {
+        return "t" + JSON.stringify(tree);
+    }
+    return null;
+}
 
 export default class MatchesPattern extends BooleanComponent {
     static componentType = "matchesPattern";
@@ -17,6 +67,11 @@ export default class MatchesPattern extends BooleanComponent {
         attributes.pattern = {
             createComponentOfType: "math",
             description: "Math expression pattern to match against.",
+        };
+        attributes.parameters = {
+            createComponentOfType: "mathList",
+            description:
+                "Variables in the pattern that act as placeholders. Repeating one in the pattern requires the same subexpression at each occurrence. When specified, blanks in the pattern are matched literally.",
         };
         attributes.allowImplicitIdentities = {
             description:
@@ -140,47 +195,150 @@ export default class MatchesPattern extends BooleanComponent {
                     attributeName: "pattern",
                     variableNames: ["value"],
                 },
+                parametersAttr: {
+                    dependencyType: "attributeComponent",
+                    attributeName: "parameters",
+                    variableNames: ["maths"],
+                },
             }),
             definition({ dependencyValues }) {
                 let patternVariables = [];
                 if (!dependencyValues.patternAttr) {
                     return {
-                        setValue: { pattern: "\uff3f", patternVariables },
+                        setValue: { pattern: BLANK, patternVariables },
                     };
                 }
 
-                let originalVariablesInPattern =
-                    dependencyValues.patternAttr.stateValues.value.variables();
+                let patternExpression =
+                    dependencyValues.patternAttr.stateValues.value;
+                let originalVariablesInPattern = patternExpression.variables();
 
                 let ind = 26 * 27 + 1; // starts with variable AAA
 
-                function replacePatternVariables(tree) {
-                    if (tree === "\uff3f") {
-                        let newVar = numberToLetters(ind);
+                // A placeholder is given a name the pattern cannot already
+                // contain, so a parameter called `e` or `pi`, or one that
+                // collides with math-expressions' own bookkeeping keys, can
+                // never be confused with a literal in the pattern.
+                function nextPatternVariable() {
+                    let newVar = numberToLetters(ind);
+                    ind++;
+                    while (originalVariablesInPattern.includes(newVar)) {
+                        newVar = numberToLetters(ind);
                         ind++;
-                        while (originalVariablesInPattern.includes(newVar)) {
-                            newVar = numberToLetters(ind);
-                            ind++;
-                        }
+                    }
+                    return newVar;
+                }
 
-                        patternVariables.push(newVar);
-                        return newVar;
+                if (!dependencyValues.parametersAttr) {
+                    // Without `parameters`, the blanks are the placeholders,
+                    // and each one matches independently of the others.
+                    function replaceBlanks(tree) {
+                        if (tree === BLANK) {
+                            let newVar = nextPatternVariable();
+                            patternVariables.push(newVar);
+                            return newVar;
+                        } else if (Array.isArray(tree)) {
+                            return [
+                                tree[0],
+                                ...tree.slice(1).map(replaceBlanks),
+                            ];
+                        } else {
+                            return tree;
+                        }
+                    }
+
+                    return {
+                        setValue: {
+                            pattern: replaceBlanks(patternExpression.tree),
+                            patternVariables,
+                        },
+                    };
+                }
+
+                // With `parameters`, the named parameters are the
+                // placeholders and blanks stay literal. An empty list is still
+                // a list: it says the pattern has no placeholders at all,
+                // which is the reading that holds steady when the list comes
+                // from a reference that happens to be empty.
+                let position =
+                    dependencyValues.parametersAttr.position || undefined;
+                let sendDiagnostics = [];
+
+                let rejected = [];
+                let substitutions = new Map(); // parameter key -> placeholder
+                let parametersByPlaceholder = new Map(); // placeholder -> text
+
+                for (let parameter of dependencyValues.parametersAttr
+                    .stateValues.maths) {
+                    if (!isVariableTree(parameter.tree)) {
+                        rejected.push(parameter.toString());
+                        continue;
+                    }
+                    let key = parameterKey(parameter.tree);
+                    if (substitutions.has(key)) {
+                        // the same parameter listed twice is one placeholder
+                        continue;
+                    }
+                    let placeholder = nextPatternVariable();
+                    substitutions.set(key, placeholder);
+                    parametersByPlaceholder.set(
+                        placeholder,
+                        parameter.toString(),
+                    );
+                    patternVariables.push(placeholder);
+                }
+
+                if (rejected.length > 0) {
+                    sendDiagnostics.push(
+                        codedDiagnostic({
+                            type: "warning",
+                            code: "doenet-w0117",
+                            args: { parameters: rejected },
+                            position,
+                        }),
+                    );
+                }
+
+                let substituted = new Set();
+
+                function replaceParameters(tree) {
+                    // The node is checked before its children, so that a
+                    // parameter such as `x_1` is replaced whole rather than
+                    // through the `x` inside it.
+                    let placeholder = substitutions.get(parameterKey(tree));
+                    if (placeholder !== undefined) {
+                        substituted.add(placeholder);
+                        return placeholder;
                     } else if (Array.isArray(tree)) {
                         return [
                             tree[0],
-                            ...tree.slice(1).map(replacePatternVariables),
+                            ...tree.slice(1).map(replaceParameters),
                         ];
                     } else {
                         return tree;
                     }
                 }
 
-                let pattern = replacePatternVariables(
-                    dependencyValues.patternAttr.stateValues.value.tree,
-                );
+                let pattern = replaceParameters(patternExpression.tree);
+
+                let absent = [...parametersByPlaceholder]
+                    .filter(([placeholder]) => !substituted.has(placeholder))
+                    .map(([_, text]) => text);
+
+                if (absent.length > 0) {
+                    sendDiagnostics.push(
+                        codedDiagnostic({
+                            type: "warning",
+                            code: "doenet-w0118",
+                            args: { parameters: absent },
+                            position,
+                        }),
+                    );
+                }
 
                 return {
                     setValue: { pattern, patternVariables },
+                    sendDiagnostics,
                 };
             },
         };
@@ -247,7 +405,7 @@ export default class MatchesPattern extends BooleanComponent {
                     dependencyValues.mathChildren[0].stateValues.value;
 
                 if (
-                    mathValue.variables().includes("\uff3f") &&
+                    mathValue.variables().includes(BLANK) &&
                     !dependencyValues.matchExpressionWithBlanks
                 ) {
                     // don't match a math value with a blank
@@ -307,9 +465,15 @@ export default class MatchesPattern extends BooleanComponent {
                             )
                     ) {
                         value = true;
+                        // A parameter that does not occur in the pattern is
+                        // never bound. It keeps its place in the list so that
+                        // `patternMatches` always lines up with the order the
+                        // parameters were named in, and reports a blank.
+                        // `??`, as a placeholder can legitimately be bound to
+                        // `0` via `allowImplicitIdentities`.
                         allPatternMatches =
                             dependencyValues.patternVariables.map((v) =>
-                                me.fromAst(matchResult[v]),
+                                me.fromAst(matchResult[v] ?? BLANK),
                             );
                     }
                 }

--- a/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
+++ b/packages/doenetml-worker-javascript/src/components/MatchesPattern.js
@@ -74,11 +74,13 @@ export default class MatchesPattern extends BooleanComponent {
         attributes.pattern = {
             createComponentOfType: "math",
             description: "Math expression pattern to match against.",
+            highlighted: true,
         };
         attributes.parameters = {
             createComponentOfType: "mathList",
             description:
                 "Variables in the pattern that act as placeholders. Repeating one in the pattern requires the same subexpression at each occurrence. When specified, blanks in the pattern are matched literally.",
+            highlighted: true,
         };
         attributes.allowImplicitIdentities = {
             description:
@@ -87,6 +89,7 @@ export default class MatchesPattern extends BooleanComponent {
             createStateVariable: "allowImplicitIdentities",
             defaultValue: false,
             public: true,
+            highlighted: true,
         };
         attributes.allowPermutations = {
             description:
@@ -95,6 +98,7 @@ export default class MatchesPattern extends BooleanComponent {
             createStateVariable: "allowPermutations",
             defaultValue: true,
             public: true,
+            highlighted: true,
         };
         attributes.requireNumericMatches = {
             description: "Whether numeric placeholders must match numbers.",
@@ -102,6 +106,7 @@ export default class MatchesPattern extends BooleanComponent {
             createStateVariable: "requireNumericMatches",
             defaultValue: false,
             public: true,
+            highlighted: true,
         };
         attributes.requireVariableMatches = {
             description: "Whether variable placeholders must match variables.",
@@ -109,6 +114,7 @@ export default class MatchesPattern extends BooleanComponent {
             createStateVariable: "requireVariableMatches",
             defaultValue: false,
             public: true,
+            highlighted: true,
         };
         attributes.excludeMatches = {
             description: "Patterns whose matches are excluded.",
@@ -116,6 +122,7 @@ export default class MatchesPattern extends BooleanComponent {
             createStateVariable: "excludeMatches",
             defaultValue: [],
             public: true,
+            highlighted: true,
         };
         attributes.matchExpressionWithBlanks = {
             description: "Whether to allow expressions with blanks to match.",
@@ -123,6 +130,7 @@ export default class MatchesPattern extends BooleanComponent {
             createStateVariable: "matchExpressionWithBlanks",
             defaultValue: false,
             public: true,
+            highlighted: true,
         };
 
         return attributes;
@@ -342,6 +350,7 @@ export default class MatchesPattern extends BooleanComponent {
                 },
             ],
             public: true,
+            highlighted: true,
             shadowingInstructions: {
                 createComponentOfType: "boolean",
             },
@@ -482,6 +491,7 @@ export default class MatchesPattern extends BooleanComponent {
         stateVariableDefinitions.numMatches = {
             description: "The number of matches found.",
             public: true,
+            highlighted: true,
             shadowingInstructions: {
                 createComponentOfType: "number",
             },
@@ -504,6 +514,7 @@ export default class MatchesPattern extends BooleanComponent {
         stateVariableDefinitions.patternMatches = {
             description: "The list of matched sub-expressions.",
             public: true,
+            highlighted: true,
             shadowingInstructions: {
                 createComponentOfType: "math",
             },

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
@@ -1073,7 +1073,10 @@ describe("MatchesPattern tag tests @group3", async () => {
         });
     });
 
-    it("a primed parameter can be a placeholder", async () => {
+    it("a primed symbol is not a variable, so it is not a parameter", async () => {
+        // `parameters` is a `<_variableNameList>`, which takes a bare symbol
+        // or a subscripted one. A prime is neither, here as everywhere else
+        // a list of variable names is accepted.
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
   <p>Expression: <mathInput name="expr" /></p>
@@ -1082,12 +1085,19 @@ describe("MatchesPattern tag tests @group3", async () => {
   `,
         });
 
+        // With the one parameter refused, the pattern has no placeholders and
+        // is matched exactly.
         await checkMatches({
             core,
             resolvePathToNodeIdx,
-            numMatches: 1,
-            expected: { "g(x)+g(y)": ["g"], "g(x)+h(y)": false },
+            numMatches: 0,
+            expected: { "g(x)+g(y)": false, "f'(x)+f'(y)": [] },
         });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0017");
+        expect(warnings[0].args).eqls({ value: "f'" });
     });
 
     it("parameters honor requireNumericMatches and requireVariableMatches", async () => {
@@ -1227,7 +1237,7 @@ describe("MatchesPattern tag tests @group3", async () => {
 
         const { warnings } = getDiagnosticsByType(core);
         expect(warnings.length).eq(1);
-        expect(warnings[0].code).eq("doenet-w0118");
+        expect(warnings[0].code).eq("doenet-w0117");
         expect(warnings[0].args).eqls({ parameters: ["b"] });
         expect(warnings[0].message).eq(
             "`<matchesPattern>`: the parameter b does not occur in the pattern, so it will always match a blank.",
@@ -1250,13 +1260,13 @@ describe("MatchesPattern tag tests @group3", async () => {
             expected: { "3x": ["3"], "3z": false },
         });
 
+        // `<_variableNameList>` reports each entry it refused.
         const { warnings } = getDiagnosticsByType(core);
-        expect(warnings.length).eq(1);
-        expect(warnings[0].code).eq("doenet-w0117");
-        expect(warnings[0].args).eqls({ parameters: ["2", "x^2"] });
-        expect(warnings[0].message).eq(
-            "`<matchesPattern>`: ignoring 2 and x^2 in `parameters`, as a parameter must be a variable.",
-        );
+        expect(warnings.map((w) => [w.code, w.args])).eqls([
+            ["doenet-w0017", { value: "2" }],
+            ["doenet-w0017", { value: "x^2" }],
+        ]);
+        expect(warnings[0].message).eq("Invalid value of a variable: `2`");
     });
 
     it("a blank listed as a parameter is ignored with a warning", async () => {
@@ -1268,20 +1278,8 @@ describe("MatchesPattern tag tests @group3", async () => {
 
         const { warnings } = getDiagnosticsByType(core);
         expect(warnings.length).eq(1);
-        expect(warnings[0].code).eq("doenet-w0117");
-        expect(warnings[0].args).eqls({ parameters: ["＿"] });
-    });
-
-    it("the same rejected parameter listed twice is reported once", async () => {
-        const { core } = await createTestCore({
-            doenetML: `
-  <matchesPattern name="m" pattern="ax" parameters="2 2 x^2 x^2">3x</matchesPattern>
-  `,
-        });
-
-        const { warnings } = getDiagnosticsByType(core);
-        expect(warnings.length).eq(1);
-        expect(warnings[0].args).eqls({ parameters: ["2", "x^2"] });
+        expect(warnings[0].code).eq("doenet-w0017");
+        expect(warnings[0].args).eqls({ value: "＿" });
     });
 
     it("a parameter is renamed away from a variable already in the pattern", async () => {
@@ -1339,7 +1337,7 @@ describe("MatchesPattern tag tests @group3", async () => {
 
         let warnings = getDiagnosticsByType(core).warnings;
         expect(warnings.length).eq(1);
-        expect(warnings[0].code).eq("doenet-w0118");
+        expect(warnings[0].code).eq("doenet-w0117");
 
         // Returning to `a` and back to `b` recomputes both ways without
         // raising the same warning a second time.
@@ -1414,7 +1412,7 @@ describe("MatchesPattern tag tests @group3", async () => {
             expected: { "3x+3": false },
         });
         expect(getDiagnosticsByType(core).warnings.length).eq(1);
-        expect(getDiagnosticsByType(core).warnings[0].code).eq("doenet-w0118");
+        expect(getDiagnosticsByType(core).warnings[0].code).eq("doenet-w0117");
 
         await updateMathInputValue({
             latex: "ax+a",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
@@ -1248,4 +1248,161 @@ describe("MatchesPattern tag tests @group3", async () => {
         expect(warnings[0].code).eq("doenet-w0117");
         expect(warnings[0].args).eqls({ parameters: ["＿"] });
     });
+
+    it("the same rejected parameter listed twice is reported once", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+  <matchesPattern name="m" pattern="ax" parameters="2 2 x^2 x^2">3x</matchesPattern>
+  `,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].args).eqls({ parameters: ["2", "x^2"] });
+    });
+
+    it("a parameter is renamed away from a variable already in the pattern", async () => {
+        // A placeholder must not be spelled like something the pattern
+        // matches literally, so the generated name skips `AAA`.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <math name="pat" splitSymbols="false">AAA b + b</math>
+  <p>Expression: <mathInput name="expr" splitSymbols="false" /></p>
+  <p><matchesPattern name="m" pattern="$pat" parameters="b">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "AAA 3 + 3": ["3"], "AAA 3 + 4": false },
+        });
+    });
+
+    it("changing parameters at runtime recomputes the match", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Parameters: <mathInput name="params" prefill="a" /></p>
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="ax+a" parameters="$params">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": ["3"], "3x+4": false },
+        });
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+
+        // `b` does not occur in the pattern, so nothing is a placeholder any
+        // more and only the literal `ax+a` matches.
+        await updateMathInputValue({
+            latex: "b",
+            componentIdx: await resolvePathToNodeIdx("params"),
+            core,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": false, "ax+a": ["＿"] },
+        });
+
+        let warnings = getDiagnosticsByType(core).warnings;
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0118");
+
+        // Returning to `a` and back to `b` recomputes both ways without
+        // raising the same warning a second time.
+        await updateMathInputValue({
+            latex: "a",
+            componentIdx: await resolvePathToNodeIdx("params"),
+            core,
+        });
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": ["3"] },
+        });
+
+        await updateMathInputValue({
+            latex: "b",
+            componentIdx: await resolvePathToNodeIdx("params"),
+            core,
+        });
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": false },
+        });
+        expect(getDiagnosticsByType(core).warnings.length).eq(1);
+    });
+
+    it("changing the pattern at runtime recomputes the match", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Pattern: <mathInput name="pat" prefill="ax+a" /></p>
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="$pat" parameters="a">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": ["3"], "3x+4": false },
+        });
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+
+        await updateMathInputValue({
+            latex: "ax^2+a",
+            componentIdx: await resolvePathToNodeIdx("pat"),
+            core,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": false, "3x^2+3": ["3"] },
+        });
+
+        // A pattern that no longer mentions `a` warns; going back clears the
+        // way for a match again.
+        await updateMathInputValue({
+            latex: "bx+b",
+            componentIdx: await resolvePathToNodeIdx("pat"),
+            core,
+        });
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": false },
+        });
+        expect(getDiagnosticsByType(core).warnings.length).eq(1);
+        expect(getDiagnosticsByType(core).warnings[0].code).eq("doenet-w0118");
+
+        await updateMathInputValue({
+            latex: "ax+a",
+            componentIdx: await resolvePathToNodeIdx("pat"),
+            core,
+        });
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": ["3"] },
+        });
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
@@ -1270,11 +1270,19 @@ describe("MatchesPattern tag tests @group3", async () => {
     });
 
     it("a blank listed as a parameter is ignored with a warning", async () => {
-        const { core } = await createTestCore({
+        const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
   <matchesPattern name="m" pattern="()x" parameters="()">3x</matchesPattern>
   `,
         });
+
+        // Had the blank been taken as a parameter, `3x` would have matched it.
+        // Refused, it leaves the pattern with no placeholders and a literal
+        // blank to match.
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const m = stateVariables[await resolvePathToNodeIdx("m")].stateValues;
+        expect(m.value).eq(false);
+        expect(m.numMatches).eq(0);
 
         const { warnings } = getDiagnosticsByType(core);
         expect(warnings.length).eq(1);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
@@ -1017,7 +1017,7 @@ describe("MatchesPattern tag tests @group3", async () => {
         ).eq(0);
     });
 
-    it("subscripted parameters are replaced whole", async () => {
+    it("distinct subscripted parameters are separate placeholders", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
   <p>Expression: <mathInput name="expr" /></p>
@@ -1108,6 +1108,8 @@ describe("MatchesPattern tag tests @group3", async () => {
             expected: { "3x+3": ["3"], "ax+a": false },
         });
 
+        // `mv` takes the opposite view of the `ax+a` left in the input above:
+        // a variable is what it requires.
         const stateVariables = await core.returnAllStateVariables(false, true);
         expect(
             stateVariables[await resolvePathToNodeIdx("mv")].stateValues.value,
@@ -1126,6 +1128,8 @@ describe("MatchesPattern tag tests @group3", async () => {
   <p>Expression: <mathInput name="expr" /></p>
   <p><matchesPattern name="m" pattern="ax+a" parameters="a" allowImplicitIdentities>$expr</matchesPattern></p>
   <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  <p><matchesPattern name="m2" pattern="ax+b" parameters="a b" allowImplicitIdentities>$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m2.patternMatches" name="mm2" /></p>
   `,
         });
 
@@ -1133,8 +1137,27 @@ describe("MatchesPattern tag tests @group3", async () => {
             core,
             resolvePathToNodeIdx,
             numMatches: 1,
-            expected: { "x+1": ["1"], "3x+3": ["3"], "3x+4": false },
+            expected: {
+                "x+1": ["1"],
+                "3x+3": ["3"],
+                "3x+4": false,
+                "3x": false,
+            },
         });
+
+        // `m2` still matches the `3x` left in the input above, with `b` bound
+        // to the missing constant term. A binding of `0` is a match, not the
+        // blank an unbound parameter reports.
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m2")].stateValues.value,
+        ).to.be.true;
+        expect(
+            cleanLatex(
+                stateVariables[await resolvePathToNodeIdx("mm2[2]")].stateValues
+                    .latex,
+            ),
+        ).eq("0");
     });
 
     it("parameters honor allowPermutations", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
@@ -5,10 +5,60 @@ import {
     updateBooleanInputValue,
     updateMathInputValue,
 } from "../utils/actions";
+import { getDiagnosticsByType } from "../utils/diagnostics";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
 vi.mock("hyperformula");
+
+/**
+ * Drive a `<matchesPattern>` through a table of expressions.
+ *
+ * Expects a document that names its `<mathInput>` `expr`, its
+ * `<matchesPattern>` `m`, and a `<mathList extend="$m.patternMatches">` `mm`.
+ * `expected` maps the latex to type to the matches expected back, in order,
+ * or to `false` when the pattern should not match.
+ */
+async function checkMatches({
+    core,
+    resolvePathToNodeIdx,
+    numMatches,
+    expected,
+}: {
+    core: any;
+    resolvePathToNodeIdx: (path: string) => Promise<number>;
+    numMatches: number;
+    expected: Record<string, string[] | false>;
+}) {
+    for (let expr in expected) {
+        await updateMathInputValue({
+            latex: expr,
+            componentIdx: await resolvePathToNodeIdx("expr"),
+            core,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const res = expected[expr];
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m")].stateValues.value,
+            expr,
+        ).eq(res !== false);
+
+        for (let ind = 1; ind <= numMatches; ind++) {
+            const match =
+                stateVariables[await resolvePathToNodeIdx(`mm[${ind}]`)];
+            if (res === false) {
+                expect(match, `${expr}, match ${ind}`).eq(undefined);
+            } else {
+                expect(
+                    cleanLatex(match.stateValues.latex),
+                    `${expr}, match ${ind}`,
+                ).eq(res[ind - 1]);
+            }
+        }
+    }
+}
 
 describe("MatchesPattern tag tests @group3", async () => {
     it("match linear pattern", async () => {
@@ -813,5 +863,363 @@ describe("MatchesPattern tag tests @group3", async () => {
                 );
             }
         }
+    });
+
+    it("a repeated parameter requires the same subexpression each time", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="sin(a)^2+cos(a)^2" parameters="a">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: {
+                "\\sin(x)^2+\\cos(x)^2": ["x"],
+                "\\sin(y)^2+\\cos(y)^2": ["y"],
+                "\\cos(3t)^2+\\sin(3t)^2": ["3t"],
+                "\\sin(x)^2+\\cos(y)^2": false,
+                "\\sin(x)^2+\\cos(x)^3": false,
+            },
+        });
+    });
+
+    it("match several parameters at once", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="sin(xz)+exp(xa)+y" parameters="x y">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 2,
+            expected: {
+                "\\sin(qz)+\\exp(qa)+9": ["q", "9"],
+                "\\sin((u+v)z)+\\exp((u+v)a)+9": ["u+v", "9"],
+                // the two occurrences of `x` disagree
+                "\\sin(qz)+\\exp(ra)+9": false,
+                // `z` and `a` are literals, not placeholders
+                "\\sin(z)+\\exp(a)+9": false,
+            },
+        });
+    });
+
+    it("a parameter is a placeholder everywhere it occurs in the pattern", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="x+x" parameters="x">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: {
+                "q+q": ["q"],
+                // `x` cannot also be a literal in a pattern that names it
+                "x+x": ["x"],
+                "q+r": false,
+            },
+        });
+    });
+
+    it("blanks are matched literally when parameters are specified", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="ax+()" parameters="a" matchExpressionWithBlanks="$matchBlanks">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  <p><booleanInput name="matchBlanks" /></p>
+  `,
+        });
+
+        // The `()` no longer absorbs the second term, so only an expression
+        // that has a blank of its own can match — and that needs
+        // `matchExpressionWithBlanks`.
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+5": false, "3x+": false },
+        });
+
+        await updateBooleanInputValue({
+            boolean: true,
+            componentIdx: await resolvePathToNodeIdx("matchBlanks"),
+            core,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+5": false, "3x+": ["3"] },
+        });
+    });
+
+    it("an empty parameter list leaves the pattern with no placeholders", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="3x+()" parameters="" matchExpressionWithBlanks>$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 0,
+            expected: { "3x+5": false, "3x+": [] },
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m")].stateValues
+                .numMatches,
+        ).eq(0);
+    });
+
+    it("subscripted parameters are replaced whole", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="x_1+x_2 x_1" parameters="x_1 x_2">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 2,
+            expected: { "q+rq": ["q", "r"], "q+rs": false },
+        });
+    });
+
+    it("a subscripted parameter is not reached through its base", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="x+x_1 x" parameters="x x_1">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        // If `x_1` were rewritten through the `x` inside it, it could no
+        // longer be a placeholder of its own and `r` would not match.
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 2,
+            expected: { "q+rq": ["q", "r"], "q+rs": false },
+        });
+    });
+
+    it("a function name can be a parameter", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="f(x)+f(y)" parameters="f">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: {
+                "\\sin(x)+\\sin(y)": ["\\sin"],
+                "\\sin(x)+\\cos(y)": false,
+            },
+        });
+    });
+
+    it("a primed parameter can be a placeholder", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="f'(x)+f'(y)" parameters="f'">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "g(x)+g(y)": ["g"], "g(x)+h(y)": false },
+        });
+    });
+
+    it("parameters honor requireNumericMatches and requireVariableMatches", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="cx+c" parameters="c" requireNumericMatches>$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  <p><matchesPattern name="mv" pattern="cx+c" parameters="c" requireVariableMatches>$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$mv.patternMatches" name="mvm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": ["3"], "ax+a": false },
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("mv")].stateValues.value,
+        ).to.be.true;
+        expect(
+            cleanLatex(
+                stateVariables[await resolvePathToNodeIdx("mvm[1]")].stateValues
+                    .latex,
+            ),
+        ).eq("a");
+    });
+
+    it("parameters honor allowImplicitIdentities", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="ax+a" parameters="a" allowImplicitIdentities>$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "x+1": ["1"], "3x+3": ["3"], "3x+4": false },
+        });
+    });
+
+    it("parameters honor allowPermutations", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="ax+a" parameters="a">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  <p><matchesPattern name="noperm" pattern="ax+a" parameters="a" allowPermutations="false">$expr</matchesPattern></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3+3x": ["3"] },
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("noperm")].stateValues
+                .value,
+        ).to.be.false;
+    });
+
+    it("parameters honor excludeMatches", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="ax+a" parameters="a" excludeMatches="q">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x+3": ["3"], "qx+q": false },
+        });
+    });
+
+    it("a parameter missing from the pattern keeps its place and warns", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="ax" parameters="a b">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        // `b` stays in the list so that `patternMatches` keeps lining up with
+        // the order the parameters were named in.
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 2,
+            expected: { "3x": ["3", "＿"] },
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m")].stateValues
+                .numMatches,
+        ).eq(2);
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0118");
+        expect(warnings[0].args).eqls({ parameters: ["b"] });
+        expect(warnings[0].message).eq(
+            "`<matchesPattern>`: the parameter b does not occur in the pattern, so it will always match a blank.",
+        );
+    });
+
+    it("a parameter that is not a variable is ignored with a warning", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="yx" parameters="2 x^2 y">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 1,
+            expected: { "3x": ["3"], "3z": false },
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0117");
+        expect(warnings[0].args).eqls({ parameters: ["2", "x^2"] });
+        expect(warnings[0].message).eq(
+            "`<matchesPattern>`: ignoring 2 and x^2 in `parameters`, as a parameter must be a variable.",
+        );
+    });
+
+    it("a blank listed as a parameter is ignored with a warning", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+  <matchesPattern name="m" pattern="()x" parameters="()">3x</matchesPattern>
+  `,
+        });
+
+        const { warnings } = getDiagnosticsByType(core);
+        expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0117");
+        expect(warnings[0].args).eqls({ parameters: ["＿"] });
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
@@ -934,6 +934,32 @@ describe("MatchesPattern tag tests @group3", async () => {
         });
     });
 
+    it("a parameter named twice is a single placeholder", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <p>Expression: <mathInput name="expr" /></p>
+  <p><matchesPattern name="m" pattern="ax+b" parameters="a b a">$expr</matchesPattern></p>
+  <p>Matches: <mathList extend="$m.patternMatches" name="mm" /></p>
+  `,
+        });
+
+        // Listing `a` again adds no entry to `patternMatches`, so `b` stays
+        // the second match.
+        await checkMatches({
+            core,
+            resolvePathToNodeIdx,
+            numMatches: 2,
+            expected: { "3x+5": ["3", "5"] },
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m")].stateValues
+                .numMatches,
+        ).eq(2);
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+    });
+
     it("blanks are matched literally when parameters are specified", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -209,5 +209,7 @@
     "doenet-w0113": "schema-element-not-allowed-at-root",
     "doenet-w0114": "schema-element-not-allowed-inside",
     "doenet-w0115": "schema-attribute-unrecognized",
-    "doenet-w0116": "schema-attribute-value-not-allowed"
+    "doenet-w0116": "schema-attribute-value-not-allowed",
+    "doenet-w0117": "matches-pattern-parameter-not-variable",
+    "doenet-w0118": "matches-pattern-parameter-not-in-pattern"
 }

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -210,6 +210,5 @@
     "doenet-w0114": "schema-element-not-allowed-inside",
     "doenet-w0115": "schema-attribute-unrecognized",
     "doenet-w0116": "schema-attribute-value-not-allowed",
-    "doenet-w0117": "matches-pattern-parameter-not-variable",
-    "doenet-w0118": "matches-pattern-parameter-not-in-pattern"
+    "doenet-w0117": "matches-pattern-parameter-not-in-pattern"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -318,6 +318,26 @@ math-operators-operand-number-required = Must specify a operandNumber when extra
 
 eigen-decomposition-failed = Could not calculate eigenvalues of matrix
 
+## `<matchesPattern>`
+
+# Translators: `parameters` is an attribute name and stays in English.
+# $parameters lists the rejected entries as the author wrote them;
+# $parametersCount is how many there were.
+matches-pattern-parameter-not-variable =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: ignoring { $parameters } in `parameters`, as a parameter must be a variable.
+       *[other] `<matchesPattern>`: ignoring { $parameters } in `parameters`, as a parameter must be a variable.
+    }
+
+# Translators: `parameters` is an attribute name and stays in English.
+# $parameters lists the parameters as the author wrote them;
+# $parametersCount is how many there were.
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: the parameter { $parameters } does not occur in the pattern, so it will always match a blank.
+       *[other] `<matchesPattern>`: the parameters { $parameters } do not occur in the pattern, so they will always match a blank.
+    }
+
 ## PreFigure renderer
 
 # Translators: xLabelPosition, yLabelPosition and their values are attribute

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -322,12 +322,9 @@ eigen-decomposition-failed = Could not calculate eigenvalues of matrix
 
 # Translators: `parameters` is an attribute name and stays in English.
 # $parameters lists the rejected entries as the author wrote them;
-# $parametersCount is how many there were.
-matches-pattern-parameter-not-variable =
-    { $parametersCount ->
-        [one] `<matchesPattern>`: ignoring { $parameters } in `parameters`, as a parameter must be a variable.
-       *[other] `<matchesPattern>`: ignoring { $parameters } in `parameters`, as a parameter must be a variable.
-    }
+# $parametersCount is how many there were, for languages that need it (the
+# English wording reads the same either way).
+matches-pattern-parameter-not-variable = `<matchesPattern>`: ignoring { $parameters } in `parameters`, as a parameter must be a variable.
 
 # Translators: `parameters` is an attribute name and stays in English.
 # $parameters lists the parameters as the author wrote them;

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -321,12 +321,6 @@ eigen-decomposition-failed = Could not calculate eigenvalues of matrix
 ## `<matchesPattern>`
 
 # Translators: `parameters` is an attribute name and stays in English.
-# $parameters lists the rejected entries as the author wrote them;
-# $parametersCount is how many there were, for languages that need it (the
-# English wording reads the same either way).
-matches-pattern-parameter-not-variable = `<matchesPattern>`: ignoring { $parameters } in `parameters`, as a parameter must be a variable.
-
-# Translators: `parameters` is an attribute name and stays in English.
 # $parameters lists the parameters as the author wrote them;
 # $parametersCount is how many there were.
 matches-pattern-parameter-not-in-pattern =

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -264,6 +264,14 @@ math-operators-operand-number-required = Se debe especificar operandNumber al ex
 
 eigen-decomposition-failed = No se pudieron calcular los valores propios de la matriz
 
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: el parámetro { $parameters } no aparece en el patrón, por lo que siempre coincidirá con un espacio en blanco.
+       *[other] `<matchesPattern>`: los parámetros { $parameters } no aparecen en el patrón, por lo que siempre coincidirán con un espacio en blanco.
+    }
+
 ## Renderizador PreFigure
 
 prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" no es compatible con el renderizador prefigure; se usa el comportamiento de posición derecha.

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -201,6 +201,8 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0114": "schema-element-not-allowed-inside",
     "doenet-w0115": "schema-attribute-unrecognized",
     "doenet-w0116": "schema-attribute-value-not-allowed",
+    "doenet-w0117": "matches-pattern-parameter-not-variable",
+    "doenet-w0118": "matches-pattern-parameter-not-in-pattern",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -201,8 +201,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0114": "schema-element-not-allowed-inside",
     "doenet-w0115": "schema-attribute-unrecognized",
     "doenet-w0116": "schema-attribute-value-not-allowed",
-    "doenet-w0117": "matches-pattern-parameter-not-variable",
-    "doenet-w0118": "matches-pattern-parameter-not-in-pattern",
+    "doenet-w0117": "matches-pattern-parameter-not-in-pattern",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -370,6 +370,8 @@ export type MessageKey =
     | "solve-equations-cannot-evaluate"
     | "math-operators-operand-number-required"
     | "eigen-decomposition-failed"
+    | "matches-pattern-parameter-not-variable"
+    | "matches-pattern-parameter-not-in-pattern"
     | "prefigure-x-label-position-unsupported"
     | "prefigure-y-label-position-unsupported"
     | "prefigure-invalid-axis-bounds"
@@ -928,6 +930,8 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "solve-equations-cannot-evaluate",
     "math-operators-operand-number-required",
     "eigen-decomposition-failed",
+    "matches-pattern-parameter-not-variable",
+    "matches-pattern-parameter-not-in-pattern",
     "prefigure-x-label-position-unsupported",
     "prefigure-y-label-position-unsupported",
     "prefigure-invalid-axis-bounds",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -370,7 +370,6 @@ export type MessageKey =
     | "solve-equations-cannot-evaluate"
     | "math-operators-operand-number-required"
     | "eigen-decomposition-failed"
-    | "matches-pattern-parameter-not-variable"
     | "matches-pattern-parameter-not-in-pattern"
     | "prefigure-x-label-position-unsupported"
     | "prefigure-y-label-position-unsupported"
@@ -930,7 +929,6 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "solve-equations-cannot-evaluate",
     "math-operators-operand-number-required",
     "eigen-decomposition-failed",
-    "matches-pattern-parameter-not-variable",
     "matches-pattern-parameter-not-in-pattern",
     "prefigure-x-label-position-unsupported",
     "prefigure-y-label-position-unsupported",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -144179,6 +144179,12 @@
                         "string"
                     ]
                 },
+                "parameters": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "allowImplicitIdentities": {
                     "optional": true,
                     "type": [

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -115709,16 +115709,19 @@
                 {
                     "name": "pattern",
                     "description": "Math expression pattern to match against.",
+                    "highlighted": true,
                     "type": "math"
                 },
                 {
                     "name": "parameters",
                     "description": "Variables in the pattern that act as placeholders. Repeating one in the pattern requires the same subexpression at each occurrence. When specified, blanks in the pattern are matched literally.",
+                    "highlighted": true,
                     "type": "mathList"
                 },
                 {
                     "name": "allowImplicitIdentities",
                     "description": "Whether to allow implicit identity transformations when matching.",
+                    "highlighted": true,
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -115729,6 +115732,7 @@
                 {
                     "name": "allowPermutations",
                     "description": "Whether to allow permutations of operands when matching.",
+                    "highlighted": true,
                     "defaultValue": true,
                     "values": [
                         "true",
@@ -115739,6 +115743,7 @@
                 {
                     "name": "requireNumericMatches",
                     "description": "Whether numeric placeholders must match numbers.",
+                    "highlighted": true,
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -115749,6 +115754,7 @@
                 {
                     "name": "requireVariableMatches",
                     "description": "Whether variable placeholders must match variables.",
+                    "highlighted": true,
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -115759,12 +115765,14 @@
                 {
                     "name": "excludeMatches",
                     "description": "Patterns whose matches are excluded.",
+                    "highlighted": true,
                     "defaultValue": [],
                     "type": "mathList"
                 },
                 {
                     "name": "matchExpressionWithBlanks",
                     "description": "Whether to allow expressions with blanks to match.",
+                    "highlighted": true,
                     "defaultValue": false,
                     "values": [
                         "true",
@@ -115884,42 +115892,48 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether to allow implicit identity transformations when matching.",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "highlighted": true
                 },
                 {
                     "name": "allowPermutations",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether to allow permutations of operands when matching.",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "highlighted": true
                 },
                 {
                     "name": "requireNumericMatches",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether numeric placeholders must match numbers.",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "highlighted": true
                 },
                 {
                     "name": "requireVariableMatches",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether variable placeholders must match variables.",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "highlighted": true
                 },
                 {
                     "name": "excludeMatches",
                     "type": "mathList",
                     "isArray": false,
                     "description": "Patterns whose matches are excluded.",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "highlighted": true
                 },
                 {
                     "name": "matchExpressionWithBlanks",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether to allow expressions with blanks to match.",
-                    "fromAttribute": true
+                    "fromAttribute": true,
+                    "highlighted": true
                 },
                 {
                     "name": "hidden",
@@ -115955,7 +115969,8 @@
                     "name": "value",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the input matches the pattern."
+                    "description": "Whether the input matches the pattern.",
+                    "highlighted": true
                 },
                 {
                     "name": "text",
@@ -115967,13 +115982,15 @@
                     "name": "numMatches",
                     "type": "number",
                     "isArray": false,
-                    "description": "The number of matches found."
+                    "description": "The number of matches found.",
+                    "highlighted": true
                 },
                 {
                     "name": "patternMatches",
                     "type": "math",
                     "isArray": true,
                     "description": "The list of matched sub-expressions.",
+                    "highlighted": true,
                     "numDimensions": 1,
                     "indexedArrayDescription": [
                         {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -115716,7 +115716,7 @@
                     "name": "parameters",
                     "description": "Variables in the pattern that act as placeholders. Repeating one in the pattern requires the same subexpression at each occurrence. When specified, blanks in the pattern are matched literally.",
                     "highlighted": true,
-                    "type": "mathList"
+                    "type": "_variableNameList"
                 },
                 {
                     "name": "allowImplicitIdentities",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -115712,6 +115712,11 @@
                     "type": "math"
                 },
                 {
+                    "name": "parameters",
+                    "description": "Variables in the pattern that act as placeholders. Repeating one in the pattern requires the same subexpression at each occurrence. When specified, blanks in the pattern are matched literally.",
+                    "type": "mathList"
+                },
+                {
                     "name": "allowImplicitIdentities",
                     "description": "Whether to allow implicit identity transformations when matching.",
                     "defaultValue": false,


### PR DESCRIPTION
## What this changes

`<matchesPattern>` writes its placeholders as blanks — `pattern="()x+()"` — and each blank matches independently of the others. There is no way to say *"and the same expression here,"* so a pattern for the Pythagorean identity cannot be written at all: `pattern="sin(_)^2+cos(_)^2"` happily accepts `sin(x)^2+cos(y)^2`, and `pattern="sin(a)^2+cos(a)^2"` treats `a` as a literal and rejects `sin(x)^2+cos(x)^2`.

This adds a `parameters` attribute naming the variables in `pattern` that stand for a subexpression rather than for themselves. A name repeated in the pattern has to match the **same** subexpression at each occurrence:

```xml
<matchesPattern pattern="sin(a)^2+cos(a)^2" parameters="a">$mi</matchesPattern>
```

accepts `sin(x)^2+cos(x)^2` and turns down `sin(x)^2+cos(y)^2`. Several parameters work the same way — `pattern="sin(xz)+exp(xa)+y" parameters="x y"` matches `sin(qz)+exp(qa)+9` but not `sin(qz)+exp(ra)+9`.

Leaving `parameters` off changes nothing.

The issue proposed indexed blanks (`_1`, `_2`). Naming the placeholders was chosen instead: `_1` reads like a programming language, where a pattern that names its parts reads like the expression it is a pattern for.

## How

`math-expressions` already requires repeated wildcards to bind to equal subtrees, so the only new work is choosing which strings are wildcards.

`stateVariableDefinitions.pattern` already rewrote every blank in the pattern into a freshly generated name (`AAA`, `AAB`, …, skipping names the pattern already uses) and recorded them in `patternVariables`. `parameters` is a second rewrite rule over that same machinery: replace each *parameter subtree* instead of each blank. Both rules run through one tree walk that takes what to replace as a callback. Everything downstream — the wildcard map, `requireNumericMatches` / `requireVariableMatches`, `allowImplicitIdentities`, `excludeMatches`, `patternMatches` — reads only `patternVariables` and is untouched apart from one guard.

Generating a name rather than handing `math-expressions` the author's own is what lets a parameter be subscripted: `x_1` is `["_","x",1]`, an array, which cannot be a wildcard key at all. The generated name also steps past every variable the pattern already uses, so a pattern that happens to spell `AAA` still has it matched literally.

`parameters` is a `<_variableNameList>`, the component `<function variables>`, `<solveEquations variables>`, `<line variables>` and `<odeSystem variables>` already take. It judges each entry with `isValidVariable` and reports a bad one as `doenet-w0017`, so this component neither restates the rule nor invents its own wording for it. `parameterKey`, which keys both the parameter list and every node of the pattern, asks `isValidVariable` too — the rule that decided which parameters were accepted is the rule a pattern node is measured against, and the two cannot drift apart.

The pattern walk checks a node before descending into it, so `parameters="x x_1"` replaces `["_","x",1]` whole rather than through the `x` inside it.

## Decisions worth reviewing

- **A parameter must be a variable name** — whatever `isValidVariable` accepts: a plain symbol or a subscripted one, including a function name (`parameters="f"` with `pattern="f(x)+f(y)"` binds `f` to `sin`). A number, a compound expression, or a blank is dropped with `doenet-w0017`, the same warning every other variable-name list raises. Note this means **a prime is not a parameter**: `isValidVariable` turns `f'` down, here as in `<function variables>`. Whether it should learn primes is a question for every attribute that takes variable names, not one this PR answers.
- **A parameter absent from the pattern keeps its place** in `patternMatches` and reports a blank, with warning `doenet-w0117`. Filtering it out would make one typo silently shift the index of every later parameter, and `patternMatches[2]` should keep meaning "the second name I wrote."
- **An empty list is still a list.** `parameters=""` — or a reference that resolves to nothing — means specified with zero placeholders: blanks stay literal and the pattern matches exactly. The alternative would make `parameters="$params"` change meaning when `$params` empties out.
- **Specifying `parameters` makes `()` a literal blank.** A pattern cannot ask for both kinds of placeholder at once. Such a pattern only matches an expression that has a blank of its own, which still needs `matchExpressionWithBlanks`.
- **A name listed twice counts once.** `parameters="a b a"` is two placeholders, so `patternMatches[2]` is still what `b` matched.

## Docs

The reference page now leads with `parameters`. Both pre-existing examples were rewritten to use it — `y = a + b + c` for "a sum of three terms", `y = m x + b` for slope-intercept — each verified to behave identically to its blanks version, plus a new example for the repeated-parameter case. Blanks are kept, described in a short closing section.

The attribute/property listing is regrouped too. It renders as collapsible sections — a hand-picked "Highlighted" one that starts open, then closed accordions for functional groups, "Other", and "Common to all components" — and `<matchesPattern>` picked nothing, so all twenty of its non-common attributes sat in one closed pile in alphabetical order, `pattern` among them. The eight attributes that describe the matching itself, and the three properties that report its result, are now `highlighted`. What is left in "Other" is the comparison machinery inherited from `<boolean>` — `symbolicEquality`, `expandOnCompare`, `allowedErrorInNumbers` and the rest — which says nothing about how a pattern is matched. `highlighted` is docs-only metadata; no other component's schema entry changes (166 → 183 highlighted entries, all 17 on `matchesPattern`).

## Testing

20 new cases in `matchespattern.test.ts` covering the issue's own case, several parameters, a parameter repeated, the same name listed twice collapsing to one placeholder, blanks going literal, the empty list, subscripted parameters, a primed one being refused, a function name, a subscripted parameter not being reached through its base, each of `requireNumericMatches` / `requireVariableMatches` / `allowImplicitIdentities` (including a parameter that an implicit identity binds to `0`, which is a match and not the blank an unbound parameter reports) / `allowPermutations` / `excludeMatches`, both the refusal of an ineligible entry and the parameter that names no part of the pattern, a generated placeholder stepping around a variable the pattern already uses, and `pattern` or `parameters` arriving from a reference that changes at runtime — the state variable recomputes both ways, and a warning already raised is not raised again.

`matchespattern.test.ts` (26 total), `matchingPatterns.test.ts` and `diagnosticCodes.test.ts` pass; `lint:i18n`, `check:docs-coverage` and `prettier:check` are clean; the static schemas are regenerated and committed. No Cypress tests — this component has none.

The one message added carries its Spanish, so no locale falls back to English on this branch. A missing translation is reported as coverage rather than as a failure, so it would otherwise have shipped rendering its English to a Spanish reader.

Closes #1315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




