### PR TITLE
Warn about an unusable graph grid instead of failing

### DIFF
--- a/.changeset/graph-grid-invalid-warning.md
+++ b/.changeset/graph-grid-invalid-warning.md
@@ -10,6 +10,6 @@ Graph: warn about an unusable `grid` value instead of failing.
 
 A `grid` whose pieces could not be parsed — `grid="(1, 2)"`, where the space falls inside the parentheses — took the whole document down with a red `Expecting ) or ]` box. It is now reported as an invalid value like any other.
 
-Values that were already ignored in silence, such as `grid="(1,2) (3,4)"`, `grid="0 1"`, and `grid="1"`, now say so: the warning names the value and the forms `grid` accepts. A value that comes from a reference stays quiet, since an unfilled `<mathInput>` is not an authoring mistake.
+Values that were already ignored in silence, such as `grid="(1,2) (3,4)"`, `grid="0 1"`, and `grid="1"`, now say so: the warning names the value and the forms `grid` accepts. A value that comes from a reference stays quiet: `grid="$gx $gy"` is unusable until the reader fills the inputs in, and `grid="$choice"` is how a reader picks `none`, `medium`, or `dense` in the first place.
 
 The editor's own description of `grid` was offering values it never accepted — `off`, `minor`, `major`. It now describes the values it does accept.

--- a/.changeset/graph-grid-invalid-warning.md
+++ b/.changeset/graph-grid-invalid-warning.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Graph: warn about an unusable `grid` value instead of failing.
+
+A `grid` whose pieces could not be parsed — `grid="(1, 2)"`, where the space falls inside the parentheses — took the whole document down with a red `Expecting ) or ]` box. It is now reported as an invalid value like any other.
+
+Values that were already ignored in silence, such as `grid="(1,2) (3,4)"`, `grid="0 1"`, and `grid="1"`, now say so: the warning names the value and the forms `grid` accepts. A value that comes from a reference stays quiet, since an unfilled `<mathInput>` is not an authoring mistake.

--- a/.changeset/graph-grid-invalid-warning.md
+++ b/.changeset/graph-grid-invalid-warning.md
@@ -11,3 +11,5 @@ Graph: warn about an unusable `grid` value instead of failing.
 A `grid` whose pieces could not be parsed — `grid="(1, 2)"`, where the space falls inside the parentheses — took the whole document down with a red `Expecting ) or ]` box. It is now reported as an invalid value like any other.
 
 Values that were already ignored in silence, such as `grid="(1,2) (3,4)"`, `grid="0 1"`, and `grid="1"`, now say so: the warning names the value and the forms `grid` accepts. A value that comes from a reference stays quiet, since an unfilled `<mathInput>` is not an authoring mistake.
