### PR TITLE
Let updateValue set a whole-array property such as a vector's tail

### DIFF
--- a/.changeset/updatevalue-whole-array-property.md
+++ b/.changeset/updatevalue-whole-array-property.md
@@ -8,6 +8,8 @@
 
 Targeting one of these did nothing before: `<updateValue target="$v.tail" newValue="(7,8)" />` left the vector where it was, and the only way through was to update `tail.x` and `tail.y` separately from a `<triggerSet>`. The new value's components are now spread across the property's entries, so a single `<updateValue>` moves the tail, head, or displacement.
 
+Setting a property this way makes the same change as dragging a point that extends it — `<point extend="$v.tail" />` — rather than the same change as dragging the vector's own tail handle, which additionally holds the head in place.
+
 The same applies to other one-dimensional coordinate properties, including a `<point>`'s `xs` and a `<circle>`'s `center`. Properties holding a list of points, such as a `<polygon>`'s `vertices`, are unchanged.
 
 Closes #1529.

--- a/.changeset/updatevalue-whole-array-property.md
+++ b/.changeset/updatevalue-whole-array-property.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+`<updateValue>` can now set a property that holds a whole list of coordinates, such as a vector's `tail`, `head`, or `displacement`.
+
+Targeting one of these did nothing before: `<updateValue target="$v.tail" newValue="(7,8)" />` left the vector where it was, and the only way through was to update `tail.x` and `tail.y` separately from a `<triggerSet>`. The new value's components are now spread across the property's entries, so a single `<updateValue>` moves the tail, head, or displacement — matching what dragging the corresponding handle in a graph does.
+
+The same applies to other one-dimensional coordinate properties, including a `<point>`'s `xs` and a `<circle>`'s `center`. Properties holding a list of points, such as a `<polygon>`'s `vertices`, are unchanged.
+
+Closes #1529.

--- a/.changeset/updatevalue-whole-array-property.md
+++ b/.changeset/updatevalue-whole-array-property.md
@@ -6,7 +6,7 @@
 
 `<updateValue>` can now set a property that holds a whole list of coordinates, such as a vector's `tail`, `head`, or `displacement`.
 
-Targeting one of these did nothing before: `<updateValue target="$v.tail" newValue="(7,8)" />` left the vector where it was, and the only way through was to update `tail.x` and `tail.y` separately from a `<triggerSet>`. The new value's components are now spread across the property's entries, so a single `<updateValue>` moves the tail, head, or displacement — matching what dragging the corresponding handle in a graph does.
+Targeting one of these did nothing before: `<updateValue target="$v.tail" newValue="(7,8)" />` left the vector where it was, and the only way through was to update `tail.x` and `tail.y` separately from a `<triggerSet>`. The new value's components are now spread across the property's entries, so a single `<updateValue>` moves the tail, head, or displacement.
 
 The same applies to other one-dimensional coordinate properties, including a `<point>`'s `xs` and a `<circle>`'s `center`. Properties holding a list of points, such as a `<polygon>`'s `vertices`, are unchanged.
 

--- a/packages/docs-nextra/pages/reference/updateValue.mdx
+++ b/packages/docs-nextra/pages/reference/updateValue.mdx
@@ -60,6 +60,28 @@ An `<updateValue>{:dn}` is used to change the value of a `<number>{:dn}` based o
 
 
 
+---
+
+### Example: Move the tail of a `<vector>{:dn}`
+
+
+```doenet-editor-horiz
+<graph size="small">
+  <shortDescription>A graph of a vector</shortDescription>
+  <vector name="v" tail="(1,1)" head="(4,3)"/>
+</graph>
+
+<updateValue target="$v.tail" newValue="(-3,-2)">
+  <label>Move tail</label>
+</updateValue>
+```
+
+
+
+An `<updateValue>{:dn}` can also set a property that holds a whole list of coordinates, such as a vector's `tail`. The coordinates of `newValue` are distributed across the property, so a single `<updateValue>{:dn}` moves the whole tail at once.
+
+
+
 ## Attribute Examples
 
 ### Attribute Example: target

--- a/packages/docs-nextra/pages/reference/updateValue.mdx
+++ b/packages/docs-nextra/pages/reference/updateValue.mdx
@@ -78,7 +78,7 @@ An `<updateValue>{:dn}` is used to change the value of a `<number>{:dn}` based o
 
 
 
-An `<updateValue>{:dn}` can also set a property that holds a whole list of coordinates, such as a vector's `tail`. The coordinates of `newValue` are distributed across the property, so a single `<updateValue>{:dn}` moves the whole tail at once.
+An `<updateValue>{:dn}` is used to set the `tail` property of a `<vector>{:dn}`, which holds a whole list of coordinates. The coordinates of `newValue` are distributed across the property, so a single `<updateValue>{:dn}` moves the tail while leaving the head in place. Properties such as a `<vector>{:dn}`'s `head`, a `<point>{:dn}`'s `xs`, and a `<circle>{:dn}`'s `center` can be set the same way.
 
 
 

