### PR TITLE
fix: bundle Comlink into the iframe boot script instead of loading it from a CDN

### DIFF
--- a/.changeset/iframe-bundle-comlink.md
+++ b/.changeset/iframe-bundle-comlink.md
@@ -4,4 +4,4 @@
 
 Bundle Comlink into the iframe's boot script instead of importing it from unpkg at runtime.
 
-Every `DoenetViewer`/`DoenetEditor` iframe used to `import` Comlink from `https://unpkg.com` before its boot script could run, so the whole document waited on a public CDN it had no control over. If that request was slow, blocked, or intercepted, the iframe stayed on the loading placeholder indefinitely — no timeout, no error. Comlink is now compiled into the boot script, so an iframe boots with no third-party network dependency.
+Every `DoenetViewer`/`DoenetEditor` iframe used to `import` Comlink from `https://unpkg.com` before any of its boot script could run. If that request was slow, blocked, or intercepted, the iframe stayed on its loading placeholder indefinitely — no timeout, no error. Comlink is compiled into the boot script now, so an iframe boots with no third-party network dependency.

--- a/.changeset/iframe-bundle-comlink.md
+++ b/.changeset/iframe-bundle-comlink.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml-iframe": patch
+---
+
+Bundle Comlink into the iframe's boot script instead of importing it from unpkg at runtime.
+
+Every `DoenetViewer`/`DoenetEditor` iframe used to `import` Comlink from `https://unpkg.com` before its boot script could run, so the whole document waited on a public CDN it had no control over. If that request was slow, blocked, or intercepted, the iframe stayed on the loading placeholder indefinitely — no timeout, no error. Comlink is now compiled into the boot script, so an iframe boots with no third-party network dependency.

--- a/packages/doenetml-iframe/cypress.config.ts
+++ b/packages/doenetml-iframe/cypress.config.ts
@@ -85,16 +85,14 @@ export default defineConfig({
                 ],
                 optimizeDeps: {
                     exclude: ["@doenet/standalone"],
-                    // `DoenetViewer.virtualKeyboard.cy.tsx` imports
-                    // @doenet/virtual-keyboard's SOURCE by relative path, so
-                    // these two arrive with it — but only for that one spec of
-                    // 20. A run that skips it leaves `node_modules/.vite`
-                    // holding 8 deps; the next fuller run discovers these
-                    // mid-flight, re-optimizes, and reloads the page out from
-                    // under whatever spec is mounting. Pre-include them so
-                    // every run starts from the same set. CI always begins from
-                    // a cold cache (`npm ci` recreates `node_modules`), so this
-                    // is local-dev hygiene, not a CI fix.
+                    // Only `DoenetViewer.virtualKeyboard.cy.tsx` pulls these in
+                    // (it imports @doenet/virtual-keyboard's source by relative
+                    // path), so a `--spec`-narrowed run that skips it leaves a
+                    // partial `node_modules/.vite`; the next fuller run then
+                    // discovers them mid-flight, re-optimizes, and reloads the
+                    // page out from under whatever spec is mounting. Pre-include
+                    // them so every run starts from the same set. CI always
+                    // begins from a cold cache, so this is local-dev hygiene.
                     include: ["@ariakit/react", "classnames"],
                 },
             },

--- a/packages/doenetml-iframe/cypress.config.ts
+++ b/packages/doenetml-iframe/cypress.config.ts
@@ -85,6 +85,17 @@ export default defineConfig({
                 ],
                 optimizeDeps: {
                     exclude: ["@doenet/standalone"],
+                    // `DoenetViewer.virtualKeyboard.cy.tsx` imports
+                    // @doenet/virtual-keyboard's SOURCE by relative path, so
+                    // these two arrive with it — but only for that one spec of
+                    // 20. A run that skips it leaves `node_modules/.vite`
+                    // holding 8 deps; the next fuller run discovers these
+                    // mid-flight, re-optimizes, and reloads the page out from
+                    // under whatever spec is mounting. Pre-include them so
+                    // every run starts from the same set. CI always begins from
+                    // a cold cache (`npm ci` recreates `node_modules`), so this
+                    // is local-dev hygiene, not a CI fix.
+                    include: ["@ariakit/react", "classnames"],
                 },
             },
         },

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -1,11 +1,12 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetEditor.
 import type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
-// Comlink is imported here so the iife build bundles it into this script.
-// The srcdoc used to `import` it from unpkg instead, which put a public-CDN
-// round trip on the critical path of every single iframe boot: until that
-// module resolved, this script — and with it the `iframeReady` handshake the
-// parent waits for — did not run at all.
+// Comlink must be imported *here*, so the iife build bundles it into this
+// script — never from the srcdoc. The srcdoc used to `import` it from unpkg,
+// and an `import` declaration is resolved before any of the module body runs:
+// a CDN fetch that stalled left this whole script unexecuted, the `iframeReady`
+// handshake the parent waits for unsent, and the iframe stuck on its loading
+// placeholder with no timeout and no error.
 import * as ComlinkEditor from "comlink";
 
 declare const editorId: string;

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -1,15 +1,16 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetEditor.
 import type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
