### PR TITLE
test(doenetml-iframe): de-flake the style-palette callback spec

### DIFF
--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.stylePalettes.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.stylePalettes.cy.tsx
@@ -75,9 +75,23 @@ describe("DoenetViewer (iframe wrapper) — style palette discovery", () => {
             >(undefined);
             const [ready, setReady] = React.useState(false);
 
-            React.useEffect(() => {
-                const timer = setTimeout(() => setReady(true), 10);
-                return () => clearTimeout(timer);
+            // `ready` is false for the first render, so the callback the
+            // viewer sees then — the value its `useRef` captures — is
+            // `undefined`; a listener that closed over that mount-time value
+            // would never report, which is what this spec exists to catch.
+            //
+            // Flipping `ready` from a *layout* effect rather than a timer is
+            // what keeps that deterministic. React flushes a state update made
+            // here synchronously, so the real callback is installed within the
+            // same task as the mount — before the iframe can possibly post
+            // `iframeReady`. Palettes are reported exactly once, on that
+            // message, so a callback that arrives even a millisecond late
+            // misses it forever: with a `setTimeout`, the timer and the boot
+            // both landed around 250ms (the boot starves the timer, and a warm
+            // second boot is fast) and the test failed whenever the message won
+            // by a millisecond or two.
+            React.useLayoutEffect(() => {
+                setReady(true);
             }, []);
 
             return (

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.stylePalettes.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.stylePalettes.cy.tsx
@@ -67,12 +67,12 @@ describe("DoenetViewer (iframe wrapper) — style palette discovery", () => {
     });
 
     it("reports palettes to a callback absent at the first render", () => {
-        // `onStylePalettes` is `undefined` on the first render — the render
-        // whose value the viewer captures in a ref, and whose closure its
-        // (deps-empty) message listener keeps for good. The palettes are
-        // therefore reported only if that listener reads the callback back
-        // out of the ref instead of using the `undefined` it closed over,
-        // which is the regression this spec exists to catch.
+        // `onStylePalettes` is `undefined` on the first render: that is what
+        // the viewer's `useRef` initializes with, and what its (deps-empty)
+        // message listener closes over for good. The palettes therefore
+        // reach the callback only if the viewer both refreshes that ref on
+        // every render and has the listener read the callback back out of it
+        // — the regression this spec exists to catch.
         function Harness() {
             const [palettes, setPalettes] = React.useState<
                 StylePaletteInfo[] | null | undefined

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.stylePalettes.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.stylePalettes.cy.tsx
@@ -66,30 +66,32 @@ describe("DoenetViewer (iframe wrapper) — style palette discovery", () => {
             });
     });
 
-    it("reports palettes to a callback passed after mount", () => {
-        // The message listener has empty deps, so it must read the callback
-        // through a ref rather than closing over the mount-time value.
+    it("reports palettes to a callback absent at the first render", () => {
+        // `onStylePalettes` is `undefined` on the first render — the render
+        // whose value the viewer captures in a ref, and whose closure its
+        // (deps-empty) message listener keeps for good. The palettes are
+        // therefore reported only if that listener reads the callback back
+        // out of the ref instead of using the `undefined` it closed over,
+        // which is the regression this spec exists to catch.
         function Harness() {
             const [palettes, setPalettes] = React.useState<
                 StylePaletteInfo[] | null | undefined
             >(undefined);
             const [ready, setReady] = React.useState(false);
 
-            // `ready` is false for the first render, so the callback the
-            // viewer sees then — the value its `useRef` captures — is
-            // `undefined`; a listener that closed over that mount-time value
-            // would never report, which is what this spec exists to catch.
+            // Install the real callback from a *layout* effect, never a
+            // timer: React flushes the re-render it schedules synchronously,
+            // so the callback is in place within the same task as the mount,
+            // before the iframe can post `iframeReady`. That matters because
+            // palettes are reported exactly once, on that message (#1626), so
+            // a callback arriving even a millisecond late misses them
+            // forever — with `setTimeout(..., 10)` the timer and the boot both
+            // landed near 250ms (evaluating the ~32 MB bundle starves the
+            // parent's timers) and the spec failed whenever the message won.
             //
-            // Flipping `ready` from a *layout* effect rather than a timer is
-            // what keeps that deterministic. React flushes a state update made
-            // here synchronously, so the real callback is installed within the
-            // same task as the mount — before the iframe can possibly post
-            // `iframeReady`. Palettes are reported exactly once, on that
-            // message, so a callback that arrives even a millisecond late
-            // misses it forever: with a `setTimeout`, the timer and the boot
-            // both landed around 250ms (the boot starves the timer, and a warm
-            // second boot is fast) and the test failed whenever the message won
-            // by a millisecond or two.
+            // The flip side is that this spec covers only a callback missing
+            // at the first render, not one attached after the boot has already
+            // finished; see #1626 for that gap.
             React.useLayoutEffect(() => {
                 setReady(true);
             }, []);


### PR DESCRIPTION
## The flake

`DoenetViewer.stylePalettes.cy.tsx` → *reports palettes to a callback passed after mount* fails intermittently in the `doenetml-iframe-cypress` job. It is not rare: **3 runs in 5 on current `main`** on my machine, and it took down all three attempts on an unrelated PR ([#1621](https://github.com/Doenet/DoenetML/pull/1621)).

When it fails the spec burns its full 15s timeout with the count still reading `pending`, i.e. the callback was never invoked.

## Why it races

The harness attaches `onStylePalettes` only after a `setTimeout(..., 10)` flips a `ready` flag, so the spec quietly depends on that timer beating the iframe's boot. Two things conspire against it:

- Booting the ~32 MB standalone bundle blocks the parent's main thread, so the "10ms" timer does not actually fire at 10ms — instrumenting it showed **~250ms**.
- This is the spec's *second* viewer, so the bundle is warm and the boot is fast — `iframeReady` also lands at **~250ms**.

Logging both in the same run, across five runs:

```
render @4 ready=false | ready flips @267 | RAW iframeReady @269   ← failed (no report)
render @4 ready=false | ready flips @58  | RAW iframeReady @549   ← passed
render @4 ready=false | ready flips @54  | RAW iframeReady @520   ← passed
render @5 ready=false | ready flips @262 | RAW iframeReady @264   ← failed (no report)
render @5 ready=false | ready flips @252 | RAW iframeReady @254   ← failed (no report)
```

They land **2ms apart**. `setReady(true)` from a timer schedules a re-render, and it is that re-render which writes the callback into `onStylePalettesRef`; when the `message` event is dispatched before React commits it, the ref still holds `undefined`.

Losing the race is unrecoverable rather than merely slow: palettes are reported exactly once, on `iframeReady` (`iframe-viewer-index.ts`), so a callback installed a millisecond late never hears about them.

## The fix

Flip the flag from a **layout effect** instead of a timer. React flushes a state update made there synchronously, so the real callback is installed within the same task as the mount — before the iframe can post anything. No timing assumption remains.

The spec keeps exactly the power it was written for: `onStylePalettes` is still `undefined` on the **first render** — the render whose value the viewer captures in `useRef(onStylePalettes)`, and whose closure its deps-empty `message` listener keeps for good. A listener using that closed-over value would still never report.

What it gives up is coverage of a callback attached *after* the boot has finished: the layout effect now installs it before `iframeReady` by construction. That gap is a property of the wrapper rather than of this spec — `onStylePalettes` is a one-shot push, so a genuinely late callback misses the palettes forever. It is filed as **#1626**, together with a proposed fix and the regression test to add alongside it, and is deliberately not addressed here so this PR stays test-only.

The spec's comments now name both the mechanism and that gap, and the test is renamed to *reports palettes to a callback absent at the first render* so its title states what it actually exercises.

## Verification

- **5 consecutive passes** of the spec after the change (vs. 3-in-5 failures before), on top of 8 during development — and 5 more on the second review pass, plus one after the final comment edit.
- Still catches its regression: deleting the `onStylePalettesRef.current = onStylePalettes;` line in `src/index.tsx` — the line this spec exists to guard — fails it (16s, timing out on `pending`), while the sibling spec (which passes its callback inline at mount) still passes. Re-confirmed on the second review pass.
- Full `doenetml-iframe` component suite green: **48/48**.

Test-only change, so no changeset (matching #1151, the previous de-flake here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