--- a/packages/docs-nextra/pages/reference/updateValue.mdx
+++ b/packages/docs-nextra/pages/reference/updateValue.mdx
@@ -78,7 +78,7 @@ An `<updateValue>{:dn}` is used to change the value of a `<number>{:dn}` based o
 
 
 
-An `<updateValue>{:dn}` is used to set the `tail` property of a `<vector>{:dn}`, which holds a whole list of coordinates. The coordinates of `newValue` are distributed across the property, so a single `<updateValue>{:dn}` moves the tail while leaving the head in place. Properties such as a `<vector>{:dn}`'s `head`, a `<point>{:dn}`'s `xs`, and a `<circle>{:dn}`'s `center` can be set the same way.
+An `<updateValue>{:dn}` is used to set the `tail` property of a `<vector>{:dn}`, which holds a whole list of coordinates: the coordinates of `newValue` are distributed across the property, so one `<updateValue>{:dn}` moves the entire tail. Properties such as a `<vector>{:dn}`'s `head`, a `<point>{:dn}`'s `xs`, and a `<circle>{:dn}`'s `center` can be set the same way.
 
 
 

--- a/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
@@ -589,10 +589,22 @@ export class EssentialValueWriter {
                           component,
                       );
 
-            if (stateVarObj.isArray && desiredValue instanceof me.class) {
-                desiredValue = spreadMathOverWholeArray(
-                    inverseDefinitionArgs.arraySize,
+            // An instruction targeting a whole array — e.g.
+            // `<updateValue target="$v.tail" newValue="(7,8)" />` — carries a
+            // single math expression rather than one value per array key, so
+            // spread its components over the keys. Only one-dimensional arrays
+            // qualify: there, component `ind` of the expression is the value
+            // for array key `ind`.
+            if (
+                stateVarObj.isArray &&
+                stateVarObj.numDimensions === 1 &&
+                desiredValue instanceof me.class
+            ) {
+                desiredValue = spreadMathOverArrayKeys(
                     desiredValue,
+                    stateVarObj.getAllArrayKeys(
+                        inverseDefinitionArgs.arraySize,
+                    ),
                 );
             }
 
@@ -1496,27 +1508,6 @@ function spreadMathOverArrayKeys(
         }
     }
     return desiredValuesForArray;
-}
-
-/**
- * Spread a math expression across every array key of an array state variable
- * of size `arraySize`. Reached when an update instruction targets a whole
- * array — e.g. `<updateValue target="$v.tail" newValue="(7,8)" />` — so the
- * new value arrives as a single expression rather than one entry per array
- * key.
- *
- * Multidimensional arrays have no unambiguous component-to-key mapping, so
- * their value is passed through untouched.
- */
-function spreadMathOverWholeArray(arraySize: number[], value: any) {
-    if (arraySize.length !== 1) {
-        return value;
-    }
-
-    const arrayKeys = Array.from({ length: arraySize[0] }, (_, ind) =>
-        String(ind),
-    );
-    return spreadMathOverArrayKeys(value, arrayKeys);
 }
 
 /**

--- a/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
@@ -555,11 +555,9 @@ export class EssentialValueWriter {
             let arrayKeys: string[] = inverseDefinitionArgs.arrayKeys;
             let desiredValuesForArray: Record<string, any> = {};
             if (arrayKeys.length === 1) {
-                if ("value" in instruction) {
-                    desiredValuesForArray[arrayKeys[0]] = instruction.value;
-                } else if ("valueOfStateVariable" in instruction) {
+                if (instructionCarriesDesiredValue(instruction)) {
                     desiredValuesForArray[arrayKeys[0]] =
-                        await this._resolveValueOfStateVariable(
+                        await this._desiredValueFromInstruction(
                             instruction,
                             component,
                         );
@@ -577,24 +575,19 @@ export class EssentialValueWriter {
             inverseDefinitionArgs.desiredStateVariableValues = {
                 [arrayStateVariable]: desiredValuesForArray,
             };
-        } else if (
-            "value" in instruction ||
-            "valueOfStateVariable" in instruction
-        ) {
-            let desiredValue =
-                "value" in instruction
-                    ? instruction.value
-                    : await this._resolveValueOfStateVariable(
-                          instruction,
-                          component,
-                      );
+        } else if (instructionCarriesDesiredValue(instruction)) {
+            let desiredValue = await this._desiredValueFromInstruction(
+                instruction,
+                component,
+            );
 
             // An instruction targeting a whole array — e.g.
-            // `<updateValue target="$v.tail" newValue="(7,8)" />` — carries a
-            // single math expression rather than one value per array key, so
-            // spread its components over the keys. Only one-dimensional arrays
-            // qualify: there, component `ind` of the expression is the value
-            // for array key `ind`.
+            // `<updateValue target="$v.tail" newValue="(7,8)" />` — carries one
+            // math expression for the entire array, while the inverse
+            // definition expects a value per array key. A one-dimensional
+            // array maps the two unambiguously (component `ind` of the
+            // expression belongs to array key `ind`), so spread the expression
+            // over the keys; a multidimensional array is passed through whole.
             if (
                 stateVarObj.isArray &&
                 stateVarObj.numDimensions === 1 &&
@@ -1454,6 +1447,20 @@ export class EssentialValueWriter {
     }
 
     /**
+     * The value an update instruction asks for, whether it carries the value
+     * inline as `value` or by reference as `valueOfStateVariable`. Guard the
+     * call with `instructionCarriesDesiredValue`.
+     */
+    async _desiredValueFromInstruction(
+        instruction: any,
+        component: any,
+    ): Promise<any> {
+        return "value" in instruction
+            ? instruction.value
+            : await this._resolveValueOfStateVariable(instruction, component);
+    }
+
+    /**
      * Forward an inverse-definition recursion: invoke
      * `requestComponentChanges` with the prepared `inst` instruction,
      * propagating `treatAsInitialChange` from `newInstruction` and threading
@@ -1480,11 +1487,20 @@ export class EssentialValueWriter {
 }
 
 /**
+ * Whether an update instruction names a value to change to, which it does
+ * either inline (`value`) or by reference (`valueOfStateVariable`).
+ */
+function instructionCarriesDesiredValue(instruction: Record<string, any>) {
+    return "value" in instruction || "valueOfStateVariable" in instruction;
+}
+
+/**
  * Distribute the math expression `value` over `arrayKeys`, producing the
  * array-key-keyed object an array state variable's inverse definition expects.
  *
- * A single key takes the expression whole; otherwise each key gets the
- * corresponding component of the expression.
+ * A single key takes the expression whole, so that a size-one array and its
+ * lone entry accept the same value; otherwise each key gets the corresponding
+ * component of the expression.
  */
 function spreadMathOverArrayKeys(
     value: any,

--- a/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
@@ -591,16 +591,28 @@ export class EssentialValueWriter {
                 [arrayStateVariable]: desiredValuesForArray,
             };
         } else {
+            let desiredValue;
+            let haveDesiredValue = true;
             if ("value" in instruction) {
-                inverseDefinitionArgs.desiredStateVariableValues = {
-                    [stateVariable]: instruction.value,
-                };
+                desiredValue = instruction.value;
             } else if ("valueOfStateVariable" in instruction) {
+                desiredValue = await this._resolveValueOfStateVariable(
+                    instruction,
+                    component,
+                );
+            } else {
+                haveDesiredValue = false;
+            }
+
+            if (haveDesiredValue) {
+                if (stateVarObj.isArray && desiredValue instanceof me.class) {
+                    desiredValue = await spreadMathOverArrayKeys(
+                        stateVarObj,
+                        desiredValue,
+                    );
+                }
                 inverseDefinitionArgs.desiredStateVariableValues = {
-                    [stateVariable]: await this._resolveValueOfStateVariable(
-                        instruction,
-                        component,
-                    ),
+                    [stateVariable]: desiredValue,
                 };
             }
         }
