### PR TITLE
Give a nested document its own language in the DOM

### DIFF
--- a/.changeset/nested-document-lang.md
+++ b/.changeset/nested-document-lang.md
@@ -10,4 +10,4 @@ Let a nested `<document lang>` reach the rendered page.
 
 An inner `<document lang="es">` already resolved its language in the core and had its computed prose translated, but nothing in the DOM said so: the `lang` attribute was only ever written for the activity as a whole, so a screen reader read the Spanish subtree with an English voice.
 
-The inner document now carries its own `lang`, and only when its language differs from the one already in effect around it. A nested document that declares nothing still says nothing, so an activity that declared no language keeps inheriting the embedding page's rather than being pinned to English.
+The inner document now carries its own `lang` — but only when its language differs from the one already in effect around it. A nested document that merely restates the surrounding language still says nothing, so an activity that declared no language keeps inheriting the embedding page's rather than being pinned to English.

--- a/.changeset/nested-document-lang.md
+++ b/.changeset/nested-document-lang.md
@@ -10,4 +10,4 @@ Let a nested `<document lang>` reach the rendered page.
 
 An inner `<document lang="es">` already resolved its language in the core and had its computed prose translated, but nothing in the DOM said so: the `lang` attribute was only ever written for the activity as a whole, so a screen reader read the Spanish subtree with an English voice.
 
-The inner document now carries its own `lang` — but only when its language differs from the one already in effect around it. A nested document that merely restates the surrounding language still says nothing, so an activity that declared no language keeps inheriting the embedding page's rather than being pinned to English.
+The inner document now carries its own `lang` — but only when its language differs from the one already in effect around it. A nested document that merely restates the surrounding language adds no attribute, since the DOM already says it.

--- a/.changeset/nested-document-lang.md
+++ b/.changeset/nested-document-lang.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Let a nested `<document lang>` reach the rendered page.
+
+An inner `<document lang="es">` already resolved its language in the core and had its computed prose translated, but nothing in the DOM said so: the `lang` attribute was only ever written for the activity as a whole, so a screen reader read the Spanish subtree with an English voice.
+
+The inner document now carries its own `lang`, and only when its language differs from the one already in effect around it. A nested document that declares nothing still says nothing, so an activity that declared no language keeps inheriting the embedding page's rather than being pinned to English.

