### PR TITLE
Draw the graph grid in the prefigure renderer

### DIFF
--- a/.changeset/prefigure-grid.md
+++ b/.changeset/prefigure-grid.md
@@ -12,8 +12,6 @@ Graph: draw the grid in the prefigure renderer.
 
 - `grid` (or `grid="medium"`) lets PreFigure pick the spacing from the axis limits, so the grid follows the graph's bounds.
 - `grid="dense"` subdivides that spacing to add the finer lines.
-- `grid="dx dy"` places lines on multiples of `dx` and `dy`, as the doenet renderer does.
+- `grid="dx dy"` places lines on multiples of `dx` and `dy`, as the Doenet renderer does.
 
-The grid is drawn behind the axes and the graph's contents, and takes a dimmer stroke in dark mode.
-
-Closes #1242.
+The grid is drawn behind the axes and the graph's contents, and takes a dimmer stroke in dark mode. A spacing so fine that it would fill the graph with thousands of lines is dropped with a warning.

--- a/.changeset/prefigure-grid.md
+++ b/.changeset/prefigure-grid.md
@@ -1,0 +1,19 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Graph: draw the grid in the prefigure renderer.
+
+`grid` was silently ignored when a `<graph>` rendered with `renderer="prefigure"`. It now draws, using PreFigure's own `<grid>` element:
+
+- `grid` (or `grid="medium"`) lets PreFigure pick the spacing from the axis limits, so the grid follows the graph's bounds.
+- `grid="dense"` subdivides that spacing to add the finer lines.
+- `grid="dx dy"` places lines on multiples of `dx` and `dy`, as the doenet renderer does.
+
+The grid is drawn behind the axes and the graph's contents, and takes a dimmer stroke in dark mode.
+
+Closes #1242.

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-live-validation.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-live-validation.test.ts
@@ -46,6 +46,28 @@ describe("Graph prefigure renderer live validation @group4", () => {
                     ),
                     expectText: "regionBetweenCurves",
                 },
