### PR TITLE
Always label the rendered document with the language it renders in

### DIFF
--- a/.changeset/i18n-phase-0-infrastructure.md
+++ b/.changeset/i18n-phase-0-infrastructure.md
@@ -8,7 +8,7 @@
 
 Add a `lang` attribute to `<document>` and `documentLocale` / `uiLocale` settings to the viewer and editor, laying the groundwork for translated activities.
 
-`<document lang="es-MX">` declares what language the content is written in. The rendered activity then carries a matching `lang` attribute, so screen readers pronounce the content with the right voice and rules — an accessibility improvement that applies today, before any strings are translated. An activity that declares no language keeps carrying none, inheriting whatever the surrounding page declares.
+`<document lang="es-MX">` declares what language the content is written in. The rendered activity then carries a matching `lang` attribute, so screen readers pronounce the content with the right voice and rules — an accessibility improvement that applies today, before any strings are translated.
 
 `<document>` also gains a public `locale` property reporting the language tag actually in effect, whether that came from an authored `lang` or from the host.
 

--- a/.changeset/wrapper-lang-always-declared.md
+++ b/.changeset/wrapper-lang-always-declared.md
@@ -6,8 +6,8 @@
 "doenet-vscode-extension": patch
 ---
 
-Always label the rendered document with the language it was rendered in.
+Always label the rendered activity with the language it was rendered in.
 
-An activity that declared no language — no `<document lang>`, no `documentLocale` from the host — used to render with no `lang` attribute at all, on the theory that inheriting the embedding page's language beat asserting English. But English was not a guess: it is the language the core computes its prose in and the chrome renders in for such a document. So a Spanish page embedding an undeclared activity produced an English "Check Work" and an English "thick red line" inside a subtree the DOM declared as Spanish, and a screen reader read them with a Spanish voice.
+The container the viewer renders carries a `lang` attribute even when nobody declared a language — no `<document lang>`, no `documentLocale` from the host. Such an activity is labeled `en`, which is what it is: English is the language the core computes its prose in and the chrome renders in when nothing says otherwise. Were the container left unlabeled, its subtree would inherit the embedding page's language instead, so a Spanish page could wrap an English "Check Work" and an English "thick red line" in a subtree the DOM called Spanish, and a screen reader would read them with a Spanish voice.
 
-The wrapper now always carries the language the content was actually rendered in. Nothing changes for an activity that declares one; an undeclared activity is labeled `en`, which is what it is. An author who wrote in another language and never said so is asked for the same `lang="es"` that already fixes their computed prose and their chrome.
+An author who wrote in another language and never said so should declare it — `<document lang="es">` — the same fix that already gets them Spanish style descriptions and Spanish chrome.

--- a/.changeset/wrapper-lang-always-declared.md
+++ b/.changeset/wrapper-lang-always-declared.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Always label the rendered document with the language it was rendered in.
+
+An activity that declared no language — no `<document lang>`, no `documentLocale` from the host — used to render with no `lang` attribute at all, on the theory that inheriting the embedding page's language beat asserting English. But English was not a guess: it is the language the core computes its prose in and the chrome renders in for such a document. So a Spanish page embedding an undeclared activity produced an English "Check Work" and an English "thick red line" inside a subtree the DOM declared as Spanish, and a screen reader read them with a Spanish voice.
+
+The wrapper now always carries the language the content was actually rendered in. Nothing changes for an activity that declares one; an undeclared activity is labeled `en`, which is what it is. An author who wrote in another language and never said so is asked for the same `lang="es"` that already fixes their computed prose and their chrome.

--- a/.changeset/wrapper-lang-always-declared.md
+++ b/.changeset/wrapper-lang-always-declared.md
@@ -8,6 +8,6 @@
 
 Always label the rendered activity with the language it was rendered in.
 
-The container the viewer renders carries a `lang` attribute even when nobody declared a language — no `<document lang>`, no `documentLocale` from the host. Such an activity is labeled `en`, which is what it is: English is the language the core computes its prose in and the chrome renders in when nothing says otherwise. Were the container left unlabeled, its subtree would inherit the embedding page's language instead, so a Spanish page could wrap an English "Check Work" and an English "thick red line" in a subtree the DOM called Spanish, and a screen reader would read them with a Spanish voice.
+The container the viewer renders carries a `lang` attribute even when nobody declared a language — no `<document lang>`, no `documentLocale` from the host. Such an activity is labeled `en`, the language the core computes its prose in. Were the container left unlabeled, its subtree would inherit the embedding page's language instead, so a Spanish page could wrap an English "Check Work" and an English "thick red line" in a subtree the DOM called Spanish, and a screen reader would read them with a Spanish voice.
 
 An author who wrote in another language and never said so should declare it — `<document lang="es">` — the same fix that already gets them Spanish style descriptions and Spanish chrome.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -203,8 +203,8 @@ differ — a Spanish-speaking student may work a French physics problem.
 
 The rendered container always carries a `lang` attribute naming the language
 the content was rendered in, so screen readers pronounce it with the right
-voice and rules. When neither route declares one that is `en` — the language
-such an activity's computed prose and chrome are in.
+voice and rules. When neither route declares one, that language is `en` — what
+such an activity's computed prose and chrome are written in.
 
 Passing `null` (or dropping the prop) clears any of the three, exactly as with
 `styleOverrides`.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -203,8 +203,8 @@ differ — a Spanish-speaking student may work a French physics problem.
 
 The rendered container always carries a `lang` attribute naming the language
 the content was rendered in, so screen readers pronounce it with the right
-voice and rules. When neither route declares one, that language is `en` — what
-such an activity's computed prose and chrome are written in.
+voice and rules. When neither route declares one, that language is `en` — the
+language the core computes such an activity's prose in.
 
 Passing `null` (or dropping the prop) clears any of the three, exactly as with
 `styleOverrides`.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -201,11 +201,10 @@ differ — a Spanish-speaking student may work a French physics problem.
   only those passes nothing; a catalog supplied here wins over a bundled one
   for the same locale, which is how a deployment corrects a translation.
 