--- a/.changeset/nested-document-lang.md
+++ b/.changeset/nested-document-lang.md
@@ -2,6 +2,8 @@
 "@doenet/doenetml": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
 ---
 
 Let a nested `<document lang>` reach the rendered page.

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -332,19 +332,17 @@ export default class Document extends BaseComponent {
         // Only a nested document ever needs one — the viewer labels the whole
         // activity from the outermost document's language, on the wrapper it
         // renders around it — and only when this document's language differs
-        // from the one already in effect around it. Re-asserting a language on
-        // every nested section would be worse than saying nothing: an activity
-        // that declared none should keep inheriting the embedding page's
-        // language rather than being pinned to English.
+        // from the one already in effect around it.
         //
-        // The ancestor's `locale` is the language in effect: every enclosing
-        // document either declared its own or inherited one the same way, so
-        // the chain is already resolved by the time it gets here. The one thing
-        // it cannot see is that the viewer omits `lang` entirely when nobody
-        // declared a language — the core is always handed a tag, English at
-        // worst — so a nested document that declares English inside an
-        // undeclared activity stays silent and inherits the page's language,
-        // exactly as the activity around it does.
+        // The enclosing document's `locale` is that language: every document
+        // above this one either declared its own or inherited one the same way,
+        // so the chain is already resolved by the time it gets here. The one
+        // thing it cannot see is that the viewer omits the wrapper's `lang`
+        // entirely when nobody declared a language — the core is always handed
+        // a tag, English at worst. So a nested document that only restates the
+        // language around it stays silent: redundant where an outer document
+        // declared that language, and wrong where nobody did, since `lang="en"`
+        // there would claim English over an embedding page that said otherwise.
         stateVariableDefinitions.renderedLang = {
             forRenderer: true,
             returnDependencies: () => ({

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -292,14 +292,9 @@ export default class Document extends BaseComponent {
             // language differs from the one already in effect around it.
             //
             // A nested document that only restates the surrounding language
-            // therefore stays silent: the tag would add nothing where an outer
-            // document declared that language, and would be wrong where nobody
-            // declared one at all. That last case is the core's blind spot —
-            // it is always handed a tag, English at worst, so it cannot tell a
-            // host that asked for English from a host that said nothing — but
-            // the viewer can, and leaves the wrapper's `lang` off there, where
-            // an inner `lang="en"` would claim English over an embedding page
-            // that said otherwise.
+            // therefore stays silent: the DOM already says it. The wrapper
+            // always carries the outermost document's language, so "already in
+            // effect" is known here at every depth.
             additionalStateVariablesDefined: [
                 { variableName: "renderedLang", forRenderer: true },
             ],

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -268,8 +268,9 @@ export default class Document extends BaseComponent {
 
         // The content's language, as a BCP-47 tag. Drives translation of the
         // prose the core computes (style descriptions and the like) and, via
-        // `renderedLang`, the `lang` attribute of the rendered document, which
-        // is what lets a screen reader pronounce the content correctly.
+        // `renderedLang` below, the `lang` attribute the DOM carries over a
+        // nested document's subtree — which is what lets a screen reader
+        // pronounce that content correctly.
         //
         // Precedence: an authored `lang` attribute wins over the locale the
         // hosting page supplied via `setLocaleData`, which falls back to "en".
@@ -290,13 +291,15 @@ export default class Document extends BaseComponent {
             // the wrapper it renders around it — and only when this document's
             // language differs from the one already in effect around it.
             //
-            // The one thing the core cannot see is that the viewer omits the
-            // wrapper's `lang` entirely when nobody declared a language: the
-            // core is always handed a tag, English at worst. So a nested
-            // document that only restates the language around it stays silent —
-            // redundant where an outer document declared that language, and
-            // wrong where nobody did, since `lang="en"` there would claim
-            // English over an embedding page that said otherwise.
+            // A nested document that only restates the surrounding language
+            // therefore stays silent: the tag would add nothing where an outer
+            // document declared that language, and would be wrong where nobody
+            // declared one at all. That last case is the core's blind spot —
+            // it is always handed a tag, English at worst, so it cannot tell a
+            // host that asked for English from a host that said nothing — but
+            // the viewer can, and leaves the wrapper's `lang` off there, where
+            // an inner `lang="en"` would claim English over an embedding page
+            // that said otherwise.
             additionalStateVariablesDefined: [
                 { variableName: "renderedLang", forRenderer: true },
             ],

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -267,18 +267,14 @@ export default class Document extends BaseComponent {
         };
 
         // The content's language, as a BCP-47 tag. Drives translation of the
-        // prose the core computes (style descriptions and the like) and the
-        // `lang` attribute of the rendered document, which is what lets a
-        // screen reader pronounce the content correctly.
+        // prose the core computes (style descriptions and the like) and, via
+        // `renderedLang`, the `lang` attribute of the rendered document, which
+        // is what lets a screen reader pronounce the content correctly.
         //
         // Precedence: an authored `lang` attribute wins over the locale the
         // hosting page supplied via `setLocaleData`, which falls back to "en".
         // The author knows what language they wrote in; the host only knows
         // what language it would prefer.
-        //
-        // A nested document's language reaches the DOM through `renderedLang`
-        // below, not through this variable: the `lang` attribute has to say
-        // nothing where nothing was declared, and this one always has a tag.
         stateVariableDefinitions.locale = {
             description:
                 "The BCP-47 language tag in effect for the document's content.",
@@ -286,6 +282,24 @@ export default class Document extends BaseComponent {
             shadowingInstructions: {
                 createComponentOfType: "text",
             },
+            // `renderedLang` is the tag the section renderer puts in a `lang`
+            // attribute, or null for no attribute at all (#1546). Same
+            // language as `locale`, narrowed to where the DOM has something to
+            // add: only a nested document ever needs a tag — the viewer labels
+            // the whole activity from the outermost document's language, on
+            // the wrapper it renders around it — and only when this document's
+            // language differs from the one already in effect around it.
+            //
+            // The one thing the core cannot see is that the viewer omits the
+            // wrapper's `lang` entirely when nobody declared a language: the
+            // core is always handed a tag, English at worst. So a nested
+            // document that only restates the language around it stays silent —
+            // redundant where an outer document declared that language, and
+            // wrong where nobody did, since `lang="en"` there would claim
+            // English over an embedding page that said otherwise.
+            additionalStateVariablesDefined: [
+                { variableName: "renderedLang", forRenderer: true },
+            ],
             returnDependencies: () => ({
                 lang: {
                     dependencyType: "attributePrimitive",
@@ -304,67 +318,27 @@ export default class Document extends BaseComponent {
                 // A blank `lang` counts as absent, matching
                 // `resolveDocumentLocale`.
                 const lang = dependencyValues.lang?.trim();
-                if (!lang && dependencyValues.documentAncestor) {
-                    // Nested inside another document, and this one didn't
-                    // declare a language of its own: inherit rather than
-                    // jumping back to the host's locale.
-                    return {
-                        setValue: {
-                            locale: dependencyValues.documentAncestor
-                                .stateValues.locale,
-                        },
-                    };
-                }
-                return {
-                    setValue: {
-                        locale: resolveDocumentLocale(
-                            lang,
-                            dependencyValues.hostLocale,
-                        ),
-                    },
-                };
-            },
-        };
-
-        // The tag the section renderer puts in a `lang` attribute for this
-        // document, or null for no attribute at all (#1546).
-        //
-        // Only a nested document ever needs one — the viewer labels the whole
-        // activity from the outermost document's language, on the wrapper it
-        // renders around it — and only when this document's language differs
-        // from the one already in effect around it.
-        //
-        // The enclosing document's `locale` is that language: every document
-        // above this one either declared its own or inherited one the same way,
-        // so the chain is already resolved by the time it gets here. The one
-        // thing it cannot see is that the viewer omits the wrapper's `lang`
-        // entirely when nobody declared a language — the core is always handed
-        // a tag, English at worst. So a nested document that only restates the
-        // language around it stays silent: redundant where an outer document
-        // declared that language, and wrong where nobody did, since `lang="en"`
-        // there would claim English over an embedding page that said otherwise.
-        stateVariableDefinitions.renderedLang = {
-            forRenderer: true,
-            returnDependencies: () => ({
-                locale: {
-                    dependencyType: "stateVariable",
-                    variableName: "locale",
-                },
-                documentAncestor: {
-                    dependencyType: "ancestor",
-                    componentType: "document",
-                    variableNames: ["locale"],
-                },
-            }),
-            definition({ dependencyValues }) {
+                // The language already in effect around this document, if it
+                // is nested in one: every document above it either declared its
+                // own or inherited one the same way, so that chain is resolved
+                // by the time it gets here.
                 const inherited =
                     dependencyValues.documentAncestor?.stateValues.locale;
+                // Nested inside another document without declaring a language
+                // of its own: inherit rather than jumping back to the host's
+                // locale.
+                const locale =
+                    !lang && inherited
+                        ? inherited
+                        : resolveDocumentLocale(
+                              lang,
+                              dependencyValues.hostLocale,
+                          );
                 return {
                     setValue: {
+                        locale,
                         renderedLang:
-                            inherited && dependencyValues.locale !== inherited
-                                ? dependencyValues.locale
-                                : null,
+                            inherited && locale !== inherited ? locale : null,
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -276,14 +276,9 @@ export default class Document extends BaseComponent {
         // The author knows what language they wrote in; the host only knows
         // what language it would prefer.
         //
-        // Known gap (#1546): only the *outer* document's language reaches the
-        // DOM. The viewer puts `lang` on the wrapper it renders around the
-        // whole activity; a nested `<document lang="de">` resolves this state
-        // variable correctly — and since Phase 2 (#1517) describes its
-        // graphics in that language — but renders through the section
-        // renderer, which emits no `lang`, so a screen reader keeps the outer
-        // document's voice. Closing it needs `forRenderer` here plus renderer
-        // changes.
+        // A nested document's language reaches the DOM through `renderedLang`
+        // below, not through this variable: the `lang` attribute has to say
+        // nothing where nothing was declared, and this one always has a tag.
         stateVariableDefinitions.locale = {
             description:
                 "The BCP-47 language tag in effect for the document's content.",
@@ -326,6 +321,52 @@ export default class Document extends BaseComponent {
                             lang,
                             dependencyValues.hostLocale,
                         ),
+                    },
+                };
+            },
+        };
+
+        // The tag the section renderer puts in a `lang` attribute for this
+        // document, or null for no attribute at all (#1546).
+        //
+        // Only a nested document ever needs one — the viewer labels the whole
+        // activity from the outermost document's language, on the wrapper it
+        // renders around it — and only when this document's language differs
+        // from the one already in effect around it. Re-asserting a language on
+        // every nested section would be worse than saying nothing: an activity
+        // that declared none should keep inheriting the embedding page's
+        // language rather than being pinned to English.
+        //
+        // The ancestor's `locale` is the language in effect: every enclosing
+        // document either declared its own or inherited one the same way, so
+        // the chain is already resolved by the time it gets here. The one thing
+        // it cannot see is that the viewer omits `lang` entirely when nobody
+        // declared a language — the core is always handed a tag, English at
+        // worst — so a nested document that declares English inside an
+        // undeclared activity stays silent and inherits the page's language,
+        // exactly as the activity around it does.
+        stateVariableDefinitions.renderedLang = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                locale: {
+                    dependencyType: "stateVariable",
+                    variableName: "locale",
+                },
+                documentAncestor: {
+                    dependencyType: "ancestor",
+                    componentType: "document",
+                    variableNames: ["locale"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                const inherited =
+                    dependencyValues.documentAncestor?.stateValues.locale;
+                return {
+                    setValue: {
+                        renderedLang:
+                            inherited && dependencyValues.locale !== inherited
+                                ? dependencyValues.locale
+                                : null,
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -283,18 +283,17 @@ export default class Document extends BaseComponent {
             shadowingInstructions: {
                 createComponentOfType: "text",
             },
-            // `renderedLang` is the tag the section renderer puts in a `lang`
-            // attribute, or null for no attribute at all (#1546). Same
-            // language as `locale`, narrowed to where the DOM has something to
-            // add: only a nested document ever needs a tag — the viewer labels
-            // the whole activity from the outermost document's language, on
-            // the wrapper it renders around it — and only when this document's
+            // `renderedLang` is the tag the section renderer writes as a
+            // `lang` attribute, or null for no attribute at all (#1546). The
+            // same language as `locale`, narrowed to where the DOM has
+            // something to add: only a nested document, and only when its
             // language differs from the one already in effect around it.
             //
-            // A nested document that only restates the surrounding language
-            // therefore stays silent: the DOM already says it. The wrapper
-            // always carries the outermost document's language, so "already in
-            // effect" is known here at every depth.
+            // The viewer labels the whole activity from the outermost
+            // document's language, on the wrapper it renders around it. So the
+            // outermost document needs no tag of its own, a nested one that
+            // merely restates the surrounding language would say nothing new,
+            // and "already in effect" is known here at every depth.
             additionalStateVariablesDefined: [
                 { variableName: "renderedLang", forRenderer: true },
             ],
@@ -313,28 +312,26 @@ export default class Document extends BaseComponent {
                 },
             }),
             definition({ dependencyValues }) {
-                // A blank `lang` counts as absent, matching
-                // `resolveDocumentLocale`.
-                const lang = dependencyValues.lang?.trim();
                 // The language already in effect around this document, if it
-                // is nested in one: every document above it either declared its
-                // own or inherited one the same way, so that chain is resolved
-                // by the time it gets here.
+                // is nested in one: every document above it either declared
+                // its own or inherited one the same way, so that chain is
+                // resolved by the time it gets here.
                 const inherited =
                     dependencyValues.documentAncestor?.stateValues.locale;
-                // Nested inside another document without declaring a language
-                // of its own: inherit rather than jumping back to the host's
-                // locale.
-                const locale =
-                    !lang && inherited
-                        ? inherited
-                        : resolveDocumentLocale(
-                              lang,
-                              dependencyValues.hostLocale,
-                          );
+                // An enclosing document stands in for the host's locale, so a
+                // nested document that declares no language of its own follows
+                // the one it sits in rather than jumping back to the host's.
+                // `resolveDocumentLocale` does the rest: it trims, so a blank
+                // `lang` counts as absent, and normalizes, so the comparison
+                // below is between canonical tags.
+                const locale = resolveDocumentLocale(
+                    dependencyValues.lang,
+                    inherited ?? dependencyValues.hostLocale,
+                );
                 return {
                     setValue: {
                         locale,
+                        // Silent wherever the DOM already says this language.
                         renderedLang:
                             inherited && locale !== inherited ? locale : null,
                     },

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
@@ -469,6 +469,19 @@ describe("Document tag tests @group4", async () => {
                 );
             });
 
+            it("is null when a nested document restates English nobody declared", async () => {
+                // The known gap: the core is always handed a locale ("en" when
+                // the host names none), so it cannot tell a host that declared
+                // English from a host that said nothing — the distinction the
+                // viewer uses to leave the wrapper's `lang` off. An inner
+                // `lang="en"` therefore reads as a restatement, and the subtree
+                // keeps inheriting the embedding page's language.
+                const doenetML = `<document><document name="inner" lang="en"><p>hello</p></document></document>`;
+                expect(await renderedLangOf(doenetML, undefined, "inner")).eq(
+                    null,
+                );
+            });
+
             it("labels a nested document in a language other than the host's", async () => {
                 const doenetML = `<document><document name="inner" lang="es"><p>hola</p></document></document>`;
                 expect(await renderedLangOf(doenetML, "fr", "inner")).eq("es");

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
@@ -320,11 +320,12 @@ describe("Document tag tests @group4", async () => {
     // `setLocaleData` > "en" — the author knows what language they wrote in,
     // the host only knows what it would prefer to receive.
     describe("document lang / locale", () => {
-        async function localeOf(
+        /** The state values of the document at `path`, from a fresh core. */
+        async function documentStateValues(
             doenetML: string,
             documentLocale?: string,
             path = "_document1",
-        ): Promise<string> {
+        ) {
             const { core, resolvePathToNodeIdx } = await createTestCore({
                 doenetML,
                 documentLocale,
@@ -333,7 +334,15 @@ describe("Document tag tests @group4", async () => {
                 false,
                 true,
             );
-            return stateVariables[await resolvePathToNodeIdx(path)].stateValues
+            return stateVariables[await resolvePathToNodeIdx(path)].stateValues;
+        }
+
+        async function localeOf(
+            doenetML: string,
+            documentLocale?: string,
+            path = "_document1",
+        ): Promise<string> {
+            return (await documentStateValues(doenetML, documentLocale, path))
                 .locale;
         }
 
@@ -412,16 +421,9 @@ describe("Document tag tests @group4", async () => {
                 documentLocale?: string,
                 path = "_document1",
             ): Promise<string | null> {
-                const { core, resolvePathToNodeIdx } = await createTestCore({
-                    doenetML,
-                    documentLocale,
-                });
-                const stateVariables = await core.returnAllStateVariables(
-                    false,
-                    true,
-                );
-                return stateVariables[await resolvePathToNodeIdx(path)]
-                    .stateValues.renderedLang;
+                return (
+                    await documentStateValues(doenetML, documentLocale, path)
+                ).renderedLang;
             }
 
             it("is null on the outermost document", async () => {
@@ -467,7 +469,7 @@ describe("Document tag tests @group4", async () => {
                 );
             });
 
-            it("labels a nested document in a language the host's differs from", async () => {
+            it("labels a nested document in a language other than the host's", async () => {
                 const doenetML = `<document><document name="inner" lang="es"><p>hola</p></document></document>`;
                 expect(await renderedLangOf(doenetML, "fr", "inner")).eq("es");
             });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
@@ -469,13 +469,9 @@ describe("Document tag tests @group4", async () => {
                 );
             });
 
-            it("is null when a nested document restates English nobody declared", async () => {
-                // The known gap: the core is always handed a locale ("en" when
-                // the host names none), so it cannot tell a host that declared
-                // English from a host that said nothing — the distinction the
-                // viewer uses to leave the wrapper's `lang` off. An inner
-                // `lang="en"` therefore reads as a restatement, and the subtree
-                // keeps inheriting the embedding page's language.
+            it("is null when a nested document restates the default English", async () => {
+                // An undeclared activity is rendered in English and its
+                // wrapper says so, so an inner `lang="en"` adds nothing.
                 const doenetML = `<document><document name="inner" lang="en"><p>hello</p></document></document>`;
                 expect(await renderedLangOf(doenetML, undefined, "inner")).eq(
                     null,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
@@ -399,5 +399,96 @@ describe("Document tag tests @group4", async () => {
             const doenetML = `<document lang="fr"><document name="inner" lang="de"><p>guten Tag</p></document></document>`;
             expect(await localeOf(doenetML, "es-MX", "inner")).eq("de");
         });
+
+        // i18n (#1546): the tag the section renderer turns into a `lang`
+        // attribute. Unlike `locale`, which always has a tag, this one is null
+        // wherever the DOM should say nothing — on the outermost document,
+        // whose language the viewer puts on the wrapper around the whole
+        // activity, and on any nested document that would only re-assert the
+        // language already in effect around it.
+        describe("renderedLang", () => {
+            async function renderedLangOf(
+                doenetML: string,
+                documentLocale?: string,
+                path = "_document1",
+            ): Promise<string | null> {
+                const { core, resolvePathToNodeIdx } = await createTestCore({
+                    doenetML,
+                    documentLocale,
+                });
+                const stateVariables = await core.returnAllStateVariables(
+                    false,
+                    true,
+                );
+                return stateVariables[await resolvePathToNodeIdx(path)]
+                    .stateValues.renderedLang;
+            }
+
+            it("is null on the outermost document", async () => {
+                // Its language is the wrapper's job; emitting it here as well
+                // would say nothing new.
+                expect(
+                    await renderedLangOf(
+                        `<document lang="fr"><p>bonjour</p></document>`,
+                        "es-MX",
+                    ),
+                ).eq(null);
+            });
+
+            it("is null on a nested document that inherits", async () => {
+                const doenetML = `<document lang="fr"><document name="inner"><p>bonjour</p></document></document>`;
+                expect(await renderedLangOf(doenetML, "es-MX", "inner")).eq(
+                    null,
+                );
+            });
+
+            it("labels a nested document in another language", async () => {
+                const doenetML = `<document lang="fr"><document name="inner" lang="de"><p>guten Tag</p></document></document>`;
+                expect(await renderedLangOf(doenetML, "es-MX", "inner")).eq(
+                    "de",
+                );
+            });
+
+            it("is null when a nested document restates the same language", async () => {
+                // Normalized before the comparison, so the author's casing
+                // cannot turn a restatement into a difference.
+                const doenetML = `<document lang="fr"><document name="inner" lang="FR"><p>bonjour</p></document></document>`;
+                expect(await renderedLangOf(doenetML, "es-MX", "inner")).eq(
+                    null,
+                );
+            });
+
+            it("is null when a nested document restates the host's locale", async () => {
+                // The host's locale reaches the DOM on the wrapper, so an inner
+                // document that names it again changes nothing.
+                const doenetML = `<document><document name="inner" lang="es-MX"><p>hola</p></document></document>`;
+                expect(await renderedLangOf(doenetML, "es-MX", "inner")).eq(
+                    null,
+                );
+            });
+
+            it("labels a nested document in a language the host's differs from", async () => {
+                const doenetML = `<document><document name="inner" lang="es"><p>hola</p></document></document>`;
+                expect(await renderedLangOf(doenetML, "fr", "inner")).eq("es");
+            });
+
+            it("follows the language in effect through intervening documents", async () => {
+                const doenetML = `<document lang="fr"><document name="mid"><document name="inner" lang="de"><p>guten Tag</p></document></document></document>`;
+                expect(await renderedLangOf(doenetML, "es-MX", "mid")).eq(null);
+                expect(await renderedLangOf(doenetML, "es-MX", "inner")).eq(
+                    "de",
+                );
+            });
+
+            it("labels a nested document that returns to an outer language", async () => {
+                // The middle document changed the language, so the innermost
+                // has to say it is back to French even though the outermost
+                // document declared it.
+                const doenetML = `<document lang="fr"><document name="mid" lang="de"><document name="inner" lang="fr"><p>bonjour</p></document></document></document>`;
+                expect(await renderedLangOf(doenetML, "es-MX", "inner")).eq(
+                    "fr",
+                );
+            });
+        });
     });
 });

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -40,6 +40,7 @@ interface SectionSVs {
     sectionNumber?: string;
     level: number;
     containerTag: string;
+    renderedLang?: string | null;
     justSubmitted: boolean;
     firstChildListItemAlignment?: string;
     firstVisibleChildAdjustedForListItem?: any;
@@ -170,7 +171,16 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         content: React.ReactNode,
         style: React.CSSProperties,
     ) => {
-        const props = { id, style, ref };
+        // Only a nested `<document>` in a language of its own supplies
+        // `renderedLang`; every other section leaves the attribute off so the
+        // subtree keeps whatever language is already in effect around it (the
+        // viewer labels the whole activity from the outermost document).
+        const props = {
+            id,
+            style,
+            ref,
+            lang: SVs.renderedLang ?? undefined,
+        };
 
         switch (SVs.containerTag) {
             case "aside":

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -53,9 +53,10 @@ Those rules all settle one language for the activity as a whole. A nested
 `renderedLang` state variable hands the section renderer a tag only when the
 nested document's language differs from the one already in effect around it,
 and the renderer emits `lang` only when it gets one. A nested document that
-merely restated the surrounding language would stay quiet for the same reason
-the wrapper does — an activity nobody declared a language for must keep
-inheriting the embedding page's rather than being pinned to English.
+merely restates the surrounding language stays silent — the tag would add
+nothing where an outer document declared that language, and would pin the
+subtree to English where nobody declared anything at all, which is exactly what
+the wrapper's `undefined` avoids.
 
 ## Catalog layout
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -38,6 +38,13 @@ otherwise the content's language. Both normalize what they return (`ES-mx` →
 `es-MX`) and treat a blank tag as unset, so a hand-typed `lang` and a
 hand-configured prop negotiate the same way a canonical tag does.
 
+A nested `<document lang>` labels its own subtree on top of that: `<document>`'s
+`renderedLang` state variable hands the section renderer a tag only when the
+nested document's language differs from the one already in effect around it,
+and the renderer emits `lang` only when it gets one. Restating the surrounding
+language on every nested section would be worse than staying quiet, for the
+same reason the wrapper stays quiet.
+
 A tag they cannot parse is left alone rather than rejected — `en_US`, the POSIX
 spelling, is the usual way a host mis-keys a catalog, and rewriting it would
 stop that catalog from being found. So such a tag keys and negotiates like any

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -38,13 +38,6 @@ otherwise the content's language. Both normalize what they return (`ES-mx` →
 `es-MX`) and treat a blank tag as unset, so a hand-typed `lang` and a
 hand-configured prop negotiate the same way a canonical tag does.
 
-A nested `<document lang>` labels its own subtree on top of that: `<document>`'s
-`renderedLang` state variable hands the section renderer a tag only when the
-nested document's language differs from the one already in effect around it,
-and the renderer emits `lang` only when it gets one. Restating the surrounding
-language on every nested section would be worse than staying quiet, for the
-same reason the wrapper stays quiet.
-
 A tag they cannot parse is left alone rather than rejected — `en_US`, the POSIX
 spelling, is the usual way a host mis-keys a catalog, and rewriting it would
 stop that catalog from being found. So such a tag keys and negotiates like any
@@ -54,6 +47,15 @@ whenever the tag is one `Intl` can't parse — otherwise Fluent's
 `Intl.PluralRules` throws and the whole message resolves to `{???}` — and
 `createDiagnosticFormatter` joins its lists the same way. The host's own words
 are kept; only the counting and number conventions fall back.
+
+Those rules all settle one language for the activity as a whole. A nested
+`<document lang>` labels its own subtree on top of that: `<document>`'s
+`renderedLang` state variable hands the section renderer a tag only when the
+nested document's language differs from the one already in effect around it,
+and the renderer emits `lang` only when it gets one. A nested document that
+merely restated the surrounding language would stay quiet for the same reason
+the wrapper does — an activity nobody declared a language for must keep
+inheriting the embedding page's rather than being pinned to English.
 
 ## Catalog layout
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -33,6 +33,15 @@ claims a language the content was not rendered in. An undeclared activity is
 labeled `en` — not a guess about what its author wrote, but a report of the
 language the core computed its prose in.
 
+That wrapper settles one language for the activity as a whole; a nested
+`<document lang>` labels its own subtree on top of it. `<document>`'s
+`renderedLang` state variable hands the section renderer a tag only when the
+nested document's language differs from the one already in effect around it,
+and the renderer emits `lang` only when it is given one. A nested document that
+merely restates the surrounding language stays silent, for the same reason the
+wrapper does: the tag would add nothing where an outer document declared that
+language, and would assert English where nobody declared anything.
+
 `resolveUiLocale` applies the chrome's rule — the configured `uiLocale`,
 otherwise the content's language. Both normalize what they return (`ES-mx` →
 `es-MX`) and treat a blank tag as unset, so a hand-typed `lang` and a
@@ -47,16 +56,6 @@ whenever the tag is one `Intl` can't parse — otherwise Fluent's
 `Intl.PluralRules` throws and the whole message resolves to `{???}` — and
 `createDiagnosticFormatter` joins its lists the same way. The host's own words
 are kept; only the counting and number conventions fall back.
-
-Those rules all settle one language for the activity as a whole. A nested
-`<document lang>` labels its own subtree on top of that: `<document>`'s
-`renderedLang` state variable hands the section renderer a tag only when the
-nested document's language differs from the one already in effect around it,
-and the renderer emits `lang` only when it gets one. A nested document that
-merely restates the surrounding language stays silent — the tag would add
-nothing where an outer document declared that language, and would pin the
-subtree to English where nobody declared anything at all, which is exactly what
-the wrapper's `undefined` avoids.
 
 ## Catalog layout
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -38,9 +38,8 @@ That wrapper settles one language for the activity as a whole; a nested
 `renderedLang` state variable hands the section renderer a tag only when the
 nested document's language differs from the one already in effect around it,
 and the renderer emits `lang` only when it is given one. A nested document that
-merely restates the surrounding language stays silent, for the same reason the
-wrapper does: the tag would add nothing where an outer document declared that
-language, and would assert English where nobody declared anything.
+merely restates the surrounding language stays silent, because the DOM already
+says it.
 
 `resolveUiLocale` applies the chrome's rule — the configured `uiLocale`,
 otherwise the content's language. Both normalize what they return (`ES-mx` →

--- a/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
@@ -1,3 +1,7 @@
+// The `lang` the viewer writes on the wrapper it renders around the whole
+// activity. A nested `<document lang>` labels its own subtree on top of that;
+// those cases live in `i18n.cy.js`, where the same activity also checks the
+// prose the core translated into that language.
 describe("Document language Tests", { tags: ["@group5"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -294,8 +294,8 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         });
 
         it("says nothing where a nested document inherits", () => {
-            // Re-asserting the surrounding language would pin the subtree to a
-            // tag it should simply be inheriting.
+            // The wrapper already declares this subtree's language; repeating
+            // it on every nested section would add nothing.
             render({ doenetML: nested() });
 
             cy.get("#desc").should("have.text", "thick dashed red line");

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -261,10 +261,16 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         // prose the core computes; this is the other half — the DOM has to say
         // so too, or a screen reader pronounces Spanish content with an
         // English voice.
-        const nested = (innerLang) => `
+        //
+        // The inner document computes a style description, so one activity
+        // exercises both halves at once: the prose the core translated, and
+        // the language the DOM declares over it.
+        function nested(innerLang) {
+            const lang = innerLang ? ` lang="${innerLang}"` : "";
+            return `
         <document lang="en">
           <p name="outer">Read the description below.</p>
-          <document name="inner" ${innerLang}>
+          <document name="inner"${lang}>
             <setup>
               <styleDefinition styleNumber="1" lineColor="red" lineWidth="6"
                 lineStyle="dashed" />
@@ -273,9 +279,10 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             <p name="desc">$l.styleDescriptionWithNoun</p>
           </document>
         </document>`;
+        }
 
         it("labels a nested document with its own language", () => {
-            render({ doenetML: nested(`lang="es"`) });
+            render({ doenetML: nested("es") });
 
             cy.get("#desc").should(
                 "have.text",
@@ -290,7 +297,7 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         it("says nothing where a nested document inherits", () => {
             // Re-asserting the surrounding language would pin the subtree to a
             // tag it should simply be inheriting.
-            render({ doenetML: nested("") });
+            render({ doenetML: nested() });
 
             cy.get("#desc").should("have.text", "thick dashed red line");
             cy.get("#inner").should("not.have.attr", "lang");

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -256,6 +256,47 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         });
     });
 
+    describe("nested documents", () => {
+        // A nested `<document lang>` resolves in the core and translates the
+        // prose the core computes; this is the other half — the DOM has to say
+        // so too, or a screen reader pronounces Spanish content with an
+        // English voice.
+        const nested = (innerLang) => `
+        <document lang="en">
+          <p name="outer">Read the description below.</p>
+          <document name="inner" ${innerLang}>
+            <setup>
+              <styleDefinition styleNumber="1" lineColor="red" lineWidth="6"
+                lineStyle="dashed" />
+            </setup>
+            <graph><line through="(0,0) (1,1)" name="l" /></graph>
+            <p name="desc">$l.styleDescriptionWithNoun</p>
+          </document>
+        </document>`;
+
+        it("labels a nested document with its own language", () => {
+            render({ doenetML: nested(`lang="es"`) });
+
+            cy.get("#desc").should(
+                "have.text",
+                "línea discontinua gruesa roja",
+            );
+            // The wrapper still speaks for the activity as a whole; the inner
+            // document declares the difference on its own subtree.
+            cy.get(".doenet-viewer").should("have.attr", "lang", "en");
+            cy.get("#inner").should("have.attr", "lang", "es");
+        });
+
+        it("says nothing where a nested document inherits", () => {
+            // Re-asserting the surrounding language would pin the subtree to a
+            // tag it should simply be inheriting.
+            render({ doenetML: nested("") });
+
+            cy.get("#desc").should("have.text", "thick dashed red line");
+            cy.get("#inner").should("not.have.attr", "lang");
+        });
+    });
+
     describe("diagnostics", () => {
         // Neither chrome nor content: raised in the worker, read by whoever is
         // looking at the screen. So they follow `uiLocale` even though the

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -269,7 +269,6 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             const lang = innerLang ? ` lang="${innerLang}"` : "";
             return `
         <document lang="en">
-          <p name="outer">Read the description below.</p>
           <document name="inner"${lang}>
             <setup>
               <styleDefinition styleNumber="1" lineColor="red" lineWidth="6"


### PR DESCRIPTION
A nested `<document lang="es">` resolved its language correctly in the core and, since #1517, had its computed prose translated — but nothing in the DOM said so. The viewer writes `lang` on the wrapper it renders around the whole activity; an inner `<document>` renders through the section renderer, which emitted no `lang` at all. So Spanish prose sat inside a subtree the DOM still declared as English, and a screen reader pronounced it with an English voice.

## What changed

**Core** — `<document>`'s `locale` state variable now also defines `renderedLang` (`forRenderer: true`), through `additionalStateVariablesDefined`, so both come out of one dependency set and cannot drift. It carries a tag only when the document has a `<document>` ancestor *and* its resolved locale differs from that ancestor's; otherwise `null`.

**Renderer** — `section.tsx`'s `renderContainer` emits `lang` when it is given one. Every other section, and the outermost document, stay silent and inherit.

The issue proposed `forRenderer: true` on `locale` itself, with the renderer deciding when to emit. That is not enough: `locale` always holds a tag, so the renderer would have to re-derive "differs from what is already in effect" without knowing the nesting chain. Comparing against the enclosing document's `locale` in the core gets it right at any depth — including a third-level document that returns to a language an outer one declared, which *has* to re-assert it because the document between them changed it.

The wrapper always carries the language the whole activity renders in (#1595), so "the language already in effect" is known at every depth.

## Tests

- `document.test.ts` — nine cases for `renderedLang`: null on the outermost document, null when a nested one inherits, the tag when it declares its own, null when it restates the same language (`FR` vs `fr`, normalized before comparison), null when it restates the host's locale or the default English, the tag when it differs from the host's, an intervening document that declares nothing, and an inner document returning to an outer language.
- `i18n.cy.js` — a nested-documents block asserting the inner document carries `lang="es"` while the wrapper stays `en` and the inner style description renders in Spanish, plus the inheriting case asserting no attribute at all.

All six `DocViewer` Cypress specs pass (49 tests), and `sectioning.cy.js` was run for the section renderer.

Closes #1546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



