### PR TITLE
fix: render angle brackets in math input prefillLatex

### DIFF
--- a/.changeset/mathinput-bare-angle-brackets.md
+++ b/.changeset/mathinput-bare-angle-brackets.md
@@ -12,6 +12,8 @@ Show angle brackets in a math input whose `prefillLatex` writes them without `\l
 
 MathQuill recognizes `\langle` as a delimiter but had no rule for what follows it, so it took only the one block an ordinary LaTeX command takes — just the `2` — and then had nothing left to give `\rangle`. That failed the parse of the whole expression, and a math field whose LaTeX will not parse renders as empty. `\left\langle 2, 3 \right\rangle` worked, but that is not how the brackets are usually written.
 
-An opening delimiter written without `\left` now takes everything up to its matching partner, the way it behaves when typed: `\langle 2, 3 \rangle`, `\langle \rangle`, `\lVert x \rVert`, and nestings of them all render. One with no partner — `\langle 2, 3` — keeps all of its contents and shows the same half-open bracket typing one produces, rather than closing after the first term.
+An opening delimiter written without `\left` now takes everything up to its matching partner, the way it behaves when typed: `\langle 2, 3 \rangle`, `\langle \rangle`, `\lVert x \rVert`, and nestings of them all render. One with no partner — `\langle 2, 3`, or `\langle` by itself — keeps all of its contents and shows the same half-open bracket typing one produces, rather than closing after the first term.
+
+The closing delimiter no longer takes a term of its own either, which fixes anything written after a matched pair: `\lVert v \rVert^2` drew the `\rVert` around the exponent, rendering ‖v‖‖²‖, and now renders the norm squared. A closing delimiter with nothing to close still leaves the field blank, and now does so wherever it sits — `2 \rangle 3` used to render 2⟨3⟩, wrapping whatever followed the stray delimiter in a bracket pair of its own.
 
 Closes #1336.

--- a/.changeset/mathinput-bare-angle-brackets.md
+++ b/.changeset/mathinput-bare-angle-brackets.md
@@ -6,14 +6,12 @@
 "doenet-vscode-extension": patch
 ---
 
-Show angle brackets in a math input whose `prefillLatex` writes them without `\left` and `\right`.
+Show angle brackets and norm bars in a math input whose `prefillLatex` writes them without `\left` and `\right`.
 
-`<mathInput prefillLatex="\langle 2, 3 \rangle" />` rendered an empty field. The vector reached the input's `value` correctly — only the field the reader looks at was blank, so the prefill was invisible.
-
-MathQuill recognizes `\langle` as a delimiter but had no rule for what follows it, so it took only the one block an ordinary LaTeX command takes — just the `2` — and then had nothing left to give `\rangle`. That failed the parse of the whole expression, and a math field whose LaTeX will not parse renders as empty. `\left\langle 2, 3 \right\rangle` worked, but that is not how the brackets are usually written.
+`<mathInput prefillLatex="\langle 2, 3 \rangle" />` rendered an empty field. The vector reached the input's `value` correctly — only the field the reader looks at was blank, so the prefill was invisible. MathQuill recognized `\langle` as a delimiter but had no rule for what follows it, so it took only the one block an ordinary LaTeX command takes — just the `2` — and had nothing left to give `\rangle`. That failed the parse of the whole expression, and a math field whose LaTeX will not parse renders as empty. `\left\langle 2, 3 \right\rangle` worked, but that is not how the brackets are usually written.
 
 An opening delimiter written without `\left` now takes everything up to its matching partner, the way it behaves when typed: `\langle 2, 3 \rangle`, `\langle \rangle`, `\lVert x \rVert`, and nestings of them all render. One with no partner — `\langle 2, 3`, or `\langle` by itself — keeps all of its contents and shows the same half-open bracket typing one produces, rather than closing after the first term.
 
-The closing delimiter no longer takes a term of its own either, which fixes anything written after a matched pair: `\lVert v \rVert^2` drew the `\rVert` around the exponent, rendering ‖v‖‖²‖, and now renders the norm squared. A closing delimiter with nothing to close still leaves the field blank, and now does so wherever it sits — `2 \rangle 3` used to render 2⟨3⟩, wrapping whatever followed the stray delimiter in a bracket pair of its own.
+The closing delimiter no longer takes a term of its own either, which fixes anything written after a matched pair: `\lVert v \rVert^2` drew the `\rVert` around the exponent, rendering ‖v‖‖²‖, and now renders the norm squared. A closing delimiter with nothing to close still leaves the field blank, and now does so wherever it sits — `2 \rangle 3` used to render 2⟨3⟩, wrapping whatever followed the stray delimiter in a pair of its own.
 
 Closes #1336.

--- a/.changeset/mathinput-bare-angle-brackets.md
+++ b/.changeset/mathinput-bare-angle-brackets.md
@@ -8,10 +8,10 @@
 
 Show angle brackets in a math input whose `prefillLatex` writes them without `\left` and `\right`.
 
-`<mathInput prefillLatex="\langle 2, 3 \rangle" />` rendered an empty field. The vector reached the input's `value` correctly — only the field the reader looks at was blank, so the prefill was invisible and unrecoverable by typing over it.
+`<mathInput prefillLatex="\langle 2, 3 \rangle" />` rendered an empty field. The vector reached the input's `value` correctly — only the field the reader looks at was blank, so the prefill was invisible.
 
-MathQuill parses `\langle` as a delimiter but had no rule for what follows it, so it read the single group a normal LaTeX command takes — just the `2` — and then had nothing left to give `\rangle`. That failed the parse of the whole expression, and a math field with unparseable LaTeX renders as empty. `\left\langle 2, 3 \right\rangle` worked, but that is not how the brackets are usually written.
+MathQuill recognizes `\langle` as a delimiter but had no rule for what follows it, so it took only the one block an ordinary LaTeX command takes — just the `2` — and then had nothing left to give `\rangle`. That failed the parse of the whole expression, and a math field whose LaTeX will not parse renders as empty. `\left\langle 2, 3 \right\rangle` worked, but that is not how the brackets are usually written.
 
-A delimiter written on its own now takes everything up to its matching partner, the way it behaves when typed: `\langle 2, 3 \rangle`, `\langle \rangle`, `\lVert x \rVert`, and nestings of them all render. An opening delimiter with no partner — `\langle 2, 3` — keeps its contents and shows the same half-open bracket typing one produces, rather than closing after the first term.
+An opening delimiter written without `\left` now takes everything up to its matching partner, the way it behaves when typed: `\langle 2, 3 \rangle`, `\langle \rangle`, `\lVert x \rVert`, and nestings of them all render. One with no partner — `\langle 2, 3` — keeps all of its contents and shows the same half-open bracket typing one produces, rather than closing after the first term.
 
 Closes #1336.

--- a/.changeset/mathinput-bare-angle-brackets.md
+++ b/.changeset/mathinput-bare-angle-brackets.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Show angle brackets in a math input whose `prefillLatex` writes them without `\left` and `\right`.
+
+`<mathInput prefillLatex="\langle 2, 3 \rangle" />` rendered an empty field. The vector reached the input's `value` correctly — only the field the reader looks at was blank, so the prefill was invisible and unrecoverable by typing over it.
+
+MathQuill parses `\langle` as a delimiter but had no rule for what follows it, so it read the single group a normal LaTeX command takes — just the `2` — and then had nothing left to give `\rangle`. That failed the parse of the whole expression, and a math field with unparseable LaTeX renders as empty. `\left\langle 2, 3 \right\rangle` worked, but that is not how the brackets are usually written.
+
+A delimiter written on its own now takes everything up to its matching partner, the way it behaves when typed: `\langle 2, 3 \rangle`, `\langle \rangle`, `\lVert x \rVert`, and nestings of them all render. An opening delimiter with no partner — `\langle 2, 3` — keeps its contents and shows the same half-open bracket typing one produces, rather than closing after the first term.
+
+Closes #1336.

--- a/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
+++ b/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
@@ -10450,10 +10450,11 @@ var Bracket = /** @class */ (function (_super) {
     // `\rangle`, `\lVert`, `\rVert`) reach the parser through LatexCmds rather
     // than through LatexCmds.left, so they arrive without the `\left` / `\right`
     // that supplies their contents. MathCommand's inherited parser reads one
-    // braced block, which is wrong for a delimiter: `\langle 2,3 \rangle` gave
-    // the bracket just `2` and then had no block left for `\rangle`, so the
-    // whole parse failed and the field rendered empty. Parse them the way typing
-    // them behaves instead -- an opening delimiter takes everything up to its
+    // block -- a braced group, or a single token when there are no braces --
+    // which is wrong for a delimiter: `\langle 2,3 \rangle` gave the bracket
+    // just `2` and then had no block left for `\rangle`, so the whole parse
+    // failed and the field rendered empty. Parse them the way typing them
+    // behaves instead -- an opening delimiter takes everything up to its
     // matching closing delimiter, and stays one-sided when that delimiter never
     // comes. (Char-typed brackets such as `(` are unaffected: they have no
     // LatexCmds entry and still parse as plain symbols.)
@@ -10467,18 +10468,18 @@ var Bracket = /** @class */ (function (_super) {
             // LatexCmds.right keeps `\right` available to LatexCmds.left.
             return Parser.fail("unmatched " + closeCtrlSeq);
         }
-        // Match the closing control sequence but not a longer name that merely
-        // starts with it, so `\ranglex` stays the unknown command it is. This is
-        // the `(?![a-zA-Z])` guard LatexCmds.left applies to `\right\rangle`.
-        var closeRegex = new RegExp(
-            "^" +
-                closeCtrlSeq.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
-                (/[a-zA-Z]$/.test(closeCtrlSeq) ? "(?![a-zA-Z])" : ""),
-        );
+        var closeParser = Parser.string(closeCtrlSeq);
+        if (/[a-zA-Z]$/.test(closeCtrlSeq)) {
+            // Don't accept a longer command name that merely starts with the
+            // closing sequence, so `\ranglex` stays the unknown command it is.
+            // This is the `(?![a-zA-Z])` guard LatexCmds.left applies to
+            // `\right\rangle`.
+            closeParser = closeParser.skip(Parser.regex(/^(?![a-zA-Z])/));
+        }
         return latexMathParser.then(function (block) {
             // `latexMathParser` stops at the closing delimiter because of the
             // failure above, leaving it for us to match here.
-            return Parser.regex(closeRegex)
+            return closeParser
                 .result(0) // matched pair: a two-sided bracket
                 .or(Parser.succeed(L)) // unmatched: stay one-sided (open)
                 .map(function (side) {

--- a/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
+++ b/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
@@ -10446,6 +10446,49 @@ var Bracket = /** @class */ (function (_super) {
         ctx.uncleanedLatex += "\\right" + this.sides[R].ctrlSeq;
         this.checkCursorContextClose(ctx);
     };
+    // DOENET: brackets that LaTeX writes as a control sequence (`\langle`,
+    // `\rangle`, `\lVert`, `\rVert`) reach the parser through LatexCmds rather
+    // than through LatexCmds.left, so they arrive without the `\left` / `\right`
+    // that supplies their contents. MathCommand's inherited parser reads one
+    // braced block, which is wrong for a delimiter: `\langle 2,3 \rangle` gave
+    // the bracket just `2` and then had no block left for `\rangle`, so the
+    // whole parse failed and the field rendered empty. Parse them the way typing
+    // them behaves instead -- an opening delimiter takes everything up to its
+    // matching closing delimiter, and stays one-sided when that delimiter never
+    // comes. (Char-typed brackets such as `(` are unaffected: they have no
+    // LatexCmds entry and still parse as plain symbols.)
+    Bracket.prototype.parser = function () {
+        var self = this;
+        var closeCtrlSeq = this.sides[R].ctrlSeq.trim();
+        if (this.side === R) {
+            // A closing delimiter has no contents to its right, and the block
+            // to its left is already parsed and out of reach. Fail so that an
+            // enclosing opening delimiter gets to consume it, exactly as
+            // LatexCmds.right keeps `\right` available to LatexCmds.left.
+            return Parser.fail("unmatched " + closeCtrlSeq);
+        }
+        // Match the closing control sequence but not a longer name that merely
+        // starts with it, so `\ranglex` stays the unknown command it is. This is
+        // the `(?![a-zA-Z])` guard LatexCmds.left applies to `\right\rangle`.
+        var closeRegex = new RegExp(
+            "^" +
+                closeCtrlSeq.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+                (/[a-zA-Z]$/.test(closeCtrlSeq) ? "(?![a-zA-Z])" : ""),
+        );
+        return latexMathParser.then(function (block) {
+            // `latexMathParser` stops at the closing delimiter because of the
+            // failure above, leaving it for us to match here.
+            return Parser.regex(closeRegex)
+                .result(0) // matched pair: a two-sided bracket
+                .or(Parser.succeed(L)) // unmatched: stay one-sided (open)
+                .map(function (side) {
+                    self.side = side;
+                    self.blocks = [block];
+                    block.adopt(self, 0, 0);
+                    return self;
+                });
+        });
+    };
     Bracket.prototype.mathspeak = function (opts) {
         var open = this.sides[L].ch,
             close = this.sides[R].ch;

--- a/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
+++ b/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
@@ -10447,18 +10447,18 @@ var Bracket = /** @class */ (function (_super) {
         this.checkCursorContextClose(ctx);
     };
     // DOENET: local patch to this vendored bundle -- preserve it when updating
-    // MathQuill from upstream.
-    // Brackets that LaTeX writes as a control sequence (`\langle`,
-    // `\rangle`, `\lVert`, `\rVert`) reach the parser through LatexCmds rather
-    // than through LatexCmds.left, so they arrive without the `\left` / `\right`
-    // that supplies their contents. MathCommand's inherited parser reads one
-    // block -- a braced group, or a single token when there are no braces --
-    // which is wrong for a delimiter: `\langle 2,3 \rangle` gave the bracket
-    // just `2` and then had no block left for `\rangle`, so the whole parse
-    // failed and the field rendered empty. Parse them the way typing them
-    // behaves instead -- an opening delimiter takes everything up to its
-    // matching closing delimiter, and stays one-sided when that delimiter never
-    // comes. (Char-typed brackets such as `(` are unaffected: they have no
+    // MathQuill from upstream. See Doenet/DoenetML#1336.
+    //
+    // The delimiters LaTeX writes as control sequences (`\langle`, `\rangle`,
+    // `\lVert`, `\rVert`) reach the parser through LatexCmds rather than through
+    // LatexCmds.left, so nothing has supplied their contents, and MathCommand's
+    // inherited parser gives them the one block an ordinary command takes -- a
+    // braced group, or a single token when there are no braces. So
+    // `\langle 2,3 \rangle` gave the bracket just `2` and left no block for
+    // `\rangle`, failing the parse of the whole expression and so rendering the
+    // field empty. Parse them the way typing them behaves instead: an opening
+    // delimiter takes everything up to its matching close, and stays one-sided
+    // when that close never comes. (Char-typed brackets such as `(` have no
     // LatexCmds entry and still parse as plain symbols.)
     Bracket.prototype.parser = function () {
         var self = this;
@@ -10472,10 +10472,10 @@ var Bracket = /** @class */ (function (_super) {
         }
         var closeParser = Parser.string(closeCtrlSeq);
         if (/[a-zA-Z]$/.test(closeCtrlSeq)) {
-            // Don't accept a longer command name that merely starts with the
-            // closing sequence, so `\ranglex` stays the unknown command it is.
-            // This is the `(?![a-zA-Z])` guard LatexCmds.left applies to
-            // `\right\rangle`.
+            // The `(?![a-zA-Z])` guard LatexCmds.left applies to
+            // `\right\rangle`: don't accept a longer command name that merely
+            // starts with the closing sequence, so `\ranglex` stays the unknown
+            // command it is.
             closeParser = closeParser.skip(Parser.regex(/^(?![a-zA-Z])/));
         }
         return latexMathParser.then(function (block) {

--- a/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
+++ b/packages/doenetml/src/Viewer/renderers/mathquill/mathquill.js
@@ -10446,7 +10446,9 @@ var Bracket = /** @class */ (function (_super) {
         ctx.uncleanedLatex += "\\right" + this.sides[R].ctrlSeq;
         this.checkCursorContextClose(ctx);
     };
-    // DOENET: brackets that LaTeX writes as a control sequence (`\langle`,
+    // DOENET: local patch to this vendored bundle -- preserve it when updating
+    // MathQuill from upstream.
+    // Brackets that LaTeX writes as a control sequence (`\langle`,
     // `\rangle`, `\lVert`, `\rVert`) reach the parser through LatexCmds rather
     // than through LatexCmds.left, so they arrive without the `\left` / `\right`
     // that supplies their contents. MathCommand's inherited parser reads one

--- a/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
+++ b/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
@@ -2,20 +2,17 @@ import React from "react";
 import { EditableMathField } from "../../../src/Viewer/renderers/mathquill/EditableMathField";
 import type { MathField } from "../../../src/Viewer/renderers/mathquill/types";
 
-// MathQuill's LaTeX parser and the delimiters it writes as control sequences
-// (Doenet/DoenetML#1336): `\langle`, `\rangle`, `\lVert` and `\rVert` reach the
-// parser as commands rather than through `\left` / `\right`, and it used to read
-// the one block an ordinary command takes -- a braced group, or a single token
-// when there are no braces. So `\langle 2, 3 \rangle` gave the bracket just the
-// `2` and had nothing left for `\rangle`, failing the parse of the whole
-// expression -- and a field whose LaTeX will not parse renders empty, which is
-// what `prefillLatex="\langle 2, 3 \rangle"` showed.
+// The delimiters MathQuill's LaTeX parser reads as commands rather than through
+// `\left` / `\right` -- `\langle`, `\rangle`, `\lVert`, `\rVert` -- used to take
+// only the one block an ordinary command takes, so `\langle 2, 3 \rangle` failed
+// to parse and `prefillLatex="\langle 2, 3 \rangle"` rendered an empty field
+// (Doenet/DoenetML#1336). See `Bracket.prototype.parser` in `mathquill.js`.
 //
 // A field re-serializes what it parsed, always in `\left…\right` form, so its
-// exported LaTeX is the parse result: `""` means the parse failed and the field
-// is blank. That is what the first test asserts. What the export cannot show is
-// whether a bracket ended up a matched pair or a one-sided one, since the two
-// serialize identically; the second test reads that off the DOM.
+// exported LaTeX is the parse result and `""` means the parse failed and the
+// field is blank. What the export cannot show is whether a bracket ended up a
+// matched pair or a one-sided one, since the two serialize identically; the
+// second test reads that off the DOM.
 
 /** LaTeX in, the LaTeX the mounted field exports back out. */
 const CASES: Record<string, string> = {
@@ -27,9 +24,8 @@ const CASES: Record<string, string> = {
     "\\left\\langle 2, 3 \\right\\rangle": "\\left\\langle2,3\\right\\rangle",
     // The other control-sequence delimiter pair.
     "\\lVert x \\rVert": "\\left\\lVert x\\right\\rVert",
-    // A matched close ends the bracket and leaves what follows it alone. Before
-    // the fix this norm-squared rendered as ‖v‖‖²‖: the `\rVert` took the `^2`
-    // as its one block and so became a second, phantom pair.
+    // A matched close ends the bracket and leaves what follows it alone; the
+    // `\rVert` used to take the `^2` as its block, rendering ‖v‖‖²‖.
     "\\lVert v \\rVert^2": "\\left\\lVert v\\right\\rVert^{2}",
     // Nested, and nested inside a command's group.
     "\\langle \\langle a \\rangle, b \\rangle":
@@ -43,9 +39,8 @@ const CASES: Record<string, string> = {
     // there was no block after it for the old parser to take.
     "\\langle": "\\left\\langle\\right\\rangle",
     // A closing delimiter has nothing to close over, wherever it sits, and a
-    // mismatched pair is rejected: unparseable, so the field stays blank. The
-    // first two were blank before the fix as well; `2 \rangle 3` rendered 2⟨3⟩,
-    // wrapping whatever followed the stray close in a pair of its own.
+    // mismatched pair is rejected: unparseable, so the field stays blank.
+    // `2 \rangle 3` used to render 2⟨3⟩, wrapping what followed the stray close.
     "\\rangle": "",
     "2, 3 \\rangle": "",
     "2 \\rangle 3": "",
@@ -57,11 +52,10 @@ const CASES: Record<string, string> = {
 /**
  * Mounts a field on `latex` and yields the MathField behind it.
  *
- * `mathquillDidMount` is the only handle on that object, so the reference is
- * captured through it. It fires from a mount effect, which runs after
- * `cy.mount` resolves, so wait on the markup MathQuill installs before reading;
- * the local starts null so a mount that never reports back fails loudly instead
- * of reusing the previous case's field.
+ * `mathquillDidMount` is the only handle on that object, and it fires from a
+ * mount effect that runs after `cy.mount` resolves, so wait on the markup
+ * MathQuill installs before reading. The local starts null so a mount that never
+ * reports back fails loudly instead of reusing the previous case's field.
  */
 function mountField(latex: string): Cypress.Chainable<MathField> {
     let field: MathField | null = null;

--- a/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
+++ b/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
@@ -95,12 +95,21 @@ describe("MathQuill parses bracket delimiters written without \\left and \\right
     it("leaves an unmatched opening delimiter one-sided", () => {
         // A one-sided bracket draws its missing partner as the greyed
         // `mq-ghost` that typing an unmatched bracket produces, where a matched
-        // pair draws two real delimiters.
+        // pair draws two real delimiters. Assert each delimiter is present as
+        // well as ungreyed: a blank field draws neither, so "no ghost" alone
+        // would hold on the empty field the bug produced.
         mountField("\\langle 2, 3 \\rangle");
-        cy.get(".mq-ghost").should("not.exist");
+        cy.get(".mq-bracket-l")
+            .should("exist")
+            .and("not.have.class", "mq-ghost");
+        cy.get(".mq-bracket-r")
+            .should("exist")
+            .and("not.have.class", "mq-ghost");
 
         mountField("\\langle 2, 3");
-        cy.get(".mq-bracket-r.mq-ghost").should("exist");
-        cy.get(".mq-bracket-l.mq-ghost").should("not.exist");
+        cy.get(".mq-bracket-l")
+            .should("exist")
+            .and("not.have.class", "mq-ghost");
+        cy.get(".mq-bracket-r").should("have.class", "mq-ghost");
     });
 });

--- a/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
+++ b/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { EditableMathField } from "../../../src/Viewer/renderers/mathquill/EditableMathField";
+
+// MathQuill's LaTeX parser and the delimiters it writes as control sequences
+// (Doenet/DoenetML#1336): `\langle`, `\rangle`, `\lVert` and `\rVert` reach the
+// parser as commands rather than through `\left` / `\right`, and it used to read
+// the single braced group an ordinary command takes. So `\langle 2, 3 \rangle`
+// gave the bracket just the `2` and had nothing left for `\rangle`, failing the
+// parse of the whole expression -- and a field whose LaTeX will not parse
+// renders empty, which is what `prefillLatex="\langle 2, 3 \rangle"` showed.
+//
+// A field re-serializes what it parsed, always in `\left…\right` form, so its
+// exported LaTeX is the parse result: `""` means the parse failed and the field
+// is blank. That is what these cases assert.
+
+/** LaTeX in, the LaTeX the mounted field exports back out. */
+const CASES: Record<string, string> = {
+    // The issue: both delimiters present, no `\left` / `\right`.
+    "\\langle 2, 3 \\rangle": "\\left\\langle2,3\\right\\rangle",
+    // Empty, the issue's second case.
+    "\\langle  \\rangle": "\\left\\langle\\right\\rangle",
+    // Still works when written the long way.
+    "\\left\\langle 2, 3 \\right\\rangle": "\\left\\langle2,3\\right\\rangle",
+    // The other control-sequence delimiter pair.
+    "\\lVert x \\rVert": "\\left\\lVert x\\right\\rVert",
+    // Nested, and nested inside a command's group.
+    "\\langle \\langle a \\rangle, b \\rangle":
+        "\\left\\langle\\left\\langle a\\right\\rangle,b\\right\\rangle",
+    "\\frac{\\langle a, b \\rangle}{2}":
+        "\\frac{\\left\\langle a,b\\right\\rangle}{2}",
+    // An opening delimiter with no partner keeps all of its contents, rather
+    // than closing after the first term. (`\left` alone would fail outright.)
+    "\\langle 2, 3": "\\left\\langle2,3\\right\\rangle",
+    // A closing delimiter has nothing to close over, and a mismatched pair is
+    // rejected: unparseable, so the field stays blank as it always did.
+    "\\rangle": "",
+    "2, 3 \\rangle": "",
+    "\\langle 2, 3 \\rVert": "",
+    // `\ranglex` is an unknown command, not `\rangle` followed by `x`.
+    "\\langle a \\ranglex": "",
+};
+
+/**
+ * Mounts a field on `latex` and yields the LaTeX it exports back.
+ *
+ * `mathquillDidMount` is the only handle on the underlying MathField, so the
+ * reference is captured through it. It fires from a mount effect, which runs
+ * after `cy.mount` resolves, so wait on the markup MathQuill installs before
+ * reading; the local starts null so a mount that never reports back fails
+ * loudly instead of reusing the previous case's field.
+ */
+function exportedLatex(latex: string): Cypress.Chainable<string> {
+    let field: any = null;
+    cy.mount(
+        <EditableMathField
+            latex={latex}
+            mathquillDidMount={(mf: any) => {
+                field = mf;
+            }}
+        />,
+    );
+    cy.get(".mq-editable-field").should("exist");
+    return cy.then(() => {
+        expect(
+            field,
+            `field mounted for ${JSON.stringify(latex)}`,
+        ).to.not.equal(null);
+        return field.latex();
+    });
+}
+
+describe("MathQuill parses bracket delimiters written without \\left and \\right", () => {
+    it("renders the delimiter pairs it can match and stays blank otherwise", () => {
+        const actual: Record<string, string> = {};
+
+        for (const latex of Object.keys(CASES)) {
+            exportedLatex(latex).then((exported) => {
+                actual[latex] = exported;
+            });
+        }
+
+        cy.then(() => {
+            expect(actual).to.deep.equal(CASES);
+        });
+    });
+});

--- a/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
+++ b/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { EditableMathField } from "../../../src/Viewer/renderers/mathquill/EditableMathField";
+import type { MathField } from "../../../src/Viewer/renderers/mathquill/types";
 
 // MathQuill's LaTeX parser and the delimiters it writes as control sequences
 // (Doenet/DoenetML#1336): `\langle`, `\rangle`, `\lVert` and `\rVert` reach the
 // parser as commands rather than through `\left` / `\right`, and it used to read
-// the single braced group an ordinary command takes. So `\langle 2, 3 \rangle`
-// gave the bracket just the `2` and had nothing left for `\rangle`, failing the
-// parse of the whole expression -- and a field whose LaTeX will not parse
-// renders empty, which is what `prefillLatex="\langle 2, 3 \rangle"` showed.
+// the one block an ordinary command takes -- a braced group, or a single token
+// when there are no braces. So `\langle 2, 3 \rangle` gave the bracket just the
+// `2` and had nothing left for `\rangle`, failing the parse of the whole
+// expression -- and a field whose LaTeX will not parse renders empty, which is
+// what `prefillLatex="\langle 2, 3 \rangle"` showed.
 //
 // A field re-serializes what it parsed, always in `\left…\right` form, so its
 // exported LaTeX is the parse result: `""` means the parse failed and the field
@@ -50,11 +52,11 @@ const CASES: Record<string, string> = {
  * loudly instead of reusing the previous case's field.
  */
 function exportedLatex(latex: string): Cypress.Chainable<string> {
-    let field: any = null;
+    let field: MathField | null = null;
     cy.mount(
         <EditableMathField
             latex={latex}
-            mathquillDidMount={(mf: any) => {
+            mathquillDidMount={(mf: MathField) => {
                 field = mf;
             }}
         />,
@@ -65,7 +67,7 @@ function exportedLatex(latex: string): Cypress.Chainable<string> {
             field,
             `field mounted for ${JSON.stringify(latex)}`,
         ).to.not.equal(null);
-        return field.latex();
+        return field!.latex();
     });
 }
 

--- a/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
+++ b/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
@@ -106,7 +106,11 @@ describe("MathQuill parses bracket delimiters written without \\left and \\right
             .should("exist")
             .and("not.have.class", "mq-ghost");
 
+        // The old parser drew this same real-left-and-ghost-right pair, so the
+        // greying alone says nothing here -- it put the pair around the `2`
+        // alone and left `,3` outside it. Assert what the bracket holds too.
         mountField("\\langle 2, 3");
+        cy.get(".mq-bracket-middle").should("have.text", "2,3");
         cy.get(".mq-bracket-l")
             .should("exist")
             .and("not.have.class", "mq-ghost");

--- a/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
+++ b/packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx
@@ -13,7 +13,9 @@ import type { MathField } from "../../../src/Viewer/renderers/mathquill/types";
 //
 // A field re-serializes what it parsed, always in `\left…\right` form, so its
 // exported LaTeX is the parse result: `""` means the parse failed and the field
-// is blank. That is what these cases assert.
+// is blank. That is what the first test asserts. What the export cannot show is
+// whether a bracket ended up a matched pair or a one-sided one, since the two
+// serialize identically; the second test reads that off the DOM.
 
 /** LaTeX in, the LaTeX the mounted field exports back out. */
 const CASES: Record<string, string> = {
@@ -25,6 +27,10 @@ const CASES: Record<string, string> = {
     "\\left\\langle 2, 3 \\right\\rangle": "\\left\\langle2,3\\right\\rangle",
     // The other control-sequence delimiter pair.
     "\\lVert x \\rVert": "\\left\\lVert x\\right\\rVert",
+    // A matched close ends the bracket and leaves what follows it alone. Before
+    // the fix this norm-squared rendered as ‖v‖‖²‖: the `\rVert` took the `^2`
+    // as its one block and so became a second, phantom pair.
+    "\\lVert v \\rVert^2": "\\left\\lVert v\\right\\rVert^{2}",
     // Nested, and nested inside a command's group.
     "\\langle \\langle a \\rangle, b \\rangle":
         "\\left\\langle\\left\\langle a\\right\\rangle,b\\right\\rangle",
@@ -33,25 +39,31 @@ const CASES: Record<string, string> = {
     // An opening delimiter with no partner keeps all of its contents, rather
     // than closing after the first term. (`\left` alone would fail outright.)
     "\\langle 2, 3": "\\left\\langle2,3\\right\\rangle",
-    // A closing delimiter has nothing to close over, and a mismatched pair is
-    // rejected: unparseable, so the field stays blank as it always did.
+    // On its own it is just the delimiter, which used to render nothing at all:
+    // there was no block after it for the old parser to take.
+    "\\langle": "\\left\\langle\\right\\rangle",
+    // A closing delimiter has nothing to close over, wherever it sits, and a
+    // mismatched pair is rejected: unparseable, so the field stays blank. The
+    // first two were blank before the fix as well; `2 \rangle 3` rendered 2⟨3⟩,
+    // wrapping whatever followed the stray close in a pair of its own.
     "\\rangle": "",
     "2, 3 \\rangle": "",
+    "2 \\rangle 3": "",
     "\\langle 2, 3 \\rVert": "",
     // `\ranglex` is an unknown command, not `\rangle` followed by `x`.
     "\\langle a \\ranglex": "",
 };
 
 /**
- * Mounts a field on `latex` and yields the LaTeX it exports back.
+ * Mounts a field on `latex` and yields the MathField behind it.
  *
- * `mathquillDidMount` is the only handle on the underlying MathField, so the
- * reference is captured through it. It fires from a mount effect, which runs
- * after `cy.mount` resolves, so wait on the markup MathQuill installs before
- * reading; the local starts null so a mount that never reports back fails
- * loudly instead of reusing the previous case's field.
+ * `mathquillDidMount` is the only handle on that object, so the reference is
+ * captured through it. It fires from a mount effect, which runs after
+ * `cy.mount` resolves, so wait on the markup MathQuill installs before reading;
+ * the local starts null so a mount that never reports back fails loudly instead
+ * of reusing the previous case's field.
  */
-function exportedLatex(latex: string): Cypress.Chainable<string> {
+function mountField(latex: string): Cypress.Chainable<MathField> {
     let field: MathField | null = null;
     cy.mount(
         <EditableMathField
@@ -67,7 +79,7 @@ function exportedLatex(latex: string): Cypress.Chainable<string> {
             field,
             `field mounted for ${JSON.stringify(latex)}`,
         ).to.not.equal(null);
-        return field!.latex();
+        return field as unknown as MathField;
     });
 }
 
@@ -76,13 +88,25 @@ describe("MathQuill parses bracket delimiters written without \\left and \\right
         const actual: Record<string, string> = {};
 
         for (const latex of Object.keys(CASES)) {
-            exportedLatex(latex).then((exported) => {
-                actual[latex] = exported;
+            mountField(latex).then((field) => {
+                actual[latex] = field.latex();
             });
         }
 
         cy.then(() => {
             expect(actual).to.deep.equal(CASES);
         });
+    });
+
+    it("leaves an unmatched opening delimiter one-sided", () => {
+        // A one-sided bracket draws its missing partner as the greyed
+        // `mq-ghost` that typing an unmatched bracket produces, where a matched
+        // pair draws two real delimiters.
+        mountField("\\langle 2, 3 \\rangle");
+        cy.get(".mq-ghost").should("not.exist");
+
+        mountField("\\langle 2, 3");
+        cy.get(".mq-bracket-r.mq-ghost").should("exist");
+        cy.get(".mq-bracket-l.mq-ghost").should("not.exist");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
@@ -135,12 +135,22 @@ describe("MathInput Tag Tests", { tags: ["@group2"] }, function () {
             "contain.text",
             "left angle-bracket, , right angle-bracket",
         );
-        cy.get("#e .mq-root-block").should("have.text", "");
 
-        // Both delimiters are real, not the ghost half of a one-sided bracket.
-        cy.get("#v .mq-ghost").should("not.exist");
-        cy.get("#e .mq-ghost").should("not.exist");
+        // Both delimiters are drawn, and neither is the greyed ghost half of a
+        // one-sided bracket. Assert they are present as well as ungreyed: the
+        // empty field the bug produced draws no delimiter to be a ghost either,
+        // so "no ghost" on its own would have held for it too.
+        for (const name of ["v", "e"]) {
+            cy.get(`#${name} .mq-bracket-l`)
+                .should("exist")
+                .and("not.have.class", "mq-ghost");
+            cy.get(`#${name} .mq-bracket-r`)
+                .should("exist")
+                .and("not.have.class", "mq-ghost");
+        }
 
+        // The value was never the broken part -- only the rendered field was
+        // blank -- so this checks that the field and the value now agree.
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
@@ -115,6 +115,40 @@ describe("MathInput Tag Tests", { tags: ["@group2"] }, function () {
         //     });
     });
 
+    it("prefillLatex renders angle brackets written without \\left and \\right", () => {
+        // MathQuill used to require `\left\langle ... \right\rangle`; given the
+        // bare `\langle ... \rangle` that authors write, its parser failed and
+        // the field rendered empty (#1336).
+        postDoenetML(`
+    <p>vector: <mathInput name="v" prefillLatex="\\langle 2, 3 \\rangle" /></p>
+    <p>empty: <mathInput name="e" prefillLatex="\\langle  \\rangle" /></p>
+    `);
+
+        // The delimiters themselves are drawn as SVG, so the field's mathspeak
+        // (what a screen reader announces) is where they show up as text.
+        cy.get("#v .mq-mathspeak").should(
+            "contain.text",
+            "left angle-bracket, 2 , 3 , right angle-bracket",
+        );
+        cy.get("#v .mq-root-block").should("have.text", "2,3");
+        cy.get("#e .mq-mathspeak").should(
+            "contain.text",
+            "left angle-bracket, , right angle-bracket",
+        );
+        cy.get("#e .mq-root-block").should("have.text", "");
+
+        // Both delimiters are real, not the ghost half of a one-sided bracket.
+        cy.get("#v .mq-ghost").should("not.exist");
+        cy.get("#e .mq-ghost").should("not.exist");
+
+        cy.window().then(async (win) => {
+            let stateVariables = await win.returnAllStateVariables1();
+            expect(
+                stateVariables[await win.resolvePath1("v")].stateValues.value,
+            ).eqls(["altvector", 2, 3]);
+        });
+    });
+
     it("check ignoreUpdate bug 1", () => {
         // if set core to delay 1 second on updates
         // then the refresh on blur (from the focus field recoil atoms changing)


### PR DESCRIPTION
Closes #1336.

`<mathInput prefillLatex="\langle 2, 3 \rangle" />` rendered an empty field, as did `prefillLatex="\langle  \rangle"`. The vector reached the input's `value` correctly (`["altvector", 2, 3]`) — only the field the reader looks at was blank, so the prefill was invisible.

## Cause

MathQuill's LaTeX parser reaches `\langle`, `\rangle`, `\lVert` and `\rVert` through `LatexCmds`, as commands rather than through the `\left` / `\right` handling that supplies a delimiter's contents. With no parser of their own they fell back to `MathCommand.prototype.parser`, which reads the one block an ordinary command takes — a braced group, or a single token when there are no braces. So `\langle 2, 3 \rangle` gave the bracket just the `2`, and then had no block left for `\rangle`. That failed the parse of the whole expression, and `renderLatexMathFromScratch` empties the field when the LaTeX will not parse.

The same rule made a closing delimiter take a term of its own whenever one was there to take, which corrupted expressions that did parse: `\lVert v \rVert^2` put the `\rVert` around the exponent and rendered ‖v‖‖²‖ instead of the norm squared, and `2 \rangle 3` rendered 2⟨3⟩ from a stray delimiter.

`\left\langle 2, 3 \right\rangle` worked, but that is not how the brackets are usually written. Char-typed brackets like `(` were never affected — they have no `LatexCmds` entry and parse as plain symbols.

## Fix

`Bracket.prototype.parser` in the vendored `mathquill.js` now parses these delimiters the way they behave when typed:

- An **opening** delimiter takes everything up to its matching closing delimiter, and nothing beyond it. When the closing sequence ends in a letter it is matched with the same `(?![a-zA-Z])` guard `LatexCmds.left` applies to `\right\rangle`, so `\ranglex` stays the unknown command it is.
- With **no matching close**, it keeps all of its contents and stays one-sided, rather than closing after the first term: `\langle 2, 3` now renders the half-open bracket typing one produces, where before it rendered ⟨2⟩,3. `\langle` on its own now renders the bare delimiter instead of nothing at all.
- A **closing** delimiter fails, so an enclosing opening delimiter gets to consume it — the same mechanism `LatexCmds.right` already uses to keep `\right` available to `LatexCmds.left`. One with nothing to close leaves the field blank, as `\rangle` and `2, 3 \rangle` already did; what changes is that it now does so wherever it sits, instead of wrapping what follows it in a pair of its own. Mismatched pairs (`\langle 2, 3 \rVert`) render blank as before.

## Tests

- **Component test** (`packages/doenetml/test/cypress/component/MathQuill.bracketLatex.cy.tsx`) — mounts `EditableMathField` on a table of LaTeX inputs and asserts the LaTeX each field exports back, which is `""` when the parse failed. Covers the issue's two cases, the `\left`-written form, `\lVert`, `\lVert v \rVert^2`, nesting, nesting inside `\frac`, the two unmatched-open cases, and the five inputs that should stay blank (a stray close in three positions, a mismatched pair, and `\ranglex`). A second test reads the one thing the exported LaTeX cannot show — it serializes a one-sided bracket and a matched pair identically — off the DOM: `\langle 2, 3` draws its missing partner as an `mq-ghost`, a matched pair draws two ungreyed delimiters. Since the greying on its own does not tell either case apart from the old parser, each also asserts something the old parser got wrong: the matched pair, that each delimiter is *present* as well as ungreyed (the empty field the bug produced draws no delimiter to be a ghost either); the one-sided one, that the bracket holds `2,3` (the old parser drew this same real-left-and-ghost-right pair, around the `2` alone, with `,3` outside it).
- **e2e test** (`mathinput.cy.js`) — asserts the rendered field for both of the issue's prefills: the delimiters in its mathspeak (they are drawn as SVG, so mathspeak is where they appear as text), the vector field's contents, that both delimiters are drawn and neither is the ghost half of a one-sided bracket, and the resulting `value`.

Every assertion in both tests was run against the `main` bundle. Each fails there except the ones that deliberately pin behavior the fix does not change: `\left\langle 2, 3 \right\rangle` still parsing, the four inputs that stay blank either way, and the `value` the input always computed correctly. Those constrain the new parser instead of the bug — dropping the `(?![a-zA-Z])` guard, for one, makes `\langle a \ranglex` render ⟨a⟩x.

`mathinput.cy.js` passes in full (32 tests); `test:e2e-group2` passes apart from a pre-existing YouTube-network flake in `video.cy.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


