### PR TITLE
Let the schema drive autocomplete in VS Code

### DIFF
--- a/.changeset/vscode-explicit-completions.md
+++ b/.changeset/vscode-explicit-completions.md
@@ -21,6 +21,10 @@ them inline instead left element suggestions working while attribute
 suggestions appeared to be missing entirely. Doenet documents now ask for the
 widget by default.
 
+Both defaults are contributed under `[doenet]`, which raises the extension's
+minimum VS Code version to 1.85 — the release where
+`editor.wordBasedSuggestions` became an enum.
+
 The language server also attaches to Doenet documents on any filesystem rather
 than only `file:` and `untitled:` ones, so completions, diagnostics, hovers and
 formatting work on vscode.dev, github.dev, and in virtual workspaces.

--- a/.changeset/vscode-explicit-completions.md
+++ b/.changeset/vscode-explicit-completions.md
@@ -13,6 +13,14 @@ the web editor, and keeps narrowing it as you type. Word-based suggestions are
 off by default in Doenet documents, where they only ever compete with the
 schema; `"[doenet]": { "editor.wordBasedSuggestions": ... }` turns them back on.
 
+Attribute suggestions no longer depend on how the editor is configured to
+auto-suggest. Typing `<math exp` reaches the language server only if quick
+suggestions open the suggestion widget — unlike `<`, which is a trigger
+character the server is always asked about — so an editor configured to render
+them inline instead left element suggestions working while attribute
+suggestions appeared to be missing entirely. Doenet documents now ask for the
+widget by default.
+
 The language server also attaches to Doenet documents on any filesystem rather
 than only `file:` and `untitled:` ones, so completions, diagnostics, hovers and
 formatting work on vscode.dev, github.dev, and in virtual workspaces.

--- a/.changeset/vscode-explicit-completions.md
+++ b/.changeset/vscode-explicit-completions.md
@@ -13,13 +13,13 @@ the web editor, and keeps narrowing it as you type. Word-based suggestions are
 off by default in Doenet documents, where they only ever compete with the
 schema; `"[doenet]": { "editor.wordBasedSuggestions": ... }` turns them back on.
 
-Attribute suggestions no longer depend on how the editor is configured to
-auto-suggest. Typing `<math exp` reaches the language server only if quick
-suggestions open the suggestion widget — unlike `<`, which is a trigger
-character the server is always asked about — so an editor configured to render
-them inline instead left element suggestions working while attribute
-suggestions appeared to be missing entirely. Doenet documents now ask for the
-widget by default.
+Attribute suggestions no longer go missing. Typing `<math exp` reaches the
+language server only if quick suggestions open the suggestion widget — unlike
+`<`, which is a trigger character the server is always asked about — so an
+editor configured to render them inline instead left element suggestions
+working while attribute suggestions appeared to be missing entirely. Doenet
+documents now ask for the widget by default; an explicit
+`editor.quickSuggestions` setting still wins.
 
 Both defaults are contributed under `[doenet]`, which raises the extension's
 minimum VS Code version to 1.85 — the release where