@@ -1469,6 +1481,42 @@ export class EssentialValueWriter {
             newStateVariableValues,
         });
     }
+}
+
+/**
+ * Spread a math expression across the array keys of a one-dimensional array
+ * state variable, producing the array-key-keyed object its inverse definition
+ * expects. Reached when an update instruction targets a whole array — e.g.
+ * `<updateValue target="$v.tail" newValue="(7,8)" />` — so the new value
+ * arrives as one expression rather than one entry per component.
+ *
+ * A single-entry array takes the expression whole; otherwise each component is
+ * pulled out with `get_component`. Multidimensional arrays have no unambiguous
+ * component-to-key mapping, so their value is passed through untouched.
+ */
+async function spreadMathOverArrayKeys(stateVarObj: any, value: any) {
+    const arraySize = await stateVarObj.arraySize;
+
+    if (arraySize.length !== 1) {
+        return value;
+    }
+
+    if (arraySize[0] === 1) {
+        return { 0: value };
+    }
+
+    const desiredValuesForArray: Record<string, any> = {};
+    for (let ind = 0; ind < arraySize[0]; ind++) {
+        try {
+            desiredValuesForArray[ind] = value.get_component(ind);
+        } catch (e) {
+            // `get_component(ind)` throws when the expression has no such
+            // component (it is shorter than the array, or is not a vector at
+            // all); leave the slot unset so the inverse definition keeps the
+            // current value for that key.
+        }
+    }
+    return desiredValuesForArray;
 }
 
 /**

--- a/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
@@ -552,69 +552,53 @@ export class EssentialValueWriter {
             let arrayStateVariable = stateVarObj.arrayStateVariable;
             stateVariableForWorkspace = arrayStateVariable;
 
+            let arrayKeys: string[] = inverseDefinitionArgs.arrayKeys;
             let desiredValuesForArray: Record<string, any> = {};
-            if (inverseDefinitionArgs.arrayKeys.length === 1) {
+            if (arrayKeys.length === 1) {
                 if ("value" in instruction) {
-                    desiredValuesForArray[inverseDefinitionArgs.arrayKeys[0]] =
-                        instruction.value;
+                    desiredValuesForArray[arrayKeys[0]] = instruction.value;
                 } else if ("valueOfStateVariable" in instruction) {
-                    desiredValuesForArray[inverseDefinitionArgs.arrayKeys[0]] =
+                    desiredValuesForArray[arrayKeys[0]] =
                         await this._resolveValueOfStateVariable(
                             instruction,
                             component,
                         );
                 }
-            } else {
-                for (let [
-                    ind,
-                    arrayKey,
-                ] of inverseDefinitionArgs.arrayKeys.entries()) {
-                    if (Array.isArray(instruction.value)) {
-                        desiredValuesForArray[arrayKey] =
-                            instruction.value[ind];
-                    } else if (instruction.value instanceof me.class) {
-                        try {
-                            desiredValuesForArray[arrayKey] =
-                                instruction.value.get_component(ind);
-                        } catch (e) {
-                            // `get_component(ind)` throws when `ind` is out of
-                            // range for this math expression; treat it as "no
-                            // desired value for this arrayKey" and leave the
-                            // slot unset. Any other exception shape would also
-                            // be swallowed here — narrow if a concrete error
-                            // type from math-expressions becomes available.
-                        }
-                    }
+            } else if (Array.isArray(instruction.value)) {
+                for (let [ind, arrayKey] of arrayKeys.entries()) {
+                    desiredValuesForArray[arrayKey] = instruction.value[ind];
                 }
+            } else if (instruction.value instanceof me.class) {
+                desiredValuesForArray = spreadMathOverArrayKeys(
+                    instruction.value,
+                    arrayKeys,
+                );
             }
             inverseDefinitionArgs.desiredStateVariableValues = {
                 [arrayStateVariable]: desiredValuesForArray,
             };
-        } else {
-            let desiredValue;
-            let haveDesiredValue = true;
-            if ("value" in instruction) {
-                desiredValue = instruction.value;
-            } else if ("valueOfStateVariable" in instruction) {
-                desiredValue = await this._resolveValueOfStateVariable(
-                    instruction,
-                    component,
+        } else if (
+            "value" in instruction ||
+            "valueOfStateVariable" in instruction
+        ) {
+            let desiredValue =
+                "value" in instruction
+                    ? instruction.value
+                    : await this._resolveValueOfStateVariable(
+                          instruction,
+                          component,
+                      );
+
+            if (stateVarObj.isArray && desiredValue instanceof me.class) {
+                desiredValue = spreadMathOverWholeArray(
+                    inverseDefinitionArgs.arraySize,
+                    desiredValue,
                 );
-            } else {
-                haveDesiredValue = false;
             }
 
-            if (haveDesiredValue) {
-                if (stateVarObj.isArray && desiredValue instanceof me.class) {
-                    desiredValue = await spreadMathOverArrayKeys(
-                        stateVarObj,
-                        desiredValue,
-                    );
-                }
-                inverseDefinitionArgs.desiredStateVariableValues = {
-                    [stateVariable]: desiredValue,
-                };
-            }
+            inverseDefinitionArgs.desiredStateVariableValues = {
+                [stateVariable]: desiredValue,
+            };
         }
 
         let stateVariableWorkspace =
@@ -1484,39 +1468,55 @@ export class EssentialValueWriter {
 }
 
 /**
- * Spread a math expression across the array keys of a one-dimensional array
- * state variable, producing the array-key-keyed object its inverse definition
- * expects. Reached when an update instruction targets a whole array — e.g.
- * `<updateValue target="$v.tail" newValue="(7,8)" />` — so the new value
- * arrives as one expression rather than one entry per component.
+ * Distribute the math expression `value` over `arrayKeys`, producing the
+ * array-key-keyed object an array state variable's inverse definition expects.
  *
- * A single-entry array takes the expression whole; otherwise each component is
- * pulled out with `get_component`. Multidimensional arrays have no unambiguous
- * component-to-key mapping, so their value is passed through untouched.
+ * A single key takes the expression whole; otherwise each key gets the
+ * corresponding component of the expression.
  */