+// Comlink is imported here so the iife build bundles it into this script.
+// The srcdoc used to `import` it from unpkg instead, which put a public-CDN
+// round trip on the critical path of every single iframe boot: until that
+// module resolved, this script — and with it the `iframeReady` handshake the
+// parent waits for — did not run at all.
+import * as ComlinkEditor from "comlink";
 
 declare const editorId: string;
 declare const doenetEditorProps: Record<string, any>;
 declare const doenetEditorPropsSpecified: string[];
-declare const ComlinkEditor: {
-    expose: Function;
-    windowEndpoint: Function;
-    releaseProxy: symbol;
-};
 declare global {
     interface Window {
         renderDoenetEditorToContainer: (

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -1,13 +1,14 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetEditor.
 import type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
-// Comlink must be imported *here*, so the iife build bundles it into this
-// script — never from the srcdoc. The srcdoc used to `import` it from unpkg,
-// and an `import` declaration is resolved before any of the module body runs:
-// a CDN fetch that stalled left this whole script unexecuted, the `iframeReady`
-// handshake the parent waits for unsent, and the iframe stuck on its loading
-// placeholder with no timeout and no error.
-import * as ComlinkEditor from "comlink";
+// Comlink must be imported *here* so the iife build compiles it into this
+// script, never supplied as a free binding by the srcdoc. The srcdoc used to
+// `import` it from unpkg, and an `import` declaration is resolved before any
+// of the module body runs: a CDN fetch that stalled left this whole script
+// unexecuted, the `iframeReady` handshake the parent waits for unsent, and the
+// iframe stuck on its loading placeholder with no timeout and no error.
+// `test/cypress/component/srcdocSelfContained.cy.ts` guards the invariant.
+import * as Comlink from "comlink";
 
 declare const editorId: string;
 declare const doenetEditorProps: Record<string, any>;
@@ -90,7 +91,7 @@ function functionPropArgsToMap(
 
 function releaseFunctionProxy(fn: Function) {
     try {
-        (fn as any)?.[ComlinkEditor.releaseProxy]?.();
+        (fn as any)?.[Comlink.releaseProxy]?.();
     } catch (e) {
         console.warn(
             "iframe DoenetEditor: failed to release stale Comlink proxy",
@@ -189,7 +190,7 @@ async function waitForStandaloneBundle(timeoutMs: number): Promise<boolean> {
     return false;
 }
 
-ComlinkEditor.expose(
+Comlink.expose(
     {
         renderEditorWithFunctionProps,
         updateEditorProps(updatedSerializableProps: Record<string, any>) {
@@ -271,7 +272,7 @@ ComlinkEditor.expose(
             editorControlHandle.updateRenderedView();
         },
     },
-    ComlinkEditor.windowEndpoint(globalThis.parent),
+    Comlink.windowEndpoint(globalThis.parent),
 );
 
 /**
@@ -323,7 +324,7 @@ function renderWithLastAugmentedProps() {
 
 // Defer `iframeReady` until the standalone bundle has defined
 // `renderDoenetEditorToContainer`. See `waitForStandaloneBundle` above
-// for why this gate is load-bearing. ComlinkEditor.expose above has
+// for why this gate is load-bearing. Comlink.expose above has
 // already run so the Comlink endpoint is wired and ready for the parent
 // to call as soon as we signal — there's just no point signalling
 // until the function the parent will eventually invoke is in place.

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -1,13 +1,10 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetViewer.
 
-// Comlink must be imported *here*, so the iife build bundles it into this
-// script — never from the srcdoc. The srcdoc used to `import` it from unpkg,
-// and an `import` declaration is resolved before any of the module body runs:
-// a CDN fetch that stalled left this whole script unexecuted, the `iframeReady`
-// handshake the parent waits for unsent, and the iframe stuck on its loading
-// placeholder with no timeout and no error.
-import * as ComlinkViewer from "comlink";
+// Comlink must be imported *here* so the iife build compiles it into this
+// script, never supplied as a free binding by the srcdoc. See the equivalent
+// import in iframe-editor-index.ts for the cold-boot hang that motivated it.
+import * as Comlink from "comlink";
 
 declare const viewerId: string;
 declare const doenetViewerProps: Record<string, any>;
@@ -118,7 +115,7 @@ function functionPropArgsToMap(
 
 function releaseFunctionProxy(fn: Function) {
     try {
-        (fn as any)?.[ComlinkViewer.releaseProxy]?.();
+        (fn as any)?.[Comlink.releaseProxy]?.();
     } catch (e) {
         console.warn(
             "iframe DoenetViewer: failed to release stale Comlink proxy",
@@ -216,7 +213,7 @@ async function waitForStandaloneBundle(timeoutMs: number): Promise<boolean> {
     return false;
 }
 
-ComlinkViewer.expose(
+Comlink.expose(
     {
         renderViewerWithFunctionProps,
         updateViewerProps(updatedSerializableProps: Record<string, any>) {
@@ -279,7 +276,7 @@ ComlinkViewer.expose(
             }
         },
     },
-    ComlinkViewer.windowEndpoint(globalThis.parent),
+    Comlink.windowEndpoint(globalThis.parent),
 );
 
 /**

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -1,11 +1,12 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetViewer.
-//
-// Comlink is imported here so the iife build bundles it into this script.
-// The srcdoc used to `import` it from unpkg instead, which put a public-CDN
-// round trip on the critical path of every single iframe boot: until that
-// module resolved, this script — and with it the `iframeReady` handshake the
-// parent waits for — did not run at all.
+
+// Comlink must be imported *here*, so the iife build bundles it into this
+// script — never from the srcdoc. The srcdoc used to `import` it from unpkg,
+// and an `import` declaration is resolved before any of the module body runs:
+// a CDN fetch that stalled left this whole script unexecuted, the `iframeReady`
+// handshake the parent waits for unsent, and the iframe stuck on its loading
+// placeholder with no timeout and no error.
 import * as ComlinkViewer from "comlink";
 
 declare const viewerId: string;

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -1,5 +1,13 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetViewer.
+//
+// Comlink is imported here so the iife build bundles it into this script.
+// The srcdoc used to `import` it from unpkg instead, which put a public-CDN
+// round trip on the critical path of every single iframe boot: until that
+// module resolved, this script — and with it the `iframeReady` handshake the
+// parent waits for — did not run at all.
+import * as ComlinkViewer from "comlink";
+
 declare const viewerId: string;
 declare const doenetViewerProps: Record<string, any>;
 declare const doenetViewerPropsSpecified: string[];
@@ -10,24 +18,22 @@ declare const doenetSharedCoreWorker: boolean | undefined;
 // Baked into the srcdoc for windowed (mountPolicy) viewers. Guarded with
 // `typeof` at the use site like doenetSharedCoreWorker.
 declare const doenetWindowedViewer: boolean | undefined;
-declare const ComlinkViewer: {
-    expose: Function;
-    windowEndpoint: Function;
-    releaseProxy: symbol;
-};
-interface Window {
-    renderDoenetViewerToContainer: (
-        container: Element,
-        doenetMLSource?: string,
-        config?: object,
-    ) => void;
-    doenetGlobalConfig: Record<string, any>;
-    /**
-     * Style-palette discovery, defined by standalone bundles new enough to
-     * ship it. Feature-detected (not version-gated) so an older bundle
-     * simply reports no palettes.
-     */
-    getDoenetStylePalettes?: () => unknown[];
+
+declare global {
+    interface Window {
+        renderDoenetViewerToContainer: (
+            container: Element,
+            doenetMLSource?: string,
+            config?: object,
+        ) => void;
+        doenetGlobalConfig: Record<string, any>;
+        /**
+         * Style-palette discovery, defined by standalone bundles new enough to
+         * ship it. Feature-detected (not version-gated) so an older bundle
+         * simply reports no palettes.
+         */
+        getDoenetStylePalettes?: () => unknown[];
+    }
 }
 
 // Module-scope state below is per-iframe-document: each `<DoenetViewer>` lives

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -112,10 +112,13 @@ export function createHtmlForDoenetViewer(
             const doenetSharedCoreWorker = ${JSON.stringify(!!useSharedCoreWorker)};
             const doenetWindowedViewer = ${JSON.stringify(!!windowed)};
 
-            // Compiled by vite and inlined here verbatim. It reads the consts
-            // declared just above out of this module's scope, and carries its
-            // own bundled copy of Comlink — nothing it needs in order to boot
-            // is fetched from the network.
+            // The boot script, compiled by vite and inlined verbatim. It
+            // reads the consts declared just above out of this module's
+            // scope and carries its own compiled-in copy of Comlink, so
+            // nothing it needs in order to reach iframeReady is fetched from
+            // the network -- test/cypress/component/srcdocSelfContained.cy.ts
+            // guards that. (No backticks in this comment: it lives inside a
+            // template literal.)
             ${viewerIframeJsSource}
         </script>
         <div id="root" data-doenet-message-parent="true" data-doenet-send-resize-events="true">
@@ -159,10 +162,13 @@ export function createHtmlForDoenetEditor(
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};
             const doenetEditorPropsSpecified = ${JSON.stringify(doenetEditorPropsSpecified)};
 
-            // Compiled by vite and inlined here verbatim. It reads the consts
-            // declared just above out of this module's scope, and carries its
-            // own bundled copy of Comlink — nothing it needs in order to boot
-            // is fetched from the network.
+            // The boot script, compiled by vite and inlined verbatim. It
+            // reads the consts declared just above out of this module's
+            // scope and carries its own compiled-in copy of Comlink, so
+            // nothing it needs in order to reach iframeReady is fetched from
+            // the network -- test/cypress/component/srcdocSelfContained.cy.ts
+            // guards that. (No backticks in this comment: it lives inside a
+            // template literal.)
             ${editorIframeJsSource}
         </script>
         <div id="root" data-doenet-message-parent="true">

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -112,9 +112,10 @@ export function createHtmlForDoenetViewer(
             const doenetSharedCoreWorker = ${JSON.stringify(!!useSharedCoreWorker)};
             const doenetWindowedViewer = ${JSON.stringify(!!windowed)};
 
-            // This source code has been compiled by vite and should be directly included.
-            // It assumes that viewerId, doenetViewerProps, and doenetViewerPropsSpecified
-            // are defined in the enclosing scope. It carries its own copy of Comlink.
+            // Compiled by vite and inlined here verbatim. It reads the consts
+            // declared just above out of this module's scope, and carries its
+            // own bundled copy of Comlink — nothing it needs in order to boot
+            // is fetched from the network.
             ${viewerIframeJsSource}
         </script>
         <div id="root" data-doenet-message-parent="true" data-doenet-send-resize-events="true">
@@ -158,9 +159,10 @@ export function createHtmlForDoenetEditor(
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};
             const doenetEditorPropsSpecified = ${JSON.stringify(doenetEditorPropsSpecified)};
 
-            // This source code has been compiled by vite and should be directly included.
-            // It assumes that editorId, doenetEditorProps, and doenetEditorPropsSpecified
-            // are defined in the enclosing scope. It carries its own copy of Comlink.
+            // Compiled by vite and inlined here verbatim. It reads the consts
+            // declared just above out of this module's scope, and carries its
+            // own bundled copy of Comlink — nothing it needs in order to boot
+            // is fetched from the network.
             ${editorIframeJsSource}
         </script>
         <div id="root" data-doenet-message-parent="true">

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -76,6 +76,32 @@ function createIframeBodyOpenTag(darkMode: IframeDarkMode) {
 }
 
 /**
+ * Build the srcdoc's inline boot script: the `const` declarations the compiled
+ * entry point reads out of the surrounding module scope, followed by that entry
+ * point (`iframe-{viewer,editor}-index.iife.js`) inlined verbatim.
+ *
+ * The entry point carries its own compiled-in copy of Comlink, so nothing this
+ * script needs in order to reach `iframeReady` comes off the network. Keep it
+ * that way: an `import` declaration is resolved before any of a module's body
+ * runs, so a fetch that stalls leaves the whole boot script unexecuted, the
+ * handshake unsent, and the iframe parked on its loading placeholder with no
+ * timeout and no error. `test/cypress/component/srcdocSelfContained.cy.ts`
+ * guards the invariant.
+ */
+function createBootScript(
+    boundConsts: Record<string, unknown>,
+    compiledEntryPoint: string,
+) {
+    const declarations = Object.entries(boundConsts)
+        .map(([name, value]) => `const ${name} = ${JSON.stringify(value)};`)
+        .join("\n            ");
+    return `<script type="module">
+            ${declarations}
+            ${compiledEntryPoint}
+        </script>`;
+}
+
+/**
  * Create HTML for a single page document that renders the given DoenetML.
  */
 export function createHtmlForDoenetViewer(
@@ -105,22 +131,16 @@ export function createHtmlForDoenetViewer(
     <html style="overflow:hidden">
     ${createIframeHead(standaloneUrl, cssUrl)}
     ${createIframeBodyOpenTag(doenetViewerProps.darkMode)}
-        <script type="module">
-            const viewerId = "${id}";
-            const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
-            const doenetViewerPropsSpecified = ${JSON.stringify(doenetViewerPropsSpecified)};
-            const doenetSharedCoreWorker = ${JSON.stringify(!!useSharedCoreWorker)};
-            const doenetWindowedViewer = ${JSON.stringify(!!windowed)};
-
-            // The boot script, compiled by vite and inlined verbatim. It
-            // reads the consts declared just above out of this module's
-            // scope and carries its own compiled-in copy of Comlink, so
-            // nothing it needs in order to reach iframeReady is fetched from
-            // the network -- test/cypress/component/srcdocSelfContained.cy.ts
-            // guards that. (No backticks in this comment: it lives inside a
-            // template literal.)
-            ${viewerIframeJsSource}
-        </script>
+        ${createBootScript(
+            {
+                viewerId: id,
+                doenetViewerProps,
+                doenetViewerPropsSpecified,
+                doenetSharedCoreWorker: !!useSharedCoreWorker,
+                doenetWindowedViewer: !!windowed,
+            },
+            viewerIframeJsSource,
+        )}
         <div id="root" data-doenet-message-parent="true" data-doenet-send-resize-events="true">
             <div class="doenet-loading" style="text-align:center">
                 <p><img src="https://www.doenet.org/Doenet_Logo_Frontpage.png"/></p>
@@ -157,20 +177,14 @@ export function createHtmlForDoenetEditor(
     <html style="overflow:hidden">
     ${createIframeHead(standaloneUrl, cssUrl)}
     ${createIframeBodyOpenTag(doenetEditorProps.darkMode)}
-        <script type="module">
-            const editorId = "${id}";
-            const doenetEditorProps = ${JSON.stringify(augmentedProps)};
-            const doenetEditorPropsSpecified = ${JSON.stringify(doenetEditorPropsSpecified)};
-
-            // The boot script, compiled by vite and inlined verbatim. It
-            // reads the consts declared just above out of this module's
-            // scope and carries its own compiled-in copy of Comlink, so
-            // nothing it needs in order to reach iframeReady is fetched from
-            // the network -- test/cypress/component/srcdocSelfContained.cy.ts
-            // guards that. (No backticks in this comment: it lives inside a
-            // template literal.)
-            ${editorIframeJsSource}
-        </script>
+        ${createBootScript(
+            {
+                editorId: id,
+                doenetEditorProps: augmentedProps,
+                doenetEditorPropsSpecified,
+            },
+            editorIframeJsSource,
+        )}
         <div id="root" data-doenet-message-parent="true">
             <script type="text/doenetml">${doenetML}</script>
         </div>

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -100,7 +100,6 @@ export function createHtmlForDoenetViewer(
         doenetViewerPropsSpecified.push("initializedCallback");
     }
 
-    // XXX: rather than serving Comlink from the cdn, below, serve it directly
     // TODO: rather than load the Doenet logo from doenet.org, serve it directly
     return `
     <html style="overflow:hidden">
@@ -112,10 +111,10 @@ export function createHtmlForDoenetViewer(
             const doenetViewerPropsSpecified = ${JSON.stringify(doenetViewerPropsSpecified)};
             const doenetSharedCoreWorker = ${JSON.stringify(!!useSharedCoreWorker)};
             const doenetWindowedViewer = ${JSON.stringify(!!windowed)};
-            import * as ComlinkViewer from "https://unpkg.com/comlink/dist/esm/comlink.mjs";
 
             // This source code has been compiled by vite and should be directly included.
-            // It assumes that viewerId, doenetViewerProps, doenetViewerPropsSpecified, and ComlinkViewer are defined in the global scope.
+            // It assumes that viewerId, doenetViewerProps, and doenetViewerPropsSpecified
+            // are defined in the enclosing scope. It carries its own copy of Comlink.
             ${viewerIframeJsSource}
         </script>
         <div id="root" data-doenet-message-parent="true" data-doenet-send-resize-events="true">
@@ -158,10 +157,10 @@ export function createHtmlForDoenetEditor(
             const editorId = "${id}";
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};
             const doenetEditorPropsSpecified = ${JSON.stringify(doenetEditorPropsSpecified)};
-            import * as ComlinkEditor from "https://unpkg.com/comlink/dist/esm/comlink.mjs";
-            
+
             // This source code has been compiled by vite and should be directly included.
-            // It assumes that editorId, doenetEditorProps, doenetEditorPropsSpecified, and ComlinkEditor are defined in the global scope.
+            // It assumes that editorId, doenetEditorProps, and doenetEditorPropsSpecified
+            // are defined in the enclosing scope. It carries its own copy of Comlink.
             ${editorIframeJsSource}
         </script>
         <div id="root" data-doenet-message-parent="true">

--- a/packages/doenetml-iframe/test/cypress/component/DoenetEditor.srcDocRebuildReplay.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetEditor.srcDocRebuildReplay.cy.tsx
@@ -50,16 +50,7 @@ import {
 //      a rebuilt iframe either runs the bundle fast or it hangs
 //      forever inside Chrome's module loader for that iframe document.
 //
-// One cause of that "hangs forever in the module loader" state has since
-// been found and removed (#1608): the srcDoc's inline module used to
-// `import` Comlink from unpkg, and an `import` declaration is resolved
-// before any of the module body runs — so a CDN fetch that never
-// resolved left the whole boot script unexecuted and `iframeReady`
-// unsent. Comlink is bundled into the boot script now. The retry loop
-// below is kept because the pathology was never fully characterised and
-// costs nothing on a healthy boot.
-//
-// Two complementary changes on this branch:
+// Two complementary changes were made at the time:
 //
 //   a) `iframe-{editor,viewer}-index.ts` now defers `iframeReady`
 //      until `window.renderDoenetEditorToContainer` (or Viewer) has
@@ -80,6 +71,17 @@ import {
 //      after the fact. But a fresh rebuild gives a fresh iframe with
 //      a fresh chance to run the bundle, and the bimodal pattern means
 //      a couple of retries cumulatively reach near-certain success.
+//
+// LATER (#1608): one cause of the "bundle never executes at all" state
+// in (b) turned out not to be a Chrome pathology after all. The srcDoc's
+// inline boot module used to `import` Comlink from unpkg, and an
+// `import` declaration is resolved before any of the module body runs —
+// so a CDN fetch that never resolved left the whole boot script
+// unexecuted and `iframeReady` unsent, which is exactly the
+// `hasCmContent=false` timeline captured above. Comlink is compiled into
+// the boot script now (see `srcdocSelfContained.cy.ts`). The retry loop
+// is kept because the pathology was never fully characterised and costs
+// nothing on a healthy boot.
 //
 // `CYPRESS_REPRO_REBUILDS=N` (default 1) lets a maintainer crank up the
 // outer iteration count locally to multiply rebuild attempts per cypress

--- a/packages/doenetml-iframe/test/cypress/component/DoenetEditor.srcDocRebuildReplay.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetEditor.srcDocRebuildReplay.cy.tsx
@@ -50,6 +50,15 @@ import {
 //      a rebuilt iframe either runs the bundle fast or it hangs
 //      forever inside Chrome's module loader for that iframe document.
 //
+// One cause of that "hangs forever in the module loader" state has since
+// been found and removed (#1608): the srcDoc's inline module used to
+// `import` Comlink from unpkg, and an `import` declaration is resolved
+// before any of the module body runs — so a CDN fetch that never
+// resolved left the whole boot script unexecuted and `iframeReady`
+// unsent. Comlink is bundled into the boot script now. The retry loop
+// below is kept because the pathology was never fully characterised and
+// costs nothing on a healthy boot.
+//
 // Two complementary changes on this branch:
 //
 //   a) `iframe-{editor,viewer}-index.ts` now defers `iframeReady`

--- a/packages/doenetml-iframe/test/cypress/component/srcdocSelfContained.cy.ts
+++ b/packages/doenetml-iframe/test/cypress/component/srcdocSelfContained.cy.ts
@@ -61,16 +61,32 @@ describe("iframe srcdoc is self-contained", () => {
             const script = bootScriptOf(html);
             // An `import`/`export` of any kind puts module resolution back in
             // front of the handshake, which is exactly what hung before.
-            expect(script).to.not.match(/^\s*(import|export)\b/m);
-            expect(script).to.not.include("import(");
-            expect(script).to.not.match(/https?:\/\//);
-            expect(html).to.not.include("unpkg.com");
+            expect(
+                script,
+                "boot script has no import/export declaration",
+            ).to.not.match(/^\s*(import|export)\b/m);
+            expect(
+                script,
+                "boot script has no dynamic import()",
+            ).to.not.include("import(");
+            expect(script, "boot script names no URL").to.not.match(
+                /https?:\/\//,
+            );
+            expect(html, "srcdoc never reaches for unpkg").to.not.include(
+                "unpkg.com",
+            );
         });
 
         it(`${name}: boot script carries its own copy of Comlink`, () => {
             // Comlink's module-scope symbols are compiled in, rather than
             // arriving as a free `Comlink*` binding supplied by the srcdoc.
-            expect(bootScriptOf(html)).to.include('Symbol("Comlink.proxy")');
+            // If a Comlink upgrade ever renames this marker, re-point the
+            // assertion at whatever the new compiled-in equivalent is — do
+            // not drop it.
+            expect(
+                bootScriptOf(html),
+                "Comlink's own source is compiled into the boot script",
+            ).to.include('Symbol("Comlink.proxy")');
         });
     }
 });

--- a/packages/doenetml-iframe/test/cypress/component/srcdocSelfContained.cy.ts
+++ b/packages/doenetml-iframe/test/cypress/component/srcdocSelfContained.cy.ts
@@ -1,0 +1,76 @@
+import {
+    createHtmlForDoenetEditor,
+    createHtmlForDoenetViewer,
+} from "../../../src/utils";
+
+// Regression guard for the cold-boot hang: the srcdoc's inline boot module
+// used to `import` Comlink from unpkg. An `import` declaration is resolved
+// before any of the module body runs, so a CDN fetch that stalled left the
+// whole boot script unexecuted and the `iframeReady` handshake unsent — the
+// iframe sat on its loading placeholder forever, with no timeout, no error,
+// and no console output. Comlink is compiled into the boot script now.
+//
+// The invariant held here: everything the boot script needs in order to reach
+// `iframeReady` is already in the srcdoc. Two things are deliberately exempt.
+// The standalone bundle at `standaloneUrl` is fetched over the network by
+// design (the host picks its DoenetML version), but the boot script polls for
+// it instead of blocking on it, so a slow fetch only delays mounting rather
+// than suppressing the handshake. The loading-placeholder logo is an `<img>`,
+// so it blocks nothing at all.
+
+// The inline boot script is the only `<script type="module">` with nothing
+// after `module` — the standalone bundle's tag carries a `src=` attribute.
+const INLINE_BOOT_SCRIPT = /<script type="module">([\s\S]*?)<\/script>/;
+
+function bootScriptOf(html: string): string {
+    const match = html.match(INLINE_BOOT_SCRIPT);
+    expect(match, "srcdoc contains an inline boot script").to.not.be.null;
+    return match![1];
+}
+
+const STANDALONE_URL = "https://example.com/doenet-standalone.js";
+const CSS_URL = "https://example.com/style.css";
+
+const SRCDOCS: [name: string, html: string][] = [
+    [
+        "viewer",
+        createHtmlForDoenetViewer(
+            "viewer-1",
+            "<p>hello</p>",
+            {},
+            STANDALONE_URL,
+            CSS_URL,
+        ),
+    ],
+    [
+        "editor",
+        createHtmlForDoenetEditor(
+            "editor-1",
+            "<p>hello</p>",
+            "100%",
+            {},
+            STANDALONE_URL,
+            CSS_URL,
+        ),
+    ],
+];
+
+describe("iframe srcdoc is self-contained", () => {
+    for (const [name, html] of SRCDOCS) {
+        it(`${name}: nothing gates the boot script on the network`, () => {
+            const script = bootScriptOf(html);
+            // An `import`/`export` of any kind puts module resolution back in
+            // front of the handshake, which is exactly what hung before.
+            expect(script).to.not.match(/^\s*(import|export)\b/m);
+            expect(script).to.not.include("import(");
+            expect(script).to.not.match(/https?:\/\//);
+            expect(html).to.not.include("unpkg.com");
+        });
+
+        it(`${name}: boot script carries its own copy of Comlink`, () => {
+            // Comlink's module-scope symbols are compiled in, rather than
+            // arriving as a free `Comlink*` binding supplied by the srcdoc.
+            expect(bootScriptOf(html)).to.include('Symbol("Comlink.proxy")');
+        });
+    }
+});

--- a/packages/doenetml-iframe/test/cypress/component/srcdocSelfContained.cy.ts
+++ b/packages/doenetml-iframe/test/cypress/component/srcdocSelfContained.cy.ts
@@ -14,9 +14,10 @@ import {
 // `iframeReady` is already in the srcdoc. Two things are deliberately exempt.
 // The standalone bundle at `standaloneUrl` is fetched over the network by
 // design (the host picks its DoenetML version), but the boot script polls for
-// it instead of blocking on it, so a slow fetch only delays mounting rather
-// than suppressing the handshake. The loading-placeholder logo is an `<img>`,
-// so it blocks nothing at all.
+// it rather than importing it. The module body runs either way, so a fetch
+// that never lands ends in a bounded timeout and an explicit error posted to
+// the parent instead of permanent silence. The loading-placeholder logo is an
+// `<img>`, so it blocks nothing at all.
 
 // The inline boot script is the only `<script type="module">` with nothing
 // after `module` — the standalone bundle's tag carries a `src=` attribute.


### PR DESCRIPTION
## What

Every `DoenetViewer`/`DoenetEditor` iframe used to load Comlink from a public CDN before it could boot:

```html
<script type="module">
    const editorId = "…";
    import * as ComlinkEditor from "https://unpkg.com/comlink/dist/esm/comlink.mjs";
    …the compiled boot script…
</script>
```

`import` declarations are resolved before any of the module body runs, so **nothing** in the boot script executed until unpkg answered — including the `iframeReady` handshake the parent wrapper waits on before it calls `renderDoenetEditorToContainer`. If that request was slow, blocked, or mangled in transit, the iframe sat on its loading placeholder forever: no timeout, no error, no console output.

This PR bundles Comlink into the compiled `iframe-viewer-index.iife.js` / `iframe-editor-index.iife.js` instead, so an iframe boots with no third-party network dependency. The srcdoc's inline script now has no imports at all. (There has been an `XXX: rather than serving Comlink from the cdn, below, serve it directly` note at that call site since it was written.)

## Why — this is the `doenetml-iframe-cypress` flake

Instrumenting the failing spec under the issue's reproduction (`taskset -c 0-3`, cold `node_modules/.vite`) caught the failure mode exactly:

| | without the fix | with the fix |
|---|---|---|
| standalone bundle evaluated (`window.renderDoenetEditorToContainer` defined) | 1.39 s | 1.33 s |
| `iframeReady` message received by the parent | **never** (watched 40 s) | 1.33 s |
| `.cm-content` rendered | **never** | 2.33 s |
| iframe subresources | `doenet-standalone.js`, `style.css`, **`unpkg.com/comlink/…`** | `doenet-standalone.js`, `style.css` |

That explains every observation recorded in the issue:

- **"The assertion is never a wrong value, always a missing one."** The bundle loads fine; only the handshake is missing.
- **"It is not merely slow" — a 90 s budget did not rescue it.** There is nothing to wait for.
- **All three `runMode` retries burn the full timeout.** A retry does get a fresh iframe document, but not a fresh network — whatever kept the CDN fetch from resolving on the first attempt is still true on the second and third, so each one stalls the same way.
- **The flake is environmental, not a code regression.** It depends on whether a public CDN fetch through Cypress's proxy resolves under load.

It also matches the diagnosis already written into `DoenetEditor.srcDocRebuildReplay.cy.tsx`'s header — "the rebuilt iframe's srcDoc was committed and its 3 inline `<script>` tags were in the DOM, but … CodeMirror never happened … it hangs forever inside Chrome's module loader for that iframe document". A `LATER (#1608)` note is appended to that header naming the cause; the spec's in-test retry loop stays, since the pathology was never fully characterised and the loop costs nothing on a healthy boot.

## Measurements

Full suite, `packages/doenetml-iframe`, Chrome headless, `taskset -c 0-3`, `rm -rf node_modules/.vite` before each run:

| | result | cypress duration | spec 1 | spec 2 |
|---|---|---|---|---|
| `main` | ✖ 1 of 20 failed | 02:23 | 45 s ✖ (3 × 15 s) | 33 s (retried) |
| this branch, run 1 | ✖ 1 of 20 failed | 01:55 | 1 s ✔ | 3 s ✔ |
| this branch, run 2 | ✔ all passed | 03:53 | 1 s ✔ | 3 s ✔ |
| this branch, run 3 | ✔ all passed | 01:25 | 1 s ✔ | 3 s ✔ |

The specs that were dependably failing at the front of the suite now finish in one to three seconds on every run.

Residual flakiness remains: run 2 spent 2:34 in `DoenetEditor.srcDocRebuildReplay` (a rebuilt iframe not running the standalone bundle at all — the other, already-documented pathology, which that spec's in-test retry loop absorbs), and run 1 lost `DoenetViewer.stylePalettes`. So this closes the mechanism the issue's reproduction exposed, not every possible slow-runner failure.

## Regression test

`test/cypress/component/srcdocSelfContained.cy.ts` builds both srcdocs and asserts the inline boot script has no `import`/`export` declaration, no dynamic `import()`, and no `http(s)://` URL, and that Comlink really is compiled into it rather than supplied as a free binding from the srcdoc. It is pure string inspection of `createHtmlForDoenetViewer` / `createHtmlForDoenetEditor` output — it never mounts an iframe and runs in well under a second.

The invariant it holds is the general one, not just "don't use unpkg": whatever the boot script needs in order to reach `iframeReady` must already be in the srcdoc. Two things stay deliberately exempt — the standalone bundle at `standaloneUrl` (fetched by design, but polled for rather than blocked on) and the loading-placeholder logo (an `<img>`, so it gates nothing).

## Also here

`packages/doenetml-iframe/cypress.config.ts` gains the `optimizeDeps.include: ["@ariakit/react", "classnames"]` guard the issue recommends. `DoenetViewer.virtualKeyboard.cy.tsx` is the only spec that pulls those two in (it imports `@doenet/virtual-keyboard`'s source by relative path), so a `--spec`-narrowed run leaves `node_modules/.vite` holding 8 of the 10 deps and the next fuller run re-optimizes and reloads the page mid-spec. CI always starts from a cold cache, so this is local-dev hygiene rather than part of the fix.

`iframe-viewer-index.ts`'s `Window` augmentation moves into a `declare global` block: adding the `import` makes the file a module, so a bare top-level `interface Window` would no longer merge with the global one.

The `ComlinkViewer` / `ComlinkEditor` aliases are renamed to plain `Comlink`. The suffixes only ever existed because the srcdoc injected the namespace under those names; now that it is an ordinary module import, the two files match the `import * as Comlink from "comlink"` form used everywhere else in the repo.

Both srcdoc builders in `utils.ts` emitted the same `<script type="module">` shape — a run of `const` declarations followed by the compiled entry point — so that now goes through one `createBootScript` helper, alongside the file's existing `createIframeHead` / `createIframeBodyOpenTag`. That also puts the explanation of why the script must stay import-free in a JSDoc block rather than in a comment nested inside a template literal, where a backtick would end the literal and `${...}` would interpolate.

Closes #1608.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