-When a language is declared — by either route — the rendered container carries
-a matching `lang` attribute, so screen readers pronounce the content with the
-right voice and rules. When neither declares one it carries no `lang` at all
-and inherits the embedding page's, a better guess than asserting English over
-a page that said `<html lang="es">`.
+The rendered container always carries a `lang` attribute naming the language
+the content was rendered in, so screen readers pronounce it with the right
+voice and rules. When neither route declares one that is `en` — the language
+such an activity's computed prose and chrome are in.
 
 Passing `null` (or dropping the prop) clears any of the three, exactly as with
 `styleOverrides`.

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -22,9 +22,8 @@ import { MdError } from "react-icons/md";
 import { get as idb_get } from "idb-keyval";
 import { createCoreWorker, initializeCoreWorker } from "../utils/docUtils";
 import {
-    DEFAULT_LOCALE,
-    declaredDocumentLocale,
     localeResourceKey,
+    resolveDocumentLocale,
     resolveUiLocale,
     type Translator,
 } from "@doenet/i18n";
@@ -550,17 +549,14 @@ export function DocViewer({
 
     const [ignoreRendererError, setIgnoreRendererError] = useState(false);
 
-    // The content language somebody declared — the `documentLocale` prop,
-    // overridden by an authored `<document lang>` — or `undefined` when nobody
-    // did. Seeded from the prop so the wrapper is labeled correctly from the
-    // first paint, then corrected once the source is parsed.
-    const [declaredLocale, setDeclaredLocale] = useState(() =>
-        declaredDocumentLocale(undefined, documentLocale),
+    // The content's language — the `documentLocale` prop, overridden by an
+    // authored `<document lang>`, English when neither says anything. What the
+    // core translates into, and what the wrapper's `lang` reports. Seeded from
+    // the prop so the wrapper is labeled correctly from the first paint, then
+    // corrected once the source is parsed.
+    const [effectiveDocumentLocale, setEffectiveDocumentLocale] = useState(() =>
+        resolveDocumentLocale(undefined, documentLocale),
     );
-    // What the core will actually translate into: undeclared content is
-    // treated as English. (The wrapper's `lang` deliberately does *not* fall
-    // back this way — see `initializeCoreWorker`.)
-    const effectiveDocumentLocale = declaredLocale ?? DEFAULT_LOCALE;
     // The chrome's language: whatever the host configured, otherwise the
     // content's.
     const effectiveUiLocale = resolveUiLocale(
@@ -974,7 +970,7 @@ export function DocViewer({
             documentLocale,
             localeResources,
         });
-        setDeclaredLocale(result.declaredDocumentLocale);
+        setEffectiveDocumentLocale(result.resolvedDocumentLocale);
         return result;
     }
 
@@ -2312,9 +2308,9 @@ export function DocViewer({
             <div
                 style={viewerStyle}
                 className="doenet-viewer"
-                // Omitted when nobody declared a language, so the content
-                // inherits the embedding page's rather than claiming English.
-                lang={declaredLocale}
+                // Always the language the content is actually rendered in, so
+                // a screen reader pronounces it the way the core wrote it.
+                lang={effectiveDocumentLocale}
                 ref={viewerContainerRef}
             >
                 {errorOverview}

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -950,11 +950,11 @@ export function DocViewer({
 
     /**
      * Initialize a core worker for this document, recording the content
-     * language it declared.
+     * language it resolved to.
      *
-     * The declared locale depends on the DoenetML (an authored
-     * `<document lang>` overrides the prop), so it isn't known until the
-     * source has been parsed — which `initializeCoreWorker` does anyway.
+     * That language depends on the DoenetML (an authored `<document lang>`
+     * overrides the prop), so it isn't known until the source has been parsed
+     * — which `initializeCoreWorker` does anyway.
      */
     async function initializeCoreWorkerForDoc(worker: Remote<CoreWorker>) {
         const result = await initializeCoreWorker({

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -167,9 +167,9 @@ export function DoenetViewer({
      * would prefer. Selects the language of prose the core computes (style
      * descriptions and the like), and sets `lang` on the rendered wrapper — an
      * accessibility win for screen-reader pronunciation independent of any
-     * translation. Leave it unset and the wrapper carries no `lang` at all,
-     * inheriting the embedding page's rather than claiming English. Changing
-     * it rebuilds the document.
+     * translation. Leave it unset and both the core and the wrapper use `en`,
+     * which is the language such a document is rendered in. Changing it
+     * rebuilds the document.
      */
     documentLocale?: string | null;
     /**
@@ -445,9 +445,9 @@ type DoenetEditorProps = {
      * would prefer. Selects the language of prose the core computes (style
      * descriptions and the like), and sets `lang` on the rendered wrapper — an
      * accessibility win for screen-reader pronunciation independent of any
-     * translation. Leave it unset and the wrapper carries no `lang` at all,
-     * inheriting the embedding page's rather than claiming English. Changing
-     * it rebuilds the document.
+     * translation. Leave it unset and both the core and the wrapper use `en`,
+     * which is the language such a document is rendered in. Changing it
+     * rebuilds the document.
      */
     documentLocale?: string | null;
     /**

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -9,8 +9,8 @@ import {
 } from "@doenet/parser";
 import {
     DEFAULT_LOCALE,
-    declaredDocumentLocale,
     normalizeLocaleTag,
+    resolveDocumentLocale,
 } from "@doenet/i18n";
 import { readDocumentLang } from "./documentLang";
 
@@ -295,22 +295,23 @@ export async function initializeCoreWorker({
         },
     });
 
-    // The content language somebody declared, for the `lang` attribute on the
-    // rendered wrapper. Resolved from the DAST we already parsed rather than
-    // asked of the core, so it is available before the first render — a screen
-    // reader should not have to wait for evaluation to learn what language it
-    // is reading. The core resolves the same value with the same helper for
-    // its own `document.locale` state variable.
+    // The content's language, for the `lang` attribute on the rendered
+    // wrapper. Resolved from the DAST we already parsed rather than asked of
+    // the core, so it is available before the first render — a screen reader
+    // should not have to wait for evaluation to learn what language it is
+    // reading. The core resolves the same value with the same helper for its
+    // own `document.locale` state variable, from the same two inputs.
     //
-    // `undefined` when neither the document nor the host declared a language.
-    // The core still treats such content as English, but the wrapper stays
-    // silent rather than asserting `lang="en"` over an embedding page that
-    // said `<html lang="es">` — an unfounded guess is worse for a screen
-    // reader than inheriting the page's.
-    const declaredLocale = declaredDocumentLocale(
+    // English when neither the document nor the host declared a language.
+    // That is not a guess: it is the language the core computes its prose in
+    // and the chrome renders in for such a document, so the `lang` attribute
+    // reports what the activity is actually rendered in rather than letting
+    // the subtree inherit a claim from the embedding page that nothing else
+    // here honors.
+    const resolvedLocale = resolveDocumentLocale(
         readDocumentLang(dast),
         documentLocale,
     );
 
-    return { ...result, declaredDocumentLocale: declaredLocale };
+    return { ...result, resolvedDocumentLocale: resolvedLocale };
 }

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -7,11 +7,7 @@ import {
     lezerToDast,
     normalizeDocumentDast,
 } from "@doenet/parser";
-import {
-    DEFAULT_LOCALE,
-    normalizeLocaleTag,
-    resolveDocumentLocale,
-} from "@doenet/i18n";
+import { resolveDocumentLocale } from "@doenet/i18n";
 import { readDocumentLang } from "./documentLang";
 
 export type CoreWorkerHandle = {
@@ -270,11 +266,14 @@ export async function initializeCoreWorker({
     await coreWorker.setFlags({ flags });
     // Sent unconditionally, even with nothing configured: a reused worker
     // (the shared-core pool) would otherwise keep the previous document's
-    // locale. Normalized here so the tag the core stores is canonical for
+    // locale. The host's half of the rule only: the core applies the authored
+    // `<document lang>` itself, once per document, so a nested one resolves
+    // against its own ancestor rather than against this. Run through the
+    // shared helper all the same, so the tag the core stores is canonical for
     // everything that later negotiates against it.
     await coreWorker.setLocaleData({
         localeData: {
-            locale: normalizeLocaleTag(documentLocale ?? "") || DEFAULT_LOCALE,
+            locale: resolveDocumentLocale(undefined, documentLocale),
             resources: localeResources ?? {},
         },
     });

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -299,15 +299,10 @@ export async function initializeCoreWorker({
     // wrapper. Resolved from the DAST we already parsed rather than asked of
     // the core, so it is available before the first render — a screen reader
     // should not have to wait for evaluation to learn what language it is
-    // reading. The core resolves the same value with the same helper for its
-    // own `document.locale` state variable, from the same two inputs.
-    //
-    // English when neither the document nor the host declared a language.
-    // That is not a guess: it is the language the core computes its prose in
-    // and the chrome renders in for such a document, so the `lang` attribute
-    // reports what the activity is actually rendered in rather than letting
-    // the subtree inherit a claim from the embedding page that nothing else
-    // here honors.
+    // reading. The core resolves the same value from the same two inputs with
+    // the same helper, for its own `document.locale` state variable, so the
+    // attribute always reports the language the content was rendered in —
+    // English, for a document neither the author nor the host declared one for.
     const resolvedLocale = resolveDocumentLocale(
         readDocumentLang(dast),
         documentLocale,

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -266,11 +266,12 @@ export async function initializeCoreWorker({
     await coreWorker.setFlags({ flags });
     // Sent unconditionally, even with nothing configured: a reused worker
     // (the shared-core pool) would otherwise keep the previous document's
-    // locale. The host's half of the rule only: the core applies the authored
-    // `<document lang>` itself, once per document, so a nested one resolves
-    // against its own ancestor rather than against this. Run through the
-    // shared helper all the same, so the tag the core stores is canonical for
-    // everything that later negotiates against it.
+    // locale. Only the host's half of the rule is applied here: the core
+    // applies an authored `<document lang>` per `<document>` it finds, so a
+    // nested one resolves against its own ancestor rather than against this
+    // ambient fallback. It goes through the shared helper all the same, so the
+    // fallback to English is written in one place and the tag the core stores
+    // is canonical for everything that later negotiates against it.
     await coreWorker.setLocaleData({
         localeData: {
             locale: resolveDocumentLocale(undefined, documentLocale),
@@ -298,10 +299,10 @@ export async function initializeCoreWorker({
     // wrapper. Resolved from the DAST we already parsed rather than asked of
     // the core, so it is available before the first render — a screen reader
     // should not have to wait for evaluation to learn what language it is
-    // reading. The core resolves the same value from the same two inputs with
-    // the same helper, for its own `document.locale` state variable, so the
-    // attribute always reports the language the content was rendered in —
-    // English, for a document neither the author nor the host declared one for.
+    // reading. The core reaches the same tag for its own `document.locale`,
+    // running the same helper over the same authored `lang` and the locale
+    // sent above, so the attribute always reports the language the content was
+    // rendered in — English, for a document nobody declared one for.
     const resolvedLocale = resolveDocumentLocale(
         readDocumentLang(dast),
         documentLocale,

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -266,12 +266,13 @@ export async function initializeCoreWorker({
     await coreWorker.setFlags({ flags });
     // Sent unconditionally, even with nothing configured: a reused worker
     // (the shared-core pool) would otherwise keep the previous document's
-    // locale. Only the host's half of the rule is applied here: the core
-    // applies an authored `<document lang>` per `<document>` it finds, so a
-    // nested one resolves against its own ancestor rather than against this
-    // ambient fallback. It goes through the shared helper all the same, so the
-    // fallback to English is written in one place and the tag the core stores
-    // is canonical for everything that later negotiates against it.
+    // locale. Only the host's half of the rule is applied here — an authored
+    // `<document lang>` belongs to the `<document>` carrying it, and the core
+    // applies it there, once per `<document>`, so what it wants from the host
+    // is the ambient preference to fall back on. It goes through the shared
+    // helper all the same, so the fallback to English is written in one place
+    // and the tag the core stores is canonical for everything that later
+    // negotiates against it.
     await coreWorker.setLocaleData({
         localeData: {
             locale: resolveDocumentLocale(undefined, documentLocale),

--- a/packages/doenetml/src/utils/documentLang.test.ts
+++ b/packages/doenetml/src/utils/documentLang.test.ts
@@ -9,21 +9,16 @@ function langOf(doenetML: string) {
 }
 
 /**
- * The content language the core will translate into. Mirrors what
- * `initializeCoreWorker` computes, and must match the `document.locale` state
- * variable the worker derives from the same source — see the "document lang /
- * locale" tests in `@doenet/doenetml-worker-javascript`.
+ * The content language the core will translate into, which is also the tag the
+ * viewer puts in the wrapper's `lang` attribute — one resolution for both, so
+ * the DOM never claims a language the content was not rendered in. Mirrors
+ * what `initializeCoreWorker` computes, and must match the `document.locale`
+ * state variable the worker derives from the same source — see the "document
+ * lang / locale" tests in `@doenet/doenetml-worker-javascript`.
  */
 function effectiveLocale(doenetML: string, documentLocale?: string) {
     return resolveDocumentLocale(langOf(doenetML), documentLocale);
 }
-
-/**
- * The value the viewer puts in the wrapper's `lang` attribute — the same tag
- * the core is handed, so the DOM never claims a language the content was not
- * rendered in.
- */
-const wrapperLang = effectiveLocale;
 
 describe("readDocumentLang", () => {
     it("reads an authored lang", () => {
@@ -63,7 +58,15 @@ describe("readDocumentLang", () => {
 
 describe("effective document locale", () => {
     it("defaults to en", () => {
+        // Which is what the wrapper's `lang` then says. Not a guess about what
+        // the author wrote: English is what the core computes such a
+        // document's prose in and what its chrome renders in, so the attribute
+        // reports the language actually on screen rather than letting the
+        // subtree inherit the embedding page's.
         expect(effectiveLocale(`<p>hello</p>`)).eq("en");
+        expect(effectiveLocale(`<document lang=" "><p>hi</p></document>`)).eq(
+            "en",
+        );
     });
 
     it("uses the host locale when the document declares none", () => {
@@ -89,23 +92,5 @@ describe("effective document locale", () => {
         expect(
             effectiveLocale(`<document lang=" "><p>hi</p></document>`, "de"),
         ).eq("de");
-    });
-});
-
-describe("wrapper lang attribute", () => {
-    it("labels the wrapper whenever a language was declared", () => {
-        expect(wrapperLang(`<document lang="fr"><p>bonjour</p></document>`)).eq(
-            "fr",
-        );
-        expect(wrapperLang(`<p>hola</p>`, "es-MX")).eq("es-MX");
-    });
-
-    it("labels an undeclared document English", () => {
-        // Not a guess about what the author wrote: English is what the core
-        // computes such a document's prose in and what its chrome renders in,
-        // so the attribute reports the language actually on screen rather than
-        // letting the subtree inherit the embedding page's.
-        expect(wrapperLang(`<p>hello</p>`)).eq("en");
-        expect(wrapperLang(`<document lang=" "><p>hi</p></document>`)).eq("en");
     });
 });

--- a/packages/doenetml/src/utils/documentLang.test.ts
+++ b/packages/doenetml/src/utils/documentLang.test.ts
@@ -60,9 +60,9 @@ describe("effective document locale", () => {
     it("defaults to en", () => {
         // And so what the wrapper's `lang` says. Not a guess about what the
         // author wrote: English is what the core computes such a document's
-        // prose in and what its chrome renders in, so the attribute reports
-        // the language actually on screen rather than letting the subtree
-        // inherit the embedding page's.
+        // prose in, so the attribute reports the language the content was
+        // rendered in rather than letting the subtree inherit the embedding
+        // page's.
         expect(effectiveLocale(`<p>hello</p>`)).eq("en");
     });
 

--- a/packages/doenetml/src/utils/documentLang.test.ts
+++ b/packages/doenetml/src/utils/documentLang.test.ts
@@ -58,15 +58,12 @@ describe("readDocumentLang", () => {
 
 describe("effective document locale", () => {
     it("defaults to en", () => {
-        // Which is what the wrapper's `lang` then says. Not a guess about what
-        // the author wrote: English is what the core computes such a
-        // document's prose in and what its chrome renders in, so the attribute
-        // reports the language actually on screen rather than letting the
-        // subtree inherit the embedding page's.
+        // And so what the wrapper's `lang` says. Not a guess about what the
+        // author wrote: English is what the core computes such a document's
+        // prose in and what its chrome renders in, so the attribute reports
+        // the language actually on screen rather than letting the subtree
+        // inherit the embedding page's.
         expect(effectiveLocale(`<p>hello</p>`)).eq("en");
-        expect(effectiveLocale(`<document lang=" "><p>hi</p></document>`)).eq(
-            "en",
-        );
     });
 
     it("uses the host locale when the document declares none", () => {
@@ -92,5 +89,8 @@ describe("effective document locale", () => {
         expect(
             effectiveLocale(`<document lang=" "><p>hi</p></document>`, "de"),
         ).eq("de");
+        expect(effectiveLocale(`<document lang=" "><p>hi</p></document>`)).eq(
+            "en",
+        );
     });
 });

--- a/packages/doenetml/src/utils/documentLang.test.ts
+++ b/packages/doenetml/src/utils/documentLang.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { lezerToDast, normalizeDocumentDast } from "@doenet/parser";
-import { declaredDocumentLocale, resolveDocumentLocale } from "@doenet/i18n";
+import { resolveDocumentLocale } from "@doenet/i18n";
 
 import { readDocumentLang } from "./documentLang";
 
@@ -18,10 +18,12 @@ function effectiveLocale(doenetML: string, documentLocale?: string) {
     return resolveDocumentLocale(langOf(doenetML), documentLocale);
 }
 
-/** The value the viewer puts in the wrapper's `lang` attribute, if any. */
-function wrapperLang(doenetML: string, documentLocale?: string) {
-    return declaredDocumentLocale(langOf(doenetML), documentLocale);
-}
+/**
+ * The value the viewer puts in the wrapper's `lang` attribute — the same tag
+ * the core is handed, so the DOM never claims a language the content was not
+ * rendered in.
+ */
+const wrapperLang = effectiveLocale;
 
 describe("readDocumentLang", () => {
     it("reads an authored lang", () => {
@@ -98,12 +100,12 @@ describe("wrapper lang attribute", () => {
         expect(wrapperLang(`<p>hola</p>`, "es-MX")).eq("es-MX");
     });
 
-    it("is omitted when neither the document nor the host declared one", () => {
-        // The embedding page's `lang` then applies, which is a better guess
-        // than asserting English over a host that said `<html lang="es">`.
-        expect(wrapperLang(`<p>hello</p>`)).eq(undefined);
-        expect(wrapperLang(`<document lang=" "><p>hi</p></document>`)).eq(
-            undefined,
-        );
+    it("labels an undeclared document English", () => {
+        // Not a guess about what the author wrote: English is what the core
+        // computes such a document's prose in and what its chrome renders in,
+        // so the attribute reports the language actually on screen rather than
+        // letting the subtree inherit the embedding page's.
+        expect(wrapperLang(`<p>hello</p>`)).eq("en");
+        expect(wrapperLang(`<document lang=" "><p>hi</p></document>`)).eq("en");
     });
 });

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -35,9 +35,9 @@ on screen, since its computed prose and its chrome are English.
 `resolveUiLocale` applies the chrome's rule — the configured `uiLocale`,
 otherwise the content's language.
 
-All three normalize what they return (`ES-mx` → `es-MX`) and treat a blank tag
-as unset, so a hand-typed `lang` and a hand-configured prop negotiate the same
-way a canonical tag does.
+Both normalize what they return (`ES-mx` → `es-MX`) and treat a blank tag as
+unset, so a hand-typed `lang` and a hand-configured prop negotiate the same way
+a canonical tag does.
 
 A tag they cannot parse is left alone rather than rejected — `en_US`, the POSIX
 spelling, is the usual way a host mis-keys a catalog, and rewriting it would

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -32,12 +32,11 @@ viewer puts it in the `lang` attribute on the rendered wrapper, so the DOM never
 claims a language the content was not rendered in. An undeclared activity is
 labeled `en` — not a guess about what its author wrote, but a report of what is
 on screen, since its computed prose and its chrome are English.
-`resolveUiLocale` applies the chrome's rule — the configured `uiLocale`,
-otherwise the content's language.
 
-Both normalize what they return (`ES-mx` → `es-MX`) and treat a blank tag as
-unset, so a hand-typed `lang` and a hand-configured prop negotiate the same way
-a canonical tag does.
+`resolveUiLocale` applies the chrome's rule — the configured `uiLocale`,
+otherwise the content's language. Both normalize what they return (`ES-mx` →
+`es-MX`) and treat a blank tag as unset, so a hand-typed `lang` and a
+hand-configured prop negotiate the same way a canonical tag does.
 
 A tag they cannot parse is left alone rather than rejected — `en_US`, the POSIX
 spelling, is the usual way a host mis-keys a catalog, and rewriting it would

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -27,12 +27,13 @@ should still say "thick red line" in French.
 fully Spanish without the host configuring anything.
 
 `resolveDocumentLocale` applies that rule and supplies `"en"` when nobody
-declared anything; `declaredDocumentLocale` applies the same rule but returns
-`undefined` in that case. The viewer uses the second for the `lang` attribute
-on the rendered wrapper: an activity whose language nobody stated inherits the
-embedding page's, rather than asserting English over a host that said
-`<html lang="es">`. `resolveUiLocale` applies the chrome's rule — the
-configured `uiLocale`, otherwise the content's language.
+declared anything. One tag, two consumers: the core translates into it, and the
+viewer puts it in the `lang` attribute on the rendered wrapper, so the DOM never
+claims a language the content was not rendered in. An undeclared activity is
+labeled `en` — not a guess about what its author wrote, but a report of what is
+on screen, since its computed prose and its chrome are English.
+`resolveUiLocale` applies the chrome's rule — the configured `uiLocale`,
+otherwise the content's language.
 
 All three normalize what they return (`ES-mx` → `es-MX`) and treat a blank tag
 as unset, so a hand-typed `lang` and a hand-configured prop negotiate the same

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -30,8 +30,8 @@ fully Spanish without the host configuring anything.
 declared anything. One tag, two consumers: the core translates into it, and the
 viewer puts it in the `lang` attribute on the rendered wrapper, so the DOM never
 claims a language the content was not rendered in. An undeclared activity is
-labeled `en` — not a guess about what its author wrote, but a report of what is
-on screen, since its computed prose and its chrome are English.
+labeled `en` — not a guess about what its author wrote, but a report of the
+language the core computed its prose in.
 
 `resolveUiLocale` applies the chrome's rule — the configured `uiLocale`,
 otherwise the content's language. Both normalize what they return (`ES-mx` →

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -9,7 +9,6 @@ export {
 export {
     negotiateLocales,
     normalizeLocaleTag,
-    declaredDocumentLocale,
     resolveDocumentLocale,
     resolveUiLocale,
     type NegotiateLocalesOptions,

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -42,44 +42,27 @@ export function negotiateLocales(
 }
 
 /**
- * The content language somebody actually declared: an authored
- * `<document lang>` if there is one, otherwise the locale the hosting page
- * asked for, normalized. `undefined` when neither said anything.
+ * Apply the document-locale precedence rule: an authored `<document lang>`
+ * beats the locale the hosting page asked for, which beats English. A blank
+ * tag counts as unset, so a hand-typed `lang=" "` falls through to the host's.
  *
  * The author knows what language they wrote the content in; the host only
  * knows what language it would prefer to receive — hence the precedence.
  *
- * Internal to {@link resolveDocumentLocale}, which supplies English for the
- * undeclared case. Nothing outside acts on the difference: English is the
- * language the core computes its prose in and the chrome renders in when
- * nobody declares one, so it is the language such a document is in, and the
- * rendered `lang` attribute says so.
- */
-function declaredDocumentLocale(
-    authoredLang: string | null | undefined,
-    hostLocale: string | null | undefined,
-): string | undefined {
-    const tag = (authoredLang ?? "").trim() || (hostLocale ?? "").trim();
-    if (tag === "") {
-        return undefined;
-    }
-    return normalizeLocaleTag(tag) || undefined;
-}
-
-/**
- * Apply the document-locale precedence rule: an authored `<document lang>`
- * beats the locale the hosting page asked for, which beats English.
- *
  * Shared by the main thread and the worker (whose `document.locale` state
  * variable drives translated content), so the language the viewer reports, the
  * language the core translates into, and the `lang` attribute the viewer
- * renders can never drift apart.
+ * renders can never drift apart. Nothing needs to tell "English" apart from
+ * "nobody said so": English is what the core computes its prose in and what
+ * the chrome renders in when nobody declares a language, so it is the language
+ * such a document is in.
  */
 export function resolveDocumentLocale(
     authoredLang: string | null | undefined,
     hostLocale: string | null | undefined,
 ): string {
-    return declaredDocumentLocale(authoredLang, hostLocale) ?? DEFAULT_LOCALE;
+    const declared = (authoredLang ?? "").trim() || (hostLocale ?? "").trim();
+    return normalizeLocaleTag(declared) || DEFAULT_LOCALE;
 }
 
 /**

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -48,11 +48,14 @@ export function negotiateLocales(
  *
  * The author knows what language they wrote the content in; the host only
  * knows what language it would prefer to receive — hence the precedence.
- * Callers that need a language regardless want {@link resolveDocumentLocale},
- * which supplies English; this one preserves the difference between "English"
- * and "nobody said", which is what the rendered `lang` attribute turns on.
+ *
+ * Internal to {@link resolveDocumentLocale}, which supplies English for the
+ * undeclared case. Nothing outside acts on the difference: English is the
+ * language the core computes its prose in and the chrome renders in when
+ * nobody declares one, so it is the language such a document is in, and the
+ * rendered `lang` attribute says so.
  */
-export function declaredDocumentLocale(
+function declaredDocumentLocale(
     authoredLang: string | null | undefined,
     hostLocale: string | null | undefined,
 ): string | undefined {
@@ -68,8 +71,9 @@ export function declaredDocumentLocale(
  * beats the locale the hosting page asked for, which beats English.
  *
  * Shared by the main thread and the worker (whose `document.locale` state
- * variable drives translated content), so the language the viewer reports and
- * the language the core translates into can never drift apart.
+ * variable drives translated content), so the language the viewer reports, the
+ * language the core translates into, and the `lang` attribute the viewer
+ * renders can never drift apart.
  */
 export function resolveDocumentLocale(
     authoredLang: string | null | undefined,

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -49,13 +49,15 @@ export function negotiateLocales(
  * The author knows what language they wrote the content in; the host only
  * knows what language it would prefer to receive — hence the precedence.
  *
- * Shared by the main thread and the worker (whose `document.locale` state
- * variable drives translated content), so the language the viewer reports, the
- * language the core translates into, and the `lang` attribute the viewer
- * renders can never drift apart. Nothing needs to tell "English" apart from
- * "nobody said so": English is what the core computes its prose in and what
- * the chrome renders in when nobody declares a language, so it is the language
- * such a document is in.
+ * Shared by the main thread and the worker, so the language the core
+ * translates into, the `document.locale` an author reads, and the `lang`
+ * attribute the viewer renders can never drift apart. Nothing needs to tell
+ * "English" apart from "nobody said so": English is what the core computes its
+ * prose in and what the chrome renders in when nobody declares a language, so
+ * it is the language such a document is in.
+ *
+ * @param authoredLang The `lang` on `<document>`, if the author wrote one.
+ * @param hostLocale The `documentLocale` the hosting page asked for, if any.
  */
 export function resolveDocumentLocale(
     authoredLang: string | null | undefined,

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -51,11 +51,13 @@ export function negotiateLocales(
  *
  * Shared by the main thread and the worker, so the language the core
  * translates into, the `document.locale` an author reads, and the `lang`
- * attribute the viewer renders can never drift apart.
+ * attribute the viewer renders all come out of one rule rather than three
+ * copies of it.
  *
- * Nothing needs to tell "English" apart from "nobody said so": English is what
- * the core computes its prose in and what the chrome renders in when nobody
- * declares a language, so it is the language such a document is in.
+ * Nothing needs to tell "English" apart from "nobody said so": English is the
+ * language the core computes an undeclared document's prose in, so it is the
+ * language such a document is in — which is what the viewer's `lang` attribute
+ * reports.
  *
  * @param authoredLang The `lang` on `<document>`, if the author wrote one.
  * @param hostLocale The `documentLocale` the hosting page asked for, if any.

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -51,10 +51,11 @@ export function negotiateLocales(
  *
  * Shared by the main thread and the worker, so the language the core
  * translates into, the `document.locale` an author reads, and the `lang`
- * attribute the viewer renders can never drift apart. Nothing needs to tell
- * "English" apart from "nobody said so": English is what the core computes its
- * prose in and what the chrome renders in when nobody declares a language, so
- * it is the language such a document is in.
+ * attribute the viewer renders can never drift apart.
+ *
+ * Nothing needs to tell "English" apart from "nobody said so": English is what
+ * the core computes its prose in and what the chrome renders in when nobody
+ * declares a language, so it is the language such a document is in.
  *
  * @param authoredLang The `lang` on `<document>`, if the author wrote one.
  * @param hostLocale The `documentLocale` the hosting page asked for, if any.

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-    declaredDocumentLocale,
     negotiateLocales,
     normalizeLocaleTag,
     resolveDocumentLocale,
@@ -55,21 +54,6 @@ describe("resolveDocumentLocale", () => {
     it("normalizes whatever it returns", () => {
         expect(resolveDocumentLocale("ES-mx", undefined)).toBe("es-MX");
         expect(resolveDocumentLocale(undefined, "PT-br")).toBe("pt-BR");
-    });
-});
-
-describe("declaredDocumentLocale", () => {
-    it("follows the same precedence as resolveDocumentLocale", () => {
-        expect(declaredDocumentLocale("fr", "es-MX")).toBe("fr");
-        expect(declaredDocumentLocale(undefined, "ES-mx")).toBe("es-MX");
-    });
-
-    it("is undefined when nobody declared a language", () => {
-        // The distinction `resolveDocumentLocale` erases: the viewer leaves
-        // `lang` off the wrapper here rather than asserting English over
-        // whatever the embedding page declared.
-        expect(declaredDocumentLocale(undefined, undefined)).toBe(undefined);
-        expect(declaredDocumentLocale("  ", null)).toBe(undefined);
     });
 });
 

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -117,11 +117,10 @@ An authored `<document lang="es-MX">` overrides `documentLocale`: the author
 knows what language they wrote in, the host only knows what it would prefer to
 receive.
 
-When a language is declared — by either route — the rendered container carries
-a matching `lang` attribute, so screen readers pronounce the content with the
-right voice and rules. When neither declares one, the container carries no
-`lang` at all and inherits the embedding page's, which is a better guess than
-asserting English over a page that said `<html lang="es">`.
+The rendered container always carries a `lang` attribute naming the language
+the content was rendered in, so screen readers pronounce it with the right
+voice and rules. When neither route declares one that is `en` — the language
+such an activity's computed prose and chrome are in.
 
 Changing `documentLocale` rebuilds the document, since it changes every string
 the core computes; `uiLocale` updates in place.

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -119,8 +119,8 @@ receive.
 
 The rendered container always carries a `lang` attribute naming the language
 the content was rendered in, so screen readers pronounce it with the right
-voice and rules. When neither route declares one that is `en` — the language
-such an activity's computed prose and chrome are in.
+voice and rules. When neither route declares one, that language is `en` — what
+such an activity's computed prose and chrome are written in.
 
 Changing `documentLocale` rebuilds the document, since it changes every string
 the core computes; `uiLocale` updates in place.

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -119,8 +119,8 @@ receive.
 
 The rendered container always carries a `lang` attribute naming the language
 the content was rendered in, so screen readers pronounce it with the right
-voice and rules. When neither route declares one, that language is `en` — what
-such an activity's computed prose and chrome are written in.
+voice and rules. When neither route declares one, that language is `en` — the
+language the core computes such an activity's prose in.
 
 Changing `documentLocale` rebuilds the document, since it changes every string
 the core computes; `uiLocale` updates in place.

--- a/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
@@ -4,9 +4,9 @@ describe("Document language Tests", { tags: ["@group5"] }, function () {
         cy.visit("/");
     });
 
-    function renderDoenetML(doenetML) {
+    function renderDoenetML(doenetML, documentLocale) {
         cy.window().then((win) => {
-            win.postMessage({ doenetML }, "*");
+            win.postMessage({ doenetML, documentLocale }, "*");
         });
     }
 
@@ -43,11 +43,16 @@ describe("Document language Tests", { tags: ["@group5"] }, function () {
         cy.get(".doenet-viewer").should("have.attr", "lang", "en");
     });
 
-    it("treats a blank lang as absent", () => {
-        renderDoenetML(`<document lang="  "><p name="p">hello</p></document>`);
+    it("falls through a blank lang to the host's locale", () => {
+        // A blank `lang` counts as unset all the way to the DOM: the label is
+        // the host's tag, not the empty one the author typed.
+        renderDoenetML(
+            `<document lang="  "><p name="p">hallo</p></document>`,
+            "de",
+        );
 
-        cy.get("#p").should("have.text", "hello");
-        cy.get(".doenet-viewer").should("have.attr", "lang", "en");
+        cy.get("#p").should("have.text", "hallo");
+        cy.get(".doenet-viewer").should("have.attr", "lang", "de");
     });
 
     it("exposes the language in effect as the document's locale property", () => {

--- a/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
@@ -34,9 +34,9 @@ describe("Document language Tests", { tags: ["@group5"] }, function () {
     });
 
     it("labels an undeclared document English", () => {
-        // The language the activity is actually rendered in: its computed
-        // prose and its chrome are English when nobody declared otherwise, so
-        // the container says so rather than inheriting the page's `lang`.
+        // The language the activity is actually rendered in: the core
+        // computes its prose in English when nobody declared otherwise, so the
+        // container says so rather than inheriting the page's `lang`.
         renderDoenetML(`<p name="p">hello</p>`);
 
         cy.get("#p").should("have.text", "hello");

--- a/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/documentLang.cy.js
@@ -33,20 +33,21 @@ describe("Document language Tests", { tags: ["@group5"] }, function () {
         cy.get(".doenet-viewer").should("have.attr", "lang", "es-MX");
     });
 
-    it("leaves the container unlabeled when no language was declared", () => {
-        // Inheriting the embedding page's `lang` beats asserting English over
-        // a host that said `<html lang="es">`.
+    it("labels an undeclared document English", () => {
+        // The language the activity is actually rendered in: its computed
+        // prose and its chrome are English when nobody declared otherwise, so
+        // the container says so rather than inheriting the page's `lang`.
         renderDoenetML(`<p name="p">hello</p>`);
 
         cy.get("#p").should("have.text", "hello");
-        cy.get(".doenet-viewer").should("not.have.attr", "lang");
+        cy.get(".doenet-viewer").should("have.attr", "lang", "en");
     });
 
     it("treats a blank lang as absent", () => {
         renderDoenetML(`<document lang="  "><p name="p">hello</p></document>`);
 
         cy.get("#p").should("have.text", "hello");
-        cy.get(".doenet-viewer").should("not.have.attr", "lang");
+        cy.get(".doenet-viewer").should("have.attr", "lang", "en");
     });
 
     it("exposes the language in effect as the document's locale property", () => {


### PR DESCRIPTION
An activity that declared no language — no `<document lang>`, no `documentLocale` from the host — rendered with no `lang` attribute on the viewer's wrapper, so its subtree inherited the embedding page's language. The stated rationale was that inheriting beats asserting English over a host that said `<html lang="es">`.

That reasoning doesn't hold up:

- **English there was never a guess.** It is the tag the core is handed (`initializeCoreWorker` resolves the host's `documentLocale` and sends `en` when there is none), the language it computes style descriptions in, and — since `uiLocale` defaults to the content's language — the language the chrome renders in. The strings in an undeclared activity really are English.
- **Omitting `lang` doesn't say "unknown".** HTML has no such state; the subtree inherits the nearest ancestor's tag. So the choice was never "assert vs. stay silent", it was "report the tag we actually rendered in" vs. "adopt the page's claim", and the page's claim is not read by any other part of the system — nothing in `doenetml`, `standalone`, or `doenetml-iframe` reads `document.documentElement.lang`.
- **It cost a third state.** The language model is two parameters, `documentLocale` and `uiLocale`, but the DOM layer had a third distinction — declared vs. undeclared — that only this attribute acted on.

## What changed

`resolveDocumentLocale` now feeds the wrapper as well as the core, so the DOM never claims a language the content wasn't rendered in. `declaredDocumentLocale`, whose only purpose was preserving "English" vs. "nobody said" for this attribute, is gone: its body folds into `resolveDocumentLocale`'s two lines and it drops out of `@doenet/i18n`'s exports. `initializeCoreWorker` returns `resolvedDocumentLocale` in place of `declaredDocumentLocale`, and `DocViewer` holds one locale instead of a declared/effective pair.

The last hand-inlined copy of the rule goes with it. The locale `initializeCoreWorker` sends the worker was spelled out as `normalizeLocaleTag(documentLocale ?? "") || DEFAULT_LOCALE`, a few lines above the helper call it duplicates, and now calls the helper too — with no authored language, since an authored `<document lang>` belongs to the `<document>` carrying it and the core applies it there, once per `<document>`; what the host supplies is the ambient preference to fall back on. The fallback to English is written in exactly one place.

## Behavior change

An activity that declares nothing is now labeled `lang="en"` instead of carrying no attribute. The case this could regress: an author who wrote Spanish prose, declared no language, and embedded it in a Spanish page — the wrapper now says `en` where it used to inherit `es`. That activity already gets English style descriptions and an English check-work button, so this makes the DOM consistent with what is on screen rather than introducing a new error, and the fix is the same `lang="es"` that fixes the rest of it.

## Docs

The `@doenet/standalone` and `@doenet/doenetml-iframe` READMEs each documented the old rule in their language section; both now say the container always names the language the content was rendered in — for an undeclared activity, the language the core computes its prose in. (The chrome follows that language by default but need not: a host can set `uiLocale` on its own, so these notes state the prose rather than claiming both.) The `documentLocale` TSDoc on `DoenetViewer` and `DoenetEditor` — what a host reads in editor autocomplete — said leaving it unset left the wrapper unlabeled, and now says both the core and the wrapper use `en`. `@doenet/i18n`'s README loses the `declaredDocumentLocale` half of its explanation, and the "all three" that counted it. The unreleased `i18n-phase-0-infrastructure` changeset promised the old behavior in the same release these notes ship in, so that sentence is dropped — the new changeset owns the undeclared case.

## Tests

- `documentLang.cy.js` — the spec asserting the container is unlabeled now asserts `lang="en"`. The blank-`lang` spec asserted that same fact a second time once undeclared meant `en`, so it now renders a blank `lang` under `documentLocale="de"` and asserts the wrapper falls through to `de` — the fall-through the spec is named for, checked in the DOM rather than only in the unit tests.
- `documentLang.test.ts` — the wrapper-attribute block folds into the effective-locale block: with one resolution behind both, a separate `wrapperLang` helper was the same function under a second name asserting the same facts. Its blank-`lang` case joins the existing blank-`lang` case rather than the defaults-to-English one.
- `negotiate.test.ts` — the `declaredDocumentLocale` block is gone with the export; `resolveDocumentLocale`'s own cases already cover the precedence, the blank-tag fall-through, and the fallback.

All six `DocViewer` Cypress specs pass (47 tests), alongside the two unit suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
