### PR TITLE
Keep a graph's math labels out of the tab order

### DIFF
--- a/.changeset/graph-math-labels-out-of-tab-order.md
+++ b/.changeset/graph-math-labels-out-of-tab-order.md
@@ -11,5 +11,3 @@ Graphs: stop math drawn inside a graph from taking a keyboard tab stop.
 A graph is presented to assistive technology as a single image named by its `<shortDescription>` — or hidden entirely, when it is `decorative` — so a label drawn inside it is not separately reachable. MathJax, though, marks every expression it renders as focusable, which put a tab stop on each math label in the graph: `<graph><label><m>A</m></label></graph>` made keyboard users stop on an `A` that is not in the accessibility tree and does nothing when focused.
 
 Math drawn inside a graph is now skipped when tabbing. Math elsewhere on the page is unchanged, as are the graph's own keyboard-navigable objects and any input or button anchored in it — those still take focus as before.
-
-Closes #1538.

--- a/.changeset/graph-math-labels-out-of-tab-order.md
+++ b/.changeset/graph-math-labels-out-of-tab-order.md
@@ -8,8 +8,8 @@
 
 Stop math inside a graph from taking a keyboard tab stop.
 
-A graph is presented to assistive technology as a single image named by its `<shortDescription>`, so nothing drawn inside it is separately reachable. MathJax, though, marks every expression it renders as focusable, which put a tab stop on each math label in the graph — `<graph><label><m>A</m></label></graph>` made keyboard users stop on an `A` that is not in the accessibility tree and does nothing when focused.
+A graph is presented to assistive technology as a single image named by its `<shortDescription>` — or hidden entirely, when it is `decorative` — so a label drawn inside it is not separately reachable. MathJax, though, marks every expression it renders as focusable, which put a tab stop on each math label in the graph: `<graph><label><m>A</m></label></graph>` made keyboard users stop on an `A` that is not in the accessibility tree and does nothing when focused.
 
-Math rendered inside a graph is now skipped when tabbing, along with the rest of the graph's contents. Math elsewhere on the page is unchanged, and the graph's own keyboard-navigable objects still take focus as before.
+Math drawn inside a graph is now skipped when tabbing. Math elsewhere on the page is unchanged, as are the graph's own keyboard-navigable objects and any input or button anchored in it — those still take focus as before.
 
 Closes #1538.

--- a/.changeset/graph-math-labels-out-of-tab-order.md
+++ b/.changeset/graph-math-labels-out-of-tab-order.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop math inside a graph from taking a keyboard tab stop.
+
+A graph is presented to assistive technology as a single image named by its `<shortDescription>`, so nothing drawn inside it is separately reachable. MathJax, though, marks every expression it renders as focusable, which put a tab stop on each math label in the graph — `<graph><label><m>A</m></label></graph>` made keyboard users stop on an `A` that is not in the accessibility tree and does nothing when focused.
+
+Math rendered inside a graph is now skipped when tabbing, along with the rest of the graph's contents. Math elsewhere on the page is unchanged, and the graph's own keyboard-navigable objects still take focus as before.
+
+Closes #1538.

--- a/.changeset/graph-math-labels-out-of-tab-order.md
+++ b/.changeset/graph-math-labels-out-of-tab-order.md
@@ -6,7 +6,7 @@
 "doenet-vscode-extension": patch
 ---
 
-Stop math inside a graph from taking a keyboard tab stop.
+Graphs: stop math drawn inside a graph from taking a keyboard tab stop.
 
 A graph is presented to assistive technology as a single image named by its `<shortDescription>` — or hidden entirely, when it is `decorative` — so a label drawn inside it is not separately reachable. MathJax, though, marks every expression it renders as focusable, which put a tab stop on each math label in the graph: `<graph><label><m>A</m></label></graph>` made keyboard users stop on an `A` that is not in the accessibility tree and does nothing when focused.
 

--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -175,9 +175,9 @@ export default function JSXGraphRenderer({
         }
     }, [board]);
 
