### PR TITLE
Graph Accessibility and Visual Hierarchy Improvements

### DIFF
--- a/.changeset/graph-visual-hierarchy-introduced.md
+++ b/.changeset/graph-visual-hierarchy-introduced.md
@@ -1,0 +1,18 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Graphs: introduce a visual hierarchy for grid lines, axes, and labels.
+
+Graph rendering no longer paints all graph elements with `--canvasText`.
+Grid lines now use `--graphGrid`, while axes and tick labels use
+`--graphAxes`; graph navigation controls continue to use `--canvasText`.
+
+This improves visual distinction between graph structure and primary
+content in both light and dark themes while preserving readability and
+accessibility.
+
+Added Cypress regression coverage to verify the hierarchy remains applied
+to axes, tick labels, grid lines, and navigation controls in both themes.

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -267,13 +267,15 @@ div.jxgbox input[type="checkbox"] {
 }
 
 /* CSS attributes will (permantely) overwrite attributes set in JSXGraph */
+/*
 .JXGimage {
-    /* opacity: 1.0; */
+    opacity: 1.0;
 }
 
 .JXGimageHighlight {
-    /* opacity: 0.6; */
+    opacity: 0.6; 
 }
+*/
 
 .jxgbox :focus {
     outline-width: 0.5px;

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -84,9 +84,8 @@ html {
     --indicatorHoverBlue: var(--lightBlue);
     --buttonHoverBlue: var(--lightBlue);
     --doenetTagColor: #3e844a;
-    --graphElements: #757575;
-    --graphTicks: #595959;
-    --graphText: var(--canvasText);
+    --graphGrid: #757575;
+    --graphAxes: #555555;
 }
 
 [data-theme="dark"] {
@@ -118,9 +117,8 @@ html {
     --indicatorHoverBlue: #5b8cb5;
     --buttonHoverBlue: hsl(209, 54%, 82%);
     --doenetTagColor: #5cb870;
-    --graphElements: #8d8d8d;
-    --graphTicks: #959595;
-    --graphText: var(--canvasText);
+    --graphGrid: #7e7e7e;
+    --graphAxes: #aeaeae;
 }
 .doenet-viewer {
     font-family: "Open Sans" !important;
@@ -267,17 +265,15 @@ div.jxgbox input[type="checkbox"] {
 }
 
 /* CSS attributes will (permantely) overwrite attributes set in JSXGraph */
-/*
+
 .JXGimage {
-    opacity: 1.0;
+    /* opacity: 1.0; */
 }
 
 .JXGimageHighlight {
-    opacity: 0.6; 
+    /* opacity: 0.6; */
 }
-*/
-
-.jxgbox :focus {
+*/ .jxgbox :focus {
     outline-width: 0.5px;
     outline-style: dotted;
 }
@@ -301,7 +297,6 @@ div.jxgbox input[type="checkbox"] {
     color: #666;
 }
 
-/*
 .JXG_navigation_button_left {
 }
 
@@ -334,7 +329,6 @@ div.jxgbox input[type="checkbox"] {
 
 .JXG_navigation_button_screenshot {
 }
-*/
 
 .JXG_navigation_button:hover {
     border-radius: 2px;
@@ -469,21 +463,6 @@ div.jxgbox input[type="checkbox"] {
  */
 .doenet-viewer .doenet-tag {
     color: var(--doenetTagColor);
-}
-
-/* Set default graph contents to ~4.6:1 contrast ratio */
-.jxgbox * {
-    --canvasText: var(--graphElements);
-}
-
-/* Set text components back to Canvas text color. */
-.jxgbox .JXGtext,
-.jxgbox .JXG_navigation .JXG_navigation_button {
-    --canvasText: var(--graphText);
-}
-
-.jxgbox .JXGtext[id*="ticks"] {
-    --canvasText: var(--graphTicks);
 }
 
 /**************************************************

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -84,6 +84,9 @@ html {
     --indicatorHoverBlue: var(--lightBlue);
     --buttonHoverBlue: var(--lightBlue);
     --doenetTagColor: #3e844a;
+    --graphElements: #757575;
+    --graphTicks: #595959;
+    --graphText: var(--canvasText);
 }
 
 [data-theme="dark"] {
@@ -115,6 +118,9 @@ html {
     --indicatorHoverBlue: #5b8cb5;
     --buttonHoverBlue: hsl(209, 54%, 82%);
     --doenetTagColor: #5cb870;
+    --graphElements: #8d8d8d;
+    --graphTicks: #959595;
+    --graphText: var(--canvasText);
 }
 .doenet-viewer {
     font-family: "Open Sans" !important;
@@ -293,6 +299,7 @@ div.jxgbox input[type="checkbox"] {
     color: #666;
 }
 
+/*
 .JXG_navigation_button_left {
 }
 
@@ -325,6 +332,7 @@ div.jxgbox input[type="checkbox"] {
 
 .JXG_navigation_button_screenshot {
 }
+*/
 
 .JXG_navigation_button:hover {
     border-radius: 2px;
@@ -459,6 +467,21 @@ div.jxgbox input[type="checkbox"] {
  */
 .doenet-viewer .doenet-tag {
     color: var(--doenetTagColor);
+}
+
+/* Set default graph contents to ~4.6:1 contrast ratio */
+.jxgbox * {
+    --canvasText: var(--graphElements);
+}
+
+/* Set text components back to Canvas text color. */
+.jxgbox .JXGtext,
+.jxgbox .JXG_navigation .JXG_navigation_button {
+    --canvasText: var(--graphText);
+}
+
+.jxgbox .JXGtext[id*="ticks"] {
+    --canvasText: var(--graphTicks);
 }
 
 /**************************************************

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -273,7 +273,8 @@ div.jxgbox input[type="checkbox"] {
 .JXGimageHighlight {
     /* opacity: 0.6; */
 }
-*/ .jxgbox :focus {
+
+.jxgbox :focus {
     outline-width: 0.5px;
     outline-style: dotted;
 }

--- a/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
@@ -133,7 +133,7 @@ export function createYAxis({
             position,
             offset,
             anchorx,
-            strokeColor: "var(--canvasText)",
+            strokeColor: "var(--graphAxes)",
             highlight: false,
         };
         if (SVs.yLabelHasLatex) {
@@ -142,7 +142,7 @@ export function createYAxis({
     }
     previousYaxisWithLabelRef.current = Boolean(SVs.yLabel);
 
-    yaxisOptions.strokeColor = "var(--canvasText)";
+    yaxisOptions.strokeColor = "var(--graphAxes)";
     yaxisOptions.highlight = false;
 
     yaxisOptions.ticks = {
@@ -150,11 +150,11 @@ export function createYAxis({
         label: {
             offset: [12, -2],
             layer: 2,
-            strokeColor: "var(--canvasText)",
-            highlightStrokeColor: "var(--canvasText)",
+            strokeColor: "var(--graphAxes)",
+            highlightStrokeColor: "var(--graphAxes)",
             highlightStrokeOpacity: 1,
         },
-        strokeColor: "var(--canvasText)",
+        strokeColor: "var(--graphGrid)",
         strokeOpacity: 0.5,
         digits: 4,
         drawLabels: SVs.displayYAxisTickLabels,
@@ -227,7 +227,7 @@ export function createXAxis({
             position,
             offset,
             anchorx,
-            strokeColor: "var(--canvasText)",
+            strokeColor: "var(--graphAxes)",
             highlight: false,
         };
         if (SVs.xLabelHasLatex) {
@@ -241,11 +241,11 @@ export function createXAxis({
         label: {
             offset: [-5, -15],
             layer: 2,
-            strokeColor: "var(--canvasText)",
-            highlightStrokeColor: "var(--canvasText)",
+            strokeColor: "var(--graphAxes)",
+            highlightStrokeColor: "var(--graphAxes)",
             highlightStrokeOpacity: 1,
         },
-        strokeColor: "var(--canvasText)",
+        strokeColor: "var(--graphGrid)",
         strokeOpacity: 0.5,
         digits: 4,
         drawLabels: SVs.displayXAxisTickLabels,
@@ -259,7 +259,7 @@ export function createXAxis({
             xaxisOptions.ticks.scaleSymbol = scaleSymbol;
         }
     }
-    xaxisOptions.strokeColor = "var(--canvasText)";
+    xaxisOptions.strokeColor = "var(--graphAxes)";
     xaxisOptions.highlight = false;
 
     // Only control real ticks (height != -1), not grid lines (height = -1)

--- a/packages/test-cypress/cypress/e2e/accessibility/graphVisualHierarchy.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphVisualHierarchy.cy.js
@@ -1,0 +1,97 @@
+/**
+ * Regression coverage for graph visual hierarchy styling.
+ *
+ * These tests verify that graph elements are assigned the intended design
+ * tokens in both light and dark themes:
+ *
+ *   - Grid lines use --graphGrid (lowest visual emphasis)
+ *   - Axes and tick labels use --graphAxes (medium emphasis)
+ *   - Navigation controls use --canvasText (highest emphasis)
+ *
+ * The primary goal is to ensure that JSXGraph-generated DOM elements receive
+ * the correct CSS-variable-based styling and that future selector changes do
+ * not silently break the hierarchy. In particular, this protects against
+ * regressions where tick labels fail to receive the graphAxes styling
+ * (for example, due to selectors no longer matching the generated tick-label
+ * elements).
+ *
+ * The tests intentionally verify token usage rather than specific color values
+ * so that theme palettes may evolve without requiring test updates, while still
+ * enforcing the intended visual hierarchy:
+ *
+ *   graphGrid -> graphAxes -> canvasText
+ *
+ * Coverage is exercised in both light and dark mode because the hierarchy is
+ * theme-dependent and all graph affordances must remain visually distinct in
+ * each theme.
+ */
+describe("Graph visual hierarchy", { tags: ["@group5"] }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+    });
+
+    function postGraph({ darkMode = false } = {}) {
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<graph name="g" grid="medium">
+    <point>(1,2)</point>
+</graph>
+`,
+                    ...(darkMode ? { darkMode: "dark" } : {}),
+                },
+                "*",
+            );
+        });
+    }
+
+    function expectedHierarchyApplied() {
+        cy.get(".jxgbox").should("exist");
+
+        // Axes use graphAxes
+        cy.get('.jxgbox line[stroke="var(--graphAxes)"]').should(
+            "have.length.at.least",
+            1,
+        );
+
+        // Tick labels use graphAxes
+        cy.get('.jxgbox text[fill="var(--graphAxes)"]').should(
+            "have.length.at.least",
+            5,
+        );
+
+        // Grid uses graphGrid
+        cy.get('.jxgbox path[stroke="var(--graphGrid)"]').should(
+            "have.length.at.least",
+            1,
+        );
+    }
+
+    function expectNavigationUsesCanvasText() {
+        cy.get(".JXG_navigation").should("exist");
+
+        cy.get(".JXG_navigation_button").each(($button) => {
+            expect($button.attr("style")).to.contain(
+                "color: var(--canvasText)",
+            );
+        });
+    }
+
+    it("applies graph hierarchy styling in light mode", () => {
+        postGraph();
+
+        expectedHierarchyApplied();
+        expectNavigationUsesCanvasText();
+    });
+
+    it("applies graph hierarchy styling in dark mode", () => {
+        postGraph({ darkMode: true });
+
+        cy.get('[data-theme="dark"]').should("exist");
+
+        expectedHierarchyApplied();
+        expectNavigationUsesCanvasText();
+    });
+});


### PR DESCRIPTION
# Summary

Implemented a targeted light/dark mode styling update for JSXGraph components to establish a clearer visual hierarchy while improving overall graph readability and accessibility.

## Key Changes

- **Graph text remains unchanged**, continuing to use the original `canvasText` variable, which provides approximately **21:1 contrast** against the background. This preserves maximum readability for labels, annotations, and other primary textual content. Includes Graph Navigation controls.

- **Axes, tick marks, and tick labels** were explicitly targeted and updated to use colors meeting **WCAG 2.2 AAA contrast requirements (~7:1)**. This increases the prominence of structural graph elements while maintaining a clear distinction from primary graph text.

- **Grid lines** were updated to approximately **4.6:1 contrast**, creating a more subtle visual presence that supports graph interpretation without competing for attention.

- Equivalent contrast levels were implemented for both **light and dark themes**, ensuring consistent visual emphasis and readability regardless of color mode.

### Resulting Visual Hierarchy

1. **Graph text and Graph Navigation** (highest emphasis, ~21:1 contrast)
2. **Axes and tick labels** (strong secondary emphasis, ~7:1 contrast)
3. **Grid lines** (supporting visual guidance, ~4.6:1 contrast)

These changes significantly improve graph readability, accessibility, and overall visual clarity by reducing clutter while preserving strong navigational and interpretive cues.

### Commented out Empty Rulesets

Commented out several empty rulesets within the stylesheet. This allows them to be removed during CSS minification, resulting in a modest reduction in the delivered stylesheet size and eliminating unnecessary declarations from the final build.