--- a/.changeset/vscode-explicit-completions.md
+++ b/.changeset/vscode-explicit-completions.md
@@ -1,0 +1,23 @@
+---
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+VS Code: Ctrl+Space now offers Doenet elements anywhere in a document.
+
+Pressing Ctrl+Space (or Ctrl+I / Cmd+I) where no `<` has been typed used to
+produce nothing from the language server, so VS Code fell back to its own
+word-based suggestions — words scraped out of the file, which read as invented
+tags and attributes. It now opens the element menu, the same as Ctrl+Space in
+the web editor, and keeps narrowing it as you type. Word-based suggestions are
+off by default in Doenet documents, where they only ever compete with the
+schema; `"[doenet]": { "editor.wordBasedSuggestions": ... }` turns them back on.
+
+The language server also attaches to Doenet documents on any filesystem rather
+than only `file:` and `untitled:` ones, so completions, diagnostics, hovers and
+formatting work on vscode.dev, github.dev, and in virtual workspaces.
+
+Two fixes alongside: the preview no longer throws when the last editor closes
+or focus leaves the editor area, and the extension declares a valid SPDX
+license so it can be mirrored to the Open VSX registry (#1317) — publishing
+there needs only an `OVSX_PAT` repository secret.

--- a/.changeset/vscode-explicit-completions.md
+++ b/.changeset/vscode-explicit-completions.md
@@ -30,6 +30,6 @@ than only `file:` and `untitled:` ones, so completions, diagnostics, hovers and
 formatting work on vscode.dev, github.dev, and in virtual workspaces.
 
 Two fixes alongside: the preview no longer throws when the last editor closes
-or focus leaves the editor area, and the extension declares a valid SPDX
-license so it can be mirrored to the Open VSX registry (#1317) — publishing
-there needs only an `OVSX_PAT` repository secret.
+or focus leaves the editor area, and the extension now publishes to the Open
+VSX registry as well as the VS Code Marketplace, putting it within reach of
+VS Code-compatible editors such as VSCodium (#1317).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -318,8 +318,14 @@ jobs:
             - name: Publish extension to Open VSX
               if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
               run: |
+                  # The Marketplace publish above is the release; the Open VSX
+                  # mirror is a second copy of the same VSIX.  Warn rather than
+                  # fail when the token is missing, so a release that has
+                  # already gone out to npm and the Marketplace is not left red
+                  # over a mirror that can be re-run on its own.
                   if [ -z "${OVSX_PAT}" ]; then
-                      echo "::warning::OVSX_PAT secret is not set — the Open VSX release was not published."
+                      echo "::warning::OVSX_PAT repository secret is not set — the Open VSX release was not published."
+                      echo "Add OVSX_PAT as a repository-level secret (Settings → Secrets → Actions) to enable Open VSX publishing."
                       exit 0
                   fi
                   npm run publish:openvsx -w @doenet/vscode-extension

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,10 @@ jobs:
     # Secret requirement: `VSCE_PAT` must be configured as a **repository-level**
     # secret (not only in the `production` environment) for this job to publish.
     # If the secret is absent the publish step emits a warning and exits cleanly.
+    # `OVSX_PAT` does the same for the Open VSX mirror, which is what puts the
+    # extension within reach of VS Code-compatible editors such as VSCodium
+    # (#1317).  Each registry is published independently: a missing token for
+    # one leaves the other's publish untouched.
     dev-vscode-extension:
         name: Dev VS Code Extension Pre-release
         runs-on: ubuntu-latest
@@ -201,6 +205,18 @@ jobs:
                   npm run publish:prerelease -w @doenet/vscode-extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+            - name: Publish Open VSX pre-release
+              if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+              run: |
+                  if [ -z "${OVSX_PAT}" ]; then
+                      echo "::warning::OVSX_PAT repository secret is not set — Open VSX pre-release was not published."
+                      echo "Add OVSX_PAT as a repository-level secret (Settings → Secrets → Actions) to enable Open VSX pre-release publishing."
+                      exit 0
+                  fi
+                  npm run publish:openvsx:prerelease -w @doenet/vscode-extension
+              env:
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
     production-release:
         name: Production Release
@@ -298,3 +314,14 @@ jobs:
               run: npm run publish -w @doenet/vscode-extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+            - name: Publish extension to Open VSX
+              if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+              run: |
+                  if [ -z "${OVSX_PAT}" ]; then
+                      echo "::warning::OVSX_PAT secret is not set — the Open VSX release was not published."
+                      exit 0
+                  fi
+                  npm run publish:openvsx -w @doenet/vscode-extension
+              env:
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -315,14 +315,13 @@ jobs:
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
-            - name: Publish extension to Open VSX
+            - name: Publish Open VSX release
               if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
               run: |
-                  # The Marketplace publish above is the release; the Open VSX
-                  # mirror is a second copy of the same VSIX.  Warn rather than
-                  # fail when the token is missing, so a release that has
-                  # already gone out to npm and the Marketplace is not left red
-                  # over a mirror that can be re-run on its own.
+                  # Warn rather than fail when the token is missing, so a
+                  # release that has already gone out to npm and the
+                  # Marketplace is not left red over a mirror that can be
+                  # re-run on its own.
                   if [ -z "${OVSX_PAT}" ]; then
                       echo "::warning::OVSX_PAT repository secret is not set — the Open VSX release was not published."
                       echo "Add OVSX_PAT as a repository-level secret (Settings → Secrets → Actions) to enable Open VSX publishing."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1725,10 +1725,33 @@
             "resolved": "packages/webwork-to-doenetml",
             "link": true
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.3",
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/runtime": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
             "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+            "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3974,6 +3997,19 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
         "node_modules/@next/env": {
             "version": "15.5.20",
             "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
@@ -4132,6 +4168,286 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/@node-rs/crc32": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32/-/crc32-1.10.6.tgz",
+            "integrity": "sha512-+llXfqt+UzgoDzT9of5vPQPGqTAVCohU74I9zIBkNo5TH6s2P31DFJOGsJQKN207f0GHnYv5pV3wh3BCY/un/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "optionalDependencies": {
+                "@node-rs/crc32-android-arm-eabi": "1.10.6",
+                "@node-rs/crc32-android-arm64": "1.10.6",
+                "@node-rs/crc32-darwin-arm64": "1.10.6",
+                "@node-rs/crc32-darwin-x64": "1.10.6",
+                "@node-rs/crc32-freebsd-x64": "1.10.6",
+                "@node-rs/crc32-linux-arm-gnueabihf": "1.10.6",
+                "@node-rs/crc32-linux-arm64-gnu": "1.10.6",
+                "@node-rs/crc32-linux-arm64-musl": "1.10.6",
+                "@node-rs/crc32-linux-x64-gnu": "1.10.6",
+                "@node-rs/crc32-linux-x64-musl": "1.10.6",
+                "@node-rs/crc32-wasm32-wasi": "1.10.6",
+                "@node-rs/crc32-win32-arm64-msvc": "1.10.6",
+                "@node-rs/crc32-win32-ia32-msvc": "1.10.6",
+                "@node-rs/crc32-win32-x64-msvc": "1.10.6"
+            }
+        },
+        "node_modules/@node-rs/crc32-android-arm-eabi": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.10.6.tgz",
+            "integrity": "sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-android-arm64": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.10.6.tgz",
+            "integrity": "sha512-Vl/JbjCinCw/H9gEpZveWCMjxjcEChDcDBM8S4hKay5yyoRCUHJPuKr4sjVDBeOm+1nwU3oOm6Ca8dyblwp4/w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-darwin-arm64": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.10.6.tgz",
+            "integrity": "sha512-kARYANp5GnmsQiViA5Qu74weYQ3phOHSYQf0G+U5wB3NB5JmBHnZcOc46Ig21tTypWtdv7u63TaltJQE41noyg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-darwin-x64": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.10.6.tgz",
+            "integrity": "sha512-Q99bevJVMfLTISpkpKBlXgtPUItrvTWKFyiqoKH5IvscZmLV++NH4V13Pa17GTBmv9n18OwzgQY4/SRq6PQNVA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-freebsd-x64": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.10.6.tgz",
+            "integrity": "sha512-66hpawbNjrgnS9EDMErta/lpaqOMrL6a6ee+nlI2viduVOmRZWm9Rg9XdGTK/+c4bQLdtC6jOd+Kp4EyGRYkAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.10.6.tgz",
+            "integrity": "sha512-E8Z0WChH7X6ankbVm8J/Yym19Cq3otx6l4NFPS6JW/cWdjv7iw+Sps2huSug+TBprjbcEA+s4TvEwfDI1KScjg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-linux-arm64-gnu": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.10.6.tgz",
+            "integrity": "sha512-LmWcfDbqAvypX0bQjQVPmQGazh4dLiVklkgHxpV4P0TcQ1DT86H/SWpMBMs/ncF8DGuCQ05cNyMv1iddUDugoQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-linux-arm64-musl": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.10.6.tgz",
+            "integrity": "sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-linux-x64-gnu": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.10.6.tgz",
+            "integrity": "sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-linux-x64-musl": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.10.6.tgz",
+            "integrity": "sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-wasm32-wasi": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-wasm32-wasi/-/crc32-wasm32-wasi-1.10.6.tgz",
+            "integrity": "sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^0.2.5"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@node-rs/crc32-win32-arm64-msvc": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.10.6.tgz",
+            "integrity": "sha512-x50AXiSxn5Ccn+dCjLf1T7ZpdBiV1Sp5aC+H2ijhJO4alwznvXgWbopPRVhbp2nj0i+Gb6kkDUEyU+508KAdGQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-win32-ia32-msvc": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.10.6.tgz",
+            "integrity": "sha512-DpDxQLaErJF9l36aghe1Mx+cOnYLKYo6qVPqPL9ukJ5rAGLtCdU0C+Zoi3gs9ySm8zmbFgazq/LvmsZYU42aBw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@node-rs/crc32-win32-x64-msvc": {
+            "version": "1.10.6",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.10.6.tgz",
+            "integrity": "sha512-5B1vXosIIBw1m2Rcnw62IIfH7W9s9f7H7Ma0rRuhT8HR4Xh8QCgw6NJSI2S2MCngsGktYnAhyUvs81b7efTyQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -5649,6 +5965,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@types/argparse": {
@@ -11710,6 +12037,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/define-lazy-prop": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -11718,6 +12063,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/degenerator": {
@@ -13475,6 +13838,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/globalthis": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/globby": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -13612,6 +13992,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -14427,6 +14820,26 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ci-info": "^2.0.0"
+            },
+            "bin": {
+                "is-ci": "bin.js"
+            }
+        },
+        "node_modules/is-ci/node_modules/ci-info": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -14603,6 +15016,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-it-type": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/is-it-type/-/is-it-type-5.1.3.tgz",
+            "integrity": "sha512-AX2uU0HW+TxagTgQXOJY7+2fbFHemC7YFBwN1XqD8qQMKdtfbOC8OC3fUb4s5NU59a3662Dzwto8tWDdZYRXxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "globalthis": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/is-npm": {
@@ -18688,6 +19114,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/obug": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -18974,6 +19410,42 @@
             "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/ovsx": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-1.0.2.tgz",
+            "integrity": "sha512-N0gWlINGgoOA2Sn0AhrF9L3ap40a/QbsFUpMDKR+CKYyZGJeTFEoNGngplLHjAYtcjrrZv2jX2K7ktPzxWjPNg==",
+            "dev": true,
+            "license": "EPL-2.0",
+            "dependencies": {
+                "@vscode/vsce": "^3.7.1",
+                "commander": "^6.2.1",
+                "follow-redirects": "^1.16.0",
+                "is-ci": "^2.0.0",
+                "leven": "^3.1.0",
+                "semver": "^7.6.0",
+                "tmp": "^0.2.3",
+                "yauzl-promise": "^4.0.0"
+            },
+            "bin": {
+                "ovsx": "bin/ovsx"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/ovsx/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/p-filter": {
             "version": "2.1.0",
@@ -22493,6 +22965,16 @@
                 "simple-concat": "^1.0.0"
             }
         },
+        "node_modules/simple-invariant": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/simple-invariant/-/simple-invariant-2.0.1.tgz",
+            "integrity": "sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/sirv": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -25769,6 +26251,21 @@
                 "fd-slicer": "~1.1.0"
             }
         },
+        "node_modules/yauzl-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yauzl-promise/-/yauzl-promise-4.0.0.tgz",
+            "integrity": "sha512-/HCXpyHXJQQHvFq9noqrjfa/WpQC2XYs3vI7tBiAi4QiIU1knvYhZGaO1QPjwIVMdqflxbmwgMXtYeaRiAE0CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@node-rs/crc32": "^1.7.0",
+                "is-it-type": "^5.1.2",
+                "simple-invariant": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/yauzl/node_modules/buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -26634,30 +27131,31 @@
         "packages/vscode-extension": {
             "name": "@doenet/vscode-extension",
             "version": "0.7.21",
-            "license": "AGPL",
+            "license": "AGPL-3.0-or-later",
             "devDependencies": {
                 "@types/vscode": "^1.99.0",
                 "@types/vscode-webview": "^1.57.5",
                 "@vscode/test-electron": "^2.4.1",
                 "@vscode/vsce": "^3.9.1",
                 "@vscode/webview-ui-toolkit": "^1.4.0",
+                "ovsx": "^1.0.2",
                 "vscode-languageclient": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.12"
             },
             "engines": {
-                "vscode": "^1.76.0"
+                "vscode": "^1.85.0"
             }
         },
         "packages/vscode-extension/extension": {
             "name": "doenet-vscode-extension",
             "version": "0.7.21",
-            "license": "AGPL",
+            "license": "AGPL-3.0-or-later",
             "devDependencies": {
                 "@types/vscode": "^1.76.0",
                 "@types/vscode-webview": "^1.57.3"
             },
             "engines": {
-                "vscode": "^1.76.0"
+                "vscode": "^1.85.0"
             }
         },
         "packages/webwork-to-doenetml": {

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -47,7 +47,7 @@ Extension packaging and publishing is automated as part of the production releas
 
 #### Publishing the extension
 
-The production release workflow automatically publishes to the VS Code Marketplace after npm packages are published.
+The production release workflow automatically publishes to the VS Code Marketplace after npm packages are published, then publishes the same extension to the [Open VSX registry](https://open-vsx.org), where VS Code-compatible editors such as VSCodium find it. Open VSX publishing needs an `OVSX_PAT` repository secret; without it that step warns and the rest of the release proceeds. To publish it by hand, run `npm run publish:openvsx -w packages/vscode-extension` with `OVSX_PAT` set to an [open-vsx.org](https://open-vsx.org) access token for the `doenet` namespace.
 
 If the extension publish step fails (e.g., token expiration, transient network issues):
 

--- a/packages/vscode-extension/extension/README.md
+++ b/packages/vscode-extension/extension/README.md
@@ -7,7 +7,7 @@ A Visual Studio Code extension to make writing [Doenet](https://doenet.org) docu
 
 ## Features
 
--   Syntax highlighting and auto-completion for `.doenet` files
+-   Syntax highlighting and auto-completion for `.doenet` files. Suggestions come from the Doenet schema and appear as you type; press Ctrl+Space (or Ctrl+I / Cmd+I) to ask for the elements available at the cursor anywhere in a document.
 -   Highlights invalid doenet attributes
 -   Previewing of doenet documents. To access, open the command pallet (Ctrl+Shift+P) and select the `Preview Doenet` action.
 -   Navigating between the source and the preview. Cmd+click (macOS) / Ctrl+click (Windows/Linux) a rendered element in the preview to put the editor's cursor on the DoenetML that produced it. In the other direction the preview follows the editor's cursor as you move it; turn that off with the `doenet.preview.scrollPreviewWithEditor` setting and scroll the preview when you ask instead, with the `Scroll Doenet Preview to Cursor` command (Ctrl+Alt+P, Cmd+Alt+P on macOS), which works either way.

--- a/packages/vscode-extension/extension/package.json
+++ b/packages/vscode-extension/extension/package.json
@@ -4,7 +4,7 @@
     "description": "A language server for DoenetML",
     "icon": "assets/doenet-small.png",
     "author": "Jason Siefken",
-    "license": "AGPL",
+    "license": "AGPL-3.0-or-later",
     "publisher": "doenet",
     "version": "0.7.21",
     "repository": {
@@ -21,7 +21,7 @@
         "language-server"
     ],
     "engines": {
-        "vscode": "^1.76.0"
+        "vscode": "^1.85.0"
     },
     "browser": "./build/extension/index.js",
     "contributes": {
@@ -71,6 +71,11 @@
                 "enablement": "resourceLangId == doenet",
                 "command": "doenet.revealCursorInPreview",
                 "title": "Scroll Doenet Preview to Cursor"
+            },
+            {
+                "enablement": "resourceLangId == doenet",
+                "command": "doenet.triggerSuggest",
+                "title": "Trigger Doenet Suggestions"
             }
         ],
         "keybindings": [
@@ -79,9 +84,27 @@
                 "key": "ctrl+alt+p",
                 "mac": "cmd+alt+p",
                 "when": "editorTextFocus && editorLangId == doenet"
+            },
+            {
+                "command": "doenet.triggerSuggest",
+                "key": "ctrl+space",
+                "mac": "ctrl+space",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == doenet && !suggestWidgetVisible"
+            },
+            {
+                "command": "doenet.triggerSuggest",
+                "key": "ctrl+i",
+                "mac": "cmd+i",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == doenet && !suggestWidgetVisible"
             }
         ],
         "menus": {
+            "commandPalette": [
+                {
+                    "command": "doenet.triggerSuggest",
+                    "when": "false"
+                }
+            ],
             "editor/title": [
                 {
                     "command": "doenet.showPreview",
@@ -89,6 +112,11 @@
                     "when": "resourceLangId == doenet"
                 }
             ]
+        },
+        "configurationDefaults": {
+            "[doenet]": {
+                "editor.wordBasedSuggestions": "off"
+            }
         },
         "configuration": {
             "title": "Doenet",

--- a/packages/vscode-extension/extension/package.json
+++ b/packages/vscode-extension/extension/package.json
@@ -115,6 +115,9 @@
         },
         "configurationDefaults": {
             "[doenet]": {
+                "editor.quickSuggestions": {
+                    "other": "on"
+                },
                 "editor.wordBasedSuggestions": "off"
             }
         },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "DoenetML support",
     "description": "A language server for DoenetML",
     "author": "Jason Siefken",
-    "license": "AGPL",
+    "license": "AGPL-3.0-or-later",
     "version": "0.7.21",
     "repository": {
         "type": "git",
@@ -14,7 +14,7 @@
         "Doenet DoenetML"
     ],
     "engines": {
-        "vscode": "^1.76.0"
+        "vscode": "^1.85.0"
     },
     "exports": {
         "./language-server": {
@@ -35,6 +35,8 @@
         "package": "cd ./extension && vsce package --no-dependencies --out ../",
         "publish": "cd ./extension && vsce publish --no-dependencies",
         "publish:prerelease": "cd ./extension && vsce publish --pre-release --no-dependencies",
+        "publish:openvsx": "cd ./extension && ovsx publish --no-dependencies",
+        "publish:openvsx:prerelease": "cd ./extension && ovsx publish --pre-release --no-dependencies",
         "run-in-browser:firefox": "vscode-test-web --browserType=firefox --extensionDevelopmentPath=./extension .",
         "run-in-browser:chrome": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=./extension .",
         "run-in-browser": "npm run run-in-browser:firefox"
@@ -93,6 +95,7 @@
     },
     "devDependencies": {
         "@vscode/vsce": "^3.9.1",
+        "ovsx": "^1.0.2",
         "@types/vscode": "^1.99.0",
         "@types/vscode-webview": "^1.57.5",
         "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -141,7 +141,8 @@ async function setupLanguageServer(context: ExtensionContext) {
 // which is what the web editor's CodeMirror client sends as
 // `context.explicit`.
 let pendingExplicitCompletion: { uri: string; version: number } | undefined;
-let inExplicitCompletionSession = false;
+/** Document whose in-flight completion session was opened by Ctrl+Space. */
+let explicitCompletionSessionUri: string | undefined;
 
 /**
  * Completion params carrying the `explicit` flag `@doenet/lsp` reads. It is an
@@ -160,34 +161,37 @@ type ExplicitCompletionParams = CompletionParams & {
 function registerTriggerSuggestCommand() {
     return commands.registerCommand("doenet.triggerSuggest", async () => {
         const document = vscode.window.activeTextEditor?.document;
-        if (document?.languageId === "doenet") {
-            pendingExplicitCompletion = {
-                uri: String(document.uri),
-                version: document.version,
-            };
-        }
+        // Assigned either way: this keystroke supersedes whatever an earlier
+        // one left pending, so landing somewhere without a Doenet document
+        // clears the flag rather than leaving the older one to be claimed.
+        pendingExplicitCompletion =
+            document?.languageId === "doenet"
+                ? { uri: String(document.uri), version: document.version }
+                : undefined;
         await commands.executeCommand("editor.action.triggerSuggest");
     });
 }
 
 /**
- * True when this completion request is the one `doenet.triggerSuggest` just
- * asked for. Consumes the pending flag, so a request VS Code raises on its own
- * is never mistaken for one the user asked for.
+ * True when this completion request belongs to a session `doenet.triggerSuggest`
+ * opened. A request that starts a session consumes the pending flag, so one VS
+ * Code raises on its own is never mistaken for one the user asked for.
  */
 function isExplicitCompletion(
     document: vscode.TextDocument,
     context: vscode.CompletionContext,
 ): boolean {
+    const uri = String(document.uri);
     // A list marked `isIncomplete` makes VS Code re-ask as the user keeps
     // typing. Those follow-ups belong to the session Ctrl+Space opened, so
     // they inherit its explicitness — otherwise the element menu would empty
-    // out on the first keystroke after it appeared.
+    // out on the first keystroke after it appeared. Only within that session's
+    // own document: a refresh anywhere else belongs to a different session.
     if (
         context.triggerKind ===
         vscode.CompletionTriggerKind.TriggerForIncompleteCompletions
     ) {
-        return inExplicitCompletionSession;
+        return explicitCompletionSessionUri === uri;
     }
     // Any other request begins a new session. Matching the document version
     // as well as the URI expires a flag whose keystroke never produced a
@@ -195,11 +199,11 @@ function isExplicitCompletion(
     // and the version has moved on.
     const pending = pendingExplicitCompletion;
     pendingExplicitCompletion = undefined;
-    inExplicitCompletionSession =
-        pending !== undefined &&
-        pending.uri === String(document.uri) &&
-        pending.version === document.version;
-    return inExplicitCompletionSession;
+    explicitCompletionSessionUri =
+        pending?.uri === uri && pending.version === document.version
+            ? uri
+            : undefined;
+    return explicitCompletionSessionUri !== undefined;
 }
 
 /**
@@ -209,7 +213,9 @@ function isExplicitCompletion(
  * The request has to be issued by hand rather than through `next`:
  * `asCompletionParams` rebuilds the context from `triggerKind` and
  * `triggerCharacter` alone, so an extra field set on the way in is dropped
- * before the request goes out.
+ * before the request goes out. What `next` would otherwise have done around
+ * the request — honoring cancellation, routing a rejection through the
+ * client's own error handling — is reproduced below.
  */
 async function provideCompletionItemWithExplicitFlag(
     document: vscode.TextDocument,
@@ -230,19 +236,33 @@ async function provideCompletionItemWithExplicitFlag(
         ...params,
         context: { ...params.context, explicit: true },
     };
-    const result = await client.sendRequest(
-        CompletionRequest.type,
-        explicitParams,
-        token,
-    );
-    if (token.isCancellationRequested) {
-        return null;
+    try {
+        const result = await client.sendRequest(
+            CompletionRequest.type,
+            explicitParams,
+            token,
+        );
+        if (token.isCancellationRequested) {
+            return null;
+        }
+        // No commit characters to pass along: the server advertises
+        // `triggerCharacters` but no `allCommitCharacters`.
+        return await client.protocol2CodeConverter.asCompletionResult(
+            result,
+            undefined,
+            token,
+        );
+    } catch (error) {
+        // A request the next keystroke cancelled, or one that arrived while
+        // the server was restarting, rejects in the ordinary course of typing.
+        // The client knows which of those to swallow and which to surface.
+        return client.handleFailedRequest(
+            CompletionRequest.type,
+            token,
+            error,
+            null,
+        );
     }
-    return client.protocol2CodeConverter.asCompletionResult(
-        result,
-        undefined,
-        token,
-    );
 }
 
 function registerFormatCommand(commandName: string, requestName: string) {

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -10,6 +10,9 @@ import {
 import * as vscode from "vscode";
 
 import {
+    CompletionContext,
+    CompletionParams,
+    CompletionRequest,
     LanguageClient,
     LanguageClientOptions,
     TextEdit,
@@ -61,14 +64,18 @@ async function setupLanguageServer(context: ExtensionContext) {
 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        // Register the server for plain text documents
-        documentSelector: [
-            { scheme: "file", language: "doenet" },
-            { scheme: "untitled", language: "doenet" },
-        ],
+        // Every Doenet document, whatever filesystem it came from. Naming
+        // schemes here would limit the server to `file:` and `untitled:`,
+        // which leaves it silent in exactly the places a web extension is
+        // meant to work: vscode.dev and github.dev serve their files as
+        // `vscode-vfs:`, and a virtual workspace can use any scheme at all.
+        documentSelector: [{ language: "doenet" }],
         initializationOptions: doenetWorkerBlobUrl
             ? { doenetWorkerUrl: doenetWorkerBlobUrl }
             : undefined,
+        middleware: {
+            provideCompletionItem: provideCompletionItemWithExplicitFlag,
+        },
     };
 
     // Create a worker. The worker main file implements the language server.
@@ -92,6 +99,8 @@ async function setupLanguageServer(context: ExtensionContext) {
         // Start the client. This will also launch the server.
         await client.start();
 
+        const triggerSuggest = registerTriggerSuggestCommand();
+
         const formatAsDoenet = registerFormatCommand(
             "doenet.formatAsDoenetML",
             "doenet.formatAsDoenetML",
@@ -106,6 +115,7 @@ async function setupLanguageServer(context: ExtensionContext) {
         );
 
         context.subscriptions.push(
+            triggerSuggest,
             formatAsDoenet,
             formatAsXML,
             formatAsMarkdown,
@@ -114,6 +124,126 @@ async function setupLanguageServer(context: ExtensionContext) {
         revokeDoenetWorkerBlobUrl();
         throw e;
     }
+}
+
+// The language server opens its element menu on an explicit completion
+// invocation even where no `<` has been typed — the same Ctrl+Space that
+// offers `<point>`, `<graph>`, … in the web editor. LSP has no field for "the
+// user asked for this": VS Code reports `Invoked` both for Ctrl+Space and for
+// the quick suggestions that fire on a typed letter, so a server keying off
+// `triggerKind` alone would dump the element menu into the middle of a
+// sentence. `doenet.triggerSuggest` records the keystroke and
+// `provideCompletionItemWithExplicitFlag` marks the request it produces,
+// which is what the web editor's CodeMirror client sends as
+// `context.explicit`.
+let pendingExplicitCompletion: { uri: string; version: number } | undefined;
+let inExplicitCompletionSession = false;
+
+/**
+ * Completion params carrying the `explicit` flag `@doenet/lsp` reads. It is an
+ * extension to the protocol's own `CompletionContext`, so it has to be spelled
+ * out here for the request to type-check.
+ */
+type ExplicitCompletionParams = CompletionParams & {
+    context: CompletionContext & { explicit: true };
+};
+
+/**
+ * Take over Ctrl+Space for Doenet documents so the completion request it
+ * produces can be marked explicit, then hand off to the built-in command that
+ * actually opens the widget.
+ */
+function registerTriggerSuggestCommand() {
+    return commands.registerCommand("doenet.triggerSuggest", async () => {
+        const document = vscode.window.activeTextEditor?.document;
+        if (document?.languageId === "doenet") {
+            pendingExplicitCompletion = {
+                uri: String(document.uri),
+                version: document.version,
+            };
+        }
+        await commands.executeCommand("editor.action.triggerSuggest");
+    });
+}
+
+/**
+ * True when this completion request is the one `doenet.triggerSuggest` just
+ * asked for. Consumes the pending flag, so a request VS Code raises on its own
+ * is never mistaken for one the user asked for.
+ */
+function isExplicitCompletion(
+    document: vscode.TextDocument,
+    context: vscode.CompletionContext,
+): boolean {
+    // A list marked `isIncomplete` makes VS Code re-ask as the user keeps
+    // typing. Those follow-ups belong to the session Ctrl+Space opened, so
+    // they inherit its explicitness — otherwise the element menu would empty
+    // out on the first keystroke after it appeared.
+    if (
+        context.triggerKind ===
+        vscode.CompletionTriggerKind.TriggerForIncompleteCompletions
+    ) {
+        return inExplicitCompletionSession;
+    }
+    // Any other request begins a new session. Matching the document version
+    // as well as the URI expires a flag whose keystroke never produced a
+    // request: by the time quick suggestions fire again the user has typed,
+    // and the version has moved on.
+    const pending = pendingExplicitCompletion;
+    pendingExplicitCompletion = undefined;
+    inExplicitCompletionSession =
+        pending !== undefined &&
+        pending.uri === String(document.uri) &&
+        pending.version === document.version;
+    return inExplicitCompletionSession;
+}
+
+/**
+ * Completion middleware that adds `explicit: true` to the request context for
+ * a Ctrl+Space invocation.
+ *
+ * The request has to be issued by hand rather than through `next`:
+ * `asCompletionParams` rebuilds the context from `triggerKind` and
+ * `triggerCharacter` alone, so an extra field set on the way in is dropped
+ * before the request goes out.
+ */
+async function provideCompletionItemWithExplicitFlag(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    context: vscode.CompletionContext,
+    token: vscode.CancellationToken,
+    next: (
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        context: vscode.CompletionContext,
+        token: vscode.CancellationToken,
+    ) => vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList>,
+) {
+    if (!isExplicitCompletion(document, context)) {
+        return next(document, position, context, token);
+    }
+    const params = client.code2ProtocolConverter.asCompletionParams(
+        document,
+        position,
+        context,
+    );
+    const explicitParams: ExplicitCompletionParams = {
+        ...params,
+        context: { ...params.context, explicit: true },
+    };
+    const result = await client.sendRequest(
+        CompletionRequest.type,
+        explicitParams,
+        token,
+    );
+    if (token.isCancellationRequested) {
+        return null;
+    }
+    return client.protocol2CodeConverter.asCompletionResult(
+        result,
+        undefined,
+        token,
+    );
 }
 
 function registerFormatCommand(commandName: string, requestName: string) {
@@ -206,7 +336,9 @@ function setupPreviewWindow(context: ExtensionContext) {
     });
 
     vscode.window.onDidChangeActiveTextEditor((e) => {
-        if (e.document.languageId !== "doenet") {
+        // No editor is active whenever the last one closes, or focus lands
+        // somewhere that isn't a text editor at all.
+        if (e?.document.languageId !== "doenet") {
             return;
         }
         DoenetPreviewPanel.setSource(e.document.getText());

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -43,10 +43,9 @@ export async function deactivate(): Promise<void> {
  * Setup the language server.
  */
 async function setupLanguageServer(context: ExtensionContext) {
-    // Ctrl+Space is bound to `doenet.triggerSuggest` in every Doenet document,
-    // so the command has to exist even when the server below fails to start:
-    // an unregistered command turns the keystroke into an "unknown command"
-    // error instead of the suggestion widget.
+    // Registered before anything below that can throw: Ctrl+Space is bound to
+    // `doenet.triggerSuggest` in every Doenet document, and an unregistered
+    // command turns the keystroke into an "unknown command" error.
     context.subscriptions.push(registerTriggerSuggestCommand());
 
     // Read the bundled doenetml-worker file and create a blob URL from it.
@@ -71,11 +70,9 @@ async function setupLanguageServer(context: ExtensionContext) {
 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
-        // Every Doenet document, whatever filesystem it came from. Naming
-        // schemes here would limit the server to `file:` and `untitled:`,
-        // which leaves it silent in exactly the places a web extension is
-        // meant to work: vscode.dev and github.dev serve their files as
-        // `vscode-vfs:`, and a virtual workspace can use any scheme at all.
+        // Doenet documents on every filesystem: vscode.dev and github.dev
+        // serve their files as `vscode-vfs:`, and a virtual workspace can use
+        // any scheme at all.
         documentSelector: [{ language: "doenet" }],
         initializationOptions: doenetWorkerBlobUrl
             ? { doenetWorkerUrl: doenetWorkerBlobUrl }
@@ -130,25 +127,18 @@ async function setupLanguageServer(context: ExtensionContext) {
     }
 }
 
-// The language server opens its element menu on an explicit completion
-// invocation even where no `<` has been typed — the same Ctrl+Space that
-// offers `<point>`, `<graph>`, … in the web editor. LSP has no field for "the
-// user asked for this": VS Code reports `Invoked` both for Ctrl+Space and for
-// the quick suggestions that fire on a typed letter, so a server keying off
-// `triggerKind` alone would dump the element menu into the middle of a
-// sentence. `doenet.triggerSuggest` records the keystroke and
-// `provideCompletionItemWithExplicitFlag` marks the request it produces,
-// which is what the web editor's CodeMirror client sends as
-// `context.explicit`.
+// `context.explicit` — a Doenet extension to the LSP completion context, sent
+// by the web editor's CodeMirror client — asks the language server for its
+// element menu even where no `<` has been typed, the same list Ctrl+Space
+// offers there. `triggerKind` can't stand in for it: VS Code reports `Invoked`
+// both for Ctrl+Space and for the quick suggestions that fire on a typed
+// letter. So `doenet.triggerSuggest` records the keystroke and
+// `provideCompletionItemWithExplicitFlag` marks the request it produces.
 let pendingExplicitCompletion: { uri: string; version: number } | undefined;
 /** Document whose in-flight completion session was opened by Ctrl+Space. */
 let explicitCompletionSessionUri: string | undefined;
 
-/**
- * Completion params carrying the `explicit` flag `@doenet/lsp` reads. It is an
- * extension to the protocol's own `CompletionContext`, so it has to be spelled
- * out here for the request to type-check.
- */
+/** Completion params carrying the `explicit` flag `@doenet/lsp` reads. */
 type ExplicitCompletionParams = CompletionParams & {
     context: CompletionContext & { explicit: true };
 };
@@ -162,8 +152,8 @@ function registerTriggerSuggestCommand() {
     return commands.registerCommand("doenet.triggerSuggest", async () => {
         const document = vscode.window.activeTextEditor?.document;
         // Assigned either way: this keystroke supersedes whatever an earlier
-        // one left pending, so landing somewhere without a Doenet document
-        // clears the flag rather than leaving the older one to be claimed.
+        // one left pending, so landing outside a Doenet document clears the
+        // flag.
         pendingExplicitCompletion =
             document?.languageId === "doenet"
                 ? { uri: String(document.uri), version: document.version }
@@ -173,9 +163,8 @@ function registerTriggerSuggestCommand() {
 }
 
 /**
- * True when this completion request belongs to a session `doenet.triggerSuggest`
- * opened. A request that starts a session consumes the pending flag, so one VS
- * Code raises on its own is never mistaken for one the user asked for.
+ * True when this completion request belongs to a session
+ * `doenet.triggerSuggest` opened.
  */
 function isExplicitCompletion(
     document: vscode.TextDocument,
@@ -183,20 +172,21 @@ function isExplicitCompletion(
 ): boolean {
     const uri = String(document.uri);
     // A list marked `isIncomplete` makes VS Code re-ask as the user keeps
-    // typing. Those follow-ups belong to the session Ctrl+Space opened, so
-    // they inherit its explicitness — otherwise the element menu would empty
-    // out on the first keystroke after it appeared. Only within that session's
-    // own document: a refresh anywhere else belongs to a different session.
+    // typing. Those follow-ups inherit the session's explicitness, so the
+    // element menu keeps narrowing instead of emptying out on the first
+    // keystroke — within the session's own document, since a refresh
+    // elsewhere belongs to a different session.
     if (
         context.triggerKind ===
         vscode.CompletionTriggerKind.TriggerForIncompleteCompletions
     ) {
         return explicitCompletionSessionUri === uri;
     }
-    // Any other request begins a new session. Matching the document version
-    // as well as the URI expires a flag whose keystroke never produced a
-    // request: by the time quick suggestions fire again the user has typed,
-    // and the version has moved on.
+    // Any other request begins a new session, and consumes the pending flag so
+    // that a request VS Code raises on its own can't claim it later. Matching
+    // the document version as well as the URI expires a flag whose keystroke
+    // never produced a request: by the time quick suggestions fire again the
+    // user has typed, and the version has moved on.
     const pending = pendingExplicitCompletion;
     pendingExplicitCompletion = undefined;
     explicitCompletionSessionUri =
@@ -210,12 +200,11 @@ function isExplicitCompletion(
  * Completion middleware that adds `explicit: true` to the request context for
  * a Ctrl+Space invocation.
  *
- * The request has to be issued by hand rather than through `next`:
+ * The request goes out by hand rather than through `next`: the client's
  * `asCompletionParams` rebuilds the context from `triggerKind` and
- * `triggerCharacter` alone, so an extra field set on the way in is dropped
- * before the request goes out. What `next` would otherwise have done around
- * the request — honoring cancellation, routing a rejection through the
- * client's own error handling — is reproduced below.
+ * `triggerCharacter` alone, dropping any other field set on the way in. The
+ * cancellation and error handling `next` would have wrapped it in is
+ * reproduced below.
  */
 async function provideCompletionItemWithExplicitFlag(
     document: vscode.TextDocument,

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -15,6 +15,7 @@ import {
     CompletionRequest,
     LanguageClient,
     LanguageClientOptions,
+    ProvideCompletionItemsSignature,
     TextEdit,
 } from "vscode-languageclient/browser";
 import { DoenetPreviewPanel } from "./preview-panel/doenet-preview-panel";
@@ -42,6 +43,12 @@ export async function deactivate(): Promise<void> {
  * Setup the language server.
  */
 async function setupLanguageServer(context: ExtensionContext) {
+    // Ctrl+Space is bound to `doenet.triggerSuggest` in every Doenet document,
+    // so the command has to exist even when the server below fails to start:
+    // an unregistered command turns the keystroke into an "unknown command"
+    // error instead of the suggestion widget.
+    context.subscriptions.push(registerTriggerSuggestCommand());
+
     // Read the bundled doenetml-worker file and create a blob URL from it.
     // The language server (running as a web worker) needs to spawn its own
     // rust-backed core sub-worker for path resolution — that's how it
@@ -99,8 +106,6 @@ async function setupLanguageServer(context: ExtensionContext) {
         // Start the client. This will also launch the server.
         await client.start();
 
-        const triggerSuggest = registerTriggerSuggestCommand();
-
         const formatAsDoenet = registerFormatCommand(
             "doenet.formatAsDoenetML",
             "doenet.formatAsDoenetML",
@@ -115,7 +120,6 @@ async function setupLanguageServer(context: ExtensionContext) {
         );
 
         context.subscriptions.push(
-            triggerSuggest,
             formatAsDoenet,
             formatAsXML,
             formatAsMarkdown,
@@ -212,12 +216,7 @@ async function provideCompletionItemWithExplicitFlag(
     position: vscode.Position,
     context: vscode.CompletionContext,
     token: vscode.CancellationToken,
-    next: (
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: vscode.CompletionContext,
-        token: vscode.CancellationToken,
-    ) => vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList>,
+    next: ProvideCompletionItemsSignature,
 ) {
     if (!isExplicitCompletion(document, context)) {
         return next(document, position, context, token);

--- a/packages/vscode-extension/test/language-server.test.ts
+++ b/packages/vscode-extension/test/language-server.test.ts
@@ -470,6 +470,25 @@ describe("explicit completion invocation", () => {
         expect(next).toHaveBeenCalledTimes(2);
     });
 
+    it("keeps Ctrl+Space bound when the language server fails to start", async () => {
+        hoisted.readFile.mockResolvedValue(
+            makeSubarrayBytes('console.log("worker");'),
+        );
+        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+        hoisted.start.mockRejectedValue(new Error("start failed"));
+
+        const { activate } = await import("../src/extension/index");
+        await expect(activate(createContext() as any)).rejects.toThrow(
+            "start failed",
+        );
+
+        // Without the command the keybinding resolves to nothing and
+        // Ctrl+Space reports an unknown command.
+        expect(
+            hoisted.registerCommand.mock.calls.map((call) => call[0]),
+        ).toContain("doenet.triggerSuggest");
+    });
+
     it("expires a flag whose keystroke never produced a request", async () => {
         const { provideCompletionItem, triggerSuggest } =
             await activateForCompletion();

--- a/packages/vscode-extension/test/language-server.test.ts
+++ b/packages/vscode-extension/test/language-server.test.ts
@@ -4,6 +4,15 @@ const hoisted = vi.hoisted(() => ({
     readFile: vi.fn(),
     joinPath: vi.fn(),
     registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+    executeCommand: vi.fn(async () => {}),
+    asCompletionParams: vi.fn(
+        (_document: unknown, _position: unknown, context: unknown) => ({
+            textDocument: { uri: "file:///test.doenet" },
+            position: { line: 0, character: 0 },
+            context,
+        }),
+    ),
+    asCompletionResult: vi.fn(async (result: unknown) => result),
     onDidChangeTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
     onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
     onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
@@ -27,6 +36,12 @@ vi.mock("vscode", () => ({
     },
     commands: {
         registerCommand: hoisted.registerCommand,
+        executeCommand: hoisted.executeCommand,
+    },
+    CompletionTriggerKind: {
+        Invoke: 0,
+        TriggerCharacter: 1,
+        TriggerForIncompleteCompletions: 2,
     },
     Uri: {
         joinPath: hoisted.joinPath,
@@ -66,9 +81,18 @@ vi.mock("vscode-languageclient/browser", () => {
         start = hoisted.start;
         stop = hoisted.stop;
         sendRequest = hoisted.sendRequest;
+        code2ProtocolConverter = {
+            asCompletionParams: hoisted.asCompletionParams,
+        };
+        protocol2CodeConverter = {
+            asCompletionResult: hoisted.asCompletionResult,
+        };
     }
 
-    return { LanguageClient: MockLanguageClient };
+    return {
+        LanguageClient: MockLanguageClient,
+        CompletionRequest: { type: "textDocument/completion" },
+    };
 });
 
 class FakeWorker {
@@ -112,43 +136,46 @@ function stubUrlStatics(
     vi.stubGlobal("URL", UrlWithBlobStatics);
 }
 
+beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    FakeWorker.instances = [];
+    hoisted.readFile.mockReset();
+    hoisted.joinPath.mockReset();
+    hoisted.registerCommand.mockClear();
+    hoisted.executeCommand.mockClear();
+    hoisted.asCompletionParams.mockClear();
+    hoisted.asCompletionResult.mockClear();
+    hoisted.onDidChangeTextDocument.mockClear();
+    hoisted.onDidSaveTextDocument.mockClear();
+    hoisted.onDidChangeActiveTextEditor.mockClear();
+    hoisted.onDidChangeTextEditorSelection.mockClear();
+    hoisted.start.mockReset();
+    hoisted.stop.mockClear();
+    hoisted.sendRequest.mockClear();
+    hoisted.languageClientCalls.length = 0;
+    hoisted.joinPath.mockImplementation(
+        (...parts: Array<{ path?: string } | string>) =>
+            makeUri(
+                parts
+                    .map((part) =>
+                        typeof part === "string"
+                            ? part
+                            : (part.path ?? String(part)),
+                    )
+                    .join("/"),
+            ),
+    );
+    vi.stubGlobal("Worker", FakeWorker);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
 describe("Doenet vscode extension", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.unstubAllGlobals();
-        vi.resetModules();
-        FakeWorker.instances = [];
-        hoisted.readFile.mockReset();
-        hoisted.joinPath.mockReset();
-        hoisted.registerCommand.mockClear();
-        hoisted.onDidChangeTextDocument.mockClear();
-        hoisted.onDidSaveTextDocument.mockClear();
-        hoisted.onDidChangeActiveTextEditor.mockClear();
-        hoisted.onDidChangeTextEditorSelection.mockClear();
-        hoisted.start.mockReset();
-        hoisted.stop.mockClear();
-        hoisted.sendRequest.mockClear();
-        hoisted.languageClientCalls.length = 0;
-        hoisted.joinPath.mockImplementation(
-            (...parts: Array<{ path?: string } | string>) =>
-                makeUri(
-                    parts
-                        .map((part) =>
-                            typeof part === "string"
-                                ? part
-                                : (part.path ?? String(part)),
-                        )
-                        .join("/"),
-                ),
-        );
-        vi.stubGlobal("Worker", FakeWorker);
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
-        vi.unstubAllGlobals();
-    });
-
     it("passes the bundled worker to the language server and revokes the blob URL on deactivate", async () => {
         const expectedSource = 'console.log("worker");';
         hoisted.readFile.mockResolvedValue(makeSubarrayBytes(expectedSource));
@@ -255,5 +282,211 @@ describe("Doenet vscode extension", () => {
 
         await deactivate();
         expect(revokeObjectURL).not.toHaveBeenCalled();
+    });
+
+    it("registers the language server for Doenet documents on every filesystem", async () => {
+        hoisted.readFile.mockResolvedValue(
+            makeSubarrayBytes('console.log("worker");'),
+        );
+        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+
+        const { activate } = await import("../src/extension/index");
+        await activate(createContext() as any);
+
+        const options = hoisted.languageClientCalls[0]?.options as {
+            documentSelector: unknown;
+        };
+        // A `scheme` here would leave the server silent on vscode.dev and
+        // github.dev, whose files arrive as `vscode-vfs:`.
+        expect(options.documentSelector).toEqual([{ language: "doenet" }]);
+    });
+
+    it("survives the active editor going away", async () => {
+        hoisted.readFile.mockResolvedValue(
+            makeSubarrayBytes('console.log("worker");'),
+        );
+        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+
+        const { activate } = await import("../src/extension/index");
+        await activate(createContext() as any);
+
+        const onActiveEditorChanged = hoisted.onDidChangeActiveTextEditor.mock
+            .calls[0][0] as (editor: unknown) => void;
+        expect(() => onActiveEditorChanged(undefined)).not.toThrow();
+    });
+});
+
+describe("explicit completion invocation", () => {
+    const DOC = {
+        uri: { toString: () => "file:///test.doenet" },
+        languageId: "doenet",
+        version: 3,
+    };
+    const AUTO = { triggerKind: 0 };
+    const TYPED_CHARACTER = { triggerKind: 1, triggerCharacter: "<" };
+    const INCOMPLETE_REFRESH = { triggerKind: 2 };
+
+    /**
+     * Activate the extension and return the pieces the completion path is
+     * built from: the middleware the language client was configured with, and
+     * the command Ctrl+Space is bound to.
+     */
+    async function activateForCompletion() {
+        hoisted.readFile.mockResolvedValue(
+            makeSubarrayBytes('console.log("worker");'),
+        );
+        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+
+        const vscode = (await import("vscode")) as any;
+        vscode.window.activeTextEditor = { document: DOC };
+
+        const { activate } = await import("../src/extension/index");
+        await activate(createContext() as any);
+
+        const options = hoisted.languageClientCalls[0]?.options as {
+            middleware: { provideCompletionItem: Function };
+        };
+        const triggerSuggest = hoisted.registerCommand.mock.calls.find(
+            (call) => call[0] === "doenet.triggerSuggest",
+        )?.[1] as () => Promise<void>;
+
+        return {
+            provideCompletionItem: options.middleware.provideCompletionItem,
+            triggerSuggest,
+        };
+    }
+
+    /** The `context` of the completion request the middleware sent. */
+    function sentContext() {
+        return (hoisted.sendRequest.mock.calls[0]?.[1] as { context: unknown })
+            ?.context;
+    }
+
+    it("marks the request Ctrl+Space produced as explicit", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+        hoisted.sendRequest.mockResolvedValue([{ label: "point" }]);
+
+        await triggerSuggest();
+        // The command hands the actual widget over to VS Code's own.
+        expect(hoisted.executeCommand).toHaveBeenCalledWith(
+            "editor.action.triggerSuggest",
+        );
+
+        const result = await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            { isCancellationRequested: false },
+            next,
+        );
+
+        expect(next).not.toHaveBeenCalled();
+        expect(sentContext()).toMatchObject({ explicit: true });
+        expect(result).toEqual([{ label: "point" }]);
+    });
+
+    it("leaves a request the user did not ask for to the default handler", async () => {
+        const { provideCompletionItem } = await activateForCompletion();
+        const next = vi.fn(async () => [{ label: "graph" }]);
+
+        const result = await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            { isCancellationRequested: false },
+            next,
+        );
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(hoisted.sendRequest).not.toHaveBeenCalled();
+        expect(result).toEqual([{ label: "graph" }]);
+    });
+
+    it("keeps the refreshes of an explicit list explicit", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+        hoisted.sendRequest.mockResolvedValue([]);
+
+        await triggerSuggest();
+        await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            { isCancellationRequested: false },
+            next,
+        );
+        // An `isIncomplete` list makes VS Code re-ask as the user types. The
+        // element menu would empty out on the first keystroke if these
+        // follow-ups lost the flag.
+        await provideCompletionItem(
+            DOC,
+            { line: 0, character: 1 },
+            INCOMPLETE_REFRESH,
+            { isCancellationRequested: false },
+            next,
+        );
+
+        expect(next).not.toHaveBeenCalled();
+        expect(hoisted.sendRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not carry explicitness into the next completion session", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+        hoisted.sendRequest.mockResolvedValue([]);
+
+        await triggerSuggest();
+        await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            { isCancellationRequested: false },
+            next,
+        );
+        hoisted.sendRequest.mockClear();
+
+        // Typing `<` starts a session of its own, and so does the quick
+        // suggestion that follows it.
+        await provideCompletionItem(
+            DOC,
+            { line: 0, character: 1 },
+            TYPED_CHARACTER,
+            { isCancellationRequested: false },
+            next,
+        );
+        await provideCompletionItem(
+            DOC,
+            { line: 0, character: 2 },
+            INCOMPLETE_REFRESH,
+            { isCancellationRequested: false },
+            next,
+        );
+
+        expect(hoisted.sendRequest).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(2);
+    });
+
+    it("expires a flag whose keystroke never produced a request", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+
+        await triggerSuggest();
+        // The user typed instead, so the request that eventually arrives is a
+        // quick suggestion against a document that has moved on.
+        await provideCompletionItem(
+            { ...DOC, version: DOC.version + 1 },
+            { line: 0, character: 0 },
+            AUTO,
+            { isCancellationRequested: false },
+            next,
+        );
+
+        expect(hoisted.sendRequest).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/vscode-extension/test/language-server.test.ts
+++ b/packages/vscode-extension/test/language-server.test.ts
@@ -138,25 +138,27 @@ function stubUrlStatics(
     vi.stubGlobal("URL", UrlWithBlobStatics);
 }
 
+/**
+ * The bundled worker reads back cleanly and its blob URL is
+ * `blob:doenet-worker`, for tests that are not about either.
+ */
+function stubBundledWorker() {
+    hoisted.readFile.mockResolvedValue(
+        makeSubarrayBytes('console.log("worker");'),
+    );
+    stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+}
+
 beforeEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.resetModules();
+    // The extension keeps module-level state (the blob URL, the pending
+    // Ctrl+Space flag), so every test imports it afresh against clean mocks.
+    // Resetting returns each `hoisted` mock to the implementation it was
+    // created with.
+    vi.resetAllMocks();
     FakeWorker.instances = [];
-    hoisted.readFile.mockReset();
-    hoisted.joinPath.mockReset();
-    hoisted.registerCommand.mockClear();
-    hoisted.executeCommand.mockClear();
-    hoisted.asCompletionParams.mockClear();
-    hoisted.asCompletionResult.mockClear();
-    hoisted.handleFailedRequest.mockClear();
-    hoisted.onDidChangeTextDocument.mockClear();
-    hoisted.onDidSaveTextDocument.mockClear();
-    hoisted.onDidChangeActiveTextEditor.mockClear();
-    hoisted.onDidChangeTextEditorSelection.mockClear();
-    hoisted.start.mockReset();
-    hoisted.stop.mockClear();
-    hoisted.sendRequest.mockClear();
     hoisted.languageClientCalls.length = 0;
     hoisted.joinPath.mockImplementation(
         (...parts: Array<{ path?: string } | string>) =>
@@ -218,10 +220,7 @@ describe("Doenet vscode extension", () => {
     });
 
     it("waits for the language client to finish starting before activate resolves", async () => {
-        hoisted.readFile.mockResolvedValue(
-            makeSubarrayBytes('console.log("worker");'),
-        );
-        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+        stubBundledWorker();
 
         let resolveStart: (() => void) | undefined;
         hoisted.start.mockImplementation(
@@ -288,10 +287,7 @@ describe("Doenet vscode extension", () => {
     });
 
     it("registers the language server for Doenet documents on every filesystem", async () => {
-        hoisted.readFile.mockResolvedValue(
-            makeSubarrayBytes('console.log("worker");'),
-        );
-        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+        stubBundledWorker();
 
         const { activate } = await import("../src/extension/index");
         await activate(createContext() as any);
@@ -305,10 +301,7 @@ describe("Doenet vscode extension", () => {
     });
 
     it("survives the active editor going away", async () => {
-        hoisted.readFile.mockResolvedValue(
-            makeSubarrayBytes('console.log("worker");'),
-        );
-        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+        stubBundledWorker();
 
         const { activate } = await import("../src/extension/index");
         await activate(createContext() as any);
@@ -326,25 +319,23 @@ describe("explicit completion invocation", () => {
         version: 3,
     };
     const OTHER_DOC = {
+        ...DOC,
         uri: { toString: () => "file:///other.doenet" },
-        languageId: "doenet",
-        version: 3,
     };
+    const POSITION = { line: 0, character: 0 };
     const AUTO = { triggerKind: 0 };
     const TYPED_CHARACTER = { triggerKind: 1, triggerCharacter: "<" };
     const INCOMPLETE_REFRESH = { triggerKind: 2 };
     const LIVE = { isCancellationRequested: false };
 
     /**
-     * Activate the extension and return the pieces the completion path is
-     * built from: the middleware the language client was configured with, and
-     * the command Ctrl+Space is bound to.
+     * Activate the extension and return the completion path's moving parts:
+     * `complete()` runs the middleware the language client was configured
+     * with, `next` is the default handler that middleware falls back to, and
+     * `triggerSuggest` is the command Ctrl+Space is bound to.
      */
     async function activateForCompletion() {
-        hoisted.readFile.mockResolvedValue(
-            makeSubarrayBytes('console.log("worker");'),
-        );
-        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+        stubBundledWorker();
 
         const vscode = (await import("vscode")) as any;
         vscode.window.activeTextEditor = { document: DOC };
@@ -352,18 +343,31 @@ describe("explicit completion invocation", () => {
         const { activate } = await import("../src/extension/index");
         await activate(createContext() as any);
 
-        const options = hoisted.languageClientCalls[0]?.options as {
+        const { middleware } = hoisted.languageClientCalls[0]?.options as {
             middleware: { provideCompletionItem: Function };
         };
         const triggerSuggest = hoisted.registerCommand.mock.calls.find(
             (call) => call[0] === "doenet.triggerSuggest",
         )?.[1] as () => Promise<void>;
+        const next = vi.fn();
 
-        return {
-            provideCompletionItem: options.middleware.provideCompletionItem,
-            triggerSuggest,
-            vscode,
-        };
+        function complete(
+            context: unknown,
+            {
+                document = DOC,
+                token = LIVE,
+            }: { document?: unknown; token?: unknown } = {},
+        ) {
+            return middleware.provideCompletionItem(
+                document,
+                POSITION,
+                context,
+                token,
+                next,
+            );
+        }
+
+        return { complete, next, triggerSuggest, vscode };
     }
 
     /** The `context` of the completion request the middleware sent. */
@@ -373,24 +377,17 @@ describe("explicit completion invocation", () => {
     }
 
     it("marks the request Ctrl+Space produced as explicit", async () => {
-        const { provideCompletionItem, triggerSuggest } =
+        const { complete, next, triggerSuggest } =
             await activateForCompletion();
-        const next = vi.fn();
         hoisted.sendRequest.mockResolvedValue([{ label: "point" }]);
 
         await triggerSuggest();
-        // The command hands the actual widget over to VS Code's own.
+        // The command hands the widget itself over to VS Code's own.
         expect(hoisted.executeCommand).toHaveBeenCalledWith(
             "editor.action.triggerSuggest",
         );
 
-        const result = await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        const result = await complete(AUTO);
 
         expect(next).not.toHaveBeenCalled();
         expect(sentContext()).toMatchObject({ explicit: true });
@@ -398,16 +395,10 @@ describe("explicit completion invocation", () => {
     });
 
     it("leaves a request the user did not ask for to the default handler", async () => {
-        const { provideCompletionItem } = await activateForCompletion();
-        const next = vi.fn(async () => [{ label: "graph" }]);
+        const { complete, next } = await activateForCompletion();
+        next.mockResolvedValue([{ label: "graph" }]);
 
-        const result = await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        const result = await complete(AUTO);
 
         expect(next).toHaveBeenCalledTimes(1);
         expect(hoisted.sendRequest).not.toHaveBeenCalled();
@@ -415,76 +406,41 @@ describe("explicit completion invocation", () => {
     });
 
     it("keeps the refreshes of an explicit list explicit", async () => {
-        const { provideCompletionItem, triggerSuggest } =
+        const { complete, next, triggerSuggest } =
             await activateForCompletion();
-        const next = vi.fn();
         hoisted.sendRequest.mockResolvedValue([]);
 
         await triggerSuggest();
-        await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        await complete(AUTO);
         // An `isIncomplete` list makes VS Code re-ask as the user types. The
         // element menu would empty out on the first keystroke if these
         // follow-ups lost the flag.
-        await provideCompletionItem(
-            DOC,
-            { line: 0, character: 1 },
-            INCOMPLETE_REFRESH,
-            LIVE,
-            next,
-        );
+        await complete(INCOMPLETE_REFRESH);
 
         expect(next).not.toHaveBeenCalled();
         expect(hoisted.sendRequest).toHaveBeenCalledTimes(2);
     });
 
     it("does not carry explicitness into the next completion session", async () => {
-        const { provideCompletionItem, triggerSuggest } =
+        const { complete, next, triggerSuggest } =
             await activateForCompletion();
-        const next = vi.fn();
         hoisted.sendRequest.mockResolvedValue([]);
 
         await triggerSuggest();
-        await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        await complete(AUTO);
         hoisted.sendRequest.mockClear();
 
         // Typing `<` starts a session of its own, and so does the quick
         // suggestion that follows it.
-        await provideCompletionItem(
-            DOC,
-            { line: 0, character: 1 },
-            TYPED_CHARACTER,
-            LIVE,
-            next,
-        );
-        await provideCompletionItem(
-            DOC,
-            { line: 0, character: 2 },
-            INCOMPLETE_REFRESH,
-            LIVE,
-            next,
-        );
+        await complete(TYPED_CHARACTER);
+        await complete(INCOMPLETE_REFRESH);
 
         expect(hoisted.sendRequest).not.toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(2);
     });
 
     it("keeps Ctrl+Space bound when the language server fails to start", async () => {
-        hoisted.readFile.mockResolvedValue(
-            makeSubarrayBytes('console.log("worker");'),
-        );
-        stubUrlStatics(() => "blob:doenet-worker", vi.fn());
+        stubBundledWorker();
         hoisted.start.mockRejectedValue(new Error("start failed"));
 
         const { activate } = await import("../src/extension/index");
@@ -500,77 +456,51 @@ describe("explicit completion invocation", () => {
     });
 
     it("expires a flag whose keystroke never produced a request", async () => {
-        const { provideCompletionItem, triggerSuggest } =
+        const { complete, next, triggerSuggest } =
             await activateForCompletion();
-        const next = vi.fn();
 
         await triggerSuggest();
         // The user typed instead, so the request that eventually arrives is a
         // quick suggestion against a document that has moved on.
-        await provideCompletionItem(
-            { ...DOC, version: DOC.version + 1 },
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        await complete(AUTO, {
+            document: { ...DOC, version: DOC.version + 1 },
+        });
 
         expect(hoisted.sendRequest).not.toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
     });
 
     it("does not mark a request in another document explicit", async () => {
-        const { provideCompletionItem, triggerSuggest } =
+        const { complete, next, triggerSuggest } =
             await activateForCompletion();
-        const next = vi.fn();
 
         await triggerSuggest();
         // Same version, different file: a suggestion raised in a second editor
         // is not the one Ctrl+Space asked for.
-        await provideCompletionItem(
-            OTHER_DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        await complete(AUTO, { document: OTHER_DOC });
 
         expect(hoisted.sendRequest).not.toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
     });
 
     it("does not extend an explicit session into another document", async () => {
-        const { provideCompletionItem, triggerSuggest } =
+        const { complete, next, triggerSuggest } =
             await activateForCompletion();
-        const next = vi.fn();
         hoisted.sendRequest.mockResolvedValue([]);
 
         await triggerSuggest();
-        await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        await complete(AUTO);
         // An `isIncomplete` refresh raised in a second editor belongs to that
         // editor's own session, whatever this document's session is doing.
-        await provideCompletionItem(
-            OTHER_DOC,
-            { line: 0, character: 1 },
-            INCOMPLETE_REFRESH,
-            LIVE,
-            next,
-        );
+        await complete(INCOMPLETE_REFRESH, { document: OTHER_DOC });
 
         expect(hoisted.sendRequest).toHaveBeenCalledTimes(1);
         expect(next).toHaveBeenCalledTimes(1);
     });
 
     it("drops a pending flag when the next keystroke lands outside a Doenet document", async () => {
-        const { provideCompletionItem, triggerSuggest, vscode } =
+        const { complete, next, triggerSuggest, vscode } =
             await activateForCompletion();
-        const next = vi.fn();
 
         await triggerSuggest();
         vscode.window.activeTextEditor = {
@@ -580,22 +510,14 @@ describe("explicit completion invocation", () => {
         await triggerSuggest();
         expect(hoisted.executeCommand).toHaveBeenCalledTimes(2);
 
-        await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        await complete(AUTO);
 
         expect(hoisted.sendRequest).not.toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
     });
 
     it("hands a rejected request to the client's own error handling", async () => {
-        const { provideCompletionItem, triggerSuggest } =
-            await activateForCompletion();
-        const next = vi.fn();
+        const { complete, triggerSuggest } = await activateForCompletion();
         const failure = new Error("content modified");
         hoisted.sendRequest.mockRejectedValue(failure);
 
@@ -603,13 +525,7 @@ describe("explicit completion invocation", () => {
         // Going around `next` means going around the rejection handling it
         // carries: a request cancelled by the next keystroke must not surface
         // as an unhandled error.
-        const result = await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            LIVE,
-            next,
-        );
+        const result = await complete(AUTO);
 
         expect(hoisted.handleFailedRequest).toHaveBeenCalledWith(
             "textDocument/completion",
@@ -621,9 +537,7 @@ describe("explicit completion invocation", () => {
     });
 
     it("answers a cancelled request with nothing", async () => {
-        const { provideCompletionItem, triggerSuggest } =
-            await activateForCompletion();
-        const next = vi.fn();
+        const { complete, triggerSuggest } = await activateForCompletion();
         const token = { isCancellationRequested: false };
         hoisted.sendRequest.mockImplementation(async () => {
             token.isCancellationRequested = true;
@@ -631,13 +545,7 @@ describe("explicit completion invocation", () => {
         });
 
         await triggerSuggest();
-        const result = await provideCompletionItem(
-            DOC,
-            { line: 0, character: 0 },
-            AUTO,
-            token,
-            next,
-        );
+        const result = await complete(AUTO, { token });
 
         expect(result).toBeNull();
         expect(hoisted.asCompletionResult).not.toHaveBeenCalled();

--- a/packages/vscode-extension/test/language-server.test.ts
+++ b/packages/vscode-extension/test/language-server.test.ts
@@ -13,6 +13,7 @@ const hoisted = vi.hoisted(() => ({
         }),
     ),
     asCompletionResult: vi.fn(async (result: unknown) => result),
+    handleFailedRequest: vi.fn(() => null),
     onDidChangeTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
     onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
     onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
@@ -87,6 +88,7 @@ vi.mock("vscode-languageclient/browser", () => {
         protocol2CodeConverter = {
             asCompletionResult: hoisted.asCompletionResult,
         };
+        handleFailedRequest = hoisted.handleFailedRequest;
     }
 
     return {
@@ -147,6 +149,7 @@ beforeEach(() => {
     hoisted.executeCommand.mockClear();
     hoisted.asCompletionParams.mockClear();
     hoisted.asCompletionResult.mockClear();
+    hoisted.handleFailedRequest.mockClear();
     hoisted.onDidChangeTextDocument.mockClear();
     hoisted.onDidSaveTextDocument.mockClear();
     hoisted.onDidChangeActiveTextEditor.mockClear();
@@ -322,9 +325,15 @@ describe("explicit completion invocation", () => {
         languageId: "doenet",
         version: 3,
     };
+    const OTHER_DOC = {
+        uri: { toString: () => "file:///other.doenet" },
+        languageId: "doenet",
+        version: 3,
+    };
     const AUTO = { triggerKind: 0 };
     const TYPED_CHARACTER = { triggerKind: 1, triggerCharacter: "<" };
     const INCOMPLETE_REFRESH = { triggerKind: 2 };
+    const LIVE = { isCancellationRequested: false };
 
     /**
      * Activate the extension and return the pieces the completion path is
@@ -353,6 +362,7 @@ describe("explicit completion invocation", () => {
         return {
             provideCompletionItem: options.middleware.provideCompletionItem,
             triggerSuggest,
+            vscode,
         };
     }
 
@@ -378,7 +388,7 @@ describe("explicit completion invocation", () => {
             DOC,
             { line: 0, character: 0 },
             AUTO,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
 
@@ -395,7 +405,7 @@ describe("explicit completion invocation", () => {
             DOC,
             { line: 0, character: 0 },
             AUTO,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
 
@@ -415,7 +425,7 @@ describe("explicit completion invocation", () => {
             DOC,
             { line: 0, character: 0 },
             AUTO,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
         // An `isIncomplete` list makes VS Code re-ask as the user types. The
@@ -425,7 +435,7 @@ describe("explicit completion invocation", () => {
             DOC,
             { line: 0, character: 1 },
             INCOMPLETE_REFRESH,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
 
@@ -444,7 +454,7 @@ describe("explicit completion invocation", () => {
             DOC,
             { line: 0, character: 0 },
             AUTO,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
         hoisted.sendRequest.mockClear();
@@ -455,14 +465,14 @@ describe("explicit completion invocation", () => {
             DOC,
             { line: 0, character: 1 },
             TYPED_CHARACTER,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
         await provideCompletionItem(
             DOC,
             { line: 0, character: 2 },
             INCOMPLETE_REFRESH,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
 
@@ -501,11 +511,135 @@ describe("explicit completion invocation", () => {
             { ...DOC, version: DOC.version + 1 },
             { line: 0, character: 0 },
             AUTO,
-            { isCancellationRequested: false },
+            LIVE,
             next,
         );
 
         expect(hoisted.sendRequest).not.toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not mark a request in another document explicit", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+
+        await triggerSuggest();
+        // Same version, different file: a suggestion raised in a second editor
+        // is not the one Ctrl+Space asked for.
+        await provideCompletionItem(
+            OTHER_DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            LIVE,
+            next,
+        );
+
+        expect(hoisted.sendRequest).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not extend an explicit session into another document", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+        hoisted.sendRequest.mockResolvedValue([]);
+
+        await triggerSuggest();
+        await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            LIVE,
+            next,
+        );
+        // An `isIncomplete` refresh raised in a second editor belongs to that
+        // editor's own session, whatever this document's session is doing.
+        await provideCompletionItem(
+            OTHER_DOC,
+            { line: 0, character: 1 },
+            INCOMPLETE_REFRESH,
+            LIVE,
+            next,
+        );
+
+        expect(hoisted.sendRequest).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops a pending flag when the next keystroke lands outside a Doenet document", async () => {
+        const { provideCompletionItem, triggerSuggest, vscode } =
+            await activateForCompletion();
+        const next = vi.fn();
+
+        await triggerSuggest();
+        vscode.window.activeTextEditor = {
+            document: { ...DOC, languageId: "markdown" },
+        };
+        // The widget still opens; it is only the marking that is dropped.
+        await triggerSuggest();
+        expect(hoisted.executeCommand).toHaveBeenCalledTimes(2);
+
+        await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            LIVE,
+            next,
+        );
+
+        expect(hoisted.sendRequest).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it("hands a rejected request to the client's own error handling", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+        const failure = new Error("content modified");
+        hoisted.sendRequest.mockRejectedValue(failure);
+
+        await triggerSuggest();
+        // Going around `next` means going around the rejection handling it
+        // carries: a request cancelled by the next keystroke must not surface
+        // as an unhandled error.
+        const result = await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            LIVE,
+            next,
+        );
+
+        expect(hoisted.handleFailedRequest).toHaveBeenCalledWith(
+            "textDocument/completion",
+            LIVE,
+            failure,
+            null,
+        );
+        expect(result).toBeNull();
+    });
+
+    it("answers a cancelled request with nothing", async () => {
+        const { provideCompletionItem, triggerSuggest } =
+            await activateForCompletion();
+        const next = vi.fn();
+        const token = { isCancellationRequested: false };
+        hoisted.sendRequest.mockImplementation(async () => {
+            token.isCancellationRequested = true;
+            return [{ label: "point" }];
+        });
+
+        await triggerSuggest();
+        const result = await provideCompletionItem(
+            DOC,
+            { line: 0, character: 0 },
+            AUTO,
+            token,
+            next,
+        );
+
+        expect(result).toBeNull();
+        expect(hoisted.asCompletionResult).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## The problem

The VS Code extension has always had a language server behind it, and most of
what it offers did work — element names, close tags, `$ref` and `$ref.member`
chains, enumerated attribute values, child suggestions. Two gaps made it feel
like the schema wasn't there at all:

**Attribute suggestions never appeared.** Typing `<math exp` offered nothing,
while `<ma` offered `math`, `mathInput`, … The two reach the server by
different routes: `<` is a registered **trigger character**, so the server is
asked about it unconditionally, but an attribute name has no trigger character
and depends entirely on the editor deciding to auto-suggest. Where that is
routed inline instead of to the suggestion widget, element suggestions keep
working while attribute suggestions look like they have vanished — and the slot
they would have filled goes to whatever renders ghost text.

**Ctrl+Space produced nothing** anywhere the previous character wasn't `<`, so
VS Code fell back to word-based suggestions: words scraped out of the current
file, which read as invented tags and attributes.

## The fixes

**Attributes.** Doenet documents now ask for the suggestion widget by default
(`editor.quickSuggestions.other`), settled in the one place that knows the
schema is worth showing. An explicit user or workspace setting still wins, so
anyone who prefers inline suggestions in Doenet files keeps them.

**Ctrl+Space.** The server opens its element menu for an explicit invocation
even with no leading `<`, but it learns the invocation was explicit from
`context.explicit` — a field only the CodeMirror client sets. VS Code can't set
it: LSP has no such field, and `triggerKind` can't stand in, because VS Code
reports `Invoked` both for Ctrl+Space and for the quick suggestions that fire on
a typed letter. A server keying off `triggerKind` alone would drop the whole
element menu into the middle of a sentence.

So a `doenet.triggerSuggest` command bound to Ctrl+Space (and Ctrl+I / Cmd+I,
matching the built-in's own bindings) records the keystroke and hands off to
`editor.action.triggerSuggest`; completion middleware marks the request it
produces. The request is issued by hand rather than through `next` because the
client's `asCompletionParams` rebuilds the context from `triggerKind` and
`triggerCharacter` alone, dropping anything else set on the way in. The command
is hidden from the command palette (`"when": "false"`), where it would read as
a second, Doenet-flavored copy of a built-in the palette already lists.

Refreshes of an `isIncomplete` list inherit the flag, so the menu keeps
narrowing as you type (`Ctrl+Space` → `poin` → `point`, `pointList`,
`polyline`, …) instead of emptying on the first keystroke — within the document
the session belongs to, so a second editor's refreshes stay its own. Any other
request starts a fresh session, and a pending flag is matched on document URI
and version, so a keystroke that never produced a request can't leak into a
later quick suggestion. Going around `next` also means going around the
rejection handling it carries, so the hand-issued request routes failures back
through `client.handleFailedRequest`: a completion the next keystroke cancels
is ordinary, not something to report.

Word-based suggestions are off by default in Doenet documents, where they only
ever compete with the schema.

## Also here

- **The server attaches to Doenet documents on any filesystem**, not just
  `file:` and `untitled:`. It was silent on vscode.dev and github.dev, which
  serve files as `vscode-vfs:`, and in virtual workspaces generally.
- **The preview no longer throws when no editor is active** — which happens
  every time the last editor closes or focus leaves the editor area.
  `onDidChangeActiveTextEditor` hands you `undefined` there. It had been
  filling the web extension host log with `TypeError: Cannot read properties of
  undefined (reading 'document')`; it's caught per-listener, so it was noise
  rather than breakage.
- **The extension mirrors to Open VSX**, putting it within reach of
  VS Code-compatible editors such as VSCodium. There are `publish:openvsx`
  scripts mirroring the `vsce` ones, both publish channels mirror when an
  `OVSX_PAT` secret is present, and the manifests declare a valid SPDX license
  (`AGPL` isn't one). Absent the secret each channel warns and exits cleanly
  rather than failing the run — in the production job that keeps a release
  which has already reached npm and the Marketplace from going red over a
  mirror that can be re-run on its own. The `doenet` namespace and the
  `OVSX_PAT` repository secret both exist, so the first pre-release publish
  goes out with the next successful CI run on `main`. The namespace is
  unverified, which shows the publisher as unverified in the listing but does
  not affect installability; claiming it is a separate request to the Eclipse
  Foundation.
- **`engines.vscode` moves `^1.76.0` → `^1.85.0`**, the release where
  `editor.wordBasedSuggestions` became an enum, so the contributed defaults are
  valid against the schema they're declared under.
- **READMEs.** The marketplace README's feature list now names the Ctrl+Space
  gesture, and the package README's publishing section covers the Open VSX
  channel alongside the Marketplace one.

`doenet.triggerSuggest` is registered before the language client is built, so a
server that fails to start leaves Ctrl+Space opening the built-in widget rather
than reporting an unknown command.

Closes #1317.

## Verification

Beyond the unit tests, I drove a real VS Code build headlessly
(`vscode-test-web` + Playwright) against the built extension and read the
suggestion widget's actual contents at each cursor position. Flipping only the
contributed default confirms it is what governs the attribute case:

| contributed `[doenet]` default | `<ma` | `<math exp` | `<math exp` + Ctrl+Space |
|---|---|---|---|
| `other: "off"` | `math`, `mathInput`, … | *nothing* | `expand` |
| `other: "on"` | `math`, `mathInput`, … | `expand` | `expand` |

Ctrl+Space in the body went from `hello`, `text` (the file's own words) to
`title`, `setup`, `p`, `math`, `graph`, `answer`, … And `<gra`, `<point s`,
`displayMode="`, `</`, `$`, `$m.`, and `<` inside `<answer>` were re-checked to
confirm nothing that already worked regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