-async function spreadMathOverArrayKeys(stateVarObj: any, value: any) {
-    const arraySize = await stateVarObj.arraySize;
-
-    if (arraySize.length !== 1) {
-        return value;
-    }
-
-    if (arraySize[0] === 1) {
-        return { 0: value };
+function spreadMathOverArrayKeys(
+    value: any,
+    arrayKeys: string[],
+): Record<string, any> {
+    if (arrayKeys.length === 1) {
+        return { [arrayKeys[0]]: value };
     }
 
     const desiredValuesForArray: Record<string, any> = {};
-    for (let ind = 0; ind < arraySize[0]; ind++) {
+    for (let [ind, arrayKey] of arrayKeys.entries()) {
         try {
-            desiredValuesForArray[ind] = value.get_component(ind);
+            desiredValuesForArray[arrayKey] = value.get_component(ind);
         } catch (e) {
             // `get_component(ind)` throws when the expression has no such
             // component (it is shorter than the array, or is not a vector at
             // all); leave the slot unset so the inverse definition keeps the
-            // current value for that key.
+            // current value for that key. Any other exception shape would also
+            // be swallowed here — narrow if a concrete error type from
+            // math-expressions becomes available.
         }
     }
     return desiredValuesForArray;
+}
+
+/**
+ * Spread a math expression across every array key of an array state variable
+ * of size `arraySize`. Reached when an update instruction targets a whole
+ * array — e.g. `<updateValue target="$v.tail" newValue="(7,8)" />` — so the
+ * new value arrives as a single expression rather than one entry per array
+ * key.
+ *
+ * Multidimensional arrays have no unambiguous component-to-key mapping, so
+ * their value is passed through untouched.
+ */
+function spreadMathOverWholeArray(arraySize: number[], value: any) {
+    if (arraySize.length !== 1) {
+        return value;
+    }
+
+    const arrayKeys = Array.from({ length: arraySize[0] }, (_, ind) =>
+        String(ind),
+    );
+    return spreadMathOverArrayKeys(value, arrayKeys);
 }
 
 /**

--- a/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/core/EssentialValueWriter.ts
@@ -555,9 +555,11 @@ export class EssentialValueWriter {
             let arrayKeys: string[] = inverseDefinitionArgs.arrayKeys;
             let desiredValuesForArray: Record<string, any> = {};
             if (arrayKeys.length === 1) {
-                if (instructionCarriesDesiredValue(instruction)) {
+                if ("value" in instruction) {
+                    desiredValuesForArray[arrayKeys[0]] = instruction.value;
+                } else if ("valueOfStateVariable" in instruction) {
                     desiredValuesForArray[arrayKeys[0]] =
-                        await this._desiredValueFromInstruction(
+                        await this._resolveValueOfStateVariable(
                             instruction,
                             component,
                         );
@@ -575,11 +577,17 @@ export class EssentialValueWriter {
             inverseDefinitionArgs.desiredStateVariableValues = {
                 [arrayStateVariable]: desiredValuesForArray,
             };
-        } else if (instructionCarriesDesiredValue(instruction)) {
-            let desiredValue = await this._desiredValueFromInstruction(
-                instruction,
-                component,
-            );
+        } else if (
+            "value" in instruction ||
+            "valueOfStateVariable" in instruction
+        ) {
+            let desiredValue =
+                "value" in instruction
+                    ? instruction.value
+                    : await this._resolveValueOfStateVariable(
+                          instruction,
+                          component,
+                      );
 
             // An instruction targeting a whole array — e.g.
             // `<updateValue target="$v.tail" newValue="(7,8)" />` — carries one
@@ -1447,20 +1455,6 @@ export class EssentialValueWriter {
     }
 
     /**
-     * The value an update instruction asks for, whether it carries the value
-     * inline as `value` or by reference as `valueOfStateVariable`. Guard the
-     * call with `instructionCarriesDesiredValue`.
-     */
-    async _desiredValueFromInstruction(
-        instruction: any,
-        component: any,
-    ): Promise<any> {
-        return "value" in instruction
-            ? instruction.value
-            : await this._resolveValueOfStateVariable(instruction, component);
-    }
-
-    /**
      * Forward an inverse-definition recursion: invoke
      * `requestComponentChanges` with the prepared `inst` instruction,
      * propagating `treatAsInitialChange` from `newInstruction` and threading
@@ -1487,20 +1481,12 @@ export class EssentialValueWriter {
 }
 
 /**
- * Whether an update instruction names a value to change to, which it does
- * either inline (`value`) or by reference (`valueOfStateVariable`).
- */
-function instructionCarriesDesiredValue(instruction: Record<string, any>) {
-    return "value" in instruction || "valueOfStateVariable" in instruction;
-}
-
-/**
  * Distribute the math expression `value` over `arrayKeys`, producing the
  * array-key-keyed object an array state variable's inverse definition expects.
  *
- * A single key takes the expression whole, so that a size-one array and its
- * lone entry accept the same value; otherwise each key gets the corresponding
- * component of the expression.
+ * A single key takes the expression whole, so that a size-one array accepts
+ * the same value its lone entry would; otherwise each key gets the
+ * corresponding component of the expression.
  */
 function spreadMathOverArrayKeys(
     value: any,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/updatevalue.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/updatevalue.test.ts
@@ -3268,6 +3268,47 @@ describe("UpdateValue tag tests @group1", async () => {
         ).eq("");
     });
 
+    it("update a property that holds a whole list of coordinates", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <point name="P">(1,2)</point>
+    <circle name="c" center="(3,4)" />
+    <updateValue name="uvXs" target="$P.xs" newValue="(5,6)" />
+    <updateValue name="uvCenter" target="$c.center" newValue="(7,8)" />
+    `,
+        });
+
+        async function check_coords(xs: number[], center: number[]) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[
+                    await resolvePathToNodeIdx("P")
+                ].stateValues.xs.map((v) => v.tree),
+            ).eqls(xs);
+            expect(
+                stateVariables[
+                    await resolvePathToNodeIdx("c")
+                ].stateValues.center.map((v) => v.tree),
+            ).eqls(center);
+        }
+
+        await check_coords([1, 2], [3, 4]);
+
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uvXs"),
+            core,
+        });
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uvCenter"),
+            core,
+        });
+
+        await check_coords([5, 6], [7, 8]);
+    });
+
     it("updateValue warnings with invalid targets", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/updatevalue.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/updatevalue.test.ts
@@ -3273,12 +3273,18 @@ describe("UpdateValue tag tests @group1", async () => {
             doenetML: `
     <point name="P">(1,2)</point>
     <circle name="c" center="(3,4)" />
+    <point name="Q">9</point>
     <updateValue name="uvXs" target="$P.xs" newValue="(5,6)" />
     <updateValue name="uvCenter" target="$c.center" newValue="(7,8)" />
+    <updateValue name="uvOneDim" target="$Q.xs" newValue="10" />
     `,
         });
 
-        async function check_coords(xs: number[], center: number[]) {
+        async function check_coords(
+            xs: number[],
+            center: number[],
+            oneDimXs: number[],
+        ) {
             const stateVariables = await core.returnAllStateVariables(
                 false,
                 true,
@@ -3293,20 +3299,24 @@ describe("UpdateValue tag tests @group1", async () => {
                     await resolvePathToNodeIdx("c")
                 ].stateValues.center.map((v) => v.tree),
             ).eqls(center);
+            expect(
+                stateVariables[
+                    await resolvePathToNodeIdx("Q")
+                ].stateValues.xs.map((v) => v.tree),
+            ).eqls(oneDimXs);
         }
 
-        await check_coords([1, 2], [3, 4]);
+        await check_coords([1, 2], [3, 4], [9]);
 
-        await updateValue({
-            componentIdx: await resolvePathToNodeIdx("uvXs"),
-            core,
-        });
-        await updateValue({
-            componentIdx: await resolvePathToNodeIdx("uvCenter"),
-            core,
-        });
+        for (const name of ["uvXs", "uvCenter", "uvOneDim"]) {
+            await updateValue({
+                componentIdx: await resolvePathToNodeIdx(name),
+                core,
+            });
+        }
 
-        await check_coords([5, 6], [7, 8]);
+        // a one-entry coordinate property takes the new value whole
+        await check_coords([5, 6], [7, 8], [10]);
     });
 
     it("updateValue warnings with invalid targets", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/vector.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/vector.test.ts
@@ -6440,7 +6440,8 @@ describe("Vector Tag Tests @group4", function () {
             stateVariables,
         });
 
-        // moving the tail carries the head along, leaving the displacement alone
+        // this vector is specified by its displacement, so moving the tail
+        // carries the head along, leaving the displacement alone
         await updateValue({
             componentIdx: await resolvePathToNodeIdx("uvTail"),
             core,
@@ -6481,5 +6482,41 @@ describe("Vector Tag Tests @group4", function () {
             d: [9, 1],
             stateVariables,
         });
+    });
+
+    it("update the tail of an extended vector with updateValue", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <vector name="v">(3,4)</vector>
+  <vector extend="$v" name="v2" />
+
+  <updateValue name="uvTail" target="$v2.tail" newValue="(7,8)" />
+    `,
+        });
+
+        async function check_both(t: number[], h: number[], d: number[]) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            for (const name of ["v", "v2"]) {
+                check_vec_htd({
+                    componentIdx: await resolvePathToNodeIdx(name),
+                    t,
+                    h,
+                    d,
+                    stateVariables,
+                });
+            }
+        }
+
+        await check_both([0, 0], [3, 4], [3, 4]);
+
+        // the extension passes the whole tail through to the original vector
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uvTail"),
+            core,
+        });
+        await check_both([7, 8], [10, 12], [3, 4]);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/vector.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/vector.test.ts
@@ -5,6 +5,7 @@ import {
     moveVector,
     updateBooleanInputValue,
     updateMathInputValue,
+    updateValue,
 } from "../utils/actions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
 import { getDiagnosticsByType } from "../utils/diagnostics";