+
+The editor's own description of `grid` was offering values it never accepted — `off`, `minor`, `major`. It now describes the values it does accept.

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -79,43 +79,37 @@ function gridSpacingFromGroup(group, dependencyValues) {
  * open around them.
  */
 function groupGridAttrChildren(attrChildren) {
-    let groupedChildren = [];
+    const groupedChildren = [];
     let pieces = [];
 
-    for (let child of attrChildren) {
+    // Closes the group being built, if anything is in it.
+    const endGroup = () => {
+        if (pieces.length > 0) {
+            groupedChildren.push(pieces);
+            pieces = [];
+        }
+    };
+
+    for (const child of attrChildren) {
         if (typeof child !== "string") {
             pieces.push(child);
             continue;
         }
 
-        let stringPieces = child.split(/\s+/);
-        let s0 = stringPieces[0];
-
-        if (s0 === "") {
-            // started with a space
-            if (pieces.length > 0) {
-                groupedChildren.push(pieces);
-                pieces = [];
+        for (const [ind, piece] of child.split(/\s+/).entries()) {
+            // Splitting on whitespace puts a space before every piece but the
+            // first, and an empty first piece means the child led with one.
+            // Either way the group that was open ends at that space.
+            if (ind > 0 || piece === "") {
+                endGroup();
             }
-        } else {
-            pieces.push(s0);
-        }
-
-        for (let s of stringPieces.slice(1)) {
-            // if have more than one piece, must have had a space in between pieces
-            if (pieces.length > 0) {
-                groupedChildren.push(pieces);
-                pieces = [];
-            }
-            if (s !== "") {
-                pieces.push(s);
+            if (piece !== "") {
+                pieces.push(piece);
             }
         }
     }
 
-    if (pieces.length > 0) {
-        groupedChildren.push(pieces);
-    }
+    endGroup();
 
     return groupedChildren;
 }
@@ -2111,10 +2105,17 @@ export default class Graph extends BlockComponent {
                             dependencyType: "stateVariable",
                             variableName: "gridAttrCompChildren",
                         },
-                        // Every child of the attribute, including any the text
-                        // attribute could not accept and so left out of
-                        // `gridAttrCompChildren`. Used only to tell an authored
-                        // value from one that came from elsewhere.
+                        // Every child of the attribute, used only to tell a
+                        // value the author spelled out from one that came from
+                        // elsewhere. It has to be every child rather than
+                        // `gridAttrCompChildren`, because a child a text
+                        // attribute cannot accept at all — `grid="$aPoint"` —
+                        // is missing from `gridAttrCompChildren` and from the
+                        // attribute's value alike. Judged on what survives, the
+                        // value would look authored, and the warning below
+                        // would quote the empty remnant the dropped child left
+                        // behind, on top of the "invalid format" warning that
+                        // child already raised.
                         allGridAttrChildren: {
                             dependencyType: "child",
                             parentIdx: stateValues.gridAttrCompName,
@@ -2162,15 +2163,6 @@ export default class Graph extends BlockComponent {
                 // is not the author's to fix. The cost is that a reference to a
                 // value the author got wrong, as in `grid="1 $negativeNumber"`,
                 // goes unreported.
-                //
-                // The test runs over every child rather than over
-                // `attrChildren`, because a child the text attribute could not
-                // accept at all — `grid="$aPoint"` — is missing from
-                // `attrChildren` and from `attrValue` alike. Left to
-                // `attrChildren` the value would look authored, and the warning
-                // would quote the empty remnant the dropped child left behind,
-                // on top of the "invalid format" warning the child already
-                // raised.
                 const authoredInFull =
                     dependencyValues.allGridAttrChildren.every(
                         (child) => typeof child === "string",

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -2100,13 +2100,25 @@ export default class Graph extends BlockComponent {
                     returnNumberDisplayAttributeComponentShadowing(),
             },
             forRenderer: true,
-            stateVariablesDeterminingDependencies: ["gridAttrCompChildren"],
+            stateVariablesDeterminingDependencies: [
+                "gridAttrCompName",
+                "gridAttrCompChildren",
+            ],
             returnDependencies({ stateValues }) {
                 if (stateValues.gridAttrCompChildren) {
                     let dependencies = {
                         gridAttrCompChildren: {
                             dependencyType: "stateVariable",
                             variableName: "gridAttrCompChildren",
+                        },
+                        // Every child of the attribute, including any the text
+                        // attribute could not accept and so left out of
+                        // `gridAttrCompChildren`. Used only to tell an authored
+                        // value from one that came from elsewhere.
+                        allGridAttrChildren: {
+                            dependencyType: "child",
+                            parentIdx: stateValues.gridAttrCompName,
+                            includeAllChildren: true,
                         },
                         gridAttr: {
                             dependencyType: "attributeComponent",
@@ -2150,9 +2162,19 @@ export default class Graph extends BlockComponent {
                 // is not the author's to fix. The cost is that a reference to a
                 // value the author got wrong, as in `grid="1 $negativeNumber"`,
                 // goes unreported.
-                const authoredInFull = attrChildren.every(
-                    (child) => typeof child === "string",
-                );
+                //
+                // The test runs over every child rather than over
+                // `attrChildren`, because a child the text attribute could not
+                // accept at all — `grid="$aPoint"` — is missing from
+                // `attrChildren` and from `attrValue` alike. Left to
+                // `attrChildren` the value would look authored, and the warning
+                // would quote the empty remnant the dropped child left behind,
+                // on top of the "invalid format" warning the child already
+                // raised.
+                const authoredInFull =
+                    dependencyValues.allGridAttrChildren.every(
+                        (child) => typeof child === "string",
+                    );
 
                 const noGrid = () => ({
                     setValue: { grid: "none" },

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -26,6 +26,96 @@ import {
 import { returnGraphPrefigureStateVariableDefinitions } from "../utils/prefigure/stateVariable";
 import { codedDiagnostic } from "../utils/diagnostics";
 
+/**
+ * Evaluates one whitespace-separated group of the `grid` attribute to the
+ * positive spacing it stands for, or null when it does not stand for one.
+ *
+ * A group can hold more than one piece: `grid="2$a 3$b"` puts `2` and `$a` in
+ * the same group, and their product is the spacing.
+ *
+ * `me.fromText` throws on text it cannot parse — `grid="(1, 2)"` splits on the
+ * space into `(1,` and `2)`, neither of which parses — so every parse is
+ * guarded. An unparseable piece makes its group unusable rather than taking
+ * the whole document down with it.
+ */
+function gridSpacingFromGroup({ group, attrChildren, dependencyValues }) {
+    let spacing = 1;
+
+    for (let piece of group) {
+        let factor;
+
+        if (typeof piece === "string") {
+            try {
+                factor = me.fromText(piece).evaluate_to_constant();
+            } catch (e) {
+                return null;
+            }
+        } else {
+            // A non-string piece was adapted from a number or math component.
+            let childInd = attrChildren.indexOf(piece);
+            factor = dependencyValues["childAdapter" + childInd];
+            if (factor instanceof me.class) {
+                factor = factor.evaluate_to_constant();
+            }
+        }
+
+        spacing *= factor;
+    }
+
+    // Rejects zero and negatives, and the null or NaN that an expression
+    // without a constant value evaluates to.
+    return spacing > 0 ? spacing : null;
+}
+
+/**
+ * Splits the `grid` attribute's children into whitespace-separated groups.
+ *
+ * Whitespace only ever appears inside string children, so a group runs until a
+ * string child contributes a space. Non-string children join whatever group is
+ * open around them.
+ */
+function groupGridAttrChildren(attrChildren) {
+    let groupedChildren = [];
+    let pieces = [];
+
+    for (let child of attrChildren) {
+        if (typeof child !== "string") {
+            pieces.push(child);
+            continue;
+        }
+
+        let stringPieces = child.split(/\s+/);
+        let s0 = stringPieces[0];
+
+        if (s0 === "") {
+            // started with a space
+            if (pieces.length > 0) {
+                groupedChildren.push(pieces);
+                pieces = [];
+            }
+        } else {
+            pieces.push(s0);
+        }
+
+        for (let s of stringPieces.slice(1)) {
+            // if have more than one piece, must have had a space in between pieces
+            if (pieces.length > 0) {
+                groupedChildren.push(pieces);
+                pieces = [];
+            }
+            if (s !== "") {
+                pieces.push(s);
+            }
+        }
+    }
+
+    if (pieces.length > 0) {
+        groupedChildren.push(pieces);
+    }
+
+    return groupedChildren;
+}
+
 export default class Graph extends BlockComponent {
     constructor(args) {
         super(args);
@@ -2045,9 +2135,32 @@ export default class Graph extends BlockComponent {
                     };
                 }
 
-                let grid = dependencyValues.gridAttr.stateValues.value
-                    .toLowerCase()
-                    .trim();
+                const attrChildren = dependencyValues.gridAttrCompChildren;
+                const attrValue = dependencyValues.gridAttr.stateValues.value;
+
+                // Only a value the author spelled out can be reported as
+                // invalid. When the attribute contains a reference, an unusable
+                // value is usually a `<mathInput>` the reader has not filled in
+                // yet, and warning about it would fire on every load.
+                const authoredInFull = attrChildren.every(
+                    (child) => typeof child === "string",
+                );
+
+                const noGrid = () => ({
+                    setValue: { grid: "none" },
+                    setCreateComponentOfType: { grid: "text" },
+                    sendDiagnostics: authoredInFull
+                        ? [
+                              codedDiagnostic({
+                                  type: "warning",
+                                  code: "doenet-w0119",
+                                  args: { grid: attrValue },
+                              }),
+                          ]
+                        : [],
+                });
+
+                let grid = attrValue.toLowerCase().trim();
                 if (grid === "true") {
                     grid = "medium";
                 } else if (grid === "false") {
@@ -2060,124 +2173,28 @@ export default class Graph extends BlockComponent {
                     };
                 }
 
-                // group the children separated by spaces contained in string children
-
-                let groupedChildren = [];
-                let pieces = [];
-
-                for (let child of dependencyValues.gridAttrCompChildren) {
-                    if (typeof child !== "string") {
-                        pieces.push(child);
-                    } else {
-                        let stringPieces = child.split(/\s+/);
-                        let s0 = stringPieces[0];
-
-                        if (s0 === "") {
-                            // started with a space
-                            if (pieces.length > 0) {
-                                groupedChildren.push(pieces);
-                                pieces = [];
-                            }
-                        } else {
-                            pieces.push(s0);
-                        }
-
-                        for (let s of stringPieces.slice(1)) {
-                            // if have more than one piece, must have had a space in between pieces
-                            if (pieces.length > 0) {
-                                groupedChildren.push(pieces);
-                                pieces = [];
-                            }
-                            if (s !== "") {
-                                pieces.push(s);
-                            }
-                        }
-                    }
-                }
-
-                if (pieces.length > 0) {
-                    groupedChildren.push(pieces);
-                }
+                const groupedChildren = groupGridAttrChildren(attrChildren);
 
                 if (groupedChildren.length < 2) {
                     // if don't have at least two pieces separated by spaces, it isn't valid
-                    return {
-                        setValue: { grid: "none" },
-                        setCreateComponentOfType: { grid: "text" },
-                    };
+                    return noGrid();
                 }
 
                 grid = [];
 
                 for (let group of groupedChildren) {
-                    // each of the two grouped children must represent a positive number
-                    if (group.length === 1) {
-                        let child = group[0];
-                        if (typeof child === "string") {
-                            let num = me.fromText(child).evaluate_to_constant();
-                            if (num > 0) {
-                                grid.push(num);
-                            } else {
-                                return {
-                                    setValue: { grid: "none" },
-                                    setCreateComponentOfType: { grid: "text" },
-                                };
-                            }
-                        } else {
-                            // have a single non-string child.  See if it was adapted from number/math
-                            let childInd =
-                                dependencyValues.gridAttrCompChildren.indexOf(
-                                    child,
-                                );
+                    // each of the grouped children must represent a positive number
+                    const spacing = gridSpacingFromGroup({
+                        group,
+                        attrChildren,
+                        dependencyValues,
+                    });
 
-                            let num =
-                                dependencyValues["childAdapter" + childInd];
-                            if (num instanceof me.class) {
-                                num = num.evaluate_to_constant();
-                            }
-
-                            if (num > 0) {
-                                grid.push(num);
-                            } else {
-                                return {
-                                    setValue: { grid: "none" },
-                                    setCreateComponentOfType: { grid: "text" },
-                                };
-                            }
-                        }
-                    } else {
-                        // have a group of multiple children
-                        // multiply them together
-                        let num = 1;
-                        for (let piece of group) {
-                            if (typeof piece === "string") {
-                                num *= me
-                                    .fromText(piece)
-                                    .evaluate_to_constant();
-                            } else {
-                                let childInd =
-                                    dependencyValues.gridAttrCompChildren.indexOf(
-                                        piece,
-                                    );
-
-                                let factor =
-                                    dependencyValues["childAdapter" + childInd];
-                                if (factor instanceof me.class) {
-                                    factor = factor.evaluate_to_constant();
-                                }
-                                num *= factor;
-                            }
-                        }
-
-                        if (num > 0) {
-                            grid.push(num);
-                        } else {
-                            return {
-                                setValue: { grid: "none" },
-                                setCreateComponentOfType: { grid: "text" },
-                            };
-                        }
+                    if (spacing === null) {
+                        return noGrid();
                     }
+
+                    grid.push(spacing);
                 }
 
                 return {

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -97,9 +97,9 @@ function groupGridAttrChildren(attrChildren) {
         }
 
         for (const [ind, piece] of child.split(/\s+/).entries()) {
-            // Splitting on whitespace puts a space before every piece but the
-            // first, and an empty first piece means the child led with one.
-            // Either way the group that was open ends at that space.
+            // A space preceded every piece but the first, and an empty first
+            // piece means the child led with one. Either way the group that
+            // was open ends at that space.
             if (ind > 0 || piece === "") {
                 endGroup();
             }

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -2143,9 +2143,13 @@ export default class Graph extends BlockComponent {
                 const attrValue = dependencyValues.gridAttr.stateValues.value;
 
                 // Only a value the author spelled out can be reported as
-                // invalid. When the attribute contains a reference, an unusable
-                // value is usually a `<mathInput>` the reader has not filled in
-                // yet, and warning about it would fire on every load.
+                // invalid. Once the attribute contains a reference, an unusable
+                // value is not reliably a mistake: it is usually a `<mathInput>`
+                // the reader has not filled in yet — warning about that would
+                // fire on every load — or one they have filled in badly, which
+                // is not the author's to fix. The cost is that a reference to a
+                // value the author got wrong, as in `grid="1 $negativeNumber"`,
+                // goes unreported.
                 const authoredInFull = attrChildren.every(
                     (child) => typeof child === "string",
                 );

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -37,8 +37,12 @@ import { codedDiagnostic } from "../utils/diagnostics";
  * space into `(1,` and `2)`, neither of which parses — so every parse is
  * guarded. An unparseable piece makes its group unusable rather than taking
  * the whole document down with it.
+ *
+ * A non-string piece is read out of `dependencyValues`, which carries both the
+ * attribute's children (`gridAttrCompChildren`, whose order gives each piece
+ * its index) and one `childAdapter<index>` per child.
  */
-function gridSpacingFromGroup({ group, attrChildren, dependencyValues }) {
+function gridSpacingFromGroup(group, dependencyValues) {
     let spacing = 1;
 
     for (let piece of group) {
@@ -47,12 +51,12 @@ function gridSpacingFromGroup({ group, attrChildren, dependencyValues }) {
         if (typeof piece === "string") {
             try {
                 factor = me.fromText(piece).evaluate_to_constant();
-            } catch (e) {
+            } catch {
                 return null;
             }
         } else {
             // A non-string piece was adapted from a number or math component.
-            let childInd = attrChildren.indexOf(piece);
+            let childInd = dependencyValues.gridAttrCompChildren.indexOf(piece);
             factor = dependencyValues["childAdapter" + childInd];
             if (factor instanceof me.class) {
                 factor = factor.evaluate_to_constant();
@@ -434,7 +438,7 @@ export default class Graph extends BlockComponent {
             createComponentOfType: "text",
             valueForTrue: "medium",
             description:
-                "Grid density to render on the graph (off, minor, medium, or major).",
+                'Grid line spacing on the graph: none, medium, dense, or two positive numbers giving the x and y spacing, such as grid="1 0.5".',
         };
 
         Object.assign(attributes, returnNumberDisplayAttributes());
@@ -2184,11 +2188,10 @@ export default class Graph extends BlockComponent {
 
                 for (let group of groupedChildren) {
                     // each of the grouped children must represent a positive number
-                    const spacing = gridSpacingFromGroup({
+                    const spacing = gridSpacingFromGroup(
                         group,
-                        attrChildren,
                         dependencyValues,
-                    });
+                    );
 
                     if (spacing === null) {
                         return noGrid();

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1483,6 +1483,29 @@ describe("Graph tag tests @group2", async () => {
         expect(getDiagnosticsByType(core).warnings.length).eq(0);
     });
 
+    it("a grid the attribute cannot hold is not quoted back at the author", async () => {
+        // A `<point>` is not something a text attribute can hold, so it never
+        // reaches the grid definition: it is dropped from the attribute's
+        // children and from its value alike, leaving an empty value behind.
+        // Core already reports the attribute's format; quoting the remnant of
+        // the dropped child back as if the author had typed it would be a
+        // second warning saying something that was never written.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<point name="p" /><graph name="g" grid="$p" />`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g")].stateValues.grid,
+        ).eq("none");
+
+        const warnings = getDiagnosticsByType(core).warnings;
+        expect(warnings.length).eq(1);
+        expect(warnings[0].message).contain(
+            "Invalid format for attribute grid of `<graph>`",
+        );
+    });
+
     it("correctly shadow references to number list grid", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1389,12 +1389,26 @@ describe("Graph tag tests @group2", async () => {
                 `grid="${gridValue}"`,
             ).eq(0);
         }
+
+        // A bare `grid` carries no value of its own, so it never reaches the
+        // pieces the definition splits apart. It is still `medium`.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<graph name="g" grid />`,
+        });
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g")].stateValues.grid,
+        ).eq("medium");
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
     });
 
-    it("an unfilled input in a grid value stays quiet", async () => {
+    it("a grid value from a reference stays quiet", async () => {
         // An unusable value coming from a reference is normally an input the
         // reader has not filled in yet, so it must not warn on load — only a
-        // value the author spelled out in full does.
+        // value the author spelled out in full does. A reference is also how a
+        // graph gets a grid the reader chooses, so an unusable one is not even
+        // reliably a mistake: `$ti` below is unusable until the reader types
+        // `dense` into it.
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <mathInput name="gx" />
@@ -1437,6 +1451,35 @@ describe("Graph tag tests @group2", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("g2")].stateValues.grid,
         ).eqls([6, 4.5]);
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+
+        // A reader who types a value the graph cannot use gets no grid and
+        // still no warning: the mistake is not the author's to fix.
+        await updateMathInputValue({
+            latex: "-1",
+            componentIdx: await resolvePathToNodeIdx("gx"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g")].stateValues.grid,
+        ).eq("none");
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+
+        // A single reference is the one way an author gets a reader-chosen
+        // `none`/`medium`/`dense`, so it must not be reported as unusable just
+        // because it cannot be split into two spacings.
+        await updateTextInputValue({
+            text: "dense",
+            componentIdx: await resolvePathToNodeIdx("ti"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g3")].stateValues.grid,
+        ).eq("dense");
         expect(getDiagnosticsByType(core).warnings.length).eq(0);
     });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1309,6 +1309,120 @@ describe("Graph tag tests @group2", async () => {
         ).eqls([((3 * Math.PI) / 5) * 2, ((1.5 * Math.E) / 6) * 3]);
     });
 
+    it("an unusable grid value warns instead of crashing", async () => {
+        // `grid` takes two positive numbers separated by a space. Everything
+        // here is a way of getting that wrong, including values whose pieces
+        // `me.fromText` cannot parse at all: `grid="(1, 2)"` splits on its
+        // space into `(1,` and `2)`, which used to throw out of the state
+        // variable and take down the whole document.
+        const unusableValues = [
+            "(1, 2)",
+            "(1,2) (3,4)",
+            "1, 2",
+            "0 1",
+            "1 -2",
+            "foo bar",
+            "1",
+            "",
+        ];
+
+        for (const gridValue of unusableValues) {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `<graph name="g" grid="${gridValue}" />`,
+            });
+
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("g")].stateValues
+                    .grid,
+                `grid="${gridValue}"`,
+            ).eq("none");
+
+            const diagnostics = getDiagnosticsByType(core);
+            expect(diagnostics.errors.length, `grid="${gridValue}"`).eq(0);
+            expect(
+                diagnostics.warnings.filter((warning) =>
+                    warning.message.includes(
+                        `cannot interpret grid="${gridValue}"`,
+                    ),
+                ).length,
+                `grid="${gridValue}"`,
+            ).eq(1);
+        }
+    });
+
+    it("a usable grid value warns about nothing", async () => {
+        const usableValues = ["none", "medium", "dense", "true", "false"];
+
+        for (const gridValue of usableValues) {
+            const { core } = await createTestCore({
+                doenetML: `<graph name="g" grid="${gridValue}" />`,
+            });
+
+            expect(
+                getDiagnosticsByType(core).warnings.length,
+                `grid="${gridValue}"`,
+            ).eq(0);
+        }
+
+        const { core } = await createTestCore({
+            doenetML: `<graph name="g" grid="1 pi/2" />`,
+        });
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+    });
+
+    it("an unfilled input in a grid value stays quiet", async () => {
+        // An unusable value coming from a reference is normally an input the
+        // reader has not filled in yet, so it must not warn on load — only a
+        // value the author spelled out in full does.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <mathInput name="gx" />
+    <mathInput name="gy" />
+    <graph name="g" grid="$gx $gy" />
+    <graph name="g2" grid="2$gx 3$gy" />
+    <textInput name="ti" />
+    <graph name="g3" grid="$ti" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g")].stateValues.grid,
+        ).eq("none");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g2")].stateValues.grid,
+        ).eq("none");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g3")].stateValues.grid,
+        ).eq("none");
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+
+        // Filling the inputs in still produces the grid it always did.
+        await updateMathInputValue({
+            latex: "3",
+            componentIdx: await resolvePathToNodeIdx("gx"),
+            core,
+        });
+        await updateMathInputValue({
+            latex: "1.5",
+            componentIdx: await resolvePathToNodeIdx("gy"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g")].stateValues.grid,
+        ).eqls([3, 1.5]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g2")].stateValues.grid,
+        ).eqls([6, 4.5]);
+        expect(getDiagnosticsByType(core).warnings.length).eq(0);
+    });
+
     it("correctly shadow references to number list grid", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1343,35 +1343,52 @@ describe("Graph tag tests @group2", async () => {
 
             const diagnostics = getDiagnosticsByType(core);
             expect(diagnostics.errors.length, `grid="${gridValue}"`).eq(0);
+            expect(diagnostics.warnings.length, `grid="${gridValue}"`).eq(1);
+            expect(diagnostics.warnings[0].code, `grid="${gridValue}"`).eq(
+                "doenet-w0119",
+            );
             expect(
-                diagnostics.warnings.filter((warning) =>
-                    warning.message.includes(
-                        `cannot interpret grid="${gridValue}"`,
-                    ),
-                ).length,
+                diagnostics.warnings[0].message,
                 `grid="${gridValue}"`,
-            ).eq(1);
+            ).contain(`cannot interpret grid="${gridValue}"`);
         }
     });
 
     it("a usable grid value warns about nothing", async () => {
-        const usableValues = ["none", "medium", "dense", "true", "false"];
+        // The value each of these resolves to is what the definition produced
+        // before it was refactored into a single product loop.
+        const usableValues: [string, string | number[]][] = [
+            ["none", "none"],
+            ["medium", "medium"],
+            ["dense", "dense"],
+            ["true", "medium"],
+            ["false", "none"],
+            ["MEDIUM", "medium"],
+            ["1 pi/2", [1, Math.PI / 2]],
+            ["  2   3  ", [2, 3]],
+            ["2/3 3/4", [2 / 3, 3 / 4]],
+        ];
 
-        for (const gridValue of usableValues) {
-            const { core } = await createTestCore({
+        for (const [gridValue, expectedGrid] of usableValues) {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
                 doenetML: `<graph name="g" grid="${gridValue}" />`,
             });
+
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("g")].stateValues
+                    .grid,
+                `grid="${gridValue}"`,
+            ).eqls(expectedGrid);
 
             expect(
                 getDiagnosticsByType(core).warnings.length,
                 `grid="${gridValue}"`,
             ).eq(0);
         }
-
-        const { core } = await createTestCore({
-            doenetML: `<graph name="g" grid="1 pi/2" />`,
-        });
-        expect(getDiagnosticsByType(core).warnings.length).eq(0);
     });
 
     it("an unfilled input in a grid value stays quiet", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1501,6 +1501,7 @@ describe("Graph tag tests @group2", async () => {
 
         const warnings = getDiagnosticsByType(core).warnings;
         expect(warnings.length).eq(1);
+        expect(warnings[0].code).eq("doenet-w0106");
         expect(warnings[0].message).contain(
             "Invalid format for attribute grid of `<graph>`",
         );

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -211,5 +211,6 @@
     "doenet-w0115": "schema-attribute-unrecognized",
     "doenet-w0116": "schema-attribute-value-not-allowed",
     "doenet-w0117": "matches-pattern-parameter-not-in-pattern",
-    "doenet-w0118": "prefigure-grid-spacing-too-fine"
+    "doenet-w0118": "prefigure-grid-spacing-too-fine",
+    "doenet-w0119": "graph-grid-invalid"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -329,6 +329,14 @@ matches-pattern-parameter-not-in-pattern =
        *[other] `<matchesPattern>`: the parameters { $parameters } do not occur in the pattern, so they will always match a blank.
     }
 
+## `<graph>`
+
+# Translators: grid is an attribute name and none, medium and dense are its
+# values; all four stay in English, as does the example. $grid is the value the
+# author wrote, reproduced verbatim — it reached this message precisely because
+# it was not one of the forms listed.
+graph-grid-invalid = `<graph>`: cannot interpret grid="{ $grid }". It must be none, medium, dense, or two positive numbers separated by a space, such as grid="1 0.5". No grid is drawn.
+
 ## PreFigure renderer
 
 # Translators: xLabelPosition, yLabelPosition and their values are attribute

--- a/packages/i18n/locales/es/diagnostics.ftl
+++ b/packages/i18n/locales/es/diagnostics.ftl
@@ -272,6 +272,10 @@ matches-pattern-parameter-not-in-pattern =
        *[other] `<matchesPattern>`: los parámetros { $parameters } no aparecen en el patrón, por lo que siempre coincidirán con un espacio en blanco.
     }
 
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: no se puede interpretar grid="{ $grid }". Debe ser none, medium, dense o dos números positivos separados por un espacio, como grid="1 0.5". No se dibuja ninguna cuadrícula.
+
 ## Renderizador PreFigure
 
 prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" no es compatible con el renderizador prefigure; se usa el comportamiento de posición derecha.

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -203,6 +203,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0116": "schema-attribute-value-not-allowed",
     "doenet-w0117": "matches-pattern-parameter-not-in-pattern",
     "doenet-w0118": "prefigure-grid-spacing-too-fine",
+    "doenet-w0119": "graph-grid-invalid",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -371,6 +371,7 @@ export type MessageKey =
     | "math-operators-operand-number-required"
     | "eigen-decomposition-failed"
     | "matches-pattern-parameter-not-in-pattern"
+    | "graph-grid-invalid"
     | "prefigure-x-label-position-unsupported"
     | "prefigure-y-label-position-unsupported"
     | "prefigure-invalid-axis-bounds"
@@ -932,6 +933,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "math-operators-operand-number-required",
     "eigen-decomposition-failed",
     "matches-pattern-parameter-not-in-pattern",
+    "graph-grid-invalid",
     "prefigure-x-label-position-unsupported",
     "prefigure-y-label-position-unsupported",
     "prefigure-invalid-axis-bounds",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -86844,7 +86844,7 @@
                 },
                 {
                     "name": "grid",
-                    "description": "Grid density to render on the graph (off, minor, medium, or major).",
+                    "description": "Grid line spacing on the graph: none, medium, dense, or two positive numbers giving the x and y spacing, such as grid=\"1 0.5\".",
                     "type": "text"
                 },
                 {


### PR DESCRIPTION
Closes #1601.

## The crash

```xml
<graph grid="(1, 2)" name="g"></graph>
```

replaced the whole document with a red `Expecting ) or ]` box.

`grid` takes two positive numbers separated by whitespace, so that value is wrong — but a wrong attribute value should be ignored with a warning, not take down the document.

The definition splits the attribute on whitespace and parses each piece on its own. Here the space falls *inside* the parentheses, so the split cuts the tuple in half:

```
"(1, 2)"  →  ["(1,", "2)"]
```

Two pieces, so it clears the "at least two pieces" check and reaches `me.fromText("(1,")`, which throws. Nothing caught it, so the exception escaped the state-variable definition. Neither of the definition's two `me.fromText` calls was guarded; the refactor below leaves a single call site, and it is.

## The silent failures

Values that parse but do not yield two positive numbers were already falling back to no grid without saying anything, which left the author with a gridless graph and no reason for it. They now warn:

| Value | Before | After |
| --- | --- | --- |
| `grid="(1, 2)"` | Document crashes | Warning, no grid |
| `grid="(1,2) (3,4)"` | Silently no grid | Warning, no grid |
| `grid="1, 2"` | Silently no grid | Warning, no grid |
| `grid="0 1"` | Silently no grid | Warning, no grid |
| `grid="1"` | Silently no grid | Warning, no grid |
| `grid=""` | Silently no grid | Warning, no grid |

New warning `doenet-w0119`, in both catalogs: *"`<graph>`: cannot interpret grid="…". It must be none, medium, dense, or two positive numbers separated by a space, such as grid="1 0.5". No grid is drawn."*

## What stays quiet

Only a value the author spelled out in full is reported — the check is whether every child of the attribute is a literal string. Once the attribute holds a reference, an unusable value is not reliably a mistake, for two separate reasons.

It may be an input the reader has not filled in yet:

```xml
<mathInput name="gx" /><mathInput name="gy" />
<graph grid="$gx $gy" />
```

That graph has no grid until both inputs are filled, and warning about it would fire on every load. The same holds after they are filled: a reader who types `-1` gets no grid, and that is not the author's mistake to fix.

A lone reference is also how an author hands the choice of grid to the reader:

```xml
<textInput name="choice" />
<graph grid="$choice" />
```

`grid="$choice"` cannot be split into two spacings, but it resolves to `none`, `medium`, or `dense` as soon as the reader types one — so it must not be reported as unusable in the meantime.

The check runs over *every* child of the attribute, not only the ones a text attribute can hold. A reference to something it cannot hold at all — `grid="$aPoint"` — is dropped from the attribute's children and from its value alike, so a check over what survives would read as an authored empty value and quote that empty remnant back at an author who never typed it, on top of the `Invalid format for attribute grid` warning the dropped child already raises.

The cost of the rule is that a reference to a value the author got wrong, as in `grid="1 $negativeNumber"`, goes unreported. It also keeps the existing `fixed grids` test's `[NaN]` cases warning-free.

## The attribute's own description

`grid`'s schema description read *"Grid density to render on the graph (off, minor, medium, or major)."* Three of those four values are not accepted — `off`, `minor` and `major` all land on the new warning. Editor autocomplete and hover were offering authors values the component rejects, so the description now names what `grid` takes, matching what `packages/docs-nextra/pages/reference/graph2.mdx` already documents, and `packages/static-assets/src/generated/doenet-schema.json` is regenerated.

## Refactor

The grouping and the per-group evaluation move out to two module-level functions. That collapses the single-piece and multi-piece branches, which were computing a product over the same pieces by two different routes — the definition body goes from 148 lines to 79. The grouping keeps one loop over the pieces a string child splits into, rather than treating the first piece as a special case, and closes an open group through a single `endGroup` helper rather than repeating the same flush three times.

The refactor is meant to be behavior-preserving, and was checked as such: a probe over 36 `grid` values — keywords, casing, whitespace runs, two- and four-number lists, expressions, adapted `<number>`/`<math>` references, and every failing form — produced byte-identical `grid` state values before and after. The grouping rewrite was checked the same way, against the implementation it replaces, over every child array of up to three children drawn from a whitespace-heavy alphabet.

## Deliberately unchanged

`grid="1 2 3"` still resolves to `[1, 2, 3]` and draws a grid from the first two numbers. It is not a silent *failure* — a grid does appear — so it is left alone rather than folded into this warning.

## Testing

- Four new cases in `graph.test.ts`: eight unusable values each raise exactly one `doenet-w0119` naming the value and leave `grid` at `"none"`; nine usable values plus a bare `grid` resolve to the spacings they always did and warn about nothing; a referenced grid stays quiet whether its inputs are unfilled, filled with something unusable, or filled with `dense`, while still producing the right spacings when they are filled with numbers; and `grid="$aPoint"` raises only the `Invalid format for attribute grid` warning it always did.
- `src/test/tagSpecific/graph.test.ts` 41/41, `src/test/prefigure/` 180 passed / 2 skipped (the prefigure renderer reads this state variable), `packages/i18n` lint clean at 214 codes across both locales, and the schema is regenerated and up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

