### PR TITLE
Give style descriptions the syntactic position, and seed five inflecting languages

### DIFF
--- a/.changeset/style-description-case-and-portuguese.md
+++ b/.changeset/style-description-case-and-portuguese.md
@@ -6,25 +6,19 @@
 "doenet-vscode-extension": patch
 ---
 
-Fix the German and Russian style descriptions that were inflected for the wrong position, and add a Portuguese catalog.
+Fix the German and Russian style descriptions that were inflected for the wrong position, and add Portuguese, Turkish, Polish, Hindi and Amharic catalogs.
 
 Style descriptions handed adjectives one token, the gender of the noun they describe. That is enough while a phrase is rendered in one place, but three of them are rendered in two — a border's adjectives, the background colour, and the text colour beside it — and a language that inflects for case needs a different form in each. German and Russian had to spend their one token on a case and were wrong in the other position:
 
 - `borderStyleDescription` read `dicken` and `толстой` instead of `dicker` and `толстая`
 - `textStyleDescription` read `roter auf gelber Hintergrund` instead of `rot auf gelbem Hintergrund`, and `красный на жёлтый фоне` instead of `красный на жёлтом фоне`
 
-Descriptions now carry the syntactic position alongside the gender, so a catalog can select on both. The positions are named rather than the cases, because which case a position governs is the translation's business. A language with no case ignores the new argument, so English, Spanish, French, Italian, Dutch, Chinese, Japanese, Korean, Vietnamese, Indonesian, Somali and Hmong Njua are byte-identical.
+Descriptions now carry the syntactic position alongside the gender, so a catalog can select on both. A language with no case ignores the new argument, so English, Spanish, French, Italian, Dutch, Chinese, Japanese, Korean, Vietnamese, Indonesian, Somali and Hmong Njua are byte-identical.
 
-Portuguese, Turkish, Polish, Hindi and Amharic join the catalogs, each covering all four namespaces.
+Five catalogs join, each covering all four namespaces. Portuguese is Brazilian, which is what a bare `pt` means; `pt-AO` and `pt-MZ` reach it too, and a European `pt-PT` could be added later without disturbing it. Its border is feminine where Spanish's is masculine, so the border clause reads `com uma borda grossa`. Turkish inflects none of this — its suffixes attach to the noun rather than to the adjectives in front of it — and a noun counted by a numeral stays singular.
 
-Portuguese is Brazilian, which is what a bare `pt` means; `pt-AO` and `pt-MZ` reach it too, and a European `pt-PT` could be added later without disturbing it. Its border is feminine where Spanish's is masculine, so the border clause reads `com uma borda grossa`.
+Polish and Hindi are the two that needed the new argument. Polish style words land in three different cases, so from one set of words it now renders `grube`, `z grubym obramowaniem` and `czerwony na żółtym tle`. Hindi's marked adjectives — the ones ending in -ा — take the oblique before a postposition, so a border reads `मोटा` alone and `मोटे किनारे के साथ` in the clause, while unmarked ones like लाल never change; it uses Latin digits, unlike Marathi and Nepali, which share the script but not the numbering system.
 
-Turkish inflects none of this — its suffixes attach to the noun rather than to the adjectives in front of it — and a noun counted by a numeral stays singular, so a count reads the same in both of its plural branches.
+Amharic is written in the Ge'ez script, which runs left to right, so it needs none of the right-to-left support DoenetML lacks. It leaves the element and anion names untranslated, as Somali and Hmong Njua do and for the same reason — there is no settled Amharic chemical nomenclature to seed from — so those names fall back to English and `lint:i18n` reports the gap.
 
-Polish is the catalog this change was needed for. Its style words land in three different cases: nominative alone, instrumental after «z» in the border clause, locative after «na» in the background clause. From one set of words it now renders `grube`, `z grubym obramowaniem` and `czerwony na żółtym tle`.
-
-Hindi is the second one to use it. Its marked adjectives — the ones ending in -ा — take the oblique before a postposition, so a border reads `मोटा` alone and `मोटे किनारे के साथ` in the clause; the unmarked ones like लाल never change. It uses Latin digits, unlike Marathi and Nepali, which share the script but not the numbering system.
-
-Amharic is written in the Ge'ez script, which runs left to right, so it needs none of the right-to-left support DoenetML lacks. Its style words are the invariable kind, so neither gender nor case is selected on. It leaves the element names untranslated, as Somali and Hmong Njua do and for the same reason — there is no settled Amharic chemical nomenclature to seed from.
-
-Like the others, it is an **unreviewed machine-generated seed** and says so in every file's header.
+Like the others, every one of the five is an **unreviewed machine-generated seed** and says so in every file's header.

--- a/.changeset/style-description-case-and-portuguese.md
+++ b/.changeset/style-description-case-and-portuguese.md
@@ -1,0 +1,20 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix the German and Russian style descriptions that were inflected for the wrong position, and add a Portuguese catalog.
+
+Style descriptions handed adjectives one token, the gender of the noun they describe. That is enough while a phrase is rendered in one place, but three of them are rendered in two — a border's adjectives, the background colour, and the text colour beside it — and a language that inflects for case needs a different form in each. German and Russian had to spend their one token on a case and were wrong in the other position:
+
+- `borderStyleDescription` read `dicken` and `толстой` instead of `dicker` and `толстая`
+- `textStyleDescription` read `roter auf gelber Hintergrund` instead of `rot auf gelbem Hintergrund`, and `красный на жёлтый фоне` instead of `красный на жёлтом фоне`
+
+Descriptions now carry the syntactic position alongside the gender, so a catalog can select on both. The positions are named rather than the cases, because which case a position governs is the translation's business. A language with no case ignores the new argument, so English, Spanish, French, Italian, Dutch, Chinese, Japanese, Korean, Vietnamese, Indonesian, Somali and Hmong Njua are byte-identical.
+
+Portuguese joins the catalogs, covering all four namespaces at full coverage. It is Brazilian, which is what a bare `pt` means; `pt-AO` and `pt-MZ` reach it too, and a European `pt-PT` could be added later without disturbing it. Its border is feminine where Spanish's is masculine, so the border clause reads `com uma borda grossa`.
+
+Like the others, it is an **unreviewed machine-generated seed** and says so in every file's header.

--- a/.changeset/style-description-case-and-portuguese.md
+++ b/.changeset/style-description-case-and-portuguese.md
@@ -8,7 +8,7 @@
 
 Fix the German and Russian style descriptions that were inflected for the wrong position, and add Portuguese, Turkish, Polish, Hindi and Amharic catalogs.
 
-Style descriptions handed adjectives one token, the gender of the noun they describe. That is enough while a phrase is rendered in one place, but three of them are rendered in two — a border's adjectives, the background colour, and the text colour beside it — and a language that inflects for case needs a different form in each. German and Russian had to spend their one token on a case and were wrong in the other position:
+Style descriptions handed adjectives one token, the gender of the noun they describe. That is enough while a phrase is rendered in one place, but three of them are rendered in two — a border's adjectives, the background colour, and the text colour beside it — and a language that inflects for case needs a different form in each. German and Russian had one token to spend, so each fork came out right in one position and wrong in the other:
 
 - `borderStyleDescription` read `dicken` and `толстой` instead of `dicker` and `толстая`
 - `textStyleDescription` read `roter auf gelber Hintergrund` instead of `rot auf gelbem Hintergrund`, and `красный на жёлтый фоне` instead of `красный на жёлтом фоне`

--- a/.changeset/style-description-case-and-portuguese.md
+++ b/.changeset/style-description-case-and-portuguese.md
@@ -15,6 +15,12 @@ Style descriptions handed adjectives one token, the gender of the noun they desc
 
 Descriptions now carry the syntactic position alongside the gender, so a catalog can select on both. The positions are named rather than the cases, because which case a position governs is the translation's business. A language with no case ignores the new argument, so English, Spanish, French, Italian, Dutch, Chinese, Japanese, Korean, Vietnamese, Indonesian, Somali and Hmong Njua are byte-identical.
 
-Portuguese joins the catalogs, covering all four namespaces at full coverage. It is Brazilian, which is what a bare `pt` means; `pt-AO` and `pt-MZ` reach it too, and a European `pt-PT` could be added later without disturbing it. Its border is feminine where Spanish's is masculine, so the border clause reads `com uma borda grossa`.
+Portuguese, Turkish and Polish join the catalogs, each covering all four namespaces at full coverage.
+
+Portuguese is Brazilian, which is what a bare `pt` means; `pt-AO` and `pt-MZ` reach it too, and a European `pt-PT` could be added later without disturbing it. Its border is feminine where Spanish's is masculine, so the border clause reads `com uma borda grossa`.
+
+Turkish inflects none of this — its suffixes attach to the noun rather than to the adjectives in front of it — and a noun counted by a numeral stays singular, so a count reads the same in both of its plural branches.
+
+Polish is the catalog this change was needed for. Its style words land in three different cases: nominative alone, instrumental after «z» in the border clause, locative after «na» in the background clause. From one set of words it now renders `grube`, `z grubym obramowaniem` and `czerwony na żółtym tle`.
 
 Like the others, it is an **unreviewed machine-generated seed** and says so in every file's header.

--- a/.changeset/style-description-case-and-portuguese.md
+++ b/.changeset/style-description-case-and-portuguese.md
@@ -15,12 +15,16 @@ Style descriptions handed adjectives one token, the gender of the noun they desc
 
 Descriptions now carry the syntactic position alongside the gender, so a catalog can select on both. The positions are named rather than the cases, because which case a position governs is the translation's business. A language with no case ignores the new argument, so English, Spanish, French, Italian, Dutch, Chinese, Japanese, Korean, Vietnamese, Indonesian, Somali and Hmong Njua are byte-identical.
 
-Portuguese, Turkish and Polish join the catalogs, each covering all four namespaces at full coverage.
+Portuguese, Turkish, Polish, Hindi and Amharic join the catalogs, each covering all four namespaces.
 
 Portuguese is Brazilian, which is what a bare `pt` means; `pt-AO` and `pt-MZ` reach it too, and a European `pt-PT` could be added later without disturbing it. Its border is feminine where Spanish's is masculine, so the border clause reads `com uma borda grossa`.
 
 Turkish inflects none of this — its suffixes attach to the noun rather than to the adjectives in front of it — and a noun counted by a numeral stays singular, so a count reads the same in both of its plural branches.
 
 Polish is the catalog this change was needed for. Its style words land in three different cases: nominative alone, instrumental after «z» in the border clause, locative after «na» in the background clause. From one set of words it now renders `grube`, `z grubym obramowaniem` and `czerwony na żółtym tle`.
+
+Hindi is the second one to use it. Its marked adjectives — the ones ending in -ा — take the oblique before a postposition, so a border reads `मोटा` alone and `मोटे किनारे के साथ` in the clause; the unmarked ones like लाल never change. It uses Latin digits, unlike Marathi and Nepali, which share the script but not the numbering system.
+
+Amharic is written in the Ge'ez script, which runs left to right, so it needs none of the right-to-left support DoenetML lacks. Its style words are the invariable kind, so neither gender nor case is selected on. It leaves the element names untranslated, as Somali and Hmong Njua do and for the same reason — there is no settled Amharic chemical nomenclature to seed from.
 
 Like the others, it is an **unreviewed machine-generated seed** and says so in every file's header.

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
@@ -140,4 +140,28 @@ describe("style descriptions follow the document locale @group4", () => {
             "negro con un fondo amarillo",
         );
     });
+
+    it("inflects a text description for the position each word lands in", async () => {
+        // `textColor` and `backgroundColor` report their word standing alone;
+        // `textStyleDescription` puts the same two words in a sentence, where
+        // German wants the colour predicative and the background dative behind
+        // `auf`. English and Spanish cannot tell the two apart, so this is what
+        // holds the `text-clause` and `background-clause` arguments the shared
+        // definitions pass (#1606) — dropping either leaves every expectation
+        // above green.
+        const doenetML = `
+        <setup>
+          <styleDefinition styleNumber="1" textColor="red" backgroundColor="yellow" />
+        </setup>
+        <text name="t" styleNumber="1">hallo</text>
+        <text name="c" extend="$t.textColor" />
+        <text name="b" extend="$t.backgroundColor" />
+        <text name="d" extend="$t.textStyleDescription" />
+        `;
+        expect(await descriptions(doenetML, ["c", "b", "d"], "de")).toEqual({
+            c: "roter",
+            b: "gelber",
+            d: "rot auf gelbem Hintergrund",
+        });
+    });
 });

--- a/packages/doenetml/dev/main.tsx
+++ b/packages/doenetml/dev/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { DoenetViewer, DoenetEditor } from "../src/index";
+import { SUPPORTED_LOCALES } from "@doenet/i18n";
 import "./main.css";
 
 // @ts-ignore
@@ -214,10 +215,15 @@ function App() {
                     />
                 </label>
                 {/* Suggestions only — the inputs stay free text so an
-                    unrecognized tag can be typed to watch it negotiate. */}
+                    unrecognized tag can be typed to watch it negotiate. Every
+                    catalog the repo ships is listed, read off `SUPPORTED_LOCALES`
+                    so that seeding a new one needs no edit here, plus two tags
+                    with no catalog of their own: `es-MX`, which negotiates down
+                    to `es`, and `en-XA`, which does not negotiate at all. */}
                 <datalist id="dev-locale-options">
-                    <option value="en" />
-                    <option value="es" />
+                    {SUPPORTED_LOCALES.map(({ locale, label }) => (
+                        <option key={locale} value={locale} label={label} />
+                    ))}
                     <option value="es-MX" />
                     <option value="en-XA" />
                 </datalist>

--- a/packages/doenetml/dev/main.tsx
+++ b/packages/doenetml/dev/main.tsx
@@ -218,8 +218,11 @@ function App() {
                     unrecognized tag can be typed to watch it negotiate. Every
                     catalog the repo ships is listed, read off `SUPPORTED_LOCALES`
                     so that seeding a new one needs no edit here, plus two tags
-                    with no catalog of their own: `es-MX`, which negotiates down
-                    to `es`, and `en-XA`, which does not negotiate at all. */}
+                    that name no directory under `locales/`: `es-MX`, which
+                    negotiates down to `es`, and `en-XA`, the pseudo-locale,
+                    which the chrome generates from English on demand — so it is
+                    worth typing into the UI locale rather than the document
+                    one. */}
                 <datalist id="dev-locale-options">
                     {SUPPORTED_LOCALES.map(({ locale, label }) => (
                         <option key={locale} value={locale} label={label} />

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -348,6 +348,17 @@ piece selects a different branch rather than substituting an empty string —
 that is what lets a translation reorder and re-punctuate each combination on
 its own terms.
 
+Gender is not the only thing an adjective has to agree with. Three sets of
+words are rendered in two places each — a border's adjectives, the background
+colour, and the text colour beside it — once standing alone as a state
+variable reports them and once embedded in a clause, and a language that
+inflects for case wants a different form in each. So every adjective is handed
+`$role` as well, naming the *position* the phrase is going into rather than
+the case it takes: which case a position governs is the catalog's business,
+exactly as `$gender`'s token set already is. `locales/en/content.ftl` lists the
+positions, and German, Russian, Polish and Hindi are the catalogs that select
+on them.
+
 Even the noun is not one string. A regular polygon is "5-sided regular polygon"
 in English but "polígono regular … de 5 lados" in Spanish, wrapped around the
 adjectives rather than sitting beside them, so `noun-regular-polygon` answers

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -66,19 +66,21 @@ locales/<locale>/
   editor.ftl        # editor and LSP surfaces                — uiLocale
 ```
 
-English is the source of truth. Every translation — `de`, `es`, `fr`, `hnj`,
-`id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`, `so`, `tr`, `vi`, `zh-Hans`,
-`zh-Hant` — is an **unreviewed machine-generated seed**, which each file's own
-header says at the top, and which is what #1521's translation platform is for.
-None has been read by a speaker. Correcting one needs no permission and no
-coordination: a wrong string is just wrong, and the English is one key away.
+English is the source of truth. Every translation — `am`, `de`, `es`, `fr`,
+`hi`, `hnj`, `id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`, `so`, `tr`, `vi`,
+`zh-Hans`, `zh-Hant` — is an **unreviewed machine-generated seed**, which each
+file's own header says at the top, and which is what #1521's translation
+platform is for. None has been read by a speaker. Correcting one needs no
+permission and no coordination: a wrong string is just wrong, and the English is
+one key away.
 
-Three of them are deliberately partial, all in the same place: Somali, Hmong
-Njua and Vietnamese leave `element-name` and `element-anion-name` out, so those
-130 keys fall back to English and `lint:i18n` reports the gap. The first two
-have no settled chemical nomenclature to seed from. Vietnamese has two, and the
-current one is English — school chemistry has moved from the transliterated
-names to the IUPAC forms — so the fallback is already what the curriculum uses.
+Four of them are deliberately partial, all in the same place: Somali, Hmong
+Njua, Amharic and Vietnamese leave `element-name` and `element-anion-name` out,
+so those 130 keys fall back to English and `lint:i18n` reports the gap. The
+first three have no settled chemical nomenclature to seed from. Vietnamese has
+two, and the current one is English — school chemistry has moved from the
+transliterated names to the IUPAC forms — so the fallback is already what the
+curriculum uses.
 
 A directory is named for a **script** rather than a language only where two
 scripts of one language are translated separately, which today is Chinese.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -67,11 +67,11 @@ locales/<locale>/
 ```
 
 English is the source of truth. Every translation — `de`, `es`, `fr`, `hnj`,
-`id`, `it`, `ja`, `ko`, `nl`, `ru`, `so`, `vi`, `zh-Hans`, `zh-Hant` — is an
-**unreviewed machine-generated seed**, which each file's own header says at the
-top, and which is what #1521's translation platform is for. None has been read
-by a speaker. Correcting one needs no permission and no coordination: a wrong
-string is just wrong, and the English is one key away.
+`id`, `it`, `ja`, `ko`, `nl`, `pt`, `ru`, `so`, `vi`, `zh-Hans`, `zh-Hant` — is
+an **unreviewed machine-generated seed**, which each file's own header says at
+the top, and which is what #1521's translation platform is for. None has been
+read by a speaker. Correcting one needs no permission and no coordination: a
+wrong string is just wrong, and the English is one key away.
 
 Three of them are deliberately partial, all in the same place: Somali, Hmong
 Njua and Vietnamese leave `element-name` and `element-anion-name` out, so those

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -67,11 +67,11 @@ locales/<locale>/
 ```
 
 English is the source of truth. Every translation — `de`, `es`, `fr`, `hnj`,
-`id`, `it`, `ja`, `ko`, `nl`, `pt`, `ru`, `so`, `vi`, `zh-Hans`, `zh-Hant` — is
-an **unreviewed machine-generated seed**, which each file's own header says at
-the top, and which is what #1521's translation platform is for. None has been
-read by a speaker. Correcting one needs no permission and no coordination: a
-wrong string is just wrong, and the English is one key away.
+`id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`, `so`, `tr`, `vi`, `zh-Hans`,
+`zh-Hant` — is an **unreviewed machine-generated seed**, which each file's own
+header says at the top, and which is what #1521's translation platform is for.
+None has been read by a speaker. Correcting one needs no permission and no
+coordination: a wrong string is just wrong, and the English is one key away.
 
 Three of them are deliberately partial, all in the same place: Somali, Hmong
 Njua and Vietnamese leave `element-name` and `element-anion-name` out, so those

--- a/packages/i18n/locales/am/chrome.ftl
+++ b/packages/i18n/locales/am/chrome.ftl
@@ -1,0 +1,139 @@
+# Amharic viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Amharic is written in the Ge'ez script, which runs left to right, so this
+# needs none of the right-to-left support DoenetML lacks (#1614). It uses Latin
+# digits, and Ge'ez punctuation for the full stop (።) and the comma (፣).
+#
+# Controls take the bare imperative, which is what Amharic puts on a button.
+
+
+## Answer submission
+
+answer-checking = በማረጋገጥ ላይ...
+answer-submitting = በመላክ ላይ...
+
+answer-checking-status = መልሱ በመረጋገጥ ላይ ነው
+answer-submitting-status = መልሱ በመላክ ላይ ነው
+
+answer-correct = ትክክል
+answer-incorrect = ስህተት
+
+answer-response-saved = መልሱ ተቀምጧል
+
+answer-percent-credit = { $percent }% ነጥብ
+answer-percent-correct = { $percent }% ትክክል
+answer-percent-short = { $percent }%
+
+max-credit-available = ከፍተኛው ሊገኝ የሚችል ነጥብ፦ { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] የቀረ ሙከራ የለም
+        [one] { $count } ሙከራ ቀርቷል
+       *[other] { $count } ሙከራዎች ቀርተዋል
+    }
+
+validation-correct = (ትክክል)
+validation-incorrect = (ስህተት)
+validation-partially-correct = (በከፊል ትክክል)
+
+answer-show-responses =
+    { $count ->
+        [one] የ{ $answerId } { $count } መልስ አሳይ
+       *[other] የ{ $answerId } { $count } መልሶች አሳይ
+    }
+
+
+## Disclosure panels
+
+feedback-heading = አስተያየት
+
+collapsible-click-to-open = (ለመክፈት ጠቅ ያድርጉ)
+collapsible-click-to-close = (ለመዝጋት ጠቅ ያድርጉ)
+
+collapsible-initializing = በመዘጋጀት ላይ...
+
+footnote-show = የግርጌ ማስታወሻ አሳይ
+footnote-hide = የግርጌ ማስታወሻ ደብቅ
+
+description-more-information = ተጨማሪ መረጃ
+
+
+## Controls
+
+slider-previous = ቀዳሚ
+slider-next = ቀጣይ
+
+keyboard-open = ቁልፍ ሰሌዳ ክፈት
+keyboard-close = ቁልፍ ሰሌዳ ዝጋ
+
+matrix-remove-row = ረድፍ አስወግድ
+matrix-add-row = ረድፍ ጨምር
+matrix-remove-column = ዓምድ አስወግድ
+matrix-add-column = ዓምድ ጨምር
+
+subset-add-remove-points = ነጥቦች ጨምር/አስወግድ
+subset-toggle-points-intervals = በነጥቦችና በክፍተቶች መካከል ቀያይር
+subset-move-points = ነጥቦችን አንቀሳቅስ
+subset-clear = አጽዳ
+
+# A `box` here is one orbital, drawn as a square: ሳጥን.
+orbital-add-row = ረድፍ ጨምር
+orbital-remove-row = ረድፍ አስወግድ
+orbital-add-box = ሳጥን ጨምር
+orbital-remove-box = ሳጥን አስወግድ
+orbital-add-up-arrow = ወደ ላይ ቀስት ጨምር
+orbital-add-down-arrow = ወደ ታች ቀስት ጨምር
+orbital-remove-arrow = ቀስት አስወግድ
+
+orbital-row-label = የረድፍ { $row } መለያ
+
+pretzel-answer = መልስ
+
+summary-statistics-caption = የ{ $column } አጠቃላይ ስታቲስቲክስ
+
+
+## Math input
+
+math-input-preview-region = የሒሳብ አገላለጽ ቅድመ ዕይታ
+math-input-preview = ቅድመ ዕይታ
+math-input-invalid-expression = ልክ ያልሆነ አገላለጽ፦
+
+
+## Document status
+
+viewer-initializing = በመዘጋጀት ላይ...
+
+
+## Errors
+
+error-heading = ስህተት
+
+error-found-at =
+    { $span ->
+        [line] በመስመር { $startLine } ላይ ተገኝቷል።
+       *[lines] በመስመሮች { $startLine }–{ $endLine } ላይ ተገኝቷል።
+    }
+
+document-contains-errors = ይህ ሰነድ ስህተቶች አሉት።
+
+diagnostic-heading-error = ስህተት
+diagnostic-heading-warning = ማስጠንቀቂያ
+diagnostic-heading-information = መረጃ
+diagnostic-heading-hint = ፍንጭ
+
+accessibility-heading-level-1 = የWCAG AA ተደራሽነት ጥሰት
+accessibility-heading-level-2 = የተደራሽነት ማሳሰቢያ
+
+something-went-wrong = የሆነ ስህተት ተከስቷል።
+
+renderer-load-failed = አንድ አሳያ መጫን አልቻለም። እባክዎ ገጹን እንደገና ይጫኑ።
+
+core-start-failed = የሰነድ መመልከቻው ሊጀመር አልቻለም። እባክዎ ገጹን እንደገና ይጫኑ።

--- a/packages/i18n/locales/am/content.ftl
+++ b/packages/i18n/locales/am/content.ftl
@@ -1,0 +1,246 @@
+# Amharic content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Amharic is written in the Ge'ez script, which runs left to right — so nothing
+# here needs the right-to-left support DoenetML does not yet have (#1614).
+#
+# Amharic marks gender on verbs and on some adjectives, but the colour, width
+# and pattern words below are the invariable kind: ቀይ is ቀይ whatever it
+# describes. So `$gender` goes unused here, as it does in English. Amharic also
+# does not inflect an attributive adjective for case, so `$role` goes unread
+# too — the postpositions that would govern one attach to the noun.
+#
+# Adjectives precede the noun, as in English, so the composition messages keep
+# the English order.
+
+
+## የቅጥ ቃላት
+
+color =
+    .black = ጥቁር
+    .white = ነጭ
+    .gray = ግራጫ
+    .red = ቀይ
+    .orange = ብርቱካናማ
+    .yellow = ቢጫ
+    .green = አረንጓዴ
+    .cyan = ሲያን
+    .blue = ሰማያዊ
+    .purple = ወይን ጠጅ
+    .pink = ሮዝ
+    .brown = ቡናማ
+
+line-width =
+    .thick = ወፍራም
+    .thin = ቀጭን
+
+line-style =
+    .dashed = ሰረዝ ያለው
+    .dotted = ነጥብ ያለው
+
+# የስም ሐረጎች፦ ከ«ያለው» በፊት ይመጣሉ እና ከምንም ጋር አይስማሙም።
+fill-style =
+    .horizontal = አግድም መስመሮች
+    .vertical = ቀጥ ያሉ መስመሮች
+    .diagonal = ሰያፍ መስመሮች
+    .backdiagonal = ተቃራኒ ሰያፍ መስመሮች
+    .dots = ነጥቦች
+    .diamonds = አልማዞች
+
+noun =
+    .line = መስመር
+    .line-segment = የመስመር ክፍል
+    .ray = ጨረር
+    .vector = ቬክተር
+    .curve = ጠምዛዛ
+    .function = ተግባር
+    .parabola = ፓራቦላ
+    .polyline = ስባሪ መስመር
+    .polygon = ብዙ ጎን
+    .triangle = ሦስት ማዕዘን
+    .rectangle = አራት ማዕዘን
+    .circle = ክብ
+    .region = ክልል
+    .point = ነጥብ
+    .square = ካሬ
+    .diamond = አልማዝ
+    .cross = መስቀል
+    .plus = የመደመር ምልክት
+
+# የጎን ብዛቱ ከስሙ በፊት ስለሚመጣ ከራስጌው ጋር ተጣምሮ ይቀራል፤ ጭራ የለም።
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } ጎን ያለው ወጥ ብዙ ጎን
+    }
+
+# Amharic's adjectives here do not vary by gender, so every noun answers the
+# same and the answer goes unused — as in English.
+noun-gender = neuter
+
+
+## የቅጥ ጥምረት
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = የተሞላ
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } ያለው { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } ያለው { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } ያለው { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «ያለው» carries the "with a … border" sense itself, so Amharic needs no
+# article and the `-article` branches read the same as the ones without.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } ጠርዝ ያለው
+        [and] እና { $border } ጠርዝ ያለው
+        [and-article] እና { $border } ጠርዝ ያለው
+       *[with] { $border } ጠርዝ ያለው
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = ያልተሞላ
+
+style-text =
+    { $parts ->
+        [background] { $color } በ{ $background } ዳራ ላይ
+       *[plain] { $color }
+    }
+
+style-background-none = የለም
+
+
+## የቡሊያን ቃላት
+
+boolean-true = እውነት
+boolean-false = ሐሰት
+
+
+## የመልስ አዝራሮች
+
+answer-submit-label = አረጋግጥ
+answer-submit-label-no-correctness = መልስ ላክ
+
+
+## ክፍሎች
+
+section-name =
+    .activity = እንቅስቃሴ
+    .aside = ጎንዮሽ ማስታወሻ
+    .cascade = ተከታታይ
+    .definition = ትርጓሜ
+    .example = ምሳሌ
+    .exercise = መልመጃ
+    .exercises = መልመጃዎች
+    .given-answer = መልስ
+    .note = ማስታወሻ
+    .objectives = ዓላማዎች
+    .paragraphs = አንቀጾች
+    .part = ክፍል
+    .problem = ጥያቄ
+    .problems = ጥያቄዎች
+    .proof = ማረጋገጫ
+    .question = ጥያቄ
+    .section = ንዑስ ክፍል
+    .solution = መፍትሔ
+    .task = ተግባር
+    .theorem = ሒሳባዊ ሕግ
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = ፍንጭ
+
+
+## ሠንጠረዦችና ሥዕሎች
+
+table-name =
+    { $parts ->
+        [numbered] ሠንጠረዥ { $enumeration }
+        [numbered-title] ሠንጠረዥ { $enumeration }{ ": " }
+        [unnumbered-title] ሠንጠረዥ{ ": " }
+       *[unnumbered] ሠንጠረዥ
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] ሥዕል { $enumeration }
+        [numbered-caption] ሥዕል { $enumeration }{ ": " }
+        [unnumbered-caption] ሥዕል{ ": " }
+       *[unnumbered] ሥዕል
+    }
+
+
+## የገጽ መቆጣጠሪያዎች
+
+paginator-previous = ቀዳሚ
+paginator-next = ቀጣይ
+paginator-page = ገጽ
+
+paginator-page-status = { $pageLabel } { $currentPage } ከ{ $numPages }
+
+
+## በክፍል የተገለጹ ተግባራት
+
+piecewise-condition-or = ወይም
+piecewise-condition-if = ከሆነ
+piecewise-condition-otherwise = ካልሆነ
+
+
+## ኬሚስትሪ
+
+# `element-name` and `element-anion-name` are deliberately omitted, and those
+# 130 keys fall back to English.
+#
+# Amharic has no settled chemical nomenclature to seed from — school chemistry
+# is taught largely in English in Ethiopia, and the transliterations that do
+# circulate are not standardised. Inventing a set would be worse than the
+# English fallback, which is what a student would meet in a textbook anyway.
+# `lint:i18n` reports the gap until a chemist who writes Amharic supplies them.
+# This is the same choice Somali and Hmong Njua make, and for the same reason.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = ልክ ያልሆነ የኬሚካል ምልክት
+chemistry-invalid-ionic-compound = ልክ ያልሆነ ionic ውህድ

--- a/packages/i18n/locales/am/content.ftl
+++ b/packages/i18n/locales/am/content.ftl
@@ -243,4 +243,4 @@ piecewise-condition-otherwise = ካልሆነ
 ion-name-oxidation-state = { $name } ({ $numeral })
 
 chemistry-invalid-symbol = ልክ ያልሆነ የኬሚካል ምልክት
-chemistry-invalid-ionic-compound = ልክ ያልሆነ ionic ውህድ
+chemistry-invalid-ionic-compound = ልክ ያልሆነ አዮኒክ ውህድ

--- a/packages/i18n/locales/am/content.ftl
+++ b/packages/i18n/locales/am/content.ftl
@@ -17,7 +17,7 @@
 # the English order.
 
 
-## የቅጥ ቃላት
+## Style vocabulary
 
 color =
     .black = ጥቁር
@@ -41,7 +41,7 @@ line-style =
     .dashed = ሰረዝ ያለው
     .dotted = ነጥብ ያለው
 
-# የስም ሐረጎች፦ ከ«ያለው» በፊት ይመጣሉ እና ከምንም ጋር አይስማሙም።
+# Noun phrases: they come in front of «ያለው» and agree with nothing.
 fill-style =
     .horizontal = አግድም መስመሮች
     .vertical = ቀጥ ያሉ መስመሮች
@@ -70,7 +70,8 @@ noun =
     .cross = መስቀል
     .plus = የመደመር ምልክት
 
-# የጎን ብዛቱ ከስሙ በፊት ስለሚመጣ ከራስጌው ጋር ተጣምሮ ይቀራል፤ ጭራ የለም።
+# Amharic keeps the side count in front of the noun, so the whole thing is one
+# head and there is no tail.
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
@@ -82,7 +83,7 @@ noun-regular-polygon =
 noun-gender = neuter
 
 
-## የቅጥ ጥምረት
+## Style composition
 
 style-stroke =
     { $parts ->
@@ -144,19 +145,19 @@ style-text =
 style-background-none = የለም
 
 
-## የቡሊያን ቃላት
+## Boolean words
 
 boolean-true = እውነት
 boolean-false = ሐሰት
 
 
-## የመልስ አዝራሮች
+## Answer buttons
 
 answer-submit-label = አረጋግጥ
 answer-submit-label-no-correctness = መልስ ላክ
 
 
-## ክፍሎች
+## Sectional blocks
 
 section-name =
     .activity = እንቅስቃሴ
@@ -193,7 +194,7 @@ section-title-prefix =
 hint-title = ፍንጭ
 
 
-## ሠንጠረዦችና ሥዕሎች
+## Tables and figures
 
 table-name =
     { $parts ->
@@ -212,7 +213,7 @@ figure-name =
     }
 
 
-## የገጽ መቆጣጠሪያዎች
+## Paginator controls
 
 paginator-previous = ቀዳሚ
 paginator-next = ቀጣይ
@@ -221,14 +222,14 @@ paginator-page = ገጽ
 paginator-page-status = { $pageLabel } { $currentPage } ከ{ $numPages }
 
 
-## በክፍል የተገለጹ ተግባራት
+## Piecewise functions
 
 piecewise-condition-or = ወይም
 piecewise-condition-if = ከሆነ
 piecewise-condition-otherwise = ካልሆነ
 
 
-## ኬሚስትሪ
+## Chemistry
 
 # `element-name` and `element-anion-name` are deliberately omitted, and those
 # 130 keys fall back to English.

--- a/packages/i18n/locales/am/diagnostics.ftl
+++ b/packages/i18n/locales/am/diagnostics.ftl
@@ -282,7 +282,7 @@ data-frame-inconsistent-row-lengths = የመረጃው ቅርጽ ልክ አይደ
 
 data-frame-duplicate-column-names = መረጃው የተደጋገሙ የዓምድ ስሞች አሉት። በcomponentIdx :{ $componentIdx } ተገኝቷል
 
-data-frame-missing-column-name = መረጃው የዓምድ ስም ይጎለዋል። በcomponentIdx :{ $componentIdx } ተገኝቷል
+data-frame-missing-column-name = መረጃው የዓምድ ስም ይጎድለዋል። በcomponentIdx :{ $componentIdx } ተገኝቷል
 
 ## `<answer>` and scoring
 
@@ -426,7 +426,7 @@ annotation-ref-outside-graph = `<annotation>`፦ `ref` ልክ አይደለም፤
 
 annotation-ref-unsupported-target = `<annotation>`፦ `ref` ልክ አይደለም፤ በprefigure ልወጣ ውስጥ ዒላማው የሚደገፍ ሥዕላዊ ነገር አይደለም። ማብራሪያው ተትቷል።
 
-annotation-text-missing = `<annotation>`፦ `text` ይጎላል ወይም ባዶ ነው፤ ባዶ ጽሑፍ ወጥቷል።
+annotation-text-missing = `<annotation>`፦ `text` ይጎድላል ወይም ባዶ ነው፤ ባዶ ጽሑፍ ወጥቷል።
 
 ## Composites and references
 

--- a/packages/i18n/locales/am/diagnostics.ftl
+++ b/packages/i18n/locales/am/diagnostics.ftl
@@ -224,9 +224,9 @@ intersection-too-many-items = ከሁለት በላይ ነገሮች መገናኛ �
 
 ## Other math components
 
-ionic-compound-not-two-ions = ከሁለት ion ውጭ ላለ ionic ውህድ ገና አልተተገበረም።
+ionic-compound-not-two-ions = ከሁለት አዮን ውጭ ላለ አዮኒክ ውህድ ገና አልተተገበረም።
 
-ionic-compound-needs-cation-and-anion = ionic ውህድ የተተገበረው ለአንድ cation እና ለአንድ anion ብቻ ነው።
+ionic-compound-needs-cation-and-anion = አዮኒክ ውህድ የተተገበረው ለአንድ አዎንታዊ አዮን እና ለአንድ አሉታዊ አዮን ብቻ ነው።
 
 solve-equations-cannot-evaluate = ቀመሩ ሊሰላ ስላልቻለ መፍታት አይቻልም፦ { $equation }
 

--- a/packages/i18n/locales/am/diagnostics.ftl
+++ b/packages/i18n/locales/am/diagnostics.ftl
@@ -1,0 +1,606 @@
+# Amharic diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = ሁለት ጫፎች ሲገለጹ { $attributes } ችላ ይባላል
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ጫፍና መካከለኛ ነጥብ አብረው ሲገለጹ { $attributes } ችላ ይባላል
+
+line-segment-midpoint-offset-without-midpoint = መካከለኛ ነጥብ ከሌለ midpointOffset ውጤት የለውም
+
+## `<line>`
+
+line-points-undetermined-dimensions = ልኬታቸው ባልታወቁ ነጥቦች የሚያልፍ መስመር።
+
+line-points-too-few-dimensions = መስመሩ ቢያንስ ባለሁለት ልኬት ነጥቦች ማለፍ አለበት።
+
+line-points-depend-on-variables = መስመሩ በተለዋዋጮች በሚመሠረቱ ነጥቦች ያልፋል፦ { $variables }።
+
+line-equation-invalid-format = በተለዋዋጮች { $variable1 } እና { $variable2 } የተጻፈው የመስመር ቀመር ቅርጸት ልክ አይደለም።
+
+## `<ray>`
+
+ray-overprescribed-through = ጨረሩ በthrough፣ endpoint እና direction በአንድ ጊዜ ተወስኗል። የተገለጸው through ችላ ተብሏል።
+
+ray-dimension-mismatch = በጨረሩ ውስጥ numDimensions አይመሳሰሉም።
+
+## `<vector>`
+
+vector-overprescribed-head = ቬክተሩ በhead፣ tail እና displacement በአንድ ጊዜ ተወስኗል። የተገለጸው head ችላ ተብሏል።
+
+vector-dimension-mismatch = በቬክተሩ ውስጥ numDimensions አይመሳሰሉም።
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = ወደ `<{ $component }>` መሳብ አይቻልም፤ የnearestPoint የሁኔታ ተለዋዋጭ የለውም።
+
+constrain-to-without-nearest-point = በ`<{ $component }>` መገደብ አይቻልም፤ የnearestPoint የሁኔታ ተለዋዋጭ የለውም።
+
+constrain-to-interior-without-nearest-point = በ`<{ $component }>` ውስጠኛ ክፍል መገደብ አይቻልም፤ የnearestPoint የሁኔታ ተለዋዋጭ የለውም።
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ኢንላይን ላልሆነ choiceInput labelPosition ችላ ይባላል
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = የindices ብዛት ከchoice ልጆች ብዛት ጋር ስለማይመሳሰል ለchoiceInput የተገለጹት indices ችላ ተብለዋል።
+
+pretzel-indices-count-mismatch = የindices ብዛት ከproblem ልጆች ብዛት ጋር ስለማይመሳሰል ለproblem የተገለጹት indices ችላ ተብለዋል።
+
+shuffle-indices-count-mismatch = የindices ብዛት ከአካላት ብዛት ጋር ስለማይመሳሰል ለshuffle የተገለጹት indices ችላ ተብለዋል።
+
+indices-ignored-out-of-range = አንዳንድ ጠቋሚዎች ከክልል ውጭ ስለሆኑ ለ{ $component } የተገለጹት indices ችላ ተብለዋል።
+
+pretzel-indices-repeated = አንዳንድ ጠቋሚዎች ስለተደጋገሙ ለpretzel የተገለጹት indices ችላ ተብለዋል።
+
+pretzel-circuit-first-index = በcircuit ሁነታ የመጀመሪያው ጠቋሚ 1 መሆን ስላለበት ለpretzel የተገለጹት indices ችላ ተብለዋል።
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ከጽሑፍ ልጆች ጋር እንዲሠራ የ`type` ባሕርይ መገለጽ አለበት።
+
+invalid-type-defaulting-to-math = ለ{ $component } አካል ዓይነት { $type } ልክ አይደለም። math፣ text፣ number ወይም boolean መሆን አለበት። math ጥቅም ላይ ውሏል።
+
+string-not-valid-component-to-arrange = ጽሑፍ "{ $value }" ለ{ $component } ትክክለኛ አካል አይደለም። ችላ ተብሏል።
+
+## Types and variables
+
+invalid-type-defaulting-to-number = ዓይነት { $type } ልክ አይደለም፤ ዓይነቱ ወደ number ተቀይሯል።
+
+invalid-variable-value = የተለዋዋጭ እሴት ልክ አይደለም፦ `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = የዓይነት ጠቋሚ { $index } ቁጥር መሆን አለበት
+
+variant-index-must-be-integer = የዓይነት ጠቋሚ { $index } ኢንቲጀር መሆን አለበት
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ለፍጹም ልኬቶች አልተተገበረም። ስፋቶቹ ወደ አንጻራዊ ተቀይረዋል።
+
+side-by-side-absolute-margins = `<{ $component }>` ለፍጹም ልኬቶች አልተተገበረም። ኅዳጎቹ ወደ አንጻራዊ ተቀይረዋል።
+
+side-by-side-no-block-child = ልክ ያልሆነ `<{ $component }>`፦ ቢያንስ አንድ የብሎክ ልጅ ሊኖረው ይገባል።
+
+## `<label>`
+
+label-for-ignored-on-graphical = በሥዕላዊ `<label>` ላይ ያለው `for` ባሕርይ ችላ ይባላል።
+
+label-for-must-resolve-to-one = በ`<label>` ላይ ያለው `for` ባሕርይ በትክክል ወደ አንድ አካል መድረስ አለበት።
+
+label-for-unresolved = በ`<label>` ላይ ያለው `for` ባሕርይ ወደ አካል ሊደርስ አልቻለም።
+
+label-for-answer-with-authored-inputs = በ`<label>` ላይ ያለው `for` ባሕርይ ግቤቶቹ በግልጽ የተጻፉለትን `<answer>` ያመለክታል፤ በቀጥታ ግቤቱን ያመልክቱ።
+
+label-for-answer-without-input = በ`<label>` ላይ ያለው `for` ባሕርይ መለያ የሚሰጠው ግቤት የሌለውን `<answer>` ያመለክታል።
+
+label-for-must-reference-input-or-answer = በ`<label>` ላይ ያለው `for` ባሕርይ ግቤትን ወይም መልስን ማመልከት አለበት።
+
+## Accessibility
+
+accessibility-short-description-or-decorative = ለተደራሽነት ሲባል `<{ $component }>` አጭር መግለጫ ሊኖረው ወይም እንደ ጌጥ መገለጽ አለበት።
+
+accessibility-video-short-description = ለተደራሽነት ሲባል `<video>` አጭር መግለጫ ሊኖረው ይገባል።
+
+accessibility-input-short-description-or-label = ለተደራሽነት ሲባል `<{ $component }>` አጭር መግለጫ ወይም መለያ ሊኖረው ይገባል።
+
+accessibility-answer-input-short-description-or-label = ለተደራሽነት ሲባል ግቤት የሚፈጥር `<answer>` አጭር መግለጫ ወይም መለያ ሊኖረው ይገባል።
+
+accessibility-short-description-contains-math = አጭር መግለጫዎች እንደ `<{ $component }>` ያሉ የሒሳብ አካላትን መያዝ የለባቸውም። ሒሳቡን በቃላት ይግለጹ።
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ለክፍል ርዕስ ጽሑፍ በቂ ንጽጽር የለውም (ጨለማ ሁነታ) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ ቢያንስ { $threshold }:1 ያስፈልጋል)።
+       *[other] { $colorName } ለክፍል ርዕስ ጽሑፍ በቂ ንጽጽር የለውም ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ ቢያንስ { $threshold }:1 ያስፈልጋል)።
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = ነጥቦቹ ቁጥራዊ እሴት በሌላቸው ጊዜ በ{ $count } ነጥቦች የሚያልፍ `<circle>` ገና አልተተገበረም።
+
+circle-too-many-through-points = ከ3 በላይ ነጥቦች የሚያልፍ ክብ ማስላት አይቻልም።
+
+circle-overprescribed-radius-center-points = ራዲየስ፣ ማዕከልና የሚያልፍባቸው ነጥቦች በአንድ ጊዜ ሲገለጹ ክብ ማስላት አይቻልም።
+
+circle-center-with-multiple-points = የተገለጸ ማዕከል ያለውና ከ1 በላይ ነጥብ የሚያልፍ ክብ ማስላት አይቻልም።
+
+circle-radius-too-small = ክቡን ማስላት አይቻልም፦ በሁለቱ ነጥቦች መካከል ያለው ርቀት { $distance } ስለሆነ የተገለጸው ራዲየስ { $radius } በጣም ትንሽ ነው።
+
+circle-radius-with-many-points = በተገለጸ ራዲየስ ከሁለት በላይ ነጥቦች የሚያልፍ ክብ መፍጠር አይቻልም።
+
+circle-invalid-center-or-through-points = የክቡ ማዕከል ወይም የሚያልፍባቸው ነጥቦች ልክ አይደሉም።
+
+circle-radius-center-with-multiple-points = የተገለጸ ማዕከል ያለውና ከ1 በላይ ነጥብ የሚያልፍ ክብ ራዲየስ ማስላት አይቻልም።
+
+circle-change-radius-non-numerical = የሚያልፍባቸው ነጥቦች ቁጥራዊ ያልሆኑ ክብ ራዲየስ መቀየር አይቻልም
+
+circle-radius-with-points-non-numerical = ቁጥራዊ እሴቶች በሌሉበት፣ በተገለጸ ራዲየስ ከአንድ በላይ ነጥብ የሚያልፍ ክብ መፍጠር አይቻልም።
+
+circle-change-center-non-numerical = ቁጥራዊ ባልሆኑ ነጥቦች የሚያልፍ ክብ ማዕከል መቀየር ገና አልተተገበረም።
+
+## `<function>`
+
+function-domain-insufficient-dimensions = የተግባሩ ጎራ ልኬቶች በቂ አይደሉም። ጎራው { $intervals } ክፍተቶች አሉት፣ ተግባሩ ግን { $inputs } ግቤቶች አሉት።
+
+function-domain-invalid-format = የተግባሩ ጎራ ቅርጸት ልክ አይደለም።
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] ቁጥራዊ ያልሆነውን የተግባር ከፍተኛ እሴት ችላ በማለት ላይ።
+        [minimum] ቁጥራዊ ያልሆነውን የተግባር ዝቅተኛ እሴት ችላ በማለት ላይ።
+        [extremum] ቁጥራዊ ያልሆነውን የተግባር ጫፍ እሴት ችላ በማለት ላይ።
+        [point] ቁጥራዊ ያልሆነውን የተግባር ነጥብ ችላ በማለት ላይ።
+        [slope] ቁጥራዊ ያልሆነውን የተግባር ተዳፋት ችላ በማለት ላይ።
+       *[other] ቁጥራዊ ያልሆነውን የተግባር { $type } ችላ በማለት ላይ።
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] ባዶ የሆነውን የተግባር ከፍተኛ እሴት ችላ በማለት ላይ።
+        [minimum] ባዶ የሆነውን የተግባር ዝቅተኛ እሴት ችላ በማለት ላይ።
+        [extremum] ባዶ የሆነውን የተግባር ጫፍ እሴት ችላ በማለት ላይ።
+        [point] ባዶ የሆነውን የተግባር ነጥብ ችላ በማለት ላይ።
+       *[other] ባዶ የሆነውን የተግባር { $type } ችላ በማለት ላይ።
+    }
+
+function-points-too-close = ተግባሩ በጣም የተቀራረቡ ሁለት ነጥቦች አሉት። ተግባሩን መግለጽ አይቻልም።
+
+function-iterates-input-output-mismatch = የተግባር ድግግሞሽ የሚቻለው የግቤቶች ብዛት ከውጤቶች ብዛት ጋር ሲተካከል ብቻ ነው። ይህ ተግባር { $inputs } ግቤቶችና { $outputs } ውጤቶች አሉት።
+
+## `<sequence>`
+
+sequence-invalid-length = የተከታታዩ ርዝመት ልክ አይደለም። አሉታዊ ያልሆነ ኢንቲጀር መሆን አለበት።
+
+sequence-invalid-step = የተከታታዩ ርምጃ ልክ አይደለም። ለ{ $type } ዓይነት ተከታታይ ቁጥር መሆን አለበት።
+
+sequence-invalid-endpoint-number = የቁጥር ተከታታይ "{ $attribute }" ልክ አይደለም። ቁጥር መሆን አለበት።
+
+sequence-invalid-endpoint-letters = የፊደል ተከታታይ "{ $attribute }" ልክ አይደለም። የፊደላት ጥምረት መሆን አለበት።
+
+sequence-invalid-endpoint = የተከታታዩ "{ $attribute }" ልክ አይደለም።
+
+select-from-sequence-coprime-not-numbers = ቁጥሮች ስላልተመረጡ coprime ችላ ተብሏል
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations ስለተገለጸ coprime ችላ ተብሏል
+
+## Resolving a `target`
+
+target-not-found = ለ`<{ $source }>` target ልክ አይደለም፦ ዒላማው አልተገኘም።
+
+target-state-variable-not-found = ለ`<{ $source }>` target ልክ አይደለም፦ በ`<{ $component }>` ላይ "{ $property }" የተባለ የሁኔታ ተለዋዋጭ አልተገኘም።
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = የ`<odeSystem>` ተለዋዋጮች ከነጻው ተለዋዋጭ የተለዩ መሆን አለባቸው።
+
+ode-system-duplicate-variable-names = በተደጋገሙ ጥገኛ ተለዋዋጭ ስሞች የODE የቀኝ ወገን ተግባራትን መግለጽ አይቻልም።
+
+ode-system-rhs-function-error = የODE የቀኝ ወገን ተግባርን መግለጽ አይቻልም። የmathjs ተግባር ሲፈጠር ስህተት ተከስቷል።
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = በ{ $count } መስመሮች መካከል ያለውን ማዕዘን መግለጽ አይቻልም
+
+angle-invalid-through-point = በ`<angle>` through ውስጥ ልክ ያልሆነ ነጥብ አለ
+
+parabola-vertex-too-many-points = የተገለጸ ጫፍ ያለውና ከ1 በላይ ነጥብ የሚያልፍ ፓራቦላ ገና አልተተገበረም።
+
+parabola-too-many-points = ከ3 በላይ ነጥቦች የሚያልፍ ፓራቦላ ገና አልተተገበረም።
+
+intersection-too-many-items = ከሁለት በላይ ነገሮች መገናኛ ገና አልተተገበረም
+
+## Other math components
+
+ionic-compound-not-two-ions = ከሁለት ion ውጭ ላለ ionic ውህድ ገና አልተተገበረም።
+
+ionic-compound-needs-cation-and-anion = ionic ውህድ የተተገበረው ለአንድ cation እና ለአንድ anion ብቻ ነው።
+
+solve-equations-cannot-evaluate = ቀመሩ ሊሰላ ስላልቻለ መፍታት አይቻልም፦ { $equation }
+
+math-operators-operand-number-required = የሒሳብ ኦፐራንድ ሲወጣ operandNumber መገለጽ አለበት።
+
+eigen-decomposition-failed = የማትሪክሱ ባሕርያዊ እሴቶች ሊሰሉ አልቻሉም
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`፦ ግቤት { $parameters } በስርዓተ ጥለቱ ውስጥ ስለማይገኝ ሁልጊዜ ባዶን ያዛምዳል።
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`፦ grid="{ $grid }" ሊተረጎም አልቻለም። none፣ medium፣ dense ወይም በክፍተት የተለያዩ ሁለት አዎንታዊ ቁጥሮች መሆን አለበት፣ ለምሳሌ grid="1 0.5"። ፍርግርግ አይሳልም።
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`፦ በprefigure አሳያ ውስጥ xLabelPosition="left" አይደገፍም፤ የቀኝ ጎን ባሕርይ ጥቅም ላይ ውሏል።
+
+prefigure-y-label-position-unsupported = `<graph>`፦ በprefigure አሳያ ውስጥ yLabelPosition="bottom" አይደገፍም፤ የላይኛው ጎን ባሕርይ ጥቅም ላይ ውሏል።
+
+prefigure-invalid-axis-bounds = `<graph>`፦ ለprefigure ልወጣ የዘንጎች ወሰን ልክ አይደለም፤ ነባሪው bbox (-10,-10,10,10) ጥቅም ላይ ውሏል።
+
+prefigure-invalid-width = `<graph>`፦ ለprefigure ልወጣ ስፋቱ ልክ አይደለም፤ ነባሪው የሥዕል ስፋት 425 ጥቅም ላይ ውሏል።
+
+prefigure-invalid-aspect-ratio = `<graph>`፦ ለprefigure ልወጣ aspectRatio ልክ አይደለም፤ ነባሪው ጥምርታ 1 ጥቅም ላይ ውሏል።
+
+prefigure-grid-spacing-too-fine = `<graph>`፦ ከዘንጎቹ ወሰን አንጻር የፍርግርጉ ክፍተት በጣም ጥብቅ ነው፤ በprefigure አሳያ ውስጥ ፍርግርጉ ተትቷል።
+
+prefigure-annotations-not-rendered = `<graph>`፦ የPreFigure አሳያ ጥቅም ላይ ካልዋለ ማብራሪያዎች አይሳሉም።
+
+multiple-annotations-children = በ`<graph>` ውስጥ በርካታ `<annotations>` ልጆች ተገኝተዋል፤ ከመጨረሻው በስተቀር ሁሉም ችላ ተብለዋል።
+
+## Referring to other components
+
+copy-unrecognized-component-type = ያልታወቀ የአካል ዓይነት ማስፋት ወይም መቅዳት አይቻልም፦ { $type }።
+
+copy-prop-not-found = በ{ $component } ዓይነት አካል ላይ { $property } ባሕርይ አልተገኘም
+
+collect-no-source = ለcollect ምንጭ አልተገኘም።
+
+collect-invalid-component-type = `<{ $component }>` ትክክለኛ የአካል ዓይነት ስላልሆነ የዚህ ዓይነት አካላትን መሰብሰብ አይቻልም።
+
+reference-index-unavailable = ጠቋሚ `{ $reference }` ማመልከት አይቻልም
+
+## `<callAction>`
+
+component-action-unavailable = በአካል `{ $reference }` ላይ { $action } መጥራት አይቻልም
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = የመረጃው ቅርጽ ልክ አይደለም። የረድፎቹ ርዝመት አይመሳሰልም። በcomponentIdx :{ $componentIdx } ተገኝቷል
+
+data-frame-duplicate-column-names = መረጃው የተደጋገሙ የዓምድ ስሞች አሉት። በcomponentIdx :{ $componentIdx } ተገኝቷል
+
+data-frame-missing-column-name = መረጃው የዓምድ ስም ይጎለዋል። በcomponentIdx :{ $componentIdx } ተገኝቷል
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = የዚህ መልስ አንድ award በራሱ በanswer መለያ በተላከው መልስ ላይ የተመሠረተ ነው፤ ይህም ያልታሰበ ባሕርይ ያስከትላል።
+
+answer-max-num-attempts-in-section-wide-check-work = የሙከራዎቹ ብዛት በያዥው ስለሚቆጣጠር፣ `sectionWideCheckWork` ባለው ያዥ ውስጥ ባለ `<answer>` ላይ `maxNumAttempts` ማስቀመጥ ውጤት የለውም። `maxNumAttempts` በያዥው ላይ ያስቀምጡ።
+
+nested-section-wide-check-work-max-num-attempts = የሙከራዎቹ ብዛት በውጪኛው ያዥ ስለሚቆጣጠር፣ `sectionWideCheckWork` ባለው ሌላ ያዥ ውስጥ ባለ `sectionWideCheckWork` ያዥ ላይ `maxNumAttempts` ማስቀመጥ ውጤት የለውም። `maxNumAttempts` በውጪኛው ያዥ ላይ ያስቀምጡ።
+
+answer-attributes-need-symbolic-equality = symbolicEquality ካልተቀመጠ የ{ $attributes } ባሕርይ ውጤት አይኖረውም።
+
+answer-invalid-type = ለanswer ዓይነቱ ልክ አይደለም፦ { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = አካል `<{ $component }>` ስም ስለሌለው እንደ ሞጁል ባሕርይ ሊያገለግል አይችልም
+
+module-attribute-name-already-defined = የአካል ዓይነት `<module>` አስቀድሞ "{ $name }" ባሕርይ ስለገለጸ አካል `<{ $component } name="{ $name }">` እንደ ሞጁል ባሕርይ ሊያገለግል አይችልም።
+
+conditional-content-condition-ignored = case ወይም else ልጆች ባሉት `<conditionalContent>` አካል ላይ `condition` ባሕርይ ችላ ይባላል።
+
+slider-markers-type-mismatch = የምልክቶቹ ዓይነት ከተንሸራታቹ ዓይነት ጋር አይመሳሰልም።
+
+pretzel-problem-needs-statement-and-answer = ልክ ያልሆነ pretzel፦ እያንዳንዱ `<problem>` አንድ `<statement>` እና አንድ `<answer>` መያዝ አለበት።
+
+pretzel-circuit-first-problem-distractor = ልክ ያልሆነ pretzel፦ በmode="circuit" የመጀመሪያው `<problem>` አሳሳች ምርጫ ሊሆን አይችልም።
+
+## Attribute values
+
+attribute-invalid-values = ለባሕርይ `{ $attribute }` እሴት { $values } ልክ አይደለም፤ ችላ ተብሏል።
+
+attribute-must-be-references = ለባሕርይ `{ $attribute }` እሴት `{ $value }` ልክ አይደለም። ባሕርዩ በ`$` ከሚጀምሩ ማጣቀሻዎች መገንባት አለበት።
+
+math-input-invalid-function-names = <mathInput>፦ በ{ $attribute } ውስጥ ልክ ያልሆኑ የተግባር ስሞች ችላ ተብለዋል፦ { $names }። የእያንዳንዱ ስም የሚታየው ክፍል ቢያንስ 2 ቁምፊዎች (ፊደላት ወይም ሰረዞች) ሊኖሩት ይገባል፤ ከዚያ በኋላ አማራጭ `|<mathspeak ተለዋጭ>` ቅጥያ ሊመጣ ይችላል።
+
+## Building components from the source
+
+component-type-invalid = የአካል ዓይነት ልክ አይደለም፦ `<{ $componentType }>`
+
+attribute-repeated = ባሕርይ { $attribute } መደገም አይችልም።
+
+attribute-invalid-for-component = ባሕርይ "{ $attribute }" ለ`<{ $componentType }>` ዓይነት አካል ልክ አይደለም።
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    የቅጥ ትርጓሜ { $styleNumber } ለ{ $context ->
+        [text-on-background] የጽሑፍ ቀለም ከዳራ ቀለም አንጻር
+        [high-contrast] ከፍተኛ ንጽጽር ያለው ቀለም ከሸራው አንጻር
+        [line] የመስመር ቀለም ከሸራው አንጻር
+        [marker] የምልክት ቀለም ከሸራው አንጻር
+       *[text-on-canvas] የጽሑፍ ቀለም ከሸራው አንጻር
+    } በቂ ንጽጽር የለውም{ $mode ->
+        [dark] { " (ጨለማ ሁነታ)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ ቢያንስ { $threshold }:1 ያስፈልጋል)።
+
+style-definition-dark-mode-text-background-contrast =
+    የቅጥ ትርጓሜ { $styleNumber } ለብርሃን ሁነታ በቂ ንጽጽር ያላቸውን ቀለሞች ቢገልጽም፣ ከእነዚህ እሴቶች የተገኙት የጨለማ ሁነታ ቀለሞች በጽሑፍ ቀለምና በዳራ ቀለም መካከል በቂ ንጽጽር የላቸውም ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ ቢያንስ { $threshold }:1 ያስፈልጋል)። { $suggestion ->
+        [available] በጨለማ ሁነታ በቂ ንጽጽር ለማረጋገጥ የብርሃን ሁነታውን ንጽጽር ይጨምሩ (ለምሳሌ { $lightAttribute }="{ $lightColor }" ያስቀምጡ) ወይም የጨለማ ሁነታውን ቀለም ይሽሩ (ለምሳሌ { $darkAttribute }="{ $darkColor }" ያስቀምጡ)።
+       *[none] በጨለማ ሁነታ በቂ ንጽጽር ለማረጋገጥ የብርሃን ሁነታውን ንጽጽር ይጨምሩ ወይም የተገኙትን ቀለሞች በtextColorDarkMode እና/ወይም በbackgroundColorDarkMode ይሽሩ።
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    የቅጥ ትርጓሜ { $styleNumber } ለብርሃን ሁነታ በቂ ንጽጽር ያለው የጽሑፍ ቀለም ቢገልጽም፣ ከዚህ እሴት የተገኘው የጨለማ ሁነታ የጽሑፍ ቀለም ከሸራው አንጻር በቂ ንጽጽር የለውም ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ ቢያንስ { $threshold }:1 ያስፈልጋል)። { $suggestion ->
+        [available] በጨለማ ሁነታ በቂ ንጽጽር ለማረጋገጥ የብርሃን ሁነታውን ንጽጽር ይጨምሩ (ለምሳሌ textColor="{ $lightColor }" ያስቀምጡ) ወይም የጨለማ ሁነታውን ቀለም ይሽሩ (ለምሳሌ textColorDarkMode="{ $darkColor }" ያስቀምጡ)።
+       *[none] በጨለማ ሁነታ በቂ ንጽጽር ለማረጋገጥ የብርሃን ሁነታውን ንጽጽር ይጨምሩ ወይም የተገኘውን ቀለም በtextColorDarkMode ይሽሩ።
+    }
+
+section-multiple-style-palettes = አንድ ክፍል አንድ <stylePalette> ብቻ መምረጥ ይችላል፤ የመጨረሻው ጥቅም ላይ ውሏል።
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect አሉታዊ ያልሆነ ኢንቲጀር ስላልሆነ የ{ $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-num-to-select-not-constant-number = numToSelect ቋሚ ስላልሆነ የ{ $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-with-replacement-not-constant-boolean = withReplacement ቋሚ የቡሊያን እሴት ስላልሆነ የ{ $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-select-weight-disables-unique = አንድ ምርጫ selectWeight ወይም selectForVariants ከገለጸ የselect ልዩ ዓይነቶች ይሰናከላሉ
+
+variant-coprime-undetermined = coprime ሁልጊዜ ሐሰት መሆኑ ስላልተረጋገጠ የ{ $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-attribute-not-constant = { $attribute } ቋሚ ስላልሆነ የ{ $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-attribute-not-number = { $attribute } ቁጥር ስላልሆነ የ{ $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } { $expected ->
+        [letters-combination] የፊደላት ጥምረት
+        [math-expression] ትክክለኛ የሒሳብ አገላለጽ
+        [integer] ኢንቲጀር
+       *[number] ቁጥር
+    } ስላልሆነ የ{ $type } ዓይነት { $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-length-not-integer = length ኢንቲጀር ስላልሆነ የ{ $component } ልዩ ዓይነቶች ሊወሰኑ አይችሉም።
+
+variant-sort-not-implemented = sort ያለው { $component } ልዩ ዓይነቶች ገና አልተተገበሩም
+
+variant-exclude-combinations-not-implemented = excludeCombinations ያለው { $component } ልዩ ዓይነቶች ገና አልተተገበሩም
+
+variant-math-exclude-not-implemented = exclude ያለው የmath ዓይነት { $component } ልዩ ዓይነቶች ገና አልተተገበሩም
+
+variant-non-constant-exclude-not-implemented = ቋሚ ያልሆነ exclude ያለው { $component } ልዩ ዓይነቶች ገና አልተተገበሩም
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }፦ በግራፍ prefigure አሳያ ውስጥ አይደገፍም፤ ዘሩ ተዘሏል።
+
+prefigure-descendant-invalid-geometry = { $subject }፦ ጂኦሜትሪው ውሱን ያልሆነ ወይም ያልተሟላ ነው፤ ዘሩ ተዘሏል።
+
+prefigure-curve-label-omitted = { $subject }፦ በተለወጡ የጠምዛዛ አካላት ላይ መለያዎች አይደገፉም፤ መለያው ተትቷል።
+
+prefigure-curve-unsupported-definition-type = { $subject }፦ የማይደገፍ የጠምዛዛ ተግባር ትርጓሜ ዓይነት '{ $definitionType }'፤ ዘሩ ተዘሏል።
+
+prefigure-region-flip-functions-unsupported = { $subject }፦ በregionBetweenCurves ላይ የflipFunctions ባሕርይ አይደገፍም፤ ዘሩ ተዘሏል።
+
+prefigure-region-non-formula-child = { $subject }፦ regionBetweenCurves የቀመር ዓይነት ንዑስ ተግባራትን ብቻ ይደግፋል፤ ዘሩ ተዘሏል።
+
+prefigure-label-position-unsupported =
+    { $subject }፦ ለ{ $labelKind ->
+        [line-family] የመስመር ቤተሰብ መለያ
+       *[point] የነጥብ መለያ
+    } labelPosition '{ $labelPosition }' አይደገፍም፤ የPreFigure ነባሪ አሰላለፍ ጥቅም ላይ ውሏል።
+
+prefigure-fill-style-unsupported = { $subject }፦ የመሙያ ቅጥ '{ $fillStyle }' በPreFigure አይደገፍም፤ ወደ ሙሉ መሙያ ተቀይሯል።
+
+prefigure-line-style-unknown = { $subject }፦ ያልታወቀ የመስመር ቅጥ '{ $lineStyle }' ከPreFigure ውጤት ተትቷል።
+
+prefigure-marker-style-mapped-to-diamond = { $subject }፦ የምልክት ቅጥ '{ $markerStyle }' ወደ PreFigure ቅጥ 'diamond' ተዛምዷል።
+
+prefigure-marker-style-unsupported = { $subject }፦ የምልክት ቅጥ '{ $markerStyle }' በPreFigure አይደገፍም፤ ነባሪው ቅጥ ጥቅም ላይ ውሏል።
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`፦ `ref` ልክ አይደለም፤ ዒላማው ሊወሰን አልቻለም። ማብራሪያው ተትቷል።
+
+annotation-ref-multiple-targets = `<annotation>`፦ `ref` ወደ በርካታ ዒላማዎች ደርሷል፤ የመጀመሪያው ዒላማ ጥቅም ላይ ውሏል።
+
+annotation-ref-outside-graph = `<annotation>`፦ `ref` ልክ አይደለም፤ ዒላማው ከያዘው ግራፍ ውጭ ነው። ማብራሪያው ተትቷል።
+
+annotation-ref-unsupported-target = `<annotation>`፦ `ref` ልክ አይደለም፤ በprefigure ልወጣ ውስጥ ዒላማው የሚደገፍ ሥዕላዊ ነገር አይደለም። ማብራሪያው ተትቷል።
+
+annotation-text-missing = `<annotation>`፦ `text` ይጎላል ወይም ባዶ ነው፤ ባዶ ጽሑፍ ወጥቷል።
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] ዑደታዊ ጥገኝነት ተገኝቷል።
+       *[other] `<{ $componentType }>` አካልን የሚያካትት ዑደታዊ ጥገኝነት ተገኝቷል።
+    }
+
+reference-no-referent = ለማጣቀሻው ዒላማ አልተገኘም፦ `{ $reference }`
+
+reference-multiple-referents = ለማጣቀሻው በርካታ ዒላማዎች ተገኝተዋል፦ `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = የ`<{ $componentType }>` ባሕርይ { $attribute } ቅርጸት ልክ አይደለም።
+
+children-invalid = የ`<{ $componentType }>` ልጆች ልክ አይደሉም፦ ልክ ያልሆኑ ልጆች ተገኝተዋል፦ { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = ለባሕርይ `{ $attribute }` እሴት `{ $value }` ልክ አይደለም፤ እሴት `{ $default }` ጥቅም ላይ ውሏል
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] የDoenetML ስሪት { $version } አልተገኘም።
+       *[other] የDoenetML ስሪት { $version } አልተገኘም። ወደ ስሪት { $fallback } ተመልሷል
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = ልክ ያልሆነ DoenetML፦ { $content }
+
+parse-tag-missing-close-tag = ልክ ያልሆነ DoenetML፦ መለያ `{ $tag }` መዝጊያ መለያ የለውም። ራሱን የሚዘጋ መለያ ወይም `</{ $tagName }>` መለያ ይጠበቅ ነበር።
+
+parse-tag-error = ልክ ያልሆነ DoenetML፦ በመለያ `<{ $tagName }>` ውስጥ ስህተት አለ
+
+parse-attribute-missing-value = ልክ ያልሆነ DoenetML፦ ባሕርይ `{ $attribute }` እሴት የጎደለው ይመስላል።
+
+parse-attribute-invalid = ልክ ያልሆነ DoenetML፦ ባሕርይ `{ $attribute }` ልክ አይደለም
+
+parse-attribute-value-invalid = ልክ ያልሆነ DoenetML፦ የባሕርይ እሴት `{ $value }` ልክ አይደለም
+
+parse-attribute-value-quote-mismatch = ልክ ያልሆነ DoenetML፦ የባሕርይ እሴት `{ $value }` ልክ አይደለም። የጥቅስ ምልክቶቹ አይመሳሰሉም። አንድ `{ $quote }` የጎደለ ይመስላል
+
+parse-open-tag-name-missing = ልክ ያልሆነ DoenetML፦ ስም የሌለው መለያ ተገኝቷል፣ ለምሳሌ `<`
+
+parse-tag-not-closed = ልክ ያልሆነ DoenetML፦ መለያ `{ $tag }` አልተዘጋም (አንድ `>` የጎደለ ይመስላል)።
+
+parse-self-closing-tag-name-missing = ልክ ያልሆነ DoenetML፦ ስም የሌለው መለያ ተገኝቷል `<{ $content }>`
+
+parse-self-closing-tag-not-closed = ልክ ያልሆነ DoenetML፦ መለያ `{ $tag }` አልተዘጋም (`/>` የጎደለ ይመስላል)።
+
+parse-tag-invalid-attributes = ልክ ያልሆነ DoenetML፦ መለያ `{ $tag }` ትክክል አይደለም። ባሕርያቱ ስህተት ሊኖራቸው ይችላል።
+
+parse-close-tag-name-missing = ልክ ያልሆነ DoenetML፦ ስም የሌለው መዝጊያ መለያ ተገኝቷል፣ ለምሳሌ `</`
+
+parse-attribute-value-unquoted = የባሕርይ እሴቶች በጥቅስ ምልክቶች መከበብ አለባቸው፦ `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = ልክ ያልሆነ DoenetML፦ መዝጊያ መለያ `{ $tag }` ተገኝቷል፣ ነገር ግን ተመሳሳይ መክፈቻ መለያ የለም
+
+parse-close-tag-mismatched = ልክ ያልሆነ DoenetML፦ መዝጊያ መለያው አይመሳሰልም። `</{ $expected }>` ይጠበቅ ነበር። `{ $found }` ተገኝቷል
+
+parser-node-unconvertible = ኖድ { $node } ወደ Dast ኖድ ሊለወጥ አልቻለም።
+
+## Names
+
+name-attribute-invalid =
+    ባሕርይ name='{ $name }' ልክ አይደለም። { $reason ->
+        [characters] ስሞች ፊደላትን፣ ቁጥሮችን፣ ከስር መስመርን ወይም ሰረዝን ብቻ ሊይዙ ይችላሉ።
+       *[start] ስሞች በፊደል መጀመር አለባቸው።
+    }
+
+component-name-invalid-start = የአካል ስም "{ $name }" ልክ አይደለም። ስሞች በፊደል መጀመር አለባቸው።
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = የvideoWatched ዓይነት answer የvideo ባሕርይ ሊኖረው ይገባል
+
+answer-video-watched-video-not-reference = የvideoWatched ዓይነት answer የvideo ባሕርዩ ማጣቀሻ መሆን አለበት
+
+answer-name-not-single-text = የanswer name ባሕርይ አንድ የጽሑፍ ልጅ ብቻ ሊኖረው ይገባል
+
+## Referencing another document
+
+external-doenetml-recursion-limit = በጣም ብዙ የድግግሞሽ ደረጃዎች ስላሉ ውጫዊ DoenetML ማግኘት አልተቻለም። ዑደታዊ ማጣቀሻ ይኖር ይሆን?
+
+external-doenetml-unavailable = ከ{ $attribute }="{ $uri }" DoenetML ማግኘት አልተቻለም
+
+external-doenetml-type-mismatch = ከ{ $attribute }="{ $uri }" የተገኘው DoenetML ልክ አይደለም፦ ከአካል ዓይነት "{ $componentType }" ጋር አልተመሳሰለም
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] ባሕርይ `{ $from }` ከአገልግሎት ውጭ ነው፤ በምትኩ `{ $to }` ይጠቀሙ።
+       *[other] [deprecation] በ`<{ $component }>` ላይ ያለው ባሕርይ `{ $from }` ከአገልግሎት ውጭ ነው፤ በምትኩ `{ $to }` ይጠቀሙ።
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }` ደግሞ ስለተገለጸ ባሕርይ `{ $from }` ከአገልግሎት ውጭ ሆኖ ችላ ተብሏል።
+       *[other] [deprecation] `{ $to }` ደግሞ ስለተገለጸ በ`<{ $component }>` ላይ ያለው ባሕርይ `{ $from }` ከአገልግሎት ውጭ ሆኖ ችላ ተብሏል።
+    }
+
+deprecated-attribute-ignored = [deprecation] በ`<{ $component }>` ላይ ያለው ባሕርይ `{ $attribute }` ከአገልግሎት ውጭ ሆኖ ችላ ተብሏል።
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` የእንግሊዝኛን ብዙ ቁጥር ብቻ መሥራት ስለሚችል፣ በ{ $locale } በተጻፈ ሰነድ ውስጥ ጽሑፉ ሳይለወጥ ይቀራል። የብዙ ቁጥር ቅርጹን በቀጥታ ይጻፉ፣ ወይም በ`pluralForm` ባሕርይ ይግለጹ።
+
+
+## Checking against the schema
+
+schema-element-unrecognized = አካል `<{ $tag }>` የሚታወቅ የDoenet አካል አይደለም።
+
+schema-element-not-allowed-at-root = አካል `<{ $tag }>` በሰነዱ ሥር ላይ አይፈቀድም።
+
+schema-element-not-allowed-inside = አካል `<{ $tag }>` በ`<{ $parent }>` ውስጥ አይፈቀድም።
+
+schema-attribute-unrecognized = አካል `<{ $tag }>` `{ $attribute }` የተባለ ባሕርይ የለውም።
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] የአካል `<{ $tag }>` ባሕርይ `{ $attribute }` እያንዳንዱ ንጥል ከሚከተሉት አንዱ የሆነ ዝርዝር መሆን አለበት፦ { $allowed }
+       *[other] የአካል `<{ $tag }>` ባሕርይ `{ $attribute }` ከሚከተሉት አንዱ መሆን አለበት፦ { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = ለselect የዓይነት ስሙ ልክ አይደለም። የዓይነት ስም { $variantName } በ{ $numOptions } ምርጫዎች ውስጥ ይገኛል፣ የሚመረጠው ብዛት ግን { $numToSelect } ነው።
+
+select-variant-name-without-options = ለselect ዓይነቶች ተገልጸዋል፣ ነገር ግን ለሚቻለው የዓይነት ስም ምርጫዎች የሉም፦ { $variantName }።
+
+select-variant-name-not-possible = ለselect የተገለጸው የዓይነት ስም { $variantName } ሊሆን የሚችል የዓይነት ስም አይደለም።
+
+select-too-few-options = ከ{ $numOptions } አካላት ብቻ { $numToSelect } መምረጥ አይቻልም።
+
+select-from-sequence-too-few-values = ርዝመቱ { $length } ከሆነ ተከታታይ { $numToSelect } እሴቶች መምረጥ አይቻልም።
+
+select-from-sequence-indices-count-mismatch = ለselect የተገለጹት ጠቋሚዎች ብዛት ከሚመረጠው ብዛት ጋር መመሳሰል አለበት
+
+select-from-sequence-indices-not-integers = ለselect የተገለጹት ጠቋሚዎች ሁሉ ኢንቲጀሮች መሆን አለባቸው
+
+select-from-sequence-index-excluded = ለselectfromsequence የተገለጸው ጠቋሚ የተገለለ ነበር
+
+select-from-sequence-indices-excluded-combination = ለselectfromsequence የተገለጹት ጠቋሚዎች የተገለለ ጥምረት ነበሩ
+
+select-from-sequence-coprime-not-positive-integers = አዎንታዊ ኢንቲጀሮች ስላልተመረጡ የcoprime ጥምረቶች መምረጥ አይቻልም።
+
+select-from-sequence-coprime-common-factor = coprime ቁጥሮች መምረጥ አይቻልም። ሁሉም ሊሆኑ የሚችሉ እሴቶች የጋራ አካፋይ አላቸው። (የተገለጹት "from" ወይም "to" እሴቶች ከ"step" ጋር coprime መሆን አለባቸው።)
+
+select-from-sequence-coprime-single-number = ከ1 የተለየ ከአንድ ነጠላ ቁጥር የcoprime ጥምረቶች መምረጥ አይቻልም።
+
+select-from-sequence-excluded-too-many-combinations = በselectFromSequence ውስጥ ከ70% በላይ ጥምረቶች ተገልለዋል
+
+select-from-sequence-coprime-none-found = coprime ቁጥሮች መምረጥ አልተቻለም። ሁሉም ሊሆኑ የሚችሉ እሴቶች የጋራ አካፋይ አላቸው።
+
+select-from-sequence-too-few-unique-values = ርዝመቱ { $numPossibleValues } ከሆነ ተከታታይ { $numToSelect } የተለያዩ እሴቶች መምረጥ አይቻልም
+
+select-prime-numbers-too-few-values = ርዝመቱ { $numValues } ከሆነ የቀዳሚ ቁጥሮች ዝርዝር { $numToSelect } እሴቶች መምረጥ አይቻልም
+
+select-prime-numbers-values-count-mismatch = ለselect የተገለጹት እሴቶች ብዛት ከሚመረጠው ብዛት ጋር መመሳሰል አለበት
+
+select-prime-numbers-values-not-prime = ለselect prime number የተገለጹት እሴቶች ሁሉ በቀዳሚ ቁጥሮች ዝርዝር ውስጥ መሆን አለባቸው
+
+select-prime-numbers-values-excluded-combination = ለselectPrimeNumbers የተገለጹት እሴቶች የተገለለ ጥምረት ነበሩ
+
+select-prime-numbers-excluded-too-many-combinations = በselectPrimeNumbers ውስጥ ከ70% በላይ ጥምረቶች ተገልለዋል
+
+select-random-combination-fluke = እጅግ ባልተጠበቀ አጋጣሚ የዘፈቀደ እሴቶች ጥምረት መምረጥ አልተቻለም
+
+select-random-value-fluke = እጅግ ባልተጠበቀ አጋጣሚ የዘፈቀደ እሴት መምረጥ አልተቻለም

--- a/packages/i18n/locales/am/editor.ftl
+++ b/packages/i18n/locales/am/editor.ftl
@@ -1,0 +1,205 @@
+# Amharic editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] ዳግም አስጀምር
+       *[update] አዘምን
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] መመልከቻውን { $word }
+       *[other] መመልከቻውን { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = ዓይነት
+editor-variant-filter = አጣራ...
+editor-variant-next = ቀጣዩን ዓይነት ምረጥ
+editor-variant-previous = ቀዳሚውን ዓይነት ምረጥ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] የWCAG AA ተደራሽነት ጥሰት ተገኝቷል። የተደራሽነት ሪፖርቱን ለ{ $action ->
+            [close] መዝጋት
+           *[open] መክፈት
+        } ጠቅ ያድርጉ።
+        [advisories] የተደራሽነት ሪፖርቱን ለ{ $action ->
+            [close] መዝጋት
+           *[open] መክፈት
+        } ጠቅ ያድርጉ። የWCAG AA ጥሰት አልተገኘም፣ ነገር ግን ተጨማሪ የተደራሽነት ምክሮች አሉ።
+       *[clean] የተደራሽነት ሪፖርቱን ለ{ $action ->
+            [close] መዝጋት
+           *[open] መክፈት
+        } ጠቅ ያድርጉ። የተደራሽነት ችግር አልተገኘም።
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] የWCAG AA ተደራሽነት ጥሰት ተገኝቷል። { $count } የWCAG AA ጥሰቶች ተገኝተዋል። የተደራሽነት ሪፖርቱን ለ{ $action ->
+            [close] መዝጋት
+           *[open] መክፈት
+        } ጠቅ ያድርጉ።
+        [advisories] የWCAG AA ጥሰት አልተገኘም። { $count } ተጨማሪ የተደራሽነት ምክሮች ተገኝተዋል። የተደራሽነት ሪፖርቱን ለ{ $action ->
+            [close] መዝጋት
+           *[open] መክፈት
+        } ጠቅ ያድርጉ።
+       *[clean] የWCAG AA ጥሰት አልተገኘም። የተደራሽነት ሪፖርቱን ለ{ $action ->
+            [close] መዝጋት
+           *[open] መክፈት
+        } ጠቅ ያድርጉ።
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = የDoenetML ስሪት { $version }
+
+editor-tab-help = አውዳዊ እገዛ
+editor-tab-help-short = አውድ
+editor-tab-errors = ስህተቶች
+editor-tab-warnings = ማስጠንቀቂያዎች
+editor-tab-info = መረጃ
+editor-tab-accessibility = ተደራሽነት
+editor-tab-responses = የተላኩ መልሶች
+
+editor-tab-with-count = { $label }፦ { $count }
+
+editor-options = የአርታዒ አማራጮች
+editor-format-as-doenetml = እንደ DoenetML አቅርብ
+editor-format-as-xml = እንደ XML አቅርብ
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = መስመር #{ $line }
+
+editor-no-errors = ስህተት የለም
+editor-no-warnings = ማስጠንቀቂያ የለም
+editor-no-info = የመረጃ ምርመራ የለም
+
+editor-show-info-annotations = በአርታዒው ውስጥ የመረጃ ምርመራዎችን አሳይ
+editor-show-accessibility-annotations = በአርታዒው ውስጥ የተደራሽነት ምርመራዎችን አሳይ
+
+editor-accessibility-learn-more = Doenet ተደራሽነትን እንዴት እንደሚመለከት ይወቁ
+
+editor-accessibility-violations-heading = የተደራሽነት ጥሰቶች ({ $standard })
+
+editor-accessibility-other-heading = ሌሎች የተደራሽነት ችግሮች
+editor-none-found = ምንም አልተገኘም
+
+
+## Submitted responses
+
+editor-no-responses = እስካሁን የተላከ መልስ የለም
+editor-response-answer-id = Answer Id
+editor-response-response = መልስ
+editor-response-credit = ነጥብ
+editor-response-submitted = ተልኳል
+
+
+## The context-help panel
+
+help-placeholder = ሰነዱን ለማየት ጠቋሚውን በመለያ ስም፣ በባሕርይ ወይም በ{ $ref } ላይ ያድርጉ።
+
+help-unsupported-ref-chain = እንደ { $example } ላሉ ባለብዙ ክፍል ማጣቀሻዎች እገዛ ገና አልተደገፈም።
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ለማጣቀሻው ዒላማ አልተገኘም፦ { $ref }።
+        [multiple] ለማጣቀሻው በርካታ ዒላማዎች ተገኝተዋል፦ { $ref }።
+       *[indeterminate] የ{ $ref } ዒላማ ሊወሰን አልቻለም።
+    }
+
+help-learn-about-references = ስለ ማጣቀሻዎች ይወቁ →
+help-reference-page = የማጣቀሻ ገጽ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] በ{ $element } ውስጥ
+       *[top] በላይኛው ደረጃ
+    }{ $allowed ->
+        [none] { " — እዚህ ምንም ሊገባ አይችልም።" }
+        [text] { " — እዚህ ጽሑፍ መጻፍ ይችላሉ።" }
+        [text-and-components] { " — እዚህ ጽሑፍ ይጻፉ፣ ወይም እነዚህን ይሞክሩ፦" }
+       *[components] { " — የሚሞከሩ ነገሮች፦" }
+    }
+
+help-suggestions-footer = ሁሉንም { $total } አካላት ለማየት { $shortcut } ይጫኑ።
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } የ{ $target } ማጣቀሻ ነው።
+       *[other] { $ref } የ{ $target } ማጣቀሻ ነው (መስመር { $line })።
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] በ{ $owner } እንደ { $role } ተጨምሯል።
+       *[other] በ{ $owner } በመስመር { $line } ላይ እንደ { $role } ተጨምሯል።
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } የ{ $element } የ{ $property } ባሕርይ ማጣቀሻ ነው።
+       *[other] { $ref } የ{ $element } የ{ $property } ባሕርይ ማጣቀሻ ነው (መስመር { $line })።
+    }
+
+help-kind-attribute = ባሕርይ
+help-kind-snippet = የኮድ ቁራጭ
+help-kind-array-entry = የድርድር ግቤት
+
+help-default = ነባሪ፦
+help-active-default = በሥራ ላይ ያለ ነባሪ፦
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] የተፈቀዱ እሴቶች (ለእያንዳንዱ አንድ)፦
+       *[other] የተፈቀዱ እሴቶች፦
+    }
+
+help-suggested-values = የተጠቆሙ እሴቶች፦
+
+help-inserts = ያስገባል፦
+
+help-coordinates =
+    { $count ->
+        [one] መጋጠሚያ፦
+       *[other] መጋጠሚያዎች፦
+    }
+
+help-type = ዓይነት፦
+
+help-resolved-style = የተወሰነ ቅጥ (styleNumber { $styleNumber })፦
+
+help-resolved-function-names = የተወሰኑ የተግባር ስሞች፦
+help-reset-list = የዚህ ግቤት ዳግም ማስጀመሪያ ዝርዝር፦
+help-added-on-input = በዚህ ግቤት ላይ የተጨመረ፦
+help-removed-on-input = በዚህ ግቤት ላይ የተወገደ፦
+
+help-reset-overrides = { $reset } ከ{ $additional } እና ከ{ $removed } ይቀድማል።

--- a/packages/i18n/locales/am/editor.ftl
+++ b/packages/i18n/locales/am/editor.ftl
@@ -29,10 +29,10 @@ editor-update-viewer-title =
 
 ## The variant picker
 
-editor-variant = ዓይነት
+editor-variant = ተለዋጭ
 editor-variant-filter = አጣራ...
-editor-variant-next = ቀጣዩን ዓይነት ምረጥ
-editor-variant-previous = ቀዳሚውን ዓይነት ምረጥ
+editor-variant-next = ቀጣዩን ተለዋጭ ምረጥ
+editor-variant-previous = ቀዳሚውን ተለዋጭ ምረጥ
 
 
 ## The accessibility status button
@@ -87,8 +87,8 @@ editor-tab-responses = የተላኩ መልሶች
 editor-tab-with-count = { $label }፦ { $count }
 
 editor-options = የአርታዒ አማራጮች
-editor-format-as-doenetml = እንደ DoenetML አቅርብ
-editor-format-as-xml = እንደ XML አቅርብ
+editor-format-as-doenetml = እንደ DoenetML ቅረጽ
+editor-format-as-xml = እንደ XML ቅረጽ
 
 
 ## The diagnostics panel
@@ -113,7 +113,7 @@ editor-none-found = ምንም አልተገኘም
 ## Submitted responses
 
 editor-no-responses = እስካሁን የተላከ መልስ የለም
-editor-response-answer-id = Answer Id
+editor-response-answer-id = የመልስ መለያ
 editor-response-response = መልስ
 editor-response-credit = ነጥብ
 editor-response-submitted = ተልኳል
@@ -121,7 +121,7 @@ editor-response-submitted = ተልኳል
 
 ## The context-help panel
 
-help-placeholder = ሰነዱን ለማየት ጠቋሚውን በመለያ ስም፣ በባሕርይ ወይም በ{ $ref } ላይ ያድርጉ።
+help-placeholder = ማብራሪያ ለማየት ጠቋሚውን በመለያ ስም፣ በባሕርይ ወይም በ{ $ref } ላይ ያድርጉ።
 
 help-unsupported-ref-chain = እንደ { $example } ላሉ ባለብዙ ክፍል ማጣቀሻዎች እገዛ ገና አልተደገፈም።
 

--- a/packages/i18n/locales/de/content.ftl
+++ b/packages/i18n/locales/de/content.ftl
@@ -6,131 +6,226 @@
 #
 # German inflects, and it inflects the other way round from Spanish: attributive
 # adjectives go *before* the noun and take an ending that depends on the noun's
-# gender. A description is a standalone phrase with no article, so the strong
-# endings apply — `-er` masculine, `-e` feminine, `-es` neuter — and `$gender`
-# carries all three, since German has a neuter. It carries a fourth token,
-# `datm`, for the one phrase that is not nominative; `noun-gender` says which
-# and why.
+# gender and on the case its position governs.
+#
+# Every adjective below therefore selects on `$role` first — which position the
+# words are going into — and only then, where it matters, on `$gender`:
+#
+#   standalone          a phrase with no article, so the strong nominative
+#                       endings apply: `-er` m, `-e` f, `-es` n
+#   border-clause       after `mit einem` / `und einem`, which govern the
+#                       dative: `-en`, the same for every gender
+#   background-clause   after a bare `auf`, dative with no article, so the
+#                       strong ending: `-em`
+#   text-clause         predicative, where German does not inflect at all: the
+#                       bare stem, `rot auf gelbem Hintergrund`
+#
+# The last three need no gender branch: each is only ever used of one noun, and
+# that noun's gender is fixed (der Rand, der Hintergrund, der Text).
+#
+# This replaces the `datm` token an earlier seed carried inside `$gender`. One
+# token could hold a gender or a case but not both, so whichever of the two
+# positions it was tuned for, the other came out wrong (#1606).
 
 
 ## Style vocabulary
 
 color =
     .black =
-        { $gender ->
-            [f] schwarze
-            [n] schwarzes
-            [datm] schwarzen
-           *[m] schwarzer
+        { $role ->
+            [border-clause] schwarzen
+            [background-clause] schwarzem
+            [text-clause] schwarz
+            *[standalone]
+                { $gender ->
+                    [f] schwarze
+                    [n] schwarzes
+                    *[m] schwarzer
+                }
         }
     .white =
-        { $gender ->
-            [f] weiße
-            [n] weißes
-            [datm] weißen
-           *[m] weißer
+        { $role ->
+            [border-clause] weißen
+            [background-clause] weißem
+            [text-clause] weiß
+            *[standalone]
+                { $gender ->
+                    [f] weiße
+                    [n] weißes
+                    *[m] weißer
+                }
         }
     .gray =
-        { $gender ->
-            [f] graue
-            [n] graues
-            [datm] grauen
-           *[m] grauer
+        { $role ->
+            [border-clause] grauen
+            [background-clause] grauem
+            [text-clause] grau
+            *[standalone]
+                { $gender ->
+                    [f] graue
+                    [n] graues
+                    *[m] grauer
+                }
         }
     .red =
-        { $gender ->
-            [f] rote
-            [n] rotes
-            [datm] roten
-           *[m] roter
+        { $role ->
+            [border-clause] roten
+            [background-clause] rotem
+            [text-clause] rot
+            *[standalone]
+                { $gender ->
+                    [f] rote
+                    [n] rotes
+                    *[m] roter
+                }
         }
     .orange =
-        { $gender ->
-            [f] orangefarbene
-            [n] orangefarbenes
-            [datm] orangefarbenen
-           *[m] orangefarbener
+        { $role ->
+            [border-clause] orangefarbenen
+            [background-clause] orangefarbenem
+            [text-clause] orangefarben
+            *[standalone]
+                { $gender ->
+                    [f] orangefarbene
+                    [n] orangefarbenes
+                    *[m] orangefarbener
+                }
         }
     .yellow =
-        { $gender ->
-            [f] gelbe
-            [n] gelbes
-            [datm] gelben
-           *[m] gelber
+        { $role ->
+            [border-clause] gelben
+            [background-clause] gelbem
+            [text-clause] gelb
+            *[standalone]
+                { $gender ->
+                    [f] gelbe
+                    [n] gelbes
+                    *[m] gelber
+                }
         }
     .green =
-        { $gender ->
-            [f] grüne
-            [n] grünes
-            [datm] grünen
-           *[m] grüner
+        { $role ->
+            [border-clause] grünen
+            [background-clause] grünem
+            [text-clause] grün
+            *[standalone]
+                { $gender ->
+                    [f] grüne
+                    [n] grünes
+                    *[m] grüner
+                }
         }
     .cyan =
-        { $gender ->
-            [f] cyanfarbene
-            [n] cyanfarbenes
-            [datm] cyanfarbenen
-           *[m] cyanfarbener
+        { $role ->
+            [border-clause] cyanfarbenen
+            [background-clause] cyanfarbenem
+            [text-clause] cyanfarben
+            *[standalone]
+                { $gender ->
+                    [f] cyanfarbene
+                    [n] cyanfarbenes
+                    *[m] cyanfarbener
+                }
         }
     .blue =
-        { $gender ->
-            [f] blaue
-            [n] blaues
-            [datm] blauen
-           *[m] blauer
+        { $role ->
+            [border-clause] blauen
+            [background-clause] blauem
+            [text-clause] blau
+            *[standalone]
+                { $gender ->
+                    [f] blaue
+                    [n] blaues
+                    *[m] blauer
+                }
         }
     .purple =
-        { $gender ->
-            [f] violette
-            [n] violettes
-            [datm] violetten
-           *[m] violetter
+        { $role ->
+            [border-clause] violetten
+            [background-clause] violettem
+            [text-clause] violett
+            *[standalone]
+                { $gender ->
+                    [f] violette
+                    [n] violettes
+                    *[m] violetter
+                }
         }
     .pink =
-        { $gender ->
-            [f] rosafarbene
-            [n] rosafarbenes
-            [datm] rosafarbenen
-           *[m] rosafarbener
+        { $role ->
+            [border-clause] rosafarbenen
+            [background-clause] rosafarbenem
+            [text-clause] rosafarben
+            *[standalone]
+                { $gender ->
+                    [f] rosafarbene
+                    [n] rosafarbenes
+                    *[m] rosafarbener
+                }
         }
     .brown =
-        { $gender ->
-            [f] braune
-            [n] braunes
-            [datm] braunen
-           *[m] brauner
+        { $role ->
+            [border-clause] braunen
+            [background-clause] braunem
+            [text-clause] braun
+            *[standalone]
+                { $gender ->
+                    [f] braune
+                    [n] braunes
+                    *[m] brauner
+                }
         }
 
 line-width =
     .thick =
-        { $gender ->
-            [f] dicke
-            [n] dickes
-            [datm] dicken
-           *[m] dicker
+        { $role ->
+            [border-clause] dicken
+            [background-clause] dickem
+            [text-clause] dick
+            *[standalone]
+                { $gender ->
+                    [f] dicke
+                    [n] dickes
+                    *[m] dicker
+                }
         }
     .thin =
-        { $gender ->
-            [f] dünne
-            [n] dünnes
-            [datm] dünnen
-           *[m] dünner
+        { $role ->
+            [border-clause] dünnen
+            [background-clause] dünnem
+            [text-clause] dünn
+            *[standalone]
+                { $gender ->
+                    [f] dünne
+                    [n] dünnes
+                    *[m] dünner
+                }
         }
 
 line-style =
     .dashed =
-        { $gender ->
-            [f] gestrichelte
-            [n] gestricheltes
-            [datm] gestrichelten
-           *[m] gestrichelter
+        { $role ->
+            [border-clause] gestrichelten
+            [background-clause] gestricheltem
+            [text-clause] gestrichelt
+            *[standalone]
+                { $gender ->
+                    [f] gestrichelte
+                    [n] gestricheltes
+                    *[m] gestrichelter
+                }
         }
     .dotted =
-        { $gender ->
-            [f] gepunktete
-            [n] gepunktetes
-            [datm] gepunkteten
-           *[m] gepunkteter
+        { $role ->
+            [border-clause] gepunkteten
+            [background-clause] gepunktetem
+            [text-clause] gepunktet
+            *[standalone]
+                { $gender ->
+                    [f] gepunktete
+                    [n] gepunktetes
+                    *[m] gepunkteter
+                }
         }
 
 # Noun phrases: they follow `mit` and agree with nothing.
@@ -175,24 +270,14 @@ noun-regular-polygon =
 # names: `border` (der Rand, m), `fill` (die Füllung, f), `text` (der Text, m),
 # `background` (der Hintergrund, m).
 #
-# `border` answers `datm` — masculine *dative* — rather than plain `m`, because
-# the only place its adjectives are rendered is after `mit einem` / `und einem`
-# in `style-border-clause`, and both govern the dative: „mit einem dicken
-# Rand“, not „mit einem dicker Rand“. `$gender` is a single token that this
-# catalog chooses the meaning of, so carrying a case in it is what the
-# mechanism allows; what it cannot do is carry two, and
-# `borderStyleDescription` — the state variable that renders a border's style
-# on its own, with no preposition — therefore also comes out dative. Fixing
-# that properly means the code passing a case alongside the gender (#1606).
-#
-# `background` faces the same fork and is resolved the other way: it stays
-# nominative, so `backgroundColor` reads right on its own and the „auf …
-# Hintergrund“ clause in `style-text` carries the nominative with it. The two
-# nouns split because a border is named by a clause far more often than alone,
-# and a background the reverse.
+# Every one of them answers a plain gender now. `border` and `background` used
+# to answer a case instead — `datm` — because each is rendered in two positions
+# and a single token could only suit one of them. `$role` carries that
+# distinction, so this message is back to answering the one question its name
+# asks (#1606).
 noun-gender =
     { $noun ->
-        [border] datm
+        [border] m
         [line] f
         [curve] f
         [function] f
@@ -234,11 +319,16 @@ style-with-noun =
     }
 
 style-filled-word =
-    { $gender ->
-        [f] gefüllte
-        [n] gefülltes
-        [datm] gefüllten
-       *[m] gefüllter
+    { $role ->
+        [border-clause] gefüllten
+        [background-clause] gefülltem
+        [text-clause] gefüllt
+        *[standalone]
+            { $gender ->
+                [f] gefüllte
+                [n] gefülltes
+                *[m] gefüllter
+            }
     }
 
 style-filled =
@@ -256,14 +346,15 @@ style-filled-with-noun =
     }
 
 # „Rand“ is masculine, so the border's adjectives agree with it and not with
-# the shape it surrounds — in the dative, which is what `noun-gender` gives it
-# the `datm` token for.
+# the shape it surrounds. `mit` and `und einem` govern the dative, which is
+# what the `border-clause` branch of every adjective supplies.
 #
 # Every branch takes the article, including the two English leaves it off. A
 # bare dative would want the strong ending („mit dickem Rand“) rather than the
-# weak one, which is a second form the one `$gender` token cannot also carry;
-# German is happy with the article in all four, so this collapses the
-# distinction rather than getting one of them wrong.
+# weak one, and that is a second form the `border-clause` branch would have to
+# split to carry. German is happy with the article in all four, so keeping it
+# collapses the distinction rather than getting one of them wrong — the one
+# thing here that `$role` did not have to fix.
 style-border-clause =
     { $parts ->
         [with-article] mit einem { $border } Rand
@@ -284,6 +375,11 @@ style-fill =
 
 style-unfilled = ungefüllt
 
+# „auf“ with no article governs the strong dative, which is the
+# `background-clause` ending; the text colour beside it is predicative, which
+# in German is the bare stem. So this reads „rot auf gelbem Hintergrund“, where
+# the `textColor` and `backgroundColor` variables — the standalone side of the
+# same two words — read „roter“ and „gelber“.
 style-text =
     { $parts ->
         [background] { $color } auf { $background } Hintergrund

--- a/packages/i18n/locales/de/content.ftl
+++ b/packages/i18n/locales/de/content.ftl
@@ -36,11 +36,11 @@ color =
             [border-clause] schwarzen
             [background-clause] schwarzem
             [text-clause] schwarz
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] schwarze
                     [n] schwarzes
-                    *[m] schwarzer
+                   *[m] schwarzer
                 }
         }
     .white =
@@ -48,11 +48,11 @@ color =
             [border-clause] weißen
             [background-clause] weißem
             [text-clause] weiß
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] weiße
                     [n] weißes
-                    *[m] weißer
+                   *[m] weißer
                 }
         }
     .gray =
@@ -60,11 +60,11 @@ color =
             [border-clause] grauen
             [background-clause] grauem
             [text-clause] grau
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] graue
                     [n] graues
-                    *[m] grauer
+                   *[m] grauer
                 }
         }
     .red =
@@ -72,11 +72,11 @@ color =
             [border-clause] roten
             [background-clause] rotem
             [text-clause] rot
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] rote
                     [n] rotes
-                    *[m] roter
+                   *[m] roter
                 }
         }
     .orange =
@@ -84,11 +84,11 @@ color =
             [border-clause] orangefarbenen
             [background-clause] orangefarbenem
             [text-clause] orangefarben
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] orangefarbene
                     [n] orangefarbenes
-                    *[m] orangefarbener
+                   *[m] orangefarbener
                 }
         }
     .yellow =
@@ -96,11 +96,11 @@ color =
             [border-clause] gelben
             [background-clause] gelbem
             [text-clause] gelb
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] gelbe
                     [n] gelbes
-                    *[m] gelber
+                   *[m] gelber
                 }
         }
     .green =
@@ -108,11 +108,11 @@ color =
             [border-clause] grünen
             [background-clause] grünem
             [text-clause] grün
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] grüne
                     [n] grünes
-                    *[m] grüner
+                   *[m] grüner
                 }
         }
     .cyan =
@@ -120,11 +120,11 @@ color =
             [border-clause] cyanfarbenen
             [background-clause] cyanfarbenem
             [text-clause] cyanfarben
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] cyanfarbene
                     [n] cyanfarbenes
-                    *[m] cyanfarbener
+                   *[m] cyanfarbener
                 }
         }
     .blue =
@@ -132,11 +132,11 @@ color =
             [border-clause] blauen
             [background-clause] blauem
             [text-clause] blau
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] blaue
                     [n] blaues
-                    *[m] blauer
+                   *[m] blauer
                 }
         }
     .purple =
@@ -144,11 +144,11 @@ color =
             [border-clause] violetten
             [background-clause] violettem
             [text-clause] violett
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] violette
                     [n] violettes
-                    *[m] violetter
+                   *[m] violetter
                 }
         }
     .pink =
@@ -156,11 +156,11 @@ color =
             [border-clause] rosafarbenen
             [background-clause] rosafarbenem
             [text-clause] rosafarben
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] rosafarbene
                     [n] rosafarbenes
-                    *[m] rosafarbener
+                   *[m] rosafarbener
                 }
         }
     .brown =
@@ -168,11 +168,11 @@ color =
             [border-clause] braunen
             [background-clause] braunem
             [text-clause] braun
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] braune
                     [n] braunes
-                    *[m] brauner
+                   *[m] brauner
                 }
         }
 
@@ -182,11 +182,11 @@ line-width =
             [border-clause] dicken
             [background-clause] dickem
             [text-clause] dick
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] dicke
                     [n] dickes
-                    *[m] dicker
+                   *[m] dicker
                 }
         }
     .thin =
@@ -194,11 +194,11 @@ line-width =
             [border-clause] dünnen
             [background-clause] dünnem
             [text-clause] dünn
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] dünne
                     [n] dünnes
-                    *[m] dünner
+                   *[m] dünner
                 }
         }
 
@@ -208,11 +208,11 @@ line-style =
             [border-clause] gestrichelten
             [background-clause] gestricheltem
             [text-clause] gestrichelt
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] gestrichelte
                     [n] gestricheltes
-                    *[m] gestrichelter
+                   *[m] gestrichelter
                 }
         }
     .dotted =
@@ -220,11 +220,11 @@ line-style =
             [border-clause] gepunkteten
             [background-clause] gepunktetem
             [text-clause] gepunktet
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] gepunktete
                     [n] gepunktetes
-                    *[m] gepunkteter
+                   *[m] gepunkteter
                 }
         }
 
@@ -318,17 +318,13 @@ style-with-noun =
        *[noun] { $description } { $noun }
     }
 
+# Only ever said of the shape itself, so it is standalone in every
+# description and takes no `$role` branch.
 style-filled-word =
-    { $role ->
-        [border-clause] gefüllten
-        [background-clause] gefülltem
-        [text-clause] gefüllt
-        *[standalone]
-            { $gender ->
-                [f] gefüllte
-                [n] gefülltes
-                *[m] gefüllter
-            }
+    { $gender ->
+        [f] gefüllte
+        [n] gefülltes
+       *[m] gefüllter
     }
 
 style-filled =

--- a/packages/i18n/locales/de/content.ftl
+++ b/packages/i18n/locales/de/content.ftl
@@ -270,11 +270,13 @@ noun-regular-polygon =
 # names: `border` (der Rand, m), `fill` (die Füllung, f), `text` (der Text, m),
 # `background` (der Hintergrund, m).
 #
-# Every one of them answers a plain gender now. `border` and `background` used
-# to answer a case instead — `datm` — because each is rendered in two positions
-# and a single token could only suit one of them. `$role` carries that
-# distinction, so this message is back to answering the one question its name
-# asks (#1606).
+# Every one of them answers a plain gender now. `border` used to answer a case
+# instead — `datm` — because its adjectives are rendered in two positions and a
+# single token could only suit one of them; it was tuned for the clause, so the
+# standalone `borderStyleDescription` came out dative. `background` kept its
+# plain gender and so was wrong the other way round, nominative behind `auf`.
+# `$role` carries the distinction now, and this message is back to answering
+# the one question its name asks (#1606).
 noun-gender =
     { $noun ->
         [border] m

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -17,8 +17,26 @@
 ## `resolveColorWord` deliberately preserves.
 ##
 ## Every adjective here is handed `$gender`, the grammatical gender of the noun
-## it describes (see `noun-gender`). English has no agreement and ignores it; a
-## language that inflects selects on it.
+## it describes (see `noun-gender`), and `$role`, the syntactic position the
+## phrase it belongs to is going into. English has no agreement and ignores
+## both; a language that inflects selects on them.
+##
+## `$role` is one of:
+##
+##   standalone          the phrase stands on its own, which is where all but
+##                       the three below are
+##   border-clause       inside `style-border-clause`, behind its preposition
+##   background-clause   the background colour inside `style-text`, behind its
+##                       preposition
+##   text-clause         the text colour beside it, inside `style-text`
+##
+## The last three exist because those words are rendered in two places each —
+## once alone, as `borderStyleDescription`, `backgroundColor` and `textColor`
+## report them, and once embedded in a clause. A language that inflects for
+## case needs a different form in each, and no amount of `$gender` can say
+## which is wanted. Which case a position governs is the catalog's business:
+## `border-clause` is a dative in German, an instrumental in Russian and
+## Polish, and nothing at all in a language that does not inflect.
 
 # The canonical color families a color value resolves to.
 color =
@@ -155,6 +173,8 @@ style-with-noun =
 # `$gender`, and a message reference resolves only inside its own bundle, so a
 # locale that translated `style-filled` but not this word would render the
 # reference literally instead of falling back to English.
+#
+# Said only of the shape itself, so its `$role` is always `standalone`.
 style-filled-word = filled
 
 # A filled shape, and the pattern its interior is drawn with, if any.
@@ -200,6 +220,10 @@ style-fill =
 style-unfilled = unfilled
 
 # How a piece of text is styled: its color, and the background behind it.
+#
+# The only composition message with no `$role`: its two words sit in two
+# different positions, so they arrive already inflected for `text-clause` and
+# `background-clause` respectively and no one token would describe them both.
 style-text =
     { $parts ->
         [background] { $color } with a { $background } background

--- a/packages/i18n/locales/en/content.ftl
+++ b/packages/i18n/locales/en/content.ftl
@@ -158,6 +158,9 @@ style-stroke =
 # English has none today, so it only ever selects `noun` for itself — the other
 # variant is still what a partly-translated locale falls back to, and dropping
 # it would drop that locale's side count.
+#
+# The phrase it builds is never governed by anything, so its `$role` is always
+# `standalone`.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }

--- a/packages/i18n/locales/hi/chrome.ftl
+++ b/packages/i18n/locales/hi/chrome.ftl
@@ -1,0 +1,140 @@
+# Hindi viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Hindi uses Latin digits (`latn` in CLDR), so a count renders as 1,234 and not
+# in Devanagari numerals — unlike Marathi and Nepali, which share the script
+# but not the numbering system.
+#
+# Controls take the bare imperative Hindi puts on a button — `कीबोर्ड खोलें` —
+# which is the आप form without the honorific auxiliary.
+
+
+## Answer submission
+
+answer-checking = जाँचा जा रहा है...
+answer-submitting = भेजा जा रहा है...
+
+answer-checking-status = उत्तर जाँचा जा रहा है
+answer-submitting-status = उत्तर भेजा जा रहा है
+
+answer-correct = सही
+answer-incorrect = ग़लत
+
+answer-response-saved = उत्तर सहेजा गया
+
+answer-percent-credit = { $percent }% अंक
+answer-percent-correct = { $percent }% सही
+answer-percent-short = { $percent }%
+
+max-credit-available = अधिकतम संभव अंक: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] कोई प्रयास शेष नहीं
+        [one] { $count } प्रयास शेष
+       *[other] { $count } प्रयास शेष
+    }
+
+validation-correct = (सही)
+validation-incorrect = (ग़लत)
+validation-partially-correct = (आंशिक रूप से सही)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } का { $count } उत्तर दिखाएँ
+       *[other] { $answerId } के { $count } उत्तर दिखाएँ
+    }
+
+
+## Disclosure panels
+
+feedback-heading = प्रतिक्रिया
+
+collapsible-click-to-open = (खोलने के लिए क्लिक करें)
+collapsible-click-to-close = (बंद करने के लिए क्लिक करें)
+
+collapsible-initializing = आरंभ किया जा रहा है...
+
+footnote-show = पादटिप्पणी दिखाएँ
+footnote-hide = पादटिप्पणी छिपाएँ
+
+description-more-information = अधिक जानकारी
+
+
+## Controls
+
+slider-previous = पिछला
+slider-next = अगला
+
+keyboard-open = कीबोर्ड खोलें
+keyboard-close = कीबोर्ड बंद करें
+
+matrix-remove-row = पंक्ति हटाएँ
+matrix-add-row = पंक्ति जोड़ें
+matrix-remove-column = स्तंभ हटाएँ
+matrix-add-column = स्तंभ जोड़ें
+
+subset-add-remove-points = बिंदु जोड़ें/हटाएँ
+subset-toggle-points-intervals = बिंदुओं और अंतरालों के बीच बदलें
+subset-move-points = बिंदु खिसकाएँ
+subset-clear = साफ़ करें
+
+# A `box` here is one orbital, drawn as a square: खाना.
+orbital-add-row = पंक्ति जोड़ें
+orbital-remove-row = पंक्ति हटाएँ
+orbital-add-box = खाना जोड़ें
+orbital-remove-box = खाना हटाएँ
+orbital-add-up-arrow = ऊपर का तीर जोड़ें
+orbital-add-down-arrow = नीचे का तीर जोड़ें
+orbital-remove-arrow = तीर हटाएँ
+
+orbital-row-label = पंक्ति { $row } का लेबल
+
+pretzel-answer = उत्तर
+
+summary-statistics-caption = { $column } के वर्णनात्मक सांख्यिकी
+
+
+## Math input
+
+math-input-preview-region = गणितीय व्यंजक का पूर्वावलोकन
+math-input-preview = पूर्वावलोकन
+math-input-invalid-expression = अमान्य व्यंजक:
+
+
+## Document status
+
+viewer-initializing = आरंभ किया जा रहा है...
+
+
+## Errors
+
+error-heading = त्रुटि
+
+error-found-at =
+    { $span ->
+        [line] पंक्ति { $startLine } में मिली।
+       *[lines] पंक्तियों { $startLine }–{ $endLine } में मिली।
+    }
+
+document-contains-errors = इस दस्तावेज़ में त्रुटियाँ हैं!
+
+diagnostic-heading-error = त्रुटि
+diagnostic-heading-warning = चेतावनी
+diagnostic-heading-information = जानकारी
+diagnostic-heading-hint = संकेत
+
+accessibility-heading-level-1 = WCAG AA सुगम्यता उल्लंघन
+accessibility-heading-level-2 = सुगम्यता चेतावनी
+
+something-went-wrong = कुछ ग़लत हो गया।
+
+renderer-load-failed = एक रेंडरर लोड नहीं हो सका। कृपया पृष्ठ फिर से लोड करें।
+
+core-start-failed = दस्तावेज़ दर्शक शुरू नहीं किया जा सका। कृपया पृष्ठ फिर से लोड करें।

--- a/packages/i18n/locales/hi/chrome.ftl
+++ b/packages/i18n/locales/hi/chrome.ftl
@@ -85,11 +85,12 @@ subset-toggle-points-intervals = बिंदुओं और अंतराल
 subset-move-points = बिंदु खिसकाएँ
 subset-clear = साफ़ करें
 
-# A `box` here is one orbital, drawn as a square: खाना.
+# A `box` here is one orbital, drawn as a square: खाँचा. Not खाना, whose first
+# reading is "food".
 orbital-add-row = पंक्ति जोड़ें
 orbital-remove-row = पंक्ति हटाएँ
-orbital-add-box = खाना जोड़ें
-orbital-remove-box = खाना हटाएँ
+orbital-add-box = खाँचा जोड़ें
+orbital-remove-box = खाँचा हटाएँ
 orbital-add-up-arrow = ऊपर का तीर जोड़ें
 orbital-add-down-arrow = नीचे का तीर जोड़ें
 orbital-remove-arrow = तीर हटाएँ

--- a/packages/i18n/locales/hi/content.ftl
+++ b/packages/i18n/locales/hi/content.ftl
@@ -1,0 +1,473 @@
+# Hindi content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Hindi adjectives fall into two classes. *Marked* ones end in -ा and inflect —
+# काला / काली / काले — while *unmarked* ones never change: लाल, सफ़ेद, नारंगी,
+# गुलाबी, बैंगनी, स्लेटी, फ़िरोज़ी. Only the marked ones select below; the rest
+# answer the same in every branch.
+#
+# A marked adjective takes the oblique -े before a noun governed by a
+# postposition, so `$role` matters here as it does in Polish, though for a
+# different reason — this is case in the direct/oblique sense rather than a
+# seven-way paradigm:
+#
+#   standalone          direct, agreeing with the noun described
+#   border-clause       oblique, before «किनारे के साथ» — किनारा is masculine
+#   background-clause   feminine, agreeing with पृष्ठभूमि, which a marked
+#                       adjective spells the same in direct and oblique
+#   text-clause         direct masculine, agreeing with पाठ
+#
+# Hindi uses Latin digits (`latn` in CLDR), so numbers render as 1,234.5 and
+# not in Devanagari numerals — unlike Marathi and Nepali, which share the
+# script but not the numbering system.
+
+
+## शैली शब्दावली
+
+color =
+    .black =
+        { $role ->
+            [border-clause] काले
+            [background-clause] काली
+            [text-clause] काला
+           *[standalone]
+                { $gender ->
+                    [f] काली
+                   *[m] काला
+                }
+        }
+    .white = सफ़ेद
+    .gray = स्लेटी
+    .red = लाल
+    .orange = नारंगी
+    .yellow =
+        { $role ->
+            [border-clause] पीले
+            [background-clause] पीली
+            [text-clause] पीला
+           *[standalone]
+                { $gender ->
+                    [f] पीली
+                   *[m] पीला
+                }
+        }
+    .green =
+        { $role ->
+            [border-clause] हरे
+            [background-clause] हरी
+            [text-clause] हरा
+           *[standalone]
+                { $gender ->
+                    [f] हरी
+                   *[m] हरा
+                }
+        }
+    .cyan = फ़िरोज़ी
+    .blue =
+        { $role ->
+            [border-clause] नीले
+            [background-clause] नीली
+            [text-clause] नीला
+           *[standalone]
+                { $gender ->
+                    [f] नीली
+                   *[m] नीला
+                }
+        }
+    .purple = बैंगनी
+    .pink = गुलाबी
+    .brown =
+        { $role ->
+            [border-clause] भूरे
+            [background-clause] भूरी
+            [text-clause] भूरा
+           *[standalone]
+                { $gender ->
+                    [f] भूरी
+                   *[m] भूरा
+                }
+        }
+
+line-width =
+    .thick =
+        { $role ->
+            [border-clause] मोटे
+            [background-clause] मोटी
+            [text-clause] मोटा
+           *[standalone]
+                { $gender ->
+                    [f] मोटी
+                   *[m] मोटा
+                }
+        }
+    .thin =
+        { $role ->
+            [border-clause] पतले
+            [background-clause] पतली
+            [text-clause] पतला
+           *[standalone]
+                { $gender ->
+                    [f] पतली
+                   *[m] पतला
+                }
+        }
+
+# Both are unmarked, so neither inflects.
+line-style =
+    .dashed = खंडित
+    .dotted = बिंदुदार
+
+# संज्ञा वाक्यांश: ये «वाले» से पहले आते हैं और किसी से मेल नहीं खाते।
+fill-style =
+    .horizontal = क्षैतिज रेखाओं
+    .vertical = ऊर्ध्वाधर रेखाओं
+    .diagonal = विकर्ण रेखाओं
+    .backdiagonal = विपरीत विकर्ण रेखाओं
+    .dots = बिंदुओं
+    .diamonds = समचतुर्भुजों
+
+noun =
+    .line = रेखा
+    .line-segment = रेखाखंड
+    .ray = किरण
+    .vector = सदिश
+    .curve = वक्र
+    .function = फलन
+    .parabola = परवलय
+    .polyline = बहुरेखा
+    .polygon = बहुभुज
+    .triangle = त्रिभुज
+    .rectangle = आयत
+    .circle = वृत्त
+    .region = क्षेत्र
+    .point = बिंदु
+    .square = वर्ग
+    .diamond = समचतुर्भुज
+    .cross = क्रॉस
+    .plus = धन चिह्न
+
+# भुजाओं की गिनती संज्ञा से पहले आती है, इसलिए यह सिर पर ही जुड़ जाती है और
+# कोई पुच्छ नहीं बचता।
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } भुजाओं वाला सम बहुभुज
+    }
+
+# ऊपर की संज्ञाओं के अलावा `$noun` «regular-polygon» (बहुभुज, पु.) हो सकता है
+# या उस वाक्यांश का शीर्ष जिसे विवरण नाम नहीं देता: «border» (किनारा, पु.),
+# «fill» (भराव, पु.), «text» (पाठ, पु.), «background» (पृष्ठभूमि, स्त्री.)।
+noun-gender =
+    { $noun ->
+        [line] f
+        [ray] f
+        [polyline] f
+        [curve] f
+        [background] f
+       *[other] m
+    }
+
+
+## शैली संयोजन
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# विशेषण संज्ञा से पहले आते हैं, अंग्रेज़ी की तरह।
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word =
+    { $role ->
+        [border-clause] भरे हुए
+        [background-clause] भरी हुई
+        [text-clause] भरा हुआ
+       *[standalone]
+            { $gender ->
+                [f] भरी हुई
+               *[m] भरा हुआ
+            }
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } वाला { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } वाला { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «के साथ» एक परसर्ग है, इसलिए «किनारा» तिर्यक रूप «किनारे» लेता है और उसके
+# विशेषण भी — यही `border-clause` शाखा देती है। हिंदी में उपपद नहीं होता,
+# इसलिए `-article` शाखाएँ बाकी जैसी ही पढ़ी जाती हैं।
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } किनारे के साथ
+        [and] और { $border } किनारे के साथ
+        [and-article] और { $border } किनारे के साथ
+       *[with] { $border } किनारे के साथ
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = बिना भराव
+
+# «पर» भी परसर्ग है, पर «पृष्ठभूमि» स्त्रीलिंग है और चिह्नित विशेषण का
+# स्त्रीलिंग रूप सीधे और तिर्यक दोनों में एक ही रहता है।
+style-text =
+    { $parts ->
+        [background] { $background } पृष्ठभूमि पर { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = कोई नहीं
+
+
+## बूलीय शब्द
+
+boolean-true = सत्य
+boolean-false = असत्य
+
+
+## उत्तर बटन
+
+answer-submit-label = जाँचें
+answer-submit-label-no-correctness = उत्तर भेजें
+
+
+## खंड
+
+section-name =
+    .activity = गतिविधि
+    .aside = पार्श्व टिप्पणी
+    .cascade = क्रमिका
+    .definition = परिभाषा
+    .example = उदाहरण
+    .exercise = अभ्यास
+    .exercises = अभ्यास
+    .given-answer = उत्तर
+    .note = टिप्पणी
+    .objectives = उद्देश्य
+    .paragraphs = अनुच्छेद
+    .part = भाग
+    .problem = प्रश्न
+    .problems = प्रश्न
+    .proof = प्रमाण
+    .question = सवाल
+    .section = अनुभाग
+    .solution = हल
+    .task = कार्य
+    .theorem = प्रमेय
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = संकेत
+
+
+## सारणियाँ और चित्र
+
+table-name =
+    { $parts ->
+        [numbered] सारणी { $enumeration }
+        [numbered-title] सारणी { $enumeration }{ ": " }
+        [unnumbered-title] सारणी{ ": " }
+       *[unnumbered] सारणी
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] चित्र { $enumeration }
+        [numbered-caption] चित्र { $enumeration }{ ": " }
+        [unnumbered-caption] चित्र{ ": " }
+       *[unnumbered] चित्र
+    }
+
+
+## पृष्ठ नियंत्रण
+
+paginator-previous = पिछला
+paginator-next = अगला
+paginator-page = पृष्ठ
+
+paginator-page-status = { $numPages } में से { $pageLabel } { $currentPage }
+
+
+## खंडशः फलन
+
+piecewise-condition-or = या
+piecewise-condition-if = यदि
+piecewise-condition-otherwise = अन्यथा
+
+
+## रसायन विज्ञान
+
+element-name =
+    .h = हाइड्रोजन
+    .he = हीलियम
+    .li = लिथियम
+    .be = बेरिलियम
+    .b = बोरॉन
+    .c = कार्बन
+    .n = नाइट्रोजन
+    .o = ऑक्सीजन
+    .f = फ्लोरीन
+    .ne = नियॉन
+    .na = सोडियम
+    .mg = मैग्नीशियम
+    .al = ऐलुमिनियम
+    .si = सिलिकॉन
+    .p = फॉस्फोरस
+    .s = सल्फर
+    .cl = क्लोरीन
+    .ar = आर्गन
+    .k = पोटैशियम
+    .ca = कैल्शियम
+    .sc = स्कैंडियम
+    .ti = टाइटेनियम
+    .v = वैनेडियम
+    .cr = क्रोमियम
+    .mn = मैंगनीज़
+    .fe = लोहा
+    .co = कोबाल्ट
+    .ni = निकल
+    .cu = ताँबा
+    .zn = जस्ता
+    .ga = गैलियम
+    .ge = जर्मेनियम
+    .as = आर्सेनिक
+    .se = सेलेनियम
+    .br = ब्रोमीन
+    .kr = क्रिप्टॉन
+    .rb = रुबिडियम
+    .sr = स्ट्रॉन्शियम
+    .y = इट्रियम
+    .zr = ज़िरकोनियम
+    .nb = नाइओबियम
+    .mo = मॉलिब्डेनम
+    .tc = टेक्नीशियम
+    .ru = रुथेनियम
+    .rh = रोडियम
+    .pd = पैलेडियम
+    .ag = चाँदी
+    .cd = कैडमियम
+    .in = इंडियम
+    .sn = टिन
+    .sb = ऐंटिमनी
+    .te = टेल्यूरियम
+    .i = आयोडीन
+    .xe = ज़ेनॉन
+    .cs = सीज़ियम
+    .ba = बेरियम
+    .la = लैंथेनम
+    .ce = सीरियम
+    .pr = प्रेज़ियोडाइमियम
+    .nd = नियोडाइमियम
+    .pm = प्रोमीथियम
+    .sm = समेरियम
+    .eu = यूरोपियम
+    .gd = गैडोलिनियम
+    .tb = टर्बियम
+    .dy = डिस्प्रोसियम
+    .ho = होल्मियम
+    .er = अर्बियम
+    .tm = थुलियम
+    .yb = इटर्बियम
+    .lu = ल्यूटीशियम
+    .hf = हैफ़नियम
+    .ta = टैंटलम
+    .w = टंगस्टन
+    .re = रीनियम
+    .os = ऑस्मियम
+    .ir = इरिडियम
+    .pt = प्लैटिनम
+    .au = सोना
+    .hg = पारा
+    .tl = थैलियम
+    .pb = सीसा
+    .bi = बिस्मथ
+    .po = पोलोनियम
+    .at = ऐस्टैटीन
+    .rn = रेडॉन
+    .fr = फ्रैंशियम
+    .ra = रेडियम
+    .ac = ऐक्टिनियम
+    .th = थोरियम
+    .pa = प्रोटैक्टिनियम
+    .u = यूरेनियम
+    .np = नेप्ट्यूनियम
+    .pu = प्लूटोनियम
+    .am = अमेरिशियम
+    .cm = क्यूरियम
+    .bk = बर्केलियम
+    .cf = कैलिफ़ोर्नियम
+    .es = आइंस्टीनियम
+    .fm = फ़र्मियम
+    .md = मेंडेलीवियम
+    .no = नोबेलियम
+    .lr = लॉरेंशियम
+    .rf = रदरफ़ोर्डियम
+    .db = डब्नियम
+    .sg = सीबोर्गियम
+    .bh = बोहरियम
+    .hs = हैसियम
+    .mt = माइट्नेरियम
+    .ds = डार्मस्टेटियम
+    .rg = रोएंटजेनियम
+    .cn = कोपरनिसियम
+    .nh = निहोनियम
+    .fl = फ्लेरोवियम
+    .mc = मॉस्कोवियम
+    .lv = लिवरमोरियम
+    .ts = टेनेसीन
+    .og = ओगेनेसन
+
+element-anion-name =
+    .h = हाइड्राइड
+    .c = कार्बाइड
+    .n = नाइट्राइड
+    .o = ऑक्साइड
+    .f = फ्लोराइड
+    .p = फॉस्फाइड
+    .s = सल्फ़ाइड
+    .cl = क्लोराइड
+    .br = ब्रोमाइड
+    .i = आयोडाइड
+    .at = ऐस्टैटाइड
+    .ts = टेनेसाइड
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = अमान्य रासायनिक संकेत
+chemistry-invalid-ionic-compound = अमान्य आयनिक यौगिक

--- a/packages/i18n/locales/hi/content.ftl
+++ b/packages/i18n/locales/hi/content.ftl
@@ -191,16 +191,12 @@ style-with-noun =
        *[noun] { $description } { $noun }
     }
 
+# Only ever said of the shape itself, so it is standalone in every
+# description and takes no `$role` branch.
 style-filled-word =
-    { $role ->
-        [border-clause] भरे हुए
-        [background-clause] भरी हुई
-        [text-clause] भरा हुआ
-       *[standalone]
-            { $gender ->
-                [f] भरी हुई
-               *[m] भरा हुआ
-            }
+    { $gender ->
+        [f] भरी हुई
+       *[m] भरा हुआ
     }
 
 style-filled =

--- a/packages/i18n/locales/hi/content.ftl
+++ b/packages/i18n/locales/hi/content.ftl
@@ -25,7 +25,7 @@
 # script but not the numbering system.
 
 
-## शैली शब्दावली
+## Style vocabulary
 
 color =
     .black =
@@ -120,7 +120,10 @@ line-style =
     .dashed = खंडित
     .dotted = बिंदुदार
 
-# संज्ञा वाक्यांश: ये «वाले» से पहले आते हैं और किसी से मेल नहीं खाते।
+# Noun phrases in the oblique plural, because their other use is in front of
+# «वाला» — a postposition, which puts what precedes it in the oblique. They
+# agree with nothing. `style-fill` therefore has to give them something to hang
+# off rather than print them bare, the way German and Russian do.
 fill-style =
     .horizontal = क्षैतिज रेखाओं
     .vertical = ऊर्ध्वाधर रेखाओं
@@ -149,29 +152,28 @@ noun =
     .cross = क्रॉस
     .plus = धन चिह्न
 
-# भुजाओं की गिनती संज्ञा से पहले आती है, इसलिए यह सिर पर ही जुड़ जाती है और
-# कोई पुच्छ नहीं बचता।
+# Hindi keeps the side count in front of the noun, so the whole thing is one
+# head and there is no tail.
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
        *[head] { $numSides } भुजाओं वाला सम बहुभुज
     }
 
-# ऊपर की संज्ञाओं के अलावा `$noun` «regular-polygon» (बहुभुज, पु.) हो सकता है
-# या उस वाक्यांश का शीर्ष जिसे विवरण नाम नहीं देता: «border» (किनारा, पु.),
-# «fill» (भराव, पु.), «text» (पाठ, पु.), «background» (पृष्ठभूमि, स्त्री.)।
+# Besides the nouns above, `$noun` can be `regular-polygon` (बहुभुज, m) or the
+# head of a phrase the description never names: `border` (किनारा, m), `fill`
+# (भराव, m), `text` (पाठ, m), `background` (पृष्ठभूमि, f).
 noun-gender =
     { $noun ->
         [line] f
         [ray] f
         [polyline] f
-        [curve] f
         [background] f
        *[other] m
     }
 
 
-## शैली संयोजन
+## Style composition
 
 style-stroke =
     { $parts ->
@@ -184,7 +186,7 @@ style-stroke =
        *[color] { $color }
     }
 
-# विशेषण संज्ञा से पहले आते हैं, अंग्रेज़ी की तरह।
+# Adjectives precede the noun, as in English.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
@@ -213,9 +215,9 @@ style-filled-with-noun =
        *[plain] { $color } { $filled } { $noun }
     }
 
-# «के साथ» एक परसर्ग है, इसलिए «किनारा» तिर्यक रूप «किनारे» लेता है और उसके
-# विशेषण भी — यही `border-clause` शाखा देती है। हिंदी में उपपद नहीं होता,
-# इसलिए `-article` शाखाएँ बाकी जैसी ही पढ़ी जाती हैं।
+# «के साथ» is a postposition, so «किनारा» takes the oblique «किनारे» and so do
+# its adjectives — which is what the `border-clause` branch supplies. Hindi has
+# no article, so the `-article` branches read the same as the ones without.
 style-border-clause =
     { $parts ->
         [with-article] { $border } किनारे के साथ
@@ -224,16 +226,21 @@ style-border-clause =
        *[with] { $border } किनारे के साथ
     }
 
+# The fill-pattern words are oblique plurals, because their other use is the
+# «{ $pattern } वाला» clause in `style-filled`. So this message supplies a noun
+# for them to hang off — «भराव», masculine, which is the gender `noun-gender`
+# already answers for `fill`, so the colour agrees with it in both variants.
 style-fill =
     { $parts ->
-        [pattern] { $color } { $pattern }
-       *[plain] { $color }
+        [pattern] { $pattern } वाला { $color } भराव
+       *[plain] { $color } भराव
     }
 
 style-unfilled = बिना भराव
 
-# «पर» भी परसर्ग है, पर «पृष्ठभूमि» स्त्रीलिंग है और चिह्नित विशेषण का
-# स्त्रीलिंग रूप सीधे और तिर्यक दोनों में एक ही रहता है।
+# «पर» is a postposition too, but «पृष्ठभूमि» is feminine, and a marked
+# adjective spells its feminine the same in the direct and the oblique — so the
+# `background-clause` branch coincides with the standalone feminine.
 style-text =
     { $parts ->
         [background] { $background } पृष्ठभूमि पर { $color }
@@ -243,19 +250,19 @@ style-text =
 style-background-none = कोई नहीं
 
 
-## बूलीय शब्द
+## Boolean words
 
 boolean-true = सत्य
 boolean-false = असत्य
 
 
-## उत्तर बटन
+## Answer buttons
 
 answer-submit-label = जाँचें
 answer-submit-label-no-correctness = उत्तर भेजें
 
 
-## खंड
+## Sectional blocks
 
 section-name =
     .activity = गतिविधि
@@ -292,7 +299,7 @@ section-title-prefix =
 hint-title = संकेत
 
 
-## सारणियाँ और चित्र
+## Tables and figures
 
 table-name =
     { $parts ->
@@ -311,7 +318,7 @@ figure-name =
     }
 
 
-## पृष्ठ नियंत्रण
+## Paginator controls
 
 paginator-previous = पिछला
 paginator-next = अगला
@@ -320,14 +327,14 @@ paginator-page = पृष्ठ
 paginator-page-status = { $numPages } में से { $pageLabel } { $currentPage }
 
 
-## खंडशः फलन
+## Piecewise functions
 
 piecewise-condition-or = या
 piecewise-condition-if = यदि
 piecewise-condition-otherwise = अन्यथा
 
 
-## रसायन विज्ञान
+## Chemistry
 
 element-name =
     .h = हाइड्रोजन

--- a/packages/i18n/locales/hi/diagnostics.ftl
+++ b/packages/i18n/locales/hi/diagnostics.ftl
@@ -236,7 +236,11 @@ eigen-decomposition-failed = आव्यूह के अभिलक्षण�
 
 ## `<matchesPattern>`
 
-matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न में नहीं आता, इसलिए वह सदा रिक्त से मेल खाएगा।
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: प्राचल { $parameters } पैटर्न में नहीं आता, इसलिए वह सदा रिक्त से मेल खाएगा।
+       *[other] `<matchesPattern>`: प्राचल { $parameters } पैटर्न में नहीं आते, इसलिए वे सदा रिक्त से मेल खाएँगे।
+    }
 
 ## `<graph>`
 
@@ -292,7 +296,11 @@ answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` व�
 
 nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले किसी अन्य पात्र के भीतर स्थित `sectionWideCheckWork` पात्र पर `maxNumAttempts` सेट करने का कोई प्रभाव नहीं होता, क्योंकि प्रयासों की संख्या बाहरी पात्र नियंत्रित करता है। `maxNumAttempts` बाहरी पात्र पर सेट करें।
 
-answer-attributes-need-symbolic-equality = symbolicEquality सेट किए बिना { $attributes } विशेषता का कोई प्रभाव नहीं होगा।
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality सेट किए बिना { $attributes } विशेषता का कोई प्रभाव नहीं होगा।
+       *[other] symbolicEquality सेट किए बिना { $attributes } विशेषताओं का कोई प्रभाव नहीं होगा।
+    }
 
 answer-invalid-type = answer के लिए प्रकार अमान्य है: { $type }
 
@@ -312,7 +320,11 @@ pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="cir
 
 ## Attribute values
 
-attribute-invalid-values = विशेषता `{ $attribute }` के लिए मान { $values } अमान्य है; छोड़ा जा रहा है।
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] विशेषता `{ $attribute }` के लिए मान { $values } अमान्य है; छोड़ा जा रहा है।
+       *[other] विशेषता `{ $attribute }` के लिए मान { $values } अमान्य हैं; छोड़ा जा रहा है।
+    }
 
 attribute-must-be-references = विशेषता `{ $attribute }` के लिए मान `{ $value }` अमान्य है। विशेषता `$` से आरंभ होने वाले संदर्भों से बनी होनी चाहिए।
 

--- a/packages/i18n/locales/hi/diagnostics.ftl
+++ b/packages/i18n/locales/hi/diagnostics.ftl
@@ -1,0 +1,606 @@
+# Hindi diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = दो सिरे दिए जाने पर { $attributes } पर ध्यान नहीं दिया जाता
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = सिरा और मध्यबिंदु दोनों दिए जाने पर { $attributes } पर ध्यान नहीं दिया जाता
+
+line-segment-midpoint-offset-without-midpoint = मध्यबिंदु के बिना midpointOffset का कोई प्रभाव नहीं होता
+
+## `<line>`
+
+line-points-undetermined-dimensions = ऐसे बिंदुओं से होकर जाने वाली रेखा जिनकी विमा अनिश्चित है।
+
+line-points-too-few-dimensions = रेखा को कम से कम द्विविमीय बिंदुओं से होकर जाना चाहिए।
+
+line-points-depend-on-variables = रेखा उन बिंदुओं से होकर जाती है जो चरों पर निर्भर हैं: { $variables }।
+
+line-equation-invalid-format = चर { $variable1 } और { $variable2 } में रेखा के समीकरण का प्रारूप अमान्य है।
+
+## `<ray>`
+
+ray-overprescribed-through = किरण एक साथ through, endpoint और direction से निर्धारित है। दिए गए through को छोड़ा जा रहा है।
+
+ray-dimension-mismatch = किरण में numDimensions मेल नहीं खाते।
+
+## `<vector>`
+
+vector-overprescribed-head = सदिश एक साथ head, tail और displacement से निर्धारित है। दिए गए head को छोड़ा जा रहा है।
+
+vector-dimension-mismatch = सदिश में numDimensions मेल नहीं खाते।
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` की ओर आकर्षित नहीं किया जा सकता, क्योंकि उसमें nearestPoint अवस्था चर नहीं है।
+
+constrain-to-without-nearest-point = `<{ $component }>` तक सीमित नहीं किया जा सकता, क्योंकि उसमें nearestPoint अवस्था चर नहीं है।
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` के भीतरी भाग तक सीमित नहीं किया जा सकता, क्योंकि उसमें nearestPoint अवस्था चर नहीं है।
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = अंतःपंक्ति न होने वाले choiceInput के लिए labelPosition पर ध्यान नहीं दिया जाता
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput के लिए दिए गए indices को छोड़ा जा रहा है, क्योंकि indices की संख्या choice संतानों की संख्या से मेल नहीं खाती।
+
+pretzel-indices-count-mismatch = problem के लिए दिए गए indices को छोड़ा जा रहा है, क्योंकि indices की संख्या problem संतानों की संख्या से मेल नहीं खाती।
+
+shuffle-indices-count-mismatch = shuffle के लिए दिए गए indices को छोड़ा जा रहा है, क्योंकि indices की संख्या घटकों की संख्या से मेल नहीं खाती।
+
+indices-ignored-out-of-range = { $component } के लिए दिए गए indices को छोड़ा जा रहा है, क्योंकि कुछ अनुक्रमांक परिसर से बाहर हैं।
+
+pretzel-indices-repeated = pretzel के लिए दिए गए indices को छोड़ा जा रहा है, क्योंकि कुछ अनुक्रमांक दोहराए गए हैं।
+
+pretzel-circuit-first-index = circuit विधा में pretzel के लिए दिए गए indices को छोड़ा जा रहा है, क्योंकि पहला अनुक्रमांक 1 होना चाहिए।
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` को पाठ संतानों के साथ काम करने के लिए `type` विशेषता देनी होगी।
+
+invalid-type-defaulting-to-math = { $component } घटक के लिए प्रकार { $type } अमान्य है। यह math, text, number या boolean में से एक होना चाहिए। math का उपयोग किया जा रहा है।
+
+string-not-valid-component-to-arrange = पाठ "{ $value }" { $component } के लिए मान्य घटक नहीं है। छोड़ा जा रहा है।
+
+## Types and variables
+
+invalid-type-defaulting-to-number = प्रकार { $type } अमान्य है; प्रकार number पर सेट किया जा रहा है।
+
+invalid-variable-value = चर का मान अमान्य है: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = संस्करण अनुक्रमांक { $index } एक संख्या होनी चाहिए
+
+variant-index-must-be-integer = संस्करण अनुक्रमांक { $index } एक पूर्णांक होना चाहिए
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` निरपेक्ष मापों के लिए उपलब्ध नहीं है। चौड़ाइयाँ सापेक्ष की जा रही हैं।
+
+side-by-side-absolute-margins = `<{ $component }>` निरपेक्ष मापों के लिए उपलब्ध नहीं है। हाशिये सापेक्ष किए जा रहे हैं।
+
+side-by-side-no-block-child = अमान्य `<{ $component }>`: इसमें कम से कम एक खंड संतान होनी चाहिए।
+
+## `<label>`
+
+label-for-ignored-on-graphical = आलेखीय `<label>` पर `for` विशेषता पर ध्यान नहीं दिया जाता।
+
+label-for-must-resolve-to-one = `<label>` पर `for` विशेषता ठीक एक घटक तक पहुँचनी चाहिए।
+
+label-for-unresolved = `<label>` पर `for` विशेषता किसी घटक तक नहीं पहुँच सकी।
+
+label-for-answer-with-authored-inputs = `<label>` पर `for` विशेषता ऐसे `<answer>` का संदर्भ देती है जिसमें इनपुट स्पष्ट रूप से लिखे गए हैं; सीधे उसी इनपुट का संदर्भ दें।
+
+label-for-answer-without-input = `<label>` पर `for` विशेषता ऐसे `<answer>` का संदर्भ देती है जिसमें लेबल लगाने योग्य इनपुट नहीं है।
+
+label-for-must-reference-input-or-answer = `<label>` पर `for` विशेषता किसी इनपुट या किसी उत्तर का संदर्भ देनी चाहिए।
+
+## Accessibility
+
+accessibility-short-description-or-decorative = सुगम्यता के लिए `<{ $component }>` का या तो संक्षिप्त विवरण होना चाहिए या उसे सजावटी बताया जाना चाहिए।
+
+accessibility-video-short-description = सुगम्यता के लिए `<video>` का संक्षिप्त विवरण होना चाहिए।
+
+accessibility-input-short-description-or-label = सुगम्यता के लिए `<{ $component }>` का संक्षिप्त विवरण या लेबल होना चाहिए।
+
+accessibility-answer-input-short-description-or-label = सुगम्यता के लिए इनपुट बनाने वाले `<answer>` का संक्षिप्त विवरण या लेबल होना चाहिए।
+
+accessibility-short-description-contains-math = संक्षिप्त विवरणों में `<{ $component }>` जैसे गणितीय घटक नहीं होने चाहिए। गणित को शब्दों में लिखें।
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } का खंड शीर्षक पाठ के लिए वैषम्य अपर्याप्त है (गहरी विधा) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाहिए)।
+       *[other] { $colorName } का खंड शीर्षक पाठ के लिए वैषम्य अपर्याप्त है ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाहिए)।
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = जब बिंदुओं के संख्यात्मक मान न हों, तब { $count } बिंदुओं से होकर जाने वाला `<circle>` अभी उपलब्ध नहीं है।
+
+circle-too-many-through-points = 3 से अधिक बिंदुओं से होकर जाने वाला वृत्त परिकलित नहीं किया जा सकता।
+
+circle-overprescribed-radius-center-points = त्रिज्या, केंद्र और गुज़रने वाले बिंदु एक साथ दिए जाने पर वृत्त परिकलित नहीं किया जा सकता।
+
+circle-center-with-multiple-points = दिए गए केंद्र के साथ 1 से अधिक बिंदु से होकर जाने वाला वृत्त परिकलित नहीं किया जा सकता।
+
+circle-radius-too-small = वृत्त परिकलित नहीं किया जा सकता: दोनों बिंदुओं के बीच की दूरी { $distance } है, इसलिए दी गई त्रिज्या { $radius } बहुत छोटी है।
+
+circle-radius-with-many-points = दी गई त्रिज्या के साथ दो से अधिक बिंदुओं से होकर जाने वाला वृत्त नहीं बनाया जा सकता।
+
+circle-invalid-center-or-through-points = वृत्त का केंद्र या गुज़रने वाले बिंदु अमान्य हैं।
+
+circle-radius-center-with-multiple-points = दिए गए केंद्र के साथ 1 से अधिक बिंदु से होकर जाने वाले वृत्त की त्रिज्या परिकलित नहीं की जा सकती।
+
+circle-change-radius-non-numerical = जिस वृत्त के गुज़रने वाले बिंदु संख्यात्मक नहीं हैं, उसकी त्रिज्या नहीं बदली जा सकती
+
+circle-radius-with-points-non-numerical = संख्यात्मक मान न होने पर, दी गई त्रिज्या के साथ एक से अधिक बिंदु से होकर जाने वाला वृत्त नहीं बनाया जा सकता।
+
+circle-change-center-non-numerical = असंख्यात्मक बिंदुओं से होकर जाने वाले वृत्त का केंद्र बदलना अभी उपलब्ध नहीं है।
+
+## `<function>`
+
+function-domain-insufficient-dimensions = फलन के प्रांत की विमाएँ अपर्याप्त हैं। प्रांत में { $intervals } अंतराल हैं, पर फलन में { $inputs } इनपुट हैं।
+
+function-domain-invalid-format = फलन के प्रांत का प्रारूप अमान्य है।
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] फलन का असंख्यात्मक उच्चिष्ठ छोड़ा जा रहा है।
+        [minimum] फलन का असंख्यात्मक निम्निष्ठ छोड़ा जा रहा है।
+        [extremum] फलन का असंख्यात्मक चरम मान छोड़ा जा रहा है।
+        [point] फलन का असंख्यात्मक बिंदु छोड़ा जा रहा है।
+        [slope] फलन की असंख्यात्मक प्रवणता छोड़ी जा रही है।
+       *[other] फलन का असंख्यात्मक { $type } छोड़ा जा रहा है।
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] फलन का रिक्त उच्चिष्ठ छोड़ा जा रहा है।
+        [minimum] फलन का रिक्त निम्निष्ठ छोड़ा जा रहा है।
+        [extremum] फलन का रिक्त चरम मान छोड़ा जा रहा है।
+        [point] फलन का रिक्त बिंदु छोड़ा जा रहा है।
+       *[other] फलन का रिक्त { $type } छोड़ा जा रहा है।
+    }
+
+function-points-too-close = फलन में दो बिंदु बहुत पास-पास हैं। फलन परिभाषित नहीं किया जा सकता।
+
+function-iterates-input-output-mismatch = फलन का पुनरावर्तन तभी संभव है जब इनपुट की संख्या आउटपुट की संख्या के बराबर हो। इस फलन में { $inputs } इनपुट और { $outputs } आउटपुट हैं।
+
+## `<sequence>`
+
+sequence-invalid-length = अनुक्रम की लंबाई अमान्य है। यह ऋणेतर पूर्णांक होनी चाहिए।
+
+sequence-invalid-step = अनुक्रम का चरण अमान्य है। { $type } प्रकार के अनुक्रम के लिए यह एक संख्या होनी चाहिए।
+
+sequence-invalid-endpoint-number = संख्या अनुक्रम का "{ $attribute }" अमान्य है। यह एक संख्या होनी चाहिए।
+
+sequence-invalid-endpoint-letters = अक्षर अनुक्रम का "{ $attribute }" अमान्य है। यह अक्षरों का संयोजन होना चाहिए।
+
+sequence-invalid-endpoint = अनुक्रम का "{ $attribute }" अमान्य है।
+
+select-from-sequence-coprime-not-numbers = संख्याएँ नहीं चुनी जा रहीं, इसलिए coprime छोड़ा गया
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations दिया गया है, इसलिए coprime छोड़ा गया
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` के लिए target अमान्य है: लक्ष्य नहीं मिला।
+
+target-state-variable-not-found = `<{ $source }>` के लिए target अमान्य है: `<{ $component }>` पर "{ $property }" नाम का अवस्था चर नहीं मिला।
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` के चर स्वतंत्र चर से भिन्न होने चाहिए।
+
+ode-system-duplicate-variable-names = दोहराए गए आश्रित चर नामों के साथ ODE के दाएँ पक्ष के फलन परिभाषित नहीं किए जा सकते।
+
+ode-system-rhs-function-error = ODE के दाएँ पक्ष का फलन परिभाषित नहीं किया जा सकता। mathjs फलन बनाते समय त्रुटि हुई।
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } रेखाओं के बीच का कोण परिभाषित नहीं किया जा सकता
+
+angle-invalid-through-point = `<angle>` के through में अमान्य बिंदु है
+
+parabola-vertex-too-many-points = दिए गए शीर्ष के साथ 1 से अधिक बिंदु से होकर जाने वाला परवलय अभी उपलब्ध नहीं है।
+
+parabola-too-many-points = 3 से अधिक बिंदुओं से होकर जाने वाला परवलय अभी उपलब्ध नहीं है।
+
+intersection-too-many-items = दो से अधिक वस्तुओं का प्रतिच्छेदन अभी उपलब्ध नहीं है
+
+## Other math components
+
+ionic-compound-not-two-ions = दो आयनों के अतिरिक्त किसी और स्थिति के लिए आयनिक यौगिक अभी उपलब्ध नहीं है।
+
+ionic-compound-needs-cation-and-anion = आयनिक यौगिक केवल एक धनायन और एक ऋणायन के लिए उपलब्ध है।
+
+solve-equations-cannot-evaluate = समीकरण का मान नहीं निकाला जा सका, इसलिए वह हल नहीं किया जा सकता: { $equation }
+
+math-operators-operand-number-required = गणितीय संकार्य निकालते समय operandNumber देना आवश्यक है।
+
+eigen-decomposition-failed = आव्यूह के अभिलक्षणिक मान परिकलित नहीं किए जा सके
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: प्राचल { $parameters } पैटर्न में नहीं आता, इसलिए वह सदा रिक्त से मेल खाएगा।
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" को समझा नहीं जा सका। यह none, medium, dense, या रिक्त स्थान से अलग की गई दो धनात्मक संख्याएँ होनी चाहिए, जैसे grid="1 0.5"। कोई ग्रिड नहीं खींचा जाएगा।
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure रेंडरर में xLabelPosition="left" समर्थित नहीं है; दाईं स्थिति वाला व्यवहार अपनाया जा रहा है।
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure रेंडरर में yLabelPosition="bottom" समर्थित नहीं है; ऊपरी स्थिति वाला व्यवहार अपनाया जा रहा है।
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure रूपांतरण के लिए अक्ष सीमाएँ अमान्य हैं; पूर्वनिर्धारित bbox (-10,-10,10,10) अपनाया जा रहा है।
+
+prefigure-invalid-width = `<graph>`: prefigure रूपांतरण के लिए चौड़ाई अमान्य है; पूर्वनिर्धारित आरेख चौड़ाई 425 अपनाई जा रही है।
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure रूपांतरण के लिए aspectRatio अमान्य है; पूर्वनिर्धारित अनुपात 1 अपनाया जा रहा है।
+
+prefigure-grid-spacing-too-fine = `<graph>`: अक्ष सीमाओं की तुलना में ग्रिड का अंतराल बहुत महीन है; prefigure रेंडरर में ग्रिड छोड़ा जा रहा है।
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure रेंडरर का उपयोग न होने पर टीकाएँ नहीं खींची जाएँगी।
+
+multiple-annotations-children = `<graph>` में एक से अधिक `<annotations>` संतानें मिलीं; अंतिम को छोड़कर सभी पर ध्यान नहीं दिया जाएगा।
+
+## Referring to other components
+
+copy-unrecognized-component-type = अपरिचित घटक प्रकार को विस्तारित या प्रतिलिपित नहीं किया जा सकता: { $type }।
+
+copy-prop-not-found = { $component } प्रकार के घटक पर { $property } गुण नहीं मिला
+
+collect-no-source = collect के लिए कोई स्रोत नहीं मिला।
+
+collect-invalid-component-type = `<{ $component }>` प्रकार के घटक एकत्र नहीं किए जा सकते, क्योंकि यह मान्य घटक प्रकार नहीं है।
+
+reference-index-unavailable = अनुक्रमांक `{ $reference }` का संदर्भ नहीं दिया जा सकता
+
+## `<callAction>`
+
+component-action-unavailable = घटक `{ $reference }` पर { $action } नहीं बुलाया जा सकता
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = आँकड़ों का आकार अमान्य है। पंक्तियों की लंबाई असंगत है। componentIdx :{ $componentIdx } में मिला
+
+data-frame-duplicate-column-names = आँकड़ों में स्तंभ नाम दोहराए गए हैं। componentIdx :{ $componentIdx } में मिला
+
+data-frame-missing-column-name = आँकड़ों में एक स्तंभ नाम अनुपस्थित है। componentIdx :{ $componentIdx } में मिला
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = इस उत्तर का एक award स्वयं answer टैग द्वारा भेजे गए उत्तर पर आधारित है, जिससे अप्रत्याशित व्यवहार होगा।
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` वाले पात्र के भीतर के `<answer>` पर `maxNumAttempts` सेट करने का कोई प्रभाव नहीं होता, क्योंकि प्रयासों की संख्या पात्र नियंत्रित करता है। `maxNumAttempts` पात्र पर सेट करें।
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` वाले किसी अन्य पात्र के भीतर स्थित `sectionWideCheckWork` पात्र पर `maxNumAttempts` सेट करने का कोई प्रभाव नहीं होता, क्योंकि प्रयासों की संख्या बाहरी पात्र नियंत्रित करता है। `maxNumAttempts` बाहरी पात्र पर सेट करें।
+
+answer-attributes-need-symbolic-equality = symbolicEquality सेट किए बिना { $attributes } विशेषता का कोई प्रभाव नहीं होगा।
+
+answer-invalid-type = answer के लिए प्रकार अमान्य है: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = चूँकि घटक `<{ $component }>` का नाम नहीं है, इसे मॉड्यूल विशेषता के रूप में उपयोग नहीं किया जा सकता
+
+module-attribute-name-already-defined = घटक `<{ $component } name="{ $name }">` को मॉड्यूल की विशेषता के रूप में उपयोग नहीं किया जा सकता, क्योंकि घटक प्रकार `<module>` में "{ $name }" विशेषता पहले से परिभाषित है।
+
+conditional-content-condition-ignored = case या else संतानों वाले `<conditionalContent>` घटक पर `condition` विशेषता पर ध्यान नहीं दिया जाता।
+
+slider-markers-type-mismatch = चिह्नकों का प्रकार स्लाइडर के प्रकार से मेल नहीं खाता।
+
+pretzel-problem-needs-statement-and-answer = अमान्य pretzel: प्रत्येक `<problem>` में एक `<statement>` और एक `<answer>` होना चाहिए।
+
+pretzel-circuit-first-problem-distractor = अमान्य pretzel: mode="circuit" में पहला `<problem>` भ्रामक विकल्प नहीं हो सकता।
+
+## Attribute values
+
+attribute-invalid-values = विशेषता `{ $attribute }` के लिए मान { $values } अमान्य है; छोड़ा जा रहा है।
+
+attribute-must-be-references = विशेषता `{ $attribute }` के लिए मान `{ $value }` अमान्य है। विशेषता `$` से आरंभ होने वाले संदर्भों से बनी होनी चाहिए।
+
+math-input-invalid-function-names = <mathInput>: { $attribute } में अमान्य फलन नाम छोड़े गए: { $names }। प्रत्येक नाम के दृश्य भाग में कम से कम 2 वर्ण (अक्षर या योजक चिह्न) होने चाहिए; उसके बाद वैकल्पिक `|<mathspeak विकल्प>` प्रत्यय आ सकता है।
+
+## Building components from the source
+
+component-type-invalid = घटक प्रकार अमान्य है: `<{ $componentType }>`
+
+attribute-repeated = विशेषता { $attribute } दोहराई नहीं जा सकती।
+
+attribute-invalid-for-component = `<{ $componentType }>` प्रकार के घटक के लिए विशेषता "{ $attribute }" अमान्य है।
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    शैली परिभाषा { $styleNumber } में { $context ->
+        [text-on-background] पृष्ठभूमि रंग की तुलना में पाठ रंग
+        [high-contrast] कैनवास की तुलना में उच्च वैषम्य रंग
+        [line] कैनवास की तुलना में रेखा रंग
+        [marker] कैनवास की तुलना में चिह्नक रंग
+       *[text-on-canvas] कैनवास की तुलना में पाठ रंग
+    } के लिए वैषम्य अपर्याप्त है{ $mode ->
+        [dark] { " (गहरी विधा)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाहिए)।
+
+style-definition-dark-mode-text-background-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा के लिए पर्याप्त वैषम्य वाले रंग दिए हैं, इन मानों से व्युत्पन्न गहरी विधा के रंगों में पाठ रंग और पृष्ठभूमि रंग के बीच वैषम्य अपर्याप्त है ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाहिए)। { $suggestion ->
+        [available] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करने के लिए या तो हल्की विधा का वैषम्य बढ़ाएँ (जैसे { $lightAttribute }="{ $lightColor }" सेट करें) या गहरी विधा का रंग अधिरोहित करें (जैसे { $darkAttribute }="{ $darkColor }" सेट करें)।
+       *[none] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करने के लिए हल्की विधा का वैषम्य बढ़ाएँ या व्युत्पन्न रंगों को textColorDarkMode और/या backgroundColorDarkMode से अधिरोहित करें।
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    यद्यपि शैली परिभाषा { $styleNumber } ने हल्की विधा के लिए पर्याप्त वैषम्य वाला पाठ रंग दिया है, इस मान से व्युत्पन्न गहरी विधा के पाठ रंग का कैनवास की तुलना में वैषम्य अपर्याप्त है ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; कम से कम { $threshold }:1 चाहिए)। { $suggestion ->
+        [available] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करने के लिए या तो हल्की विधा का वैषम्य बढ़ाएँ (जैसे textColor="{ $lightColor }" सेट करें) या गहरी विधा का रंग अधिरोहित करें (जैसे textColorDarkMode="{ $darkColor }" सेट करें)।
+       *[none] गहरी विधा में पर्याप्त वैषम्य सुनिश्चित करने के लिए हल्की विधा का वैषम्य बढ़ाएँ या व्युत्पन्न रंग को textColorDarkMode से अधिरोहित करें।
+    }
+
+section-multiple-style-palettes = एक खंड केवल एक <stylePalette> चुन सकता है; अंतिम का उपयोग किया जा रहा है।
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि numToSelect ऋणेतर पूर्णांक नहीं है।
+
+variant-num-to-select-not-constant-number = { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि numToSelect अचर नहीं है।
+
+variant-with-replacement-not-constant-boolean = { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि withReplacement अचर बूलीय मान नहीं है।
+
+variant-select-weight-disables-unique = यदि कोई विकल्प selectWeight या selectForVariants देता है तो select के अद्वितीय संस्करण निष्क्रिय हो जाते हैं
+
+variant-coprime-undetermined = { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि यह तय नहीं हो सका कि coprime सदा असत्य है।
+
+variant-attribute-not-constant = { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि { $attribute } अचर नहीं है।
+
+variant-attribute-not-number = { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि { $attribute } संख्या नहीं है।
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } प्रकार के { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि { $attribute } { $expected ->
+        [letters-combination] अक्षरों का संयोजन
+        [math-expression] मान्य गणितीय व्यंजक
+        [integer] पूर्णांक
+       *[number] संख्या
+    } नहीं है।
+
+variant-length-not-integer = { $component } के अद्वितीय संस्करण निर्धारित नहीं किए जा सकते, क्योंकि length पूर्णांक नहीं है।
+
+variant-sort-not-implemented = sort वाले { $component } के अद्वितीय संस्करण अभी उपलब्ध नहीं हैं
+
+variant-exclude-combinations-not-implemented = excludeCombinations वाले { $component } के अद्वितीय संस्करण अभी उपलब्ध नहीं हैं
+
+variant-math-exclude-not-implemented = exclude वाले math प्रकार के { $component } के अद्वितीय संस्करण अभी उपलब्ध नहीं हैं
+
+variant-non-constant-exclude-not-implemented = अनचर exclude वाले { $component } के अद्वितीय संस्करण अभी उपलब्ध नहीं हैं
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: आलेख के prefigure रेंडरर में समर्थित नहीं; वंशज छोड़ा गया।
+
+prefigure-descendant-invalid-geometry = { $subject }: ज्यामिति असीमित या अपूर्ण है; वंशज छोड़ा गया।
+
+prefigure-curve-label-omitted = { $subject }: रूपांतरित वक्र तत्वों पर लेबल समर्थित नहीं; लेबल छोड़ा गया।
+
+prefigure-curve-unsupported-definition-type = { $subject }: वक्र फलन परिभाषा प्रकार '{ $definitionType }' समर्थित नहीं; वंशज छोड़ा गया।
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves पर flipFunctions विशेषता समर्थित नहीं; वंशज छोड़ा गया।
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves केवल सूत्र प्रकार के संतान फलनों का समर्थन करता है; वंशज छोड़ा गया।
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] रेखा कुल के लेबल
+       *[point] बिंदु लेबल
+    } के लिए labelPosition '{ $labelPosition }' समर्थित नहीं; PreFigure की पूर्वनिर्धारित संरेखण अपनाई जा रही है।
+
+prefigure-fill-style-unsupported = { $subject }: भराव शैली '{ $fillStyle }' PreFigure में समर्थित नहीं; ठोस भराव अपनाया जा रहा है।
+
+prefigure-line-style-unknown = { $subject }: अज्ञात रेखा शैली '{ $lineStyle }' PreFigure के आउटपुट से छोड़ी गई।
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure की 'diamond' शैली पर मानचित्रित की गई।
+
+prefigure-marker-style-unsupported = { $subject }: चिह्नक शैली '{ $markerStyle }' PreFigure में समर्थित नहीं; पूर्वनिर्धारित शैली अपनाई जा रही है।
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` अमान्य; लक्ष्य निर्धारित नहीं हो सका। टीका छोड़ी गई।
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` से कई लक्ष्य निकले; पहला लक्ष्य लिया जा रहा है।
+
+annotation-ref-outside-graph = `<annotation>`: `ref` अमान्य; लक्ष्य उसे समेटे आलेख के बाहर है। टीका छोड़ी गई।
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` अमान्य; prefigure रूपांतरण में लक्ष्य समर्थित आलेखीय वस्तु नहीं है। टीका छोड़ी गई।
+
+annotation-text-missing = `<annotation>`: `text` अनुपस्थित या रिक्त; रिक्त पाठ दिया जा रहा है।
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] चक्रीय निर्भरता का पता चला।
+       *[other] `<{ $componentType }>` घटक से जुड़ी चक्रीय निर्भरता का पता चला।
+    }
+
+reference-no-referent = इस संदर्भ का कोई लक्ष्य नहीं मिला: `{ $reference }`
+
+reference-multiple-referents = इस संदर्भ के कई लक्ष्य मिले: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` की विशेषता { $attribute } का प्रारूप अमान्य है।
+
+children-invalid = `<{ $componentType }>` की संतानें अमान्य हैं: अमान्य संतानें मिलीं: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = विशेषता `{ $attribute }` के लिए मान `{ $value }` अमान्य है; मान `{ $default }` का उपयोग किया जा रहा है
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML संस्करण { $version } नहीं मिला।
+       *[other] DoenetML संस्करण { $version } नहीं मिला। संस्करण { $fallback } पर लौटा जा रहा है
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = अमान्य DoenetML: { $content }
+
+parse-tag-missing-close-tag = अमान्य DoenetML: टैग `{ $tag }` का समापन टैग नहीं है। स्वतः बंद होने वाला टैग या `</{ $tagName }>` टैग अपेक्षित था।
+
+parse-tag-error = अमान्य DoenetML: टैग `<{ $tagName }>` में त्रुटि
+
+parse-attribute-missing-value = अमान्य DoenetML: विशेषता `{ $attribute }` का मान अनुपस्थित प्रतीत होता है।
+
+parse-attribute-invalid = अमान्य DoenetML: विशेषता `{ $attribute }` अमान्य है
+
+parse-attribute-value-invalid = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य है
+
+parse-attribute-value-quote-mismatch = अमान्य DoenetML: विशेषता मान `{ $value }` अमान्य है। उद्धरण चिह्न मेल नहीं खाते। एक `{ $quote }` अनुपस्थित प्रतीत होता है
+
+parse-open-tag-name-missing = अमान्य DoenetML: बिना नाम का टैग मिला, जैसे `<`
+
+parse-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नहीं हुआ (एक `>` अनुपस्थित प्रतीत होता है)।
+
+parse-self-closing-tag-name-missing = अमान्य DoenetML: बिना नाम का टैग मिला `<{ $content }>`
+
+parse-self-closing-tag-not-closed = अमान्य DoenetML: टैग `{ $tag }` बंद नहीं हुआ (`/>` अनुपस्थित प्रतीत होता है)।
+
+parse-tag-invalid-attributes = अमान्य DoenetML: टैग `{ $tag }` मान्य नहीं है। इसकी विशेषताएँ ग़लत हो सकती हैं।
+
+parse-close-tag-name-missing = अमान्य DoenetML: बिना नाम का समापन टैग मिला, जैसे `</`
+
+parse-attribute-value-unquoted = विशेषता मान उद्धरण चिह्नों में होने चाहिए: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = अमान्य DoenetML: समापन टैग `{ $tag }` मिला, पर उससे मेल खाता आरंभ टैग नहीं है
+
+parse-close-tag-mismatched = अमान्य DoenetML: समापन टैग मेल नहीं खाता। `</{ $expected }>` अपेक्षित था। `{ $found }` मिला
+
+parser-node-unconvertible = नोड { $node } को Dast नोड में परिवर्तित नहीं किया जा सका।
+
+## Names
+
+name-attribute-invalid =
+    विशेषता name='{ $name }' अमान्य है। { $reason ->
+        [characters] नामों में केवल अक्षर, अंक, अधोरेखा या योजक चिह्न हो सकते हैं।
+       *[start] नाम अक्षर से आरंभ होने चाहिए।
+    }
+
+component-name-invalid-start = घटक नाम "{ $name }" अमान्य है। नाम अक्षर से आरंभ होने चाहिए।
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched प्रकार के answer में video विशेषता होनी चाहिए
+
+answer-video-watched-video-not-reference = videoWatched प्रकार के answer की video विशेषता एक संदर्भ होनी चाहिए
+
+answer-name-not-single-text = answer की name विशेषता में केवल एक पाठ संतान होनी चाहिए
+
+## Referencing another document
+
+external-doenetml-recursion-limit = पुनरावर्तन के बहुत अधिक स्तरों के कारण बाहरी DoenetML प्राप्त नहीं किया जा सका। कहीं चक्रीय संदर्भ तो नहीं?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" से DoenetML प्राप्त नहीं किया जा सका
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" से प्राप्त DoenetML अमान्य है: यह घटक प्रकार "{ $componentType }" से मेल नहीं खाया
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित है; इसके बदले `{ $to }` का उपयोग करें।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित है; इसके बदले `{ $to }` का उपयोग करें।
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] विशेषता `{ $from }` अप्रचलित है और छोड़ दी गई, क्योंकि `{ $to }` भी दिया गया है।
+       *[other] [deprecation] `<{ $component }>` पर विशेषता `{ $from }` अप्रचलित है और छोड़ दी गई, क्योंकि `{ $to }` भी दिया गया है।
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` पर विशेषता `{ $attribute }` अप्रचलित है और छोड़ दी गई।
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` केवल अंग्रेज़ी का बहुवचन बना सकता है, इसलिए { $locale } में लिखे दस्तावेज़ में उसका पाठ अपरिवर्तित रहता है। बहुवचन रूप सीधे लिखें, या `pluralForm` विशेषता से दें।
+
+
+## Checking against the schema
+
+schema-element-unrecognized = तत्व `<{ $tag }>` कोई परिचित Doenet तत्व नहीं है।
+
+schema-element-not-allowed-at-root = तत्व `<{ $tag }>` दस्तावेज़ के मूल में मान्य नहीं है।
+
+schema-element-not-allowed-inside = तत्व `<{ $tag }>` `<{ $parent }>` के भीतर मान्य नहीं है।
+
+schema-attribute-unrecognized = तत्व `<{ $tag }>` में `{ $attribute }` नाम की कोई विशेषता नहीं है।
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] तत्व `<{ $tag }>` की विशेषता `{ $attribute }` एक सूची होनी चाहिए जिसकी हर मद इनमें से एक हो: { $allowed }
+       *[other] तत्व `<{ $tag }>` की विशेषता `{ $attribute }` इनमें से एक होनी चाहिए: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select के लिए संस्करण नाम अमान्य है। संस्करण नाम { $variantName } { $numOptions } विकल्पों में आता है, पर चुनने की संख्या { $numToSelect } है।
+
+select-variant-name-without-options = select के लिए संस्करण दिए गए हैं, पर संभावित संस्करण नाम के लिए कोई विकल्प नहीं है: { $variantName }।
+
+select-variant-name-not-possible = select के लिए दिया गया संस्करण नाम { $variantName } संभावित संस्करण नाम नहीं है।
+
+select-too-few-options = केवल { $numOptions } घटकों में से { $numToSelect } नहीं चुने जा सकते।
+
+select-from-sequence-too-few-values = { $length } लंबाई के अनुक्रम से { $numToSelect } मान नहीं चुने जा सकते।
+
+select-from-sequence-indices-count-mismatch = select के लिए दिए गए अनुक्रमांकों की संख्या चुनने की संख्या से मेल खानी चाहिए
+
+select-from-sequence-indices-not-integers = select के लिए दिए गए सभी अनुक्रमांक पूर्णांक होने चाहिए
+
+select-from-sequence-index-excluded = selectfromsequence के लिए दिया गया अनुक्रमांक बहिष्कृत था
+
+select-from-sequence-indices-excluded-combination = selectfromsequence के लिए दिए गए अनुक्रमांक बहिष्कृत संयोजन बनाते थे
+
+select-from-sequence-coprime-not-positive-integers = धनात्मक पूर्णांक नहीं चुने जा रहे, इसलिए सहअभाज्य संयोजन नहीं चुने जा सकते।
+
+select-from-sequence-coprime-common-factor = सहअभाज्य संख्याएँ नहीं चुनी जा सकतीं। सभी संभावित मानों में एक उभयनिष्ठ गुणनखंड है। (दिए गए "from" या "to" मान "step" के सहअभाज्य होने चाहिए।)
+
+select-from-sequence-coprime-single-number = 1 से भिन्न किसी एकल संख्या से सहअभाज्य संयोजन नहीं चुने जा सकते।
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence में 70% से अधिक संयोजन बहिष्कृत किए गए
+
+select-from-sequence-coprime-none-found = सहअभाज्य संख्याएँ नहीं चुनी जा सकीं। सभी संभावित मानों में एक उभयनिष्ठ गुणनखंड है।
+
+select-from-sequence-too-few-unique-values = { $numPossibleValues } लंबाई के अनुक्रम से { $numToSelect } भिन्न मान नहीं चुने जा सकते
+
+select-prime-numbers-too-few-values = { $numValues } लंबाई की अभाज्य सूची से { $numToSelect } मान नहीं चुने जा सकते
+
+select-prime-numbers-values-count-mismatch = select के लिए दिए गए मानों की संख्या चुनने की संख्या से मेल खानी चाहिए
+
+select-prime-numbers-values-not-prime = select prime number के लिए दिए गए सभी मान अभाज्य सूची में होने चाहिए
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers के लिए दिए गए मान बहिष्कृत संयोजन बनाते थे
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers में 70% से अधिक संयोजन बहिष्कृत किए गए
+
+select-random-combination-fluke = अत्यंत असंभव संयोग से यादृच्छिक मानों का संयोजन नहीं चुना जा सका
+
+select-random-value-fluke = अत्यंत असंभव संयोग से यादृच्छिक मान नहीं चुना जा सका

--- a/packages/i18n/locales/hi/editor.ftl
+++ b/packages/i18n/locales/hi/editor.ftl
@@ -1,0 +1,205 @@
+# Hindi editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] रीसेट करें
+       *[update] अद्यतन करें
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] दर्शक { $word }
+       *[other] दर्शक { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = संस्करण
+editor-variant-filter = छाँटें...
+editor-variant-next = अगला संस्करण चुनें
+editor-variant-previous = पिछला संस्करण चुनें
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पाया गया। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करने
+           *[open] खोलने
+        } के लिए क्लिक करें।
+        [advisories] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करने
+           *[open] खोलने
+        } के लिए क्लिक करें। कोई WCAG AA उल्लंघन नहीं मिला, पर सुगम्यता संबंधी अन्य सुझाव हैं।
+       *[clean] सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करने
+           *[open] खोलने
+        } के लिए क्लिक करें। कोई सुगम्यता समस्या नहीं मिली।
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA सुगम्यता उल्लंघन पाया गया। { $count } WCAG AA उल्लंघन मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करने
+           *[open] खोलने
+        } के लिए क्लिक करें।
+        [advisories] कोई WCAG AA उल्लंघन नहीं मिला। सुगम्यता संबंधी { $count } अन्य सुझाव मिले। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करने
+           *[open] खोलने
+        } के लिए क्लिक करें।
+       *[clean] कोई WCAG AA उल्लंघन नहीं मिला। सुगम्यता रिपोर्ट { $action ->
+            [close] बंद करने
+           *[open] खोलने
+        } के लिए क्लिक करें।
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML संस्करण { $version }
+
+editor-tab-help = प्रसंग अनुसार सहायता
+editor-tab-help-short = प्रसंग
+editor-tab-errors = त्रुटियाँ
+editor-tab-warnings = चेतावनियाँ
+editor-tab-info = जानकारी
+editor-tab-accessibility = सुगम्यता
+editor-tab-responses = भेजे गए उत्तर
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = संपादक विकल्प
+editor-format-as-doenetml = DoenetML रूप में स्वरूपित करें
+editor-format-as-xml = XML रूप में स्वरूपित करें
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = पंक्ति #{ $line }
+
+editor-no-errors = कोई त्रुटि नहीं
+editor-no-warnings = कोई चेतावनी नहीं
+editor-no-info = कोई सूचनात्मक निदान नहीं
+
+editor-show-info-annotations = संपादक में सूचनात्मक निदान दिखाएँ
+editor-show-accessibility-annotations = संपादक में सुगम्यता निदान दिखाएँ
+
+editor-accessibility-learn-more = जानें कि Doenet सुगम्यता को किस तरह देखता है
+
+editor-accessibility-violations-heading = सुगम्यता उल्लंघन ({ $standard })
+
+editor-accessibility-other-heading = अन्य सुगम्यता समस्याएँ
+editor-none-found = कुछ नहीं मिला
+
+
+## Submitted responses
+
+editor-no-responses = अभी तक कोई उत्तर नहीं भेजा गया
+editor-response-answer-id = Answer Id
+editor-response-response = उत्तर
+editor-response-credit = अंक
+editor-response-submitted = भेजा गया
+
+
+## The context-help panel
+
+help-placeholder = दस्तावेज़ीकरण देखने के लिए कर्सर को टैग नाम, विशेषता या { $ref } पर रखें।
+
+help-unsupported-ref-chain = { $example } जैसे बहु-भागीय संदर्भों की सहायता अभी उपलब्ध नहीं है।
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] इस संदर्भ का कोई लक्ष्य नहीं मिला: { $ref }।
+        [multiple] इस संदर्भ के कई लक्ष्य मिले: { $ref }।
+       *[indeterminate] { $ref } का लक्ष्य निर्धारित नहीं किया जा सका।
+    }
+
+help-learn-about-references = संदर्भों के बारे में जानें →
+help-reference-page = संदर्भ पृष्ठ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } के भीतर
+       *[top] शीर्ष स्तर पर
+    }{ $allowed ->
+        [none] { " — यहाँ कुछ नहीं रखा जा सकता।" }
+        [text] { " — यहाँ पाठ लिखा जा सकता है।" }
+        [text-and-components] { " — यहाँ पाठ लिखें, या ये आज़माएँ:" }
+       *[components] { " — ये आज़माएँ:" }
+    }
+
+help-suggestions-footer = सभी { $total } घटक देखने के लिए { $shortcut } दबाएँ।
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } का संदर्भ है।
+       *[other] { $ref }, { $target } का संदर्भ है (पंक्ति { $line })।
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } द्वारा { $role } के रूप में लाया गया।
+       *[other] { $owner } द्वारा पंक्ति { $line } में { $role } के रूप में लाया गया।
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } के { $property } गुण का संदर्भ है।
+       *[other] { $ref }, { $element } के { $property } गुण का संदर्भ है (पंक्ति { $line })।
+    }
+
+help-kind-attribute = विशेषता
+help-kind-snippet = कोड अंश
+help-kind-array-entry = सरणी प्रविष्टि
+
+help-default = पूर्वनिर्धारित:
+help-active-default = प्रभावी पूर्वनिर्धारित:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] अनुमत मान (प्रति मद एक):
+       *[other] अनुमत मान:
+    }
+
+help-suggested-values = सुझाए गए मान:
+
+help-inserts = जोड़ता है:
+
+help-coordinates =
+    { $count ->
+        [one] निर्देशांक:
+       *[other] निर्देशांक:
+    }
+
+help-type = प्रकार:
+
+help-resolved-style = निर्धारित शैली (styleNumber { $styleNumber }):
+
+help-resolved-function-names = निर्धारित फलन नाम:
+help-reset-list = इस इनपुट की रीसेट सूची:
+help-added-on-input = इस इनपुट पर जोड़ा गया:
+help-removed-on-input = इस इनपुट पर हटाया गया:
+
+help-reset-overrides = { $reset }, { $additional } और { $removed } पर वरीयता रखता है।

--- a/packages/i18n/locales/hi/editor.ftl
+++ b/packages/i18n/locales/hi/editor.ftl
@@ -29,10 +29,10 @@ editor-update-viewer-title =
 
 ## The variant picker
 
-editor-variant = संस्करण
-editor-variant-filter = छाँटें...
-editor-variant-next = अगला संस्करण चुनें
-editor-variant-previous = पिछला संस्करण चुनें
+editor-variant = रूपांतर
+editor-variant-filter = फ़िल्टर...
+editor-variant-next = अगला रूपांतर चुनें
+editor-variant-previous = पिछला रूपांतर चुनें
 
 
 ## The accessibility status button
@@ -113,7 +113,7 @@ editor-none-found = कुछ नहीं मिला
 ## Submitted responses
 
 editor-no-responses = अभी तक कोई उत्तर नहीं भेजा गया
-editor-response-answer-id = Answer Id
+editor-response-answer-id = उत्तर आईडी
 editor-response-response = उत्तर
 editor-response-credit = अंक
 editor-response-submitted = भेजा गया

--- a/packages/i18n/locales/pl/chrome.ftl
+++ b/packages/i18n/locales/pl/chrome.ftl
@@ -1,0 +1,145 @@
+# Polish viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Polish has four plural categories — `one`, `few`, `many` and `other` — and
+# every countable message below selects on all of them. `few` covers 2–4 and
+# any count ending in 2–4 except the teens; `many` covers the rest, including
+# 0. `other` catches the fractional values CLDR routes there.
+#
+# Controls take the bare imperative, which is what Polish puts on a button:
+# `Otwórz klawiaturę`, not `Proszę otworzyć klawiaturę`.
+
+
+## Answer submission
+
+answer-checking = Sprawdzanie...
+answer-submitting = Wysyłanie...
+
+answer-checking-status = Sprawdzanie odpowiedzi
+answer-submitting-status = Wysyłanie odpowiedzi
+
+answer-correct = Poprawnie
+answer-incorrect = Niepoprawnie
+
+answer-response-saved = Odpowiedź zapisana
+
+answer-percent-credit = { $percent }% punktów
+answer-percent-correct = { $percent }% poprawnie
+answer-percent-short = { $percent }%
+
+max-credit-available = Maksymalna liczba punktów: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] brak pozostałych prób
+        [one] pozostała { $count } próba
+        [few] pozostały { $count } próby
+        [many] pozostało { $count } prób
+       *[other] pozostało { $count } próby
+    }
+
+validation-correct = (Poprawnie)
+validation-incorrect = (Niepoprawnie)
+validation-partially-correct = (Częściowo poprawnie)
+
+answer-show-responses =
+    { $count ->
+        [one] Pokaż { $count } odpowiedź na { $answerId }
+        [few] Pokaż { $count } odpowiedzi na { $answerId }
+        [many] Pokaż { $count } odpowiedzi na { $answerId }
+       *[other] Pokaż { $count } odpowiedzi na { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Informacja zwrotna
+
+collapsible-click-to-open = (kliknij, aby otworzyć)
+collapsible-click-to-close = (kliknij, aby zamknąć)
+
+collapsible-initializing = Inicjowanie...
+
+footnote-show = Pokaż przypis
+footnote-hide = Ukryj przypis
+
+description-more-information = więcej informacji
+
+
+## Controls
+
+slider-previous = Poprzedni
+slider-next = Następny
+
+keyboard-open = Otwórz klawiaturę
+keyboard-close = Zamknij klawiaturę
+
+matrix-remove-row = Usuń wiersz
+matrix-add-row = Dodaj wiersz
+matrix-remove-column = Usuń kolumnę
+matrix-add-column = Dodaj kolumnę
+
+subset-add-remove-points = Dodaj/usuń punkty
+subset-toggle-points-intervals = Przełącz punkty i przedziały
+subset-move-points = Przesuń punkty
+subset-clear = Wyczyść
+
+# A `box` here is one orbital, drawn as a square: klatka.
+orbital-add-row = Dodaj wiersz
+orbital-remove-row = Usuń wiersz
+orbital-add-box = Dodaj klatkę
+orbital-remove-box = Usuń klatkę
+orbital-add-up-arrow = Dodaj strzałkę w górę
+orbital-add-down-arrow = Dodaj strzałkę w dół
+orbital-remove-arrow = Usuń strzałkę
+
+orbital-row-label = Etykieta wiersza { $row }
+
+pretzel-answer = Odpowiedź
+
+summary-statistics-caption = Statystyki opisowe dla { $column }
+
+
+## Math input
+
+math-input-preview-region = podgląd wyrażenia matematycznego
+math-input-preview = Podgląd
+math-input-invalid-expression = Nieprawidłowe wyrażenie:
+
+
+## Document status
+
+viewer-initializing = Inicjowanie...
+
+
+## Errors
+
+error-heading = Błąd
+
+error-found-at =
+    { $span ->
+        [line] Znaleziono w wierszu { $startLine }.
+       *[lines] Znaleziono w wierszach { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Ten dokument zawiera błędy!
+
+diagnostic-heading-error = Błąd
+diagnostic-heading-warning = Ostrzeżenie
+diagnostic-heading-information = Informacja
+diagnostic-heading-hint = Wskazówka
+
+accessibility-heading-level-1 = Naruszenie dostępności WCAG AA
+accessibility-heading-level-2 = Ostrzeżenie o dostępności
+
+something-went-wrong = Coś poszło nie tak.
+
+renderer-load-failed = nie udało się wczytać komponentu renderującego. Odśwież stronę.
+
+core-start-failed = Nie udało się uruchomić przeglądarki dokumentu. Odśwież stronę.

--- a/packages/i18n/locales/pl/chrome.ftl
+++ b/packages/i18n/locales/pl/chrome.ftl
@@ -8,9 +8,10 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # Polish has four plural categories — `one`, `few`, `many` and `other` — and
-# every countable message below selects on all of them. `few` covers 2–4 and
-# any count ending in 2–4 except the teens; `many` covers the rest, including
-# 0. `other` catches the fractional values CLDR routes there.
+# every message here that prints a count beside a noun selects on all of them.
+# `few` covers 2–4 and any count ending in 2–4 except the teens; `many` covers
+# the rest, including 0. `other` catches the fractional values CLDR routes
+# there.
 #
 # Controls take the bare imperative, which is what Polish puts on a button:
 # `Otwórz klawiaturę`, not `Proszę otworzyć klawiaturę`.
@@ -33,7 +34,7 @@ answer-percent-credit = { $percent }% punktów
 answer-percent-correct = { $percent }% poprawnie
 answer-percent-short = { $percent }%
 
-max-credit-available = Maksymalna liczba punktów: { $percent }%
+max-credit-available = Maksymalny dostępny wynik: { $percent }%
 
 attempts-remaining =
     { $count ->

--- a/packages/i18n/locales/pl/content.ftl
+++ b/packages/i18n/locales/pl/content.ftl
@@ -1,0 +1,584 @@
+# Polish content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Polish inflects for gender *and* for case, so every adjective below selects
+# on `$role` first — which position the words are going into — and then on
+# `$gender` where the answer still depends on one:
+#
+#   standalone          nominative, agreeing with the noun described:
+#                       `-y`/`-i` m, `-a` f, `-e` n
+#   border-clause       instrumental after «z», of «obramowanie» — neuter:
+#                       `-ym`/`-im`
+#   background-clause   locative after «na», of «tło» — also neuter, and the
+#                       neuter locative is spelled the same as the neuter
+#                       instrumental, so these two branches coincide
+#   text-clause         nominative masculine, agreeing with «tekst»
+#
+# The last three need no gender branch: each is used of exactly one noun, and
+# that noun's gender is fixed. Without `$role` this catalog could not have been
+# written at all — one token cannot hold three cases (#1606).
+#
+# Adjectives precede their noun, as in English, so the composition messages
+# keep the English order.
+
+
+## Słownictwo stylów
+
+color =
+    .black =
+        { $role ->
+            [border-clause] czarnym
+            [background-clause] czarnym
+            [text-clause] czarny
+           *[standalone]
+                { $gender ->
+                    [f] czarna
+                    [n] czarne
+                   *[m] czarny
+                }
+        }
+    .white =
+        { $role ->
+            [border-clause] białym
+            [background-clause] białym
+            [text-clause] biały
+           *[standalone]
+                { $gender ->
+                    [f] biała
+                    [n] białe
+                   *[m] biały
+                }
+        }
+    .gray =
+        { $role ->
+            [border-clause] szarym
+            [background-clause] szarym
+            [text-clause] szary
+           *[standalone]
+                { $gender ->
+                    [f] szara
+                    [n] szare
+                   *[m] szary
+                }
+        }
+    .red =
+        { $role ->
+            [border-clause] czerwonym
+            [background-clause] czerwonym
+            [text-clause] czerwony
+           *[standalone]
+                { $gender ->
+                    [f] czerwona
+                    [n] czerwone
+                   *[m] czerwony
+                }
+        }
+    .orange =
+        { $role ->
+            [border-clause] pomarańczowym
+            [background-clause] pomarańczowym
+            [text-clause] pomarańczowy
+           *[standalone]
+                { $gender ->
+                    [f] pomarańczowa
+                    [n] pomarańczowe
+                   *[m] pomarańczowy
+                }
+        }
+    .yellow =
+        { $role ->
+            [border-clause] żółtym
+            [background-clause] żółtym
+            [text-clause] żółty
+           *[standalone]
+                { $gender ->
+                    [f] żółta
+                    [n] żółte
+                   *[m] żółty
+                }
+        }
+    .green =
+        { $role ->
+            [border-clause] zielonym
+            [background-clause] zielonym
+            [text-clause] zielony
+           *[standalone]
+                { $gender ->
+                    [f] zielona
+                    [n] zielone
+                   *[m] zielony
+                }
+        }
+    .cyan =
+        { $role ->
+            [border-clause] błękitnym
+            [background-clause] błękitnym
+            [text-clause] błękitny
+           *[standalone]
+                { $gender ->
+                    [f] błękitna
+                    [n] błękitne
+                   *[m] błękitny
+                }
+        }
+    .blue =
+        { $role ->
+            [border-clause] niebieskim
+            [background-clause] niebieskim
+            [text-clause] niebieski
+           *[standalone]
+                { $gender ->
+                    [f] niebieska
+                    [n] niebieskie
+                   *[m] niebieski
+                }
+        }
+    .purple =
+        { $role ->
+            [border-clause] fioletowym
+            [background-clause] fioletowym
+            [text-clause] fioletowy
+           *[standalone]
+                { $gender ->
+                    [f] fioletowa
+                    [n] fioletowe
+                   *[m] fioletowy
+                }
+        }
+    .pink =
+        { $role ->
+            [border-clause] różowym
+            [background-clause] różowym
+            [text-clause] różowy
+           *[standalone]
+                { $gender ->
+                    [f] różowa
+                    [n] różowe
+                   *[m] różowy
+                }
+        }
+    .brown =
+        { $role ->
+            [border-clause] brązowym
+            [background-clause] brązowym
+            [text-clause] brązowy
+           *[standalone]
+                { $gender ->
+                    [f] brązowa
+                    [n] brązowe
+                   *[m] brązowy
+                }
+        }
+
+line-width =
+    .thick =
+        { $role ->
+            [border-clause] grubym
+            [background-clause] grubym
+            [text-clause] gruby
+           *[standalone]
+                { $gender ->
+                    [f] gruba
+                    [n] grube
+                   *[m] gruby
+                }
+        }
+    .thin =
+        { $role ->
+            [border-clause] cienkim
+            [background-clause] cienkim
+            [text-clause] cienki
+           *[standalone]
+                { $gender ->
+                    [f] cienka
+                    [n] cienkie
+                   *[m] cienki
+                }
+        }
+
+line-style =
+    .dashed =
+        { $role ->
+            [border-clause] przerywanym
+            [background-clause] przerywanym
+            [text-clause] przerywany
+           *[standalone]
+                { $gender ->
+                    [f] przerywana
+                    [n] przerywane
+                   *[m] przerywany
+                }
+        }
+    .dotted =
+        { $role ->
+            [border-clause] kropkowanym
+            [background-clause] kropkowanym
+            [text-clause] kropkowany
+           *[standalone]
+                { $gender ->
+                    [f] kropkowana
+                    [n] kropkowane
+                   *[m] kropkowany
+                }
+        }
+
+# Rzeczowniki w narzędniku liczby mnogiej: występują po «w» i z niczym się nie
+# uzgadniają.
+fill-style =
+    .horizontal = poziome linie
+    .vertical = pionowe linie
+    .diagonal = ukośne linie
+    .backdiagonal = odwrotnie ukośne linie
+    .dots = kropki
+    .diamonds = romby
+
+noun =
+    .line = prosta
+    .line-segment = odcinek
+    .ray = półprosta
+    .vector = wektor
+    .curve = krzywa
+    .function = funkcja
+    .parabola = parabola
+    .polyline = łamana
+    .polygon = wielokąt
+    .triangle = trójkąt
+    .rectangle = prostokąt
+    .circle = okrąg
+    .region = obszar
+    .point = punkt
+    .square = kwadrat
+    .diamond = romb
+    .cross = krzyżyk
+    .plus = plus
+
+# Polski liczy boki po rzeczowniku, więc liczba zamyka wyrażenie za
+# przymiotnikami: «gruby czerwony wielokąt foremny o 5 bokach».
+noun-regular-polygon =
+    { $part ->
+        [tail] o { $numSides } bokach
+       *[head] wielokąt foremny
+    }
+
+# Poza rzeczownikami powyżej `$noun` może być «regular-polygon» (wielokąt, m)
+# albo głową wyrażenia, którego opis nie nazywa: «border» (obramowanie, n),
+# «fill» (wypełnienie, n), «text» (tekst, m), «background» (tło, n).
+noun-gender =
+    { $noun ->
+        [line] f
+        [ray] f
+        [curve] f
+        [function] f
+        [parabola] f
+        [polyline] f
+        [border] n
+        [fill] n
+        [background] n
+       *[other] m
+    }
+
+
+## Składanie stylów
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# Przymiotniki poprzedzają rzeczownik, a dopełnienie zamyka wyrażenie.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word =
+    { $role ->
+        [border-clause] wypełnionym
+        [background-clause] wypełnionym
+        [text-clause] wypełniony
+       *[standalone]
+            { $gender ->
+                [f] wypełniona
+                [n] wypełnione
+               *[m] wypełniony
+            }
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } w { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } w { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } w { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+# «z» rządzi narzędnikiem, którego dostarcza gałąź `border-clause` każdego
+# przymiotnika. Polski nie ma rodzajnika, więc gałęzie `-article` brzmią tak
+# samo jak pozostałe.
+style-border-clause =
+    { $parts ->
+        [with-article] z { $border } obramowaniem
+        [and] i { $border } obramowaniem
+        [and-article] i { $border } obramowaniem
+       *[with] z { $border } obramowaniem
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = niewypełniony
+
+# «na» rządzi miejscownikiem, który dla rodzaju nijakiego brzmi tak samo jak
+# narzędnik — stąd wspólna postać w obu gałęziach przymiotników.
+style-text =
+    { $parts ->
+        [background] { $color } na { $background } tle
+       *[plain] { $color }
+    }
+
+style-background-none = brak
+
+
+## Słowa logiczne
+
+boolean-true = prawda
+boolean-false = fałsz
+
+
+## Przyciski odpowiedzi
+
+answer-submit-label = Sprawdź
+answer-submit-label-no-correctness = Wyślij odpowiedź
+
+
+## Bloki sekcyjne
+
+section-name =
+    .activity = Aktywność
+    .aside = Dygresja
+    .cascade = Kaskada
+    .definition = Definicja
+    .example = Przykład
+    .exercise = Ćwiczenie
+    .exercises = Ćwiczenia
+    .given-answer = Odpowiedź
+    .note = Uwaga
+    .objectives = Cele
+    .paragraphs = Akapity
+    .part = Część
+    .problem = Zadanie
+    .problems = Zadania
+    .proof = Dowód
+    .question = Pytanie
+    .section = Rozdział
+    .solution = Rozwiązanie
+    .task = Zadanie do wykonania
+    .theorem = Twierdzenie
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Wskazówka
+
+
+## Tabele i rysunki
+
+table-name =
+    { $parts ->
+        [numbered] Tabela { $enumeration }
+        [numbered-title] Tabela { $enumeration }{ ": " }
+        [unnumbered-title] Tabela{ ": " }
+       *[unnumbered] Tabela
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Rysunek { $enumeration }
+        [numbered-caption] Rysunek { $enumeration }{ ": " }
+        [unnumbered-caption] Rysunek{ ": " }
+       *[unnumbered] Rysunek
+    }
+
+
+## Sterowanie paginacją
+
+paginator-previous = Poprzednia
+paginator-next = Następna
+paginator-page = Strona
+
+paginator-page-status = { $pageLabel } { $currentPage } z { $numPages }
+
+
+## Funkcje określone przedziałami
+
+piecewise-condition-or = lub
+piecewise-condition-if = jeśli
+piecewise-condition-otherwise = w przeciwnym razie
+
+
+## Chemia
+
+element-name =
+    .h = Wodór
+    .he = Hel
+    .li = Lit
+    .be = Beryl
+    .b = Bor
+    .c = Węgiel
+    .n = Azot
+    .o = Tlen
+    .f = Fluor
+    .ne = Neon
+    .na = Sód
+    .mg = Magnez
+    .al = Glin
+    .si = Krzem
+    .p = Fosfor
+    .s = Siarka
+    .cl = Chlor
+    .ar = Argon
+    .k = Potas
+    .ca = Wapń
+    .sc = Skand
+    .ti = Tytan
+    .v = Wanad
+    .cr = Chrom
+    .mn = Mangan
+    .fe = Żelazo
+    .co = Kobalt
+    .ni = Nikiel
+    .cu = Miedź
+    .zn = Cynk
+    .ga = Gal
+    .ge = German
+    .as = Arsen
+    .se = Selen
+    .br = Brom
+    .kr = Krypton
+    .rb = Rubid
+    .sr = Stront
+    .y = Itr
+    .zr = Cyrkon
+    .nb = Niob
+    .mo = Molibden
+    .tc = Technet
+    .ru = Ruten
+    .rh = Rod
+    .pd = Pallad
+    .ag = Srebro
+    .cd = Kadm
+    .in = Ind
+    .sn = Cyna
+    .sb = Antymon
+    .te = Tellur
+    .i = Jod
+    .xe = Ksenon
+    .cs = Cez
+    .ba = Bar
+    .la = Lantan
+    .ce = Cer
+    .pr = Prazeodym
+    .nd = Neodym
+    .pm = Promet
+    .sm = Samar
+    .eu = Europ
+    .gd = Gadolin
+    .tb = Terb
+    .dy = Dysproz
+    .ho = Holm
+    .er = Erb
+    .tm = Tul
+    .yb = Iterb
+    .lu = Lutet
+    .hf = Hafn
+    .ta = Tantal
+    .w = Wolfram
+    .re = Ren
+    .os = Osm
+    .ir = Iryd
+    .pt = Platyna
+    .au = Złoto
+    .hg = Rtęć
+    .tl = Tal
+    .pb = Ołów
+    .bi = Bizmut
+    .po = Polon
+    .at = Astat
+    .rn = Radon
+    .fr = Frans
+    .ra = Rad
+    .ac = Aktyn
+    .th = Tor
+    .pa = Protaktyn
+    .u = Uran
+    .np = Neptun
+    .pu = Pluton
+    .am = Ameryk
+    .cm = Kiur
+    .bk = Berkel
+    .cf = Kaliforn
+    .es = Einstein
+    .fm = Ferm
+    .md = Mendelew
+    .no = Nobel
+    .lr = Lorens
+    .rf = Rutherford
+    .db = Dubn
+    .sg = Seaborg
+    .bh = Bohr
+    .hs = Has
+    .mt = Meitner
+    .ds = Darmsztadt
+    .rg = Roentgen
+    .cn = Kopernik
+    .nh = Nihon
+    .fl = Flerow
+    .mc = Moskow
+    .lv = Liwermor
+    .ts = Tenes
+    .og = Oganeson
+
+element-anion-name =
+    .h = Wodorek
+    .c = Węglik
+    .n = Azotek
+    .o = Tlenek
+    .f = Fluorek
+    .p = Fosforek
+    .s = Siarczek
+    .cl = Chlorek
+    .br = Bromek
+    .i = Jodek
+    .at = Astatek
+    .ts = Tenesek
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Nieprawidłowy symbol chemiczny
+chemistry-invalid-ionic-compound = Nieprawidłowy związek jonowy

--- a/packages/i18n/locales/pl/content.ftl
+++ b/packages/i18n/locales/pl/content.ftl
@@ -301,17 +301,13 @@ style-with-noun =
        *[noun] { $description } { $noun }
     }
 
+# Only ever said of the shape itself, so it is standalone in every
+# description and takes no `$role` branch.
 style-filled-word =
-    { $role ->
-        [border-clause] wypełnionym
-        [background-clause] wypełnionym
-        [text-clause] wypełniony
-       *[standalone]
-            { $gender ->
-                [f] wypełniona
-                [n] wypełnione
-               *[m] wypełniony
-            }
+    { $gender ->
+        [f] wypełniona
+        [n] wypełnione
+       *[m] wypełniony
     }
 
 style-filled =

--- a/packages/i18n/locales/pl/content.ftl
+++ b/packages/i18n/locales/pl/content.ftl
@@ -25,7 +25,7 @@
 # keep the English order.
 
 
-## Słownictwo stylów
+## Style vocabulary
 
 color =
     .black =
@@ -225,8 +225,11 @@ line-style =
                 }
         }
 
-# Rzeczowniki w narzędniku liczby mnogiej: występują po «w» i z niczym się nie
-# uzgadniają.
+# Noun phrases in the accusative plural, which is the case «w» takes when it
+# names a pattern — «w romby», the way Polish describes patterned cloth. The
+# accusative of a non-virile plural is spelled like the nominative, so the same
+# words serve `style-fill`, where they stand on their own. They agree with
+# nothing either way.
 fill-style =
     .horizontal = poziome linie
     .vertical = pionowe linie
@@ -255,17 +258,17 @@ noun =
     .cross = krzyżyk
     .plus = plus
 
-# Polski liczy boki po rzeczowniku, więc liczba zamyka wyrażenie za
-# przymiotnikami: «gruby czerwony wielokąt foremny o 5 bokach».
+# Polish counts the sides after the noun, so the count closes the phrase
+# behind the adjectives: «gruby czerwony wielokąt foremny o 5 bokach».
 noun-regular-polygon =
     { $part ->
         [tail] o { $numSides } bokach
        *[head] wielokąt foremny
     }
 
-# Poza rzeczownikami powyżej `$noun` może być «regular-polygon» (wielokąt, m)
-# albo głową wyrażenia, którego opis nie nazywa: «border» (obramowanie, n),
-# «fill» (wypełnienie, n), «text» (tekst, m), «background» (tło, n).
+# Besides the nouns above, `$noun` can be `regular-polygon` (wielokąt, m) or
+# the head of a phrase the description never names: `border` (obramowanie, n),
+# `fill` (wypełnienie, n), `text` (tekst, m), `background` (tło, n).
 noun-gender =
     { $noun ->
         [line] f
@@ -281,7 +284,7 @@ noun-gender =
     }
 
 
-## Składanie stylów
+## Style composition
 
 style-stroke =
     { $parts ->
@@ -294,7 +297,7 @@ style-stroke =
        *[color] { $color }
     }
 
-# Przymiotniki poprzedzają rzeczownik, a dopełnienie zamyka wyrażenie.
+# Adjectives precede the noun, and the complement closes the phrase.
 style-with-noun =
     { $parts ->
         [noun-tail] { $description } { $noun } { $nounTail }
@@ -324,14 +327,19 @@ style-filled-with-noun =
        *[plain] { $filled } { $color } { $noun }
     }
 
-# «z» rządzi narzędnikiem, którego dostarcza gałąź `border-clause` każdego
-# przymiotnika. Polski nie ma rodzajnika, więc gałęzie `-article` brzmią tak
-# samo jak pozostałe.
+# «z» governs the instrumental, which the `border-clause` branch of every
+# adjective supplies. Polish has no article, so the `-article` branches read
+# the same as the ones without.
+#
+# The `and-` branches keep «z» of their own. English lets one "with" cover both
+# the fill pattern and the border, but Polish names a pattern with «w» and the
+# accusative, and that preposition cannot reach the instrumental behind it — so
+# «i z … obramowaniem», never a bare «i».
 style-border-clause =
     { $parts ->
         [with-article] z { $border } obramowaniem
-        [and] i { $border } obramowaniem
-        [and-article] i { $border } obramowaniem
+        [and] i z { $border } obramowaniem
+        [and-article] i z { $border } obramowaniem
        *[with] z { $border } obramowaniem
     }
 
@@ -343,8 +351,9 @@ style-fill =
 
 style-unfilled = niewypełniony
 
-# «na» rządzi miejscownikiem, który dla rodzaju nijakiego brzmi tak samo jak
-# narzędnik — stąd wspólna postać w obu gałęziach przymiotników.
+# «na» governs the locative, which for a neuter noun is spelled like the
+# instrumental — which is why the `background-clause` and `border-clause`
+# branches of every adjective coincide.
 style-text =
     { $parts ->
         [background] { $color } na { $background } tle
@@ -354,19 +363,19 @@ style-text =
 style-background-none = brak
 
 
-## Słowa logiczne
+## Boolean words
 
 boolean-true = prawda
 boolean-false = fałsz
 
 
-## Przyciski odpowiedzi
+## Answer buttons
 
 answer-submit-label = Sprawdź
 answer-submit-label-no-correctness = Wyślij odpowiedź
 
 
-## Bloki sekcyjne
+## Sectional blocks
 
 section-name =
     .activity = Aktywność
@@ -403,7 +412,7 @@ section-title-prefix =
 hint-title = Wskazówka
 
 
-## Tabele i rysunki
+## Tables and figures
 
 table-name =
     { $parts ->
@@ -422,7 +431,7 @@ figure-name =
     }
 
 
-## Sterowanie paginacją
+## Paginator controls
 
 paginator-previous = Poprzednia
 paginator-next = Następna
@@ -431,14 +440,14 @@ paginator-page = Strona
 paginator-page-status = { $pageLabel } { $currentPage } z { $numPages }
 
 
-## Funkcje określone przedziałami
+## Piecewise functions
 
 piecewise-condition-or = lub
 piecewise-condition-if = jeśli
 piecewise-condition-otherwise = w przeciwnym razie
 
 
-## Chemia
+## Chemistry
 
 element-name =
     .h = Wodór

--- a/packages/i18n/locales/pl/diagnostics.ftl
+++ b/packages/i18n/locales/pl/diagnostics.ftl
@@ -1,0 +1,629 @@
+# Polish diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Polish has four plural categories; every countable message below selects on
+# all of them.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } jest ignorowany, gdy podano dwa końce
+       *[other] { $attributes } są ignorowane, gdy podano dwa końce
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } jest ignorowany, gdy podano jednocześnie koniec i środek
+       *[other] { $attributes } są ignorowane, gdy podano jednocześnie koniec i środek
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset nie działa bez podanego środka
+
+## `<line>`
+
+line-points-undetermined-dimensions = Prosta przechodząca przez punkty o nieokreślonym wymiarze.
+
+line-points-too-few-dimensions = Prosta musi przechodzić przez punkty co najmniej dwuwymiarowe.
+
+line-points-depend-on-variables = Prosta przechodzi przez punkty zależne od zmiennych: { $variables }.
+
+line-equation-invalid-format = Nieprawidłowy format równania prostej dla zmiennych { $variable1 } i { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Półprosta jest określona jednocześnie przez through, endpoint i direction. Podane through zostaje zignorowane.
+
+ray-dimension-mismatch = Niezgodne numDimensions w półprostej.
+
+## `<vector>`
+
+vector-overprescribed-head = Wektor jest określony jednocześnie przez head, tail i displacement. Podane head zostaje zignorowane.
+
+vector-dimension-mismatch = Niezgodne numDimensions w wektorze.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Nie można przyciągnąć do `<{ $component }>`, ponieważ nie ma on zmiennej stanu nearestPoint.
+
+constrain-to-without-nearest-point = Nie można ograniczyć do `<{ $component }>`, ponieważ nie ma on zmiennej stanu nearestPoint.
+
+constrain-to-interior-without-nearest-point = Nie można ograniczyć do wnętrza `<{ $component }>`, ponieważ nie ma on zmiennej stanu nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition jest ignorowane dla choiceInput, który nie jest inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ignorowanie indices podanych dla choiceInput, ponieważ liczba indices nie odpowiada liczbie elementów potomnych choice.
+
+pretzel-indices-count-mismatch = Ignorowanie indices podanych dla problem, ponieważ liczba indices nie odpowiada liczbie elementów potomnych problem.
+
+shuffle-indices-count-mismatch = Ignorowanie indices podanych dla shuffle, ponieważ liczba indices nie odpowiada liczbie komponentów.
+
+indices-ignored-out-of-range = Ignorowanie indices podanych dla { $component }, ponieważ część indeksów wykracza poza zakres.
+
+pretzel-indices-repeated = Ignorowanie indices podanych dla pretzel, ponieważ część indeksów się powtarza.
+
+pretzel-circuit-first-index = Ignorowanie indices podanych dla pretzel w trybie circuit, ponieważ pierwszy indeks musi wynosić 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Aby `<{ $component }>` działał z tekstowymi elementami potomnymi, trzeba podać atrybut `type`.
+
+invalid-type-defaulting-to-math = Nieprawidłowy typ { $type } dla komponentu { $component }. Musi to być math, text, number albo boolean. Używany jest math.
+
+string-not-valid-component-to-arrange = Tekst „{ $value }” nie jest prawidłowym komponentem dla { $component }. Zignorowano.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Nieprawidłowy typ { $type }; typ ustawiony na number.
+
+invalid-variable-value = Nieprawidłowa wartość zmiennej: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks wariantu { $index } musi być liczbą
+
+variant-index-must-be-integer = Indeks wariantu { $index } musi być liczbą całkowitą
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` nie obsługuje wymiarów bezwzględnych. Szerokości ustawiane są na względne.
+
+side-by-side-absolute-margins = `<{ $component }>` nie obsługuje wymiarów bezwzględnych. Marginesy ustawiane są na względne.
+
+side-by-side-no-block-child = Nieprawidłowy `<{ $component }>`: musi mieć co najmniej jeden blokowy element potomny.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atrybut `for` w graficznym `<label>` jest ignorowany.
+
+label-for-must-resolve-to-one = Atrybut `for` w `<label>` musi wskazywać dokładnie jeden komponent.
+
+label-for-unresolved = Nie udało się powiązać atrybutu `for` w `<label>` z żadnym komponentem.
+
+label-for-answer-with-authored-inputs = Atrybut `for` w `<label>` odwołuje się do `<answer>` z jawnie zapisanymi polami; odwołaj się bezpośrednio do pola.
+
+label-for-answer-without-input = Atrybut `for` w `<label>` odwołuje się do `<answer>` bez pola, które można opisać etykietą.
+
+label-for-must-reference-input-or-answer = Atrybut `for` w `<label>` musi odwoływać się do pola albo do odpowiedzi.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ze względu na dostępność `<{ $component }>` musi mieć krótki opis albo być oznaczony jako dekoracyjny.
+
+accessibility-video-short-description = Ze względu na dostępność `<video>` musi mieć krótki opis.
+
+accessibility-input-short-description-or-label = Ze względu na dostępność `<{ $component }>` musi mieć krótki opis albo etykietę.
+
+accessibility-answer-input-short-description-or-label = Ze względu na dostępność `<answer>` tworzący pole musi mieć krótki opis albo etykietę.
+
+accessibility-short-description-contains-math = Krótkie opisy nie powinny zawierać komponentów matematycznych takich jak `<{ $component }>`. Zapisz matematykę słowami.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ma niewystarczający kontrast dla tekstu nagłówka sekcji (tryb ciemny) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; wymagane co najmniej { $threshold }:1).
+       *[other] { $colorName } ma niewystarczający kontrast dla tekstu nagłówka sekcji ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; wymagane co najmniej { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Nie zaimplementowano jeszcze `<circle>` przechodzącego przez { $count } punktów, gdy punkty nie mają wartości liczbowych.
+
+circle-too-many-through-points = Nie można wyznaczyć okręgu przechodzącego przez więcej niż 3 punkty.
+
+circle-overprescribed-radius-center-points = Nie można wyznaczyć okręgu z jednocześnie podanym promieniem, środkiem i punktami przejścia.
+
+circle-center-with-multiple-points = Nie można wyznaczyć okręgu o podanym środku przechodzącego przez więcej niż 1 punkt.
+
+circle-radius-too-small = Nie można wyznaczyć okręgu: skoro odległość między dwoma punktami wynosi { $distance }, podany promień { $radius } jest za mały.
+
+circle-radius-with-many-points = Nie można utworzyć okręgu przechodzącego przez więcej niż dwa punkty przy podanym promieniu.
+
+circle-invalid-center-or-through-points = Nieprawidłowy środek albo punkty przejścia okręgu.
+
+circle-radius-center-with-multiple-points = Nie można wyznaczyć promienia okręgu o podanym środku przechodzącego przez więcej niż 1 punkt.
+
+circle-change-radius-non-numerical = Nie można zmienić promienia okręgu, którego punkty przejścia nie są liczbowe
+
+circle-radius-with-points-non-numerical = Nie można utworzyć okręgu przechodzącego przez więcej niż jeden punkt przy podanym promieniu, gdy brak wartości liczbowych.
+
+circle-change-center-non-numerical = Nie zaimplementowano jeszcze zmiany środka okręgu przechodzącego przez punkty nieliczbowe.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Niewystarczające wymiary dziedziny funkcji. Dziedzina ma { $intervals } przedziałów, a funkcja ma { $inputs } argumentów.
+
+function-domain-invalid-format = Nieprawidłowy format dziedziny funkcji.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ignorowanie nieliczbowego maksimum funkcji.
+        [minimum] Ignorowanie nieliczbowego minimum funkcji.
+        [extremum] Ignorowanie nieliczbowego ekstremum funkcji.
+        [point] Ignorowanie nieliczbowego punktu funkcji.
+        [slope] Ignorowanie nieliczbowego nachylenia funkcji.
+       *[other] Ignorowanie nieliczbowego { $type } funkcji.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ignorowanie pustego maksimum funkcji.
+        [minimum] Ignorowanie pustego minimum funkcji.
+        [extremum] Ignorowanie pustego ekstremum funkcji.
+        [point] Ignorowanie pustego punktu funkcji.
+       *[other] Ignorowanie pustego { $type } funkcji.
+    }
+
+function-points-too-close = Funkcja zawiera dwa punkty położone zbyt blisko siebie. Nie można zdefiniować funkcji.
+
+function-iterates-input-output-mismatch = Iterowanie funkcji jest możliwe tylko wtedy, gdy liczba argumentów równa się liczbie wartości. Ta funkcja ma { $inputs } argumentów i { $outputs } wartości.
+
+## `<sequence>`
+
+sequence-invalid-length = Nieprawidłowa długość ciągu. Musi to być nieujemna liczba całkowita.
+
+sequence-invalid-step = Nieprawidłowy krok ciągu. Dla ciągu typu { $type } musi to być liczba.
+
+sequence-invalid-endpoint-number = Nieprawidłowe „{ $attribute }” w ciągu liczbowym. Musi to być liczba.
+
+sequence-invalid-endpoint-letters = Nieprawidłowe „{ $attribute }” w ciągu liter. Musi to być kombinacja liter.
+
+sequence-invalid-endpoint = Nieprawidłowe „{ $attribute }” w ciągu.
+
+select-from-sequence-coprime-not-numbers = coprime zignorowane, ponieważ nie są wybierane liczby
+
+select-from-sequence-coprime-with-exclude-combinations = coprime zignorowane, ponieważ podano excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Nieprawidłowy target dla `<{ $source }>`: nie znaleziono celu.
+
+target-state-variable-not-found = Nieprawidłowy target dla `<{ $source }>`: nie znaleziono zmiennej stanu o nazwie „{ $property }” w `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Zmienne `<odeSystem>` muszą różnić się od zmiennej niezależnej.
+
+ode-system-duplicate-variable-names = Nie można zdefiniować prawych stron równań ODE przy powtarzających się nazwach zmiennych zależnych.
+
+ode-system-rhs-function-error = Nie można zdefiniować prawej strony równania ODE. Błąd podczas tworzenia funkcji mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Nie można zdefiniować kąta między { $count } prostymi
+
+angle-invalid-through-point = Nieprawidłowy punkt w through elementu `<angle>`
+
+parabola-vertex-too-many-points = Nie zaimplementowano jeszcze paraboli o podanym wierzchołku przechodzącej przez więcej niż 1 punkt.
+
+parabola-too-many-points = Nie zaimplementowano jeszcze paraboli przechodzącej przez więcej niż 3 punkty.
+
+intersection-too-many-items = Nie zaimplementowano jeszcze przecięcia więcej niż dwóch obiektów
+
+## Other math components
+
+ionic-compound-not-two-ions = Nie zaimplementowano jeszcze związku jonowego o liczbie jonów innej niż dwa.
+
+ionic-compound-needs-cation-and-anion = Związek jonowy zaimplementowano tylko dla jednego kationu i jednego anionu.
+
+solve-equations-cannot-evaluate = Nie można rozwiązać równania, ponieważ nie udało się go obliczyć: { $equation }
+
+math-operators-operand-number-required = Przy wyodrębnianiu argumentu matematycznego trzeba podać operandNumber.
+
+eigen-decomposition-failed = Nie udało się obliczyć wartości własnych macierzy
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parametr { $parameters } nie występuje we wzorcu, więc zawsze dopasuje pustą wartość.
+       *[other] `<matchesPattern>`: parametry { $parameters } nie występują we wzorcu, więc zawsze dopasują pustą wartość.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: nie można zinterpretować grid="{ $grid }". Musi to być none, medium, dense albo dwie liczby dodatnie oddzielone spacją, na przykład grid="1 0.5". Siatka nie jest rysowana.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" nie jest obsługiwane w rendererze prefigure; używane jest zachowanie dla pozycji po prawej.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" nie jest obsługiwane w rendererze prefigure; używane jest zachowanie dla pozycji u góry.
+
+prefigure-invalid-axis-bounds = `<graph>`: nieprawidłowe granice osi dla konwersji prefigure; używane jest domyślne bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: nieprawidłowa szerokość dla konwersji prefigure; używana jest domyślna szerokość rysunku 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: nieprawidłowe aspectRatio dla konwersji prefigure; używane są domyślne proporcje 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: odstęp siatki jest zbyt gęsty względem zakresu osi; siatka jest pomijana w rendererze prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: adnotacje nie będą rysowane, gdy nie jest używany renderer PreFigure.
+
+multiple-annotations-children = Znaleziono wiele elementów potomnych `<annotations>` w `<graph>`; wszystkie poza ostatnim są ignorowane.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Nie można rozszerzyć ani skopiować nierozpoznanego typu komponentu: { $type }.
+
+copy-prop-not-found = Nie znaleziono właściwości { $property } w komponencie typu { $component }
+
+collect-no-source = Nie znaleziono źródła dla collect.
+
+collect-invalid-component-type = Nie można zebrać komponentów typu `<{ $component }>`, ponieważ nie jest to prawidłowy typ komponentu.
+
+reference-index-unavailable = Nie można odwołać się do indeksu `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Nie można wywołać { $action } w komponencie `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Dane mają nieprawidłowy kształt. Wiersze mają niejednakowe długości. Znaleziono w componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Dane zawierają powtarzające się nazwy kolumn. Znaleziono w componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = W danych brakuje nazwy kolumny. Znaleziono w componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Element award tej odpowiedzi opiera się na odpowiedzi wysłanej przez sam znacznik answer, co doprowadzi do nieoczekiwanego działania.
+
+answer-max-num-attempts-in-section-wide-check-work = Ustawienie `maxNumAttempts` w `<answer>` wewnątrz kontenera z `sectionWideCheckWork` nie działa, ponieważ liczbę prób kontroluje kontener. Ustaw `maxNumAttempts` na kontenerze.
+
+nested-section-wide-check-work-max-num-attempts = Ustawienie `maxNumAttempts` na kontenerze z `sectionWideCheckWork`, który znajduje się wewnątrz innego kontenera z `sectionWideCheckWork`, nie działa, ponieważ liczbę prób kontroluje kontener zewnętrzny. Ustaw `maxNumAttempts` na kontenerze zewnętrznym.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Atrybut { $attributes } nie zadziała bez ustawionego symbolicEquality.
+       *[other] Atrybuty { $attributes } nie zadziałają bez ustawionego symbolicEquality.
+    }
+
+answer-invalid-type = Nieprawidłowy typ dla answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ponieważ komponent `<{ $component }>` nie ma nazwy, nie można go użyć jako atrybutu modułu
+
+module-attribute-name-already-defined = Komponentu `<{ $component } name="{ $name }">` nie można użyć jako atrybutu modułu, ponieważ typ komponentu `<module>` ma już zdefiniowany atrybut „{ $name }”.
+
+conditional-content-condition-ignored = Atrybut `condition` jest ignorowany w komponencie `<conditionalContent>` mającym elementy potomne case albo else.
+
+slider-markers-type-mismatch = Typ znaczników nie odpowiada typowi suwaka.
+
+pretzel-problem-needs-statement-and-answer = Nieprawidłowy pretzel: każdy `<problem>` musi zawierać jeden `<statement>` i jeden `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Nieprawidłowy pretzel: w mode="circuit" pierwszy `<problem>` nie może być dystraktorem.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Nieprawidłowa wartość { $values } atrybutu `{ $attribute }`; zignorowano.
+       *[other] Nieprawidłowe wartości { $values } atrybutu `{ $attribute }`; zignorowano.
+    }
+
+attribute-must-be-references = Nieprawidłowa wartość `{ $value }` atrybutu `{ $attribute }`. Atrybut musi składać się z odwołań zaczynających się od `$`.
+
+math-input-invalid-function-names = <mathInput>: zignorowano nieprawidłowe nazwy funkcji w { $attribute }: { $names }. Widoczna część każdej nazwy musi mieć co najmniej 2 znaki (litery albo myślniki); może po niej wystąpić opcjonalny przyrostek `|<alternatywa mathspeak>`.
+
+## Building components from the source
+
+component-type-invalid = Nieprawidłowy typ komponentu: `<{ $componentType }>`
+
+attribute-repeated = Nie można powtórzyć atrybutu { $attribute }.
+
+attribute-invalid-for-component = Nieprawidłowy atrybut „{ $attribute }” dla komponentu typu `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Definicja stylu { $styleNumber } ma niewystarczający kontrast dla { $context ->
+        [text-on-background] koloru tekstu względem koloru tła
+        [high-contrast] koloru o wysokim kontraście względem płótna
+        [line] koloru linii względem płótna
+        [marker] koloru znacznika względem płótna
+       *[text-on-canvas] koloru tekstu względem płótna
+    }{ $mode ->
+        [dark] { " (tryb ciemny)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; wymagane co najmniej { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Choć definicja stylu { $styleNumber } podaje kolory o wystarczającym kontraście dla trybu jasnego, kolory trybu ciemnego wyprowadzone z tych wartości mają niewystarczający kontrast między kolorem tekstu a kolorem tła ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; wymagane co najmniej { $threshold }:1). { $suggestion ->
+        [available] Aby zapewnić wystarczający kontrast w trybie ciemnym, zwiększ kontrast trybu jasnego (na przykład ustaw { $lightAttribute }="{ $lightColor }") albo nadpisz kolor trybu ciemnego (na przykład ustaw { $darkAttribute }="{ $darkColor }").
+       *[none] Aby zapewnić wystarczający kontrast w trybie ciemnym, zwiększ kontrast trybu jasnego albo nadpisz wyprowadzone kolory za pomocą textColorDarkMode i/lub backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Choć definicja stylu { $styleNumber } podaje kolor tekstu o wystarczającym kontraście dla trybu jasnego, kolor tekstu trybu ciemnego wyprowadzony z tej wartości ma niewystarczający kontrast względem płótna ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; wymagane co najmniej { $threshold }:1). { $suggestion ->
+        [available] Aby zapewnić wystarczający kontrast w trybie ciemnym, zwiększ kontrast trybu jasnego (na przykład ustaw textColor="{ $lightColor }") albo nadpisz kolor trybu ciemnego (na przykład ustaw textColorDarkMode="{ $darkColor }").
+       *[none] Aby zapewnić wystarczający kontrast w trybie ciemnym, zwiększ kontrast trybu jasnego albo nadpisz wyprowadzony kolor za pomocą textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Sekcja może wybrać tylko jeden <stylePalette>; używany jest ostatni.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = nie można ustalić unikatowych wariantów { $component }, ponieważ numToSelect nie jest nieujemną liczbą całkowitą.
+
+variant-num-to-select-not-constant-number = nie można ustalić unikatowych wariantów { $component }, ponieważ numToSelect nie jest stałą.
+
+variant-with-replacement-not-constant-boolean = nie można ustalić unikatowych wariantów { $component }, ponieważ withReplacement nie jest stałą wartością logiczną.
+
+variant-select-weight-disables-unique = unikatowe warianty select są wyłączone, jeśli któraś opcja podaje selectWeight albo selectForVariants
+
+variant-coprime-undetermined = nie można ustalić unikatowych wariantów { $component }, ponieważ nie da się stwierdzić, że coprime jest zawsze fałszywe.
+
+variant-attribute-not-constant = nie można ustalić unikatowych wariantów { $component }, ponieważ { $attribute } nie jest stałą.
+
+variant-attribute-not-number = nie można ustalić unikatowych wariantów { $component }, ponieważ { $attribute } nie jest liczbą.
+
+variant-attribute-wrong-type-for-sequence =
+    nie można ustalić unikatowych wariantów { $component } typu { $type }, ponieważ { $attribute } nie jest { $expected ->
+        [letters-combination] kombinacją liter
+        [math-expression] prawidłowym wyrażeniem matematycznym
+        [integer] liczbą całkowitą
+       *[number] liczbą
+    }.
+
+variant-length-not-integer = nie można ustalić unikatowych wariantów { $component }, ponieważ length nie jest liczbą całkowitą.
+
+variant-sort-not-implemented = nie zaimplementowano jeszcze unikatowych wariantów { $component } z sort
+
+variant-exclude-combinations-not-implemented = nie zaimplementowano jeszcze unikatowych wariantów { $component } z excludeCombinations
+
+variant-math-exclude-not-implemented = nie zaimplementowano jeszcze unikatowych wariantów { $component } typu math z exclude
+
+variant-non-constant-exclude-not-implemented = nie zaimplementowano jeszcze unikatowych wariantów { $component } z niestałym exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: nieobsługiwane w rendererze prefigure wykresu; element potomny pominięty.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometria nieskończona albo niepełna; element potomny pominięty.
+
+prefigure-curve-label-omitted = { $subject }: przekształcone elementy krzywej nie obsługują etykiet; etykieta pominięta.
+
+prefigure-curve-unsupported-definition-type = { $subject }: nieobsługiwany typ definicji funkcji krzywej „{ $definitionType }”; element potomny pominięty.
+
+prefigure-region-flip-functions-unsupported = { $subject }: nieobsługiwany atrybut flipFunctions w regionBetweenCurves; element potomny pominięty.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves obsługuje tylko funkcje potomne typu formuła; element potomny pominięty.
+
+prefigure-label-position-unsupported =
+    { $subject }: nieobsługiwane labelPosition „{ $labelPosition }” dla { $labelKind ->
+        [line-family] etykiety rodziny prostych
+       *[point] etykiety punktu
+    }; używane jest domyślne wyrównanie PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: styl wypełnienia „{ $fillStyle }” nie jest obsługiwany przez PreFigure; użyto wypełnienia jednolitego.
+
+prefigure-line-style-unknown = { $subject }: nieznany styl linii „{ $lineStyle }” pominięto w wyniku PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: styl znacznika „{ $markerStyle }” odwzorowano na styl „diamond” w PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: styl znacznika „{ $markerStyle }” nie jest obsługiwany przez PreFigure; użyto stylu domyślnego.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: nieprawidłowe `ref`; nie można ustalić celu. Adnotacja pominięta.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` wskazuje wiele celów; użyto pierwszego.
+
+annotation-ref-outside-graph = `<annotation>`: nieprawidłowe `ref`; cel znajduje się poza wykresem, który go zawiera. Adnotacja pominięta.
+
+annotation-ref-unsupported-target = `<annotation>`: nieprawidłowe `ref`; w konwersji prefigure cel nie jest obsługiwanym obiektem graficznym. Adnotacja pominięta.
+
+annotation-text-missing = `<annotation>`: brak `text` albo jest puste; wypisywany jest pusty tekst.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wykryto zależność cykliczną.
+       *[other] Wykryto zależność cykliczną obejmującą komponent `<{ $componentType }>`.
+    }
+
+reference-no-referent = Nie znaleziono obiektu dla odwołania: `{ $reference }`
+
+reference-multiple-referents = Znaleziono wiele obiektów dla odwołania: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Nieprawidłowy format atrybutu { $attribute } elementu `<{ $componentType }>`.
+
+children-invalid = Nieprawidłowe elementy potomne `<{ $componentType }>`: znaleziono nieprawidłowe elementy potomne: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nieprawidłowa wartość `{ $value }` atrybutu `{ $attribute }`; używana jest wartość `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Nie znaleziono wersji { $version } DoenetML.
+       *[other] Nie znaleziono wersji { $version } DoenetML. Powrót do wersji { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Nieprawidłowy DoenetML: { $content }
+
+parse-tag-missing-close-tag = Nieprawidłowy DoenetML: znacznik `{ $tag }` nie ma znacznika zamykającego. Oczekiwano znacznika samozamykającego albo znacznika `</{ $tagName }>`.
+
+parse-tag-error = Nieprawidłowy DoenetML: błąd w znaczniku `<{ $tagName }>`
+
+parse-attribute-missing-value = Nieprawidłowy DoenetML: atrybutowi `{ $attribute }` zdaje się brakować wartości.
+
+parse-attribute-invalid = Nieprawidłowy DoenetML: nieprawidłowy atrybut `{ $attribute }`
+
+parse-attribute-value-invalid = Nieprawidłowy DoenetML: nieprawidłowa wartość atrybutu `{ $value }`
+
+parse-attribute-value-quote-mismatch = Nieprawidłowy DoenetML: nieprawidłowa wartość atrybutu `{ $value }`. Cudzysłowy się nie zgadzają. Zdaje się brakować `{ $quote }`
+
+parse-open-tag-name-missing = Nieprawidłowy DoenetML: znaleziono znacznik bez nazwy, na przykład `<`
+
+parse-tag-not-closed = Nieprawidłowy DoenetML: znacznik `{ $tag }` nie został zamknięty (zdaje się brakować `>`).
+
+parse-self-closing-tag-name-missing = Nieprawidłowy DoenetML: znaleziono znacznik bez nazwy `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Nieprawidłowy DoenetML: znacznik `{ $tag }` nie został zamknięty (zdaje się brakować `/>`).
+
+parse-tag-invalid-attributes = Nieprawidłowy DoenetML: znacznik `{ $tag }` jest nieprawidłowy. Może mieć błędne atrybuty.
+
+parse-close-tag-name-missing = Nieprawidłowy DoenetML: znaleziono znacznik zamykający bez nazwy, na przykład `</`
+
+parse-attribute-value-unquoted = Wartości atrybutów muszą być ujęte w cudzysłowy: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Nieprawidłowy DoenetML: znaleziono znacznik zamykający `{ $tag }`, ale bez odpowiadającego mu znacznika otwierającego
+
+parse-close-tag-mismatched = Nieprawidłowy DoenetML: niedopasowany znacznik zamykający. Oczekiwano `</{ $expected }>`. Znaleziono `{ $found }`
+
+parser-node-unconvertible = Nie udało się przekształcić węzła { $node } w węzeł Dast.
+
+## Names
+
+name-attribute-invalid =
+    Nieprawidłowy atrybut name='{ $name }'. { $reason ->
+        [characters] Nazwy mogą zawierać tylko litery, cyfry, podkreślenia albo myślniki.
+       *[start] Nazwy muszą zaczynać się od litery.
+    }
+
+component-name-invalid-start = Nieprawidłowa nazwa komponentu „{ $name }”. Nazwy muszą zaczynać się od litery.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = answer typu videoWatched musi mieć atrybut video
+
+answer-video-watched-video-not-reference = answer typu videoWatched musi mieć atrybut video będący odwołaniem
+
+answer-name-not-single-text = Atrybut name elementu answer musi mieć dokładnie jeden tekstowy element potomny
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Nie można pobrać zewnętrznego DoenetML z powodu zbyt wielu poziomów rekurencji. Czy nie ma odwołania cyklicznego?
+
+external-doenetml-unavailable = Nie można pobrać DoenetML z { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Nieprawidłowy DoenetML pobrany z { $attribute }="{ $uri }": nie odpowiada typowi komponentu „{ $componentType }”
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atrybut `{ $from }` jest przestarzały; użyj `{ $to }`.
+       *[other] [deprecation] Atrybut `{ $from }` w `<{ $component }>` jest przestarzały; użyj `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atrybut `{ $from }` jest przestarzały i został zignorowany, ponieważ podano również `{ $to }`.
+       *[other] [deprecation] Atrybut `{ $from }` w `<{ $component }>` jest przestarzały i został zignorowany, ponieważ podano również `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atrybut `{ $attribute }` w `<{ $component }>` jest przestarzały i został zignorowany.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` potrafi tworzyć liczbę mnogą tylko po angielsku, więc w dokumencie napisanym w języku { $locale } tekst pozostaje bez zmian. Zapisz formę mnogą wprost albo podaj ją atrybutem `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Element `<{ $tag }>` nie jest rozpoznawanym elementem Doenet.
+
+schema-element-not-allowed-at-root = Element `<{ $tag }>` nie jest dozwolony w korzeniu dokumentu.
+
+schema-element-not-allowed-inside = Element `<{ $tag }>` nie jest dozwolony wewnątrz `<{ $parent }>`.
+
+schema-attribute-unrecognized = Element `<{ $tag }>` nie ma atrybutu o nazwie `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atrybut `{ $attribute }` elementu `<{ $tag }>` musi być listą, której każdy element jest jednym z: { $allowed }
+       *[other] Atrybut `{ $attribute }` elementu `<{ $tag }>` musi być jednym z: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nieprawidłowa nazwa wariantu dla select. Nazwa wariantu { $variantName } występuje w { $numOptions } opcjach, ale liczba do wybrania to { $numToSelect }.
+
+select-variant-name-without-options = Dla select podano warianty, ale brak opcji dla możliwej nazwy wariantu: { $variantName }.
+
+select-variant-name-not-possible = Nazwa wariantu { $variantName } podana dla select nie jest możliwą nazwą wariantu.
+
+select-too-few-options = Nie można wybrać { $numToSelect } komponentów spośród zaledwie { $numOptions }.
+
+select-from-sequence-too-few-values = Nie można wybrać { $numToSelect } wartości z ciągu o długości { $length }.
+
+select-from-sequence-indices-count-mismatch = Liczba indeksów podanych dla select musi odpowiadać liczbie do wybrania
+
+select-from-sequence-indices-not-integers = Wszystkie indeksy podane dla select muszą być liczbami całkowitymi
+
+select-from-sequence-index-excluded = Indeks podany dla selectfromsequence był wykluczony
+
+select-from-sequence-indices-excluded-combination = Indeksy podane dla selectfromsequence tworzyły wykluczoną kombinację
+
+select-from-sequence-coprime-not-positive-integers = Nie można wybrać kombinacji względnie pierwszych, ponieważ nie są wybierane dodatnie liczby całkowite.
+
+select-from-sequence-coprime-common-factor = Nie można wybrać liczb względnie pierwszych. Wszystkie możliwe wartości mają wspólny dzielnik. (Podane wartości „from” albo „to” muszą być względnie pierwsze z „step”.)
+
+select-from-sequence-coprime-single-number = Nie można wybrać kombinacji względnie pierwszych z pojedynczej liczby różnej od 1.
+
+select-from-sequence-excluded-too-many-combinations = Wykluczono ponad 70% kombinacji w selectFromSequence
+
+select-from-sequence-coprime-none-found = Nie udało się wybrać liczb względnie pierwszych. Wszystkie możliwe wartości mają wspólny dzielnik.
+
+select-from-sequence-too-few-unique-values = Nie można wybrać { $numToSelect } różnych wartości z ciągu o długości { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Nie można wybrać { $numToSelect } wartości z listy liczb pierwszych o długości { $numValues }
+
+select-prime-numbers-values-count-mismatch = Liczba wartości podanych dla select musi odpowiadać liczbie do wybrania
+
+select-prime-numbers-values-not-prime = Wszystkie wartości podane dla select prime number muszą znajdować się na liście liczb pierwszych
+
+select-prime-numbers-values-excluded-combination = Wartości podane dla selectPrimeNumbers tworzyły wykluczoną kombinację
+
+select-prime-numbers-excluded-too-many-combinations = Wykluczono ponad 70% kombinacji w selectPrimeNumbers
+
+select-random-combination-fluke = Przez skrajnie nieprawdopodobny zbieg okoliczności nie udało się wybrać kombinacji wartości losowych
+
+select-random-value-fluke = Przez skrajnie nieprawdopodobny zbieg okoliczności nie udało się wybrać wartości losowej

--- a/packages/i18n/locales/pl/diagnostics.ftl
+++ b/packages/i18n/locales/pl/diagnostics.ftl
@@ -11,8 +11,13 @@
 # English exactly as written. So does anything quoted back from the author's
 # own source.
 #
-# Polish has four plural categories; every countable message below selects on
-# all of them.
+# Polish counts in four plural categories, and which of them a message needs
+# depends on what the count does in it. A message that prints the number next
+# to a noun has to agree that noun with it, so it spells out `one`, `few` and
+# `many` and lets `*[other]` carry the fractional values CLDR routes there. A
+# message where the number never appears — the list messages, whose count only
+# decides whether a verb is singular or plural — has just the two forms Polish
+# offers there, so `one` and `*[other]` are the whole selection.
 
 ## `<lineSegment>`
 
@@ -140,7 +145,15 @@ accessibility-section-title-insufficient-contrast =
 
 ## `<circle>`
 
-circle-through-points-non-numerical = Nie zaimplementowano jeszcze `<circle>` przechodzącego przez { $count } punktów, gdy punkty nie mają wartości liczbowych.
+# «przez» governs the accusative, and the negation in front of it does not
+# reach inside a prepositional phrase — so the count still selects, and 2–4
+# (which is what a circle through points actually gets) needs «punkty».
+circle-through-points-non-numerical =
+    { $count ->
+        [one] Nie zaimplementowano jeszcze `<circle>` przechodzącego przez { $count } punkt, gdy punkty nie mają wartości liczbowych.
+        [few] Nie zaimplementowano jeszcze `<circle>` przechodzącego przez { $count } punkty, gdy punkty nie mają wartości liczbowych.
+       *[other] Nie zaimplementowano jeszcze `<circle>` przechodzącego przez { $count } punktów, gdy punkty nie mają wartości liczbowych.
+    }
 
 circle-too-many-through-points = Nie można wyznaczyć okręgu przechodzącego przez więcej niż 3 punkty.
 
@@ -164,7 +177,33 @@ circle-change-center-non-numerical = Nie zaimplementowano jeszcze zmiany środka
 
 ## `<function>`
 
-function-domain-insufficient-dimensions = Niewystarczające wymiary dziedziny funkcji. Dziedzina ma { $intervals } przedziałów, a funkcja ma { $inputs } argumentów.
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Niewystarczające wymiary dziedziny funkcji. Dziedzina ma { $intervals } przedział, a funkcja ma { $inputs ->
+            [one] { $inputs } argument
+            [few] { $inputs } argumenty
+            [many] { $inputs } argumentów
+           *[other] { $inputs } argumentu
+        }.
+        [few] Niewystarczające wymiary dziedziny funkcji. Dziedzina ma { $intervals } przedziały, a funkcja ma { $inputs ->
+            [one] { $inputs } argument
+            [few] { $inputs } argumenty
+            [many] { $inputs } argumentów
+           *[other] { $inputs } argumentu
+        }.
+        [many] Niewystarczające wymiary dziedziny funkcji. Dziedzina ma { $intervals } przedziałów, a funkcja ma { $inputs ->
+            [one] { $inputs } argument
+            [few] { $inputs } argumenty
+            [many] { $inputs } argumentów
+           *[other] { $inputs } argumentu
+        }.
+       *[other] Niewystarczające wymiary dziedziny funkcji. Dziedzina ma { $intervals } przedziału, a funkcja ma { $inputs ->
+            [one] { $inputs } argument
+            [few] { $inputs } argumenty
+            [many] { $inputs } argumentów
+           *[other] { $inputs } argumentu
+        }.
+    }
 
 function-domain-invalid-format = Nieprawidłowy format dziedziny funkcji.
 
@@ -189,7 +228,33 @@ function-ignoring-empty =
 
 function-points-too-close = Funkcja zawiera dwa punkty położone zbyt blisko siebie. Nie można zdefiniować funkcji.
 
-function-iterates-input-output-mismatch = Iterowanie funkcji jest możliwe tylko wtedy, gdy liczba argumentów równa się liczbie wartości. Ta funkcja ma { $inputs } argumentów i { $outputs } wartości.
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Iterowanie funkcji jest możliwe tylko wtedy, gdy liczba argumentów równa się liczbie wartości. Ta funkcja ma { $inputs } argument i { $outputs ->
+            [one] { $outputs } wartość
+            [few] { $outputs } wartości
+            [many] { $outputs } wartości
+           *[other] { $outputs } wartości
+        }.
+        [few] Iterowanie funkcji jest możliwe tylko wtedy, gdy liczba argumentów równa się liczbie wartości. Ta funkcja ma { $inputs } argumenty i { $outputs ->
+            [one] { $outputs } wartość
+            [few] { $outputs } wartości
+            [many] { $outputs } wartości
+           *[other] { $outputs } wartości
+        }.
+        [many] Iterowanie funkcji jest możliwe tylko wtedy, gdy liczba argumentów równa się liczbie wartości. Ta funkcja ma { $inputs } argumentów i { $outputs ->
+            [one] { $outputs } wartość
+            [few] { $outputs } wartości
+            [many] { $outputs } wartości
+           *[other] { $outputs } wartości
+        }.
+       *[other] Iterowanie funkcji jest możliwe tylko wtedy, gdy liczba argumentów równa się liczbie wartości. Ta funkcja ma { $inputs } argumentu i { $outputs ->
+            [one] { $outputs } wartość
+            [few] { $outputs } wartości
+            [many] { $outputs } wartości
+           *[other] { $outputs } wartości
+        }.
+    }
 
 ## `<sequence>`
 
@@ -415,7 +480,7 @@ variant-non-constant-exclude-not-implemented = nie zaimplementowano jeszcze unik
 
 prefigure-descendant-unsupported = { $subject }: nieobsługiwane w rendererze prefigure wykresu; element potomny pominięty.
 
-prefigure-descendant-invalid-geometry = { $subject }: geometria nieskończona albo niepełna; element potomny pominięty.
+prefigure-descendant-invalid-geometry = { $subject }: nieskończone lub niepełne wartości geometryczne; element potomny pominięty.
 
 prefigure-curve-label-omitted = { $subject }: przekształcone elementy krzywej nie obsługują etykiet; etykieta pominięta.
 

--- a/packages/i18n/locales/pl/editor.ftl
+++ b/packages/i18n/locales/pl/editor.ftl
@@ -1,0 +1,218 @@
+# Polish editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Polish has four plural categories; every countable message below selects on
+# all of them.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Resetuj
+       *[update] Odśwież
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } podgląd
+       *[other] { $word } podgląd { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Wariant
+editor-variant-filter = Filtruj...
+editor-variant-next = Wybierz następny wariant
+editor-variant-previous = Wybierz poprzedni wariant
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wykryto naruszenie dostępności WCAG AA. Kliknij, aby { $action ->
+            [close] zamknąć
+           *[open] otworzyć
+        } raport dostępności.
+        [advisories] Kliknij, aby { $action ->
+            [close] zamknąć
+           *[open] otworzyć
+        } raport dostępności. Nie znaleziono naruszeń WCAG AA, ale są dodatkowe zalecenia dotyczące dostępności.
+       *[clean] Kliknij, aby { $action ->
+            [close] zamknąć
+           *[open] otworzyć
+        } raport dostępności. Nie znaleziono problemów z dostępnością.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wykryto naruszenie dostępności WCAG AA. Znaleziono { $count ->
+            [one] { $count } naruszenie WCAG AA
+            [few] { $count } naruszenia WCAG AA
+            [many] { $count } naruszeń WCAG AA
+           *[other] { $count } naruszenia WCAG AA
+        }. Kliknij, aby { $action ->
+            [close] zamknąć
+           *[open] otworzyć
+        } raport dostępności.
+        [advisories] Nie wykryto naruszeń WCAG AA. Znaleziono { $count ->
+            [one] { $count } dodatkowe zalecenie dotyczące dostępności
+            [few] { $count } dodatkowe zalecenia dotyczące dostępności
+            [many] { $count } dodatkowych zaleceń dotyczących dostępności
+           *[other] { $count } dodatkowego zalecenia dotyczącego dostępności
+        }. Kliknij, aby { $action ->
+            [close] zamknąć
+           *[open] otworzyć
+        } raport dostępności.
+       *[clean] Nie wykryto naruszeń WCAG AA. Kliknij, aby { $action ->
+            [close] zamknąć
+           *[open] otworzyć
+        } raport dostępności.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML wersja { $version }
+
+editor-tab-help = Pomoc kontekstowa
+editor-tab-help-short = Kontekst
+editor-tab-errors = Błędy
+editor-tab-warnings = Ostrzeżenia
+editor-tab-info = Informacje
+editor-tab-accessibility = Dostępność
+editor-tab-responses = Wysłane odpowiedzi
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opcje edytora
+editor-format-as-doenetml = Formatuj jako DoenetML
+editor-format-as-xml = Formatuj jako XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Wiersz #{ $line }
+
+editor-no-errors = Brak błędów
+editor-no-warnings = Brak ostrzeżeń
+editor-no-info = Brak diagnostyki informacyjnej
+
+editor-show-info-annotations = Pokaż diagnostykę informacyjną w edytorze
+editor-show-accessibility-annotations = Pokaż diagnostykę dostępności w edytorze
+
+editor-accessibility-learn-more = Dowiedz się, jak Doenet podchodzi do dostępności
+
+editor-accessibility-violations-heading = Naruszenia dostępności ({ $standard })
+
+editor-accessibility-other-heading = Inne problemy z dostępnością
+editor-none-found = Nic nie znaleziono
+
+
+## Submitted responses
+
+editor-no-responses = Nie wysłano jeszcze żadnych odpowiedzi
+editor-response-answer-id = Answer Id
+editor-response-response = Odpowiedź
+editor-response-credit = Punkty
+editor-response-submitted = Wysłano
+
+
+## The context-help panel
+
+help-placeholder = Ustaw kursor na nazwie znacznika, atrybucie lub { $ref }, aby zobaczyć dokumentację.
+
+help-unsupported-ref-chain = Pomoc dla odwołań wieloczłonowych, takich jak { $example }, nie jest jeszcze obsługiwana.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Nie znaleziono obiektu dla odwołania: { $ref }.
+        [multiple] Znaleziono wiele obiektów dla odwołania: { $ref }.
+       *[indeterminate] Nie można ustalić obiektu dla { $ref }.
+    }
+
+help-learn-about-references = Dowiedz się więcej o odwołaniach →
+help-reference-page = Strona referencyjna →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Wewnątrz { $element }
+       *[top] Na najwyższym poziomie
+    }{ $allowed ->
+        [none] { " — nic tu nie może się znaleźć." }
+        [text] { " — można tu wpisać tekst." }
+        [text-and-components] { " — można tu wpisać tekst albo spróbować:" }
+       *[components] { " — do wypróbowania:" }
+    }
+
+help-suggestions-footer = Naciśnij { $shortcut }, aby zobaczyć wszystkie komponenty ({ $total }).
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } to odwołanie do { $target }.
+       *[other] { $ref } to odwołanie do { $target } (wiersz { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Wprowadzone przez { $owner } jako { $role }.
+       *[other] Wprowadzone przez { $owner } w wierszu { $line } jako { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } to odwołanie do właściwości { $property } elementu { $element }.
+       *[other] { $ref } to odwołanie do właściwości { $property } elementu { $element } (wiersz { $line }).
+    }
+
+help-kind-attribute = atrybut
+help-kind-snippet = fragment kodu
+help-kind-array-entry = element tablicy
+
+help-default = Domyślnie:
+help-active-default = Obowiązująca wartość domyślna:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Dozwolone wartości (po jednej na element):
+       *[other] Dozwolone wartości:
+    }
+
+help-suggested-values = Sugerowane wartości:
+
+help-inserts = Wstawia:
+
+help-coordinates =
+    { $count ->
+        [one] Współrzędna:
+       *[other] Współrzędne:
+    }
+
+help-type = Typ:
+
+help-resolved-style = Ustalony styl (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Ustalone nazwy funkcji:
+help-reset-list = Lista resetowania dla tego pola:
+help-added-on-input = Dodane w tym polu:
+help-removed-on-input = Usunięte w tym polu:
+
+help-reset-overrides = { $reset } ma pierwszeństwo przed { $additional } i { $removed }.

--- a/packages/i18n/locales/pl/editor.ftl
+++ b/packages/i18n/locales/pl/editor.ftl
@@ -11,8 +11,13 @@
 # `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
 # name are identifiers, not prose, and stay as written.
 #
-# Polish has four plural categories; every countable message below selects on
-# all of them.
+# Polish counts in four plural categories, and which of them a message needs
+# depends on what the count does in it. A message that prints the number next
+# to a noun has to agree that noun with it, so it spells out `one`, `few` and
+# `many` and lets `*[other]` carry the fractional values CLDR routes there. A
+# message where the number never appears — the list messages, whose count only
+# decides whether a verb is singular or plural — has just the two forms Polish
+# offers there, so `one` and `*[other]` are the whole selection.
 
 
 ## The viewer's controls
@@ -126,7 +131,7 @@ editor-none-found = Nic nie znaleziono
 ## Submitted responses
 
 editor-no-responses = Nie wysłano jeszcze żadnych odpowiedzi
-editor-response-answer-id = Answer Id
+editor-response-answer-id = Id odpowiedzi
 editor-response-response = Odpowiedź
 editor-response-credit = Punkty
 editor-response-submitted = Wysłano

--- a/packages/i18n/locales/pt/chrome.ftl
+++ b/packages/i18n/locales/pt/chrome.ftl
@@ -1,0 +1,139 @@
+# Portuguese viewer chrome. Translated from `locales/en/chrome.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Brazilian Portuguese, which is what a bare `pt` means — see the note at the
+# head of `content.ftl`.
+#
+# Controls are labelled with the bare imperative, which is what Portuguese puts
+# on a button: `Abrir teclado`, not `Abra o teclado`.
+
+
+## Answer submission
+
+answer-checking = Verificando...
+answer-submitting = Enviando...
+
+answer-checking-status = Verificando a resposta
+answer-submitting-status = Enviando a resposta
+
+answer-correct = Correto
+answer-incorrect = Incorreto
+
+answer-response-saved = Resposta salva
+
+answer-percent-credit = { $percent }% de nota
+answer-percent-correct = { $percent }% correto
+answer-percent-short = { $percent }%
+
+max-credit-available = Nota máxima disponível: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] nenhuma tentativa restante
+        [one] { $count } tentativa restante
+       *[other] { $count } tentativas restantes
+    }
+
+validation-correct = (Correto)
+validation-incorrect = (Incorreto)
+validation-partially-correct = (Parcialmente correto)
+
+answer-show-responses =
+    { $count ->
+        [one] Mostrar { $count } resposta de { $answerId }
+       *[other] Mostrar { $count } respostas de { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Comentários
+
+collapsible-click-to-open = (clique para abrir)
+collapsible-click-to-close = (clique para fechar)
+
+collapsible-initializing = Inicializando...
+
+footnote-show = Mostrar nota de rodapé
+footnote-hide = Ocultar nota de rodapé
+
+description-more-information = mais informações
+
+
+## Controls
+
+slider-previous = Anterior
+slider-next = Próximo
+
+keyboard-open = Abrir teclado
+keyboard-close = Fechar teclado
+
+matrix-remove-row = Remover linha
+matrix-add-row = Adicionar linha
+matrix-remove-column = Remover coluna
+matrix-add-column = Adicionar coluna
+
+subset-add-remove-points = Adicionar/remover pontos
+subset-toggle-points-intervals = Alternar entre pontos e intervalos
+subset-move-points = Mover pontos
+subset-clear = Limpar
+
+# A `box` here is one orbital, drawn as a square: caixa.
+orbital-add-row = Adicionar linha
+orbital-remove-row = Remover linha
+orbital-add-box = Adicionar caixa
+orbital-remove-box = Remover caixa
+orbital-add-up-arrow = Adicionar seta para cima
+orbital-add-down-arrow = Adicionar seta para baixo
+orbital-remove-arrow = Remover seta
+
+orbital-row-label = Rótulo da linha { $row }
+
+pretzel-answer = Resposta
+
+summary-statistics-caption = Estatísticas descritivas de { $column }
+
+
+## Math input
+
+math-input-preview-region = pré-visualização da expressão matemática
+math-input-preview = Pré-visualização
+math-input-invalid-expression = Expressão inválida:
+
+
+## Document status
+
+viewer-initializing = Inicializando...
+
+
+## Errors
+
+error-heading = Erro
+
+error-found-at =
+    { $span ->
+        [line] Encontrado na linha { $startLine }.
+       *[lines] Encontrado nas linhas { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Este documento contém erros!
+
+diagnostic-heading-error = Erro
+diagnostic-heading-warning = Aviso
+diagnostic-heading-information = Informação
+diagnostic-heading-hint = Dica
+
+accessibility-heading-level-1 = Violação de acessibilidade WCAG AA
+accessibility-heading-level-2 = Alerta de acessibilidade
+
+something-went-wrong = Algo deu errado.
+
+renderer-load-failed = um renderizador não pôde ser carregado. Recarregue a página.
+
+core-start-failed = Não foi possível iniciar o visualizador de documentos. Recarregue a página.

--- a/packages/i18n/locales/pt/chrome.ftl
+++ b/packages/i18n/locales/pt/chrome.ftl
@@ -10,8 +10,9 @@
 # Brazilian Portuguese, which is what a bare `pt` means — see the note at the
 # head of `content.ftl`.
 #
-# Controls are labelled with the bare imperative, which is what Portuguese puts
-# on a button: `Abrir teclado`, not `Abra o teclado`.
+# Controls are labelled with the infinitive, which is what Portuguese puts on a
+# button: `Abrir teclado`, not `Abra o teclado`. A sentence addressed to the
+# reader still takes the second person — `Recarregue a página`.
 
 
 ## Answer submission

--- a/packages/i18n/locales/pt/content.ftl
+++ b/packages/i18n/locales/pt/content.ftl
@@ -24,7 +24,7 @@
 # article in `style-border-clause` is `uma`.
 
 
-## Vocabulário de estilos
+## Style vocabulary
 
 color =
     .black =
@@ -84,7 +84,7 @@ line-style =
            *[m] pontilhado
         }
 
-# Sintagmas nominais: vêm depois de «com» e não concordam com nada.
+# Noun phrases: they follow «com» and agree with nothing.
 fill-style =
     .horizontal = linhas horizontais
     .vertical = linhas verticais
@@ -113,18 +113,18 @@ noun =
     .cross = cruz
     .plus = sinal de mais
 
-# O nome divide-se: «polígono regular» leva os adjetivos e «de 5 lados» fecha o
-# sintagma depois deles. Se o complemento viesse antes, os adjetivos ficariam
-# separados do nome com que concordam.
+# The noun is split: «polígono regular» carries the agreement and «de 5 lados»
+# closes the phrase behind the adjectives. Were the complement to come first,
+# the adjectives would be stranded away from the noun they agree with.
 noun-regular-polygon =
     { $part ->
         [tail] de { $numSides } lados
        *[head] polígono regular
     }
 
-# Além dos nomes acima, `$noun` pode ser «regular-polygon» (polígono, m) ou o
-# núcleo de um sintagma que a descrição não nomeia: «border» (borda, f),
-# «fill» (preenchimento, m), «text» (texto, m), «background» (fundo, m).
+# Besides the nouns above, `$noun` can be `regular-polygon` (polígono, m) or
+# the head of a phrase the description never names: `border` (borda, f), `fill`
+# (preenchimento, m), `text` (texto, m), `background` (fundo, m).
 noun-gender =
     { $noun ->
         [line] f
@@ -140,7 +140,7 @@ noun-gender =
     }
 
 
-## Composição de estilos
+## Style composition
 
 style-stroke =
     { $parts ->
@@ -153,7 +153,7 @@ style-stroke =
        *[color] { $color }
     }
 
-# O nome vai à frente e os adjetivos atrás: «linha tracejada grossa vermelha».
+# The noun leads and the adjectives follow: «linha tracejada grossa vermelha».
 style-with-noun =
     { $parts ->
         [noun-tail] { $noun } { $description } { $nounTail }
@@ -172,8 +172,8 @@ style-filled =
        *[plain] { $color } { $filled }
     }
 
-# O complemento fica junto ao nome, e não no fim: «polígono regular de 5 lados
-# azul preenchido».
+# The complement stays beside its own noun rather than at the end: «polígono
+# regular de 5 lados azul preenchido».
 style-filled-with-noun =
     { $parts ->
         [pattern] { $noun } { $color } { $filled } com { $pattern }
@@ -182,8 +182,8 @@ style-filled-with-noun =
        *[plain] { $noun } { $color } { $filled }
     }
 
-# «borda» é feminino, portanto os adjetivos da borda concordam com ela e não
-# com a figura que a rodeia — e o artigo é «uma».
+# «borda» is feminine, so the border's adjectives agree with it and not with
+# the shape it surrounds — and the article is «uma».
 style-border-clause =
     { $parts ->
         [with-article] com uma borda { $border }
@@ -192,7 +192,7 @@ style-border-clause =
        *[with] com borda { $border }
     }
 
-# «de cor» evita ter de concordar a cor com um padrão no plural.
+# «de cor» avoids having to agree the colour with a plural pattern word.
 style-fill =
     { $parts ->
         [pattern] { $pattern } de cor { $color }
@@ -210,19 +210,19 @@ style-text =
 style-background-none = nenhum
 
 
-## Palavras booleanas
+## Boolean words
 
 boolean-true = verdadeiro
 boolean-false = falso
 
 
-## Botões de resposta
+## Answer buttons
 
 answer-submit-label = Verificar
 answer-submit-label-no-correctness = Enviar resposta
 
 
-## Blocos seccionais
+## Sectional blocks
 
 section-name =
     .activity = Atividade
@@ -259,7 +259,7 @@ section-title-prefix =
 hint-title = Dica
 
 
-## Tabelas e figuras
+## Tables and figures
 
 table-name =
     { $parts ->
@@ -278,7 +278,7 @@ figure-name =
     }
 
 
-## Controles do paginador
+## Paginator controls
 
 paginator-previous = Anterior
 paginator-next = Próxima
@@ -287,14 +287,14 @@ paginator-page = Página
 paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
 
 
-## Funções definidas por partes
+## Piecewise functions
 
 piecewise-condition-or = ou
 piecewise-condition-if = se
 piecewise-condition-otherwise = caso contrário
 
 
-## Química
+## Chemistry
 
 element-name =
     .h = Hidrogênio

--- a/packages/i18n/locales/pt/content.ftl
+++ b/packages/i18n/locales/pt/content.ftl
@@ -1,0 +1,436 @@
+# Portuguese content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Brazilian Portuguese, which is what a bare `pt` means: CLDR fills it in as
+# `pt-Latn-BR`. European usage differs enough to be worth its own `pt-PT`
+# catalog one day, and adding one would not disturb this — the split is by
+# region, so `pt`, `pt-AO` and `pt-MZ` all keep reaching this file.
+#
+# Portuguese inflects. Adjectives follow their noun and agree with it in
+# gender, so every adjective below selects on `$gender`, the gender of the noun
+# it describes, and the composition messages put the noun first. Several
+# adjectives are invariable — cinza, laranja, verde, azul, rosa, marrom — and
+# answer the same for both.
+#
+# Portuguese does not inflect an attributive adjective for case, so `$role`
+# goes unread here, exactly as it does in Spanish and English. Only German and
+# Russian select on it.
+#
+# `borda` is feminine, where Spanish's `borde` is masculine — so the border's
+# adjectives agree the other way round from the Spanish catalog, and the
+# article in `style-border-clause` is `uma`.
+
+
+## Vocabulário de estilos
+
+color =
+    .black =
+        { $gender ->
+            [f] preta
+           *[m] preto
+        }
+    .white =
+        { $gender ->
+            [f] branca
+           *[m] branco
+        }
+    .gray = cinza
+    .red =
+        { $gender ->
+            [f] vermelha
+           *[m] vermelho
+        }
+    .orange = laranja
+    .yellow =
+        { $gender ->
+            [f] amarela
+           *[m] amarelo
+        }
+    .green = verde
+    .cyan = ciano
+    .blue = azul
+    .purple =
+        { $gender ->
+            [f] roxa
+           *[m] roxo
+        }
+    .pink = rosa
+    .brown = marrom
+
+line-width =
+    .thick =
+        { $gender ->
+            [f] grossa
+           *[m] grosso
+        }
+    .thin =
+        { $gender ->
+            [f] fina
+           *[m] fino
+        }
+
+line-style =
+    .dashed =
+        { $gender ->
+            [f] tracejada
+           *[m] tracejado
+        }
+    .dotted =
+        { $gender ->
+            [f] pontilhada
+           *[m] pontilhado
+        }
+
+# Sintagmas nominais: vêm depois de «com» e não concordam com nada.
+fill-style =
+    .horizontal = linhas horizontais
+    .vertical = linhas verticais
+    .diagonal = linhas diagonais
+    .backdiagonal = linhas diagonais invertidas
+    .dots = pontos
+    .diamonds = losangos
+
+noun =
+    .line = linha
+    .line-segment = segmento
+    .ray = semirreta
+    .vector = vetor
+    .curve = curva
+    .function = função
+    .parabola = parábola
+    .polyline = polilinha
+    .polygon = polígono
+    .triangle = triângulo
+    .rectangle = retângulo
+    .circle = círculo
+    .region = região
+    .point = ponto
+    .square = quadrado
+    .diamond = losango
+    .cross = cruz
+    .plus = sinal de mais
+
+# O nome divide-se: «polígono regular» leva os adjetivos e «de 5 lados» fecha o
+# sintagma depois deles. Se o complemento viesse antes, os adjetivos ficariam
+# separados do nome com que concordam.
+noun-regular-polygon =
+    { $part ->
+        [tail] de { $numSides } lados
+       *[head] polígono regular
+    }
+
+# Além dos nomes acima, `$noun` pode ser «regular-polygon» (polígono, m) ou o
+# núcleo de um sintagma que a descrição não nomeia: «border» (borda, f),
+# «fill» (preenchimento, m), «text» (texto, m), «background» (fundo, m).
+noun-gender =
+    { $noun ->
+        [line] f
+        [ray] f
+        [curve] f
+        [function] f
+        [parabola] f
+        [polyline] f
+        [region] f
+        [cross] f
+        [border] f
+       *[other] m
+    }
+
+
+## Composição de estilos
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $lineStyle } { $width } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $lineStyle } { $width }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# O nome vai à frente e os adjetivos atrás: «linha tracejada grossa vermelha».
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [f] preenchida
+       *[m] preenchido
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $color } { $filled } com { $pattern }
+       *[plain] { $color } { $filled }
+    }
+
+# O complemento fica junto ao nome, e não no fim: «polígono regular de 5 lados
+# azul preenchido».
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $color } { $filled } com { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $color } { $filled }
+        [pattern-tail] { $noun } { $nounTail } { $color } { $filled } com { $pattern }
+       *[plain] { $noun } { $color } { $filled }
+    }
+
+# «borda» é feminino, portanto os adjetivos da borda concordam com ela e não
+# com a figura que a rodeia — e o artigo é «uma».
+style-border-clause =
+    { $parts ->
+        [with-article] com uma borda { $border }
+        [and] e borda { $border }
+        [and-article] e uma borda { $border }
+       *[with] com borda { $border }
+    }
+
+# «de cor» evita ter de concordar a cor com um padrão no plural.
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } de cor { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = sem preenchimento
+
+style-text =
+    { $parts ->
+        [background] { $color } com um fundo { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = nenhum
+
+
+## Palavras booleanas
+
+boolean-true = verdadeiro
+boolean-false = falso
+
+
+## Botões de resposta
+
+answer-submit-label = Verificar
+answer-submit-label-no-correctness = Enviar resposta
+
+
+## Blocos seccionais
+
+section-name =
+    .activity = Atividade
+    .aside = Nota lateral
+    .cascade = Cascata
+    .definition = Definição
+    .example = Exemplo
+    .exercise = Exercício
+    .exercises = Exercícios
+    .given-answer = Resposta
+    .note = Nota
+    .objectives = Objetivos
+    .paragraphs = Parágrafos
+    .part = Parte
+    .problem = Problema
+    .problems = Problemas
+    .proof = Demonstração
+    .question = Pergunta
+    .section = Seção
+    .solution = Solução
+    .task = Tarefa
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Dica
+
+
+## Tabelas e figuras
+
+table-name =
+    { $parts ->
+        [numbered] Tabela { $enumeration }
+        [numbered-title] Tabela { $enumeration }{ ": " }
+        [unnumbered-title] Tabela{ ": " }
+       *[unnumbered] Tabela
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figura { $enumeration }
+        [numbered-caption] Figura { $enumeration }{ ": " }
+        [unnumbered-caption] Figura{ ": " }
+       *[unnumbered] Figura
+    }
+
+
+## Controles do paginador
+
+paginator-previous = Anterior
+paginator-next = Próxima
+paginator-page = Página
+
+paginator-page-status = { $pageLabel } { $currentPage } de { $numPages }
+
+
+## Funções definidas por partes
+
+piecewise-condition-or = ou
+piecewise-condition-if = se
+piecewise-condition-otherwise = caso contrário
+
+
+## Química
+
+element-name =
+    .h = Hidrogênio
+    .he = Hélio
+    .li = Lítio
+    .be = Berílio
+    .b = Boro
+    .c = Carbono
+    .n = Nitrogênio
+    .o = Oxigênio
+    .f = Flúor
+    .ne = Neônio
+    .na = Sódio
+    .mg = Magnésio
+    .al = Alumínio
+    .si = Silício
+    .p = Fósforo
+    .s = Enxofre
+    .cl = Cloro
+    .ar = Argônio
+    .k = Potássio
+    .ca = Cálcio
+    .sc = Escândio
+    .ti = Titânio
+    .v = Vanádio
+    .cr = Cromo
+    .mn = Manganês
+    .fe = Ferro
+    .co = Cobalto
+    .ni = Níquel
+    .cu = Cobre
+    .zn = Zinco
+    .ga = Gálio
+    .ge = Germânio
+    .as = Arsênio
+    .se = Selênio
+    .br = Bromo
+    .kr = Criptônio
+    .rb = Rubídio
+    .sr = Estrôncio
+    .y = Ítrio
+    .zr = Zircônio
+    .nb = Nióbio
+    .mo = Molibdênio
+    .tc = Tecnécio
+    .ru = Rutênio
+    .rh = Ródio
+    .pd = Paládio
+    .ag = Prata
+    .cd = Cádmio
+    .in = Índio
+    .sn = Estanho
+    .sb = Antimônio
+    .te = Telúrio
+    .i = Iodo
+    .xe = Xenônio
+    .cs = Césio
+    .ba = Bário
+    .la = Lantânio
+    .ce = Cério
+    .pr = Praseodímio
+    .nd = Neodímio
+    .pm = Promécio
+    .sm = Samário
+    .eu = Európio
+    .gd = Gadolínio
+    .tb = Térbio
+    .dy = Disprósio
+    .ho = Hólmio
+    .er = Érbio
+    .tm = Túlio
+    .yb = Itérbio
+    .lu = Lutécio
+    .hf = Háfnio
+    .ta = Tântalo
+    .w = Tungstênio
+    .re = Rênio
+    .os = Ósmio
+    .ir = Irídio
+    .pt = Platina
+    .au = Ouro
+    .hg = Mercúrio
+    .tl = Tálio
+    .pb = Chumbo
+    .bi = Bismuto
+    .po = Polônio
+    .at = Astato
+    .rn = Radônio
+    .fr = Frâncio
+    .ra = Rádio
+    .ac = Actínio
+    .th = Tório
+    .pa = Protactínio
+    .u = Urânio
+    .np = Netúnio
+    .pu = Plutônio
+    .am = Amerício
+    .cm = Cúrio
+    .bk = Berquélio
+    .cf = Califórnio
+    .es = Einstênio
+    .fm = Férmio
+    .md = Mendelévio
+    .no = Nobélio
+    .lr = Laurêncio
+    .rf = Rutherfórdio
+    .db = Dúbnio
+    .sg = Seabórgio
+    .bh = Bóhrio
+    .hs = Hássio
+    .mt = Meitnério
+    .ds = Darmstácio
+    .rg = Roentgênio
+    .cn = Copernício
+    .nh = Nihônio
+    .fl = Fleróvio
+    .mc = Moscóvio
+    .lv = Livermório
+    .ts = Tenesso
+    .og = Oganessônio
+
+element-anion-name =
+    .h = Hidreto
+    .c = Carbeto
+    .n = Nitreto
+    .o = Óxido
+    .f = Fluoreto
+    .p = Fosfeto
+    .s = Sulfeto
+    .cl = Cloreto
+    .br = Brometo
+    .i = Iodeto
+    .at = Astateto
+    .ts = Tenesseto
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Símbolo químico inválido
+chemistry-invalid-ionic-compound = Composto iônico inválido

--- a/packages/i18n/locales/pt/content.ftl
+++ b/packages/i18n/locales/pt/content.ftl
@@ -16,8 +16,8 @@
 # answer the same for both.
 #
 # Portuguese does not inflect an attributive adjective for case, so `$role`
-# goes unread here, exactly as it does in Spanish and English. Only German and
-# Russian select on it.
+# goes unread here, exactly as it does in Spanish and English. German, Russian,
+# Polish and Hindi are the catalogs that select on it.
 #
 # `borda` is feminine, where Spanish's `borde` is masculine — so the border's
 # adjectives agree the other way round from the Spanish catalog, and the

--- a/packages/i18n/locales/pt/diagnostics.ftl
+++ b/packages/i18n/locales/pt/diagnostics.ftl
@@ -1,0 +1,649 @@
+# Portuguese diagnostics. Translated from `locales/en/diagnostics.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Brazilian Portuguese, which is what a bare `pt` means — see the note at the
+# head of `content.ftl`.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } é ignorado quando dois extremos são especificados
+       *[other] { $attributes } são ignorados quando dois extremos são especificados
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } é ignorado quando um extremo e um ponto médio são especificados juntos
+       *[other] { $attributes } são ignorados quando um extremo e um ponto médio são especificados juntos
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset não tem efeito sem um ponto médio
+
+## `<line>`
+
+line-points-undetermined-dimensions = Reta que passa por pontos de dimensões indeterminadas.
+
+line-points-too-few-dimensions = A reta deve passar por pontos de pelo menos duas dimensões.
+
+line-points-depend-on-variables = A reta passa por pontos que dependem de variáveis: { $variables }.
+
+line-equation-invalid-format = Formato inválido para a equação da reta nas variáveis { $variable1 } e { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = A semirreta é determinada por through, endpoint e direction ao mesmo tempo. Ignorando o through especificado.
+
+ray-dimension-mismatch = numDimensions incompatível na semirreta.
+
+## `<vector>`
+
+vector-overprescribed-head = O vetor é determinado por head, tail e displacement ao mesmo tempo. Ignorando o head especificado.
+
+vector-dimension-mismatch = numDimensions incompatível no vetor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Não é possível atrair para um `<{ $component }>` porque ele não tem a variável de estado nearestPoint.
+
+constrain-to-without-nearest-point = Não é possível restringir a um `<{ $component }>` porque ele não tem a variável de estado nearestPoint.
+
+constrain-to-interior-without-nearest-point = Não é possível restringir ao interior de um `<{ $component }>` porque ele não tem a variável de estado nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition é ignorado em um choiceInput que não é inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ignorando os indices especificados para choiceInput porque a quantidade de indices não corresponde à quantidade de filhos choice.
+
+pretzel-indices-count-mismatch = Ignorando os indices especificados para problem porque a quantidade de indices não corresponde à quantidade de filhos problem.
+
+shuffle-indices-count-mismatch = Ignorando os indices especificados para shuffle porque a quantidade de indices não corresponde à quantidade de componentes.
+
+indices-ignored-out-of-range = Ignorando os indices especificados para { $component } porque alguns índices estão fora do intervalo.
+
+pretzel-indices-repeated = Ignorando os indices especificados para pretzel porque alguns índices se repetem.
+
+pretzel-circuit-first-index = Ignorando os indices especificados para pretzel no modo circuit porque o primeiro índice deve ser 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Para que `<{ $component }>` funcione com filhos de texto, o atributo `type` deve ser especificado.
+
+invalid-type-defaulting-to-math = Tipo { $type } inválido para o componente { $component }. Deve ser math, text, number ou boolean. Usando math.
+
+string-not-valid-component-to-arrange = A cadeia "{ $value }" não é um componente válido para { $component }. Ignorando.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tipo { $type } inválido; definindo o tipo como number.
+
+invalid-variable-value = Valor inválido de uma variável: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = O índice de variante { $index } deve ser um número
+
+variant-index-must-be-integer = O índice de variante { $index } deve ser um inteiro
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` não está implementado para medidas absolutas. Definindo as larguras como relativas.
+
+side-by-side-absolute-margins = `<{ $component }>` não está implementado para medidas absolutas. Definindo as margens como relativas.
+
+side-by-side-no-block-child = `<{ $component }>` inválido: ele deve ter pelo menos um filho de bloco.
+
+## `<label>`
+
+label-for-ignored-on-graphical = O atributo `for` em um `<label>` gráfico é ignorado.
+
+label-for-must-resolve-to-one = O atributo `for` em `<label>` deve resolver para exatamente um componente.
+
+label-for-unresolved = O atributo `for` em `<label>` não pôde ser resolvido para um componente.
+
+label-for-answer-with-authored-inputs = O atributo `for` em `<label>` referencia um `<answer>` com entradas escritas explicitamente; referencie a entrada diretamente.
+
+label-for-answer-without-input = O atributo `for` em `<label>` referencia um `<answer>` sem uma entrada para rotular.
+
+label-for-must-reference-input-or-answer = O atributo `for` em `<label>` deve referenciar uma entrada ou uma resposta.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Por acessibilidade, `<{ $component }>` deve ter uma descrição curta ou ser marcado como decorativo.
+
+accessibility-video-short-description = Por acessibilidade, `<video>` deve ter uma descrição curta.
+
+accessibility-input-short-description-or-label = Por acessibilidade, `<{ $component }>` deve ter uma descrição curta ou um rótulo.
+
+accessibility-answer-input-short-description-or-label = Por acessibilidade, um `<answer>` que cria uma entrada deve ter uma descrição curta ou um rótulo.
+
+accessibility-short-description-contains-math = Descrições curtas não devem conter componentes matemáticos como `<{ $component }>`. Escreva a matemática por extenso.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } tem contraste insuficiente para o texto do título da seção (modo escuro) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; exige pelo menos { $threshold }:1).
+       *[other] { $colorName } tem contraste insuficiente para o texto do título da seção ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; exige pelo menos { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Ainda não implementado: `<circle>` passando por { $count } pontos quando os pontos não têm valores numéricos.
+
+circle-too-many-through-points = Não é possível calcular um círculo que passe por mais de 3 pontos.
+
+circle-overprescribed-radius-center-points = Não é possível calcular um círculo com raio, centro e pontos de passagem especificados ao mesmo tempo.
+
+circle-center-with-multiple-points = Não é possível calcular um círculo com centro especificado que passe por mais de 1 ponto.
+
+circle-radius-too-small = Não é possível calcular o círculo: como a distância entre os dois pontos é { $distance }, o raio { $radius } especificado é pequeno demais.
+
+circle-radius-with-many-points = Não é possível criar um círculo que passe por mais de dois pontos com um raio especificado.
+
+circle-invalid-center-or-through-points = Centro ou pontos de passagem do círculo inválidos.
+
+circle-radius-center-with-multiple-points = Não é possível calcular o raio de um círculo com centro especificado que passe por mais de 1 ponto.
+
+circle-change-radius-non-numerical = Não é possível alterar o raio de um círculo cujos pontos de passagem não são numéricos
+
+circle-radius-with-points-non-numerical = Não é possível criar um círculo que passe por mais de um ponto com raio especificado quando não há valores numéricos.
+
+circle-change-center-non-numerical = Ainda não implementado: alterar o centro de um círculo que passa por pontos não numéricos.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Dimensões insuficientes para o domínio da função. O domínio tem { $intervals } intervalo, mas a função tem { $inputs ->
+            [one] { $inputs } entrada
+           *[other] { $inputs } entradas
+        }.
+       *[other] Dimensões insuficientes para o domínio da função. O domínio tem { $intervals } intervalos, mas a função tem { $inputs ->
+            [one] { $inputs } entrada
+           *[other] { $inputs } entradas
+        }.
+    }
+
+function-domain-invalid-format = Formato inválido para o domínio da função.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ignorando o máximo não numérico da função.
+        [minimum] Ignorando o mínimo não numérico da função.
+        [extremum] Ignorando o extremo não numérico da função.
+        [point] Ignorando o ponto não numérico da função.
+        [slope] Ignorando a inclinação não numérica da função.
+       *[other] Ignorando { $type } não numérico da função.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ignorando o máximo vazio da função.
+        [minimum] Ignorando o mínimo vazio da função.
+        [extremum] Ignorando o extremo vazio da função.
+        [point] Ignorando o ponto vazio da função.
+       *[other] Ignorando { $type } vazio da função.
+    }
+
+function-points-too-close = A função contém dois pontos em posições próximas demais. Não é possível definir a função.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Só é possível iterar a função quando a quantidade de entradas é igual à de saídas. Esta função tem { $inputs } entrada e { $outputs ->
+            [one] { $outputs } saída
+           *[other] { $outputs } saídas
+        }.
+       *[other] Só é possível iterar a função quando a quantidade de entradas é igual à de saídas. Esta função tem { $inputs } entradas e { $outputs ->
+            [one] { $outputs } saída
+           *[other] { $outputs } saídas
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Comprimento inválido da sequência. Deve ser um inteiro não negativo.
+
+sequence-invalid-step = Passo inválido da sequência. Deve ser um número para uma sequência do tipo { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" inválido em uma sequência numérica. Deve ser um número.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" inválido em uma sequência de letras. Deve ser uma combinação de letras.
+
+sequence-invalid-endpoint = "{ $attribute }" inválido na sequência.
+
+select-from-sequence-coprime-not-numbers = coprime ignorado porque não estão sendo selecionados números
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ignorado porque excludeCombinations foi especificado
+
+## Resolving a `target`
+
+target-not-found = target inválido para `<{ $source }>`: não foi possível encontrar o alvo.
+
+target-state-variable-not-found = target inválido para `<{ $source }>`: não foi encontrada uma variável de estado chamada "{ $property }" em um `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = As variáveis de `<odeSystem>` devem ser diferentes da variável independente.
+
+ode-system-duplicate-variable-names = Não é possível definir as funções do lado direito da EDO com nomes de variáveis dependentes repetidos.
+
+ode-system-rhs-function-error = Não é possível definir a função do lado direito da EDO. Erro ao criar a função mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Não é possível definir um ângulo entre { $count } retas
+
+angle-invalid-through-point = Ponto inválido no through de `<angle>`
+
+parabola-vertex-too-many-points = Ainda não implementado: parábola com vértice especificado passando por mais de 1 ponto.
+
+parabola-too-many-points = Ainda não implementado: parábola passando por mais de 3 pontos.
+
+intersection-too-many-items = Ainda não implementado: interseção de mais de dois objetos
+
+## Other math components
+
+ionic-compound-not-two-ions = Ainda não implementado: composto iônico com um número de íons diferente de dois.
+
+ionic-compound-needs-cation-and-anion = O composto iônico só está implementado para um cátion e um ânion.
+
+solve-equations-cannot-evaluate = Não é possível resolver a equação porque ela não pôde ser avaliada: { $equation }
+
+math-operators-operand-number-required = É preciso especificar operandNumber ao extrair um operando matemático.
+
+eigen-decomposition-failed = Não foi possível calcular os autovalores da matriz
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: o parâmetro { $parameters } não ocorre no padrão, portanto corresponderá sempre a um vazio.
+       *[other] `<matchesPattern>`: os parâmetros { $parameters } não ocorrem no padrão, portanto corresponderão sempre a um vazio.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: não foi possível interpretar grid="{ $grid }". Deve ser none, medium, dense ou dois números positivos separados por um espaço, como grid="1 0.5". Nenhuma grade é desenhada.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" não é suportado no renderizador prefigure; usando o comportamento da posição à direita.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" não é suportado no renderizador prefigure; usando o comportamento da posição no topo.
+
+prefigure-invalid-axis-bounds = `<graph>`: limites de eixo inválidos para a conversão prefigure; usando a bbox padrão (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: largura inválida para a conversão prefigure; usando a largura padrão de diagrama 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio inválido para a conversão prefigure; usando a proporção padrão 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: o espaçamento da grade é fino demais para os limites dos eixos; a grade é omitida no renderizador prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: as anotações não serão desenhadas quando o renderizador PreFigure não for usado.
+
+multiple-annotations-children = Vários filhos `<annotations>` encontrados em `<graph>`; todos são ignorados exceto o último.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Não é possível estender ou copiar um tipo de componente não reconhecido: { $type }.
+
+copy-prop-not-found = Não foi possível encontrar a propriedade { $property } em um componente do tipo { $component }
+
+collect-no-source = Nenhuma origem encontrada para collect.
+
+collect-invalid-component-type = Não é possível coletar componentes do tipo `<{ $component }>` porque esse não é um tipo de componente válido.
+
+reference-index-unavailable = Não é possível referenciar o índice `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Não é possível chamar { $action } no componente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Os dados têm formato inválido. As linhas têm comprimentos inconsistentes. Encontrado em componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Os dados têm nomes de coluna repetidos. Encontrado em componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Falta um nome de coluna nos dados. Encontrado em componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Um award desta resposta baseia-se na própria resposta enviada pela tag answer, o que levará a um comportamento inesperado.
+
+answer-max-num-attempts-in-section-wide-check-work = Definir `maxNumAttempts` em um `<answer>` dentro de um contêiner com `sectionWideCheckWork` não tem efeito, porque o número de tentativas é controlado pelo contêiner. Defina `maxNumAttempts` no contêiner.
+
+nested-section-wide-check-work-max-num-attempts = Definir `maxNumAttempts` em um contêiner com `sectionWideCheckWork` que está dentro de outro contêiner com `sectionWideCheckWork` não tem efeito, porque o número de tentativas é controlado pelo contêiner externo. Defina `maxNumAttempts` no contêiner externo.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] O atributo { $attributes } não terá efeito sem symbolicEquality definido.
+       *[other] Os atributos { $attributes } não terão efeito sem symbolicEquality definido.
+    }
+
+answer-invalid-type = Tipo inválido para answer: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Como o componente `<{ $component }>` não tem nome, ele não pode ser usado como atributo de um módulo
+
+module-attribute-name-already-defined = O componente `<{ $component } name="{ $name }">` não pode ser usado como atributo de um módulo porque o tipo de componente `<module>` já define um atributo "{ $name }".
+
+conditional-content-condition-ignored = O atributo `condition` é ignorado em um componente `<conditionalContent>` que tem filhos case ou else.
+
+slider-markers-type-mismatch = O tipo dos marcadores não corresponde ao tipo do controle deslizante.
+
+pretzel-problem-needs-statement-and-answer = pretzel inválido: cada `<problem>` deve conter um `<statement>` e um `<answer>`.
+
+pretzel-circuit-first-problem-distractor = pretzel inválido: em mode="circuit", o primeiro `<problem>` não pode ser um distrator.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Valor { $values } inválido para o atributo `{ $attribute }`; ignorando.
+       *[other] Valores { $values } inválidos para o atributo `{ $attribute }`; ignorando.
+    }
+
+attribute-must-be-references = Valor `{ $value }` inválido para o atributo `{ $attribute }`. O atributo deve ser composto de referências que comecem com `$`.
+
+math-input-invalid-function-names = <mathInput>: nomes de função inválidos ignorados em { $attribute }: { $names }. O segmento visível de cada nome deve ter pelo menos 2 caracteres (letras ou hifens); um sufixo opcional `|<alternativa mathspeak>` pode seguir.
+
+## Building components from the source
+
+component-type-invalid = Tipo de componente inválido: `<{ $componentType }>`
+
+attribute-repeated = Não é possível repetir o atributo { $attribute }.
+
+attribute-invalid-for-component = Atributo "{ $attribute }" inválido para um componente do tipo `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    A definição de estilo { $styleNumber } tem contraste insuficiente para { $context ->
+        [text-on-background] a cor do texto sobre a cor de fundo
+        [high-contrast] a cor de alto contraste sobre a tela
+        [line] a cor da linha sobre a tela
+        [marker] a cor do marcador sobre a tela
+       *[text-on-canvas] a cor do texto sobre a tela
+    }{ $mode ->
+        [dark] { " (modo escuro)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; exige pelo menos { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Embora a definição de estilo { $styleNumber } especifique cores com contraste suficiente para o modo claro, as cores de modo escuro derivadas desses valores têm contraste insuficiente entre a cor do texto e a cor de fundo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; exige pelo menos { $threshold }:1). { $suggestion ->
+        [available] Para garantir contraste suficiente no modo escuro, aumente o contraste do modo claro (por exemplo, defina { $lightAttribute }="{ $lightColor }") ou sobrescreva a cor do modo escuro (por exemplo, defina { $darkAttribute }="{ $darkColor }").
+       *[none] Para garantir contraste suficiente no modo escuro, aumente o contraste do modo claro ou sobrescreva as cores derivadas com textColorDarkMode e/ou backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Embora a definição de estilo { $styleNumber } especifique uma cor de texto com contraste suficiente para o modo claro, a cor de texto do modo escuro derivada desse valor tem contraste insuficiente sobre a tela ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; exige pelo menos { $threshold }:1). { $suggestion ->
+        [available] Para garantir contraste suficiente no modo escuro, aumente o contraste do modo claro (por exemplo, defina textColor="{ $lightColor }") ou sobrescreva a cor do modo escuro (por exemplo, defina textColorDarkMode="{ $darkColor }").
+       *[none] Para garantir contraste suficiente no modo escuro, aumente o contraste do modo claro ou sobrescreva a cor derivada com textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Uma seção só pode escolher um <stylePalette>; usando o último.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = não é possível determinar variantes únicas de { $component } porque numToSelect não é um inteiro não negativo.
+
+variant-num-to-select-not-constant-number = não é possível determinar variantes únicas de { $component } porque numToSelect não é constante.
+
+variant-with-replacement-not-constant-boolean = não é possível determinar variantes únicas de { $component } porque withReplacement não é um booleano constante.
+
+variant-select-weight-disables-unique = as variantes únicas de select são desativadas se alguma opção especificar selectWeight ou selectForVariants
+
+variant-coprime-undetermined = não é possível determinar variantes únicas de { $component } porque não se pode garantir que coprime seja sempre falso.
+
+variant-attribute-not-constant = não é possível determinar variantes únicas de { $component } porque { $attribute } não é constante.
+
+variant-attribute-not-number = não é possível determinar variantes únicas de { $component } porque { $attribute } não é um número.
+
+variant-attribute-wrong-type-for-sequence =
+    não é possível determinar variantes únicas de { $component } do tipo { $type } porque { $attribute } não é { $expected ->
+        [letters-combination] uma combinação de letras
+        [math-expression] uma expressão matemática válida
+        [integer] um inteiro
+       *[number] um número
+    }.
+
+variant-length-not-integer = não é possível determinar variantes únicas de { $component } porque length não é um inteiro.
+
+variant-sort-not-implemented = ainda não implementado: variantes únicas de um { $component } com sort
+
+variant-exclude-combinations-not-implemented = ainda não implementado: variantes únicas de um { $component } com excludeCombinations
+
+variant-math-exclude-not-implemented = ainda não implementado: variantes únicas de um { $component } do tipo math com exclude
+
+variant-non-constant-exclude-not-implemented = ainda não implementado: variantes únicas de um { $component } com exclude não constante
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: não suportado no renderizador prefigure do gráfico; descendente ignorado.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometria não finita ou incompleta; descendente ignorado.
+
+prefigure-curve-label-omitted = { $subject }: rótulos não são suportados em elementos de curva convertidos; rótulo omitido.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipo de definição de função de curva '{ $definitionType }' não suportado; descendente ignorado.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atributo flipFunctions não suportado em regionBetweenCurves; descendente ignorado.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves só suporta funções filhas do tipo fórmula; descendente ignorado.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' não suportado para { $labelKind ->
+        [line-family] rótulo de família de retas
+       *[point] rótulo de ponto
+    }; usando o alinhamento padrão do PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: o estilo de preenchimento '{ $fillStyle }' não é suportado pelo PreFigure; voltando a um preenchimento sólido.
+
+prefigure-line-style-unknown = { $subject }: estilo de linha desconhecido '{ $lineStyle }' omitido da saída do PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: estilo de marcador '{ $markerStyle }' mapeado para o estilo 'diamond' do PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: o estilo de marcador '{ $markerStyle }' não é suportado pelo PreFigure; usando o estilo padrão.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` inválido; não foi possível resolver o alvo. Anotação omitida.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` resolveu para vários alvos; usando o primeiro.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` inválido; o alvo está fora do gráfico que o contém. Anotação omitida.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` inválido; o alvo não é um objeto gráfico suportado na conversão prefigure. Anotação omitida.
+
+annotation-text-missing = `<annotation>`: `text` ausente ou vazio; emitindo texto vazio.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Dependência circular detectada.
+       *[other] Dependência circular detectada envolvendo um componente `<{ $componentType }>`.
+    }
+
+reference-no-referent = Nenhum referente encontrado para a referência: `{ $reference }`
+
+reference-multiple-referents = Vários referentes encontrados para a referência: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Formato inválido para o atributo { $attribute } de `<{ $componentType }>`.
+
+children-invalid = Filhos inválidos para `<{ $componentType }>`: foram encontrados filhos inválidos: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Valor `{ $value }` inválido para o atributo `{ $attribute }`; usando o valor `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versão { $version } do DoenetML não encontrada.
+       *[other] Versão { $version } do DoenetML não encontrada. Voltando à versão { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML inválido: { $content }
+
+parse-tag-missing-close-tag = DoenetML inválido: a tag `{ $tag }` não tem tag de fechamento. Era esperada uma tag autofechada ou uma tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML inválido: erro na tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML inválido: o atributo `{ $attribute }` parece estar sem valor.
+
+parse-attribute-invalid = DoenetML inválido: atributo `{ $attribute }` inválido
+
+parse-attribute-value-invalid = DoenetML inválido: valor de atributo `{ $value }` inválido
+
+parse-attribute-value-quote-mismatch = DoenetML inválido: valor de atributo `{ $value }` inválido. As aspas não correspondem. Parece faltar uma `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML inválido: encontrada uma tag sem nome, por exemplo `<`
+
+parse-tag-not-closed = DoenetML inválido: a tag `{ $tag }` não foi fechada (parece faltar um `>`).
+
+parse-self-closing-tag-name-missing = DoenetML inválido: encontrada uma tag sem nome `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML inválido: a tag `{ $tag }` não foi fechada (parece faltar `/>`).
+
+parse-tag-invalid-attributes = DoenetML inválido: a tag `{ $tag }` não é válida. Ela pode ter atributos incorretos.
+
+parse-close-tag-name-missing = DoenetML inválido: encontrada uma tag de fechamento sem nome, por exemplo `</`
+
+parse-attribute-value-unquoted = Os valores de atributo devem estar entre aspas: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML inválido: encontrada a tag de fechamento `{ $tag }`, mas não há tag de abertura correspondente
+
+parse-close-tag-mismatched = DoenetML inválido: tag de fechamento incompatível. Era esperada `</{ $expected }>`. Encontrada `{ $found }`
+
+parser-node-unconvertible = Não foi possível converter o nó { $node } em um nó Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atributo name='{ $name }' inválido. { $reason ->
+        [characters] Os nomes só podem conter letras, números, sublinhados ou hifens.
+       *[start] Os nomes devem começar por uma letra.
+    }
+
+component-name-invalid-start = Nome de componente "{ $name }" inválido. Os nomes devem começar por uma letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Um answer do tipo videoWatched deve ter um atributo video
+
+answer-video-watched-video-not-reference = Um answer do tipo videoWatched deve ter um atributo video que seja uma referência
+
+answer-name-not-single-text = O atributo name de answer deve ter um único filho de texto
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Não foi possível obter o DoenetML externo por excesso de níveis de recursão. Existe alguma referência circular?
+
+external-doenetml-unavailable = Não foi possível obter o DoenetML de { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML inválido obtido de { $attribute }="{ $uri }": não corresponde ao tipo de componente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] O atributo `{ $from }` está obsoleto; use `{ $to }`.
+       *[other] [deprecation] O atributo `{ $from }` em `<{ $component }>` está obsoleto; use `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] O atributo `{ $from }` está obsoleto e foi ignorado porque `{ $to }` também foi especificado.
+       *[other] [deprecation] O atributo `{ $from }` em `<{ $component }>` está obsoleto e foi ignorado porque `{ $to }` também foi especificado.
+    }
+
+deprecated-attribute-ignored = [deprecation] O atributo `{ $attribute }` em `<{ $component }>` está obsoleto e foi ignorado.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` só sabe formar plurais em inglês, portanto o texto fica inalterado em um documento escrito em { $locale }. Escreva a forma plural diretamente ou defina-a com o atributo `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = O elemento `<{ $tag }>` não é um elemento Doenet reconhecido.
+
+schema-element-not-allowed-at-root = O elemento `<{ $tag }>` não é permitido na raiz do documento.
+
+schema-element-not-allowed-inside = O elemento `<{ $tag }>` não é permitido dentro de `<{ $parent }>`.
+
+schema-attribute-unrecognized = O elemento `<{ $tag }>` não tem um atributo chamado `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] O atributo `{ $attribute }` do elemento `<{ $tag }>` deve ser uma lista cujos itens sejam cada um: { $allowed }
+       *[other] O atributo `{ $attribute }` do elemento `<{ $tag }>` deve ser um de: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nome de variante inválido para select. O nome de variante { $variantName } aparece em { $numOptions } opções, mas a quantidade a selecionar é { $numToSelect }.
+
+select-variant-name-without-options = Foram especificadas variantes para select, mas não há opções para o nome de variante possível: { $variantName }.
+
+select-variant-name-not-possible = O nome de variante { $variantName } especificado para select não é um nome de variante possível.
+
+select-too-few-options = Não é possível selecionar { $numToSelect } componentes de apenas { $numOptions }.
+
+select-from-sequence-too-few-values = Não é possível selecionar { $numToSelect } valores de uma sequência de comprimento { $length }.
+
+select-from-sequence-indices-count-mismatch = A quantidade de índices especificada para select deve corresponder à quantidade a selecionar
+
+select-from-sequence-indices-not-integers = Todos os índices especificados para select devem ser inteiros
+
+select-from-sequence-index-excluded = O índice especificado para selectfromsequence estava excluído
+
+select-from-sequence-indices-excluded-combination = Os índices especificados para selectfromsequence formavam uma combinação excluída
+
+select-from-sequence-coprime-not-positive-integers = Não é possível selecionar combinações coprimas porque não estão sendo selecionados inteiros positivos.
+
+select-from-sequence-coprime-common-factor = Não é possível selecionar números coprimos. Todos os valores possíveis têm um fator comum. (Os valores especificados de "from" ou "to" devem ser coprimos com "step".)
+
+select-from-sequence-coprime-single-number = Não é possível selecionar combinações coprimas a partir de um único número diferente de 1.
+
+select-from-sequence-excluded-too-many-combinations = Mais de 70% das combinações foram excluídas em selectFromSequence
+
+select-from-sequence-coprime-none-found = Não foi possível selecionar números coprimos. Todos os valores possíveis têm um fator comum.
+
+select-from-sequence-too-few-unique-values = Não é possível selecionar { $numToSelect } valores distintos de uma sequência de comprimento { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Não é possível selecionar { $numToSelect } valores de uma lista de primos de comprimento { $numValues }
+
+select-prime-numbers-values-count-mismatch = A quantidade de valores especificada para select deve corresponder à quantidade a selecionar
+
+select-prime-numbers-values-not-prime = Todos os valores especificados para select prime number devem estar na lista de primos
+
+select-prime-numbers-values-excluded-combination = Os valores especificados para selectPrimeNumbers formavam uma combinação excluída
+
+select-prime-numbers-excluded-too-many-combinations = Mais de 70% das combinações foram excluídas em selectPrimeNumbers
+
+select-random-combination-fluke = Por uma coincidência extremamente improvável, não foi possível selecionar uma combinação de valores aleatórios
+
+select-random-value-fluke = Por uma coincidência extremamente improvável, não foi possível selecionar um valor aleatório

--- a/packages/i18n/locales/pt/diagnostics.ftl
+++ b/packages/i18n/locales/pt/diagnostics.ftl
@@ -66,17 +66,17 @@ choice-input-label-position-ignored = labelPosition é ignorado em um choiceInpu
 
 ## Ordering children by index
 
-choice-input-indices-count-mismatch = Ignorando os indices especificados para choiceInput porque a quantidade de indices não corresponde à quantidade de filhos choice.
+choice-input-indices-count-mismatch = Ignorando os índices especificados para choiceInput porque a quantidade de índices não corresponde à quantidade de filhos choice.
 
-pretzel-indices-count-mismatch = Ignorando os indices especificados para problem porque a quantidade de indices não corresponde à quantidade de filhos problem.
+pretzel-indices-count-mismatch = Ignorando os índices especificados para problem porque a quantidade de índices não corresponde à quantidade de filhos problem.
 
-shuffle-indices-count-mismatch = Ignorando os indices especificados para shuffle porque a quantidade de indices não corresponde à quantidade de componentes.
+shuffle-indices-count-mismatch = Ignorando os índices especificados para shuffle porque a quantidade de índices não corresponde à quantidade de componentes.
 
-indices-ignored-out-of-range = Ignorando os indices especificados para { $component } porque alguns índices estão fora do intervalo.
+indices-ignored-out-of-range = Ignorando os índices especificados para { $component } porque alguns índices estão fora do intervalo.
 
-pretzel-indices-repeated = Ignorando os indices especificados para pretzel porque alguns índices se repetem.
+pretzel-indices-repeated = Ignorando os índices especificados para pretzel porque alguns índices se repetem.
 
-pretzel-circuit-first-index = Ignorando os indices especificados para pretzel no modo circuit porque o primeiro índice deve ser 1.
+pretzel-circuit-first-index = Ignorando os índices especificados para pretzel no modo circuit porque o primeiro índice deve ser 1.
 
 ## `<shuffle>` and `<sort>`
 

--- a/packages/i18n/locales/pt/editor.ftl
+++ b/packages/i18n/locales/pt/editor.ftl
@@ -122,7 +122,7 @@ editor-none-found = Nenhum encontrado
 ## Submitted responses
 
 editor-no-responses = Ainda não há respostas enviadas
-editor-response-answer-id = Answer Id
+editor-response-answer-id = Id da resposta
 editor-response-response = Resposta
 editor-response-credit = Nota
 editor-response-submitted = Enviada
@@ -179,7 +179,7 @@ help-property-is-reference =
 
 help-kind-attribute = atributo
 help-kind-snippet = trecho de código
-help-kind-array-entry = entrada de vetor
+help-kind-array-entry = entrada de array
 
 help-default = Padrão:
 help-active-default = Padrão em vigor:

--- a/packages/i18n/locales/pt/editor.ftl
+++ b/packages/i18n/locales/pt/editor.ftl
@@ -1,0 +1,214 @@
+# Portuguese editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Brazilian Portuguese, which is what a bare `pt` means — see the note at the
+# head of `content.ftl`.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Redefinir
+       *[update] Atualizar
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } visualizador
+       *[other] { $word } visualizador { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variante
+editor-variant-filter = Filtrar...
+editor-variant-next = Selecionar a próxima variante
+editor-variant-previous = Selecionar a variante anterior
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Violação de acessibilidade WCAG AA identificada. Clique para { $action ->
+            [close] fechar
+           *[open] abrir
+        } o relatório de acessibilidade.
+        [advisories] Clique para { $action ->
+            [close] fechar
+           *[open] abrir
+        } o relatório de acessibilidade. Nenhuma violação WCAG AA foi encontrada, mas há outras recomendações de acessibilidade.
+       *[clean] Clique para { $action ->
+            [close] fechar
+           *[open] abrir
+        } o relatório de acessibilidade. Nenhum problema de acessibilidade foi encontrado.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Violação de acessibilidade WCAG AA identificada. { $count ->
+            [one] { $count } violação WCAG AA encontrada
+           *[other] { $count } violações WCAG AA encontradas
+        }. Clique para { $action ->
+            [close] fechar
+           *[open] abrir
+        } o relatório de acessibilidade.
+        [advisories] Nenhuma violação WCAG AA identificada. { $count ->
+            [one] { $count } recomendação adicional de acessibilidade encontrada
+           *[other] { $count } recomendações adicionais de acessibilidade encontradas
+        }. Clique para { $action ->
+            [close] fechar
+           *[open] abrir
+        } o relatório de acessibilidade.
+       *[clean] Nenhuma violação WCAG AA identificada. Clique para { $action ->
+            [close] fechar
+           *[open] abrir
+        } o relatório de acessibilidade.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML versão { $version }
+
+editor-tab-help = Ajuda contextual
+editor-tab-help-short = Contexto
+editor-tab-errors = Erros
+editor-tab-warnings = Avisos
+editor-tab-info = Informação
+editor-tab-accessibility = Acessibilidade
+editor-tab-responses = Respostas enviadas
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opções do editor
+editor-format-as-doenetml = Formatar como DoenetML
+editor-format-as-xml = Formatar como XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linha #{ $line }
+
+editor-no-errors = Nenhum erro
+editor-no-warnings = Nenhum aviso
+editor-no-info = Nenhum diagnóstico informativo
+
+editor-show-info-annotations = Mostrar diagnósticos informativos no editor
+editor-show-accessibility-annotations = Mostrar diagnósticos de acessibilidade no editor
+
+editor-accessibility-learn-more = Saiba como o Doenet trata a acessibilidade
+
+editor-accessibility-violations-heading = Violações de acessibilidade ({ $standard })
+
+editor-accessibility-other-heading = Outros problemas de acessibilidade
+editor-none-found = Nenhum encontrado
+
+
+## Submitted responses
+
+editor-no-responses = Ainda não há respostas enviadas
+editor-response-answer-id = Answer Id
+editor-response-response = Resposta
+editor-response-credit = Nota
+editor-response-submitted = Enviada
+
+
+## The context-help panel
+
+help-placeholder = Coloque o cursor sobre um nome de tag, um atributo ou { $ref } para ver a documentação.
+
+help-unsupported-ref-chain = Ainda não há ajuda para referências de várias partes como { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Nenhum referente encontrado para a referência: { $ref }.
+        [multiple] Vários referentes encontrados para a referência: { $ref }.
+       *[indeterminate] Não foi possível determinar um referente para { $ref }.
+    }
+
+help-learn-about-references = Saiba mais sobre referências →
+help-reference-page = Página de referência →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Dentro de { $element }
+       *[top] No nível superior
+    }{ $allowed ->
+        [none] { " — nada pode ficar aqui." }
+        [text] { " — digite texto aqui." }
+        [text-and-components] { " — digite texto aqui, ou experimente:" }
+       *[components] { " — coisas para experimentar:" }
+    }
+
+help-suggestions-footer = Pressione { $shortcut } para ver todos os { $total } componentes.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } é uma referência a { $target }.
+       *[other] { $ref } é uma referência a { $target } (linha { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Introduzido por { $owner } como { $role }.
+       *[other] Introduzido por { $owner } na linha { $line } como { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } é uma referência à propriedade { $property } de { $element }.
+       *[other] { $ref } é uma referência à propriedade { $property } de { $element } (linha { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = trecho de código
+help-kind-array-entry = entrada de vetor
+
+help-default = Padrão:
+help-active-default = Padrão em vigor:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valores permitidos (um por item):
+       *[other] Valores permitidos:
+    }
+
+help-suggested-values = Valores sugeridos:
+
+help-inserts = Insere:
+
+help-coordinates =
+    { $count ->
+        [one] Coordenada:
+       *[other] Coordenadas:
+    }
+
+help-type = Tipo:
+
+help-resolved-style = Estilo resolvido (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nomes de funções resolvidos:
+help-reset-list = Lista de redefinição desta entrada:
+help-added-on-input = Adicionado nesta entrada:
+help-removed-on-input = Removido nesta entrada:
+
+help-reset-overrides = { $reset } tem prioridade sobre { $additional } e { $removed }.

--- a/packages/i18n/locales/ru/content.ftl
+++ b/packages/i18n/locales/ru/content.ftl
@@ -33,11 +33,11 @@ color =
             [border-clause] чёрной
             [background-clause] чёрном
             [text-clause] чёрный
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] чёрная
                     [n] чёрное
-                    *[m] чёрный
+                   *[m] чёрный
                 }
         }
     .white =
@@ -45,11 +45,11 @@ color =
             [border-clause] белой
             [background-clause] белом
             [text-clause] белый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] белая
                     [n] белое
-                    *[m] белый
+                   *[m] белый
                 }
         }
     .gray =
@@ -57,11 +57,11 @@ color =
             [border-clause] серой
             [background-clause] сером
             [text-clause] серый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] серая
                     [n] серое
-                    *[m] серый
+                   *[m] серый
                 }
         }
     .red =
@@ -69,11 +69,11 @@ color =
             [border-clause] красной
             [background-clause] красном
             [text-clause] красный
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] красная
                     [n] красное
-                    *[m] красный
+                   *[m] красный
                 }
         }
     .orange =
@@ -81,11 +81,11 @@ color =
             [border-clause] оранжевой
             [background-clause] оранжевом
             [text-clause] оранжевый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] оранжевая
                     [n] оранжевое
-                    *[m] оранжевый
+                   *[m] оранжевый
                 }
         }
     .yellow =
@@ -93,11 +93,11 @@ color =
             [border-clause] жёлтой
             [background-clause] жёлтом
             [text-clause] жёлтый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] жёлтая
                     [n] жёлтое
-                    *[m] жёлтый
+                   *[m] жёлтый
                 }
         }
     .green =
@@ -105,11 +105,11 @@ color =
             [border-clause] зелёной
             [background-clause] зелёном
             [text-clause] зелёный
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] зелёная
                     [n] зелёное
-                    *[m] зелёный
+                   *[m] зелёный
                 }
         }
     .cyan =
@@ -117,11 +117,11 @@ color =
             [border-clause] голубой
             [background-clause] голубом
             [text-clause] голубой
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] голубая
                     [n] голубое
-                    *[m] голубой
+                   *[m] голубой
                 }
         }
     .blue =
@@ -129,11 +129,11 @@ color =
             [border-clause] синей
             [background-clause] синем
             [text-clause] синий
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] синяя
                     [n] синее
-                    *[m] синий
+                   *[m] синий
                 }
         }
     .purple =
@@ -141,11 +141,11 @@ color =
             [border-clause] фиолетовой
             [background-clause] фиолетовом
             [text-clause] фиолетовый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] фиолетовая
                     [n] фиолетовое
-                    *[m] фиолетовый
+                   *[m] фиолетовый
                 }
         }
     .pink =
@@ -153,11 +153,11 @@ color =
             [border-clause] розовой
             [background-clause] розовом
             [text-clause] розовый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] розовая
                     [n] розовое
-                    *[m] розовый
+                   *[m] розовый
                 }
         }
     .brown =
@@ -165,11 +165,11 @@ color =
             [border-clause] коричневой
             [background-clause] коричневом
             [text-clause] коричневый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] коричневая
                     [n] коричневое
-                    *[m] коричневый
+                   *[m] коричневый
                 }
         }
 
@@ -179,11 +179,11 @@ line-width =
             [border-clause] толстой
             [background-clause] толстом
             [text-clause] толстый
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] толстая
                     [n] толстое
-                    *[m] толстый
+                   *[m] толстый
                 }
         }
     .thin =
@@ -191,11 +191,11 @@ line-width =
             [border-clause] тонкой
             [background-clause] тонком
             [text-clause] тонкий
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] тонкая
                     [n] тонкое
-                    *[m] тонкий
+                   *[m] тонкий
                 }
         }
 
@@ -205,11 +205,11 @@ line-style =
             [border-clause] штриховой
             [background-clause] штриховом
             [text-clause] штриховой
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] штриховая
                     [n] штриховое
-                    *[m] штриховой
+                   *[m] штриховой
                 }
         }
     .dotted =
@@ -217,11 +217,11 @@ line-style =
             [border-clause] пунктирной
             [background-clause] пунктирном
             [text-clause] пунктирный
-            *[standalone]
+           *[standalone]
                 { $gender ->
                     [f] пунктирная
                     [n] пунктирное
-                    *[m] пунктирный
+                   *[m] пунктирный
                 }
         }
 
@@ -307,17 +307,13 @@ style-with-noun =
        *[noun] { $description } { $noun }
     }
 
+# Only ever said of the shape itself, so it is standalone in every
+# description and takes no `$role` branch.
 style-filled-word =
-    { $role ->
-        [border-clause] закрашенной
-        [background-clause] закрашенном
-        [text-clause] закрашенный
-        *[standalone]
-            { $gender ->
-                [f] закрашенная
-                [n] закрашенное
-                *[m] закрашенный
-            }
+    { $gender ->
+        [f] закрашенная
+        [n] закрашенное
+       *[m] закрашенный
     }
 
 style-filled =

--- a/packages/i18n/locales/ru/content.ftl
+++ b/packages/i18n/locales/ru/content.ftl
@@ -5,132 +5,224 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # Russian inflects, and it has three genders. Adjectives precede their noun and
-# agree with it, so every adjective below selects on `$gender` with `m`, `f`
-# and `n`, and the composition messages keep the English adjective-then-noun
-# order. A description is a standalone phrase in the nominative, which is what
-# lets one form per gender be enough — except after the preposition the border
-# clause uses, for which `$gender` carries a fourth token, `insf`. `noun-gender`
-# says which noun answers it and why.
+# agree with it in gender and in the case their position governs, so every
+# adjective below selects on `$role` first — which position the words are going
+# into — and only then, where it matters, on `$gender`:
+#
+#   standalone          a phrase in the nominative: `-ый`/`-ой` m, `-ая` f,
+#                       `-ое` n
+#   border-clause       after «с », which governs the instrumental, of
+#                       «граница» — feminine: `-ой`
+#   background-clause   after «на … фоне», prepositional, of «фон» —
+#                       masculine: `-ом` (`-ем` after a soft stem)
+#   text-clause         nominative masculine, agreeing with «текст»
+#
+# The last three need no gender branch: each is only ever used of one noun, and
+# that noun's gender is fixed.
+#
+# This replaces the `insf` token an earlier seed carried inside `$gender`. One
+# token could hold a gender or a case but not both, so whichever of the two
+# positions it was tuned for, the other came out wrong (#1606).
 
 
 ## Style vocabulary
 
 color =
     .black =
-        { $gender ->
-            [insf] чёрной
-            [f] чёрная
-            [n] чёрное
-           *[m] чёрный
+        { $role ->
+            [border-clause] чёрной
+            [background-clause] чёрном
+            [text-clause] чёрный
+            *[standalone]
+                { $gender ->
+                    [f] чёрная
+                    [n] чёрное
+                    *[m] чёрный
+                }
         }
     .white =
-        { $gender ->
-            [insf] белой
-            [f] белая
-            [n] белое
-           *[m] белый
+        { $role ->
+            [border-clause] белой
+            [background-clause] белом
+            [text-clause] белый
+            *[standalone]
+                { $gender ->
+                    [f] белая
+                    [n] белое
+                    *[m] белый
+                }
         }
     .gray =
-        { $gender ->
-            [insf] серой
-            [f] серая
-            [n] серое
-           *[m] серый
+        { $role ->
+            [border-clause] серой
+            [background-clause] сером
+            [text-clause] серый
+            *[standalone]
+                { $gender ->
+                    [f] серая
+                    [n] серое
+                    *[m] серый
+                }
         }
     .red =
-        { $gender ->
-            [insf] красной
-            [f] красная
-            [n] красное
-           *[m] красный
+        { $role ->
+            [border-clause] красной
+            [background-clause] красном
+            [text-clause] красный
+            *[standalone]
+                { $gender ->
+                    [f] красная
+                    [n] красное
+                    *[m] красный
+                }
         }
     .orange =
-        { $gender ->
-            [insf] оранжевой
-            [f] оранжевая
-            [n] оранжевое
-           *[m] оранжевый
+        { $role ->
+            [border-clause] оранжевой
+            [background-clause] оранжевом
+            [text-clause] оранжевый
+            *[standalone]
+                { $gender ->
+                    [f] оранжевая
+                    [n] оранжевое
+                    *[m] оранжевый
+                }
         }
     .yellow =
-        { $gender ->
-            [insf] жёлтой
-            [f] жёлтая
-            [n] жёлтое
-           *[m] жёлтый
+        { $role ->
+            [border-clause] жёлтой
+            [background-clause] жёлтом
+            [text-clause] жёлтый
+            *[standalone]
+                { $gender ->
+                    [f] жёлтая
+                    [n] жёлтое
+                    *[m] жёлтый
+                }
         }
     .green =
-        { $gender ->
-            [insf] зелёной
-            [f] зелёная
-            [n] зелёное
-           *[m] зелёный
+        { $role ->
+            [border-clause] зелёной
+            [background-clause] зелёном
+            [text-clause] зелёный
+            *[standalone]
+                { $gender ->
+                    [f] зелёная
+                    [n] зелёное
+                    *[m] зелёный
+                }
         }
     .cyan =
-        { $gender ->
-            [insf] голубой
-            [f] голубая
-            [n] голубое
-           *[m] голубой
+        { $role ->
+            [border-clause] голубой
+            [background-clause] голубом
+            [text-clause] голубой
+            *[standalone]
+                { $gender ->
+                    [f] голубая
+                    [n] голубое
+                    *[m] голубой
+                }
         }
     .blue =
-        { $gender ->
-            [insf] синей
-            [f] синяя
-            [n] синее
-           *[m] синий
+        { $role ->
+            [border-clause] синей
+            [background-clause] синем
+            [text-clause] синий
+            *[standalone]
+                { $gender ->
+                    [f] синяя
+                    [n] синее
+                    *[m] синий
+                }
         }
     .purple =
-        { $gender ->
-            [insf] фиолетовой
-            [f] фиолетовая
-            [n] фиолетовое
-           *[m] фиолетовый
+        { $role ->
+            [border-clause] фиолетовой
+            [background-clause] фиолетовом
+            [text-clause] фиолетовый
+            *[standalone]
+                { $gender ->
+                    [f] фиолетовая
+                    [n] фиолетовое
+                    *[m] фиолетовый
+                }
         }
     .pink =
-        { $gender ->
-            [insf] розовой
-            [f] розовая
-            [n] розовое
-           *[m] розовый
+        { $role ->
+            [border-clause] розовой
+            [background-clause] розовом
+            [text-clause] розовый
+            *[standalone]
+                { $gender ->
+                    [f] розовая
+                    [n] розовое
+                    *[m] розовый
+                }
         }
     .brown =
-        { $gender ->
-            [insf] коричневой
-            [f] коричневая
-            [n] коричневое
-           *[m] коричневый
+        { $role ->
+            [border-clause] коричневой
+            [background-clause] коричневом
+            [text-clause] коричневый
+            *[standalone]
+                { $gender ->
+                    [f] коричневая
+                    [n] коричневое
+                    *[m] коричневый
+                }
         }
 
 line-width =
     .thick =
-        { $gender ->
-            [insf] толстой
-            [f] толстая
-            [n] толстое
-           *[m] толстый
+        { $role ->
+            [border-clause] толстой
+            [background-clause] толстом
+            [text-clause] толстый
+            *[standalone]
+                { $gender ->
+                    [f] толстая
+                    [n] толстое
+                    *[m] толстый
+                }
         }
     .thin =
-        { $gender ->
-            [insf] тонкой
-            [f] тонкая
-            [n] тонкое
-           *[m] тонкий
+        { $role ->
+            [border-clause] тонкой
+            [background-clause] тонком
+            [text-clause] тонкий
+            *[standalone]
+                { $gender ->
+                    [f] тонкая
+                    [n] тонкое
+                    *[m] тонкий
+                }
         }
 
 line-style =
     .dashed =
-        { $gender ->
-            [insf] штриховой
-            [f] штриховая
-            [n] штриховое
-           *[m] штриховой
+        { $role ->
+            [border-clause] штриховой
+            [background-clause] штриховом
+            [text-clause] штриховой
+            *[standalone]
+                { $gender ->
+                    [f] штриховая
+                    [n] штриховое
+                    *[m] штриховой
+                }
         }
     .dotted =
-        { $gender ->
-            [insf] пунктирной
-            [f] пунктирная
-            [n] пунктирное
-           *[m] пунктирный
+        { $role ->
+            [border-clause] пунктирной
+            [background-clause] пунктирном
+            [text-clause] пунктирный
+            *[standalone]
+                { $gender ->
+                    [f] пунктирная
+                    [n] пунктирное
+                    *[m] пунктирный
+                }
         }
 
 # Noun phrases in the instrumental, which is the case «с» takes. They agree
@@ -175,22 +267,11 @@ noun-regular-polygon =
 # or the head of a phrase the description never names: `border` (граница, f),
 # `fill` (заливка, f), `text` (текст, m), `background` (фон, m).
 #
-# `border` answers `insf` — feminine *instrumental* — rather than plain `f`,
-# because the only place its adjectives are rendered is after «с» in
-# `style-border-clause`, and «с» governs the instrumental: «с толстой
-# границей», not «с толстая границей». `$gender` is a single token that this
-# catalog chooses the meaning of, so carrying a case in it is what the
-# mechanism allows; what it cannot do is carry two, and
-# `borderStyleDescription` — the state variable that renders a border's style
-# on its own, with no preposition — therefore also comes out instrumental.
-# Fixing that properly means the code passing a case alongside the gender
-# (#1606).
-#
-# `background` faces the same fork and is resolved the other way: it stays
-# nominative, so `backgroundColor` reads right on its own and the «на … фоне»
-# clause in `style-text` carries the nominative with it. The two nouns split
-# because a border is named by a clause far more often than alone, and a
-# background the reverse.
+# Every one of them answers a plain gender now. `border` and `background` used
+# to answer a case instead — `insf` — because each is rendered in two positions
+# and a single token could only suit one of them. `$role` carries that
+# distinction, so this message is back to answering the one question its name
+# asks (#1606).
 noun-gender =
     { $noun ->
         [line] f
@@ -201,7 +282,7 @@ noun-gender =
         [circle] f
         [region] f
         [point] f
-        [border] insf
+        [border] f
         [fill] f
        *[other] m
     }
@@ -227,11 +308,16 @@ style-with-noun =
     }
 
 style-filled-word =
-    { $gender ->
-        [insf] закрашенной
-        [f] закрашенная
-        [n] закрашенное
-       *[m] закрашенный
+    { $role ->
+        [border-clause] закрашенной
+        [background-clause] закрашенном
+        [text-clause] закрашенный
+        *[standalone]
+            { $gender ->
+                [f] закрашенная
+                [n] закрашенное
+                *[m] закрашенный
+            }
     }
 
 style-filled =

--- a/packages/i18n/locales/ru/content.ftl
+++ b/packages/i18n/locales/ru/content.ftl
@@ -11,7 +11,7 @@
 #
 #   standalone          a phrase in the nominative: `-ый`/`-ой` m, `-ая` f,
 #                       `-ое` n
-#   border-clause       after «с », which governs the instrumental, of
+#   border-clause       after «с», which governs the instrumental, of
 #                       «граница» — feminine: `-ой`
 #   background-clause   after «на … фоне», prepositional, of «фон» —
 #                       masculine: `-ом` (`-ем` after a soft stem)
@@ -267,11 +267,13 @@ noun-regular-polygon =
 # or the head of a phrase the description never names: `border` (граница, f),
 # `fill` (заливка, f), `text` (текст, m), `background` (фон, m).
 #
-# Every one of them answers a plain gender now. `border` and `background` used
-# to answer a case instead — `insf` — because each is rendered in two positions
-# and a single token could only suit one of them. `$role` carries that
-# distinction, so this message is back to answering the one question its name
-# asks (#1606).
+# Every one of them answers a plain gender now. `border` used to answer a case
+# instead — `insf` — because its adjectives are rendered in two positions and a
+# single token could only suit one of them; it was tuned for the clause, so the
+# standalone `borderStyleDescription` came out instrumental. `background` kept
+# its plain gender and so was wrong the other way round, nominative behind
+# «на». `$role` carries the distinction now, and this message is back to
+# answering the one question its name asks (#1606).
 noun-gender =
     { $noun ->
         [line] f

--- a/packages/i18n/locales/tr/chrome.ftl
+++ b/packages/i18n/locales/tr/chrome.ftl
@@ -131,6 +131,6 @@ accessibility-heading-level-2 = Erişilebilirlik uyarısı
 
 something-went-wrong = Bir şeyler ters gitti.
 
-renderer-load-failed = bir görüntüleyici bileşeni yüklenemedi. Lütfen sayfayı yeniden yükleyin.
+renderer-load-failed = bir işleyici bileşeni yüklenemedi. Lütfen sayfayı yeniden yükleyin.
 
 core-start-failed = Belge görüntüleyici başlatılamadı. Lütfen sayfayı yeniden yükleyin.

--- a/packages/i18n/locales/tr/chrome.ftl
+++ b/packages/i18n/locales/tr/chrome.ftl
@@ -1,0 +1,136 @@
+# Turkish viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Turkish has two plural categories, but a noun counted by a numeral stays
+# singular — `3 deneme`, never `3 denemeler` — so a `{ $count }` message reads
+# the same in both branches and needs no selection beyond `[0]`, where the
+# English wording changes.
+#
+# Controls take the bare imperative, which is what Turkish puts on a button:
+# `Klavyeyi aç`, not `Klavyeyi açınız`.
+
+
+## Answer submission
+
+answer-checking = Denetleniyor...
+answer-submitting = Gönderiliyor...
+
+answer-checking-status = Yanıt denetleniyor
+answer-submitting-status = Yanıt gönderiliyor
+
+answer-correct = Doğru
+answer-incorrect = Yanlış
+
+answer-response-saved = Yanıt kaydedildi
+
+answer-percent-credit = %{ $percent } puan
+answer-percent-correct = %{ $percent } doğru
+answer-percent-short = %{ $percent }
+
+max-credit-available = Alınabilecek en yüksek puan: %{ $percent }
+
+attempts-remaining =
+    { $count ->
+        [0] deneme hakkı kalmadı
+       *[other] { $count } deneme hakkı kaldı
+    }
+
+validation-correct = (Doğru)
+validation-incorrect = (Yanlış)
+validation-partially-correct = (Kısmen doğru)
+
+answer-show-responses = { $answerId } için { $count } yanıtı göster
+
+
+## Disclosure panels
+
+feedback-heading = Geri bildirim
+
+collapsible-click-to-open = (açmak için tıklayın)
+collapsible-click-to-close = (kapatmak için tıklayın)
+
+collapsible-initializing = Hazırlanıyor...
+
+footnote-show = Dipnotu göster
+footnote-hide = Dipnotu gizle
+
+description-more-information = daha fazla bilgi
+
+
+## Controls
+
+slider-previous = Önceki
+slider-next = Sonraki
+
+keyboard-open = Klavyeyi aç
+keyboard-close = Klavyeyi kapat
+
+matrix-remove-row = Satır sil
+matrix-add-row = Satır ekle
+matrix-remove-column = Sütun sil
+matrix-add-column = Sütun ekle
+
+subset-add-remove-points = Nokta ekle/sil
+subset-toggle-points-intervals = Noktalar ve aralıklar arasında geçiş yap
+subset-move-points = Noktaları taşı
+subset-clear = Temizle
+
+# A `box` here is one orbital, drawn as a square: kutu.
+orbital-add-row = Satır ekle
+orbital-remove-row = Satır sil
+orbital-add-box = Kutu ekle
+orbital-remove-box = Kutu sil
+orbital-add-up-arrow = Yukarı ok ekle
+orbital-add-down-arrow = Aşağı ok ekle
+orbital-remove-arrow = Ok sil
+
+orbital-row-label = { $row }. satırın etiketi
+
+pretzel-answer = Yanıt
+
+summary-statistics-caption = { $column } için betimsel istatistikler
+
+
+## Math input
+
+math-input-preview-region = matematiksel ifade önizlemesi
+math-input-preview = Önizleme
+math-input-invalid-expression = Geçersiz ifade:
+
+
+## Document status
+
+viewer-initializing = Hazırlanıyor...
+
+
+## Errors
+
+error-heading = Hata
+
+error-found-at =
+    { $span ->
+        [line] { $startLine }. satırda bulundu.
+       *[lines] { $startLine }–{ $endLine }. satırlarda bulundu.
+    }
+
+document-contains-errors = Bu belge hatalar içeriyor!
+
+diagnostic-heading-error = Hata
+diagnostic-heading-warning = Uyarı
+diagnostic-heading-information = Bilgi
+diagnostic-heading-hint = İpucu
+
+accessibility-heading-level-1 = WCAG AA erişilebilirlik ihlali
+accessibility-heading-level-2 = Erişilebilirlik uyarısı
+
+something-went-wrong = Bir şeyler ters gitti.
+
+renderer-load-failed = bir görüntüleyici bileşeni yüklenemedi. Lütfen sayfayı yeniden yükleyin.
+
+core-start-failed = Belge görüntüleyici başlatılamadı. Lütfen sayfayı yeniden yükleyin.

--- a/packages/i18n/locales/tr/content.ftl
+++ b/packages/i18n/locales/tr/content.ftl
@@ -1,0 +1,370 @@
+# Turkish content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Turkish has no grammatical gender and does not inflect an attributive
+# adjective for case or number, so both `$gender` and `$role` go unused here
+# exactly as they do in English. Adjectives precede the noun, as in English, so
+# the composition messages keep the English order.
+#
+# Turkish is agglutinative, and the suffixes that would matter here attach to
+# the *noun*, not to the adjectives in front of it — which is why nothing below
+# has to vary. `kenarlıklı` ("bordered") carries its own suffix and takes the
+# border's description in front of it unchanged.
+
+
+## Style vocabulary
+
+color =
+    .black = siyah
+    .white = beyaz
+    .gray = gri
+    .red = kırmızı
+    .orange = turuncu
+    .yellow = sarı
+    .green = yeşil
+    .cyan = camgöbeği
+    .blue = mavi
+    .purple = mor
+    .pink = pembe
+    .brown = kahverengi
+
+line-width =
+    .thick = kalın
+    .thin = ince
+
+line-style =
+    .dashed = kesikli
+    .dotted = noktalı
+
+# Noun phrases: they precede `desenli` and modify nothing.
+fill-style =
+    .horizontal = yatay çizgi
+    .vertical = dikey çizgi
+    .diagonal = çapraz çizgi
+    .backdiagonal = ters çapraz çizgi
+    .dots = nokta
+    .diamonds = baklava dilimi
+
+noun =
+    .line = doğru
+    .line-segment = doğru parçası
+    .ray = ışın
+    .vector = vektör
+    .curve = eğri
+    .function = fonksiyon
+    .parabola = parabol
+    .polyline = kırık çizgi
+    .polygon = çokgen
+    .triangle = üçgen
+    .rectangle = dikdörtgen
+    .circle = çember
+    .region = bölge
+    .point = nokta
+    .square = kare
+    .diamond = eşkenar dörtgen
+    .cross = çarpı
+    .plus = artı
+
+# Turkish builds the word from the side count itself — düzgün beşgen — so the
+# whole thing is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] düzgün { $numSides }-gen
+    }
+
+# Turkish has no grammatical gender, so every noun answers the same and the
+# answer goes unused — as in English.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = dolgulu
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } desenli { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } desenli { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } desenli { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# `kenarlıklı` carries the "with a border" sense in its own suffix, so no
+# preposition and no article is needed — which makes all four branches the same
+# except for the connective English needs and Turkish does not.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } kenarlıklı
+        [and] ve { $border } kenarlıklı
+        [and-article] ve { $border } kenarlıklı
+       *[with] { $border } kenarlıklı
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = dolgusuz
+
+style-text =
+    { $parts ->
+        [background] { $background } zemin üzerinde { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = yok
+
+
+## Boolean words
+
+boolean-true = doğru
+boolean-false = yanlış
+
+
+## Answer buttons
+
+answer-submit-label = Kontrol et
+answer-submit-label-no-correctness = Yanıtı gönder
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Etkinlik
+    .aside = Yan not
+    .cascade = Kaskat
+    .definition = Tanım
+    .example = Örnek
+    .exercise = Alıştırma
+    .exercises = Alıştırmalar
+    .given-answer = Cevap
+    .note = Not
+    .objectives = Hedefler
+    .paragraphs = Paragraflar
+    .part = Bölüm
+    .problem = Problem
+    .problems = Problemler
+    .proof = İspat
+    .question = Soru
+    .section = Kısım
+    .solution = Çözüm
+    .task = Görev
+    .theorem = Teorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = İpucu
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tablo { $enumeration }
+        [numbered-title] Tablo { $enumeration }{ ": " }
+        [unnumbered-title] Tablo{ ": " }
+       *[unnumbered] Tablo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Şekil { $enumeration }
+        [numbered-caption] Şekil { $enumeration }{ ": " }
+        [unnumbered-caption] Şekil{ ": " }
+       *[unnumbered] Şekil
+    }
+
+
+## Paginator controls
+
+paginator-previous = Önceki
+paginator-next = Sonraki
+paginator-page = Sayfa
+
+paginator-page-status = { $numPages } { $pageLabel } içinden { $currentPage }
+
+
+## Piecewise functions
+
+piecewise-condition-or = veya
+piecewise-condition-if = eğer
+piecewise-condition-otherwise = aksi halde
+
+
+## Chemistry
+
+element-name =
+    .h = Hidrojen
+    .he = Helyum
+    .li = Lityum
+    .be = Berilyum
+    .b = Bor
+    .c = Karbon
+    .n = Azot
+    .o = Oksijen
+    .f = Flor
+    .ne = Neon
+    .na = Sodyum
+    .mg = Magnezyum
+    .al = Alüminyum
+    .si = Silisyum
+    .p = Fosfor
+    .s = Kükürt
+    .cl = Klor
+    .ar = Argon
+    .k = Potasyum
+    .ca = Kalsiyum
+    .sc = Skandiyum
+    .ti = Titanyum
+    .v = Vanadyum
+    .cr = Krom
+    .mn = Manganez
+    .fe = Demir
+    .co = Kobalt
+    .ni = Nikel
+    .cu = Bakır
+    .zn = Çinko
+    .ga = Galyum
+    .ge = Germanyum
+    .as = Arsenik
+    .se = Selenyum
+    .br = Brom
+    .kr = Kripton
+    .rb = Rubidyum
+    .sr = Stronsiyum
+    .y = İtriyum
+    .zr = Zirkonyum
+    .nb = Niyobyum
+    .mo = Molibden
+    .tc = Teknesyum
+    .ru = Rutenyum
+    .rh = Rodyum
+    .pd = Paladyum
+    .ag = Gümüş
+    .cd = Kadmiyum
+    .in = İndiyum
+    .sn = Kalay
+    .sb = Antimon
+    .te = Tellür
+    .i = İyot
+    .xe = Ksenon
+    .cs = Sezyum
+    .ba = Baryum
+    .la = Lantan
+    .ce = Seryum
+    .pr = Praseodim
+    .nd = Neodim
+    .pm = Prometyum
+    .sm = Samaryum
+    .eu = Evropiyum
+    .gd = Gadolinyum
+    .tb = Terbiyum
+    .dy = Disprosyum
+    .ho = Holmiyum
+    .er = Erbiyum
+    .tm = Tulyum
+    .yb = İterbiyum
+    .lu = Lutesyum
+    .hf = Hafniyum
+    .ta = Tantal
+    .w = Tungsten
+    .re = Renyum
+    .os = Osmiyum
+    .ir = İridyum
+    .pt = Platin
+    .au = Altın
+    .hg = Cıva
+    .tl = Talyum
+    .pb = Kurşun
+    .bi = Bizmut
+    .po = Polonyum
+    .at = Astatin
+    .rn = Radon
+    .fr = Fransiyum
+    .ra = Radyum
+    .ac = Aktinyum
+    .th = Toryum
+    .pa = Protaktinyum
+    .u = Uranyum
+    .np = Neptünyum
+    .pu = Plütonyum
+    .am = Amerikyum
+    .cm = Küriyum
+    .bk = Berkelyum
+    .cf = Kaliforniyum
+    .es = Aynştaynyum
+    .fm = Fermiyum
+    .md = Mendelevyum
+    .no = Nobelyum
+    .lr = Lavrensiyum
+    .rf = Rutherfordiyum
+    .db = Dubniyum
+    .sg = Seaborgiyum
+    .bh = Bohriyum
+    .hs = Hassiyum
+    .mt = Meitneriyum
+    .ds = Darmstadtiyum
+    .rg = Röntgenyum
+    .cn = Kopernikyum
+    .nh = Nihonyum
+    .fl = Flerovyum
+    .mc = Moskovyum
+    .lv = Livermoryum
+    .ts = Tennessin
+    .og = Oganesson
+
+element-anion-name =
+    .h = Hidrür
+    .c = Karbür
+    .n = Nitrür
+    .o = Oksit
+    .f = Florür
+    .p = Fosfür
+    .s = Sülfür
+    .cl = Klorür
+    .br = Bromür
+    .i = İyodür
+    .at = Astatür
+    .ts = Tennessür
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Geçersiz kimyasal sembol
+chemistry-invalid-ionic-compound = Geçersiz iyonik bileşik

--- a/packages/i18n/locales/tr/diagnostics.ftl
+++ b/packages/i18n/locales/tr/diagnostics.ftl
@@ -1,0 +1,614 @@
+# Turkish diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# A noun counted by a numeral stays singular in Turkish, so a `{ $count }`
+# message reads the same in both plural branches and needs no selection.
+#
+# Turkish suffixes agree with the vowels of the word they attach to, which
+# cannot be done to a placeable whose value is not known — an element or
+# attribute name quoted from the author's source. Those are left to stand on
+# their own rather than given a suffix that would be wrong half the time.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = İki uç nokta belirtildiğinde { $attributes } yok sayılır
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = Bir uç nokta ile bir orta nokta birlikte belirtildiğinde { $attributes } yok sayılır
+
+line-segment-midpoint-offset-without-midpoint = Orta nokta olmadan midpointOffset etkisizdir
+
+## `<line>`
+
+line-points-undetermined-dimensions = Boyutları belirsiz noktalardan geçen doğru.
+
+line-points-too-few-dimensions = Doğru, en az iki boyutlu noktalardan geçmelidir.
+
+line-points-depend-on-variables = Doğru, değişkenlere bağlı noktalardan geçiyor: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ve { $variable2 } değişkenleriyle yazılan doğru denkleminin biçimi geçersiz.
+
+## `<ray>`
+
+ray-overprescribed-through = Işın aynı anda through, endpoint ve direction ile belirlenmiş. Belirtilen through yok sayılıyor.
+
+ray-dimension-mismatch = Işında numDimensions uyuşmuyor.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektör aynı anda head, tail ve displacement ile belirlenmiş. Belirtilen head yok sayılıyor.
+
+vector-dimension-mismatch = Vektörde numDimensions uyuşmuyor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` ögesine çekilemiyor; nearestPoint durum değişkeni yok.
+
+constrain-to-without-nearest-point = `<{ $component }>` ögesine kısıtlanamıyor; nearestPoint durum değişkeni yok.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` ögesinin içine kısıtlanamıyor; nearestPoint durum değişkeni yok.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = Satır içi olmayan choiceInput için labelPosition yok sayılır
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = indices sayısı choice alt ögelerinin sayısıyla uyuşmadığı için choiceInput için belirtilen indices yok sayılıyor.
+
+pretzel-indices-count-mismatch = indices sayısı problem alt ögelerinin sayısıyla uyuşmadığı için problem için belirtilen indices yok sayılıyor.
+
+shuffle-indices-count-mismatch = indices sayısı bileşen sayısıyla uyuşmadığı için shuffle için belirtilen indices yok sayılıyor.
+
+indices-ignored-out-of-range = Bazı dizinler aralık dışında olduğu için { $component } için belirtilen indices yok sayılıyor.
+
+pretzel-indices-repeated = Bazı dizinler yinelendiği için pretzel için belirtilen indices yok sayılıyor.
+
+pretzel-circuit-first-index = circuit kipinde ilk dizin 1 olmak zorunda olduğu için pretzel için belirtilen indices yok sayılıyor.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ögesinin dizge alt ögeleriyle çalışabilmesi için `type` özniteliği belirtilmelidir.
+
+invalid-type-defaulting-to-math = { $component } bileşeni için { $type } türü geçersiz. math, text, number veya boolean olmalıdır. math kullanılıyor.
+
+string-not-valid-component-to-arrange = "{ $value }" dizgesi { $component } için geçerli bir bileşen değil. Yok sayılıyor.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = { $type } türü geçersiz; tür number olarak ayarlanıyor.
+
+invalid-variable-value = Bir değişkenin değeri geçersiz: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Varyant dizini { $index } bir sayı olmalıdır
+
+variant-index-must-be-integer = Varyant dizini { $index } bir tam sayı olmalıdır
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` mutlak ölçüler için gerçeklenmedi. Genişlikler göreli değerlere ayarlanıyor.
+
+side-by-side-absolute-margins = `<{ $component }>` mutlak ölçüler için gerçeklenmedi. Kenar boşlukları göreli değerlere ayarlanıyor.
+
+side-by-side-no-block-child = `<{ $component }>` geçersiz: en az bir blok alt ögesi olmalıdır.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Grafik `<label>` üzerindeki `for` özniteliği yok sayılır.
+
+label-for-must-resolve-to-one = `<label>` üzerindeki `for` özniteliği tam olarak bir bileşene çözümlenmelidir.
+
+label-for-unresolved = `<label>` üzerindeki `for` özniteliği bir bileşene çözümlenemedi.
+
+label-for-answer-with-authored-inputs = `<label>` üzerindeki `for` özniteliği, girdileri açıkça yazılmış bir `<answer>` ögesine başvuruyor; doğrudan o girdiye başvurun.
+
+label-for-answer-without-input = `<label>` üzerindeki `for` özniteliği, etiketlenecek girdisi olmayan bir `<answer>` ögesine başvuruyor.
+
+label-for-must-reference-input-or-answer = `<label>` üzerindeki `for` özniteliği bir girdiye ya da bir yanıta başvurmalıdır.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Erişilebilirlik için `<{ $component }>` ögesinin kısa bir açıklaması olmalı ya da süsleyici olarak belirtilmelidir.
+
+accessibility-video-short-description = Erişilebilirlik için `<video>` ögesinin kısa bir açıklaması olmalıdır.
+
+accessibility-input-short-description-or-label = Erişilebilirlik için `<{ $component }>` ögesinin kısa bir açıklaması ya da etiketi olmalıdır.
+
+accessibility-answer-input-short-description-or-label = Erişilebilirlik için girdi oluşturan bir `<answer>` ögesinin kısa bir açıklaması ya da etiketi olmalıdır.
+
+accessibility-short-description-contains-math = Kısa açıklamalar `<{ $component }>` gibi matematik bileşenleri içermemelidir. Matematiği sözcüklerle yazın.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } bölüm başlığı metni için yetersiz karşıtlığa sahip (koyu kip) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; en az { $threshold }:1 gerekir).
+       *[other] { $colorName } bölüm başlığı metni için yetersiz karşıtlığa sahip ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; en az { $threshold }:1 gerekir).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Noktaların sayısal değerleri olmadığında { $count } noktadan geçen `<circle>` henüz gerçeklenmedi.
+
+circle-too-many-through-points = 3'ten fazla noktadan geçen çember hesaplanamaz.
+
+circle-overprescribed-radius-center-points = Yarıçapı, merkezi ve geçtiği noktaları birlikte belirtilmiş çember hesaplanamaz.
+
+circle-center-with-multiple-points = Merkezi belirtilmiş ve 1'den fazla noktadan geçen çember hesaplanamaz.
+
+circle-radius-too-small = Çember hesaplanamıyor: iki nokta arasındaki uzaklık { $distance } olduğuna göre, belirtilen { $radius } yarıçapı çok küçük.
+
+circle-radius-with-many-points = Yarıçapı belirtilmiş, ikiden fazla noktadan geçen çember oluşturulamaz.
+
+circle-invalid-center-or-through-points = Çemberin merkezi ya da geçtiği noktalar geçersiz.
+
+circle-radius-center-with-multiple-points = Merkezi belirtilmiş ve 1'den fazla noktadan geçen çemberin yarıçapı hesaplanamaz.
+
+circle-change-radius-non-numerical = Geçtiği noktalar sayısal olmayan bir çemberin yarıçapı değiştirilemez
+
+circle-radius-with-points-non-numerical = Sayısal değerler yokken, yarıçapı belirtilmiş ve birden fazla noktadan geçen çember oluşturulamaz.
+
+circle-change-center-non-numerical = Sayısal olmayan noktalardan geçen bir çemberin merkezini değiştirmek henüz gerçeklenmedi.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Fonksiyonun tanım kümesi için boyutlar yetersiz. Tanım kümesinde { $intervals } aralık var, ancak fonksiyonun { $inputs } girdisi var.
+
+function-domain-invalid-format = Fonksiyonun tanım kümesinin biçimi geçersiz.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Fonksiyonun sayısal olmayan en büyük değeri yok sayılıyor.
+        [minimum] Fonksiyonun sayısal olmayan en küçük değeri yok sayılıyor.
+        [extremum] Fonksiyonun sayısal olmayan uç değeri yok sayılıyor.
+        [point] Fonksiyonun sayısal olmayan noktası yok sayılıyor.
+        [slope] Fonksiyonun sayısal olmayan eğimi yok sayılıyor.
+       *[other] Fonksiyonun sayısal olmayan { $type } değeri yok sayılıyor.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Fonksiyonun boş en büyük değeri yok sayılıyor.
+        [minimum] Fonksiyonun boş en küçük değeri yok sayılıyor.
+        [extremum] Fonksiyonun boş uç değeri yok sayılıyor.
+        [point] Fonksiyonun boş noktası yok sayılıyor.
+       *[other] Fonksiyonun boş { $type } değeri yok sayılıyor.
+    }
+
+function-points-too-close = Fonksiyonda konumları birbirine çok yakın iki nokta var. Fonksiyon tanımlanamıyor.
+
+function-iterates-input-output-mismatch = Fonksiyon yinelemesi ancak girdi sayısı çıktı sayısına eşitse olanaklıdır. Bu fonksiyonun { $inputs } girdisi ve { $outputs } çıktısı var.
+
+## `<sequence>`
+
+sequence-invalid-length = Dizinin uzunluğu geçersiz. Negatif olmayan bir tam sayı olmalıdır.
+
+sequence-invalid-step = Dizinin adımı geçersiz. { $type } türündeki bir dizi için bir sayı olmalıdır.
+
+sequence-invalid-endpoint-number = Sayı dizisinin "{ $attribute }" değeri geçersiz. Bir sayı olmalıdır.
+
+sequence-invalid-endpoint-letters = Harf dizisinin "{ $attribute }" değeri geçersiz. Bir harf birleşimi olmalıdır.
+
+sequence-invalid-endpoint = Dizinin "{ $attribute }" değeri geçersiz.
+
+select-from-sequence-coprime-not-numbers = Sayı seçilmediği için coprime yok sayıldı
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations belirtildiği için coprime yok sayıldı
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` için target geçersiz: hedef bulunamıyor.
+
+target-state-variable-not-found = `<{ $source }>` için target geçersiz: bir `<{ $component }>` üzerinde "{ $property }" adlı bir durum değişkeni bulunamıyor.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` değişkenleri bağımsız değişkenden farklı olmalıdır.
+
+ode-system-duplicate-variable-names = Yinelenen bağımlı değişken adlarıyla ODE sağ taraf fonksiyonları tanımlanamaz.
+
+ode-system-rhs-function-error = ODE sağ taraf fonksiyonu tanımlanamıyor. mathjs fonksiyonu oluşturulurken hata oluştu.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } doğru arasındaki açı tanımlanamaz
+
+angle-invalid-through-point = `<angle>` ögesinin through değerinde geçersiz nokta var
+
+parabola-vertex-too-many-points = Tepe noktası belirtilmiş ve 1'den fazla noktadan geçen parabol henüz gerçeklenmedi.
+
+parabola-too-many-points = 3'ten fazla noktadan geçen parabol henüz gerçeklenmedi.
+
+intersection-too-many-items = İkiden fazla nesnenin kesişimi henüz gerçeklenmedi
+
+## Other math components
+
+ionic-compound-not-two-ions = İki iyon dışındaki iyonik bileşikler henüz gerçeklenmedi.
+
+ionic-compound-needs-cation-and-anion = İyonik bileşik yalnızca bir katyon ve bir anyon için gerçeklendi.
+
+solve-equations-cannot-evaluate = Denklem değerlendirilemediği için çözülemiyor: { $equation }
+
+math-operators-operand-number-required = Bir matematik işleneni çıkarılırken operandNumber belirtilmelidir.
+
+eigen-decomposition-failed = Matrisin özdeğerleri hesaplanamadı
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: { $parameters } parametresi örüntüde geçmiyor, bu yüzden her zaman boşlukla eşleşecek.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" yorumlanamıyor. none, medium, dense ya da boşlukla ayrılmış iki pozitif sayı olmalıdır; örneğin grid="1 0.5". Izgara çizilmiyor.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure görüntüleyicisinde xLabelPosition="left" desteklenmiyor; sağ konum davranışı kullanılıyor.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure görüntüleyicisinde yLabelPosition="bottom" desteklenmiyor; üst konum davranışı kullanılıyor.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure dönüşümü için eksen sınırları geçersiz; varsayılan bbox (-10,-10,10,10) kullanılıyor.
+
+prefigure-invalid-width = `<graph>`: prefigure dönüşümü için genişlik geçersiz; varsayılan diyagram genişliği 425 kullanılıyor.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure dönüşümü için aspectRatio geçersiz; varsayılan en boy oranı 1 kullanılıyor.
+
+prefigure-grid-spacing-too-fine = `<graph>`: ızgara aralığı eksen sınırlarına göre çok ince; prefigure görüntüleyicisinde ızgara atlanıyor.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure görüntüleyicisi kullanılmadığında açıklamalar çizilmez.
+
+multiple-annotations-children = `<graph>` içinde birden çok `<annotations>` alt ögesi bulundu; sonuncusu dışındakiler yok sayılıyor.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Tanınmayan bir bileşen türü genişletilemez ya da kopyalanamaz: { $type }.
+
+copy-prop-not-found = { $component } türündeki bir bileşende { $property } özelliği bulunamadı
+
+collect-no-source = collect için kaynak bulunamadı.
+
+collect-invalid-component-type = `<{ $component }>` geçerli bir bileşen türü olmadığı için bu türdeki bileşenler toplanamaz.
+
+reference-index-unavailable = `{ $reference }` dizinine başvurulamıyor
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` bileşeninde { $action } çağrılamıyor
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Verinin biçimi geçersiz. Satır uzunlukları tutarsız. componentIdx :{ $componentIdx } içinde bulundu
+
+data-frame-duplicate-column-names = Veride yinelenen sütun adları var. componentIdx :{ $componentIdx } içinde bulundu
+
+data-frame-missing-column-name = Veride bir sütun adı eksik. componentIdx :{ $componentIdx } içinde bulundu
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Bu yanıtın bir award ögesi, answer etiketinin kendi gönderdiği yanıta dayanıyor; bu beklenmedik davranışa yol açar.
+
+answer-max-num-attempts-in-section-wide-check-work = Deneme sayısı kapsayıcı tarafından denetlendiği için, `sectionWideCheckWork` bulunan bir kapsayıcı içindeki `<answer>` ögesinde `maxNumAttempts` ayarlamanın etkisi olmaz. `maxNumAttempts` değerini kapsayıcıda ayarlayın.
+
+nested-section-wide-check-work-max-num-attempts = Deneme sayısı dıştaki kapsayıcı tarafından denetlendiği için, `sectionWideCheckWork` bulunan başka bir kapsayıcının içindeki `sectionWideCheckWork` kapsayıcısında `maxNumAttempts` ayarlamanın etkisi olmaz. `maxNumAttempts` değerini dıştaki kapsayıcıda ayarlayın.
+
+answer-attributes-need-symbolic-equality = symbolicEquality ayarlanmadan { $attributes } özniteliğinin etkisi olmaz.
+
+answer-invalid-type = answer için tür geçersiz: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` bileşeninin adı olmadığı için modül özniteliği olarak kullanılamaz
+
+module-attribute-name-already-defined = `<module>` bileşen türü zaten bir "{ $name }" özniteliği tanımladığı için `<{ $component } name="{ $name }">` bileşeni bir modülün özniteliği olarak kullanılamaz.
+
+conditional-content-condition-ignored = case ya da else alt ögeleri bulunan bir `<conditionalContent>` bileşeninde `condition` özniteliği yok sayılır.
+
+slider-markers-type-mismatch = İşaretçilerin türü kaydırıcının türüyle uyuşmuyor.
+
+pretzel-problem-needs-statement-and-answer = pretzel geçersiz: her `<problem>` bir `<statement>` ve bir `<answer>` içermelidir.
+
+pretzel-circuit-first-problem-distractor = pretzel geçersiz: mode="circuit" durumunda ilk `<problem>` bir çeldirici olamaz.
+
+## Attribute values
+
+attribute-invalid-values = `{ $attribute }` özniteliği için { $values } değeri geçersiz; yok sayılıyor.
+
+attribute-must-be-references = `{ $attribute }` özniteliği için `{ $value }` değeri geçersiz. Öznitelik `$` ile başlayan başvurulardan oluşmalıdır.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } içindeki geçersiz fonksiyon adları yok sayıldı: { $names }. Her adın görünen bölümü en az 2 karakter (harf ya da kısa çizgi) olmalıdır; ardından isteğe bağlı bir `|<mathspeak seçeneği>` soneki gelebilir.
+
+## Building components from the source
+
+component-type-invalid = Bileşen türü geçersiz: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } özniteliği yinelenemez.
+
+attribute-invalid-for-component = "{ $attribute }" özniteliği `<{ $componentType }>` türündeki bir bileşen için geçersiz.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } numaralı stil tanımı { $context ->
+        [text-on-background] arka plan rengine karşı metin rengi
+        [high-contrast] tuvale karşı yüksek karşıtlıklı renk
+        [line] tuvale karşı çizgi rengi
+        [marker] tuvale karşı işaretçi rengi
+       *[text-on-canvas] tuvale karşı metin rengi
+    } için yetersiz karşıtlığa sahip{ $mode ->
+        [dark] { " (koyu kip)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; en az { $threshold }:1 gerekir).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } numaralı stil tanımı açık kip için yeterli karşıtlık sağlayan renkler belirtmiş olsa da, bu değerlerden türetilen koyu kip renkleri metin rengi ile arka plan rengi arasında yetersiz karşıtlığa sahip ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; en az { $threshold }:1 gerekir). { $suggestion ->
+        [available] Koyu kipte yeterli karşıtlığı sağlamak için ya açık kip karşıtlığını artırın (örneğin { $lightAttribute }="{ $lightColor }" ayarlayın) ya da koyu kip rengini geçersiz kılın (örneğin { $darkAttribute }="{ $darkColor }" ayarlayın).
+       *[none] Koyu kipte yeterli karşıtlığı sağlamak için açık kip karşıtlığını artırın ya da türetilen renkleri textColorDarkMode ve/veya backgroundColorDarkMode ile geçersiz kılın.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } numaralı stil tanımı açık kip için yeterli karşıtlık sağlayan bir metin rengi belirtmiş olsa da, bu değerden türetilen koyu kip metin rengi tuvale karşı yetersiz karşıtlığa sahip ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; en az { $threshold }:1 gerekir). { $suggestion ->
+        [available] Koyu kipte yeterli karşıtlığı sağlamak için ya açık kip karşıtlığını artırın (örneğin textColor="{ $lightColor }" ayarlayın) ya da koyu kip rengini geçersiz kılın (örneğin textColorDarkMode="{ $darkColor }" ayarlayın).
+       *[none] Koyu kipte yeterli karşıtlığı sağlamak için açık kip karşıtlığını artırın ya da türetilen rengi textColorDarkMode ile geçersiz kılın.
+    }
+
+section-multiple-style-palettes = Bir kısım yalnızca bir <stylePalette> seçebilir; sonuncusu kullanılıyor.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect negatif olmayan bir tam sayı olmadığı için { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-num-to-select-not-constant-number = numToSelect sabit olmadığı için { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-with-replacement-not-constant-boolean = withReplacement sabit bir mantıksal değer olmadığı için { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-select-weight-disables-unique = Bir seçenek selectWeight ya da selectForVariants belirtirse select ögesinin benzersiz varyantları devre dışı kalır
+
+variant-coprime-undetermined = coprime değerinin her zaman yanlış olduğu belirlenemediği için { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-attribute-not-constant = { $attribute } sabit olmadığı için { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-attribute-not-number = { $attribute } bir sayı olmadığı için { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } bir { $expected ->
+        [letters-combination] harf birleşimi
+        [math-expression] geçerli matematiksel ifade
+        [integer] tam sayı
+       *[number] sayı
+    } olmadığı için { $type } türündeki { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-length-not-integer = length bir tam sayı olmadığı için { $component } ögesinin benzersiz varyantları belirlenemiyor.
+
+variant-sort-not-implemented = sort bulunan bir { $component } ögesinin benzersiz varyantları henüz gerçeklenmedi
+
+variant-exclude-combinations-not-implemented = excludeCombinations bulunan bir { $component } ögesinin benzersiz varyantları henüz gerçeklenmedi
+
+variant-math-exclude-not-implemented = exclude bulunan math türündeki bir { $component } ögesinin benzersiz varyantları henüz gerçeklenmedi
+
+variant-non-constant-exclude-not-implemented = Sabit olmayan exclude bulunan bir { $component } ögesinin benzersiz varyantları henüz gerçeklenmedi
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: grafik prefigure görüntüleyicisinde desteklenmiyor; alt öge atlandı.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri sonlu değil ya da eksik; alt öge atlandı.
+
+prefigure-curve-label-omitted = { $subject }: dönüştürülmüş eğri ögelerinde etiketler desteklenmiyor; etiket atlandı.
+
+prefigure-curve-unsupported-definition-type = { $subject }: desteklenmeyen eğri fonksiyonu tanım türü '{ $definitionType }'; alt öge atlandı.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves üzerinde flipFunctions özniteliği desteklenmiyor; alt öge atlandı.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves yalnızca formül türündeki alt fonksiyonları destekler; alt öge atlandı.
+
+prefigure-label-position-unsupported =
+    { $subject }: { $labelKind ->
+        [line-family] doğru ailesi etiketi
+       *[point] nokta etiketi
+    } için labelPosition '{ $labelPosition }' desteklenmiyor; PreFigure varsayılan hizalaması kullanılıyor.
+
+prefigure-fill-style-unsupported = { $subject }: '{ $fillStyle }' dolgu stili PreFigure tarafından desteklenmiyor; düz dolguya geçiliyor.
+
+prefigure-line-style-unknown = { $subject }: bilinmeyen '{ $lineStyle }' çizgi stili PreFigure çıktısından atlandı.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: '{ $markerStyle }' işaretçi stili PreFigure'ün 'diamond' stiline eşlendi.
+
+prefigure-marker-style-unsupported = { $subject }: '{ $markerStyle }' işaretçi stili PreFigure tarafından desteklenmiyor; varsayılan stil kullanılıyor.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` geçersiz; hedef çözümlenemiyor. Açıklama atlandı.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` birden çok hedefe çözümlendi; ilk hedef kullanılıyor.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` geçersiz; hedef, onu içeren grafiğin dışında. Açıklama atlandı.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` geçersiz; prefigure dönüşümünde hedef desteklenen bir grafik nesnesi değil. Açıklama atlandı.
+
+annotation-text-missing = `<annotation>`: `text` eksik ya da boş; boş metin üretiliyor.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Döngüsel bağımlılık saptandı.
+       *[other] `<{ $componentType }>` bileşenini içeren döngüsel bağımlılık saptandı.
+    }
+
+reference-no-referent = Başvuru için gönderge bulunamadı: `{ $reference }`
+
+reference-multiple-referents = Başvuru için birden çok gönderge bulundu: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` ögesinin { $attribute } özniteliğinin biçimi geçersiz.
+
+children-invalid = `<{ $componentType }>` için alt ögeler geçersiz: geçersiz alt ögeler bulundu: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` özniteliği için `{ $value }` değeri geçersiz; `{ $default }` değeri kullanılıyor
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } sürümü bulunamadı.
+       *[other] DoenetML { $version } sürümü bulunamadı. { $fallback } sürümüne dönülüyor
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML geçersiz: { $content }
+
+parse-tag-missing-close-tag = DoenetML geçersiz: `{ $tag }` etiketinin kapanış etiketi yok. Kendiliğinden kapanan bir etiket ya da bir `</{ $tagName }>` etiketi bekleniyordu.
+
+parse-tag-error = DoenetML geçersiz: `<{ $tagName }>` etiketinde hata var
+
+parse-attribute-missing-value = DoenetML geçersiz: `{ $attribute }` özniteliğinin değeri eksik görünüyor.
+
+parse-attribute-invalid = DoenetML geçersiz: `{ $attribute }` özniteliği geçersiz
+
+parse-attribute-value-invalid = DoenetML geçersiz: `{ $value }` öznitelik değeri geçersiz
+
+parse-attribute-value-quote-mismatch = DoenetML geçersiz: `{ $value }` öznitelik değeri geçersiz. Tırnak işaretleri eşleşmiyor. Bir `{ $quote }` eksik görünüyor
+
+parse-open-tag-name-missing = DoenetML geçersiz: etiket adı olmayan bir etiket bulundu; örneğin `<`
+
+parse-tag-not-closed = DoenetML geçersiz: `{ $tag }` etiketi kapatılmamış (bir `>` eksik görünüyor).
+
+parse-self-closing-tag-name-missing = DoenetML geçersiz: etiket adı olmayan bir etiket bulundu `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML geçersiz: `{ $tag }` etiketi kapatılmamış (`/>` eksik görünüyor).
+
+parse-tag-invalid-attributes = DoenetML geçersiz: `{ $tag }` etiketi geçerli değil. Öznitelikleri hatalı olabilir.
+
+parse-close-tag-name-missing = DoenetML geçersiz: etiket adı olmayan bir kapanış etiketi bulundu; örneğin `</`
+
+parse-attribute-value-unquoted = Öznitelik değerleri tırnak içine alınmalıdır: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML geçersiz: `{ $tag }` kapanış etiketi bulundu, ancak buna karşılık gelen bir açılış etiketi yok
+
+parse-close-tag-mismatched = DoenetML geçersiz: kapanış etiketi eşleşmiyor. `</{ $expected }>` bekleniyordu. `{ $found }` bulundu
+
+parser-node-unconvertible = { $node } düğümü bir Dast düğümüne dönüştürülemedi.
+
+## Names
+
+name-attribute-invalid =
+    name='{ $name }' özniteliği geçersiz. { $reason ->
+        [characters] Adlar yalnızca harf, rakam, alt çizgi ya da kısa çizgi içerebilir.
+       *[start] Adlar bir harfle başlamalıdır.
+    }
+
+component-name-invalid-start = "{ $name }" bileşen adı geçersiz. Adlar bir harfle başlamalıdır.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched türündeki bir answer ögesinin video özniteliği olmalıdır
+
+answer-video-watched-video-not-reference = videoWatched türündeki bir answer ögesinin video özniteliği bir başvuru olmalıdır
+
+answer-name-not-single-text = answer ögesinin name özniteliğinin tek bir metin alt ögesi olmalıdır
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Özyineleme düzeyi çok fazla olduğu için dış DoenetML alınamıyor. Döngüsel bir başvuru olabilir mi?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" adresinden DoenetML alınamıyor
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" adresinden alınan DoenetML geçersiz: "{ $componentType }" bileşen türüyle eşleşmedi
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` özniteliği kullanımdan kaldırıldı; yerine `{ $to }` kullanın.
+       *[other] [deprecation] `<{ $component }>` üzerindeki `{ $from }` özniteliği kullanımdan kaldırıldı; yerine `{ $to }` kullanın.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $to }` de belirtildiği için `{ $from }` özniteliği kullanımdan kaldırıldı ve yok sayıldı.
+       *[other] [deprecation] `{ $to }` de belirtildiği için `<{ $component }>` üzerindeki `{ $from }` özniteliği kullanımdan kaldırıldı ve yok sayıldı.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` üzerindeki `{ $attribute }` özniteliği kullanımdan kaldırıldı ve yok sayıldı.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` yalnızca İngilizce çoğul yapabildiği için, { $locale } dilinde yazılmış bir belgede metni olduğu gibi kalır. Çoğul biçimi doğrudan yazın ya da `pluralForm` özniteliğiyle belirtin.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` ögesi tanınan bir Doenet ögesi değil.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` ögesine belgenin kökünde izin verilmez.
+
+schema-element-not-allowed-inside = `<{ $tag }>` ögesine `<{ $parent }>` içinde izin verilmez.
+
+schema-attribute-unrecognized = `<{ $tag }>` ögesinin `{ $attribute }` adlı bir özniteliği yok.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` ögesinin `{ $attribute }` özniteliği, her ögesi şunlardan biri olan bir liste olmalıdır: { $allowed }
+       *[other] `<{ $tag }>` ögesinin `{ $attribute }` özniteliği şunlardan biri olmalıdır: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select için varyant adı geçersiz. { $variantName } varyant adı { $numOptions } seçenekte geçiyor, ancak seçilecek sayı { $numToSelect }.
+
+select-variant-name-without-options = select için varyantlar belirtilmiş, ancak olası varyant adı { $variantName } için seçenek yok.
+
+select-variant-name-not-possible = select için belirtilen { $variantName } varyant adı olası bir varyant adı değil.
+
+select-too-few-options = Yalnızca { $numOptions } bileşenden { $numToSelect } tanesi seçilemez.
+
+select-from-sequence-too-few-values = Uzunluğu { $length } olan bir diziden { $numToSelect } değer seçilemez.
+
+select-from-sequence-indices-count-mismatch = select için belirtilen dizin sayısı, seçilecek sayıyla eşleşmelidir
+
+select-from-sequence-indices-not-integers = select için belirtilen tüm dizinler tam sayı olmalıdır
+
+select-from-sequence-index-excluded = selectfromsequence için belirtilen dizin dışlananlardandı
+
+select-from-sequence-indices-excluded-combination = selectfromsequence için belirtilen dizinler dışlanan bir birleşim oluşturuyordu
+
+select-from-sequence-coprime-not-positive-integers = Pozitif tam sayılar seçilmediği için aralarında asal birleşimler seçilemez.
+
+select-from-sequence-coprime-common-factor = Aralarında asal sayılar seçilemiyor. Olası değerlerin tümünün ortak bir çarpanı var. (Belirtilen "from" ya da "to" değerleri "step" ile aralarında asal olmalıdır.)
+
+select-from-sequence-coprime-single-number = 1 olmayan tek bir sayıdan aralarında asal birleşimler seçilemez.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence içinde birleşimlerin %70'inden fazlası dışlandı
+
+select-from-sequence-coprime-none-found = Aralarında asal sayılar seçilemedi. Olası değerlerin tümünün ortak bir çarpanı var.
+
+select-from-sequence-too-few-unique-values = Uzunluğu { $numPossibleValues } olan bir diziden { $numToSelect } farklı değer seçilemez
+
+select-prime-numbers-too-few-values = Uzunluğu { $numValues } olan bir asal sayı listesinden { $numToSelect } değer seçilemez
+
+select-prime-numbers-values-count-mismatch = select için belirtilen değer sayısı, seçilecek sayıyla eşleşmelidir
+
+select-prime-numbers-values-not-prime = select prime number için belirtilen tüm değerler asal sayı listesinde bulunmalıdır
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers için belirtilen değerler dışlanan bir birleşim oluşturuyordu
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers içinde birleşimlerin %70'inden fazlası dışlandı
+
+select-random-combination-fluke = Son derece düşük bir olasılıkla, rastgele değerlerin bir birleşimi seçilemedi
+
+select-random-value-fluke = Son derece düşük bir olasılıkla, rastgele bir değer seçilemedi

--- a/packages/i18n/locales/tr/diagnostics.ftl
+++ b/packages/i18n/locales/tr/diagnostics.ftl
@@ -11,8 +11,11 @@
 # English exactly as written. So does anything quoted back from the author's
 # own source.
 #
-# A noun counted by a numeral stays singular in Turkish, so a `{ $count }`
-# message reads the same in both plural branches and needs no selection.
+# A noun counted by a numeral stays singular in Turkish, so a message that
+# prints the number next to a noun reads the same in both plural branches and
+# needs no selection. A message whose count never appears — the list messages,
+# where it only says whether one thing or several are being named — does still
+# select, because there the plural suffix is the only thing carrying it.
 #
 # Turkish suffixes agree with the vowels of the word they attach to, which
 # cannot be done to a placeable whose value is not known — an element or
@@ -244,7 +247,11 @@ eigen-decomposition-failed = Matrisin özdeğerleri hesaplanamadı
 
 ## `<matchesPattern>`
 
-matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: { $parameters } parametresi örüntüde geçmiyor, bu yüzden her zaman boşlukla eşleşecek.
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } parametresi örüntüde geçmiyor, bu yüzden her zaman boşlukla eşleşecek.
+       *[other] `<matchesPattern>`: { $parameters } parametreleri örüntüde geçmiyor, bu yüzden her zaman boşlukla eşleşecek.
+    }
 
 ## `<graph>`
 
@@ -252,9 +259,9 @@ graph-grid-invalid = `<graph>`: grid="{ $grid }" yorumlanamıyor. none, medium, 
 
 ## PreFigure renderer
 
-prefigure-x-label-position-unsupported = `<graph>`: prefigure görüntüleyicisinde xLabelPosition="left" desteklenmiyor; sağ konum davranışı kullanılıyor.
+prefigure-x-label-position-unsupported = `<graph>`: prefigure işleyicisinde xLabelPosition="left" desteklenmiyor; sağ konum davranışı kullanılıyor.
 
-prefigure-y-label-position-unsupported = `<graph>`: prefigure görüntüleyicisinde yLabelPosition="bottom" desteklenmiyor; üst konum davranışı kullanılıyor.
+prefigure-y-label-position-unsupported = `<graph>`: prefigure işleyicisinde yLabelPosition="bottom" desteklenmiyor; üst konum davranışı kullanılıyor.
 
 prefigure-invalid-axis-bounds = `<graph>`: prefigure dönüşümü için eksen sınırları geçersiz; varsayılan bbox (-10,-10,10,10) kullanılıyor.
 
@@ -262,9 +269,9 @@ prefigure-invalid-width = `<graph>`: prefigure dönüşümü için genişlik ge�
 
 prefigure-invalid-aspect-ratio = `<graph>`: prefigure dönüşümü için aspectRatio geçersiz; varsayılan en boy oranı 1 kullanılıyor.
 
-prefigure-grid-spacing-too-fine = `<graph>`: ızgara aralığı eksen sınırlarına göre çok ince; prefigure görüntüleyicisinde ızgara atlanıyor.
+prefigure-grid-spacing-too-fine = `<graph>`: ızgara aralığı eksen sınırlarına göre çok ince; prefigure işleyicisinde ızgara atlanıyor.
 
-prefigure-annotations-not-rendered = `<graph>`: PreFigure görüntüleyicisi kullanılmadığında açıklamalar çizilmez.
+prefigure-annotations-not-rendered = `<graph>`: PreFigure işleyicisi kullanılmadığında açıklamalar çizilmez.
 
 multiple-annotations-children = `<graph>` içinde birden çok `<annotations>` alt ögesi bulundu; sonuncusu dışındakiler yok sayılıyor.
 
@@ -300,7 +307,11 @@ answer-max-num-attempts-in-section-wide-check-work = Deneme sayısı kapsayıcı
 
 nested-section-wide-check-work-max-num-attempts = Deneme sayısı dıştaki kapsayıcı tarafından denetlendiği için, `sectionWideCheckWork` bulunan başka bir kapsayıcının içindeki `sectionWideCheckWork` kapsayıcısında `maxNumAttempts` ayarlamanın etkisi olmaz. `maxNumAttempts` değerini dıştaki kapsayıcıda ayarlayın.
 
-answer-attributes-need-symbolic-equality = symbolicEquality ayarlanmadan { $attributes } özniteliğinin etkisi olmaz.
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality ayarlanmadan { $attributes } özniteliğinin etkisi olmaz.
+       *[other] symbolicEquality ayarlanmadan { $attributes } özniteliklerinin etkisi olmaz.
+    }
 
 answer-invalid-type = answer için tür geçersiz: { $type }
 
@@ -320,7 +331,11 @@ pretzel-circuit-first-problem-distractor = pretzel geçersiz: mode="circuit" dur
 
 ## Attribute values
 
-attribute-invalid-values = `{ $attribute }` özniteliği için { $values } değeri geçersiz; yok sayılıyor.
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` özniteliği için { $values } değeri geçersiz; yok sayılıyor.
+       *[other] `{ $attribute }` özniteliği için { $values } değerleri geçersiz; yok sayılıyor.
+    }
 
 attribute-must-be-references = `{ $attribute }` özniteliği için `{ $value }` değeri geçersiz. Öznitelik `$` ile başlayan başvurulardan oluşmalıdır.
 
@@ -360,7 +375,7 @@ style-definition-dark-mode-text-canvas-contrast =
        *[none] Koyu kipte yeterli karşıtlığı sağlamak için açık kip karşıtlığını artırın ya da türetilen rengi textColorDarkMode ile geçersiz kılın.
     }
 
-section-multiple-style-palettes = Bir kısım yalnızca bir <stylePalette> seçebilir; sonuncusu kullanılıyor.
+section-multiple-style-palettes = Bir bölüm yalnızca bir <stylePalette> seçebilir; sonuncusu kullanılıyor.
 
 ## Unique variants
 
@@ -398,7 +413,7 @@ variant-non-constant-exclude-not-implemented = Sabit olmayan exclude bulunan bir
 
 ## PreFigure conversion
 
-prefigure-descendant-unsupported = { $subject }: grafik prefigure görüntüleyicisinde desteklenmiyor; alt öge atlandı.
+prefigure-descendant-unsupported = { $subject }: grafik prefigure işleyicisinde desteklenmiyor; alt öge atlandı.
 
 prefigure-descendant-invalid-geometry = { $subject }: geometri sonlu değil ya da eksik; alt öge atlandı.
 

--- a/packages/i18n/locales/tr/editor.ftl
+++ b/packages/i18n/locales/tr/editor.ftl
@@ -11,8 +11,11 @@
 # `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
 # name are identifiers, not prose, and stay as written.
 #
-# A noun counted by a numeral stays singular in Turkish, so a `{ $count }`
-# message reads the same in both plural branches and needs no selection.
+# A noun counted by a numeral stays singular in Turkish, so a message that
+# prints the number next to a noun reads the same in both plural branches and
+# needs no selection. A message whose count never appears — `help-coordinates`,
+# which labels one coordinate or several — does still select, because there the
+# plural suffix is the only thing carrying it.
 
 
 ## The viewer's controls
@@ -116,7 +119,7 @@ editor-none-found = Bulunamadı
 ## Submitted responses
 
 editor-no-responses = Henüz gönderilmiş yanıt yok
-editor-response-answer-id = Answer Id
+editor-response-answer-id = Yanıt kimliği
 editor-response-response = Yanıt
 editor-response-credit = Puan
 editor-response-submitted = Gönderildi
@@ -190,7 +193,11 @@ help-suggested-values = Önerilen değerler:
 
 help-inserts = Eklenen:
 
-help-coordinates = Koordinatlar:
+help-coordinates =
+    { $count ->
+        [one] Koordinat:
+       *[other] Koordinatlar:
+    }
 
 help-type = Tür:
 

--- a/packages/i18n/locales/tr/editor.ftl
+++ b/packages/i18n/locales/tr/editor.ftl
@@ -1,0 +1,204 @@
+# Turkish editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# A noun counted by a numeral stays singular in Turkish, so a `{ $count }`
+# message reads the same in both plural branches and needs no selection.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Sıfırla
+       *[update] Güncelle
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Görüntüleyiciyi { $word }
+       *[other] Görüntüleyiciyi { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varyant
+editor-variant-filter = Süz...
+editor-variant-next = Sonraki varyantı seç
+editor-variant-previous = Önceki varyantı seç
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA erişilebilirlik ihlali saptandı. Erişilebilirlik raporunu { $action ->
+            [close] kapatmak
+           *[open] açmak
+        } için tıklayın.
+        [advisories] Erişilebilirlik raporunu { $action ->
+            [close] kapatmak
+           *[open] açmak
+        } için tıklayın. WCAG AA ihlali bulunmadı, ancak başka erişilebilirlik önerileri var.
+       *[clean] Erişilebilirlik raporunu { $action ->
+            [close] kapatmak
+           *[open] açmak
+        } için tıklayın. Erişilebilirlik sorunu bulunmadı.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA erişilebilirlik ihlali saptandı. { $count } WCAG AA ihlali bulundu. Erişilebilirlik raporunu { $action ->
+            [close] kapatmak
+           *[open] açmak
+        } için tıklayın.
+        [advisories] WCAG AA ihlali saptanmadı. { $count } ek erişilebilirlik önerisi bulundu. Erişilebilirlik raporunu { $action ->
+            [close] kapatmak
+           *[open] açmak
+        } için tıklayın.
+       *[clean] WCAG AA ihlali saptanmadı. Erişilebilirlik raporunu { $action ->
+            [close] kapatmak
+           *[open] açmak
+        } için tıklayın.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML sürüm { $version }
+
+editor-tab-help = Bağlama duyarlı yardım
+editor-tab-help-short = Bağlam
+editor-tab-errors = Hatalar
+editor-tab-warnings = Uyarılar
+editor-tab-info = Bilgi
+editor-tab-accessibility = Erişilebilirlik
+editor-tab-responses = Gönderilen yanıtlar
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Düzenleyici seçenekleri
+editor-format-as-doenetml = DoenetML olarak biçimlendir
+editor-format-as-xml = XML olarak biçimlendir
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }. satır
+
+editor-no-errors = Hata yok
+editor-no-warnings = Uyarı yok
+editor-no-info = Bilgi tanılaması yok
+
+editor-show-info-annotations = Bilgi tanılamalarını düzenleyicide göster
+editor-show-accessibility-annotations = Erişilebilirlik tanılamalarını düzenleyicide göster
+
+editor-accessibility-learn-more = Doenet'in erişilebilirliğe yaklaşımını öğrenin
+
+editor-accessibility-violations-heading = Erişilebilirlik ihlalleri ({ $standard })
+
+editor-accessibility-other-heading = Diğer erişilebilirlik sorunları
+editor-none-found = Bulunamadı
+
+
+## Submitted responses
+
+editor-no-responses = Henüz gönderilmiş yanıt yok
+editor-response-answer-id = Answer Id
+editor-response-response = Yanıt
+editor-response-credit = Puan
+editor-response-submitted = Gönderildi
+
+
+## The context-help panel
+
+help-placeholder = Belgeleri görmek için imleci bir etiket adının, bir özniteliğin veya { $ref } üzerine getirin.
+
+help-unsupported-ref-chain = { $example } gibi çok parçalı başvurular için yardım henüz desteklenmiyor.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Başvuru için gönderge bulunamadı: { $ref }.
+        [multiple] Başvuru için birden çok gönderge bulundu: { $ref }.
+       *[indeterminate] { $ref } için bir gönderge belirlenemedi.
+    }
+
+help-learn-about-references = Başvurular hakkında bilgi edinin →
+help-reference-page = Başvuru sayfası →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } içinde
+       *[top] En üst düzeyde
+    }{ $allowed ->
+        [none] { " — buraya hiçbir şey konulamaz." }
+        [text] { " — buraya metin yazabilirsiniz." }
+        [text-and-components] { " — buraya metin yazabilir ya da şunları deneyebilirsiniz:" }
+       *[components] { " — denenebilecekler:" }
+    }
+
+help-suggestions-footer = { $total } bileşenin tümünü görmek için { $shortcut } tuşuna basın.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref }, { $target } ögesine bir başvurudur.
+       *[other] { $ref }, { $target } ögesine bir başvurudur ({ $line }. satır).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } tarafından { $role } olarak eklendi.
+       *[other] { $owner } tarafından { $line }. satırda { $role } olarak eklendi.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref }, { $element } ögesinin { $property } özelliğine bir başvurudur.
+       *[other] { $ref }, { $element } ögesinin { $property } özelliğine bir başvurudur ({ $line }. satır).
+    }
+
+help-kind-attribute = öznitelik
+help-kind-snippet = kod parçacığı
+help-kind-array-entry = dizi ögesi
+
+help-default = Varsayılan:
+help-active-default = Geçerli varsayılan:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] İzin verilen değerler (öge başına bir tane):
+       *[other] İzin verilen değerler:
+    }
+
+help-suggested-values = Önerilen değerler:
+
+help-inserts = Eklenen:
+
+help-coordinates = Koordinatlar:
+
+help-type = Tür:
+
+help-resolved-style = Çözümlenmiş stil (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Çözümlenmiş fonksiyon adları:
+help-reset-list = Bu girdinin sıfırlama listesi:
+help-added-on-input = Bu girdide eklenen:
+help-removed-on-input = Bu girdide kaldırılan:
+
+help-reset-overrides = { $reset }, { $additional } ve { $removed } ögelerine göre önceliklidir.

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -16,6 +16,7 @@ export type SupportedLocale =
     | "ja"
     | "ko"
     | "nl"
+    | "pt"
     | "ru"
     | "so"
     | "vi"
@@ -112,6 +113,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Dutch",
         endonym: "Nederlands",
         label: "Dutch (Nederlands)",
+    },
+    {
+        locale: "pt",
+        englishName: "Portuguese",
+        endonym: "português",
+        label: "Portuguese (português)",
     },
     {
         locale: "ru",

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -7,9 +7,11 @@
 /** A locale this repository ships a catalog for. */
 export type SupportedLocale =
     | "en"
+    | "am"
     | "de"
     | "es"
     | "fr"
+    | "hi"
     | "hnj"
     | "id"
     | "it"
@@ -63,6 +65,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "English",
     },
     {
+        locale: "am",
+        englishName: "Amharic",
+        endonym: "አማርኛ",
+        label: "Amharic (አማርኛ)",
+    },
+    {
         locale: "de",
         englishName: "German",
         endonym: "Deutsch",
@@ -79,6 +87,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "French",
         endonym: "français",
         label: "French (français)",
+    },
+    {
+        locale: "hi",
+        englishName: "Hindi",
+        endonym: "हिन्दी",
+        label: "Hindi (हिन्दी)",
     },
     {
         locale: "hnj",

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -19,6 +19,7 @@ export type SupportedLocale =
     | "pt"
     | "ru"
     | "so"
+    | "tr"
     | "vi"
     | "zh-Hans"
     | "zh-Hant";
@@ -131,6 +132,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Somali",
         endonym: "Soomaali",
         label: "Somali (Soomaali)",
+    },
+    {
+        locale: "tr",
+        englishName: "Turkish",
+        endonym: "Türkçe",
+        label: "Turkish (Türkçe)",
     },
     {
         locale: "vi",

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -16,6 +16,7 @@ export type SupportedLocale =
     | "ja"
     | "ko"
     | "nl"
+    | "pl"
     | "pt"
     | "ru"
     | "so"
@@ -114,6 +115,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Dutch",
         endonym: "Nederlands",
         label: "Dutch (Nederlands)",
+    },
+    {
+        locale: "pl",
+        englishName: "Polish",
+        endonym: "polski",
+        label: "Polish (polski)",
     },
     {
         locale: "pt",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -64964,6 +64964,10 @@
                             "description": "English"
                         },
                         {
+                            "value": "am",
+                            "description": "Amharic (አማርኛ)"
+                        },
+                        {
                             "value": "de",
                             "description": "German (Deutsch)"
                         },
@@ -64974,6 +64978,10 @@
                         {
                             "value": "fr",
                             "description": "French (français)"
+                        },
+                        {
+                            "value": "hi",
+                            "description": "Hindi (हिन्दी)"
                         },
                         {
                             "value": "hnj",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65000,6 +65000,10 @@
                             "description": "Dutch (Nederlands)"
                         },
                         {
+                            "value": "pt",
+                            "description": "Portuguese (português)"
+                        },
+                        {
                             "value": "ru",
                             "description": "Russian (русский)"
                         },

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65012,6 +65012,10 @@
                             "description": "Somali (Soomaali)"
                         },
                         {
+                            "value": "tr",
+                            "description": "Turkish (Türkçe)"
+                        },
+                        {
                             "value": "vi",
                             "description": "Vietnamese (Tiếng Việt)"
                         },

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65000,6 +65000,10 @@
                             "description": "Dutch (Nederlands)"
                         },
                         {
+                            "value": "pl",
+                            "description": "Polish (polski)"
+                        },
+                        {
                             "value": "pt",
                             "description": "Portuguese (português)"
                         },

--- a/packages/utils/src/style/styleDescriptionDefinitions.ts
+++ b/packages/utils/src/style/styleDescriptionDefinitions.ts
@@ -12,6 +12,7 @@ import {
     noBackgroundWord,
     type NounKey,
     type NounSpec,
+    type PhraseRole,
 } from "./styleDescriptions";
 
 /**
@@ -136,9 +137,10 @@ function nounSpec(noun: StyleDescriptionNoun, dependencyValues: any): NounSpec {
 function backgroundDescription(
     t: Translator,
     dependencyValues: any,
+    role: PhraseRole = "standalone",
 ): string | undefined {
     const word = colorWord(dependencyValues, "background");
-    return word ? describeColor(t, word, "background") : undefined;
+    return word ? describeColor(t, word, "background", role) : undefined;
 }
 
 /**
@@ -348,7 +350,16 @@ export function returnTextStyleDescriptionDefinitions(): StateVariableDefinition
                         colorWord(dependencyValues, "text"),
                         "text",
                     ),
-                    background: backgroundDescription(t, dependencyValues),
+                    // Looked up again rather than reusing what
+                    // `backgroundColor` reports: there the word stands alone,
+                    // here it sits behind `style-text`'s preposition, and a
+                    // language that inflects for case needs the two forms to
+                    // differ (#1606).
+                    background: backgroundDescription(
+                        t,
+                        dependencyValues,
+                        "background-clause",
+                    ),
                 });
             },
         ),

--- a/packages/utils/src/style/styleDescriptionDefinitions.ts
+++ b/packages/utils/src/style/styleDescriptionDefinitions.ts
@@ -344,17 +344,19 @@ export function returnTextStyleDescriptionDefinitions(): StateVariableDefinition
             commonDependencies,
             (dependencyValues) => {
                 const t = translatorFor(dependencyValues);
+                // Both colours are looked up again rather than reusing what
+                // `textColor` and `backgroundColor` report. Those two are the
+                // standalone side of the fork; these are the embedded side,
+                // and a language that inflects needs the forms to differ —
+                // German wants `rot auf gelbem Hintergrund` here and `roter` /
+                // `gelber` there (#1606).
                 return describeText(t, {
                     color: describeColor(
                         t,
                         colorWord(dependencyValues, "text"),
                         "text",
+                        "text-clause",
                     ),
-                    // Looked up again rather than reusing what
-                    // `backgroundColor` reports: there the word stands alone,
-                    // here it sits behind `style-text`'s preposition, and a
-                    // language that inflects for case needs the two forms to
-                    // differ (#1606).
                     background: backgroundDescription(
                         t,
                         dependencyValues,

--- a/packages/utils/src/style/styleDescriptions.ts
+++ b/packages/utils/src/style/styleDescriptions.ts
@@ -198,12 +198,15 @@ function genderOf(t: Translator, noun: string): string {
 /**
  * Which syntactic position a description is being rendered into.
  *
- * Gender alone is enough while a phrase appears in exactly one position. Two of
- * them appear in two, and a language that inflects an attributive adjective for
- * case has to tell them apart: a border's adjectives are a standalone phrase in
- * `borderStyleDescription` and the object of a preposition inside
+ * Gender alone is enough while a phrase appears in exactly one position. Three
+ * of them appear in two, and a language that inflects an attributive adjective
+ * for case has to tell them apart: a border's adjectives are a standalone
+ * phrase in `borderStyleDescription` and the object of a preposition inside
  * `style-border-clause`, where German's `mit einem …` governs the dative and
- * Russian's «с …» the instrumental. The same fork runs through `background`.
+ * Russian's «с …» the instrumental. `background` forks the same way between
+ * `backgroundColor` and `style-text`. So does the text colour beside it, which
+ * German wants attributive in the `textColor` variable (`roter`) and
+ * predicative in the sentence (`rot auf gelbem Hintergrund`).
  *
  * The names are *positions*, not cases, because which case a position governs
  * is the catalog's business — exactly as `$gender`'s token set already is. The
@@ -211,7 +214,8 @@ function genderOf(t: Translator, noun: string): string {
  *
  * A language with no case ignores `$role`, as English ignores `$gender`.
  */
-export type PhraseRole = "standalone" | "border-clause" | "background-clause";
+export type PhraseRole =
+    "standalone" | "border-clause" | "background-clause" | "text-clause";
 
 /** Look a derived word up in a vocabulary; pass an authored one through. */
 function lookUp(

--- a/packages/utils/src/style/styleDescriptions.ts
+++ b/packages/utils/src/style/styleDescriptions.ts
@@ -221,8 +221,10 @@ export type PhraseRole =
 /**
  * Look a derived word up in a vocabulary; pass an authored one through.
  *
- * `role` defaults to `"standalone"`, the position every lookup is in but the
- * three {@link PhraseRole} exists for.
+ * `role` defaults to `"standalone"`, which is where a word lands unless its
+ * caller says otherwise. Only `describeStroke` and `describeColor` ever pass
+ * anything else — they are the two that also build the embedded forms
+ * {@link PhraseRole} exists for.
  */
 function lookUp(
     t: Translator,

--- a/packages/utils/src/style/styleDescriptions.ts
+++ b/packages/utils/src/style/styleDescriptions.ts
@@ -373,6 +373,11 @@ function attachNoun(
             description,
             noun,
             nounTail: tail,
+            // Every caller names the shape and stops there, so the phrase is
+            // never governed by anything. Passed rather than left out for the
+            // same reason `style-filled-word`'s is: a catalog reading `$role`
+            // finds a value in every message that places adjectives.
+            role: "standalone",
         },
         joinPresent(description, noun, tail),
     );
@@ -618,8 +623,8 @@ export function noBackgroundWord(t: Translator): string {
  * `style-text` is the one composition message given no `$role`: its two words
  * sit in two different positions — the colour predicative, the background
  * behind a preposition — so no single token would describe them both. They
- * arrive already inflected for their own, and `$parts` tells the branches
- * apart.
+ * arrive already inflected for their own position, and `$parts` tells the
+ * branches apart.
  *
  * @param background The already-translated background color, or `undefined`
  *   when nothing is drawn behind the text. Presence is decided by the caller

--- a/packages/utils/src/style/styleDescriptions.ts
+++ b/packages/utils/src/style/styleDescriptions.ts
@@ -195,18 +195,37 @@ function genderOf(t: Translator, noun: string): string {
     return t("noun-gender", { noun }, "neuter");
 }
 
+/**
+ * Which syntactic position a description is being rendered into.
+ *
+ * Gender alone is enough while a phrase appears in exactly one position. Two of
+ * them appear in two, and a language that inflects an attributive adjective for
+ * case has to tell them apart: a border's adjectives are a standalone phrase in
+ * `borderStyleDescription` and the object of a preposition inside
+ * `style-border-clause`, where German's `mit einem …` governs the dative and
+ * Russian's «с …» the instrumental. The same fork runs through `background`.
+ *
+ * The names are *positions*, not cases, because which case a position governs
+ * is the catalog's business — exactly as `$gender`'s token set already is. The
+ * code only has to say where the words are going.
+ *
+ * A language with no case ignores `$role`, as English ignores `$gender`.
+ */
+export type PhraseRole = "standalone" | "border-clause" | "background-clause";
+
 /** Look a derived word up in a vocabulary; pass an authored one through. */
 function lookUp(
     t: Translator,
     vocabulary: Vocabulary,
     word: string | undefined,
     gender: string,
+    role: PhraseRole,
 ): string {
     if (!word) {
         return "";
     }
     const entry = vocabulary[word];
-    return entry ? entry(t, { gender }) : word;
+    return entry ? entry(t, { gender, role }) : word;
 }
 
 /**
@@ -289,15 +308,30 @@ export type StrokeWords = {
  * rather than repeating the color it just used.
  *
  * @param gender The gender of whatever the stroke describes, for agreement.
+ * @param role Which position the phrase is going into, for the languages that
+ *   inflect for case. See {@link PhraseRole}.
  */
 function describeStroke(
     t: Translator,
     words: StrokeWords,
     gender: string,
+    role: PhraseRole,
 ): string {
-    const width = lookUp(t, LINE_WIDTH_WORDS, words.lineWidthWord, gender);
-    const lineStyle = lookUp(t, LINE_STYLE_WORDS, words.lineStyleWord, gender);
-    const color = lookUp(t, COLOR_WORDS, words.colorWord, gender);
+    const width = lookUp(
+        t,
+        LINE_WIDTH_WORDS,
+        words.lineWidthWord,
+        gender,
+        role,
+    );
+    const lineStyle = lookUp(
+        t,
+        LINE_STYLE_WORDS,
+        words.lineStyleWord,
+        gender,
+        role,
+    );
+    const color = lookUp(t, COLOR_WORDS, words.colorWord, gender, role);
 
     const parts = strokeParts(width, lineStyle, color);
     if (parts === null) {
@@ -305,7 +339,7 @@ function describeStroke(
     }
     return t(
         "style-stroke",
-        { parts, width, lineStyle, color, gender },
+        { parts, width, lineStyle, color, gender, role },
         joinPresent(width, lineStyle, color),
     );
 }
@@ -346,13 +380,23 @@ export function describeStrokedShape(
     words: StrokeWords,
     { noun, withNoun }: { noun: NounSpec; withNoun: boolean },
 ): string {
-    const stroke = describeStroke(t, words, genderOf(t, noun.key));
+    const stroke = describeStroke(
+        t,
+        words,
+        genderOf(t, noun.key),
+        "standalone",
+    );
     return withNoun ? attachNoun(t, stroke, nounPhrase(t, noun)) : stroke;
 }
 
-/** A shape's border on its own, as `borderStyleDescription` reports it. */
+/**
+ * A shape's border on its own, as `borderStyleDescription` reports it.
+ *
+ * Standalone, unlike the same words inside `style-border-clause`, which is the
+ * whole reason {@link PhraseRole} exists.
+ */
 export function describeBorder(t: Translator, words: StrokeWords): string {
-    return describeStroke(t, words, genderOf(t, "border"));
+    return describeStroke(t, words, genderOf(t, "border"), "standalone");
 }
 
 export type ClosedShapeWords = StrokeWords & {
@@ -388,8 +432,20 @@ export function describeClosedShape(
     const gender = genderOf(t, noun.key);
     const phrase = withNoun ? nounPhrase(t, noun) : undefined;
 
-    const color = lookUp(t, COLOR_WORDS, words.fillColorWord, gender);
-    const pattern = lookUp(t, FILL_STYLE_WORDS, words.fillStyleWord, gender);
+    const color = lookUp(
+        t,
+        COLOR_WORDS,
+        words.fillColorWord,
+        gender,
+        "standalone",
+    );
+    const pattern = lookUp(
+        t,
+        FILL_STYLE_WORDS,
+        words.fillStyleWord,
+        gender,
+        "standalone",
+    );
     const fillParts = pattern ? "pattern" : "plain";
     // Looked up here and handed over as an argument rather than referenced
     // from the messages below: a language that inflects "filled" has to agree
@@ -433,10 +489,14 @@ export function describeClosedShape(
     // suppress the border's color there.
     const borderRepeatsFill = words.fillColorWord === words.colorWord;
     const borderGender = genderOf(t, "border");
+    // Not `"standalone"`: these words land inside `style-border-clause`, whose
+    // preposition governs a case in German and Russian. `describeBorder` builds
+    // the same words for the standalone state variable and says so.
     const border = describeStroke(
         t,
         borderRepeatsFill ? { ...words, colorWord: "" } : words,
         borderGender,
+        "border-clause",
     );
     if (!border) {
         return filledText;
@@ -453,7 +513,12 @@ export function describeClosedShape(
         " " +
         t(
             "style-border-clause",
-            { parts: borderParts, border, gender: borderGender },
+            {
+                parts: borderParts,
+                border,
+                gender: borderGender,
+                role: "border-clause",
+            },
             withNoun
                 ? `${connective} a ${border} border`
                 : `${connective} ${border} border`,
@@ -471,11 +536,29 @@ export function describeFill(
         return t("style-unfilled", undefined, "unfilled");
     }
     const gender = genderOf(t, "fill");
-    const color = lookUp(t, COLOR_WORDS, words.fillColorWord, gender);
-    const pattern = lookUp(t, FILL_STYLE_WORDS, words.fillStyleWord, gender);
+    const color = lookUp(
+        t,
+        COLOR_WORDS,
+        words.fillColorWord,
+        gender,
+        "standalone",
+    );
+    const pattern = lookUp(
+        t,
+        FILL_STYLE_WORDS,
+        words.fillStyleWord,
+        gender,
+        "standalone",
+    );
     return t(
         "style-fill",
-        { parts: pattern ? "pattern" : "plain", color, pattern, gender },
+        {
+            parts: pattern ? "pattern" : "plain",
+            color,
+            pattern,
+            gender,
+            role: "standalone",
+        },
         joinPresent(color, pattern),
     );
 }
@@ -488,7 +571,13 @@ export function describeMarker(
 ): string {
     const noun = markerWord(t, words.markerStyleWord);
     const gender = genderOf(t, words.markerStyleWord || "point");
-    const color = lookUp(t, COLOR_WORDS, words.markerColorWord, gender);
+    const color = lookUp(
+        t,
+        COLOR_WORDS,
+        words.markerColorWord,
+        gender,
+        "standalone",
+    );
     return withNoun ? attachNoun(t, color, { noun, tail: "" }) : color;
 }
 
@@ -499,17 +588,32 @@ export function describeRegion(
     { noun, withNoun }: { noun: NounSpec; withNoun: boolean },
 ): string {
     const gender = genderOf(t, noun.key);
-    const color = lookUp(t, COLOR_WORDS, words.fillColorWord, gender);
+    const color = lookUp(
+        t,
+        COLOR_WORDS,
+        words.fillColorWord,
+        gender,
+        "standalone",
+    );
     return withNoun ? attachNoun(t, color, nounPhrase(t, noun)) : color;
 }
 
-/** A color word on its own, as `textColor` and `backgroundColor` report it. */
+/**
+ * A color word on its own, as `textColor` and `backgroundColor` report it.
+ *
+ * @param role Defaults to `"standalone"`, which is what the two state variables
+ *   want. `textStyleDescription` asks for the background in
+ *   `"background-clause"` instead, because there the word sits behind a
+ *   preposition — the same fork the border has, and the reason a caller has to
+ *   look the word up twice rather than reuse one string in both places.
+ */
 export function describeColor(
     t: Translator,
     colorWord: string | undefined,
     head: PhraseHead,
+    role: PhraseRole = "standalone",
 ): string {
-    return lookUp(t, COLOR_WORDS, colorWord, genderOf(t, head));
+    return lookUp(t, COLOR_WORDS, colorWord, genderOf(t, head), role);
 }
 
 /** What `backgroundColor` answers when nothing is drawn behind the text. */
@@ -530,11 +634,20 @@ export function describeText(
     { color, background }: { color: string; background?: string },
 ): string {
     if (background === undefined) {
-        return t("style-text", { parts: "plain", color }, color);
+        return t(
+            "style-text",
+            { parts: "plain", color, role: "standalone" },
+            color,
+        );
     }
     return t(
         "style-text",
-        { parts: "background", color, background },
+        {
+            parts: "background",
+            color,
+            background,
+            role: "background-clause",
+        },
         `${color} with a ${background} background`,
     );
 }

--- a/packages/utils/src/style/styleDescriptions.ts
+++ b/packages/utils/src/style/styleDescriptions.ts
@@ -477,13 +477,21 @@ export function describeClosedShape(
                   nounTail: phrase.tail,
                   filled: filledWord,
                   gender,
+                  role: "standalone",
               },
               joinPresent(filledWord, color, phrase.noun, phrase.tail) +
                   patternClause,
           )
         : t(
               "style-filled",
-              { parts: fillParts, color, pattern, filled: filledWord, gender },
+              {
+                  parts: fillParts,
+                  color,
+                  pattern,
+                  filled: filledWord,
+                  gender,
+                  role: "standalone",
+              },
               joinPresent(filledWord, color) + patternClause,
           );
 
@@ -495,8 +503,9 @@ export function describeClosedShape(
     const borderRepeatsFill = words.fillColorWord === words.colorWord;
     const borderGender = genderOf(t, "border");
     // Not `"standalone"`: these words land inside `style-border-clause`, whose
-    // preposition governs a case in German and Russian. `describeBorder` builds
-    // the same words for the standalone state variable and says so.
+    // preposition governs a case in German, Russian and Polish, and the oblique
+    // in Hindi. `describeBorder` builds the same words for the standalone state
+    // variable and says so.
     const border = describeStroke(
         t,
         borderRepeatsFill ? { ...words, colorWord: "" } : words,

--- a/packages/utils/src/style/styleDescriptions.ts
+++ b/packages/utils/src/style/styleDescriptions.ts
@@ -22,8 +22,9 @@ import type { TranslationArgs, Translator } from "@doenet/i18n";
  * re-punctuate each combination independently.
  *
  * Adjectives are also handed `$gender`, the grammatical gender the catalog
- * assigns the noun they describe (`noun-gender`). English has no agreement and
- * ignores it.
+ * assigns the noun they describe (`noun-gender`), and `$role`, the syntactic
+ * position the phrase is going into ({@link PhraseRole}). English has no
+ * agreement and ignores both.
  *
  * ## Words in, keys out
  *
@@ -217,13 +218,18 @@ function genderOf(t: Translator, noun: string): string {
 export type PhraseRole =
     "standalone" | "border-clause" | "background-clause" | "text-clause";
 
-/** Look a derived word up in a vocabulary; pass an authored one through. */
+/**
+ * Look a derived word up in a vocabulary; pass an authored one through.
+ *
+ * `role` defaults to `"standalone"`, the position every lookup is in but the
+ * three {@link PhraseRole} exists for.
+ */
 function lookUp(
     t: Translator,
     vocabulary: Vocabulary,
     word: string | undefined,
     gender: string,
-    role: PhraseRole,
+    role: PhraseRole = "standalone",
 ): string {
     if (!word) {
         return "";
@@ -436,20 +442,8 @@ export function describeClosedShape(
     const gender = genderOf(t, noun.key);
     const phrase = withNoun ? nounPhrase(t, noun) : undefined;
 
-    const color = lookUp(
-        t,
-        COLOR_WORDS,
-        words.fillColorWord,
-        gender,
-        "standalone",
-    );
-    const pattern = lookUp(
-        t,
-        FILL_STYLE_WORDS,
-        words.fillStyleWord,
-        gender,
-        "standalone",
-    );
+    const color = lookUp(t, COLOR_WORDS, words.fillColorWord, gender);
+    const pattern = lookUp(t, FILL_STYLE_WORDS, words.fillStyleWord, gender);
     const fillParts = pattern ? "pattern" : "plain";
     // Looked up here and handed over as an argument rather than referenced
     // from the messages below: a language that inflects "filled" has to agree
@@ -458,8 +452,15 @@ export function describeClosedShape(
     // never sees it; a message reference does inherit it, but resolves only
     // within its own bundle, so a locale that translated `style-filled` and
     // not this word would render the reference literally instead of falling
-    // back to English.
-    const filledWord = t("style-filled-word", { gender }, "filled");
+    // back to English. It agrees with the shape and is only ever said of it, so
+    // its position is always `"standalone"` — passed rather than left out so
+    // that a catalog reading `$role` finds a value there, as every other
+    // adjective's lookup does.
+    const filledWord = t(
+        "style-filled-word",
+        { gender, role: "standalone" },
+        "filled",
+    );
     const patternClause = pattern ? ` with ${pattern}` : "";
 
     const filledText = phrase
@@ -540,20 +541,8 @@ export function describeFill(
         return t("style-unfilled", undefined, "unfilled");
     }
     const gender = genderOf(t, "fill");
-    const color = lookUp(
-        t,
-        COLOR_WORDS,
-        words.fillColorWord,
-        gender,
-        "standalone",
-    );
-    const pattern = lookUp(
-        t,
-        FILL_STYLE_WORDS,
-        words.fillStyleWord,
-        gender,
-        "standalone",
-    );
+    const color = lookUp(t, COLOR_WORDS, words.fillColorWord, gender);
+    const pattern = lookUp(t, FILL_STYLE_WORDS, words.fillStyleWord, gender);
     return t(
         "style-fill",
         {
@@ -575,13 +564,7 @@ export function describeMarker(
 ): string {
     const noun = markerWord(t, words.markerStyleWord);
     const gender = genderOf(t, words.markerStyleWord || "point");
-    const color = lookUp(
-        t,
-        COLOR_WORDS,
-        words.markerColorWord,
-        gender,
-        "standalone",
-    );
+    const color = lookUp(t, COLOR_WORDS, words.markerColorWord, gender);
     return withNoun ? attachNoun(t, color, { noun, tail: "" }) : color;
 }
 
@@ -592,13 +575,7 @@ export function describeRegion(
     { noun, withNoun }: { noun: NounSpec; withNoun: boolean },
 ): string {
     const gender = genderOf(t, noun.key);
-    const color = lookUp(
-        t,
-        COLOR_WORDS,
-        words.fillColorWord,
-        gender,
-        "standalone",
-    );
+    const color = lookUp(t, COLOR_WORDS, words.fillColorWord, gender);
     return withNoun ? attachNoun(t, color, nounPhrase(t, noun)) : color;
 }
 
@@ -606,10 +583,11 @@ export function describeRegion(
  * A color word on its own, as `textColor` and `backgroundColor` report it.
  *
  * @param role Defaults to `"standalone"`, which is what the two state variables
- *   want. `textStyleDescription` asks for the background in
- *   `"background-clause"` instead, because there the word sits behind a
- *   preposition — the same fork the border has, and the reason a caller has to
- *   look the word up twice rather than reuse one string in both places.
+ *   want. `textStyleDescription` asks for the same two words again in
+ *   `"text-clause"` and `"background-clause"`, because inside its sentence the
+ *   colour is predicative and the background sits behind a preposition — the
+ *   same fork the border has, and the reason a caller looks the words up twice
+ *   rather than reusing one string in both places.
  */
 export function describeColor(
     t: Translator,
@@ -628,6 +606,12 @@ export function noBackgroundWord(t: Translator): string {
 /**
  * How a piece of text is styled: "red with a blue background".
  *
+ * `style-text` is the one composition message given no `$role`: its two words
+ * sit in two different positions — the colour predicative, the background
+ * behind a preposition — so no single token would describe them both. They
+ * arrive already inflected for their own, and `$parts` tells the branches
+ * apart.
+ *
  * @param background The already-translated background color, or `undefined`
  *   when nothing is drawn behind the text. Presence is decided by the caller
  *   from the raw style, never by comparing against the translated "none" —
@@ -638,20 +622,11 @@ export function describeText(
     { color, background }: { color: string; background?: string },
 ): string {
     if (background === undefined) {
-        return t(
-            "style-text",
-            { parts: "plain", color, role: "standalone" },
-            color,
-        );
+        return t("style-text", { parts: "plain", color }, color);
     }
     return t(
         "style-text",
-        {
-            parts: "background",
-            color,
-            background,
-            role: "background-clause",
-        },
+        { parts: "background", color, background },
         `${color} with a ${background} background`,
     );
 }

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -672,12 +672,32 @@ describe("a phrase rendered in two positions", () => {
         });
     });
 
+    // Hindi's other two positions are the case where a fork exists and both
+    // sides land on the same word: `पृष्ठभूमि` is feminine, and a marked
+    // adjective spells its feminine the same direct and oblique, so `पीली`
+    // stands alone and behind `पर` alike. Asserted anyway, because the branches
+    // are there to be selected and because the sentence reorders — Hindi puts
+    // the background first, which no other locale here does.
+    it("gives Hindi one spelling in both of its text positions", () => {
+        expect(bothTextForms(hi)).toEqual({
+            textColor: "लाल",
+            backgroundColor: "पीली",
+            sentence: "पीली पृष्ठभूमि पर लाल",
+        });
+    });
+
     // The guard that keeps this from rotting: if a catalog ever collapses the
     // two positions again, these differ where they should not.
     it("keeps the two positions distinct wherever a language inflects", () => {
         for (const t of [de, ru, pl, hi]) {
             const border = bothBorderForms(t);
             expect(border.embedded).not.toContain(border.standalone);
+        }
+        // Hindi is absent here on purpose: it is the one whose background does
+        // not change shape between the two, per the case above.
+        for (const t of [de, ru, pl]) {
+            const text = bothTextForms(t);
+            expect(text.sentence).not.toContain(text.backgroundColor);
         }
     });
 });

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
     createTranslator,
     createTranslatorFromLocaleData,
+    type TranslationArgs,
     type Translator,
 } from "@doenet/i18n";
 import {
@@ -18,6 +19,7 @@ import {
     describeText,
     noBackgroundWord,
     type NounSpec,
+    type PhraseRole,
 } from "../src/style/styleDescriptions";
 
 /**
@@ -761,5 +763,164 @@ describe("a phrase rendered in two positions", () => {
         expect(patternedWithBorder(ru)).toBe(
             "закрашенный зелёный многоугольник с ромбами и тонкой красной границей",
         );
+    });
+});
+
+/**
+ * The invariant behind `$role`: every message that places an adjective is
+ * handed one.
+ *
+ * The failure mode this guards is not a wrong word but a missing argument. A
+ * message that never receives `$role` selects its default branch in every
+ * position, silently, and English — which ignores the argument — renders
+ * identically either way, so no golden expectation above moves. Two messages
+ * were in fact forgotten while this change was being written, and neither was
+ * caught by a rendering test; both were found by reading the code.
+ *
+ * So rather than assert words, this walks every description with a translator
+ * that records what it was asked for, and checks the arguments themselves. A
+ * composition message added later lands on the "must carry a role" side by
+ * default, and the completeness check below fails until the walk reaches it.
+ */
+describe("the role argument", () => {
+    /**
+     * Every member of {@link PhraseRole}, as a table rather than a list so that
+     * widening the type without deciding what it means here is a type error.
+     */
+    const ROLES: Record<PhraseRole, true> = {
+        standalone: true,
+        "border-clause": true,
+        "background-clause": true,
+        "text-clause": true,
+    };
+    const ROLE_NAMES = Object.keys(ROLES);
+
+    /**
+     * The messages that legitimately go without one, and why. Everything else
+     * places an adjective somewhere and has to say where.
+     */
+    const withoutRole = new Set([
+        "style-unfilled", // describes an absence; there is no adjective in it
+        "style-background-none", // likewise
+        "style-text", // its two words are in two positions at once
+    ]);
+
+    /** Nouns are what the adjectives agree *with*: they carry gender, not role. */
+    const isNoun = (key: string) => key.startsWith("noun");
+
+    /** Every description this module can produce, in every branch. */
+    function everyDescription(t: Translator) {
+        const words = {
+            colorWord: "red",
+            lineWidthWord: "thick",
+            lineStyleWord: "dashed",
+            fillColorWord: "blue",
+            fillStyleWord: "diamonds",
+        };
+        const nouns: NounSpec[] = [
+            { key: "line" },
+            { key: "regular-polygon", numSides: 5 },
+        ];
+
+        for (const noun of nouns) {
+            for (const withNoun of [false, true]) {
+                describeStrokedShape(t, words, { noun, withNoun });
+                describeRegion(t, words, { noun, withNoun });
+                for (const filled of [false, true]) {
+                    describeClosedShape(t, words, { filled, noun, withNoun });
+                    // A border that repeats the fill is dropped, and a fill
+                    // with no pattern takes the other branch of every message
+                    // that mentions one.
+                    describeClosedShape(
+                        t,
+                        { ...words, colorWord: words.fillColorWord },
+                        { filled, noun, withNoun },
+                    );
+                    describeClosedShape(
+                        t,
+                        { ...words, fillStyleWord: "" },
+                        { filled, noun, withNoun },
+                    );
+                }
+            }
+        }
+
+        for (const withNoun of [false, true]) {
+            describeMarker(
+                t,
+                { markerColorWord: "green", markerStyleWord: "square" },
+                { withNoun },
+            );
+        }
+        describeBorder(t, words);
+        for (const filled of [false, true]) {
+            describeFill(t, words, { filled });
+            describeFill(t, { ...words, fillStyleWord: "" }, { filled });
+        }
+        for (const role of ROLE_NAMES as PhraseRole[]) {
+            describeColor(t, "red", "text", role);
+            describeColor(t, "yellow", "background", role);
+        }
+        noBackgroundWord(t);
+        describeText(t, { color: "red" });
+        describeText(t, { color: "red", background: "yellow" });
+    }
+
+    /**
+     * What the walk asked the catalog for. The recorder delegates to English so
+     * that each message still selects a real branch and the walk reaches
+     * whatever those branches call in turn.
+     */
+    const calls: [string, TranslationArgs | undefined][] = [];
+    const recorder: Translator = (key, args, fallback) => {
+        calls.push([key, args]);
+        return en(key, args, fallback);
+    };
+    everyDescription(recorder);
+
+    /** The distinct keys failing `predicate`, so a failure names them. */
+    const offenders = (
+        predicate: (key: string, args: TranslationArgs | undefined) => boolean,
+    ) => [
+        ...new Set(calls.filter(([k, a]) => predicate(k, a)).map(([k]) => k)),
+    ];
+
+    it("reaches every message that composes a description", () => {
+        const composed = [...new Set(calls.map(([key]) => key))]
+            .filter((key) => key.startsWith("style-"))
+            .sort();
+        expect(composed).toEqual([
+            "style-background-none",
+            "style-border-clause",
+            "style-fill",
+            "style-filled",
+            "style-filled-with-noun",
+            "style-filled-word",
+            "style-stroke",
+            "style-text",
+            "style-unfilled",
+            "style-with-noun",
+        ]);
+    });
+
+    it("is handed to every adjective and every message placing one", () => {
+        expect(
+            offenders(
+                (key, args) =>
+                    !isNoun(key) &&
+                    !withoutRole.has(key) &&
+                    !ROLE_NAMES.includes(String(args?.role)),
+            ),
+        ).toEqual([]);
+    });
+
+    it("is withheld from the messages that place none", () => {
+        expect(
+            offenders(
+                (key, args) =>
+                    (isNoun(key) || withoutRole.has(key)) &&
+                    args?.role !== undefined,
+            ),
+        ).toEqual([]);
     });
 });

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -539,21 +539,24 @@ noun-regular-polygon =
  * of the border and the embedded side of the background were both wrong for
  * over a release without a test noticing.
  *
- * So every case below asserts *both* sides. German and Russian are read off
- * disk rather than stubbed, because the point is that the shipped catalogs
- * resolve the fork, not merely that the mechanism can.
+ * So every case below asserts *both* sides. The catalogs are read off disk
+ * rather than stubbed, because the point is that the shipped ones resolve the
+ * fork, not merely that the mechanism can.
  */
 describe("a phrase rendered in two positions", () => {
-    const de: Translator = createTranslatorFromLocaleData(
-        { locale: "de", resources: { de: readCatalog("de", "content") } },
-        "de",
-    );
-    const ru: Translator = createTranslatorFromLocaleData(
-        { locale: "ru", resources: { ru: readCatalog("ru", "content") } },
-        "ru",
-    );
+    /** A catalog as the worker receives it, for the four that select on role. */
+    const forLocale = (locale: string): Translator =>
+        createTranslatorFromLocaleData(
+            { locale, resources: { [locale]: readCatalog(locale, "content") } },
+            locale,
+        );
 
-    const borderWords = { lineColorWord: "black", lineWidthWord: "thick" };
+    const de = forLocale("de");
+    const ru = forLocale("ru");
+    const pl = forLocale("pl");
+    const hi = forLocale("hi");
+
+    const borderWords = { colorWord: "black", lineWidthWord: "thick" };
     const shapeWords = { ...borderWords, fillColorWord: "blue" };
     const circle: NounSpec = { key: "circle" };
 
@@ -584,8 +587,8 @@ describe("a phrase rendered in two positions", () => {
 
     it("leaves English alone, which has no case to inflect for", () => {
         expect(bothBorderForms(en)).toEqual({
-            standalone: "thick",
-            embedded: "filled blue circle with a thick border",
+            standalone: "thick black",
+            embedded: "filled blue circle with a thick black border",
         });
         expect(bothTextForms(en)).toEqual({
             textColor: "red",
@@ -607,8 +610,8 @@ describe("a phrase rendered in two positions", () => {
     // clause.
     it("gives German a nominative border alone and a dative one in the clause", () => {
         expect(bothBorderForms(de)).toEqual({
-            standalone: "dicker",
-            embedded: "gefüllter blauer Kreis mit einem dicken Rand",
+            standalone: "dicker schwarzer",
+            embedded: "gefüllter blauer Kreis mit einem dicken schwarzen Rand",
         });
     });
 
@@ -627,8 +630,8 @@ describe("a phrase rendered in two positions", () => {
     // «с». Before #1606 the standalone form came out `толстой`.
     it("gives Russian a nominative border alone and an instrumental one in the clause", () => {
         expect(bothBorderForms(ru)).toEqual({
-            standalone: "толстая",
-            embedded: "закрашенная синяя окружность с толстой границей",
+            standalone: "толстая чёрная",
+            embedded: "закрашенная синяя окружность с толстой чёрной границей",
         });
     });
 
@@ -643,10 +646,36 @@ describe("a phrase rendered in two positions", () => {
         });
     });
 
+    // Three cases from one set of words: nominative alone, instrumental after
+    // «z», locative after «na». Polish is the catalog `$role` was needed for —
+    // no single token could have carried all three.
+    it("gives Polish a different case in each of its three positions", () => {
+        expect(bothBorderForms(pl)).toEqual({
+            standalone: "grube czarne",
+            embedded:
+                "wypełniony niebieski okrąg z grubym czarnym obramowaniem",
+        });
+        expect(bothTextForms(pl)).toEqual({
+            textColor: "czerwony",
+            backgroundColor: "żółte",
+            sentence: "czerwony na żółtym tle",
+        });
+    });
+
+    // Hindi forks on the direct/oblique distinction rather than on a case
+    // paradigm: a marked adjective takes the oblique before a postposition,
+    // and an unmarked one never changes.
+    it("gives Hindi an oblique border before its postposition", () => {
+        expect(bothBorderForms(hi)).toEqual({
+            standalone: "मोटा काला",
+            embedded: "नीला भरा हुआ वृत्त मोटे काले किनारे के साथ",
+        });
+    });
+
     // The guard that keeps this from rotting: if a catalog ever collapses the
     // two positions again, these differ where they should not.
     it("keeps the two positions distinct wherever a language inflects", () => {
-        for (const t of [de, ru]) {
+        for (const t of [de, ru, pl, hi]) {
             const border = bothBorderForms(t);
             expect(border.embedded).not.toContain(border.standalone);
         }

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -528,3 +528,127 @@ noun-regular-polygon =
         );
     });
 });
+
+/**
+ * The two-position forks (#1606).
+ *
+ * Three sets of words are rendered in two syntactic positions each: a border's
+ * adjectives, the background colour, and the text colour beside it. A language
+ * that inflects for case needs a different form in each, and the bug this
+ * guards was that only one of the two was ever checked — the standalone side
+ * of the border and the embedded side of the background were both wrong for
+ * over a release without a test noticing.
+ *
+ * So every case below asserts *both* sides. German and Russian are read off
+ * disk rather than stubbed, because the point is that the shipped catalogs
+ * resolve the fork, not merely that the mechanism can.
+ */
+describe("a phrase rendered in two positions", () => {
+    const de: Translator = createTranslatorFromLocaleData(
+        { locale: "de", resources: { de: readCatalog("de", "content") } },
+        "de",
+    );
+    const ru: Translator = createTranslatorFromLocaleData(
+        { locale: "ru", resources: { ru: readCatalog("ru", "content") } },
+        "ru",
+    );
+
+    const borderWords = { lineColorWord: "black", lineWidthWord: "thick" };
+    const shapeWords = { ...borderWords, fillColorWord: "blue" };
+    const circle: NounSpec = { key: "circle" };
+
+    /** The border's adjectives, standalone and inside the clause. */
+    const bothBorderForms = (t: Translator) => ({
+        standalone: describeBorder(t, borderWords),
+        embedded: describeClosedShape(t, shapeWords, {
+            filled: true,
+            noun: circle,
+            withNoun: true,
+        }),
+    });
+
+    /** The text and background colours, standalone and inside the sentence. */
+    const bothTextForms = (t: Translator) => ({
+        textColor: describeColor(t, "red", "text"),
+        backgroundColor: describeColor(t, "yellow", "background"),
+        sentence: describeText(t, {
+            color: describeColor(t, "red", "text", "text-clause"),
+            background: describeColor(
+                t,
+                "yellow",
+                "background",
+                "background-clause",
+            ),
+        }),
+    });
+
+    it("leaves English alone, which has no case to inflect for", () => {
+        expect(bothBorderForms(en)).toEqual({
+            standalone: "thick",
+            embedded: "filled blue circle with a thick border",
+        });
+        expect(bothTextForms(en)).toEqual({
+            textColor: "red",
+            backgroundColor: "yellow",
+            sentence: "red with a yellow background",
+        });
+    });
+
+    it("leaves Spanish alone, which inflects for gender but not case", () => {
+        expect(bothTextForms(es)).toEqual({
+            textColor: "rojo",
+            backgroundColor: "amarillo",
+            sentence: "rojo con un fondo amarillo",
+        });
+    });
+
+    // Nominative standing alone, dative after `mit einem`. Before #1606 both
+    // came out `dicken`, because the catalog had to spend its one token on the
+    // clause.
+    it("gives German a nominative border alone and a dative one in the clause", () => {
+        expect(bothBorderForms(de)).toEqual({
+            standalone: "dicker",
+            embedded: "gefüllter blauer Kreis mit einem dicken Rand",
+        });
+    });
+
+    // Attributive in the two variables, predicative and dative in the
+    // sentence. Before #1606 the sentence read `roter auf gelber Hintergrund`,
+    // wrong in both halves.
+    it("gives German predicative text and a dative background in one sentence", () => {
+        expect(bothTextForms(de)).toEqual({
+            textColor: "roter",
+            backgroundColor: "gelber",
+            sentence: "rot auf gelbem Hintergrund",
+        });
+    });
+
+    // Nominative feminine agreeing with «граница» alone, instrumental after
+    // «с». Before #1606 the standalone form came out `толстой`.
+    it("gives Russian a nominative border alone and an instrumental one in the clause", () => {
+        expect(bothBorderForms(ru)).toEqual({
+            standalone: "толстая",
+            embedded: "закрашенная синяя окружность с толстой границей",
+        });
+    });
+
+    // Before #1606 the sentence read `красный на жёлтый фоне`, with the
+    // background left in the nominative behind a preposition governing the
+    // prepositional.
+    it("gives Russian a prepositional background inside the sentence", () => {
+        expect(bothTextForms(ru)).toEqual({
+            textColor: "красный",
+            backgroundColor: "жёлтый",
+            sentence: "красный на жёлтом фоне",
+        });
+    });
+
+    // The guard that keeps this from rotting: if a catalog ever collapses the
+    // two positions again, these differ where they should not.
+    it("keeps the two positions distinct wherever a language inflects", () => {
+        for (const t of [de, ru]) {
+            const border = bothBorderForms(t);
+            expect(border.embedded).not.toContain(border.standalone);
+        }
+    });
+});

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -700,4 +700,66 @@ describe("a phrase rendered in two positions", () => {
             expect(text.sentence).not.toContain(text.backgroundColor);
         }
     });
+
+    /**
+     * The fill-pattern words fork the same way the adjectives do, but without a
+     * `$role` to say so: `describeClosedShape` puts them behind a preposition
+     * ("with diamonds") while `describeFill` prints them on their own. A
+     * language that inflects a noun after a preposition therefore has to spell
+     * them for the embedded use — the one where a word is actually governed —
+     * and give `style-fill` a head noun for them to hang off, as German's
+     * „blaue Füllung mit Rauten" does. A catalog that forgets prints a bare
+     * governed form: Hindi's oblique plural «समचतुर्भुजों» with nothing
+     * governing it.
+     */
+    it("gives a governed fill pattern something to hang off when it stands alone", () => {
+        const blueDiamonds = {
+            fillColorWord: "blue",
+            fillStyleWord: "diamonds",
+        };
+        const standalone = (t: Translator) =>
+            describeFill(t, blueDiamonds, { filled: true });
+
+        expect(standalone(de)).toBe("blaue Füllung mit Rauten");
+        expect(standalone(ru)).toBe("синяя заливка с ромбами");
+        expect(standalone(hi)).toBe("समचतुर्भुजों वाला नीला भराव");
+        // Polish names a pattern with «w» and the accusative, which for a
+        // non-virile plural is spelled like the nominative — so the same words
+        // serve both positions and no head noun is needed.
+        expect(standalone(pl)).toBe("niebieskie romby");
+    });
+
+    /**
+     * English lets one "with" cover both a fill pattern and the border that
+     * follows it — "with diamonds and a thin red border". A language whose two
+     * clauses take different prepositions cannot: Polish names the pattern with
+     * «w» and the accusative, and that preposition does not reach the
+     * instrumental behind it, so the `and` branch of `style-border-clause` has
+     * to carry a «z» of its own.
+     */
+    it("repeats the preposition when the two clauses do not share one", () => {
+        const patternedWithBorder = (t: Translator) =>
+            describeClosedShape(
+                t,
+                {
+                    colorWord: "red",
+                    lineWidthWord: "thin",
+                    fillColorWord: "green",
+                    fillStyleWord: "diamonds",
+                },
+                { filled: true, noun: { key: "polygon" }, withNoun: true },
+            );
+
+        expect(patternedWithBorder(pl)).toBe(
+            "wypełniony zielony wielokąt w romby i z cienkim czerwonym obramowaniem",
+        );
+        // German and Russian do share one — „mit" and «с» govern both — so
+        // theirs stays a bare conjunction.
+        expect(patternedWithBorder(de)).toBe(
+            "gefülltes grünes Vieleck mit Rauten und einem dünnen roten Rand",
+        );
+        expect(patternedWithBorder(ru)).toBe(
+            "закрашенный зелёный многоугольник с ромбами и тонкой красной границей",
+        );
+    });
 });


### PR DESCRIPTION
Closes #1606. Part of #861.

Style descriptions could not express the difference between a phrase standing alone and the same phrase behind a preposition. This fixes that, corrects the German and Russian renderings that were wrong because of it, and adds five catalogs — one of which could not have been written before.

## One token could not carry two things

Adjectives were handed `$gender`, whose meaning the catalog defines. That is enough while a phrase is rendered in exactly one position. **Three of them are rendered in two**, and a language that inflects an attributive adjective for case has to pick one and be wrong in the other:

| words | standalone | embedded |
| --- | --- | --- |
| a border's adjectives | `borderStyleDescription` | inside `style-border-clause`, after `mit einem` / «с» |
| the background colour | `backgroundColor` | inside `style-text`, after `auf` / «на» |
| the text colour beside it | `textColor` | inside `style-text`, predicative |

German and Russian could resolve each fork one way only, and documented that at `noun-gender`. The border went to the embedded form — a `datm` / `insf` token standing in for a case — so `borderStyleDescription` came out dative and instrumental with no preposition in sight. The background and the text colour went the other way, keeping their plain nominative, so the two state variables read right and `style-text` put the nominative behind a preposition that governs neither:

```
                          before                        after
de borderStyleDescription dicken                        dicker
ru borderStyleDescription толстой                       толстая
de textStyleDescription   roter auf gelber Hintergrund  rot auf gelbem Hintergrund
ru textStyleDescription   красный на жёлтый фоне        красный на жёлтом фоне
```

The border clause is unchanged: `mit einem dicken Rand` and «с толстой границей» were already right and stay right. So are `textColor` and `backgroundColor` standing alone — `roter` and `gelber` — which is the half of the text fork that was never broken.

**The third fork is not in #1606's text**, but is in its expected output. `rot auf gelbem Hintergrund` changes the *text* colour too — attributive in the variable, predicative in the sentence — so `PhraseRole` has a `text-clause` member and `textStyleDescription` looks both of its colours up again rather than reusing what the two state variables report. Flagging it because it widened the change beyond what the issue scoped.

## Positions, not cases

The new argument names **where the words are going**, not what case that implies:

```ts
export type PhraseRole = "standalone" | "border-clause" | "background-clause" | "text-clause";
```

Which case a position governs is the catalog's business, exactly as `$gender`'s token set already is — German's `border-clause` is a dative, Russian's an instrumental, Polish's an instrumental too but its `background-clause` a locative. A language with no case never reads `$role`, as English never reads `$gender`, so **every caseless locale that already shipped renders byte-identically**: English, Spanish, French, Italian, Dutch, Chinese, Japanese, Korean, Vietnamese, Indonesian, Somali and Hmong Njua. Turkish and Amharic, new here, are caseless too. Hindi is *not* — see below.

`noun-gender` is back to answering the one question its name asks. The `datm` and `insf` tokens are gone.

Every adjective lookup and every composition message that places adjectives is handed `$role`, including `style-filled-word`, whose position is always `standalone` because the word is only ever said of the shape itself. The one exception is `style-text`: its two words are in two different positions, so no single token would describe them both, and they arrive already inflected. `locales/en/content.ftl` — the file a translator reads first — lists the positions, and the package README says why they exist.

## The fork `$role` does not cover

One more pair of words is rendered in two positions, and `$role` is not what tells them apart: the fill-pattern words. `describeClosedShape` puts them behind a preposition — "with diamonds" — while `describeFill` prints them on their own, and both ask for `standalone`, because there is only one position the *code* can name. So a language that governs a noun after a preposition spells them for the embedded use, where a word is actually governed, and gives `style-fill` a head noun for them to hang off: German's „blaue Füllung mit Rauten", Russian's «синяя заливка с ромбами», Hindi's «समचतुर्भुजों वाला नीला भराव». A catalog that forgets prints a bare governed form with nothing governing it. Polish needs no head noun — it names a pattern with «w» and the accusative, which for a non-virile plural is spelled like the nominative, so one set of words serves both.

Polish is also where English's one preposition does not stretch: "with diamonds and a thin red border" puts both clauses under one "with", but Polish's pattern takes «w» and its border the instrumental, so the `and` branch of `style-border-clause` carries a «z» of its own — «w romby i z cienkim czerwonym obramowaniem».

## Five catalogs

**Polish** is the one that needed this. Its style words land in three cases, and from a single set of words it now renders:

```
borderStyleDescription   grube                          nominative, neuter
embedded in the clause   z grubym obramowaniem          instrumental
textStyleDescription     czerwony na żółtym tle         locative
```

Before `$role` that was not expressible. Four plural categories throughout — `few` for 2–4 and counts ending 2–4 outside the teens, `many` for the rest including zero.

**Portuguese** is Brazilian, which is what a bare `pt` means. The split from European Portuguese is regional rather than by script, so unlike the Chinese pair it degrades correctly — `pt-AO` and `pt-MZ` reach this catalog and a `pt-PT` could join later. Its `borda` is feminine where Spanish's `borde` is masculine, so the border agrees the other way: `círculo azul preenchido com uma borda grossa`, and `grossa` standing alone.

**Hindi** is the second consumer of `$role`, for a different reason. Its adjectives split in two: *marked* ones ending in -ा inflect, unmarked ones never do. A marked adjective takes the oblique before a postposition, so a border reads `मोटा` alone and `मोटे किनारे के साथ` in the clause, while `लाल` and `सफ़ेद` are the same everywhere. Direct/oblique rather than a seven-way paradigm, but it forks exactly where #1606 said it would. Hindi uses Latin digits — CLDR gives it `latn` — so numbers render `1,234.5` rather than in Devanagari numerals, unlike Marathi and Nepali, which share the script but not the numbering system (#1615).

**Turkish** inflects none of this. Its suffixes attach to the noun rather than to the adjectives in front of it, so `kenarlıklı` carries the whole "with a border" sense itself. A noun counted by a numeral stays singular, so a message that prints the number beside a noun reads the same in both plural branches. A message whose count never appears still selects — `help-coordinates` labels one coordinate or several, and there the plural suffix is the only thing carrying the difference. Where a Turkish suffix would have to agree with the vowels of a placeable whose value is unknown — an element name quoted from the author's source — the noun is left bare rather than given a suffix wrong half the time.

**Amharic** is written in the Ge'ez script, which runs left to right, so it needs none of the right-to-left support DoenetML lacks (#1614). Its style words are the invariable kind, so neither `$gender` nor `$role` is selected on. It leaves the 118 element names and 12 anion names untranslated — the choice Somali and Hmong Njua already make, and for the same reason: there is no settled Amharic chemical nomenclature to seed from, school chemistry in Ethiopia is taught largely in English, and the transliterations that circulate are not standardised. It sits at 429/559 and `lint:i18n` reports the gap. The chemistry vocabulary it does keep — ion, ionic, cation, anion — is written in Ge'ez rather than left in Latin script, as every other locale writes it in its own.

## Tests

Twelve new rendering cases, **ten of which assert both sides of a fork**. That is the specific gap: the standalone border and the embedded background were both wrong for a release because only one side of each had ever been checked. All four catalogs that select on `$role` — German, Russian, Polish and Hindi — are read off disk rather than stubbed, so the tests hold the shipped catalogs and not merely the mechanism.

One fork has both sides landing on the same word: Hindi's `पृष्ठभूमि` is feminine, and a marked adjective spells its feminine the same direct and oblique. That case is asserted too rather than skipped — the branches are there to be selected, and Hindi's sentence reorders, putting the background ahead of the colour where every other catalog trails it. The guard that keeps the rest from collapsing again runs over both the border and the text, and names Hindi as the documented exception rather than quietly omitting it. The remaining two are the other pair: one covers the fill-pattern fork above in the four languages that resolve it differently, the other the preposition Polish cannot share.

Three further checks are about the *argument* rather than the words, because that is the shape the mistakes actually took. A message never handed `$role` selects its default branch in every position, silently, and English — which ignores the argument — renders identically either way, so no expectation moves. Both messages that were forgotten while this was being written were found by reading the code. So `@doenet/utils` now walks every description with a translator that records what it was asked for and checks the arguments themselves: every message that places an adjective carries a role, the ones that place none do not, and the walk has to reach all ten composition messages or it fails. A composition message added later lands on the "must carry a role" side by default.

The worker suite gains a German text description for the same reason. The `text-clause` and `background-clause` arguments that the shared state-variable definitions pass were reachable by no test at all — English and Spanish cannot tell the two positions apart, and the `@doenet/utils` cases call `describeColor` directly — so dropping either argument left every existing expectation green.

## Verification

Every message in every locale formatted under a real `FluentBundle` — 559 × 16 full catalogs plus the four partial ones. No unresolved placeables, no format errors, no leaked newlines, nothing rendering empty; every argument English passes still used unless it is a plural selector a single-category language drops; every named selector English makes still present; every DoenetML identifier surviving verbatim. Also the other direction, which is what caught `style-filled-word`: every variable a catalog *reads* is one its call site passes.

Beyond the mechanical audit, every style description each new catalog can produce was rendered under a real `FluentBundle` and read as a sentence — stroked shapes, closed shapes with and without a pattern, both border clauses, the fill and marker and region descriptions, and the text sentence in both its branches. That is what turned up the fill-pattern fork above and the missing «z», neither of which is a format error.

Catalog comments are English in all twenty locales, including the five new ones. They are addressed to whoever maintains or reviews the file, and a maintainer who cannot read the target language still has to be able to follow why a message is shaped the way it is.

`lint:i18n` green at 559 keys × 20 locales, and `@doenet/i18n`, `@doenet/utils`, `@doenet/lsp-tools` and the worker's locale suite all pass.

## Outside `packages/i18n`

One place spelled locale tags out by hand: the dev harness's locale suggestion list in `packages/doenetml/dev/main.tsx`, which offered four tags and had been stale since well before this branch. It now reads `SUPPORTED_LOCALES`, so seeding a catalog needs no edit there, and keeps the two tags that name no directory under `locales/` — `es-MX`, which negotiates down to `es`, and `en-XA`, the pseudo-locale, which the chrome generates from English on demand. Everything else that has to know the roster already derives it: the catalog loader globs the `locales/` tree, the lint and the generator read the directory, and `<document lang>`'s suggestions come from `SUPPORTED_LOCALES` through the generated schema.

## Coverage after this

Twenty locales ship catalogs. Four are deliberately partial in the same place — Somali, Hmong Njua, Amharic and Vietnamese leave the chemistry to English — and `lint:i18n` reports each gap rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