@@ -6413,5 +6414,72 @@ describe("Vector Tag Tests @group4", function () {
         expect(v1Latex).match(/10\^{-12}|10\^\{21\}|10\^21/);
         expect(v2Latex).contain("0.000000000007");
         expect(v2Latex).contain("2000000000000000000000");
+    });
+
+    it("update tail, head, and displacement with updateValue", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <graph>
+    <vector name="v">(3,4)</vector>
+  </graph>
+
+  <updateValue name="uvTail" target="$v.tail" newValue="(7,8)" />
+  <updateValue name="uvHead" target="$v.head" newValue="(8,9)" />
+  <updateValue name="uvDisplacement" target="$v.displacement" newValue="(9,1)" />
+    `,
+        });
+
+        const vIdx = await resolvePathToNodeIdx("v");
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        check_vec_htd({
+            componentIdx: vIdx,
+            t: [0, 0],
+            h: [3, 4],
+            d: [3, 4],
+            stateVariables,
+        });
+
+        // moving the tail carries the head along, leaving the displacement alone
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uvTail"),
+            core,
+        });
+        stateVariables = await core.returnAllStateVariables(false, true);
+        check_vec_htd({
+            componentIdx: vIdx,
+            t: [7, 8],
+            h: [10, 12],
+            d: [3, 4],
+            stateVariables,
+        });
+
+        // moving the head keeps the tail fixed, changing the displacement
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uvHead"),
+            core,
+        });
+        stateVariables = await core.returnAllStateVariables(false, true);
+        check_vec_htd({
+            componentIdx: vIdx,
+            t: [7, 8],
+            h: [8, 9],
+            d: [1, 1],
+            stateVariables,
+        });
+
+        // changing the displacement keeps the tail fixed, moving the head
+        await updateValue({
+            componentIdx: await resolvePathToNodeIdx("uvDisplacement"),
+            core,
+        });
+        stateVariables = await core.returnAllStateVariables(false, true);
+        check_vec_htd({
+            componentIdx: vIdx,
+            t: [7, 8],
+            h: [16, 9],
+            d: [9, 1],
+            stateVariables,
+        });
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/vector.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/vector.test.ts
@@ -6484,6 +6484,79 @@ describe("Vector Tag Tests @group4", function () {
         });
     });
 
+    it("updateValue on tail, head, or displacement matches dragging a point extending it", async () => {
+        // Setting one of these properties is the same change as dragging a
+        // point that extends it — not the same as dragging the vector's own
+        // handle, which additionally holds the opposite end in place.
+        // Each property, paired with the vector components it should leave
+        // the new value in.
+        const properties = [
+            { property: "tail", t: [7, 8], h: [10, 12], d: [3, 4] },
+            { property: "head", t: [0, 0], h: [7, 8], d: [7, 8] },
+            { property: "displacement", t: [0, 0], h: [7, 8], d: [7, 8] },
+        ];
+
+        // Applies one way of setting the property to a fresh document, then
+        // reports where the vector ended up.
+        async function resulting_htd(
+            property: string,
+            setProperty: (args: {
+                core: PublicDoenetMLCore;
+                resolvePathToNodeIdx: ResolvePathToNodeIdx;
+            }) => Promise<void>,
+        ) {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+  <graph>
+    <vector name="v">(3,4)</vector>
+    <point extend="$v.${property}" name="p" />
+  </graph>
+
+  <updateValue name="uv" target="$v.${property}" newValue="(7,8)" />
+    `,
+            });
+
+            await setProperty({ core, resolvePathToNodeIdx });
+
+            const v = (await core.returnAllStateVariables(false, true))[
+                await resolvePathToNodeIdx("v")
+            ].stateValues;
+            const components = (xs: any[]) => xs.map((x) => x.simplify().tree);
+            return {
+                t: components(v.tail),
+                h: components(v.head),
+                d: components(v.displacement),
+            };
+        }
+
+        for (const { property, ...expected } of properties) {
+            const viaUpdateValue = await resulting_htd(
+                property,
+                async ({ core, resolvePathToNodeIdx }) => {
+                    await updateValue({
+                        componentIdx: await resolvePathToNodeIdx("uv"),
+                        core,
+                    });
+                },
+            );
+            const viaDraggingPoint = await resulting_htd(
+                property,
+                async ({ core, resolvePathToNodeIdx }) => {
+                    await movePoint({
+                        componentIdx: await resolvePathToNodeIdx("p"),
+                        x: 7,
+                        y: 8,
+                        core,
+                    });
+                },
+            );
+
+            // spelled out, so neither path can pass by doing nothing
+            expect(viaUpdateValue, property).eqls(expected);
+            expect(viaDraggingPoint, property).eqls(expected);
+        }
+    });
+
     it("update the tail of an extended vector with updateValue", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `


### PR DESCRIPTION
Closes #1529.

## The bug

```xml
<graph>
  <vector name="v">(3,4)</vector>
</graph>

<updateValue target="$v.tail" newValue="(7,8)"><label>Change vector tail</label></updateValue>
```

Clicking the button did nothing. The same held for `$v.head` and `$v.displacement`, while `$v` itself worked. The only way through was to update `tail.x` and `tail.y` separately from a `<triggerSet>`.

## Cause

`requestComponentChanges` prepares the desired value for an inverse definition in two shapes. An **array entry** (`$v.tail.x`) gets its value keyed by array key, spreading a math vector across the keys with `get_component` when the entry covers several. Everything else gets the raw value.

A **whole array** (`$v.tail`) fell into "everything else", so the inverse definition received `{tail: <math (7,8)>}` where it expects `{tail: {0: <7>, 1: <8>}}`. The array wrapper then iterated the math expression's own properties looking for array keys, found none, and dropped the update — silently, with no warning.

This never came up from graph dragging because `moveVector` passes a plain JS array (`[me(7), me(8)]`), which iterates as `{0: …, 1: …}` and happens to land in the right shape.

## Fix

Before handing a whole array state variable its desired value, spread a math expression across the array keys — the same `get_component` treatment array entries already get. The spreading lives in one `spreadMathOverArrayKeys` helper shared by both paths, with a single key taking the expression whole (a size-one array and that array's lone entry then accept the same value, so `$v.tail` and `$v.tail.x` of a one-dimensional vector agree).

The keys come from the state variable's own `getAllArrayKeys`, applied to the array size that the inverse-definition arguments already resolve for every array state variable. That is the same generator `arrayInverseDefinition` uses to fill in `arrayKeys` when the caller leaves them out, so the keys spread onto always match the keys the array wrapper then looks for.

Multidimensional arrays (a `<polygon>`'s `vertices`, a `<lineSegment>`'s `endpoints`) have no unambiguous component-to-key mapping from one math vector, so their value is passed through untouched and their behavior is unchanged.

Because the fix sits at the single funnel all update instructions pass through, it also covers other one-dimensional coordinate properties that were broken the same way — a `<point>`'s `xs`, a `<circle>`'s `center`, a `<ray>`'s `endpoint` and `direction`, a `<lineSegment>`'s `midpoint`, a `<parabola>`'s `vertex`, and the `center` of the various polygon-like components. It reaches them through composites too: the target may be an extended component (`<vector extend="$v" />`) or live inside a `<repeat>`.

Setting `$v.tail` makes the same change as dragging a point that extends it — `<point extend="$v.tail" />` — which is the right thing for it to agree with, since that is how authors reach the property today. It is *not* the same as dragging the vector's own tail handle: that issues a second instruction resetting the displacement so the head stays put, whereas setting the tail alone leaves the head wherever the vector's specification puts it. The same holds for `head` and `displacement`.

## Testing

- New Vitest case in `vector.test.ts` walking tail → head → displacement through `<updateValue>` on a vector specified by its displacement: setting the tail carries the head along and leaves the displacement alone, setting the head keeps the tail fixed and changes the displacement, and setting the displacement keeps the tail fixed and moves the head.
- New Vitest case in `vector.test.ts` pinning the equivalence above: for each of `tail`, `head`, and `displacement`, `<updateValue>` and dragging a `<point extend="$v.<property>" />` leave the vector in the same place. Both routes are asserted against spelled-out coordinates, so neither can pass by doing nothing. It fails without the fix.
- New Vitest case in `vector.test.ts` for `<vector extend="$v" />`, which reaches the array through the shadow inverse definition rather than the vector's own — a distinct path that was broken in the same way.
- New Vitest case in `updatevalue.test.ts` reaching the same fix through a `<point>`'s `xs` and a `<circle>`'s `center`, plus a one-dimensional `<point>` to pin down the one-key case, where the new value is taken whole rather than decomposed.
- The full `@doenet/doenetml-worker-javascript` suite passes against the final state of this branch: 3406 passed, 38 skipped, 0 failed. Individual revisions along the way were also checked against the array-heavy suites: `vector`, `updatevalue`, `point`, `circle`, `line`, `linesegment`, `polygon`, `ray`, `matrix`, `matrixinput`, `parabola`, `curve`, `curve.bezier`, `polyline`, `triangle`, `rectangle`, `vectorlist`, `pointlist`, `triggerset`, and `mathinput` (the main source of `valueOfStateVariable` instructions, whose handling is unchanged).
- Checked by hand that the untouched cases stay untouched: multidimensional arrays (`<lineSegment>`'s `endpoints`, `<polygon>`'s `vertices`), one-dimensional arrays of non-math values (a `<numberList>`'s `numbers`, a `<textList>`'s `texts`), and a scalar `newValue` aimed at a multi-entry coordinate property, which is still a silent no-op.

## Documentation

The `<updateValue>` reference page gains a short example that moves a vector's tail, since setting a coordinate-list property is now something an author can rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