+                {
+                    doenetML: prefigureGraph("", { attrs: "grid" }),
+                    expectText: "grid (automatic spacing)",
+                },
+                {
+                    doenetML: prefigureGraph("", { attrs: 'grid="dense"' }),
+                    expectText: "grid (dense)",
+                },
+                {
+                    doenetML: prefigureGraph("", {
+                        attrs: 'grid="pi/4 .5" xMin="-0.5" xMax="2" yMin="-0.5" yMax="1.5"',
+                    }),
+                    expectText: "grid (authored spacings)",
+                },
+                {
+                    // A spacing wider than the x range, so that axis lands
+                    // entirely outside the bounding box.
+                    doenetML: prefigureGraph("", {
+                        attrs: 'grid="7 1" xMin="1" xMax="6"',
+                    }),
+                    expectText: "grid (no x lines in range)",
+                },
             ];
 
             for (const c of cases) {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { getPrefigureXML, getWarnings } from "./graph-prefigure.helpers";
+import { prefigureGraph } from "./graph-prefigure.fixtures";
+
+/**
+ * Extracts the `<grid ... />` element from a generated diagram, or null when
+ * the diagram has none.
+ */
+function gridElement(prefigureXML: string | null): string | null {
+    return prefigureXML?.match(/<grid\b[^>]*\/>/)?.[0] ?? null;
+}
+
+describe("PreFigure grid @group4", () => {
+    it("no grid attribute emits no grid element", async () => {
+        const prefigureXML = await getPrefigureXML(prefigureGraph(""));
+
+        expect(gridElement(prefigureXML)).eq(null);
+    });
+
+    it('grid="none" emits no grid element', async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: 'grid="none"' }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(null);
+    });
+
+    it("bare grid attribute uses PreFigure's own bbox-derived spacing", async () => {
+        // `grid` with no value resolves to "medium", which becomes a bare
+        // <grid />: with no spacings attribute PreFigure derives the spacing
+        // from the bounding box, so the grid follows the axis limits.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: "grid" }),
+        );
+
+        expect(gridElement(prefigureXML)).eq("<grid />");
+    });
+
+    it('grid="medium" matches the bare grid attribute', async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: 'grid="medium"' }),
+        );
+
+        expect(gridElement(prefigureXML)).eq("<grid />");
+    });
+
+    it("the grid is drawn behind the axes and the graph contents", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph('<point name="P">(1,2)</point>', {
+                attrs: "grid",
+            }),
+        );
+
+        expect(prefigureXML).eq(
+            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><grid /><axes axes="all" /><point at="point_0" p="(1,2)" style="circle" size="5" fill="#1f5dff" stroke="#1f5dff" fill-opacity="0.7" stroke-opacity="0.7" thickness="4" /></coordinates><annotations></annotations></diagram>`,
+        );
+    });
+
+    it('grid="dense" subdivides the spacing PreFigure would pick on its own', async () => {
+        // PreFigure's automatic spacing on (-10,10) is 2.5; "dense" adds
+        // JSXGraph's minor-tick lines, one every fifth of that.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: 'grid="dense"' }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(
+            `<grid spacings="((-10,0.5,10),(-10,0.5,10))" />`,
+        );
+    });
+
+    it('grid="dense" follows the axis limits', async () => {
+        // Automatic spacing on a range of 2 is 0.25, so dense lines land every
+        // 0.05; on a range of 200 it is 25, so they land every 5.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", {
+                attrs: 'grid="dense" xMin="-1" xMax="1" yMin="-100" yMax="100"',
+            }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(
+            `<grid spacings="((-1,0.05,1),(-100,5,100))" />`,
+        );
+    });
+
+    it("two numbers set the x and y spacing explicitly", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: 'grid="2 0.5"' }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(
+            `<grid spacings="((-10,2,10),(-10,0.5,10))" />`,
+        );
+    });
+
+    it("explicit spacings run between multiples of the spacing, not the bounds", async () => {
+        // The issue's example: pi/4 by 1/2 on a box whose corners are not
+        // multiples of either spacing.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", {
+                attrs: 'grid="pi/4 .5" xMin="-0.5" xMax="2" yMin="-0.5" yMax="1.5"',
+            }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(
+            `<grid spacings="((0,0.7853981633974483,1.5707963267949),(-0.5,0.5,1.5))" />`,
+        );
+    });
+
+    it("an axis with no multiple of its spacing in range contributes no lines", async () => {
+        // A spacing wider than the axis range: PreFigure needs a triple for
+        // both axes, so the x axis gets a single position below the bbox,
+        // which PreFigure skips.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", {
+                attrs: 'grid="7 1" xMin="1" xMax="6" yMin="-10" yMax="10"',
+            }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(
+            `<grid spacings="((-6,7,-6),(-10,1,10))" />`,
+        );
+    });
+
+    it("dark mode dims the grid stroke", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: 'grid="1 1"' }),
+            "g",
+            { theme: "dark" },
+        );
+
+        expect(gridElement(prefigureXML)).eq(
+            `<grid spacings="((-10,1,10),(-10,1,10))" stroke="#666666" />`,
+        );
+    });
+
+    it("a spacing too fine for the axis limits drops the grid with a warning", async () => {
+        const doenetML = prefigureGraph("", { attrs: 'grid="0.001 1"' });
+
+        expect(gridElement(await getPrefigureXML(doenetML))).eq(null);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((warning) =>
+                warning.message.includes("grid spacing is too fine"),
+            ),
+        ).eq(true);
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
@@ -82,6 +82,32 @@ describe("PreFigure grid @group4", () => {
         );
     });
 
+    it('grid="dense" breaks a spacing tie the way PreFigure does', async () => {
+        // A range of 12.5 normalizes to 1.25, and PreFigure indexes its
+        // spacing table by `round(2 * 1.25)`. Python rounds that tie down to
+        // 2 (spacing 1), where rounding half up would give 3 (spacing 2.5), so
+        // dense lines land every 0.2 rather than every 0.5.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", {
+                attrs: 'grid="dense" xMin="0" xMax="12.5"',
+            }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(
+            `<grid spacings="((0,0.2,12.4),(-10,0.5,10))" />`,
+        );
+    });
+
+    it("an empty axis range emits no grid element", async () => {
+        // PreFigure's automatic spacing never terminates on a range of zero,
+        // so a degenerate graph must not get a bare <grid /> to work from.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: 'grid xMin="3" xMax="3"' }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(null);
+    });
+
     it("two numbers set the x and y spacing explicitly", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph("", { attrs: 'grid="2 0.5"' }),

--- a/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
@@ -158,8 +158,9 @@ describe("PreFigure grid @group4", () => {
 
     it("an axis with no multiple of its spacing in range contributes no lines", async () => {
         // A spacing wider than the axis range: PreFigure needs a triple for
-        // both axes, so the x axis gets a single position below the bbox,
-        // which PreFigure skips.
+        // both axes, so the x axis gets the single position 7 — the first
+        // multiple of the spacing at or above xMin, which lands above xMax —
+        // and PreFigure skips positions outside the bbox.
         const prefigureXML = await getPrefigureXML(
             prefigureGraph("", {
                 attrs: 'grid="7 1" xMin="1" xMax="6" yMin="-10" yMax="10"',
@@ -167,7 +168,7 @@ describe("PreFigure grid @group4", () => {
         );
 
         expect(gridElement(prefigureXML)).eq(
-            `<grid spacings="((-6,7,-6),(-10,1,10))" />`,
+            `<grid spacings="((7,7,7),(-10,1,10))" />`,
         );
     });
 
@@ -181,6 +182,20 @@ describe("PreFigure grid @group4", () => {
         expect(gridElement(prefigureXML)).eq(
             `<grid spacings="((-10,1,10),(-10,1,10))" stroke="#666666" />`,
         );
+    });
+
+    it("a spacing whose grid positions overflow emits no grid element", async () => {
+        // Rounding xMin up to the next multiple of a spacing this large
+        // overflows to Infinity. PreFigure reads `spacings` as a Python
+        // expression, where `Infinity` is not a literal, so the grid has to be
+        // dropped rather than written out.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", {
+                attrs: 'grid="10^308 1" xMin="1.7e308" xMax="1.75e308"',
+            }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(null);
     });
 
     it("a spacing too fine for the axis limits drops the grid with a warning", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/grid.test.ts
@@ -108,6 +108,30 @@ describe("PreFigure grid @group4", () => {
         expect(gridElement(prefigureXML)).eq(null);
     });
 
+    it("an axis range too wide to subtract emits no grid element", async () => {
+        // Both limits are finite, but their difference overflows to Infinity.
+        // PreFigure's automatic spacing divides the width by ten until it drops
+        // to ten, which never terminates on an infinite width, so this must not
+        // reach the spacing computation in either renderer.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", {
+                attrs: 'grid="dense" xMin="-1e308" xMax="1e308"',
+            }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(null);
+    });
+
+    it("a bare grid on an unusable axis range emits no grid element", async () => {
+        // The same guard has to cover "medium": a bare <grid /> would hand the
+        // range to PreFigure's own copy of that loop.
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("", { attrs: 'grid xMin="-1e308" xMax="1e308"' }),
+        );
+
+        expect(gridElement(prefigureXML)).eq(null);
+    });
+
     it("two numbers set the x and y spacing explicitly", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph("", { attrs: 'grid="2 0.5"' }),

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/README.md
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/README.md
@@ -10,6 +10,8 @@ This folder contains graph-to-PreFigure conversion logic extracted from `Graph` 
   - Label rendering concerns: plain text vs latex, `\(...\)` delimiter replacement, line endpoint orientation, and line/vector label positioning helpers.
 - `style.js`
   - Style translation from Doenet selected styles to PreFigure attributes.
+- `grid.js`
+  - The `grid` attribute translated to PreFigure's `<grid>`, including a port of PreFigure's own automatic-spacing algorithm (`find_gridspacing()` in `prefig/core/grid_axes.py`) so `grid="dense"` subdivides the spacing PreFigure would have chosen. Keep it in step with that function.
 - `components/`
   - Component-specific geometry converters (point, line-like, vector, circle, polygon/polyline, angle).
 - `descendant.js`

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/README.md
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/README.md
@@ -4,32 +4,32 @@ This folder contains graph-to-PreFigure conversion logic extracted from `Graph` 
 
 ## Organization
 
-- `common.js`
+- `common.ts`
   - Shared low-level helpers: XML escaping, numeric/point formatting, handle generation, stable sorting.
-- `label.js`
+- `label.ts`
   - Label rendering concerns: plain text vs latex, `\(...\)` delimiter replacement, line endpoint orientation, and line/vector label positioning helpers.
-- `style.js`
+- `style.ts`
   - Style translation from Doenet selected styles to PreFigure attributes.
-- `grid.js`
+- `grid.ts`
   - The `grid` attribute translated to PreFigure's `<grid>`, including a port of PreFigure's own automatic-spacing algorithm (`find_gridspacing()` in `prefig/core/grid_axes.py`) so `grid="dense"` subdivides the spacing PreFigure would have chosen. Keep it in step with that function.
 - `components/`
   - Component-specific geometry converters (point, line-like, vector, circle, polygon/polyline, angle).
-- `descendant.js`
+- `descendant.ts`
   - Dispatcher that routes each graphical descendant to the correct component converter and normalizes warning behavior.
-- `graph.js`
+- `graph.ts`
   - Graph-level XML assembly: dimensions, bbox, axes mode, axis labels, and aggregation of converted descendants.
-- `stateVariable.js`
+- `stateVariable.ts`
   - `returnGraphPrefigureXMLStateVariableDefinition()` to keep state variable wiring out of `Graph.js`.
 
 ## Extension Workflow (Adding a New Component)
 
-1. Add a converter in `components/<component>.js`
+1. Add a converter in `components/<component>.ts`
    - Keep it geometry-focused and pure.
    - Return `null` for invalid/incomplete geometry.
-2. Register it in `descendant.js`
+2. Register it in `descendant.ts`
    - Route by `descendant.componentType`.
    - Reuse centralized warning behavior for unsupported or invalid elements.
-3. Update dependencies in `stateVariable.js`
+3. Update dependencies in `stateVariable.ts`
    - Add a new `*Descendants` dependency with required `variableNames`.
   - If a variable is only present on some inherited subtypes, set `variablesOptional: true` on that dependency config.
    - Include it in the merged `descendants` array.

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
@@ -113,8 +113,9 @@ function axesElementFromLabels({
  * 1. Convert unsupported descendants into warnings.
  * 2. Convert supported descendants to element XML in stable order.
  * 3. Compute bbox/dimensions with defensive defaults.
- * 4. Build axis metadata + labels (including unsupported-position warnings).
- * 5. Assemble and return final `<diagram>` XML + warnings.
+ * 4. Build the grid from the bbox.
+ * 5. Build axis metadata + labels (including unsupported-position warnings).
+ * 6. Assemble and return final `<diagram>` XML + warnings.
  *
  * SVG paints in document order, so the grid is emitted ahead of the axes and
  * the converted descendants to keep it behind everything it sits under.

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
@@ -6,6 +6,7 @@ import {
     warningSubjectForDescendant,
 } from "./common";
 import { labelMarkup } from "./label";
+import { gridElementFromGrid } from "./grid";
 import { convertGraphicalDescendantToPrefigure } from "./descendant";
 import { convertDoenetMLAnnotationsToPreFigureXml } from "./annotations";
 import type {
@@ -114,6 +115,9 @@ function axesElementFromLabels({
  * 3. Compute bbox/dimensions with defensive defaults.
  * 4. Build axis metadata + labels (including unsupported-position warnings).
  * 5. Assemble and return final `<diagram>` XML + warnings.
+ *
+ * SVG paints in document order, so the grid is emitted ahead of the axes and
+ * the converted descendants to keep it behind everything it sits under.
  */
 export function createPrefigureXML({
     dependencyValues,
@@ -231,6 +235,13 @@ export function createPrefigureXML({
     const heightText = formatNumber(dimensionHeight) ?? "425";
     const dimensions = `(${widthText},${heightText})`;
 
+    const gridElement = gridElementFromGrid({
+        grid: dependencyValues.grid,
+        graphBounds,
+        darkMode,
+        diagnostics,
+    });
+
     let axesElement = "";
     const axesMode = axisModeFromVisibility(dependencyValues);
 
@@ -252,7 +263,7 @@ export function createPrefigureXML({
         functionToCurveComponentIdx,
     });
 
-    const xml = `<diagram dimensions="${escapeXml(dimensions)}"><coordinates bbox="${escapeXml(bbox)}">${axesElement}${elements.join("")}</coordinates>${annotationsElement}</diagram>`;
+    const xml = `<diagram dimensions="${escapeXml(dimensions)}"><coordinates bbox="${escapeXml(bbox)}">${gridElement}${axesElement}${elements.join("")}</coordinates>${annotationsElement}</diagram>`;
 
     return { xml, diagnostics };
 }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
@@ -1,4 +1,4 @@
-import { asFiniteNumber, escapeXml, formatNumber, pushWarning } from "./common";
+import { asFiniteNumber, escapeXml, pushWarning } from "./common";
 import type { GraphBounds } from "./types";
 import type { DiagnosticRecord } from "@doenet/utils";
 
@@ -11,8 +11,9 @@ const PREFIGURE_DARK_GRID_COLOR = "#666666";
 
 // PreFigure's own spacing table (`grid_delta` in `prefig/core/grid_axes.py`),
 // reproduced so `grid="dense"` can be expressed as a subdivision of the
-// spacing PreFigure would have chosen on its own.
-const PREFIGURE_GRID_DELTA: Record<number, number> = {
+// spacing PreFigure would have chosen on its own. Typed as possibly undefined
+// so the lookup below has to answer for an index outside the table.
+const PREFIGURE_GRID_DELTA: Record<number, number | undefined> = {
     2: 0.1,
     3: 0.25,
     4: 0.25,
@@ -34,9 +35,11 @@ const PREFIGURE_GRID_DELTA: Record<number, number> = {
     20: 1,
 };
 
-// `grid="dense"` draws JSXGraph's minor tick lines as well as its major ones,
-// which is one line every fifth of the major spacing. PreFigure has no notion
-// of minor ticks, so we subdivide its automatic spacing by the same factor.
+// `grid="dense"` draws JSXGraph's minor tick lines as well as its major ones.
+// JSXGraph puts four minor ticks between major ones — one line every fifth of
+// the major spacing — for every spacing PreFigure's table can produce, so a
+// single factor covers the translation. PreFigure has no notion of minor
+// ticks, so we subdivide its automatic spacing by that same factor.
 const DENSE_SUBDIVISIONS = 5;
 
 // PreFigure emits one `<line>` per grid line, so a spacing far finer than the
@@ -91,19 +94,12 @@ function cleanNumber(value: number): number {
  * step with it so `grid="dense"` is exactly a subdivision of the spacing that
  * `grid="medium"` gets from PreFigure itself.
  *
- * Returns null for a degenerate range (PreFigure would spin forever on a range
- * of zero, since its normalizing loop multiplies the width by ten until it
- * exceeds one).
+ * The caller guarantees a positive, finite range: PreFigure's normalizing loop
+ * multiplies the width by ten until it exceeds one, which never terminates on a
+ * range of zero.
  */
-export function prefigureAutomaticGridSpacing(
-    min: number,
-    max: number,
-): number | null {
-    let distance = Math.abs(max - min);
-
-    if (!Number.isFinite(distance) || distance === 0) {
-        return null;
-    }
+function prefigureAutomaticGridSpacing(min: number, max: number): number {
+    let distance = max - min;
 
     let spacing = 1;
     while (distance > 10) {
@@ -115,10 +111,10 @@ export function prefigureAutomaticGridSpacing(
         spacing /= 10;
     }
 
-    const delta = PREFIGURE_GRID_DELTA[roundHalfToEven(2 * distance)];
-    if (delta === undefined) {
-        return null;
-    }
+    // `distance` now sits in (1, 10], so the index lands in (2, 20] and the
+    // table always answers; the fallback only guards against a rounding
+    // surprise at the ends of that interval.
+    const delta = PREFIGURE_GRID_DELTA[roundHalfToEven(2 * distance)] ?? 1;
 
     return spacing * delta;
 }
@@ -132,7 +128,9 @@ type GridTriple = [number, number, number];
  * so the triple runs from the smallest multiple at or above `min` to the
  * largest at or below `max`.
  *
- * Returns null when the grid would exceed {@link MAX_GRID_LINES_PER_AXIS}.
+ * Returns null when the grid would exceed {@link MAX_GRID_LINES_PER_AXIS}, or
+ * when a spacing small enough to overflow the division leaves no usable
+ * positions at all — both mean the same thing to the caller: too fine to draw.
  */
 function alignedGridTriple(
     min: number,
@@ -155,19 +153,24 @@ function alignedGridTriple(
         return [belowRange, spacing, belowRange];
     }
 
-    if (Math.round((last - first) / spacing) + 1 > MAX_GRID_LINES_PER_AXIS) {
+    // A non-finite endpoint means `min / spacing` overflowed, which leaves the
+    // line count Infinity or NaN; `Number.isFinite` rejects both.
+    const lineCount = Math.round((last - first) / spacing) + 1;
+    if (!Number.isFinite(lineCount) || lineCount > MAX_GRID_LINES_PER_AXIS) {
         return null;
     }
 
     return [first, spacing, last];
 }
 
-function formatGridTriple(triple: GridTriple): string | null {
-    const parts = triple.map(formatNumber);
-    if (parts.some((part) => part === null)) {
-        return null;
-    }
-    return `(${parts.join(",")})`;
+/**
+ * Writes a triple as PreFigure's `(first, spacing, last)` literal.
+ *
+ * Every component is finite by construction — {@link alignedGridTriple} rejects
+ * the triples that are not — so the default number formatting is enough.
+ */
+function formatGridTriple(triple: GridTriple): string {
+    return `(${triple.join(",")})`;
 }
 
 function positiveSpacing(value: unknown): number | null {
@@ -201,34 +204,41 @@ export function gridElementFromGrid({
     darkMode: boolean;
     diagnostics: DiagnosticRecord[];
 }): string {
+    if (grid !== "medium" && grid !== "dense" && !Array.isArray(grid)) {
+        // "none", or anything the grid state variable could not resolve.
+        return "";
+    }
+
+    const [xMin, yMin, xMax, yMax] = graphBounds;
+
+    if (!(xMax > xMin) || !(yMax > yMin)) {
+        // An empty or inverted axis range has no grid to draw, and PreFigure's
+        // automatic spacing loops forever on a range of zero, so a bare
+        // `<grid />` must not reach it. Nothing else about such a graph renders
+        // either, and `doenet-w0062` already covers non-finite bounds, so this
+        // stays quiet.
+        return "";
+    }
+
     const strokeAttr = darkMode ? ` stroke="${PREFIGURE_DARK_GRID_COLOR}"` : "";
 
     if (grid === "medium") {
         return `<grid${strokeAttr} />`;
     }
 
-    const [xMin, yMin, xMax, yMax] = graphBounds;
-
     let xSpacing: number | null;
     let ySpacing: number | null;
 
     if (grid === "dense") {
-        const xAutomatic = prefigureAutomaticGridSpacing(xMin, xMax);
-        const yAutomatic = prefigureAutomaticGridSpacing(yMin, yMax);
-        xSpacing =
-            xAutomatic === null
-                ? null
-                : cleanNumber(xAutomatic / DENSE_SUBDIVISIONS);
-        ySpacing =
-            yAutomatic === null
-                ? null
-                : cleanNumber(yAutomatic / DENSE_SUBDIVISIONS);
-    } else if (Array.isArray(grid)) {
+        xSpacing = cleanNumber(
+            prefigureAutomaticGridSpacing(xMin, xMax) / DENSE_SUBDIVISIONS,
+        );
+        ySpacing = cleanNumber(
+            prefigureAutomaticGridSpacing(yMin, yMax) / DENSE_SUBDIVISIONS,
+        );
+    } else {
         xSpacing = positiveSpacing(grid[0]);
         ySpacing = positiveSpacing(grid[1]);
-    } else {
-        // "none", or anything the grid state variable could not resolve.
-        return "";
     }
 
     if (xSpacing === null || ySpacing === null) {
@@ -243,14 +253,7 @@ export function gridElementFromGrid({
         return "";
     }
 
-    const xText = formatGridTriple(xTriple);
-    const yText = formatGridTriple(yTriple);
-
-    if (xText === null || yText === null) {
-        return "";
-    }
-
-    const spacings = `(${xText},${yText})`;
+    const spacings = `(${formatGridTriple(xTriple)},${formatGridTriple(yTriple)})`;
 
     return `<grid spacings="${escapeXml(spacings)}"${strokeAttr} />`;
 }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
@@ -36,10 +36,12 @@ const PREFIGURE_GRID_DELTA: Record<number, number | undefined> = {
 };
 
 // `grid="dense"` draws JSXGraph's minor tick lines as well as its major ones.
-// JSXGraph puts four minor ticks between major ones — one line every fifth of
-// the major spacing — for every spacing PreFigure's table can produce, so a
-// single factor covers the translation. PreFigure has no notion of minor
-// ticks, so we subdivide its automatic spacing by that same factor.
+// JSXGraph puts four minor ticks between major ones — cutting each major
+// interval into five — except when that interval is 2×10^k, where it puts three
+// (`setMinorTicks` in `doenetml/src/Viewer/renderers/utils/jsxgraph.ts`).
+// PreFigure has no notion of minor ticks, so we subdivide its automatic spacing
+// by the common factor of five rather than tracking which case JSXGraph's own
+// tick interval would have fallen into.
 const DENSE_SUBDIVISIONS = 5;
 
 // PreFigure emits one `<line>` per grid line, so a spacing far finer than the
@@ -78,13 +80,27 @@ function roundHalfToEven(value: number): number {
  *
  * Spacings are built by repeated multiplication and division by ten, so a
  * position that should read as `0.15` arrives as `0.15000000000000002` and
- * would be written into the XML that way. Fifteen significant digits is one
- * short of what a double carries, which is enough to absorb that noise while
- * leaving a genuinely irrational spacing such as `pi/4` intact to within
- * floating-point resolution.
+ * would be written into the XML that way. Fifteen significant digits is the
+ * most a double is guaranteed to carry exactly, so rounding there absorbs that
+ * noise. A genuinely irrational position such as `pi/2` moves by a relative
+ * `1e-15` instead — far below anything the rendered diagram resolves.
  */
 function cleanNumber(value: number): number {
     return Number(value.toPrecision(15));
+}
+
+/**
+ * Reports whether an axis range is one a grid can be drawn on.
+ *
+ * Both ends are finite by the time they reach here, but the width between them
+ * can still be zero, negative, or — for ends near the largest representable
+ * double — infinite. The normalizing loops in
+ * {@link prefigureAutomaticGridSpacing} divide the width by ten until it drops
+ * to ten and multiply it by ten until it passes one, so a width of zero or
+ * infinity spins forever, here and in PreFigure itself.
+ */
+function isDrawableRange(min: number, max: number): boolean {
+    return max > min && Number.isFinite(max - min);
 }
 
 /**
@@ -94,9 +110,8 @@ function cleanNumber(value: number): number {
  * step with it so `grid="dense"` is exactly a subdivision of the spacing that
  * `grid="medium"` gets from PreFigure itself.
  *
- * The caller guarantees a positive, finite range: PreFigure's normalizing loop
- * multiplies the width by ten until it exceeds one, which never terminates on a
- * range of zero.
+ * The caller guarantees a range {@link isDrawableRange} accepts, which is what
+ * makes the two loops below terminate.
  */
 function prefigureAutomaticGridSpacing(min: number, max: number): number {
     let distance = max - min;
@@ -163,16 +178,6 @@ function alignedGridTriple(
     return [first, spacing, last];
 }
 
-/**
- * Writes a triple as PreFigure's `(first, spacing, last)` literal.
- *
- * Every component is finite by construction — {@link alignedGridTriple} rejects
- * the triples that are not — so the default number formatting is enough.
- */
-function formatGridTriple(triple: GridTriple): string {
-    return `(${triple.join(",")})`;
-}
-
 function positiveSpacing(value: unknown): number | null {
     const spacing = asFiniteNumber(value);
     return spacing !== null && spacing > 0 ? spacing : null;
@@ -211,12 +216,12 @@ export function gridElementFromGrid({
 
     const [xMin, yMin, xMax, yMax] = graphBounds;
 
-    if (!(xMax > xMin) || !(yMax > yMin)) {
-        // An empty or inverted axis range has no grid to draw, and PreFigure's
-        // automatic spacing loops forever on a range of zero, so a bare
-        // `<grid />` must not reach it. Nothing else about such a graph renders
-        // either, and `doenet-w0062` already covers non-finite bounds, so this
-        // stays quiet.
+    if (!isDrawableRange(xMin, xMax) || !isDrawableRange(yMin, yMax)) {
+        // An empty, inverted, or overflowing axis range has no grid to draw,
+        // and PreFigure's automatic spacing loops forever on one, so a bare
+        // `<grid />` must not reach it either. Nothing else about such a graph
+        // renders, and `doenet-w0062` already covers non-finite bounds, so
+        // this stays quiet.
         return "";
     }
 
@@ -253,7 +258,10 @@ export function gridElementFromGrid({
         return "";
     }
 
-    const spacings = `(${formatGridTriple(xTriple)},${formatGridTriple(yTriple)})`;
+    // PreFigure reads `spacings` as a pair of `(first, spacing, last)` triples.
+    // Every component is finite by construction — `alignedGridTriple` rejects
+    // the triples that are not — so default number formatting is enough.
+    const spacings = `((${xTriple.join(",")}),(${yTriple.join(",")}))`;
 
     return `<grid spacings="${escapeXml(spacings)}"${strokeAttr} />`;
 }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
@@ -144,8 +144,9 @@ type GridTriple = [number, number, number];
  * largest at or below `max`.
  *
  * Returns null when the grid would exceed {@link MAX_GRID_LINES_PER_AXIS}, or
- * when a spacing small enough to overflow the division leaves no usable
- * positions at all — both mean the same thing to the caller: too fine to draw.
+ * when a spacing so far off the range's own scale that the arithmetic
+ * overflows leaves no usable positions at all — both mean the same thing to
+ * the caller: no grid this spacing can draw.
  */
 function alignedGridTriple(
     min: number,
@@ -159,17 +160,27 @@ function alignedGridTriple(
         spacing * Math.floor(max / spacing + MULTIPLE_TOLERANCE),
     );
 
-    if (last < first) {
-        // No multiple of the spacing falls inside the range. `spacings` has to
-        // carry a triple for both axes, so give this one a single position
-        // below the bbox; PreFigure skips positions outside the bbox and draws
-        // nothing for this axis.
-        const belowRange = cleanNumber(min - spacing);
-        return [belowRange, spacing, belowRange];
+    // Either product overflows to an infinity once the spacing is many orders
+    // of magnitude away from the range — dividing by a subnormal spacing, or
+    // rounding a bound near the largest double up by a spacing of the same
+    // size. PreFigure evaluates `spacings` as a Python expression, where
+    // `Infinity` is not a literal, so neither may reach the XML. Such a
+    // spacing draws no grid either way, so it shares the caller's warning.
+    if (!Number.isFinite(first) || !Number.isFinite(last)) {
+        return null;
     }
 
-    // A non-finite endpoint means `min / spacing` overflowed, which leaves the
-    // line count Infinity or NaN; `Number.isFinite` rejects both.
+    if (last < first) {
+        // No multiple of the spacing falls inside the range, which makes
+        // `first` — the smallest multiple at or above `min` — a position above
+        // `max`. `spacings` has to carry a triple for both axes, so hand
+        // PreFigure that one out-of-range position: it skips positions outside
+        // the bbox and draws nothing for this axis.
+        return [first, spacing, first];
+    }
+
+    // The endpoints are finite, but a subnormal spacing can still send the
+    // quotient — and so the count — to Infinity.
     const lineCount = Math.round((last - first) / spacing) + 1;
     if (!Number.isFinite(lineCount) || lineCount > MAX_GRID_LINES_PER_AXIS) {
         return null;
@@ -178,6 +189,14 @@ function alignedGridTriple(
     return [first, spacing, last];
 }
 
+/**
+ * Reads one authored spacing, or null when it is not a positive finite number.
+ *
+ * The `grid` state variable already falls back to `"none"` for a spacing that
+ * is not positive, so the only values that reach here and fail are the ones it
+ * cannot rule out: an expression that overflows, such as `grid="10^400 1"`,
+ * which arrives as `Infinity`.
+ */
 function positiveSpacing(value: unknown): number | null {
     const spacing = asFiniteNumber(value);
     return spacing !== null && spacing > 0 ? spacing : null;
@@ -247,6 +266,8 @@ export function gridElementFromGrid({
     }
 
     if (xSpacing === null || ySpacing === null) {
+        // An unusable authored spacing. The JSXGraph renderer draws nothing for
+        // one either, so this stays as quiet as that renderer does.
         return "";
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/grid.ts
@@ -1,0 +1,256 @@
+import { asFiniteNumber, escapeXml, formatNumber, pushWarning } from "./common";
+import type { GraphBounds } from "./types";
+import type { DiagnosticRecord } from "@doenet/utils";
+
+// Dark-mode grid stroke. PreFigure defaults grid lines to `#ccc`, which is
+// tuned for a white canvas; on the dark canvas (`#121212`) that reads as a
+// bright lattice sitting on top of the diagram. JSXGraph draws its grid as
+// `#c0c0c0` at half opacity, which composites to roughly this gray over the
+// dark canvas, so the two renderers land in the same place.
+const PREFIGURE_DARK_GRID_COLOR = "#666666";
+
+// PreFigure's own spacing table (`grid_delta` in `prefig/core/grid_axes.py`),
+// reproduced so `grid="dense"` can be expressed as a subdivision of the
+// spacing PreFigure would have chosen on its own.
+const PREFIGURE_GRID_DELTA: Record<number, number> = {
+    2: 0.1,
+    3: 0.25,
+    4: 0.25,
+    5: 0.5,
+    6: 0.5,
+    7: 0.5,
+    8: 0.5,
+    9: 0.5,
+    10: 0.5,
+    11: 0.5,
+    12: 1,
+    13: 1,
+    14: 1,
+    15: 1,
+    16: 1,
+    17: 1,
+    18: 1,
+    19: 1,
+    20: 1,
+};
+
+// `grid="dense"` draws JSXGraph's minor tick lines as well as its major ones,
+// which is one line every fifth of the major spacing. PreFigure has no notion
+// of minor ticks, so we subdivide its automatic spacing by the same factor.
+const DENSE_SUBDIVISIONS = 5;
+
+// PreFigure emits one `<line>` per grid line, so a spacing far finer than the
+// axis range turns into an unusable diagram (and a very slow compile). Past
+// this many lines on either axis we drop the grid and say so.
+const MAX_GRID_LINES_PER_AXIS = 1000;
+
+// PreFigure aligns grid lines to multiples of the spacing using this tolerance
+// (`find_gridspacing`), so a bound that is a multiple only up to floating-point
+// noise still gets its line. We match it.
+const MULTIPLE_TOLERANCE = 1e-10;
+
+/**
+ * Rounds half-way values to the nearest even integer, as Python's `round` does.
+ *
+ * The spacing table above is indexed by `round(2 * distance)` in PreFigure. At
+ * `2 * distance = 2.5` Python picks 2 where a round-half-up would pick 3, and
+ * those two entries disagree (0.1 vs 0.25), so the tie-breaking rule is part of
+ * the spacing PreFigure actually chooses.
+ */
+function roundHalfToEven(value: number): number {
+    const lower = Math.floor(value);
+    const fraction = value - lower;
+
+    if (fraction > 0.5) {
+        return lower + 1;
+    }
+    if (fraction < 0.5) {
+        return lower;
+    }
+    return lower % 2 === 0 ? lower : lower + 1;
+}
+
+/**
+ * Trims floating-point noise from a computed coordinate.
+ *
+ * Spacings are built by repeated multiplication and division by ten, so a
+ * position that should read as `0.15` arrives as `0.15000000000000002` and
+ * would be written into the XML that way. Fifteen significant digits is one
+ * short of what a double carries, which is enough to absorb that noise while
+ * leaving a genuinely irrational spacing such as `pi/4` intact to within
+ * floating-point resolution.
+ */
+function cleanNumber(value: number): number {
+    return Number(value.toPrecision(15));
+}
+
+/**
+ * Reproduces PreFigure's automatic grid spacing for one axis range.
+ *
+ * This is a port of `find_gridspacing()` in `prefig/core/grid_axes.py`, kept in
+ * step with it so `grid="dense"` is exactly a subdivision of the spacing that
+ * `grid="medium"` gets from PreFigure itself.
+ *
+ * Returns null for a degenerate range (PreFigure would spin forever on a range
+ * of zero, since its normalizing loop multiplies the width by ten until it
+ * exceeds one).
+ */
+export function prefigureAutomaticGridSpacing(
+    min: number,
+    max: number,
+): number | null {
+    let distance = Math.abs(max - min);
+
+    if (!Number.isFinite(distance) || distance === 0) {
+        return null;
+    }
+
+    let spacing = 1;
+    while (distance > 10) {
+        distance /= 10;
+        spacing *= 10;
+    }
+    while (distance <= 1) {
+        distance *= 10;
+        spacing /= 10;
+    }
+
+    const delta = PREFIGURE_GRID_DELTA[roundHalfToEven(2 * distance)];
+    if (delta === undefined) {
+        return null;
+    }
+
+    return spacing * delta;
+}
+
+type GridTriple = [number, number, number];
+
+/**
+ * Turns a spacing into the `(first, spacing, last)` triple PreFigure wants.
+ *
+ * Doenet places grid lines at multiples of the spacing measured from the axes,
+ * so the triple runs from the smallest multiple at or above `min` to the
+ * largest at or below `max`.
+ *
+ * Returns null when the grid would exceed {@link MAX_GRID_LINES_PER_AXIS}.
+ */
+function alignedGridTriple(
+    min: number,
+    max: number,
+    spacing: number,
+): GridTriple | null {
+    const first = cleanNumber(
+        spacing * Math.ceil(min / spacing - MULTIPLE_TOLERANCE),
+    );
+    const last = cleanNumber(
+        spacing * Math.floor(max / spacing + MULTIPLE_TOLERANCE),
+    );
+
+    if (last < first) {
+        // No multiple of the spacing falls inside the range. `spacings` has to
+        // carry a triple for both axes, so give this one a single position
+        // below the bbox; PreFigure skips positions outside the bbox and draws
+        // nothing for this axis.
+        const belowRange = cleanNumber(min - spacing);
+        return [belowRange, spacing, belowRange];
+    }
+
+    if (Math.round((last - first) / spacing) + 1 > MAX_GRID_LINES_PER_AXIS) {
+        return null;
+    }
+
+    return [first, spacing, last];
+}
+
+function formatGridTriple(triple: GridTriple): string | null {
+    const parts = triple.map(formatNumber);
+    if (parts.some((part) => part === null)) {
+        return null;
+    }
+    return `(${parts.join(",")})`;
+}
+
+function positiveSpacing(value: unknown): number | null {
+    const spacing = asFiniteNumber(value);
+    return spacing !== null && spacing > 0 ? spacing : null;
+}
+
+/**
+ * Builds the `<grid>` element for a graph, or an empty string for no grid.
+ *
+ * The three forms of Doenet's `grid` attribute map onto PreFigure like this:
+ *
+ * - `"medium"` — a bare `<grid />`. With no `spacings`, `hspacing`, or
+ *   `vspacing`, PreFigure derives the spacing from the bounding box itself,
+ *   which is what keeps the grid adapting as the graph bounds change. This is
+ *   the closest PreFigure has to the JSXGraph grid that re-scales on zoom.
+ * - `"dense"` — that same automatic spacing, subdivided
+ *   {@link DENSE_SUBDIVISIONS} ways, written out explicitly. PreFigure has no
+ *   automatic form for it, so we compute the spacing with its own algorithm and
+ *   hand back the result as `spacings`.
+ * - `[dx, dy]` — the authored spacings, aligned to multiples of `dx` and `dy`.
+ */
+export function gridElementFromGrid({
+    grid,
+    graphBounds,
+    darkMode,
+    diagnostics,
+}: {
+    grid: unknown;
+    graphBounds: GraphBounds;
+    darkMode: boolean;
+    diagnostics: DiagnosticRecord[];
+}): string {
+    const strokeAttr = darkMode ? ` stroke="${PREFIGURE_DARK_GRID_COLOR}"` : "";
+
+    if (grid === "medium") {
+        return `<grid${strokeAttr} />`;
+    }
+
+    const [xMin, yMin, xMax, yMax] = graphBounds;
+
+    let xSpacing: number | null;
+    let ySpacing: number | null;
+
+    if (grid === "dense") {
+        const xAutomatic = prefigureAutomaticGridSpacing(xMin, xMax);
+        const yAutomatic = prefigureAutomaticGridSpacing(yMin, yMax);
+        xSpacing =
+            xAutomatic === null
+                ? null
+                : cleanNumber(xAutomatic / DENSE_SUBDIVISIONS);
+        ySpacing =
+            yAutomatic === null
+                ? null
+                : cleanNumber(yAutomatic / DENSE_SUBDIVISIONS);
+    } else if (Array.isArray(grid)) {
+        xSpacing = positiveSpacing(grid[0]);
+        ySpacing = positiveSpacing(grid[1]);
+    } else {
+        // "none", or anything the grid state variable could not resolve.
+        return "";
+    }
+
+    if (xSpacing === null || ySpacing === null) {
+        return "";
+    }
+
+    const xTriple = alignedGridTriple(xMin, xMax, xSpacing);
+    const yTriple = alignedGridTriple(yMin, yMax, ySpacing);
+
+    if (xTriple === null || yTriple === null) {
+        pushWarning({ diagnostics, code: "doenet-w0118" });
+        return "";
+    }
+
+    const xText = formatGridTriple(xTriple);
+    const yText = formatGridTriple(yTriple);
+
+    if (xText === null || yText === null) {
+        return "";
+    }
+
+    const spacings = `(${xText},${yText})`;
+
+    return `<grid spacings="${escapeXml(spacings)}"${strokeAttr} />`;
+}

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -228,6 +228,10 @@ function prefigureBaseDependencies() {
             dependencyType: "stateVariable",
             variableName: "aspectRatio",
         },
+        grid: {
+            dependencyType: "stateVariable",
+            variableName: "grid",
+        },
         displayXAxis: {
             dependencyType: "stateVariable",
             variableName: "displayXAxis",

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
@@ -146,6 +146,8 @@ export interface GraphDependencyValues extends Record<string, unknown> {
     yMax?: unknown;
     width?: { size?: unknown } | null;
     aspectRatio?: unknown;
+    /** `"none"`, `"medium"`, `"dense"`, or `[dx, dy]`. */
+    grid?: unknown;
     displayXAxis?: unknown;
     displayYAxis?: unknown;
     xLabel?: unknown;

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -210,5 +210,6 @@
     "doenet-w0114": "schema-element-not-allowed-inside",
     "doenet-w0115": "schema-attribute-unrecognized",
     "doenet-w0116": "schema-attribute-value-not-allowed",
-    "doenet-w0117": "matches-pattern-parameter-not-in-pattern"
+    "doenet-w0117": "matches-pattern-parameter-not-in-pattern",
+    "doenet-w0118": "prefigure-grid-spacing-too-fine"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -344,7 +344,7 @@ prefigure-invalid-width = `<graph>`: invalid width for prefigure conversion; usi
 prefigure-invalid-aspect-ratio = `<graph>`: invalid aspectRatio for prefigure conversion; using default aspect ratio 1.
 
 # Translators: grid is an attribute name and stays in English.
-prefigure-grid-spacing-too-fine = `<graph>`: the grid spacing is too fine for the axis limits to draw in the prefigure renderer; grid omitted.
+prefigure-grid-spacing-too-fine = `<graph>`: the grid spacing is too fine for the axis limits; the grid is omitted in the prefigure renderer.
 
 prefigure-annotations-not-rendered = `<graph>`: annotations will not be rendered when not using the PreFigure renderer.
 

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -343,7 +343,9 @@ prefigure-invalid-width = `<graph>`: invalid width for prefigure conversion; usi
 
 prefigure-invalid-aspect-ratio = `<graph>`: invalid aspectRatio for prefigure conversion; using default aspect ratio 1.
 
-# Translators: grid is an attribute name and stays in English.
+# Translators: the renderer's name, prefigure, stays in English. "grid" here is
+# the coordinate grid itself rather than the attribute that asks for one, so it
+# is prose and is translated.
 prefigure-grid-spacing-too-fine = `<graph>`: the grid spacing is too fine for the axis limits; the grid is omitted in the prefigure renderer.
 
 prefigure-annotations-not-rendered = `<graph>`: annotations will not be rendered when not using the PreFigure renderer.

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -343,6 +343,9 @@ prefigure-invalid-width = `<graph>`: invalid width for prefigure conversion; usi
 
 prefigure-invalid-aspect-ratio = `<graph>`: invalid aspectRatio for prefigure conversion; using default aspect ratio 1.
 
+# Translators: grid is an attribute name and stays in English.
+prefigure-grid-spacing-too-fine = `<graph>`: the grid spacing is too fine for the axis limits to draw in the prefigure renderer; grid omitted.
+
 prefigure-annotations-not-rendered = `<graph>`: annotations will not be rendered when not using the PreFigure renderer.
 
 multiple-annotations-children = Multiple `<annotations>` children found in `<graph>`; all but the last one are ignored.

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -284,6 +284,8 @@ prefigure-invalid-width = `<graph>`: el ancho no es válido para la conversión 
 
 prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio no es válido para la conversión a prefigure; se usa la relación de aspecto predeterminada 1.
 
+prefigure-grid-spacing-too-fine = `<graph>`: el espaciado de la cuadrícula es demasiado fino para los límites de los ejes; se omite la cuadrícula en el renderizador prefigure.
+
 prefigure-annotations-not-rendered = `<graph>`: las anotaciones no se representan si no se usa el renderizador PreFigure.
 
 multiple-annotations-children = Se encontraron varios hijos `<annotations>` en `<graph>`; se ignoran todos menos el último.

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -202,6 +202,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0115": "schema-attribute-unrecognized",
     "doenet-w0116": "schema-attribute-value-not-allowed",
     "doenet-w0117": "matches-pattern-parameter-not-in-pattern",
+    "doenet-w0118": "prefigure-grid-spacing-too-fine",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -376,6 +376,7 @@ export type MessageKey =
     | "prefigure-invalid-axis-bounds"
     | "prefigure-invalid-width"
     | "prefigure-invalid-aspect-ratio"
+    | "prefigure-grid-spacing-too-fine"
     | "prefigure-annotations-not-rendered"
     | "multiple-annotations-children"
     | "copy-unrecognized-component-type"
@@ -936,6 +937,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "prefigure-invalid-axis-bounds",
     "prefigure-invalid-width",
     "prefigure-invalid-aspect-ratio",
+    "prefigure-grid-spacing-too-fine",
     "prefigure-annotations-not-rendered",
     "multiple-annotations-children",
     "copy-unrecognized-component-type",


### PR DESCRIPTION
Closes #1242.

The `grid` attribute was silently dropped when a `<graph>` rendered with `renderer="prefigure"` — nothing in the conversion pipeline read it, so the diagram came back with no grid lines. This translates it to PreFigure's own `<grid>` element, without touching the SVG PreFigure produces.

## Does PreFigure have an adaptive grid?

Yes. `<grid>` with no `spacings`, `hspacing`, or `vspacing` derives its spacing from the diagram's bounding box (`find_gridspacing()` in `prefig/core/grid_axes.py`). Doenet regenerates the diagram XML whenever `xMin`/`xMax`/`yMin`/`yMax` change, so that spacing re-derives with the bounds. The default grid therefore needs no computation on our side — a bare `<grid />` does it. Spacings are only computed for the cases PreFigure has no automatic form for.

## Mapping

| Doenet `grid` | PreFigure emitted |
| --- | --- |
| absent / `"none"` | nothing |
| `grid` / `"medium"` | `<grid />` — PreFigure's own bbox-derived spacing |
| `"dense"` | `<grid spacings="((x0,dx,x1),(y0,dy,y1))" />`, that same automatic spacing subdivided 5 ways |
| `"dx dy"` | `<grid spacings="…" />` on multiples of `dx` and `dy` |

`dense` has no automatic form in PreFigure, so `find_gridspacing()` is ported to `utils/prefigure/grid.ts` — including Python's banker's rounding on the spacing-table index, which changes the result at one table entry. Dense is then exactly a 5× subdivision of medium: on the default box, medium draws 9 lines per axis and dense draws 41 = 5×(9−1)+1, confirmed against the live build service. Five is what JSXGraph's `grid="dense"` amounts to, since it turns minor ticks into grid lines: `setMinorTicks()` puts four minor ticks in each major interval, dropping to three where that interval is 2×10^k. PreFigure has no notion of minor ticks, so we subdivide by the common factor of five rather than tracking which case JSXGraph's own tick interval fell into.

Explicit `"dx dy"` runs between multiples of the spacing rather than between the bounds, as the issue describes: for the issue's `grid="pi/4 .5"` on `(-0.5,-0.5,2,1.5)` that is `spacings="((0,0.7853981633974483,1.5707963267949),(-0.5,0.5,1.5))"`, which renders 8 lines.

## Details

- **Paint order.** `<grid>` is emitted ahead of `<axes>` and the converted descendants, so SVG document order keeps it behind everything it sits under.
- **Empty axis.** `spacings` requires a triple for both axes, but a spacing wider than an axis's range has no multiple inside it. That axis gets the first multiple at or above its lower bound, which in that case lands above its upper bound; PreFigure skips positions outside the bbox — otherwise `find_linear_positions()` gets a negative count and raises.
- **Unusable bounds.** A graph gets no grid at all, in any mode, when an axis range is empty or inverted, and also when its two limits are each finite but far enough apart that their difference overflows to infinity. PreFigure's automatic spacing terminates on neither: its normalizing loops divide the width by ten until it drops to ten and multiply it by ten until it passes one. So a bare `<grid />` must not reach it, and the ported spacing must not be asked for it. Nothing else about such a graph renders either, so this stays quiet.
- **Dark mode.** PreFigure defaults grid lines to `#ccc`, which glares against the `#121212` canvas. Dark mode gets `#666666`, roughly where JSXGraph's half-opacity `#c0c0c0` composites. PreFigure reads `stroke` off `<grid>` onto the enclosing `<g>`, and the lines it emits carry no stroke of their own, so it takes effect.
- **New warning `doenet-w0118`.** A spacing fine enough to exceed 1000 lines on an axis drops the grid rather than pushing tens of thousands of elements through the WASM compiler. The same warning covers a spacing whose alignment arithmetic overflows in either direction — PreFigure evaluates `spacings` as a Python expression, where `Infinity` is not a literal, so an infinite position must never be written out. English and Spanish catalogs both carry the message.

## Testing

- 17 new unit tests in `src/test/prefigure/grid.test.ts` covering each `grid` form, paint order, the spacing tie-break, the empty-axis, degenerate-bounds and overflowing-range cases, dark mode, and the too-fine warning.
- All 180 prefigure worker tests pass.
- Four grid cases added to the live-validation suite; run green against `prefigure.doenet.org/build` with `RUN_LIVE_PREFIGURE_VALIDATION=1`.

## Not in scope

Two other attributes in the issue's snippet remain unsupported by the prefigure renderer and are unchanged here: `xTickScaleFactor` (PreFigure has `h-pi-format`, but no general tick scaling) and `displayXAxisTicks` / `displayXAxisTickLabels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