-    // The graph as a whole carries the accessible name (its
-    // `<shortDescription>`) and is exposed as a single image, so the math in
-    // its labels must not become a tab stop of its own.
+    // MathJax marks everything it typesets as a tab stop, but a label drawn on
+    // the board is decoration on a picture; see the hook for why it must not
+    // keep that tab stop.
     useMathJaxOutOfTabOrder(boardContainer);
 
     useJSXGraphBoardSync({

--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -7,6 +7,7 @@ import {
     type AxisJXG,
 } from "./utils/jsxgraph";
 import useJSXGraphBoardSync from "./utils/useJSXGraphBoardSync";
+import { useMathJaxOutOfTabOrder } from "./utils/useMathJaxOutOfTabOrder";
 import { JXGBoard } from "./jsxgraph-distrib/types";
 import { GraphSVs } from "./graph";
 import { CallActionArgs, RendererAction } from "../useDoenetRenderer";
@@ -33,6 +34,10 @@ export default function JSXGraphRenderer({
     surfaceStyle,
 }: JSXGraphRendererProps) {
     const [board, setBoard] = useState<JXGBoard | null>(null);
+
+    // The board's container: JSXGraph appends the SVG surface and every
+    // HTML-rendered text (labels, and so the MathJax they typeset) to it.
+    const boardContainer = useRef<HTMLDivElement | null>(null);
 
     const previousBoundingbox = useRef<number[]>([0, 0, 0, 0]);
     const xaxis = useRef<AxisJXG | null | undefined>(null);
@@ -170,6 +175,11 @@ export default function JSXGraphRenderer({
         }
     }, [board]);
 
+    // The graph as a whole carries the accessible name (its
+    // `<shortDescription>`) and is exposed as a single image, so the math in
+    // its labels must not become a tab stop of its own.
+    useMathJaxOutOfTabOrder(boardContainer);
+
     useJSXGraphBoardSync({
         board,
         id,
@@ -188,7 +198,12 @@ export default function JSXGraphRenderer({
 
     return (
         <>
-            <div id={id} className="jxgbox" style={surfaceStyle} />
+            <div
+                id={id}
+                className="jxgbox"
+                style={surfaceStyle}
+                ref={boardContainer}
+            />
             {board ? (
                 <BoardContext.Provider value={board}>
                     {children}

--- a/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
@@ -1,0 +1,72 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Matches elements that browsers put in the sequential tab order because of an
+ * explicit `tabindex`. `tabindex="-1"` is focusable programmatically but not
+ * tabbable, which is exactly the state we want MathJax's output left in.
+ */
+const TAB_STOP_SELECTOR = '[tabindex]:not([tabindex="-1"])';
+
+/** MathJax renders into custom elements whose tag names all start with `mjx-`. */
+const MATHJAX_TAG_PREFIX = "MJX-";
+
+/**
+ * Take MathJax's output inside `root` out of the tab order.
+ *
+ * MathJax 4 attaches its keyboard explorer to every expression it typesets,
+ * which puts `tabindex="0"` on the `<mjx-container>` (and, once speech is
+ * generated, on the `<mjx-speech>` node inside it). That is reasonable for math
+ * in running text, but not for math inside a JSXGraph board: the board is
+ * exposed to assistive technology as a single image (or as a group whose
+ * accessible content is the `<shortDescription>`), so a tab stop on a label
+ * lands the user on something that is not in the accessibility tree and offers
+ * nothing to interact with.
+ *
+ * Only MathJax's own elements are touched: JSXGraph puts `tabindex` on the
+ * elements it wants keyboard-navigable, and those must keep it.
+ */
+export function removeMathJaxTabStops(root: Element): void {
+    root.querySelectorAll(TAB_STOP_SELECTOR).forEach((node) => {
+        if (node.tagName.startsWith(MATHJAX_TAG_PREFIX)) {
+            node.setAttribute("tabindex", "-1");
+        }
+    });
+}
+
+/**
+ * Keep MathJax's output inside `rootRef` out of the tab order, including math
+ * typeset after mount.
+ *
+ * A `MutationObserver` is needed rather than a one-shot pass: JSXGraph typesets
+ * each label when it draws or re-texts it, and MathJax sets the tab stop again
+ * whenever asynchronously generated speech arrives. Rewriting the attribute to
+ * `-1` re-triggers the observer once, which then finds nothing left to change,
+ * so this settles rather than looping.
+ */
+export function useMathJaxOutOfTabOrder(
+    rootRef: RefObject<Element | null>,
+): void {
+    useEffect(() => {
+        const root = rootRef.current;
+        if (!root) {
+            return;
+        }
+        removeMathJaxTabStops(root);
+
+        if (typeof MutationObserver === "undefined") {
+            return;
+        }
+        const observer = new MutationObserver(() => {
+            removeMathJaxTabStops(root);
+        });
+        observer.observe(root, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["tabindex"],
+        });
+        return () => {
+            observer.disconnect();
+        };
+    }, []);
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
@@ -23,9 +23,10 @@ const MATHJAX_TAG_PREFIX = "MJX-";
  * nothing to interact with.
  *
  * Only MathJax's own elements are touched: JSXGraph puts `tabindex` on the
- * elements it wants keyboard-navigable, and those must keep it.
+ * elements it wants keyboard-navigable, and a `<mathInput>` or `<button>`
+ * anchored in the board keeps its own focusable controls.
  */
-export function removeMathJaxTabStops(root: Element): void {
+function removeMathJaxTabStops(root: Element): void {
     root.querySelectorAll(TAB_STOP_SELECTOR).forEach((node) => {
         if (node.tagName.startsWith(MATHJAX_TAG_PREFIX)) {
             node.setAttribute("tabindex", "-1");
@@ -37,11 +38,15 @@ export function removeMathJaxTabStops(root: Element): void {
  * Keep MathJax's output inside `rootRef` out of the tab order, including math
  * typeset after mount.
  *
- * A `MutationObserver` is needed rather than a one-shot pass: JSXGraph typesets
- * each label when it draws or re-texts it, and MathJax sets the tab stop again
- * whenever asynchronously generated speech arrives. Rewriting the attribute to
- * `-1` re-triggers the observer once, which then finds nothing left to change,
- * so this settles rather than looping.
+ * A `MutationObserver` is needed rather than a one-shot pass: nothing has been
+ * typeset yet when this runs, JSXGraph typesets each label when it draws or
+ * re-texts it, and MathJax sets the tab stop again whenever asynchronously
+ * generated speech arrives. Rewriting the attribute to `-1` re-triggers the
+ * observer once, which then finds nothing left to change, so this settles
+ * rather than looping.
+ *
+ * `rootRef` is read once, on mount, so it must be attached to an element that
+ * the calling component renders unconditionally.
  */
 export function useMathJaxOutOfTabOrder(
     rootRef: RefObject<Element | null>,

--- a/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
@@ -14,15 +14,16 @@ const MATHJAX_TAG_PREFIX = "MJX-";
  * Take MathJax's output inside `root` out of the tab order.
  *
  * MathJax 4 attaches its keyboard explorer to every expression it typesets,
- * which puts `tabindex="0"` on the `<mjx-container>` (and, once speech is
- * generated, on the `<mjx-speech>` node inside it). That is reasonable for math
- * in running text, but not for math drawn on a JSXGraph board, where a label is
+ * which puts `tabindex="0"` on the `<mjx-container>`. That is reasonable for
+ * math in running text — and MathJax's own way of turning it off,
+ * `a11y.inTabOrder`, is a setting for the whole document, so it is no help
+ * here. Math drawn on a JSXGraph board is a different thing: a label there is
  * decoration on a picture. It is the graph as a whole that carries the
  * accessible name — `role="img"` named by the `<shortDescription>`, or
  * `role="group"` when the graph has controls beside it — and when the author
  * writes `decorative` the graph is `aria-hidden` outright, so a tab stop inside
  * it leaves focus in a subtree screen readers are told to ignore. In every case
- * the stop lands on something with nothing to announce and nothing to do.
+ * the stop lands on decoration a keyboard user cannot act on.
  *
  * Only MathJax's own elements are touched: JSXGraph puts `tabindex` on the
  * elements it wants keyboard-navigable, and a `<mathInput>` or `<button>`
@@ -42,10 +43,11 @@ function removeMathJaxTabStops(root: Element): void {
  *
  * A `MutationObserver` is needed rather than a one-shot pass: nothing has been
  * typeset yet when this runs, JSXGraph typesets each label when it draws or
- * re-texts it, and MathJax sets the tab stop again whenever asynchronously
- * generated speech arrives. Rewriting the attribute to `-1` re-triggers the
- * observer once, which then finds nothing left to change, so this settles
- * rather than looping.
+ * re-texts it, and MathJax's explorer rewrites `tabindex` itself long after
+ * that — it hands the tab stop to an `<mjx-speech>` node while a reader is
+ * exploring an expression and puts it back on the container afterwards.
+ * Rewriting the attribute to `-1` re-triggers the observer once, which then
+ * finds nothing left to change, so this settles rather than looping.
  *
  * `rootRef` is read once, on mount, so it must be attached to an element that
  * the calling component renders unconditionally.
@@ -60,9 +62,6 @@ export function useMathJaxOutOfTabOrder(
         }
         removeMathJaxTabStops(root);
 
-        if (typeof MutationObserver === "undefined") {
-            return;
-        }
         const observer = new MutationObserver(() => {
             removeMathJaxTabStops(root);
         });

--- a/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useMathJaxOutOfTabOrder.ts
@@ -16,11 +16,13 @@ const MATHJAX_TAG_PREFIX = "MJX-";
  * MathJax 4 attaches its keyboard explorer to every expression it typesets,
  * which puts `tabindex="0"` on the `<mjx-container>` (and, once speech is
  * generated, on the `<mjx-speech>` node inside it). That is reasonable for math
- * in running text, but not for math inside a JSXGraph board: the board is
- * exposed to assistive technology as a single image (or as a group whose
- * accessible content is the `<shortDescription>`), so a tab stop on a label
- * lands the user on something that is not in the accessibility tree and offers
- * nothing to interact with.
+ * in running text, but not for math drawn on a JSXGraph board, where a label is
+ * decoration on a picture. It is the graph as a whole that carries the
+ * accessible name — `role="img"` named by the `<shortDescription>`, or
+ * `role="group"` when the graph has controls beside it — and when the author
+ * writes `decorative` the graph is `aria-hidden` outright, so a tab stop inside
+ * it leaves focus in a subtree screen readers are told to ignore. In every case
+ * the stop lands on something with nothing to announce and nothing to do.
  *
  * Only MathJax's own elements are touched: JSXGraph puts `tabindex` on the
  * elements it wants keyboard-navigable, and a `<mathInput>` or `<button>`

--- a/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
@@ -22,8 +22,8 @@ function isMathJaxElement(el) {
  * `-1` is positive evidence that we rewrote one; "no tabbable MathJax found"
  * would also hold in the moment before MathJax attached its explorer, and the
  * assertion would pass without having observed anything. The sweep that follows
- * then covers the rest of MathJax's output — the `<mjx-speech>` node that
- * arrives with generated speech, and anything else `mjx-*` it adds.
+ * then covers the rest of MathJax's output: any other `mjx-*` element it puts
+ * inside the board.
  */
 function verifyMathIsNotTabbable(selector) {
     cy.get(`${selector} mjx-container`).should(($containers) => {

--- a/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
@@ -1,10 +1,11 @@
 /**
  * A graph rendered by JSXGraph is exposed to assistive technology as a single
- * image named by its `<shortDescription>`, so its contents are not reachable
- * as individual accessible objects. MathJax 4, though, attaches its keyboard
- * explorer to everything it typesets, which would otherwise put a `tabindex`
- * tab stop on each math label inside the board — a focus stop on something
- * that is neither in the accessibility tree nor interactive.
+ * image named by its `<shortDescription>` — or hidden outright, when the author
+ * writes `decorative` — so its contents are not reachable as individual
+ * accessible objects. MathJax 4, though, attaches its keyboard explorer to
+ * everything it typesets, which would otherwise put a `tabindex` tab stop on
+ * each math label inside the board — a focus stop on something that is neither
+ * in the accessibility tree nor interactive.
  */
 
 /** True when `el` is one of MathJax's own custom elements. */
@@ -34,6 +35,23 @@ function verifyMathIsNotTabbable(selector) {
     });
 }
 
+/**
+ * The control the rest of this spec rests on: MathJax really does put its
+ * output in the tab order, so an assertion that a graph's math is out of it is
+ * checking that we took the tab stop back out — not passing because MathJax
+ * never added one.
+ */
+function verifyMathIsTabbable(selector) {
+    cy.get(`${selector} mjx-container`).should("have.attr", "tabindex", "0");
+}
+
+function loadDoenetML(doenetML) {
+    cy.window().then((win) => {
+        win.postMessage({ doenetML }, "*");
+    });
+    cy.get("#ready").should("have.text", "ready");
+}
+
 describe("Graph math label tab order", { tags: ["@group5"] }, () => {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -41,21 +59,12 @@ describe("Graph math label tab order", { tags: ["@group5"] }, () => {
     });
 
     it("keeps a graph's math label out of the tab order", () => {
-        cy.window().then((win) => {
-            win.postMessage(
-                {
-                    doenetML: `
+        loadDoenetML(`
 <text name="ready">ready</text>
 <graph name="g">
   <label><m>A</m></label>
 </graph>
-`,
-                },
-                "*",
-            );
-        });
-
-        cy.get("#ready").should("have.text", "ready");
+`);
 
         // The case that matters: a graph with no interactive controls and no
         // `decorative` is exposed as a single image, which makes everything
@@ -67,47 +76,85 @@ describe("Graph math label tab order", { tags: ["@group5"] }, () => {
     });
 
     it("keeps math in a point's label out of the tab order", () => {
-        cy.window().then((win) => {
-            win.postMessage(
-                {
-                    doenetML: `
+        loadDoenetML(`
 <text name="ready">ready</text>
 <graph name="g">
   <point name="P" labelIsName>(1,2)</point>
   <point name="Q">(3,4)<label><m>x^2</m></label></point>
 </graph>
-`,
-                },
-                "*",
-            );
-        });
-
-        cy.get("#ready").should("have.text", "ready");
+`);
 
         verifyMathIsNotTabbable("#g");
+    });
+
+    it("keeps math in a decorative graph out of the tab order", () => {
+        // `decorative` drops the graph out of the accessibility tree entirely,
+        // where a tab stop inside it is worse still: focus would land on a
+        // subtree screen readers are told to ignore.
+        loadDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" decorative>
+  <label><m>A</m></label>
+</graph>
+`);
+
+        cy.get("#g-description").should("have.attr", "aria-hidden", "true");
+
+        verifyMathIsNotTabbable("#g");
+    });
+
+    it("keeps a label typeset after mount out of the tab order", () => {
+        // Nothing is typeset when the graph mounts, and JSXGraph re-typesets a
+        // label whenever its text changes — each pass hands the fresh
+        // `<mjx-container>` a new tab stop. This is what the hook's
+        // `MutationObserver` is for.
+        loadDoenetML(`
+<text name="ready">ready</text>
+<mathInput name="mi" prefill="1" />
+<graph name="g">
+  <point name="P">(1,2)<label><m>$mi</m></label></point>
+</graph>
+`);
+
+        verifyMathIsNotTabbable("#g");
+
+        cy.get("#mi textarea").type("{end}{backspace}2{enter}", {
+            force: true,
+        });
+        // Waits for the re-typeset, so the assertion below is about the
+        // `<mjx-container>` MathJax built the second time around.
+        cy.get("#g mjx-container").should("contain.text", "2");
+
+        verifyMathIsNotTabbable("#g");
+    });
+
+    it("leaves an input anchored in a graph tabbable", () => {
+        // The fix is scoped to MathJax's own elements, so the controls a graph
+        // can legitimately contain keep their tab stops.
+        loadDoenetML(`
+<text name="ready">ready</text>
+<graph name="g">
+  <mathInput name="mi" anchor="(1,1)" />
+  <label><m>A</m></label>
+</graph>
+`);
+
+        verifyMathIsNotTabbable("#g");
+        cy.get("#g textarea").should("have.attr", "tabindex", "0");
     });
 
     it("leaves math outside a graph tabbable as MathJax renders it", () => {
         // The graph is the exception; math in running text keeps whatever tab
         // behavior MathJax gives it, so this fix stays scoped to the board.
-        cy.window().then((win) => {
-            win.postMessage(
-                {
-                    doenetML: `
+        loadDoenetML(`
 <text name="ready">ready</text>
 <p name="p"><m>A</m></p>
 <graph name="g">
   <label><m>A</m></label>
 </graph>
-`,
-                },
-                "*",
-            );
-        });
+`);
 
-        cy.get("#ready").should("have.text", "ready");
-
+        verifyMathIsTabbable("#p");
         verifyMathIsNotTabbable("#g");
-        cy.get("#p mjx-container").should("not.have.attr", "tabindex", "-1");
     });
 });

--- a/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
@@ -1,0 +1,113 @@
+/**
+ * A graph rendered by JSXGraph is exposed to assistive technology as a single
+ * image named by its `<shortDescription>`, so its contents are not reachable
+ * as individual accessible objects. MathJax 4, though, attaches its keyboard
+ * explorer to everything it typesets, which would otherwise put a `tabindex`
+ * tab stop on each math label inside the board — a focus stop on something
+ * that is neither in the accessibility tree nor interactive.
+ */
+
+/** True when `el` is one of MathJax's own custom elements. */
+function isMathJaxElement(el) {
+    return el.tagName.startsWith("MJX-");
+}
+
+/**
+ * Assert that nothing MathJax rendered inside `selector` is in the sequential
+ * tab order. Wrapped in `should` so it retries while MathJax typesets.
+ */
+function verifyMathIsNotTabbable(selector) {
+    cy.get(`${selector} mjx-container`).should("exist");
+    cy.get(selector).should(($graph) => {
+        const tabbableMath = $graph
+            .find("[tabindex]")
+            .toArray()
+            .filter(
+                (el) =>
+                    isMathJaxElement(el) &&
+                    el.getAttribute("tabindex") !== "-1",
+            );
+        expect(
+            tabbableMath.map((el) => el.tagName.toLowerCase()),
+            "MathJax elements left in the tab order inside the graph",
+        ).to.deep.equal([]);
+    });
+}
+
+describe("Graph math label tab order", { tags: ["@group5"] }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("");
+    });
+
+    it("keeps a graph's math label out of the tab order", () => {
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<text name="ready">ready</text>
+<graph name="g">
+  <label><m>A</m></label>
+</graph>
+`,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ready").should("have.text", "ready");
+
+        // The case that matters: a graph with no interactive controls and no
+        // `decorative` is exposed as a single image, which makes everything
+        // drawn in it presentational — including a label a tab stop would
+        // otherwise land on.
+        cy.get("#g-description").should("have.attr", "role", "img");
+
+        verifyMathIsNotTabbable("#g");
+    });
+
+    it("keeps math in a point's label out of the tab order", () => {
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<text name="ready">ready</text>
+<graph name="g">
+  <point name="P" labelIsName>(1,2)</point>
+  <point name="Q">(3,4)<label><m>x^2</m></label></point>
+</graph>
+`,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ready").should("have.text", "ready");
+
+        verifyMathIsNotTabbable("#g");
+    });
+
+    it("leaves math outside a graph tabbable as MathJax renders it", () => {
+        // The graph is the exception; math in running text keeps whatever tab
+        // behavior MathJax gives it, so this fix stays scoped to the board.
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<text name="ready">ready</text>
+<p name="p"><m>A</m></p>
+<graph name="g">
+  <label><m>A</m></label>
+</graph>
+`,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ready").should("have.text", "ready");
+
+        verifyMathIsNotTabbable("#g");
+        cy.get("#p mjx-container").should("not.have.attr", "tabindex", "-1");
+    });
+});

--- a/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphMathLabelTabOrder.cy.js
@@ -16,9 +16,26 @@ function isMathJaxElement(el) {
 /**
  * Assert that nothing MathJax rendered inside `selector` is in the sequential
  * tab order. Wrapped in `should` so it retries while MathJax typesets.
+ *
+ * Each container is required to read `tabindex="-1"` rather than merely to be
+ * free of a tab stop. MathJax hands every container it renders a `tabindex`, so
+ * `-1` is positive evidence that we rewrote one; "no tabbable MathJax found"
+ * would also hold in the moment before MathJax attached its explorer, and the
+ * assertion would pass without having observed anything. The sweep that follows
+ * then covers the rest of MathJax's output — the `<mjx-speech>` node that
+ * arrives with generated speech, and anything else `mjx-*` it adds.
  */
 function verifyMathIsNotTabbable(selector) {
-    cy.get(`${selector} mjx-container`).should("exist");
+    cy.get(`${selector} mjx-container`).should(($containers) => {
+        const notTakenOut = $containers
+            .toArray()
+            .map((el) => el.getAttribute("tabindex"))
+            .filter((tabindex) => tabindex !== "-1");
+        expect(
+            notTakenOut,
+            "tabindex of each MathJax container inside the graph still in the tab order",
+        ).to.deep.equal([]);
+    });
     cy.get(selector).should(($graph) => {
         const tabbableMath = $graph
             .find("[tabindex]")


### PR DESCRIPTION
A graph is exposed to assistive technology as a single image, but the math labels drawn inside it were taking keyboard tab stops. Tabbing through `<graph><label><m>A</m></label></graph>` stopped on the `A`, which is neither in the accessibility tree nor interactive.

## Cause

MathJax 4 attaches its keyboard explorer to every expression it typesets and, with `a11y.inTabOrder` on by default, sets `tabindex="0"` on the `<mjx-container>`. JSXGraph typesets each HTML label in place inside the board container (`MathJax.typeset([rendNode])`), so every math label in a graph became a tab stop. Nothing in Doenet was setting that attribute.

A label drawn on the board is decoration on a picture. It is the graph as a whole that carries the accessible name: `GraphFrame` gives a non-prefigure graph `role="img"` named by its `<shortDescription>`, `role="group"` when it has controls beside it, and `aria-hidden="true"` when the author writes `decorative`. In each of those, a tab stop on a label lands on decoration a keyboard user cannot act on — and under `decorative` it leaves focus inside a subtree screen readers are told to ignore.

Turning `a11y.inTabOrder` off is not the fix: it is a setting for the whole document, and math in running text should keep its tab stop.

## Change

`useMathJaxOutOfTabOrder` rewrites `tabindex` to `-1` on MathJax's own elements (tag names starting `MJX-`) within the JSXGraph board container. A `MutationObserver` keeps it applied, because nothing is typeset yet when the hook runs, JSXGraph re-typesets a label on every `setText`, and MathJax's explorer rewrites `tabindex` itself long afterwards — it hands the tab stop to an `<mjx-speech>` node while a reader is exploring an expression and puts it back on the container when exploration ends. Rewriting the attribute re-triggers the observer once, which then finds nothing to change, so it settles rather than loops.

The hook runs in `JSXGraphRenderer`, so it covers every non-prefigure graph regardless of which state `GraphFrame` picked. Non-interactive math should not be a tab stop in any of them, and keying the behavior off a role decision made in a sibling component would break the next time that decision changes. The container ref and the observer are per renderer instance, so several graphs on a page do not interfere and a remounted graph gets a fresh observer on its new container.

Only `mjx-*` elements are touched. JSXGraph puts `tabindex` on the objects it wants keyboard-navigable and those keep it, as does a `<mathInput>` or `<button>` anchored in the board, and as does math elsewhere on the page. The `prefigure` renderer, which typesets to static SVG in a worker and has its own keyboard exploration, is untouched.

## Scope

This is the tab-order half of the issue. Whether a graph should be excluded from the accessibility tree at all — the other half — is left alone.

## Verification

- New Cypress spec (`graphMathLabelTabOrder.cy.js`, `@group5`), 6/6 pass: the issue's DoenetML (also asserting the graph is `role="img"`), a point's label, a `decorative` graph, a label re-typeset after mount, a `<mathInput>` anchored in a graph keeping its own tab stop, and a scope check that math in a `<p>` outside the graph is unaffected.
- The spec is written so it cannot pass vacuously. Every in-graph check requires each `<mjx-container>` to read `tabindex="-1"` — positive evidence that a tab stop MathJax added was taken back out, where "no tabbable MathJax found" would also hold in the moment before MathJax attaches its explorer. A second sweep then requires no `mjx-*` element anywhere in the board to be tabbable. Separately, the last test asserts positively that MathJax does put `tabindex="0"` on an `<mjx-container>` outside the graph, so the in-graph assertions are a differential against MathJax's observed behavior on the same page.
- Neutering the tag-prefix check in the built asset fails all 6 tests, so each one is exercising the fix rather than an adjacent scenario.
- The "typeset after mount" case drives a label through a `<mathInput>` and waits for the re-typeset before re-asserting, so it exercises the `MutationObserver` on a container MathJax built the second time around.
- Regression: `tagSpecific/graph.cy.js` 10/10, `labelMask.cy.js` 6/6, `lineFamilyLabels.cy.js` 1/1.

Closes #1538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
