### PR TITLE
Lay documents out right-to-left when their language is written that way

### DIFF
--- a/.changeset/right-to-left-support.md
+++ b/.changeset/right-to-left-support.md
@@ -1,0 +1,19 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Lay documents out right-to-left when their language is written that way.
+
+DoenetML emitted no `dir` anywhere, and a browser will not infer one from `lang`. An Arabic document therefore rendered right-to-left text in a left-to-right box: punctuation landed on the wrong end, and a run mixing Arabic with a Latin identifier came out in the wrong visual order. The stylesheets were written in left and right throughout, so every indent, gutter and hanging list number pointed away from the text it belonged to.
+
+The viewer now labels the document with its direction beside its language, and the chrome around it with the reader's — two attributes rather than one, because a reader whose language runs the other way from the activity's is the case this exists for. A nested `<document lang>` carries its own. Where a piece of chrome drawn inside the document runs the opposite way to it, it re-declares itself; where the two agree, nothing is added.
+
+Mathematical notation does not mirror. Graphs, the math input and its keyboard, matrices, the spreadsheet, sliders, number lines, orbital diagrams and the source editor all stay left-to-right inside a right-to-left document. What does mirror is the prose: indents, list numbering, the paginator, feedback and hint headers, the editor toolbar.
+
+Translated chrome now isolates its interpolated values, which is what keeps a Latin identifier from scrambling the words around it. English is unchanged, byte for byte. Content computed in the worker is unchanged too — those strings become state variables an author can interpolate and an `<award>` can compare, where an invisible character would be a silent wrong answer.
+
+No right-to-left catalog ships yet: `<document lang="ar">` turns the page around and leaves the words in English. Arabic and the six other languages this unblocks — Persian, Hebrew, Urdu, Pashto, Sindhi and Uyghur — follow separately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27076,6 +27076,7 @@
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@doenet/doenetml-prototype": "*",
+                "@doenet/i18n": "*",
                 "@doenet/utils": "^*",
                 "vite": "^*"
             },

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -210,6 +210,12 @@ const CodeMirror = React.memo(function CodeMirror({
             className="mathjax_ignore"
             data-theme={darkMode}
             style={{ height: "100%" }}
+            // Source code, not prose. DoenetML is XML: its tags, attributes and
+            // nesting read left-to-right whatever language the content inside
+            // them is in, and the gutter's line numbers go down the same side
+            // in every locale. The editor chrome around this may be
+            // right-to-left; the document being edited never is.
+            dir="ltr"
         >
             <ReactCodeMirror
                 style={{ height: "100%" }}

--- a/packages/codemirror/src/extensions/lsp/tooltip.css
+++ b/packages/codemirror/src/extensions/lsp/tooltip.css
@@ -32,6 +32,13 @@
     text-decoration-color: #9061d1;
 }
 
+/*
+ * The `border-left-color` rules below stay physical for two reasons: they
+ * recolor an accent bar CodeMirror itself declares as `border-left`, and
+ * mixing a logical override onto a physical declaration leaves the cascade
+ * deciding between two properties that mean the same thing; and the editor
+ * they sit in is pinned to `dir="ltr"` anyway, because it renders source.
+ */
 .cm-tooltip-lint
     .cm-diagnostic.cm-diagnostic-warning:has(
         .cm-lint-tooltip .heading.accessibility-level-1

--- a/packages/doenetml/dev/main.tsx
+++ b/packages/doenetml/dev/main.tsx
@@ -217,18 +217,27 @@ function App() {
                 {/* Suggestions only — the inputs stay free text so an
                     unrecognized tag can be typed to watch it negotiate. Every
                     catalog the repo ships is listed, read off `SUPPORTED_LOCALES`
-                    so that seeding a new one needs no edit here, plus two tags
-                    that name no directory under `locales/`: `es-MX`, which
-                    negotiates down to `es`, and `en-XA`, the pseudo-locale,
-                    which the chrome generates from English on demand — so it is
-                    worth typing into the UI locale rather than the document
-                    one. */}
+                    so that seeding a new one needs no edit here, plus four tags
+                    that name no directory under `locales/`:
+
+                    - `es-MX`, which negotiates down to `es`;
+                    - `en-XA`, the pseudo-locale, which the chrome generates
+                      from English on demand — so it is worth typing into the
+                      UI locale rather than the document one;
+                    - `en-XB`, the same catalog rendered right-to-left, which
+                      is how the layout is checked by hand while no
+                      right-to-left language has a catalog yet;
+                    - `ar`, a real right-to-left tag with no catalog, which
+                      turns the page around while leaving the words in English
+                      — the state a reader gets today if they ask for Arabic. */}
                 <datalist id="dev-locale-options">
                     {SUPPORTED_LOCALES.map(({ locale, label }) => (
                         <option key={locale} value={locale} label={label} />
                     ))}
                     <option value="es-MX" />
                     <option value="en-XA" />
+                    <option value="en-XB" label="right-to-left pseudo-locale" />
+                    <option value="ar" label="Arabic (no catalog yet)" />
                 </datalist>
                 <span className="dev-toolbar-status">
                     DoenetML source is saved to local storage as you edit.

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -276,6 +276,10 @@ div.jxgbox input[type="checkbox"] {
 
 /* CSS rules for the navigation bar */
 
+/*
+ * Physical `right`, because the board this sits in is pinned to `dir="ltr"` in
+ * `JSXGraphRenderer.tsx` — a graph is coordinate space and does not mirror.
+ */
 .JXG_navigation {
     position: absolute;
     right: 5px;

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -19,7 +19,7 @@
 
 .editor-panel .footer-menu-button {
     all: unset;
-    margin-left: auto;
+    margin-inline-start: auto;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -37,25 +37,29 @@
 }
 
 /*
- * When the footer's right edge meets the virtual keyboard's open-keyboard
+ * When the footer's trailing edge meets the virtual keyboard's open-keyboard
  * tab (showViewer={false} or viewerLocation in {"left","top"} with the
- * keyboard enabled), push the rightmost footer element inward so the icons
- * stay clickable. The reservation must match the keyboard tab's right-edge
+ * keyboard enabled), push the last footer element inward so the icons stay
+ * clickable. The reservation must match the keyboard tab's inline-end
  * footprint (`w-12` + `me-4` = 3rem + 1rem) defined in
  * `packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css`. Keep
  * this value in sync if that footprint changes. Very narrow viewports may
  * still let the tab and the icons collide; that's accepted.
+ *
+ * Logical, and it has to stay paired with the tab's own `end-0`: the tab is
+ * portaled to `document.body`, so nothing but this axis agreement keeps the
+ * space and the thing it is reserved for on the same side of the screen.
  */
 .editor-panel .editor-footer.reserve-keyboard-button-space {
     --keyboard-tab-reserve-width: 4rem;
 }
 .editor-panel .editor-footer.reserve-keyboard-button-space .footer-menu-button {
-    margin-right: var(--keyboard-tab-reserve-width);
+    margin-inline-end: var(--keyboard-tab-reserve-width);
 }
 .editor-panel
     .editor-footer.reserve-keyboard-button-space:not(:has(.footer-menu-button))
     .footer-icons {
-    margin-right: var(--keyboard-tab-reserve-width);
+    margin-inline-end: var(--keyboard-tab-reserve-width);
 }
 
 .editor-panel .footer-menu {
@@ -148,7 +152,7 @@
 
 .editor-panel .diagnostic-tab-count {
     min-width: 1.5ch;
-    text-align: right;
+    text-align: end;
     font-variant-numeric: tabular-nums;
 }
 
@@ -226,7 +230,7 @@
 
 .editor-panel .diagnostic-entry-location {
     font-weight: 600;
-    margin-right: 0.35rem;
+    margin-inline-end: 0.35rem;
 }
 
 /* Dark mode overrides for .diagnostic-entry-message code — see [data-theme="dark"] block below. */
@@ -502,6 +506,8 @@
  * Active-line gutter: CodeMirror base theme uses #e2f2ff (light blue), which
  * is garish on a dark gutter. Use a barely-lighter #363636 instead.
  */
+/* Physical, matching CodeMirror's own gutter rule; the editor renders source
+   and is pinned to `dir="ltr"` in `CodeMirror.tsx`. */
 [data-theme="dark"] .editor-panel .cm-gutters {
     background-color: #1e1e1e;
     color: #8b949e;

--- a/packages/doenetml/src/EditorViewer/variant-select.css
+++ b/packages/doenetml/src/EditorViewer/variant-select.css
@@ -1,6 +1,6 @@
 .variant-select {
     display: flex;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
 
     * {
         box-sizing: border-box;
@@ -18,19 +18,19 @@
     .select-button {
         width: 12em;
         justify-content: space-between;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-        margin-right: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
+        margin-inline-end: 0;
     }
     .prev-next-button {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-        margin-left: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
+        margin-inline-start: 0;
     }
     /* Make all .prev-next-button buttons except for the last one have zero border radius */
     .prev-next-button:not(:last-child) {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     .wrapper {
@@ -137,8 +137,7 @@
         border-radius: 0.25rem;
         border-style: none;
         background-color: hsl(204 20% 94%);
-        padding-left: 1rem;
-        padding-right: 1rem;
+        padding-inline: 1rem;
         font-size: 1rem;
         line-height: 1.5rem;
         color: black;

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -23,6 +23,7 @@ import { MdError } from "react-icons/md";
 import { get as idb_get } from "idb-keyval";
 import { createCoreWorker, initializeCoreWorker } from "../utils/docUtils";
 import {
+    directionOf,
     reachableCatalogLocales,
     resolveDocumentLocale,
     resolveUiLocale,
@@ -52,6 +53,7 @@ import {
 import type { ResolvedTheme } from "../utils/theme";
 import {
     ContentI18nProvider,
+    DocumentDirectionProvider,
     I18nProvider,
     useChromeTranslator,
     useLocaleCatalogs,
@@ -580,6 +582,10 @@ export function DocViewer({
         uiLocale,
         effectiveDocumentLocale,
     );
+    // The direction the *content* is written in, which is what the wrapper
+    // lays out. The chrome inside it may run the other way and says so for
+    // itself — see `useChromeLangDir`.
+    const documentDirection = directionOf(effectiveDocumentLocale);
     // Every language the source declares, read straight out of the DoenetML.
     // `effectiveDocumentLocale` only ever names the outermost document's, and
     // it arrives from the worker after the core has been built; a *nested*
@@ -2402,7 +2408,23 @@ export function DocViewer({
             borderColor: "var(--mainRed)",
         };
         errorOverview = (
-            <div style={errorStyle}>
+            // This banner is addressed to whoever is looking at the screen, so
+            // it is in `uiLocale` while the box around it is declared to be the
+            // content's language. Re-declared only where the two directions
+            // disagree, so the common case adds no attributes: otherwise an
+            // English "This document contains errors!" inside an Arabic
+            // document would put its exclamation mark on the wrong end.
+            // Computed here rather than through `useChromeLangDir` because this
+            // is built above the provider that hook reads.
+            <div
+                style={errorStyle}
+                {...(directionOf(effectiveUiLocale) !== documentDirection
+                    ? {
+                          lang: effectiveUiLocale,
+                          dir: directionOf(effectiveUiLocale),
+                      }
+                    : {})}
+            >
                 <b>
                     {translate(
                         "document-contains-errors",
@@ -2430,6 +2452,12 @@ export function DocViewer({
                 // Always the language the content is actually rendered in, so
                 // a screen reader pronounces it the way the core wrote it.
                 lang={effectiveDocumentLocale}
+                // And the direction that language is written in. A browser will
+                // not infer one from the other, so without this an Arabic
+                // document lays out right-to-left text in a left-to-right box:
+                // the punctuation lands on the wrong end and a mixed
+                // Latin/Arabic run comes out in the wrong visual order.
+                dir={documentDirection}
                 ref={viewerContainerRef}
             >
                 {errorOverview}
@@ -2442,9 +2470,16 @@ export function DocViewer({
                         translate={translate}
                         locale={effectiveUiLocale}
                     >
-                        <ContentI18nProvider translate={translateContent}>
-                            {documentRenderer}
-                        </ContentI18nProvider>
+                        {/* Tells the chrome below what it is drawn inside, so
+                            a piece of it can re-declare itself where the two
+                            directions disagree — see `useChromeLangDir`. */}
+                        <DocumentDirectionProvider
+                            direction={documentDirection}
+                        >
+                            <ContentI18nProvider translate={translateContent}>
+                                {documentRenderer}
+                            </ContentI18nProvider>
+                        </DocumentDirectionProvider>
                     </I18nProvider>
                 </DocContext.Provider>
             </div>

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -2279,7 +2279,7 @@ export function DocViewer({
                     borderStyle: "solid",
                     borderColor: "var(--mainRed)",
                     fontSize: "1.3em",
-                    marginLeft: "20px",
+                    marginInlineStart: "20px",
                     marginTop: "20px",
                     padding: "0.5em",
                 }}
@@ -2311,8 +2311,7 @@ export function DocViewer({
     let noCoreWarning = null;
     let viewerStyle = {
         maxWidth: "850px",
-        paddingLeft: "20px",
-        paddingRight: "20px",
+        paddingInline: "20px",
         backgroundColor: "var(--canvas)",
         containerType: "inline-size",
     };

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -52,6 +52,7 @@ import {
 } from "./coreWorkerBoot";
 import type { ResolvedTheme } from "../utils/theme";
 import {
+    chromeLangDir,
     ContentI18nProvider,
     DocumentDirectionProvider,
     I18nProvider,
@@ -2413,17 +2414,12 @@ export function DocViewer({
             // content's language. Re-declared only where the two directions
             // disagree, so the common case adds no attributes: otherwise an
             // English "This document contains errors!" inside an Arabic
-            // document would put its exclamation mark on the wrong end.
-            // Computed here rather than through `useChromeLangDir` because this
-            // is built above the provider that hook reads.
+            // document would put its exclamation mark on the wrong end. Through
+            // the pure helper rather than `useChromeLangDir` because this is
+            // built above the provider that hook reads.
             <div
                 style={errorStyle}
-                {...(directionOf(effectiveUiLocale) !== documentDirection
-                    ? {
-                          lang: effectiveUiLocale,
-                          dir: directionOf(effectiveUiLocale),
-                      }
-                    : {})}
+                {...chromeLangDir(effectiveUiLocale, documentDirection)}
             >
                 <b>
                     {translate(

--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -203,6 +203,15 @@ export default function JSXGraphRenderer({
                 className="jxgbox"
                 style={surfaceStyle}
                 ref={boardContainer}
+                // A graph is coordinate space, and mathematical notation stays
+                // left-to-right in a right-to-left language. Pinned rather than
+                // inherited because JSXGraph writes `text-anchor: start|end` on
+                // its SVG labels, which resolve against the computed direction:
+                // under RTL every tick and axis label would jump to the wrong
+                // side of the point it names, and `-5` would render as `5-`.
+                // JSXGraph appends both the SVG surface and its HTML labels
+                // here, so this one attribute covers all of it.
+                dir="ltr"
             />
             {board ? (
                 <BoardContext.Provider value={board}>

--- a/packages/doenetml/src/Viewer/renderers/_error.tsx
+++ b/packages/doenetml/src/Viewer/renderers/_error.tsx
@@ -3,7 +3,7 @@ import type { DiagnosticArgs, DiagnosticCode } from "@doenet/i18n";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { useT, useUiLocale } from "../../utils/i18n";
+import { useChromeLangDir, useT, useUiLocale } from "../../utils/i18n";
 import { useDiagnosticFormatter } from "../../utils/diagnostics";
 
 interface ErrorSVs {
@@ -27,6 +27,10 @@ export default React.memo(function Error(props: UseDoenetRendererProps) {
 
     const t = useT();
     const uiLocale = useUiLocale();
+    // The box is addressed to whoever is looking at the screen (#1570), so it
+    // is in the reader's language inside a document that may be in another.
+    // Empty unless the two run opposite ways.
+    const chromeLangDir = useChromeLangDir();
     // The same formatter the Diagnostics panel renders with, over the same
     // translator: one diagnostic now reads the same in both places, where this
     // box used to show the English the worker wrote beside a panel showing the
@@ -73,7 +77,7 @@ export default React.memo(function Error(props: UseDoenetRendererProps) {
             );
         }
         displayedMessage = (
-            <div style={errorStyle}>
+            <div style={errorStyle} {...chromeLangDir}>
                 <b>{t("error-heading", undefined, "Error")}</b>: {message}
                 {locationLine}
             </div>

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -138,7 +138,7 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
                         display: "inline",
                     }}
                 >
-                    <span style={{ marginRight: "4px" }}>{label}</span>
+                    <span style={{ marginInlineEnd: "4px" }}>{label}</span>
                     {checkWorkComponent}
                 </label>
             );

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.css
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.css
@@ -105,8 +105,8 @@
  * Style the checkmark/indicator.
  *
  * Physical `left` on purpose: the tick is two borders of a rotated box, and a
- * check mark is the same shape in every language. The marker box around it is
- * what follows the direction.
+ * check mark is the same shape and sits at the same offset within its own box
+ * in every language. The marker box around it is what follows the direction.
  */
 .doenet-viewer .boolean-container .checkmark:after {
     left: 5px;

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.css
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.css
@@ -3,10 +3,10 @@
     /* `display: inline-block` and `vertical-align` are set inline in
        booleanInput.tsx so the checkbox flows beside a wrapping label (#1245). */
     position: relative;
-    padding-left: 24px;
+    padding-inline-start: 24px;
     margin-bottom: 4px;
-    margin-right: 2px; /* 2px less than other components (6px marginRight) due to the 2px marginLeft on label */
-    margin-left: 4px;
+    margin-inline-end: 2px; /* 2px less than other components (6px inline-end margin) due to the 2px inline-start margin on label */
+    margin-inline-start: 4px;
     cursor: pointer;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -43,7 +43,7 @@
 .doenet-viewer .checkmark {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     height: 18px;
     width: 18px;
     background-color: var(--mainGray);
@@ -101,7 +101,13 @@
     display: block;
 }
 
-/* Style the checkmark/indicator */
+/*
+ * Style the checkmark/indicator.
+ *
+ * Physical `left` on purpose: the tick is two borders of a rotated box, and a
+ * check mark is the same shape in every language. The marker box around it is
+ * what follows the direction.
+ */
 .doenet-viewer .boolean-container .checkmark:after {
     left: 5px;
     top: 1px;

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -612,8 +612,8 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
                 htmlFor={inputKey}
                 style={
                     SVs.labelPosition === "left"
-                        ? { marginRight: "2px" }
-                        : { marginLeft: "2px" }
+                        ? { marginInlineEnd: "2px" }
+                        : { marginInlineStart: "2px" }
                 }
             >
                 {label}

--- a/packages/doenetml/src/Viewer/renderers/cell.tsx
+++ b/packages/doenetml/src/Viewer/renderers/cell.tsx
@@ -43,6 +43,9 @@ export default React.memo(function Cell(props: UseDoenetRendererProps) {
             properties.style!.borderBottomWidth = "thick";
         }
     }
+    // Physical, because the attribute is: an author writes `<cell right="…">`
+    // and means the right-hand edge. `halign` above is the same case. Adding
+    // logical `start`/`end` values to both is tracked separately.
     if (SVs.right !== "none") {
         properties.style!.borderRightStyle = "solid";
         if (SVs.right === "minor") {

--- a/packages/doenetml/src/Viewer/renderers/cell.tsx
+++ b/packages/doenetml/src/Viewer/renderers/cell.tsx
@@ -45,7 +45,7 @@ export default React.memo(function Cell(props: UseDoenetRendererProps) {
     }
     // Physical, because the attribute is: an author writes `<cell right="…">`
     // and means the right-hand edge. `halign` above is the same case. Adding
-    // logical `start`/`end` values to both is tracked separately.
+    // logical `start`/`end` values to both is tracked in #1627.
     if (SVs.right !== "none") {
         properties.style!.borderRightStyle = "solid";
         if (SVs.right === "minor") {

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -4,7 +4,7 @@
 .doenet-viewer .radio-container {
     display: block;
     position: relative;
-    padding-left: 24px;
+    padding-inline-start: 24px;
     margin-bottom: 4px;
     min-height: 24px;
     cursor: pointer;
@@ -45,7 +45,7 @@
 .doenet-viewer .radio-checkmark {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     height: 18px;
     width: 18px;
     background-color: var(--mainGray);
@@ -108,7 +108,14 @@
     display: block;
 }
 
-/* Style the indicator (dot/circle) */
+/*
+ * Style the indicator (dot/circle).
+ *
+ * Physical `left` on purpose: this centers a 6px dot in the 18px marker box
+ * above, whose own position is what follows the direction. Inside a
+ * fixed-size box the two are the same offset, and keeping it physical says
+ * that the glyph itself is not what mirrors.
+ */
 .doenet-viewer .radio-container .radio-checkmark:after {
     top: 6px;
     left: 6px;
@@ -124,7 +131,7 @@
 .doenet-viewer .checkbox-container {
     display: block;
     position: relative;
-    padding-left: 24px;
+    padding-inline-start: 24px;
     margin-bottom: 4px;
     min-height: 24px;
     cursor: pointer;
@@ -167,7 +174,7 @@
 .doenet-viewer .checkbox-checkmark {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     height: 18px;
     width: 18px;
     background-color: var(--mainGray);
@@ -230,7 +237,14 @@
     display: block;
 }
 
-/* Style the checkmark/indicator */
+/*
+ * Style the checkmark/indicator.
+ *
+ * Physical `left` on purpose, and here it matters: the tick is drawn from two
+ * borders of a rotated box, and a check mark is the same shape in every
+ * language. Making this logical would mirror the glyph into a backwards tick
+ * while the marker box around it had already moved.
+ */
 .doenet-viewer .checkbox-container .checkbox-checkmark:after {
     left: 5px;
     top: 1px;

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -240,10 +240,10 @@
 /*
  * Style the checkmark/indicator.
  *
- * Physical `left` on purpose, and here it matters: the tick is drawn from two
- * borders of a rotated box, and a check mark is the same shape in every
- * language. Making this logical would mirror the glyph into a backwards tick
- * while the marker box around it had already moved.
+ * Physical `left` on purpose: the tick is two borders of a rotated box, and a
+ * check mark is the same shape and sits at the same offset within its own box
+ * in every language. The marker box around it is what follows the direction.
+ * Same rule, same reason, as `booleanInput.css`.
  */
 .doenet-viewer .checkbox-container .checkbox-checkmark:after {
     left: 5px;

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -502,9 +502,9 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 id={labelId}
                 htmlFor={inlineInputId}
                 style={{
-                    marginRight:
+                    marginInlineEnd:
                         SVs.labelPosition === "right" ? undefined : "4px",
-                    marginLeft:
+                    marginInlineStart:
                         SVs.labelPosition === "right" ? "4px" : undefined,
                 }}
             >
@@ -672,7 +672,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                                     disabled={radioDisabled}
                                 />
                                 <span className={radioClassName} />
-                                <span style={{ marginLeft: "2px" }}>
+                                <span style={{ marginInlineStart: "2px" }}>
                                     {child}
                                 </span>
                             </label>
@@ -710,7 +710,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                                     }
                                 />
                                 <span className={checkboxClassName} />
-                                <span style={{ marginLeft: "2px" }}>
+                                <span style={{ marginInlineStart: "2px" }}>
                                     {child}
                                 </span>
                             </label>

--- a/packages/doenetml/src/Viewer/renderers/feedback.tsx
+++ b/packages/doenetml/src/Viewer/renderers/feedback.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faComment as thoughtBubble } from "@fortawesome/free-regular-svg-icons";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
-import { useT } from "../../utils/i18n";
+import { useChromeLangDir, useT } from "../../utils/i18n";
 import "./feedback.css";
 
 interface FeedbackSVs {
@@ -21,6 +21,9 @@ export default React.memo(function Feedback(props: UseDoenetRendererProps) {
         useDoenetRenderer<FeedbackSVs>(props);
 
     const t = useT();
+    // Only the heading is chrome; the feedback text below it is the
+    // author's and stays in the document's language and direction.
+    const chromeLangDir = useChromeLangDir();
 
     const ref = useRef(null);
 
@@ -44,7 +47,7 @@ export default React.memo(function Feedback(props: UseDoenetRendererProps) {
 
     return (
         <div ref={ref} className="feedback">
-            <span tabIndex={0}>
+            <span tabIndex={0} {...chromeLangDir}>
                 {icon} {t("feedback-heading", undefined, "Feedback")}
             </span>
             <aside id={id}>

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -121,8 +121,10 @@ export default React.memo(function FractionInput(
         <span
             id={labelId}
             style={{
-                marginRight: SVs.labelPosition === "right" ? undefined : "5px",
-                marginLeft: SVs.labelPosition === "right" ? "5px" : undefined,
+                marginInlineEnd:
+                    SVs.labelPosition === "right" ? undefined : "5px",
+                marginInlineStart:
+                    SVs.labelPosition === "right" ? "5px" : undefined,
             }}
         >
             {label}
@@ -165,7 +167,7 @@ export default React.memo(function FractionInput(
                     </tbody>
                 </table>
             </div>
-            <div style={{ marginRight: "4px" }}></div>
+            <div style={{ marginInlineEnd: "4px" }}></div>
             {checkWorkComponent}
             {description}
         </span>

--- a/packages/doenetml/src/Viewer/renderers/hint.tsx
+++ b/packages/doenetml/src/Viewer/renderers/hint.tsx
@@ -8,7 +8,7 @@ import { faLightbulb as lightOn } from "@fortawesome/free-regular-svg-icons";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
 import { addCommasForCompositeRanges } from "./utils/composites";
-import { useT } from "../../utils/i18n";
+import { useChromeLangDir, useT } from "../../utils/i18n";
 import { clickToToggleLabel } from "./utils/disclosure";
 import "./hint.css";
 
@@ -77,6 +77,10 @@ export default React.memo(function Hint(props: UseDoenetRendererProps) {
     };
 
     const openCloseText = clickToToggleLabel(t, SVs.open);
+    // The heading is mixed: `title` is the author's and follows the document,
+    // while "(click to open)" is the reader's. Only the chrome half
+    // re-declares itself, and only where the two directions disagree.
+    const chromeLangDir = useChromeLangDir();
 
     if (SVs.open) {
         if (SVs._compositeReplacementActiveRange) {
@@ -133,7 +137,7 @@ export default React.memo(function Hint(props: UseDoenetRendererProps) {
                 onKeyDown={onKeyPressFunction}
             >
                 {" "}
-                {icon} {title} {openCloseText}
+                {icon} {title} <span {...chromeLangDir}>{openCloseText}</span>
             </span>
             <span style={infoBlockStyle}>{info}</span>
         </aside>

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -328,6 +328,19 @@ function MathInputPreviewPopover({
             <div
                 id={preview.previewId}
                 className="mathInputPreviewContent"
+                // The preview is notation, like the field it previews, and it
+                // is this div that scrolls a long expression — the popover
+                // does not portal, so inside a right-to-left document it
+                // would otherwise become an RTL scroll container: it opens
+                // showing the tail of the expression, and `scrollLeft` runs
+                // from the negatives up to zero, which turns Home and End in
+                // `handlePreviewKeyDown` into two ways of showing the same
+                // end. MathJax pins `mjx-math` itself, but that is the
+                // content, not the container that scrolls it. The parse-error
+                // branch is left to inherit: it is wrapping prose, and the
+                // chrome half of it re-declares itself below when it
+                // disagrees with the document.
+                dir={showParseErrorMessage ? undefined : "ltr"}
                 tabIndex={0}
                 aria-label={t("math-input-preview", undefined, "Preview")}
                 onFocus={() => preview.setInteractingWithPreview(true)}

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -1308,8 +1308,10 @@ export default function MathInput(props: UseDoenetRendererProps) {
             id={labelId}
             htmlFor={inputKey}
             style={{
-                marginRight: SVs.labelPosition === "right" ? undefined : "2px",
-                marginLeft: SVs.labelPosition === "right" ? "2px" : undefined,
+                marginInlineEnd:
+                    SVs.labelPosition === "right" ? undefined : "2px",
+                marginInlineStart:
+                    SVs.labelPosition === "right" ? "2px" : undefined,
             }}
         >
             {label}

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -38,7 +38,7 @@ import {
     POINTER_DRAG_THRESHOLD,
 } from "./utils/graph";
 import { JXGObject } from "./jsxgraph-distrib/types";
-import { useContentT, useT } from "../../utils/i18n";
+import { useChromeLangDir, useContentT, useT } from "../../utils/i18n";
 
 const PREVIEW_UPDATE_DELAY_MS = 500;
 const PARSE_ERROR_PLACEHOLDER_LATEX = "\uff3f";
@@ -289,6 +289,12 @@ function MathInputPreviewPopover({
 }) {
     const t = useT();
 
+    // The parse-error message is chrome — the reader's language inside the
+    // document's box — while the raw expression quoted after it is what the
+    // user typed. Re-declared as one run so its trailing colon stays against
+    // the label, and empty unless the two directions disagree.
+    const chromeLangDir = useChromeLangDir();
+
     if (!showPreview) {
         return null;
     }
@@ -329,7 +335,10 @@ function MathInputPreviewPopover({
                 onKeyDown={preview.handlePreviewKeyDown}
             >
                 {showParseErrorMessage ? (
-                    <div className="mathInputPreviewErrorMessage">
+                    <div
+                        className="mathInputPreviewErrorMessage"
+                        {...chromeLangDir}
+                    >
                         <strong>
                             {t(
                                 "math-input-invalid-expression",

--- a/packages/doenetml/src/Viewer/renderers/mathquill/EditableMathField.jsx
+++ b/packages/doenetml/src/Viewer/renderers/mathquill/EditableMathField.jsx
@@ -210,7 +210,22 @@ const EditableMathField = ({
     const ariaLabel = otherProps.ariaLabel;
     delete otherProps.ariaLabel;
 
-    return <span {...otherProps} aria-label={ariaLabel} ref={wrapperElement} />;
+    // `dir="ltr"` because MathQuill has no direction story at all: its
+    // stylesheet never declares `direction`, it lays an expression out as a run
+    // of sibling inline spans in source order, and its italic-correction kerns
+    // are physical `margin-left`/`margin-right`. Inheriting `rtl` would reverse
+    // whole expressions and put every kern on the wrong side, while cursor
+    // motion — computed in MathQuill's own tree, not from CSS — kept going the
+    // other way. One attribute here covers the inline, in-graph, matrix and
+    // fraction fields, which all mount through this component.
+    return (
+        <span
+            {...otherProps}
+            dir="ltr"
+            aria-label={ariaLabel}
+            ref={wrapperElement}
+        />
+    );
 };
 
 EditableMathField.propTypes = {

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.css
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.css
@@ -1,3 +1,10 @@
+/*
+ * The brackets stay physical, and deliberately so: `matrixInput.tsx` pins this
+ * element to `dir="ltr"`, because a matrix is notation and does not mirror.
+ * There is no direction here for a logical property to follow, and writing one
+ * would suggest the brackets could swap ends — which would leave the opening
+ * bracket closing and the closing one opening.
+ */
 .doenet-viewer .matrix-input {
     position: relative;
     margin: 6px;

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
@@ -245,7 +245,12 @@ export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
                 verticalAlign: "baseline",
             }}
         >
-            <div className="matrix-input" id={id}>
+            {/* A matrix is notation: its columns are numbered left to right in
+                every language, and the brackets around it are drawn as
+                absolutely-positioned pseudo-elements that assume which side
+                they are on. A `<table>` reverses its columns under `rtl`, so
+                without this the whole matrix would come out mirrored. */}
+            <div className="matrix-input" id={id} dir="ltr">
                 <table
                     aria-labelledby={groupLabelledByIds || undefined}
                     aria-label={

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
@@ -226,8 +226,10 @@ export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
         <span
             id={labelId}
             style={{
-                marginRight: SVs.labelPosition === "right" ? undefined : "5px",
-                marginLeft: SVs.labelPosition === "right" ? "5px" : undefined,
+                marginInlineEnd:
+                    SVs.labelPosition === "right" ? undefined : "5px",
+                marginInlineStart:
+                    SVs.labelPosition === "right" ? "5px" : undefined,
             }}
         >
             {label}
@@ -264,7 +266,7 @@ export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
                     <tbody>{matrixInputs}</tbody>
                 </table>
             </div>
-            <div style={{ marginRight: "4px" }}></div>
+            <div style={{ marginInlineEnd: "4px" }}></div>
             {rowNumControls}
             {colNumControls}
             {checkWorkComponent}

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
@@ -61,7 +61,7 @@ export default React.memo(function orbitalDiagram(
         // the left of its boxes and the boxes fill left to right, in every
         // language. The rows are plain inline flow, so they would otherwise
         // reverse wholesale under `rtl`.
-        <div ref={ref} id={id} dir="ltr">
+        <div ref={ref} id={id} dir="ltr" style={{ width: "fit-content" }}>
             {rowsJSX}
         </div>
     );

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
@@ -3,6 +3,7 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
+import { LTR_ISLAND_PROPS } from "./utils/direction";
 
 const ORBITAL_ARROW_STYLE: React.CSSProperties = {
     fill: "none",
@@ -61,7 +62,7 @@ export default React.memo(function orbitalDiagram(
         // the left of its boxes and the boxes fill left to right, in every
         // language. The rows are plain inline flow, so they would otherwise
         // reverse wholesale under `rtl`.
-        <div ref={ref} id={id} dir="ltr" style={{ width: "fit-content" }}>
+        <div ref={ref} id={id} {...LTR_ISLAND_PROPS}>
             {rowsJSX}
         </div>
     );

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
@@ -57,7 +57,11 @@ export default React.memo(function orbitalDiagram(
     }
 
     return (
-        <div ref={ref} id={id}>
+        // An electron configuration is notation: the subshell label sits to
+        // the left of its boxes and the boxes fill left to right, in every
+        // language. The rows are plain inline flow, so they would otherwise
+        // reverse wholesale under `rtl`.
+        <div ref={ref} id={id} dir="ltr">
             {rowsJSX}
         </div>
     );

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
@@ -3,7 +3,7 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
-import { LTR_ISLAND_PROPS } from "./utils/direction";
+import { ltrIslandProps } from "./utils/direction";
 
 const ORBITAL_ARROW_STYLE: React.CSSProperties = {
     fill: "none",
@@ -62,7 +62,7 @@ export default React.memo(function orbitalDiagram(
         // the left of its boxes and the boxes fill left to right, in every
         // language. The rows are plain inline flow, so they would otherwise
         // reverse wholesale under `rtl`.
-        <div ref={ref} id={id} {...LTR_ISLAND_PROPS}>
+        <div ref={ref} id={id} {...ltrIslandProps()}>
             {rowsJSX}
         </div>
     );

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
@@ -252,7 +252,7 @@ export default React.memo(function orbitalDiagramInput(
         // sits to the left of its boxes and the boxes fill left to right in
         // every language, and the rows are plain inline flow that would
         // otherwise reverse wholesale under `rtl`.
-        <div ref={ref} id={id} dir="ltr">
+        <div ref={ref} id={id} dir="ltr" style={{ width: "fit-content" }}>
             {controls}
             {rowsJSX}
         </div>

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
@@ -5,6 +5,7 @@ import useDoenetRenderer, {
 import { Button } from "@doenet/ui-components";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { useT } from "../../utils/i18n";
+import { LTR_ISLAND_PROPS } from "./utils/direction";
 
 const ORBITAL_ARROW_STYLE: React.CSSProperties = {
     fill: "none",
@@ -252,7 +253,7 @@ export default React.memo(function orbitalDiagramInput(
         // sits to the left of its boxes and the boxes fill left to right in
         // every language, and the rows are plain inline flow that would
         // otherwise reverse wholesale under `rtl`.
-        <div ref={ref} id={id} dir="ltr" style={{ width: "fit-content" }}>
+        <div ref={ref} id={id} {...LTR_ISLAND_PROPS}>
             {controls}
             {rowsJSX}
         </div>

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
@@ -248,7 +248,11 @@ export default React.memo(function orbitalDiagramInput(
         );
     }
     return (
-        <div ref={ref} id={id}>
+        // Notation, like the read-only diagram it edits: the subshell label
+        // sits to the left of its boxes and the boxes fill left to right in
+        // every language, and the rows are plain inline flow that would
+        // otherwise reverse wholesale under `rtl`.
+        <div ref={ref} id={id} dir="ltr">
             {controls}
             {rowsJSX}
         </div>

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
@@ -5,7 +5,7 @@ import useDoenetRenderer, {
 import { Button } from "@doenet/ui-components";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { useT } from "../../utils/i18n";
-import { LTR_ISLAND_PROPS } from "./utils/direction";
+import { ltrIslandProps } from "./utils/direction";
 
 const ORBITAL_ARROW_STYLE: React.CSSProperties = {
     fill: "none",
@@ -253,7 +253,7 @@ export default React.memo(function orbitalDiagramInput(
         // sits to the left of its boxes and the boxes fill left to right in
         // every language, and the rows are plain inline flow that would
         // otherwise reverse wholesale under `rtl`.
-        <div ref={ref} id={id} {...LTR_ISLAND_PROPS}>
+        <div ref={ref} id={id} {...ltrIslandProps()}>
             {controls}
             {rowsJSX}
         </div>

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -304,6 +304,11 @@ export default React.memo(function Prefigure({
                     <div
                         className="svg"
                         style={svgContainerStyle}
+                        // Coordinate space, like the JSXGraph board: the SVG
+                        // carries `text-anchor` on its labels, which resolves
+                        // against the computed direction. The annotations
+                        // below are prose and are left to inherit.
+                        dir="ltr"
                         dangerouslySetInnerHTML={{ __html: svgMarkup }}
                     />
                 ) : (

--- a/packages/doenetml/src/Viewer/renderers/pretzel.css
+++ b/packages/doenetml/src/Viewer/renderers/pretzel.css
@@ -55,8 +55,8 @@
     .pretzelWrapper {
         display: grid;
         gap: 0px;
-        border-left: 1px solid var(--canvasText);
-        border-right: 1px solid var(--canvasText);
+        /* Both sides, so the pair is the same either way round. */
+        border-inline: 1px solid var(--canvasText);
     }
 
     .pretzelWrapperTop {

--- a/packages/doenetml/src/Viewer/renderers/pretzel.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pretzel.tsx
@@ -11,7 +11,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useContentT, useT } from "../../utils/i18n";
+import { useChromeLangDir, useContentT, useT } from "../../utils/i18n";
 
 interface PretzelSVs {
     [key: string]: any;
@@ -39,6 +39,12 @@ export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
     // The check-work button follows the document's language, not the
     // reader's — see `useContentT`.
     const tContent = useContentT();
+
+    // Each answer row is mixed: the "Answer" label and its colon are the
+    // reader's, while the answer beside them is the author's. Only the chrome
+    // half re-declares itself, and only where the two directions disagree —
+    // otherwise the colon lands on the wrong end of the label.
+    const chromeLangDir = useChromeLangDir();
 
     const ref = useRef(null);
 
@@ -103,7 +109,9 @@ export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
                         className="pretzelAnswer"
                         data-test="pretzel-row-answer"
                     >
-                        <b>{t("pretzel-answer", undefined, "Answer")}</b>:{" "}
+                        <span {...chromeLangDir}>
+                            <b>{t("pretzel-answer", undefined, "Answer")}</b>:
+                        </span>{" "}
                         {answer}
                     </div>
                     <div

--- a/packages/doenetml/src/Viewer/renderers/row.tsx
+++ b/packages/doenetml/src/Viewer/renderers/row.tsx
@@ -24,7 +24,7 @@ export default React.memo(function Row(props: UseDoenetRendererProps) {
     }
     // Physical, because the attribute is: an author writes `<row left="…">` and
     // means the left-hand edge. Adding a logical `start`/`end` vocabulary to
-    // the table attributes is tracked separately.
+    // the table attributes is tracked in #1627.
     if (SVs.left !== "none") {
         style.borderLeftStyle = "solid";
         if (SVs.left === "minor") {

--- a/packages/doenetml/src/Viewer/renderers/row.tsx
+++ b/packages/doenetml/src/Viewer/renderers/row.tsx
@@ -22,6 +22,9 @@ export default React.memo(function Row(props: UseDoenetRendererProps) {
     if (SVs.valign !== null) {
         style.verticalAlign = SVs.valign;
     }
+    // Physical, because the attribute is: an author writes `<row left="…">` and
+    // means the left-hand edge. Adding a logical `start`/`end` vocabulary to
+    // the table attributes is tracked separately.
     if (SVs.left !== "none") {
         style.borderLeftStyle = "solid";
         if (SVs.left === "minor") {

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -22,7 +22,14 @@ import { cesc } from "@doenet/utils";
 import { directionOf } from "@doenet/i18n";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { DocContext } from "../DocViewer";
-import { useChromeLangDir, useContentT, useT } from "../../utils/i18n";
+import {
+    chromeLangDir as chromeLangDirProps,
+    DocumentDirectionProvider,
+    useContentT,
+    useDocumentDirection,
+    useT,
+    useUiLocale,
+} from "../../utils/i18n";
 import { clickToToggleLabel } from "./utils/disclosure";
 
 interface SectionSVs {
@@ -58,11 +65,26 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
     // reader's — see `useContentT`.
     const tContent = useContentT();
 
+    // Only a nested `<document>` in a language of its own supplies
+    // `renderedLang`, and it is set exactly when that language differs from the
+    // one around it — so this is non-null precisely for the sections that turn
+    // their own subtree around, and null for every ordinary section, which
+    // inherits whatever direction it is drawn inside.
+    const nestedDirection = SVs.renderedLang
+        ? directionOf(SVs.renderedLang)
+        : null;
+    const outerDirection = useDocumentDirection();
+
     // A collapsible section's heading is mixed: the title is the author's and
     // follows the document, while "(click to open)" is the reader's. Only the
     // chrome half re-declares itself, and only where the two directions
-    // disagree.
-    const chromeLangDir = useChromeLangDir();
+    // disagree. Compared against `nestedDirection` first, because the heading
+    // is drawn *inside* the container this section is about to open — a nested
+    // document's own heading sits in its own direction, not its parent's.
+    const chromeLangDir = chromeLangDirProps(
+        useUiLocale(),
+        nestedDirection ?? outerDirection,
+    );
 
     const { darkMode } = useContext(DocContext) || {};
 
@@ -186,30 +208,43 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         // viewer labels the whole activity from the outermost document).
         //
         // The direction rides along with it and needs no state variable of its
-        // own. `renderedLang` is set exactly when this document's language
-        // differs from the one around it, so where it is absent the direction
-        // cannot have changed either — and where it is present, reading the
-        // direction off it is right in every case, including English nested in
-        // Arabic. A German document inside an English one picks up a redundant
-        // `dir="ltr"`, which says out loud what was already true.
+        // own — see `nestedDirection`. Reading it off `renderedLang` is right
+        // in every case, including English nested in Arabic. A German document
+        // inside an English one picks up a redundant `dir="ltr"`, which says
+        // out loud what was already true.
         const props = {
             id,
             style,
             ref,
             lang: SVs.renderedLang ?? undefined,
-            dir: SVs.renderedLang ? directionOf(SVs.renderedLang) : undefined,
+            dir: nestedDirection ?? undefined,
         };
 
-        switch (SVs.containerTag) {
-            case "aside":
-                return <aside {...props}>{content}</aside>;
-            case "article":
-                return <article {...props}>{content}</article>;
-            case "div":
-                return <div {...props}>{content}</div>;
-            default:
-                return <section {...props}>{content}</section>;
-        }
+        const container = (() => {
+            switch (SVs.containerTag) {
+                case "aside":
+                    return <aside {...props}>{content}</aside>;
+                case "article":
+                    return <article {...props}>{content}</article>;
+                case "div":
+                    return <div {...props}>{content}</div>;
+                default:
+                    return <section {...props}>{content}</section>;
+            }
+        })();
+
+        // Having turned this subtree around, tell the chrome inside it what it
+        // is now drawn inside. Otherwise a hint or an error box within
+        // `<document lang="ar">` would compare itself against the activity's
+        // direction, find no disagreement, and render its English parentheses
+        // the wrong way round in a right-to-left box.
+        return nestedDirection ? (
+            <DocumentDirectionProvider direction={nestedDirection}>
+                {container}
+            </DocumentDirectionProvider>
+        ) : (
+            container
+        );
     };
 
     // Inject dynamic CSS for list-item section numbers into document head

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -19,6 +19,7 @@ import {
     createCheckWorkComponent,
 } from "./utils/checkWork";
 import { cesc } from "@doenet/utils";
+import { directionOf } from "@doenet/i18n";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { DocContext } from "../DocViewer";
 import { useContentT, useT } from "../../utils/i18n";
@@ -178,11 +179,20 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         // `renderedLang`; every other section leaves the attribute off so the
         // subtree keeps whatever language is already in effect around it (the
         // viewer labels the whole activity from the outermost document).
+        //
+        // The direction rides along with it and needs no state variable of its
+        // own. `renderedLang` is set exactly when this document's language
+        // differs from the one around it, so where it is absent the direction
+        // cannot have changed either — and where it is present, reading the
+        // direction off it is right in every case, including English nested in
+        // Arabic. A German document inside an English one picks up a redundant
+        // `dir="ltr"`, which says out loud what was already true.
         const props = {
             id,
             style,
             ref,
             lang: SVs.renderedLang ?? undefined,
+            dir: SVs.renderedLang ? directionOf(SVs.renderedLang) : undefined,
         };
 
         switch (SVs.containerTag) {

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -22,7 +22,7 @@ import { cesc } from "@doenet/utils";
 import { directionOf } from "@doenet/i18n";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { DocContext } from "../DocViewer";
-import { useContentT, useT } from "../../utils/i18n";
+import { useChromeLangDir, useContentT, useT } from "../../utils/i18n";
 import { clickToToggleLabel } from "./utils/disclosure";
 
 interface SectionSVs {
@@ -58,6 +58,12 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
     // reader's — see `useContentT`.
     const tContent = useContentT();
 
+    // A collapsible section's heading is mixed: the title is the author's and
+    // follows the document, while "(click to open)" is the reader's. Only the
+    // chrome half re-declares itself, and only where the two directions
+    // disagree.
+    const chromeLangDir = useChromeLangDir();
+
     const { darkMode } = useContext(DocContext) || {};
 
     // Pick the heading box background appropriate for the current theme.
@@ -67,12 +73,11 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             ? SVs.titleColorDarkMode
             : SVs.titleColor;
 
-    // List item styling constants
-    // When a section is rendered as a list item (SVs.isListItem), the section
-    // number hangs in the gutter on the side the text starts from — the left in
-    // English, the right in Arabic. Every rule below is written in logical
-    // properties so that follows the document without a second layout.
-    // These constants control the spacing.
+    // List item styling constants. When a section is rendered as a list item
+    // (SVs.isListItem), the section number hangs in the gutter on the side the
+    // text starts from — the left in English, the right in Arabic. Every rule
+    // below is written in logical properties so that follows the document
+    // without a second layout.
     const LIST_ITEM_INDENT = "2em"; // Total width reserved for the hanging section number
     const LIST_ITEM_SPACING = "0.3em"; // Space between section number and following text
     const BOX_PADDING = "6px"; // Standard padding for boxed sections
@@ -419,7 +424,10 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
                 <FontAwesomeIcon
                     icon={SVs.open ? twirlIsOpen : twirlIsClosed}
                 />{" "}
-                {title} {clickToToggleLabel(t, SVs.open)}
+                {title}{" "}
+                <span {...chromeLangDir}>
+                    {clickToToggleLabel(t, SVs.open)}
+                </span>
             </>
         );
     }

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -67,8 +67,11 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             : SVs.titleColor;
 
     // List item styling constants
-    // When a section is rendered as a list item (SVs.isListItem), the section number
-    // hangs to the left of the content. These constants control the spacing.
+    // When a section is rendered as a list item (SVs.isListItem), the section
+    // number hangs in the gutter on the side the text starts from — the left in
+    // English, the right in Arabic. Every rule below is written in logical
+    // properties so that follows the document without a second layout.
+    // These constants control the spacing.
     const LIST_ITEM_INDENT = "2em"; // Total width reserved for the hanging section number
     const LIST_ITEM_SPACING = "0.3em"; // Space between section number and following text
     const BOX_PADDING = "6px"; // Standard padding for boxed sections
@@ -108,9 +111,9 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             return `
                 display: inline-block;
                 width: calc(${LIST_ITEM_INDENT} - ${LIST_ITEM_SPACING});
-                margin-left: calc(-1 * ${LIST_ITEM_INDENT});
-                margin-right: ${LIST_ITEM_SPACING};
-                text-align: right;
+                margin-inline-start: calc(-1 * ${LIST_ITEM_INDENT});
+                margin-inline-end: ${LIST_ITEM_SPACING};
+                text-align: end;
                 flex-shrink: 0;
             `;
         } else {
@@ -118,9 +121,9 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             // Use same width as with-heading case to ensure period alignment
             return `
                 position: absolute;
-                left: 0;
+                inset-inline-start: 0;
                 width: calc(${LIST_ITEM_INDENT} - ${LIST_ITEM_SPACING});
-                text-align: right;
+                text-align: end;
             `;
         }
     };
@@ -150,7 +153,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
                 return {
                     ...baseStyle,
                     position: "relative",
-                    paddingLeft: LIST_ITEM_INDENT,
+                    paddingInlineStart: LIST_ITEM_INDENT,
                 };
             } else {
                 // With heading: use flexbox for baseline alignment
@@ -158,7 +161,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
                     ...baseStyle,
                     display: "flex",
                     alignItems: "baseline",
-                    paddingLeft: LIST_ITEM_INDENT,
+                    paddingInlineStart: LIST_ITEM_INDENT,
                 };
             }
         }
@@ -220,6 +223,14 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         const escapedHeadingWrapperId = cesc(`${id}-heading-wrapper`);
         const escapedContentWrapperId = cesc(`${id}-content-wrapper`);
 
+        // The trailing period in `content` is left to the bidi algorithm on
+        // purpose. It is a neutral character at the end of the run, so in a
+        // right-to-left document it resolves to the far side of the digits and
+        // the marker reads `.1` — which is how a numbered list is written in
+        // Arabic and Hebrew, and what a native `<ol>` does there. Forcing it
+        // back with an LRM would make these markers disagree with every
+        // browser-rendered list on the same page.
+
         // For non-boxed sections with heading wrapper
         if (!SVs.collapsible && !SVs.boxed && hasTitle) {
             cssRules.push(`
@@ -227,9 +238,9 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
                     content: "${SVs.sectionNumber}.";
                     display: inline-block;
                     width: calc(${LIST_ITEM_INDENT} - ${LIST_ITEM_SPACING});
-                    margin-left: calc(-1 * ${LIST_ITEM_INDENT});
-                    margin-right: ${LIST_ITEM_SPACING};
-                    text-align: right;
+                    margin-inline-start: calc(-1 * ${LIST_ITEM_INDENT});
+                    margin-inline-end: ${LIST_ITEM_SPACING};
+                    text-align: end;
                     flex-shrink: 0;
                 }
             `);
@@ -256,8 +267,8 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
                     #${escapedId}::before {
                         content: "${SVs.sectionNumber}.";
                         grid-column: 1;
-                        text-align: right;
-                        padding-right: ${LIST_ITEM_SPACING};
+                        text-align: end;
+                        padding-inline-end: ${LIST_ITEM_SPACING};
                     }
 
                     #${escapedContentWrapperId} {
@@ -278,15 +289,15 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
                 }
             } else {
                 // Empty untitled list item (number only, no content): hang the
-                // number into the container's left indent.
+                // number into the container's start-side indent.
                 cssRules.push(`
                     #${escapedId}::before {
                         content: "${SVs.sectionNumber}.";
                         display: inline-block;
                         width: calc(${LIST_ITEM_INDENT} - ${LIST_ITEM_SPACING});
-                        margin-left: calc(-1 * ${LIST_ITEM_INDENT});
-                        margin-right: ${LIST_ITEM_SPACING};
-                        text-align: right;
+                        margin-inline-start: calc(-1 * ${LIST_ITEM_INDENT});
+                        margin-inline-end: ${LIST_ITEM_SPACING};
+                        text-align: end;
                         vertical-align: baseline;
                     }
                 `);
@@ -300,7 +311,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             cssRules.push(`
                 #${escapedId} .${escapedHeadingBoxClassName}::before {
                     content: "${SVs.sectionNumber}.";
-                    text-align: right;
+                    text-align: end;
                     ${getSectionNumberStyles(hasTitle)}
                 }
             `);
@@ -313,7 +324,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             cssRules.push(`
                 #${escapedId} .${escapedHeadingBoxClassName}::before {
                     content: "${SVs.sectionNumber}.";
-                    text-align: right;
+                    text-align: end;
                     ${getSectionNumberStyles(hasTitle)}
                 }
             `);
@@ -543,7 +554,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             const innerContentStyle = {
                 display: "block",
                 padding: BOX_PADDING,
-                ...(SVs.isListItem && { paddingLeft: LIST_ITEM_INDENT }),
+                ...(SVs.isListItem && { paddingInlineStart: LIST_ITEM_INDENT }),
             };
             innerContent = (
                 <div style={innerContentStyle}>
@@ -616,7 +627,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
         const contentDivStyle = {
             display: "block",
             padding: BOX_PADDING,
-            ...(SVs.isListItem && { paddingLeft: LIST_ITEM_INDENT }),
+            ...(SVs.isListItem && { paddingInlineStart: LIST_ITEM_INDENT }),
         };
 
         const headingBoxClassName = `section-heading-${id}`;
@@ -661,7 +672,7 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             : {
                   margin: "12px 0",
                   position: "relative",
-                  marginLeft: LIST_ITEM_INDENT,
+                  marginInlineStart: LIST_ITEM_INDENT,
               };
 
         return renderContainer(content, containerStyle);

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -319,27 +319,13 @@ export default React.memo(function Section(props: UseDoenetRendererProps) {
             }
         }
 
-        // For collapsible boxed sections
-        if (SVs.collapsible) {
-            const headingBoxClassName = `section-heading-${id}`;
-            const escapedHeadingBoxClassName = cesc(headingBoxClassName);
+        // For sections with a heading box: collapsible (always boxed) or
+        // statically boxed. Both draw the number the same way.
+        if (SVs.collapsible || SVs.boxed) {
+            const escapedHeadingBoxClassName = cesc(`section-heading-${id}`);
             cssRules.push(`
                 #${escapedId} .${escapedHeadingBoxClassName}::before {
                     content: "${SVs.sectionNumber}.";
-                    text-align: end;
-                    ${getSectionNumberStyles(hasTitle)}
-                }
-            `);
-        }
-
-        // For static boxed sections
-        if (SVs.boxed && !SVs.collapsible) {
-            const headingBoxClassName = `section-heading-${id}`;
-            const escapedHeadingBoxClassName = cesc(headingBoxClassName);
-            cssRules.push(`
-                #${escapedId} .${escapedHeadingBoxClassName}::before {
-                    content: "${SVs.sectionNumber}.";
-                    text-align: end;
                     ${getSectionNumberStyles(hasTitle)}
                 }
             `);

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -95,6 +95,12 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
                         display: "flex",
                         alignItems: "flex-start",
                     }),
+                    // Physical, because `<sideBySide margins="…">` is: the
+                    // author wrote a left margin and a right margin, and the
+                    // panels themselves reorder under `rtl` while these
+                    // percentages stay where they were put. Giving the
+                    // attribute logical `start`/`end` values is tracked
+                    // separately.
                     marginLeft: `${thisMarginLeft}%`,
                     marginRight: `${thisMarginRight}%`,
                     width: `${width}%`,

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -100,7 +100,7 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
                     // panels themselves reorder under `rtl` while these
                     // percentages stay where they were put. Giving the
                     // attribute logical `start`/`end` values is tracked
-                    // separately.
+                    // in #1627.
                     marginLeft: `${thisMarginLeft}%`,
                     marginRight: `${thisMarginRight}%`,
                     width: `${width}%`,

--- a/packages/doenetml/src/Viewer/renderers/slider.tsx
+++ b/packages/doenetml/src/Viewer/renderers/slider.tsx
@@ -405,8 +405,12 @@ export default React.memo(function Slider(props: UseDoenetRendererProps) {
                 on the right while the tick labels under them, being notation,
                 still read left-to-right. Pinning the track keeps the two
                 agreeing, and takes in the prev/next buttons so that "prev"
-                stays on the end of the track it steps toward. */}
-            <div dir="ltr">
+                stays on the end of the track it steps toward.
+
+                Shrink-to-fit because a pinned *block* would otherwise stretch
+                the full width and left-align its contents, stranding the track
+                at the far side of the page from the label above it. */}
+            <div dir="ltr" style={{ width: "fit-content" }}>
                 <input
                     ref={inputRef}
                     id={id}

--- a/packages/doenetml/src/Viewer/renderers/slider.tsx
+++ b/packages/doenetml/src/Viewer/renderers/slider.tsx
@@ -397,28 +397,44 @@ export default React.memo(function Slider(props: UseDoenetRendererProps) {
 
     return (
         <div>
+            {/* The label is the author's prose and follows the document. Only
+                the track below it is notation. */}
             {myLabel}
-            <input
-                ref={inputRef}
-                id={id}
-                type="range"
-                style={{ width, margin: 0, maxWidth: "100%" }}
-                value={index}
-                list={id + "-datalist"}
-                min={0}
-                max={SVs.numItems - 1}
-                onInput={(e) =>
-                    changeValue((e.target as HTMLInputElement).value, transient)
-                }
-                onMouseDown={() => setTransient(true)}
-                onMouseUp={(e) => {
-                    setTransient(false);
-                    changeValue((e.target as HTMLInputElement).value, false);
-                }}
-                disabled={SVs.disabled}
-            />
-            {dataList}
-            {controls}
+            {/* A browser reverses a native range input under `rtl`, putting
+                `min` at the right edge — which would leave the small numbers
+                on the right while the tick labels under them, being notation,
+                still read left-to-right. Pinning the track keeps the two
+                agreeing, and takes in the prev/next buttons so that "prev"
+                stays on the end of the track it steps toward. */}
+            <div dir="ltr">
+                <input
+                    ref={inputRef}
+                    id={id}
+                    type="range"
+                    style={{ width, margin: 0, maxWidth: "100%" }}
+                    value={index}
+                    list={id + "-datalist"}
+                    min={0}
+                    max={SVs.numItems - 1}
+                    onInput={(e) =>
+                        changeValue(
+                            (e.target as HTMLInputElement).value,
+                            transient,
+                        )
+                    }
+                    onMouseDown={() => setTransient(true)}
+                    onMouseUp={(e) => {
+                        setTransient(false);
+                        changeValue(
+                            (e.target as HTMLInputElement).value,
+                            false,
+                        );
+                    }}
+                    disabled={SVs.disabled}
+                />
+                {dataList}
+                {controls}
+            </div>
         </div>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/slider.tsx
+++ b/packages/doenetml/src/Viewer/renderers/slider.tsx
@@ -7,7 +7,7 @@ import { sizeToCSS } from "./utils/css";
 import { ActionButton, ActionButtonGroup } from "@doenet/ui-components";
 import { renderLabelWithLatex } from "./utils/labelWithLatex";
 import { useT } from "../../utils/i18n";
-import { LTR_ISLAND_PROPS } from "./utils/direction";
+import { ltrIslandProps } from "./utils/direction";
 
 let round_to_decimals = (x: number, n: number) => {
     try {
@@ -406,13 +406,16 @@ export default React.memo(function Slider(props: UseDoenetRendererProps) {
                 on the right while the tick labels under them, being notation,
                 still read left-to-right. Pinning the track keeps the two
                 agreeing, and takes in the prev/next buttons so that "prev"
-                stays on the end of the track it steps toward. */}
-            <div {...LTR_ISLAND_PROPS}>
+                stays on the end of the track it steps toward.
+
+                The authored width sizes the pinned box and the input fills it,
+                so that `width="50%"` still measures against the column. */}
+            <div {...ltrIslandProps(width)}>
                 <input
                     ref={inputRef}
                     id={id}
                     type="range"
-                    style={{ width, margin: 0, maxWidth: "100%" }}
+                    style={{ width: "100%", margin: 0 }}
                     value={index}
                     list={id + "-datalist"}
                     min={0}

--- a/packages/doenetml/src/Viewer/renderers/slider.tsx
+++ b/packages/doenetml/src/Viewer/renderers/slider.tsx
@@ -7,6 +7,7 @@ import { sizeToCSS } from "./utils/css";
 import { ActionButton, ActionButtonGroup } from "@doenet/ui-components";
 import { renderLabelWithLatex } from "./utils/labelWithLatex";
 import { useT } from "../../utils/i18n";
+import { LTR_ISLAND_PROPS } from "./utils/direction";
 
 let round_to_decimals = (x: number, n: number) => {
     try {
@@ -405,12 +406,8 @@ export default React.memo(function Slider(props: UseDoenetRendererProps) {
                 on the right while the tick labels under them, being notation,
                 still read left-to-right. Pinning the track keeps the two
                 agreeing, and takes in the prev/next buttons so that "prev"
-                stays on the end of the track it steps toward.
-
-                Shrink-to-fit because a pinned *block* would otherwise stretch
-                the full width and left-align its contents, stranding the track
-                at the far side of the page from the label above it. */}
-            <div dir="ltr" style={{ width: "fit-content" }}>
+                stays on the end of the track it steps toward. */}
+            <div {...LTR_ISLAND_PROPS}>
                 <input
                     ref={inputRef}
                     id={id}

--- a/packages/doenetml/src/Viewer/renderers/solution.tsx
+++ b/packages/doenetml/src/Viewer/renderers/solution.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPuzzlePiece as puzzle } from "@fortawesome/free-solid-svg-icons";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
-import { useT } from "../../utils/i18n";
+import { useChromeLangDir, useT } from "../../utils/i18n";
 import { clickToToggleLabel } from "./utils/disclosure";
 import "./solution.css";
 
@@ -32,6 +32,11 @@ export default React.memo(function Solution(props: UseDoenetRendererProps) {
     useRecordVisibilityChanges(ref, callAction, actions);
 
     const openCloseText = clickToToggleLabel(t, SVs.open);
+    // The heading is mixed: the section name and message come from the worker
+    // in the document's language, while "(click to open)" is the reader's.
+    // Only the chrome half re-declares itself, and only where the two
+    // directions disagree.
+    const chromeLangDir = useChromeLangDir();
 
     if (SVs.hidden) {
         return null;
@@ -132,7 +137,8 @@ export default React.memo(function Solution(props: UseDoenetRendererProps) {
                 onClick={onClickFunction}
                 onKeyDown={onKeyPressFunction}
             >
-                {icon} {SVs.sectionName} {SVs.message} {openCloseText}
+                {icon} {SVs.sectionName} {SVs.message}{" "}
+                <span {...chromeLangDir}>{openCloseText}</span>
             </span>
             <span style={infoBlockStyle}>{childrenToRender}</span>
         </aside>

--- a/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
+++ b/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
@@ -59,6 +59,14 @@ export default React.memo(function SpreadsheetRenderer(
             <HotTable
                 // style={{ borderRadius:"var(--mainBorderRadius)", border:"var(--mainBorder)" }}
                 licenseKey="non-commercial-and-evaluation"
+                // Handsontable reads the inherited `dir` and flips its column
+                // order to match, so an RTL document would renumber the
+                // columns from the right. Column A is column A in every
+                // language: `fixedColumnsLeft` and the cell references authors
+                // write both assume it. Stated rather than inherited because
+                // Handsontable owns this decision through its own option, not
+                // through CSS.
+                layoutDirection="ltr"
                 theme={
                     darkMode === "dark"
                         ? "ht-theme-classic-dark"

--- a/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
@@ -356,7 +356,14 @@ export default React.memo(function subsetOfReals(
     }
 
     return (
-        <div ref={ref} id={id}>
+        // A number line runs from −10 on the left to 10 on the right in every
+        // language: it is mathematical notation, not prose. Everything under
+        // here assumes that — the hash marks are laid out at fixed pixel
+        // offsets, the arrowheads are hard-coded left and right, and the
+        // pointer handler maps an x position to a value by subtracting a left
+        // edge. Pinned as one attribute on the whole widget so the controls
+        // above the axis stay on the same side as the axis itself.
+        <div ref={ref} id={id} dir="ltr">
             <div ref={bounds} style={{ display: "flex", gap: "12px" }}>
                 {controlButtons}
             </div>

--- a/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
@@ -8,7 +8,7 @@ import { ToggleButton } from "@doenet/ui-components";
 import { ToggleButtonGroup } from "@doenet/ui-components";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { useT } from "../../utils/i18n";
-import { LTR_ISLAND_PROPS } from "./utils/direction";
+import { ltrIslandProps } from "./utils/direction";
 import "./subsetOfRealsInput.css";
 
 interface PointDisplayed {
@@ -364,7 +364,7 @@ export default React.memo(function subsetOfReals(
         // pointer handler maps an x position to a value by subtracting a left
         // edge. Pinned as one attribute on the whole widget so the controls
         // above the axis stay on the same side as the axis itself.
-        <div ref={ref} id={id} {...LTR_ISLAND_PROPS}>
+        <div ref={ref} id={id} {...ltrIslandProps()}>
             <div ref={bounds} style={{ display: "flex", gap: "12px" }}>
                 {controlButtons}
             </div>

--- a/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
@@ -363,7 +363,7 @@ export default React.memo(function subsetOfReals(
         // pointer handler maps an x position to a value by subtracting a left
         // edge. Pinned as one attribute on the whole widget so the controls
         // above the axis stay on the same side as the axis itself.
-        <div ref={ref} id={id} dir="ltr">
+        <div ref={ref} id={id} dir="ltr" style={{ width: "fit-content" }}>
             <div ref={bounds} style={{ display: "flex", gap: "12px" }}>
                 {controlButtons}
             </div>

--- a/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
@@ -8,6 +8,7 @@ import { ToggleButton } from "@doenet/ui-components";
 import { ToggleButtonGroup } from "@doenet/ui-components";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { useT } from "../../utils/i18n";
+import { LTR_ISLAND_PROPS } from "./utils/direction";
 import "./subsetOfRealsInput.css";
 
 interface PointDisplayed {
@@ -363,7 +364,7 @@ export default React.memo(function subsetOfReals(
         // pointer handler maps an x position to a value by subtracting a left
         // edge. Pinned as one attribute on the whole widget so the controls
         // above the axis stay on the same side as the axis itself.
-        <div ref={ref} id={id} dir="ltr" style={{ width: "fit-content" }}>
+        <div ref={ref} id={id} {...LTR_ISLAND_PROPS}>
             <div ref={bounds} style={{ display: "flex", gap: "12px" }}>
                 {controlButtons}
             </div>

--- a/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
+++ b/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
@@ -4,7 +4,7 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { sizeToCSS } from "./utils/css";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
-import { useT } from "../../utils/i18n";
+import { useChromeLangDir, useT } from "../../utils/i18n";
 
 interface SummaryStatisticsSVs {
     [key: string]: any;
@@ -23,6 +23,12 @@ export default React.memo(function SummaryStatistics(
         useDoenetRenderer<SummaryStatisticsSVs>(props);
 
     const t = useT();
+
+    // The caption is chrome — the reader's language inside the document's box.
+    // The column name interpolated into it is the author's, which is what the
+    // translator's bidi isolation is for. Empty unless the two directions
+    // disagree.
+    const chromeLangDir = useChromeLangDir();
 
     const ref = useRef(null);
 
@@ -74,7 +80,7 @@ export default React.memo(function SummaryStatistics(
 
     return (
         <div style={{ margin: "12px 0" }} ref={ref}>
-            <p>
+            <p {...chromeLangDir}>
                 {t(
                     "summary-statistics-caption",
                     // Fluent renders `{ $column }` literally if handed a

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -739,8 +739,10 @@ export default function TextInput(props: UseDoenetRendererProps) {
             id={labelId}
             htmlFor={inputKey}
             style={{
-                marginRight: SVs.labelPosition === "right" ? undefined : "2px",
-                marginLeft: SVs.labelPosition === "right" ? "2px" : undefined,
+                marginInlineEnd:
+                    SVs.labelPosition === "right" ? undefined : "2px",
+                marginInlineStart:
+                    SVs.labelPosition === "right" ? "2px" : undefined,
             }}
         >
             {label}

--- a/packages/doenetml/src/Viewer/renderers/utils/direction.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/direction.ts
@@ -16,6 +16,12 @@
  * belongs to. Shrink-to-fit lets the surrounding direction place the box while
  * its insides keep running the other way.
  *
+ * Shrink-to-fit has one consequence worth knowing before adding an island: a
+ * percentage width inside now resolves against the widget's own content width
+ * rather than the column it sits in. Everything here is sized in pixels by
+ * default, so an authored `<slider width="50%" />` is the one case that
+ * renders narrower than it used to.
+ *
  * For an inline island, or one whose element already shrink-wraps, use a bare
  * `dir="ltr"` instead — see `EditableMathField.jsx` and `matrixInput.tsx`.
  */

--- a/packages/doenetml/src/Viewer/renderers/utils/direction.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/direction.ts
@@ -1,0 +1,25 @@
+/**
+ * Props that pin a block-level widget to left-to-right inside a document that
+ * may be running the other way.
+ *
+ * Mathematical notation does not mirror: a number line runs from −10 on the
+ * left to 10 on the right, an electron configuration fills its boxes left to
+ * right, and a slider's track counts up to the right, in Arabic and Hebrew as
+ * much as in English. Widgets built out of fixed pixel offsets, hard-coded
+ * arrowheads or a native `<input type="range">` would all come out mirrored —
+ * or, worse, half-mirrored — if they inherited `rtl`.
+ *
+ * The `width` is the half that is easy to leave off, and it is not optional. A
+ * pinned *block* still fills its container, and its left-to-right contents then
+ * align to the container's left edge — so in a right-to-left document the
+ * widget would sit at the far side of the page from the prose and the label it
+ * belongs to. Shrink-to-fit lets the surrounding direction place the box while
+ * its insides keep running the other way.
+ *
+ * For an inline island, or one whose element already shrink-wraps, use a bare
+ * `dir="ltr"` instead — see `EditableMathField.jsx` and `matrixInput.tsx`.
+ */
+export const LTR_ISLAND_PROPS = {
+    dir: "ltr",
+    style: { width: "fit-content" },
+} as const;

--- a/packages/doenetml/src/Viewer/renderers/utils/direction.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/direction.ts
@@ -9,23 +9,29 @@
  * arrowheads or a native `<input type="range">` would all come out mirrored —
  * or, worse, half-mirrored — if they inherited `rtl`.
  *
- * The `width` is the half that is easy to leave off, and it is not optional. A
- * pinned *block* still fills its container, and its left-to-right contents then
- * align to the container's left edge — so in a right-to-left document the
+ * The width is the half that is easy to leave off, and it is not optional. A
+ * pinned *block* that is as wide as its container aligns its left-to-right
+ * contents to the container's left edge — so in a right-to-left document the
  * widget would sit at the far side of the page from the prose and the label it
- * belongs to. Shrink-to-fit lets the surrounding direction place the box while
- * its insides keep running the other way.
+ * belongs to. Giving the box a width of its own lets the surrounding direction
+ * place it while its insides keep running the other way.
  *
- * Shrink-to-fit has one consequence worth knowing before adding an island: a
- * percentage width inside now resolves against the widget's own content width
- * rather than the column it sits in. Everything here is sized in pixels by
- * default, so an authored `<slider width="50%" />` is the one case that
- * renders narrower than it used to.
+ * @param width CSS width for the pinned box. Omit it to shrink-wrap the
+ * contents, which is what a widget drawn at its own intrinsic size wants. Pass
+ * the authored width when the widget has one: a percentage *inside* a
+ * shrink-wrapped box resolves against that box's own content width rather than
+ * the column, so `<slider width="50%" />` has to size the pinned box itself
+ * and stretch the widget to fill it.
+ *
+ * Either way the box is capped at the column, so an island can never widen the
+ * page — a widget that does not fit overflows its own box instead.
  *
  * For an inline island, or one whose element already shrink-wraps, use a bare
  * `dir="ltr"` instead — see `EditableMathField.jsx` and `matrixInput.tsx`.
  */
-export const LTR_ISLAND_PROPS = {
-    dir: "ltr",
-    style: { width: "fit-content" },
-} as const;
+export function ltrIslandProps(width: string = "fit-content") {
+    return {
+        dir: "ltr",
+        style: { width, maxWidth: "100%" },
+    } as const;
+}

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -44,7 +44,7 @@ import {
     useHostChromeTranslator,
     useLocaleCatalogs,
 } from "./utils/i18n";
-import { type Translator } from "@doenet/i18n";
+import { directionOf, type Direction, type Translator } from "@doenet/i18n";
 import { defaultFlags } from "./flags";
 import type { DoenetMLFlags } from "./flags";
 export type { DoenetMLFlags } from "./flags";
@@ -409,6 +409,14 @@ export function DoenetViewer({
             >
                 <div
                     data-theme={resolvedTheme}
+                    // The chrome outside the document — the variant selector,
+                    // the "initializing" notice, the error-boundary fallback —
+                    // is in the reader's language, and until now said so
+                    // nowhere. `DocViewer` re-declares both attributes on the
+                    // wrapper below for the *content's* language, so this only
+                    // governs what sits outside it.
+                    lang={hostUiLocale}
+                    dir={directionOf(hostUiLocale)}
                     ref={(r) => {
                         ref.current = r;
                         if (onInit && r) {
@@ -427,6 +435,7 @@ export function DoenetViewer({
                             }
                             theme={resolvedTheme}
                             translate={translateChrome}
+                            direction={directionOf(hostUiLocale)}
                         >
                             {variantSelector}
                             {viewer}
@@ -679,7 +688,17 @@ export const DoenetEditor = React.forwardRef<
                 src={mathjaxUrl}
                 useExistingMathJax={useExistingMathjax}
             >
-                <div data-theme={resolvedTheme} style={{ display: "contents" }}>
+                {/* The whole editor — toolbar, tabs, variant selector,
+                    diagnostics panel, context help — is chrome in the reader's
+                    language, and none of it is inside any `.doenet-viewer`.
+                    `display: contents` generates no box but both attributes
+                    still inherit, which is exactly what is wanted here. */}
+                <div
+                    data-theme={resolvedTheme}
+                    lang={hostUiLocale}
+                    dir={directionOf(hostUiLocale)}
+                    style={{ display: "contents" }}
+                >
                     <I18nProvider
                         translate={translateChrome}
                         locale={hostUiLocale}
@@ -691,6 +710,7 @@ export const DoenetEditor = React.forwardRef<
                             }
                             theme={resolvedTheme}
                             translate={translateChrome}
+                            direction={directionOf(hostUiLocale)}
                         >
                             {editor}
                         </WrapWithKeyboard>
@@ -709,12 +729,14 @@ function WrapWithKeyboard({
     externalVirtualKeyboardProvided,
     theme,
     translate,
+    direction,
     children,
 }: React.PropsWithChildren<{
     addVirtualKeyboard: boolean;
     externalVirtualKeyboardProvided: boolean;
     theme?: "dark" | "light";
     translate?: Translator;
+    direction?: Direction;
 }>) {
     const dispatch = useAppDispatch();
     const focusedMathInput = useRef<HTMLElement | null>(null);
@@ -726,8 +748,10 @@ function WrapWithKeyboard({
             // The tray lives in its own React root outside this tree (it is
             // shared by every viewer on the page), so the translator has to be
             // handed to it the same way `theme` already is — context cannot
-            // cross a root boundary.
+            // cross a root boundary. Neither can an inherited `dir`, so the
+            // direction rides the same channel.
             translate={translate}
+            direction={direction}
             onClick={(keyCommands) => {
                 dispatch(keyboardSlice.actions.setKeyboardInput(keyCommands));
             }}

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -268,6 +268,10 @@ export function DoenetViewer({
     // provider that also accounts for an authored `<document lang>`.
     const { translate: translateChrome, locale: hostUiLocale } =
         useHostChromeTranslator(uiLocale, documentLocale, availableCatalogs);
+    // The reader's writing direction. Needed twice: once as an attribute on
+    // the wrapper below, once handed to the keyboard tray, which renders into
+    // its own root and inherits nothing.
+    const hostUiDirection = directionOf(hostUiLocale);
 
     // Start off hidden and then unhide once the viewer is visible.
     // This is needed to delay the initialization of JSXgraph
@@ -416,7 +420,7 @@ export function DoenetViewer({
                     // wrapper below for the *content's* language, so this only
                     // governs what sits outside it.
                     lang={hostUiLocale}
-                    dir={directionOf(hostUiLocale)}
+                    dir={hostUiDirection}
                     ref={(r) => {
                         ref.current = r;
                         if (onInit && r) {
@@ -435,7 +439,7 @@ export function DoenetViewer({
                             }
                             theme={resolvedTheme}
                             translate={translateChrome}
-                            direction={directionOf(hostUiLocale)}
+                            direction={hostUiDirection}
                         >
                             {variantSelector}
                             {viewer}
@@ -604,6 +608,10 @@ export const DoenetEditor = React.forwardRef<
     );
     const { translate: translateChrome, locale: hostUiLocale } =
         useHostChromeTranslator(uiLocale, documentLocale, availableCatalogs);
+    // The reader's writing direction. Needed twice: once as an attribute on
+    // the wrapper below, once handed to the keyboard tray, which renders into
+    // its own root and inherits nothing.
+    const hostUiDirection = directionOf(hostUiLocale);
 
     const normalizedShowDiagnostics =
         showDiagnostics ?? showErrorsWarnings ?? true;
@@ -696,7 +704,7 @@ export const DoenetEditor = React.forwardRef<
                 <div
                     data-theme={resolvedTheme}
                     lang={hostUiLocale}
-                    dir={directionOf(hostUiLocale)}
+                    dir={hostUiDirection}
                     style={{ display: "contents" }}
                 >
                     <I18nProvider
@@ -710,7 +718,7 @@ export const DoenetEditor = React.forwardRef<
                             }
                             theme={resolvedTheme}
                             translate={translateChrome}
-                            direction={directionOf(hostUiLocale)}
+                            direction={hostUiDirection}
                         >
                             {editor}
                         </WrapWithKeyboard>

--- a/packages/doenetml/src/utils/diagnostics.test.ts
+++ b/packages/doenetml/src/utils/diagnostics.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
     createChromeTranslator,
     createDiagnosticFormatter,
+    stripBidiIsolates,
 } from "@doenet/i18n";
 import type { DiagnosticRecord } from "@doenet/utils";
 
@@ -51,7 +52,9 @@ const formatEn = createDiagnosticFormatter(createChromeTranslator("en"), "en");
 describe("localizeDiagnostics", () => {
     it("renders a coded record's message in the chrome's language", () => {
         const [localized] = localizeDiagnostics([coded], formatEs);
-        expect(localized.message).toBe(
+        // Stripped because the chrome isolates its placeables in every
+        // language but English, and the ignored attributes are one.
+        expect(stripBidiIsolates(localized.message)).toBe(
             "slope y length se ignoran cuando se especifican los dos extremos",
         );
     });

--- a/packages/doenetml/src/utils/diagnostics.ts
+++ b/packages/doenetml/src/utils/diagnostics.ts
@@ -35,6 +35,13 @@ export function useDiagnosticFormatter(
  * catalogs yet (#1518) — come back untouched, and so does the array itself
  * when nothing changed, so a document whose diagnostics are all legacy costs
  * nothing and doesn't churn a memo downstream.
+ *
+ * A *coded* record under a non-English chrome locale is re-rendered even where
+ * the catalog hasn't translated it, because the chrome isolates its placeables
+ * in every language but English and the English fallback picks the marks up
+ * too. That is deliberate — isolation follows the surface, not whichever
+ * catalog answered — and it means such a record no longer keeps its identity.
+ * The cost is a new array for those documents, not a wrong message.
  */
 export function localizeDiagnostics(
     diagnostics: DiagnosticRecord[],

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -212,10 +212,11 @@ export function useUiLocale(): string {
 }
 
 /**
- * The direction of the document this chrome is drawn inside.
+ * The direction of the document this chrome is drawn inside, or `null` where
+ * there is no surrounding document to disagree with.
  *
- * Defaults to the chrome's own, so a renderer mounted outside `DocViewer` — or
- * before the core has answered — behaves as it does today.
+ * `null` is the default so a renderer mounted outside `DocViewer` — or before
+ * the core has answered — adds no attributes and behaves as it does today.
  */
 const DocumentDirectionContext = createContext<Direction | null>(null);
 
@@ -263,8 +264,10 @@ export function chromeLangDir(
  * chrome provider inside it — so every string a renderer draws through
  * {@link useT} is the reader's language sitting in a box declared to be the
  * content's. That costs nothing while the two run the same way, and is why
- * this returns an empty object in the overwhelmingly common case: no attribute
- * appears, and no existing DOM changes.
+ * this returns an empty object in the overwhelmingly common case: spreading it
+ * then adds no attribute to the element it is spread onto. (Three of the call
+ * sites wrap their string in a `<span>` to have something to spread onto; that
+ * span is inert when the object is empty.)
  *
  * It matters when they disagree, which is the case right-to-left support
  * exists for: a Spanish-speaking reader working an Arabic activity. Without

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -286,9 +286,9 @@ export function chromeLangDir(
  * {@link useT} is the reader's language sitting in a box declared to be the
  * content's. That costs nothing while the two run the same way, and is why
  * this returns an empty object in the overwhelmingly common case: spreading it
- * then adds no attribute to the element it is spread onto. (Three of the call
- * sites wrap their string in a `<span>` to have something to spread onto; that
- * span is inert when the object is empty.)
+ * then adds no attribute to the element it is spread onto. (Several of the
+ * call sites wrap their string in a `<span>` to have something to spread onto;
+ * that span is inert when the object is empty.)
  *
  * It matters when they disagree, which is the case right-to-left support
  * exists for: a Spanish-speaking reader working an Arabic activity. Without
@@ -298,9 +298,13 @@ export function chromeLangDir(
  *
  * Spread it onto chrome that sits *inside* the document — the error box, the
  * feedback heading, the click-to-toggle text on a hint, a solution or a
- * collapsible section. Do not spread it onto anything reading
- * {@link useContentT}: the check-work widget follows the document's language
- * on purpose, so it should follow the document's direction too.
+ * collapsible section, a pretzel's answer label, the summary-statistics
+ * caption, the math-input preview's parse-error message. Do not spread it onto
+ * anything reading {@link useContentT}: the check-work widget follows the
+ * document's language on purpose, so it should follow the document's direction
+ * too. Tooltips need nothing either, for the opposite reason — Ariakit portals
+ * them to `document.body`, so they are never inside the document's box at all,
+ * and a native `title` attribute is drawn by the browser rather than by CSS.
  */
 export function useChromeLangDir(): ChromeLangDir {
     return chromeLangDir(useUiLocale(), useDocumentDirection());

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import {
     createChromeTranslator,
+    directionOf,
     loadLocaleResourcesFor,
     localeResourceKey,
     resolveDocumentLocale,
@@ -14,6 +15,7 @@ import {
     CATALOG_NAMESPACES,
     DEFAULT_LOCALE,
     EN_CHROME_TRANSLATOR,
+    type Direction,
     type Translator,
 } from "@doenet/i18n";
 
@@ -207,6 +209,70 @@ export function useT(): Translator {
  */
 export function useUiLocale(): string {
     return useContext(I18nContext).locale;
+}
+
+/**
+ * The direction the chrome is rendering in.
+ *
+ * Derived from {@link useUiLocale} rather than published beside it: direction
+ * is a function of the tag, and a second field could only ever disagree with
+ * the first.
+ */
+export function useUiDirection(): Direction {
+    return directionOf(useUiLocale());
+}
+
+/**
+ * The direction of the document this chrome is drawn inside.
+ *
+ * Defaults to the chrome's own, so a renderer mounted outside `DocViewer` — or
+ * before the core has answered — behaves as it does today.
+ */
+const DocumentDirectionContext = createContext<Direction | null>(null);
+
+export function DocumentDirectionProvider({
+    direction,
+    children,
+}: {
+    direction: Direction;
+    children: React.ReactNode;
+}) {
+    return (
+        <DocumentDirectionContext.Provider value={direction}>
+            {children}
+        </DocumentDirectionContext.Provider>
+    );
+}
+
+/**
+ * `lang` and `dir` for a piece of chrome, or `{}` when it needs neither.
+ *
+ * The viewer labels its wrapper with the *document's* language, and mounts the
+ * chrome provider inside it — so every string a renderer draws through
+ * {@link useT} is the reader's language sitting in a box declared to be the
+ * content's. That costs nothing while the two run the same way, and is why
+ * this returns an empty object in the overwhelmingly common case: no attribute
+ * appears, and no existing DOM changes.
+ *
+ * It matters when they disagree, which is the case right-to-left support
+ * exists for: a Spanish-speaking reader working an Arabic activity. Without
+ * this, their English or Spanish chrome renders inside `dir="rtl"` and its
+ * trailing punctuation, parentheses and percent signs land on the wrong end of
+ * the sentence.
+ *
+ * Spread it onto chrome that sits *inside* the document — the error box, the
+ * feedback and hint headers. Do not spread it onto anything reading
+ * {@link useContentT}: the check-work widget follows the document's language
+ * on purpose, so it should follow the document's direction too.
+ */
+export function useChromeLangDir(): { lang?: string; dir?: Direction } {
+    const locale = useUiLocale();
+    const chromeDirection = directionOf(locale);
+    const documentDirection = useContext(DocumentDirectionContext);
+    if (documentDirection === null || documentDirection === chromeDirection) {
+        return {};
+    }
+    return { lang: locale, dir: chromeDirection };
 }
 
 /**

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -212,17 +212,6 @@ export function useUiLocale(): string {
 }
 
 /**
- * The direction the chrome is rendering in.
- *
- * Derived from {@link useUiLocale} rather than published beside it: direction
- * is a function of the tag, and a second field could only ever disagree with
- * the first.
- */
-export function useUiDirection(): Direction {
-    return directionOf(useUiLocale());
-}
-
-/**
  * The direction of the document this chrome is drawn inside.
  *
  * Defaults to the chrome's own, so a renderer mounted outside `DocViewer` — or
@@ -244,6 +233,29 @@ export function DocumentDirectionProvider({
     );
 }
 
+/** What {@link useChromeLangDir} spreads onto a piece of chrome. */
+export type ChromeLangDir = { lang?: string; dir?: Direction };
+
+/**
+ * {@link useChromeLangDir} without the hook, for a caller that renders *above*
+ * {@link DocumentDirectionProvider} and so cannot read the context — today only
+ * `DocViewer`'s error banner, which is built before the providers it sits
+ * inside.
+ *
+ * @param documentDirection The direction of the surrounding document, or `null`
+ *   where there is none to disagree with.
+ */
+export function chromeLangDir(
+    uiLocale: string,
+    documentDirection: Direction | null,
+): ChromeLangDir {
+    const chromeDirection = directionOf(uiLocale);
+    if (documentDirection === null || documentDirection === chromeDirection) {
+        return {};
+    }
+    return { lang: uiLocale, dir: chromeDirection };
+}
+
 /**
  * `lang` and `dir` for a piece of chrome, or `{}` when it needs neither.
  *
@@ -261,18 +273,13 @@ export function DocumentDirectionProvider({
  * the sentence.
  *
  * Spread it onto chrome that sits *inside* the document — the error box, the
- * feedback and hint headers. Do not spread it onto anything reading
+ * feedback heading, the click-to-toggle text on a hint, a solution or a
+ * collapsible section. Do not spread it onto anything reading
  * {@link useContentT}: the check-work widget follows the document's language
  * on purpose, so it should follow the document's direction too.
  */
-export function useChromeLangDir(): { lang?: string; dir?: Direction } {
-    const locale = useUiLocale();
-    const chromeDirection = directionOf(locale);
-    const documentDirection = useContext(DocumentDirectionContext);
-    if (documentDirection === null || documentDirection === chromeDirection) {
-        return {};
-    }
-    return { lang: locale, dir: chromeDirection };
+export function useChromeLangDir(): ChromeLangDir {
+    return chromeLangDir(useUiLocale(), useContext(DocumentDirectionContext));
 }
 
 /**

--- a/packages/doenetml/src/utils/i18n.tsx
+++ b/packages/doenetml/src/utils/i18n.tsx
@@ -220,6 +220,16 @@ export function useUiLocale(): string {
  */
 const DocumentDirectionContext = createContext<Direction | null>(null);
 
+/**
+ * Declare the direction of the document the chrome below is drawn inside.
+ *
+ * Mounted twice over: once by `DocViewer` for the outermost document, and again
+ * by `section.tsx` around a nested `<document lang>`, which turns its own
+ * subtree around and so becomes what the chrome inside *it* has to agree with.
+ * Without the second, a hint inside `<document lang="ar">` would compare itself
+ * against the activity's direction and stay silent while sitting in a box
+ * running the other way.
+ */
 export function DocumentDirectionProvider({
     direction,
     children,
@@ -232,6 +242,17 @@ export function DocumentDirectionProvider({
             {children}
         </DocumentDirectionContext.Provider>
     );
+}
+
+/**
+ * The direction of the nearest enclosing document, or `null` outside any.
+ *
+ * For a renderer that both *declares* a direction and draws chrome of its own
+ * inside it — today only `section.tsx`, which has to compare its own heading
+ * against the box it is about to open rather than the one around it.
+ */
+export function useDocumentDirection(): Direction | null {
+    return useContext(DocumentDirectionContext);
 }
 
 /** What {@link useChromeLangDir} spreads onto a piece of chrome. */
@@ -282,7 +303,7 @@ export function chromeLangDir(
  * on purpose, so it should follow the document's direction too.
  */
 export function useChromeLangDir(): ChromeLangDir {
-    return chromeLangDir(useUiLocale(), useContext(DocumentDirectionContext));
+    return chromeLangDir(useUiLocale(), useDocumentDirection());
 }
 
 /**

--- a/packages/doenetml/test/cypress/component/DoenetEditor.chromeLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.chromeLocale.cy.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+import { plainTextIncluding, stripBidiIsolates } from "./utils/bidi";
 
 // The editor chrome had no `useT()` in it at all, so a reader who asked for
 // Spanish got a Spanish document inside an English editor — worst in the
@@ -61,7 +62,11 @@ describe("the editor chrome follows the reader's language", () => {
             initialOpenTab: "errors",
         });
 
-        cy.contains("Línea n.º 2", { timeout: VIEWER_TIMEOUT });
+        // The line number is a placeable, and the chrome isolates placeables
+        // in every language but English.
+        cy.get("body", { timeout: VIEWER_TIMEOUT }).should(
+            plainTextIncluding("Línea n.º 2"),
+        );
         cy.get("body").should("not.contain.text", "Line #2");
     });
 
@@ -98,7 +103,11 @@ describe("the editor chrome follows the reader's language", () => {
         }).within(() => {
             cy.get("a").should("have.text", "WCAG AA");
         });
-        cy.contains("h3", "Infracciones de accesibilidad (WCAG AA)");
+        // `WCAG AA` is a placeable — it is the name of a standard and stays
+        // in English — so the parentheses no longer hug it byte-for-byte.
+        cy.get("h3").should(
+            plainTextIncluding("Infracciones de accesibilidad (WCAG AA)"),
+        );
     });
 
     it("renders it in English when nothing asks for another language", () => {
@@ -140,6 +149,10 @@ describe("the editor chrome follows the reader's language", () => {
         );
         cy.get('[data-test="Viewer Update Button"]')
             .invoke("attr", "title")
+            // Both the verb and the shortcut are placeables, so the anchors
+            // and the space between them only line up once the isolation
+            // marks are out.
+            .then(stripBidiIsolates)
             .should("match", /^Actualizar el visor (cmd|ctrl)\+s$/);
     });
 });

--- a/packages/doenetml/test/cypress/component/DoenetEditor.contextHelpLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.contextHelpLocale.cy.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+import { stripBidiIsolates } from "./utils/bidi";
 
 // The context-help panel had no `useT()` in it, so it stayed English inside an
 // otherwise Spanish editor (Doenet/DoenetML#1580). Most of it is sentences
@@ -62,6 +63,10 @@ describe("the context-help panel follows the reader's language", () => {
 
         cy.get(".help-ref-sentence")
             .invoke("text")
+            // Both names are placeables, and U+2069 is not whitespace as far
+            // as `\s` is concerned, so the marks have to come out before the
+            // sentence matches.
+            .then(stripBidiIsolates)
             .should("match", /\$m\s+es una referencia a\s+<math>/);
         // The names inside the sentence are identifiers, still in `<code>`,
         // and still spelled the way the author wrote them.

--- a/packages/doenetml/test/cypress/component/DoenetViewer.errorLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.errorLocale.cy.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+import { plainTextIncluding } from "./utils/bidi";
 
 // The red error box rendered *inside* the document used to stay English while
 // the same diagnostic in the Diagnostics panel was translated — same error,
@@ -18,9 +19,16 @@ const VIEWER_TIMEOUT = 15_000;
 /** The box `_error.tsx` draws, identified by the border color it alone uses. */
 const ERROR_BOX = "[style*='mainRed']";
 
-/** Assert some error box on the page contains `text`. */
+/**
+ * Assert some error box on the page contains `text`.
+ *
+ * Ignores bidi isolation marks: the location line puts its line number in a
+ * placeable, and the chrome isolates placeables in every language but English.
+ */
 function errorBoxContains(text: string) {
-    return cy.contains(ERROR_BOX, text, { timeout: VIEWER_TIMEOUT });
+    return cy
+        .get(ERROR_BOX, { timeout: VIEWER_TIMEOUT })
+        .should(plainTextIncluding(text));
 }
 
 /**

--- a/packages/doenetml/test/cypress/component/utils/bidi.ts
+++ b/packages/doenetml/test/cypress/component/utils/bidi.ts
@@ -1,0 +1,22 @@
+import { stripBidiIsolates } from "@doenet/i18n";
+
+export { stripBidiIsolates };
+
+/**
+ * A `.should()` callback asserting the subject's text contains `text`, once the
+ * invisible bidi formatting characters are taken out.
+ *
+ * The chrome wraps every placeable in U+2068/U+2069 in every language but
+ * English, so `cy.contains("Línea n.º 2")` no longer matches: the marks land
+ * *inside* the string, on either side of the number. They render as nothing, so
+ * a failure diff shows two strings that look identical — which is why an
+ * assertion on translated chrome has to say out loud that it is ignoring them.
+ *
+ * Assert against English if what you mean to pin is the exact bytes, or against
+ * the code points directly if what you mean to pin is the isolation itself.
+ */
+export function plainTextIncluding(text: string) {
+    return ($el: JQuery<HTMLElement>) => {
+        expect(stripBidiIsolates($el.text())).to.include(text);
+    };
+}

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -740,11 +740,15 @@ the direction cannot have changed either.
 
 Chrome drawn *inside* the document is the reader's language in a box declared to
 be the content's. `useChromeLangDir()` re-declares it — on the in-document error
-box, the feedback heading, and the click-to-toggle text on a hint, a solution
-and a collapsible section — and returns `{}` when the two directions already
-agree, so the common case adds no attributes at all. It is not for anything
-reading `useContentT`: the check-work widget follows the document's language by
-design, so it follows its direction too. `DocViewer`'s error banner is built
+box, the feedback heading, the click-to-toggle text on a hint, a solution and a
+collapsible section, a pretzel's answer label, the summary-statistics caption,
+and the math-input preview's parse-error message — and returns `{}` when the two
+directions already agree, so the common case adds no attributes at all. It is
+not for anything reading `useContentT`: the check-work widget follows the
+document's language by design, so it follows its direction too. Nor for
+tooltips, for the opposite reason: Ariakit portals them to `document.body`, so
+they are never inside the document's box, and a native `title` attribute is
+drawn by the browser rather than by CSS. `DocViewer`'s error banner is built
 above the provider the hook reads, so it calls the same rule as the plain
 function `chromeLangDir(uiLocale, documentDirection)`.
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -715,10 +715,92 @@ is an **identifier** rather than a quantity — a line number, a `styleNumber`, 
 `string`, so that nothing groups it either. `TranslationArgs` is where that is
 written down.
 
+## Direction
+
+`directionOf(tag)` in `src/direction.ts` is the whole rule. It answers for
+**any** BCP-47 tag, not only the ones with a catalog: `lang` accepts whatever an
+author types, and `<document lang="ar">` has to lay out right-to-left whether or
+not `locales/ar/` exists. That is why direction is computed rather than recorded
+beside the catalogs — a generated field could only cover the roster, which is
+[not the bundle](#the-roster-is-not-the-bundle) and not exhaustive either.
+
+It keys on **script**, because that is what decides: Punjabi is left-to-right in
+Gurmukhi and right-to-left in Arabic, Kurdish likewise in Latin and Arabic. A
+bare `ar` or `he` resolves through `Intl.Locale`'s `maximize()`. Deliberately
+not `Intl.Locale.prototype.getTextInfo()`, which is too new to rely on and
+throws on exactly the tags `normalizeLocaleTag` is written to pass through
+untouched.
+
+Two roots carry `dir`, for the same reason there are two locales. `DocViewer`
+puts the **content's** direction on `.doenet-viewer` beside its `lang`;
+`doenetml.tsx` puts the **reader's** on the wrapper around the chrome that sits
+outside it. A nested `<document lang>` needs no state variable of its own —
+`renderedLang` is set exactly when the language changes, so where it is absent
+the direction cannot have changed either.
+
+Chrome drawn *inside* the document is the reader's language in a box declared to
+be the content's. `useChromeLangDir()` re-declares it, and returns `{}` when the
+two directions already agree — so the common case adds no attributes at all. It
+is not for anything reading `useContentT`: the check-work widget follows the
+document's language by design, so it follows its direction too.
+
+### Notation is a left-to-right island
+
+Mathematics reads left-to-right in Arabic and Hebrew as well, so a graph must
+not mirror while the prose around it does. The pins are `dir="ltr"` on the
+JSXGraph board and the prefigure SVG (both write `text-anchor: start|end`, which
+resolves against the computed direction), the MathQuill wrapper (no `direction`
+declaration anywhere, inline siblings in source order, physical kerns), the
+matrix input and spreadsheet (a `<table>` reverses its columns), the slider (a
+native range input reverses its track), the number line, the orbital diagram,
+and CodeMirror (it renders XML source). Handsontable is told through its own
+`layoutDirection` option rather than through CSS. MathJax needs nothing: its
+CHTML output already pins `direction: ltr` on `mjx-math`.
+
+The keyboard's keys are pinned in `keyboard.css` rather than by attribute,
+because `Keyboard` returns a different element per style. The tray *around*
+them follows the reader.
+
+Everything else mirrors: the paginator, prose renderers, the feedback and hint
+headers, the graph-controls panel, the editor chrome.
+
+### Testing it without a catalog
+
+`en-XB` renders text byte-identical to `en-XA` and differs only in
+`directionOf` reporting it `rtl`. So a difference between the two runs is a
+difference in layout and nothing else, and every right-to-left assertion is
+runnable before any right-to-left language is translated. It is deliberately
+not a text transform: Android's U+202E override demonstrates bidi rather than
+testing a layout, and look-alike glyphs would cost the accented text its
+readability and break the hard-coded-English sweep.
+
 ## Bidi isolation
 
-`createTranslator` defaults `useIsolating` to **false**. Fluent otherwise wraps
-every placeable in U+2068/U+2069, which is right for free-form UI text but makes
-output non-byte-identical to the English it replaces and corrupts strings that
-are later compared or hashed — and Doenet compares response text. Turn it on per
-translator for a surface that genuinely mixes RTL and LTR runs.
+An interpolated value that runs the other way from the sentence around it
+scrambles that sentence. Unicode's isolates prevent that, and Fluent adds them
+per bundle — so `useIsolating` is decided per translator, and the two
+translators want opposite answers:
+
+- **`createChromeTranslator` turns it on**, for every language but English.
+  What it renders is looked at and discarded.
+- **`createTranslatorFromLocaleData` leaves it off.** What the worker renders
+  becomes state variables an author interpolates, an `<award>` compares against
+  a response, and `answer.js` folds into a SHA-1 of the dependency graph. The
+  line is drawn at what is compared, not at what looks like prose.
+
+Isolation is uniform across a fallback chain rather than per catalog: a key the
+reader's language has not translated resolves from English and is isolated all
+the same, because the chrome around it is still the reader's.
+
+**English is excluded, and the reason is not principled.** Isolation protects a
+sentence whose placeable runs the other way, which has nothing to do with
+whether the sentence is English — an English UI naming an Arabic answer still
+gets none. It is excluded because the assertion corpus compares English chrome
+as plain text, and every phase has held English byte-identical to what it
+replaced. Turning it on for English later is a mechanical change plus a sweep
+of exact-string assertions. Keyed on the primary subtag, so `en-GB` is English
+and so are both pseudo-locales.
+
+A test asserting on translated chrome has to strip the marks with
+`stripBidiIsolates`. They render as nothing, so a failure diff otherwise shows
+two strings that look identical.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -748,6 +748,12 @@ design, so it follows its direction too. `DocViewer`'s error banner is built
 above the provider the hook reads, so it calls the same rule as the plain
 function `chromeLangDir(uiLocale, documentDirection)`.
 
+"The document" there means the *nearest* one, not the activity: a nested
+`<document lang>` turns its own subtree around, so `section.tsx` re-mounts
+`DocumentDirectionProvider` around whatever it just declared. Otherwise chrome
+inside `<document lang="ar">` would compare itself against a left-to-right
+activity, find no disagreement, and stay silent in a box running the other way.
+
 ### Notation is a left-to-right island
 
 Mathematics reads left-to-right in Arabic and Hebrew as well, so a graph must

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -755,11 +755,12 @@ not mirror while the prose around it does. The pins are `dir="ltr"` on the
 JSXGraph board and the prefigure SVG (both write `text-anchor: start|end`, which
 resolves against the computed direction), the MathQuill wrapper (no `direction`
 declaration anywhere, inline siblings in source order, physical kerns), the
-matrix input and spreadsheet (a `<table>` reverses its columns), the slider (a
-native range input reverses its track), the number line, the orbital diagram,
-and CodeMirror (it renders XML source). Handsontable is told through its own
-`layoutDirection` option rather than through CSS. MathJax needs nothing: its
-CHTML output already pins `direction: ltr` on `mjx-math`.
+matrix input (a `<table>` reverses its columns), the slider (a native range
+input reverses its track), the number line, the orbital diagram, and CodeMirror
+(it renders XML source). The spreadsheet is the one exception to the attribute:
+Handsontable reads the inherited direction through its own `layoutDirection`
+option, so it is told rather than styled. MathJax needs nothing: its CHTML
+output already pins `direction: ltr` on `mjx-math`.
 
 A pin on a *block* needs a width with it: the element still fills its
 container, and its left-to-right contents then align to the container's left
@@ -779,9 +780,9 @@ headers, the graph-controls panel, the editor chrome.
 ### Testing it without a catalog
 
 `en-XB` renders visually identical text to `en-XA` and differs only in
-`directionOf` reporting it `rtl`, plus an invisible right-to-left mark inside
-each bracket so that a value's trailing punctuation resolves the way it would
-in a real RTL sentence. A difference between the two runs is therefore a
+`directionOf` reporting it `rtl`, plus an invisible right-to-left mark against
+the outer face of each bracket so that a value's trailing punctuation resolves
+the way it would in a real RTL sentence. A difference between the two runs is a
 difference in layout and nothing else, and every right-to-left assertion is
 runnable before any right-to-left language is translated. It is deliberately
 not a text transform: Android's U+202E override demonstrates bidi rather than

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -762,13 +762,16 @@ Handsontable reads the inherited direction through its own `layoutDirection`
 option, so it is told rather than styled. MathJax needs nothing: its CHTML
 output already pins `direction: ltr` on `mjx-math`.
 
-A pin on a *block* needs a width with it: the element still fills its
-container, and its left-to-right contents then align to the container's left
-edge, stranding the widget at the far side of the page from the prose it
-belongs to. `LTR_ISLAND_PROPS` in
+A pin on a *block* needs a width with it: an element as wide as its container
+aligns its left-to-right contents to the container's left edge, stranding the
+widget at the far side of the page from the prose it belongs to.
+`ltrIslandProps()` in
 `packages/doenetml/src/Viewer/renderers/utils/direction.ts` carries the pair, so
-the shrink-to-fit half cannot be left off by accident; an inline island, or one
-whose element already shrink-wraps, takes a bare `dir="ltr"`.
+the sizing half cannot be left off by accident. It shrink-wraps by default and
+takes a width for a widget the author can size — the slider passes its own,
+because a percentage inside a shrink-wrapped box would measure against the box
+instead of the column. An inline island, or one whose element already
+shrink-wraps, takes a bare `dir="ltr"`.
 
 The keyboard's keys are pinned in `keyboard.css` rather than by attribute,
 because `Keyboard` returns a different element per style. The tray *around*

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -739,10 +739,14 @@ outside it. A nested `<document lang>` needs no state variable of its own —
 the direction cannot have changed either.
 
 Chrome drawn *inside* the document is the reader's language in a box declared to
-be the content's. `useChromeLangDir()` re-declares it, and returns `{}` when the
-two directions already agree — so the common case adds no attributes at all. It
-is not for anything reading `useContentT`: the check-work widget follows the
-document's language by design, so it follows its direction too.
+be the content's. `useChromeLangDir()` re-declares it — on the in-document error
+box, the feedback heading, and the click-to-toggle text on a hint, a solution
+and a collapsible section — and returns `{}` when the two directions already
+agree, so the common case adds no attributes at all. It is not for anything
+reading `useContentT`: the check-work widget follows the document's language by
+design, so it follows its direction too. `DocViewer`'s error banner is built
+above the provider the hook reads, so it calls the same rule as the plain
+function `chromeLangDir(uiLocale, documentDirection)`.
 
 ### Notation is a left-to-right island
 
@@ -757,6 +761,14 @@ and CodeMirror (it renders XML source). Handsontable is told through its own
 `layoutDirection` option rather than through CSS. MathJax needs nothing: its
 CHTML output already pins `direction: ltr` on `mjx-math`.
 
+A pin on a *block* needs a width with it: the element still fills its
+container, and its left-to-right contents then align to the container's left
+edge, stranding the widget at the far side of the page from the prose it
+belongs to. `LTR_ISLAND_PROPS` in
+`packages/doenetml/src/Viewer/renderers/utils/direction.ts` carries the pair, so
+the shrink-to-fit half cannot be left off by accident; an inline island, or one
+whose element already shrink-wraps, takes a bare `dir="ltr"`.
+
 The keyboard's keys are pinned in `keyboard.css` rather than by attribute,
 because `Keyboard` returns a different element per style. The tray *around*
 them follows the reader.
@@ -766,8 +778,10 @@ headers, the graph-controls panel, the editor chrome.
 
 ### Testing it without a catalog
 
-`en-XB` renders text byte-identical to `en-XA` and differs only in
-`directionOf` reporting it `rtl`. So a difference between the two runs is a
+`en-XB` renders visually identical text to `en-XA` and differs only in
+`directionOf` reporting it `rtl`, plus an invisible right-to-left mark inside
+each bracket so that a value's trailing punctuation resolves the way it would
+in a real RTL sentence. A difference between the two runs is therefore a
 difference in layout and nothing else, and every right-to-left assertion is
 runnable before any right-to-left language is translated. It is deliberately
 not a text transform: Android's U+202E override demonstrates bidi rather than

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -766,11 +766,15 @@ JSXGraph board and the prefigure SVG (both write `text-anchor: start|end`, which
 resolves against the computed direction), the MathQuill wrapper (no `direction`
 declaration anywhere, inline siblings in source order, physical kerns), the
 matrix input (a `<table>` reverses its columns), the slider (a native range
-input reverses its track), the number line, the orbital diagram, and CodeMirror
-(it renders XML source). The spreadsheet is the one exception to the attribute:
-Handsontable reads the inherited direction through its own `layoutDirection`
-option, so it is told rather than styled. MathJax needs nothing: its CHTML
-output already pins `direction: ltr` on `mjx-math`.
+input reverses its track), the number line, the orbital diagram, the math
+input's preview (the popover does not portal, and the div that scrolls a long
+expression must not become an RTL scroll container, whose `scrollLeft` runs
+from the negatives up to zero), and CodeMirror (it renders XML source). The
+spreadsheet is the one exception to the attribute: Handsontable reads the
+inherited direction through its own `layoutDirection` option, so it is told
+rather than styled. MathJax needs nothing: its CHTML output already pins
+`direction: ltr` on `mjx-math` — but only on the mathematics itself, which is
+why the preview's scroll container still needs its own pin.
 
 A pin on a *block* needs a width with it: an element as wide as its container
 aligns its left-to-right contents to the container's left edge, stranding the

--- a/packages/i18n/src/chrome.ts
+++ b/packages/i18n/src/chrome.ts
@@ -1,7 +1,12 @@
 import { DEFAULT_LOCALE, englishResources } from "./catalogs";
 import { CHROME_NAMESPACES } from "./namespaces";
 import { negotiateLocales, normalizeLocaleTag } from "./negotiate";
-import { PSEUDO_LOCALE, pseudoLocalize } from "./pseudo";
+import {
+    PSEUDO_LOCALE,
+    PSEUDO_RTL_BRACKETS,
+    PSEUDO_RTL_LOCALE,
+    pseudoLocalize,
+} from "./pseudo";
 import { createTranslator, type Translator } from "./translator";
 
 /**
@@ -32,6 +37,23 @@ function getPseudoChromeCatalog(): string {
 }
 
 /**
+ * The right-to-left pseudo-locale catalog, derived the same way.
+ *
+ * The same accented text as `en-XA` — only the brackets differ, and only by an
+ * invisible mark. `en-XB` is a *direction* fixture, not a second vocabulary:
+ * everything it renders should read exactly as `en-XA` does, so that a
+ * difference between the two runs is a difference in layout and nothing else.
+ */
+let pseudoRtlChromeCatalog: string | undefined;
+
+function getPseudoRtlChromeCatalog(): string {
+    return (pseudoRtlChromeCatalog ??= pseudoLocalize(
+        BUNDLED_CHROME_CATALOGS[DEFAULT_LOCALE],
+        { brackets: PSEUDO_RTL_BRACKETS },
+    ));
+}
+
+/**
  * Chrome catalogs available for a given request, keyed by locale.
  *
  * Host-supplied resources win over the bundled ones for the same locale, so a
@@ -45,6 +67,9 @@ function chromeResources(
     const resources: Record<string, string> = { ...BUNDLED_CHROME_CATALOGS };
     if (normalizedUiLocale === PSEUDO_LOCALE) {
         resources[PSEUDO_LOCALE] = getPseudoChromeCatalog();
+    }
+    if (normalizedUiLocale === PSEUDO_RTL_LOCALE) {
+        resources[PSEUDO_RTL_LOCALE] = getPseudoRtlChromeCatalog();
     }
     // `Object.assign` ignores a null or undefined source, so an absent
     // `hostResources` needs no special case.

--- a/packages/i18n/src/chrome.ts
+++ b/packages/i18n/src/chrome.ts
@@ -20,36 +20,30 @@ const BUNDLED_CHROME_CATALOGS: Record<string, string> = {
     [DEFAULT_LOCALE]: englishResources(CHROME_NAMESPACES),
 };
 
+type PseudoLocale = typeof PSEUDO_LOCALE | typeof PSEUDO_RTL_LOCALE;
+
+/** The pseudo-locale catalogs, each derived from English on first use. */
+const pseudoChromeCatalogs: Partial<Record<PseudoLocale, string>> = {};
+
 /**
- * The pseudo-locale catalog, derived from English on first use.
+ * The pseudo-locale catalog for `locale`, derived from English on first use.
  *
  * Deriving it rather than committing a generated `locales/en-XA/chrome.ftl`
  * means it can never drift from the English it is meant to shadow — a stale
  * pseudo catalog would report a string as extracted that no longer is, which
  * is precisely the bug the pseudo-locale exists to find.
- */
-let pseudoChromeCatalog: string | undefined;
-
-function getPseudoChromeCatalog(): string {
-    return (pseudoChromeCatalog ??= pseudoLocalize(
-        BUNDLED_CHROME_CATALOGS[DEFAULT_LOCALE],
-    ));
-}
-
-/**
- * The right-to-left pseudo-locale catalog, derived the same way.
  *
- * The same accented text as `en-XA` — only the brackets differ, and only by an
- * invisible mark. `en-XB` is a *direction* fixture, not a second vocabulary:
- * everything it renders should read exactly as `en-XA` does, so that a
- * difference between the two runs is a difference in layout and nothing else.
+ * The two differ only in their brackets, and there only by an invisible mark:
+ * `en-XB` is a *direction* fixture, not a second vocabulary, so everything it
+ * renders should read exactly as `en-XA` does and a difference between the two
+ * runs is a difference in layout and nothing else.
  */
-let pseudoRtlChromeCatalog: string | undefined;
-
-function getPseudoRtlChromeCatalog(): string {
-    return (pseudoRtlChromeCatalog ??= pseudoLocalize(
+function getPseudoChromeCatalog(locale: PseudoLocale): string {
+    return (pseudoChromeCatalogs[locale] ??= pseudoLocalize(
         BUNDLED_CHROME_CATALOGS[DEFAULT_LOCALE],
-        { brackets: PSEUDO_RTL_BRACKETS },
+        locale === PSEUDO_RTL_LOCALE
+            ? { brackets: PSEUDO_RTL_BRACKETS }
+            : undefined,
     ));
 }
 
@@ -65,11 +59,12 @@ function chromeResources(
     hostResources?: Record<string, string> | null,
 ): Record<string, string> {
     const resources: Record<string, string> = { ...BUNDLED_CHROME_CATALOGS };
-    if (normalizedUiLocale === PSEUDO_LOCALE) {
-        resources[PSEUDO_LOCALE] = getPseudoChromeCatalog();
-    }
-    if (normalizedUiLocale === PSEUDO_RTL_LOCALE) {
-        resources[PSEUDO_RTL_LOCALE] = getPseudoRtlChromeCatalog();
+    if (
+        normalizedUiLocale === PSEUDO_LOCALE ||
+        normalizedUiLocale === PSEUDO_RTL_LOCALE
+    ) {
+        resources[normalizedUiLocale] =
+            getPseudoChromeCatalog(normalizedUiLocale);
     }
     // `Object.assign` ignores a null or undefined source, so an absent
     // `hostResources` needs no special case.

--- a/packages/i18n/src/chrome.ts
+++ b/packages/i18n/src/chrome.ts
@@ -77,6 +77,31 @@ function chromeResources(
 }
 
 /**
+ * Whether the chrome in `locale` wraps its placeables in bidi isolation marks.
+ *
+ * On everywhere except English, keyed on the primary language subtag — so
+ * `en-GB` is English, and so are both pseudo-locales, which is what keeps
+ * `en-XA` and `en-XB` renderable as plain text.
+ *
+ * The rule is not principled, and pretending otherwise would mislead whoever
+ * changes it next. Isolation protects a sentence when a *placeable's*
+ * direction differs from the paragraph's, which has nothing to do with whether
+ * the paragraph is English: an English UI formatting an Arabic answer name gets
+ * no isolation here and visually strands the words around it. English is
+ * excluded because the assertion corpus compares English chrome as plain text,
+ * and every phase so far has held English byte-identical to what it replaced.
+ * Turning it on for English later is a mechanical change plus a sweep of
+ * exact-string assertions.
+ *
+ * Content is a different question and gets the opposite answer — see
+ * `createTranslatorFromLocaleData`, which never isolates.
+ */
+function isolatesPlaceables(locale: string): boolean {
+    const language = locale.split(/[-_]/)[0].toLowerCase();
+    return language !== DEFAULT_LOCALE;
+}
+
+/**
  * Build the translator for the viewer chrome.
  *
  * @param uiLocale The chrome's language, already resolved by
@@ -95,7 +120,14 @@ export function createChromeTranslator(
     const normalized = normalizeLocaleTag(uiLocale) || DEFAULT_LOCALE;
     const resources = chromeResources(normalized, hostResources);
     const locales = negotiateLocales([normalized], Object.keys(resources));
-    return createTranslator(locales, resources);
+    // Uniform across the chain, deliberately: isolation belongs to the surface
+    // being rendered, not to whichever catalog happened to answer. A key the
+    // requested locale hasn't translated resolves from English and is isolated
+    // all the same, because the chrome around it is still the requested
+    // locale's.
+    return createTranslator(locales, resources, {
+        useIsolating: isolatesPlaceables(normalized),
+    });
 }
 
 /**

--- a/packages/i18n/src/chrome.ts
+++ b/packages/i18n/src/chrome.ts
@@ -74,7 +74,7 @@ function chromeResources(
 /**
  * Whether the chrome in `locale` wraps its placeables in bidi isolation marks.
  *
- * On everywhere except English, keyed on the primary language subtag — so
+ * True for every language except English, keyed on the primary subtag — so
  * `en-GB` is English, and so are both pseudo-locales, which is what keeps
  * `en-XA` and `en-XB` renderable as plain text.
  *

--- a/packages/i18n/src/direction.ts
+++ b/packages/i18n/src/direction.ts
@@ -166,9 +166,10 @@ function directionFromRawSubtags(tag: string): Direction {
  *
  * The isolates U+2066–U+2069 are what Fluent wraps placeables in when
  * `useIsolating` is on; the marks U+200E/U+200F are what the right-to-left
- * pseudo-locale puts inside its brackets.
+ * pseudo-locale puts against its brackets. Spelled as escapes because written
+ * literally the character class would look empty.
  */
-const BIDI_FORMATTING_CHARACTERS = /[⁦-⁩‎‏]/g;
+const BIDI_FORMATTING_CHARACTERS = /[\u2066-\u2069\u200E\u200F]/g;
 
 /**
  * Strip the invisible bidi formatting characters from rendered text.

--- a/packages/i18n/src/direction.ts
+++ b/packages/i18n/src/direction.ts
@@ -1,4 +1,4 @@
-import { PSEUDO_LOCALE, PSEUDO_RTL_LOCALE } from "./pseudo";
+import { PSEUDO_RTL_LOCALE } from "./pseudo";
 
 /** The writing direction of a locale's text. */
 export type Direction = "ltr" | "rtl";
@@ -119,14 +119,12 @@ export function directionOf(tag: string): Direction {
         return "ltr";
     }
 
-    // The pseudo-locales first: both are `en-…`, so every route below would
-    // report them left-to-right. `en-XB` exists to be the exception.
-    const lower = trimmed.toLowerCase();
-    if (lower === PSEUDO_RTL_LOCALE.toLowerCase()) {
+    // The right-to-left pseudo-locale first, and only it: `en-XB` is an `en-…`
+    // tag, so every route below would resolve it from the Latin script and
+    // report it left-to-right. `en-XA` needs no carve-out, because that is
+    // already the answer it wants.
+    if (trimmed.toLowerCase() === PSEUDO_RTL_LOCALE.toLowerCase()) {
         return "rtl";
-    }
-    if (lower === PSEUDO_LOCALE.toLowerCase()) {
-        return "ltr";
     }
 
     try {

--- a/packages/i18n/src/direction.ts
+++ b/packages/i18n/src/direction.ts
@@ -1,0 +1,189 @@
+import { PSEUDO_LOCALE, PSEUDO_RTL_LOCALE } from "./pseudo";
+
+/** The writing direction of a locale's text. */
+export type Direction = "ltr" | "rtl";
+
+/**
+ * Scripts written right to left.
+ *
+ * Keyed on the ISO 15924 code, because that is what actually decides direction:
+ * a language is written in whatever script it is written in, and several are
+ * written in more than one. `pa` is left-to-right in Gurmukhi and right-to-left
+ * in Arabic; `ku` is left-to-right in Latin and right-to-left in Arabic. Asking
+ * the script rather than the language gets both right without enumerating the
+ * pairs.
+ *
+ * Includes the historic scripts CLDR marks RTL as well as the living ones. They
+ * cost a set entry each and mean an unusual but valid tag resolves rather than
+ * silently rendering the wrong way round.
+ */
+const RTL_SCRIPTS = new Set([
+    "Adlm", // Adlam
+    "Arab", // Arabic
+    "Aran", // Nastaliq
+    "Armi", // Imperial Aramaic
+    "Avst", // Avestan
+    "Cprt", // Cypriot
+    "Egyp", // Egyptian hieroglyphs
+    "Elym", // Elymaic
+    "Gara", // Garay
+    "Hatr", // Hatran
+    "Hebr", // Hebrew
+    "Hung", // Old Hungarian
+    "Khar", // Kharoshthi
+    "Lydi", // Lydian
+    "Mand", // Mandaic
+    "Mani", // Manichaean
+    "Mend", // Mende Kikakui
+    "Merc", // Meroitic cursive
+    "Mero", // Meroitic hieroglyphs
+    "Narb", // Old North Arabian
+    "Nbat", // Nabataean
+    "Nkoo", // NKo
+    "Orkh", // Old Turkic
+    "Palm", // Palmyrene
+    "Phli", // Inscriptional Pahlavi
+    "Phlp", // Psalter Pahlavi
+    "Phnx", // Phoenician
+    "Prti", // Inscriptional Parthian
+    "Rohg", // Hanifi Rohingya
+    "Samr", // Samaritan
+    "Sarb", // Old South Arabian
+    "Sogd", // Sogdian
+    "Sogo", // Old Sogdian
+    "Syrc", // Syriac
+    "Thaa", // Thaana
+    "Todr", // Todhri
+    "Yezi", // Yezidi
+]);
+
+/**
+ * Languages whose default script is right-to-left, for the fallback path.
+ *
+ * Only consulted when the script cannot be derived — a tag `Intl.Locale`
+ * refuses to parse, or an engine whose `maximize()` adds no script. A language
+ * whose default script is left-to-right is absent even if it has a
+ * right-to-left variant, because that variant names its script explicitly and
+ * is caught by {@link RTL_SCRIPTS} instead.
+ *
+ * `iw` and `ji` are the retired codes for Hebrew and Yiddish; `Intl.Locale`
+ * canonicalizes them, but the fallback path runs precisely when it did not.
+ */
+const RTL_LANGUAGES = new Set([
+    "ae", // Avestan
+    "ar", // Arabic
+    "arc", // Aramaic
+    "bcc", // Southern Balochi
+    "bqi", // Bakhtiari
+    "ckb", // Central Kurdish
+    "dv", // Divehi
+    "fa", // Persian
+    "glk", // Gilaki
+    "he", // Hebrew
+    "iw", // Hebrew (retired)
+    "ji", // Yiddish (retired)
+    "khw", // Khowar
+    "ks", // Kashmiri
+    "lrc", // Northern Luri
+    "mzn", // Mazanderani
+    "nqo", // NKo
+    "pnb", // Western Punjabi
+    "prs", // Dari
+    "ps", // Pashto
+    "sd", // Sindhi
+    "ug", // Uyghur
+    "ur", // Urdu
+    "yi", // Yiddish
+]);
+
+/**
+ * The direction a locale's text is written in.
+ *
+ * Answers for *any* BCP-47 tag, not only the ones this repository ships a
+ * catalog for: `lang` accepts whatever an author types, and
+ * `<document lang="ar">` has to lay out right-to-left whether or not
+ * `locales/ar/` exists. That is why direction is computed rather than recorded
+ * beside the catalogs.
+ *
+ * Deliberately not `Intl.Locale.prototype.getTextInfo()`. It is too new to rely
+ * on, and it throws on exactly the tags `normalizeLocaleTag` is written to pass
+ * through untouched — a POSIX-style `en_US`, or anything else hand-typed into a
+ * `lang` attribute. A tag nothing can parse must still get an answer, and the
+ * safe answer is the default.
+ *
+ * @param tag A BCP-47 tag. Anything unrecognized resolves to `"ltr"`.
+ */
+export function directionOf(tag: string): Direction {
+    const trimmed = tag.trim();
+    if (trimmed === "") {
+        return "ltr";
+    }
+
+    // The pseudo-locales first: both are `en-…`, so every route below would
+    // report them left-to-right. `en-XB` exists to be the exception.
+    const lower = trimmed.toLowerCase();
+    if (lower === PSEUDO_RTL_LOCALE.toLowerCase()) {
+        return "rtl";
+    }
+    if (lower === PSEUDO_LOCALE.toLowerCase()) {
+        return "ltr";
+    }
+
+    try {
+        const locale = new Intl.Locale(trimmed);
+        // `maximize` fills in the script CLDR considers likely for the
+        // language, which is what makes a bare `ar` or `he` resolve without
+        // listing it: `ar` maximizes to `ar-Arab-EG`.
+        const script = locale.maximize().script ?? locale.script;
+        if (script) {
+            return RTL_SCRIPTS.has(script) ? "rtl" : "ltr";
+        }
+        return RTL_LANGUAGES.has(locale.language ?? "") ? "rtl" : "ltr";
+    } catch {
+        return directionFromRawSubtags(trimmed);
+    }
+}
+
+/**
+ * Read direction off a tag `Intl.Locale` would not accept.
+ *
+ * Splits on both `-` and `_` so a POSIX-style `he_IL` resolves the way `he-IL`
+ * does. A four-letter subtag is a script and decides on its own; otherwise the
+ * primary language subtag does.
+ */
+function directionFromRawSubtags(tag: string): Direction {
+    const subtags = tag.split(/[-_]/);
+    for (const subtag of subtags.slice(1)) {
+        if (/^[A-Za-z]{4}$/.test(subtag)) {
+            const script =
+                subtag[0].toUpperCase() + subtag.slice(1).toLowerCase();
+            return RTL_SCRIPTS.has(script) ? "rtl" : "ltr";
+        }
+    }
+    return RTL_LANGUAGES.has(subtags[0].toLowerCase()) ? "rtl" : "ltr";
+}
+
+/**
+ * Unicode formatting characters that carry direction but render no glyph.
+ *
+ * The isolates U+2066–U+2069 are what Fluent wraps placeables in when
+ * `useIsolating` is on; the marks U+200E/U+200F are what the right-to-left
+ * pseudo-locale puts inside its brackets.
+ */
+const BIDI_FORMATTING_CHARACTERS = /[⁦-⁩‎‏]/g;
+
+/**
+ * Strip the invisible bidi formatting characters from rendered text.
+ *
+ * For assertions. Isolation marks live in `textContent`, survive `trim()`, and
+ * break `===` and `includes()` while being invisible in a failure diff — so a
+ * test that wants to compare a translated string as plain text has to remove
+ * them explicitly rather than discover them.
+ *
+ * Not for anything at runtime. A surface that must not carry these characters
+ * should be built by a translator that never adds them; stripping after the
+ * fact would only hide that it was the wrong translator.
+ */
+export function stripBidiIsolates(text: string): string {
+    return text.replace(BIDI_FORMATTING_CHARACTERS, "");
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -17,8 +17,12 @@ export {
 export {
     pseudoLocalize,
     PSEUDO_LOCALE,
+    PSEUDO_RTL_LOCALE,
+    PSEUDO_RTL_BRACKETS,
     type PseudoLocalizeOptions,
 } from "./pseudo";
+
+export { directionOf, stripBidiIsolates, type Direction } from "./direction";
 
 export {
     CATALOG_NAMESPACES,

--- a/packages/i18n/src/localeData.ts
+++ b/packages/i18n/src/localeData.ts
@@ -46,6 +46,13 @@ export const DEFAULT_LOCALE_DATA: LocaleData = {
  * thread and sent through. `documentLocale="es"` therefore produces Spanish
  * style descriptions with nothing configured, one load after the first paint.
  *
+ * Never isolates its placeables, unlike the chrome translator. What this builds
+ * becomes state variables — `$line.styleDescription` and the rest — that an
+ * author interpolates into prose, an `<award>` compares against a response, and
+ * the answer machinery folds into a SHA-1 of the dependency graph. Invisible
+ * marks in any of those break a comparison silently. The line is drawn at what
+ * is compared, not at what looks like prose.
+ *
  * @param locale The content locale to render in. Defaults to the one in
  *   `localeData`; the caller passes a different tag when an authored
  *   `<document lang>` overrides what the host asked for.

--- a/packages/i18n/src/pseudo.ts
+++ b/packages/i18n/src/pseudo.ts
@@ -5,6 +5,41 @@
 export const PSEUDO_LOCALE = "en-XA";
 
 /**
+ * The right-to-left pseudo-locale tag. `XB` is a user-assigned region too, and
+ * the pairing follows the convention Android and Chrome already use.
+ *
+ * Its catalog is *byte-identical* to `en-XA`'s — the same accented Latin, the
+ * same expansion padding. The only thing that differs is that `directionOf`
+ * reports it `rtl`, which is the whole point: it exercises the layout without
+ * touching the text.
+ *
+ * Deliberately not a text transform. Android's `en-XB` wraps values in
+ * U+202E RIGHT-TO-LEFT OVERRIDE, which visually reverses Latin — that
+ * demonstrates bidi rather than testing a layout, and it would make both the
+ * accented text and the manual dev harness unreadable. Mapping to Hebrew or
+ * Arabic look-alikes would cost the same and additionally break the
+ * hard-coded-English sweep, which reads `textContent` with a regex.
+ *
+ * What it *does* add is a right-to-left mark inside each bracket (see
+ * {@link PSEUDO_RTL_BRACKETS}), so the neutral characters at a value's edges —
+ * trailing periods, parentheses, colons — resolve the way they would in a real
+ * RTL sentence.
+ */
+export const PSEUDO_RTL_LOCALE = "en-XB";
+
+/**
+ * The brackets {@link PSEUDO_RTL_LOCALE} wraps its values in: the same `»`/`«`
+ * as `en-XA`, each with a U+200F RIGHT-TO-LEFT MARK inside it.
+ *
+ * The mark is invisible and adds no glyph, so the value reads exactly as it
+ * does under `en-XA`; what it changes is the bidi resolution of the neutral
+ * characters between the value and whatever surrounds it. `stripBidiIsolates`
+ * removes it, so an assertion can still compare rendered text as a plain
+ * string.
+ */
+export const PSEUDO_RTL_BRACKETS: [string, string] = ["‏»", "«‏"];
+
+/**
  * Latin letters mapped to accented look-alikes. Still readable in English, but
  * unmistakably *not* the original — which is the point: any string that shows
  * up unaccented in an `en-XA` run never went through the catalogs.

--- a/packages/i18n/src/pseudo.ts
+++ b/packages/i18n/src/pseudo.ts
@@ -20,24 +20,29 @@ export const PSEUDO_LOCALE = "en-XA";
  * Arabic look-alikes would cost the same and additionally break the
  * hard-coded-English sweep, which reads `textContent` with a regex.
  *
- * What it *does* add is a right-to-left mark inside each bracket (see
- * {@link PSEUDO_RTL_BRACKETS}), so the neutral characters at a value's edges —
- * trailing periods, parentheses, colons — resolve the way they would in a real
- * RTL sentence.
+ * What it *does* add is a right-to-left mark against the outer face of each
+ * bracket (see {@link PSEUDO_RTL_BRACKETS}), so the neutral characters at a
+ * value's edges — trailing periods, parentheses, colons — resolve the way they
+ * would in a real RTL sentence.
  */
 export const PSEUDO_RTL_LOCALE = "en-XB";
 
 /**
  * The brackets {@link PSEUDO_RTL_LOCALE} wraps its values in: the same `»`/`«`
- * as `en-XA`, each with a U+200F RIGHT-TO-LEFT MARK inside it.
+ * as `en-XA`, each preceded (opener) or followed (closer) by a U+200F
+ * RIGHT-TO-LEFT MARK — i.e. on the face turned towards the surrounding
+ * sentence, not towards the value.
  *
  * The mark is invisible and adds no glyph, so the value reads exactly as it
  * does under `en-XA`; what it changes is the bidi resolution of the neutral
- * characters between the value and whatever surrounds it. `stripBidiIsolates`
- * removes it, so an assertion can still compare rendered text as a plain
- * string.
+ * characters between the value and whatever surrounds it — which is why it
+ * goes outside the `»`, where those neutrals are. `stripBidiIsolates` removes
+ * it, so an assertion can still compare rendered text as a plain string.
+ *
+ * Spelled with escapes because the marks are invisible: written literally,
+ * these two strings look like a bare `»` and `«` in every editor.
  */
-export const PSEUDO_RTL_BRACKETS: [string, string] = ["‏»", "«‏"];
+export const PSEUDO_RTL_BRACKETS: [string, string] = ["\u200F»", "«\u200F"];
 
 /**
  * Latin letters mapped to accented look-alikes. Still readable in English, but

--- a/packages/i18n/src/pseudo.ts
+++ b/packages/i18n/src/pseudo.ts
@@ -8,10 +8,10 @@ export const PSEUDO_LOCALE = "en-XA";
  * The right-to-left pseudo-locale tag. `XB` is a user-assigned region too, and
  * the pairing follows the convention Android and Chrome already use.
  *
- * Its catalog is *byte-identical* to `en-XA`'s — the same accented Latin, the
- * same expansion padding. The only thing that differs is that `directionOf`
- * reports it `rtl`, which is the whole point: it exercises the layout without
- * touching the text.
+ * Its catalog renders *visually identical* text to `en-XA`'s — the same
+ * accented Latin, the same expansion padding. What differs is that
+ * `directionOf` reports it `rtl`, which is the whole point: it exercises the
+ * layout without touching anything a reader can see.
  *
  * Deliberately not a text transform. Android's `en-XB` wraps values in
  * U+202E RIGHT-TO-LEFT OVERRIDE, which visually reverses Latin — that

--- a/packages/i18n/src/translator.ts
+++ b/packages/i18n/src/translator.ts
@@ -47,11 +47,19 @@ export type CreateTranslatorOptions = {
     /**
      * Wrap placeables in Unicode bidi isolation marks (U+2068/U+2069).
      *
-     * Fluent defaults this on, which is right for free-form UI text but makes
-     * output non-byte-identical to the untranslated English it replaces, and
-     * corrupts strings that are later compared, hashed, or parsed (Doenet
-     * compares response text). Default off; turn it on for a surface that
-     * genuinely mixes RTL and LTR runs.
+     * Fluent defaults this on. It is right for text a reader only ever looks
+     * at, and wrong for text anything later compares, hashes, or parses —
+     * the marks are invisible, they survive `trim()`, and they break `===`.
+     * The default here is therefore off, and the two callers decide:
+     *
+     * - `createChromeTranslator` turns it **on** for every language but
+     *   English. Chrome is rendered and discarded.
+     * - `createTranslatorFromLocaleData` leaves it **off**. Worker content
+     *   becomes state variables an author can interpolate and an answer can
+     *   compare, and it can reach the response hash.
+     *
+     * Isolation also makes output non-byte-identical to the English it
+     * replaces, which is why English is the exception rather than the rule.
      */
     useIsolating?: boolean;
     /**

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { createChromeTranslator, EN_CHROME_TRANSLATOR } from "../src/chrome";
-import { PSEUDO_LOCALE } from "../src/pseudo";
+import { PSEUDO_LOCALE, PSEUDO_RTL_LOCALE } from "../src/pseudo";
+import { stripBidiIsolates } from "../src/direction";
 import { EN_CATALOGS } from "../src/catalogs";
 import esChrome from "../locales/es/chrome.ftl?raw";
 import { extractKeys } from "../scripts/catalogUtils";
@@ -155,6 +156,23 @@ describe("createChromeTranslator", () => {
             // the fallback chain of real ones.
             const t = createChromeTranslator("es", ES);
             expect(t("answer-correct")).toBe("Correcto");
+        });
+
+        it("has a right-to-left twin that renders the same words", () => {
+            // `en-XB` differs from `en-XA` in direction and nothing else, so a
+            // layout difference between the two runs cannot be blamed on the
+            // text having changed.
+            const ltr = createChromeTranslator(PSEUDO_LOCALE);
+            const rtl = createChromeTranslator(PSEUDO_RTL_LOCALE);
+            for (const key of extractKeys(EN_CATALOGS.chrome)) {
+                expect(stripBidiIsolates(rtl(key)), key).toBe(ltr(key));
+            }
+        });
+
+        it("recognizes the right-to-left tag hand-typed too", () => {
+            expect(createChromeTranslator("en-xb")("answer-correct")).toBe(
+                createChromeTranslator(PSEUDO_RTL_LOCALE)("answer-correct"),
+            );
         });
     });
 });

--- a/packages/i18n/test/chrome.test.ts
+++ b/packages/i18n/test/chrome.test.ts
@@ -80,8 +80,12 @@ describe("createChromeTranslator", () => {
         expect(t("attempts-remaining", { count: 0 })).toBe(
             "no quedan intentos",
         );
-        expect(t("attempts-remaining", { count: 1 })).toBe("queda 1 intento");
-        expect(t("attempts-remaining", { count: 4 })).toBe("quedan 4 intentos");
+        expect(stripBidiIsolates(t("attempts-remaining", { count: 1 }))).toBe(
+            "queda 1 intento",
+        );
+        expect(stripBidiIsolates(t("attempts-remaining", { count: 4 }))).toBe(
+            "quedan 4 intentos",
+        );
     });
 
     it("pluralizes around an untranslatable identifier", () => {
@@ -96,17 +100,52 @@ describe("createChromeTranslator", () => {
         );
 
         const es = createChromeTranslator("es", ES);
-        expect(es("answer-show-responses", { count: 3, answerId: "ans" })).toBe(
-            "Mostrar 3 respuestas a ans",
-        );
+        expect(
+            stripBidiIsolates(
+                es("answer-show-responses", { count: 3, answerId: "ans" }),
+            ),
+        ).toBe("Mostrar 3 respuestas a ans");
     });
 
-    it("substitutes without bidi isolation marks", () => {
-        // `useIsolating` stays off so translated output can still be compared
-        // and asserted on as plain text.
+    it("leaves English free of bidi isolation marks", () => {
+        // Every phase has held English byte-identical to the string it
+        // replaced, and the assertion corpus compares it as plain text.
         const t = createChromeTranslator("en");
         expect(t("max-credit-available", { percent: 80 })).toBe(
             "Max credit available: 80%",
+        );
+        // Including a regional English, which is English by primary subtag.
+        expect(
+            createChromeTranslator("en-GB")("max-credit-available", {
+                percent: 80,
+            }),
+        ).toBe("Max credit available: 80%");
+    });
+
+    it("isolates placeables in every other language", () => {
+        // What keeps an interpolated Latin identifier from scrambling the
+        // Arabic around it. The marks are invisible, so assert the code
+        // points rather than the rendering.
+        const es = createChromeTranslator("es", ES);
+        expect(es("max-credit-available", { percent: 80 })).toBe(
+            "Crédito máximo disponible: \u{2068}80\u{2069} %",
+        );
+    });
+
+    it("isolates a message that falls back to English", () => {
+        // Isolation follows the surface, not whichever catalog answered: the
+        // chrome around an untranslated string is still Spanish.
+        const es = createChromeTranslator("es", { es: "" });
+        expect(es("max-credit-available", { percent: 80 })).toBe(
+            "Max credit available: \u{2068}80\u{2069}%",
+        );
+    });
+
+    it("leaves a message with no placeable byte-identical either way", () => {
+        // Isolation wraps placeables and nothing else, which is what bounds
+        // the change to the handful of parameterized messages.
+        expect(createChromeTranslator("es", ES)("answer-correct")).toBe(
+            "Correcto",
         );
     });
 

--- a/packages/i18n/test/diagnostics.test.ts
+++ b/packages/i18n/test/diagnostics.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/diagnostics";
 import { EN_CATALOGS } from "../src/catalogs";
 import { createChromeTranslator } from "../src/chrome";
+import { stripBidiIsolates } from "../src/direction";
 import esDiagnostics from "../locales/es/diagnostics.ftl?raw";
 import { createTranslator, type Translator } from "../src/translator";
 import { extractKeys } from "../scripts/catalogUtils";
@@ -432,9 +433,12 @@ describe("one code, several components", () => {
             code: "doenet-w0015",
             args: { value: "a b c", component: "sort" },
         });
-        expect(message).toContain("sort");
-        expect(message).toContain('"a b c"');
-        expect(message).not.toContain("Ignoring");
+        // Stripped because the chrome isolates its placeables in every
+        // language but English, and the quotes sit on either side of one.
+        const plain = stripBidiIsolates(message);
+        expect(plain).toContain("sort");
+        expect(plain).toContain('"a b c"');
+        expect(plain).not.toContain("Ignoring");
     });
 });
 

--- a/packages/i18n/test/direction.test.ts
+++ b/packages/i18n/test/direction.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { directionOf, stripBidiIsolates } from "../src/direction";
+import { PSEUDO_LOCALE, PSEUDO_RTL_LOCALE } from "../src/pseudo";
+import { SUPPORTED_LOCALES } from "../src/generated/supportedLocales";
+
+describe("directionOf", () => {
+    it("reports the seven right-to-left languages RTL support unblocks", () => {
+        // Arabic, Persian, Hebrew, Urdu, Pashto, Sindhi, Uyghur — the set
+        // #1614 exists to make renderable.
+        for (const tag of ["ar", "fa", "he", "ur", "ps", "sd", "ug"]) {
+            expect(directionOf(tag), tag).toBe("rtl");
+        }
+    });
+
+    it("reports every locale this repository ships a catalog for LTR", () => {
+        // Not an assertion about the world — a statement about today's roster,
+        // and the thing that makes emitting `dir` inert until a right-to-left
+        // catalog lands. It is meant to fail when one does.
+        for (const { locale } of SUPPORTED_LOCALES) {
+            expect(directionOf(locale), locale).toBe("ltr");
+        }
+    });
+
+    it("follows the script rather than the language", () => {
+        // The reason direction is keyed on script: these languages are written
+        // in both, and the tag says which.
+        expect(directionOf("pa-Guru")).toBe("ltr");
+        expect(directionOf("pa-Arab")).toBe("rtl");
+        expect(directionOf("ku-Latn")).toBe("ltr");
+        expect(directionOf("ku-Arab")).toBe("rtl");
+    });
+
+    it("resolves a region- or script-qualified tag the way the bare one goes", () => {
+        expect(directionOf("ar-EG")).toBe("rtl");
+        expect(directionOf("ar-Arab-EG")).toBe("rtl");
+        expect(directionOf("he-IL")).toBe("rtl");
+        expect(directionOf("en-GB")).toBe("ltr");
+    });
+
+    it("normalizes case, because `lang` is typed by hand", () => {
+        expect(directionOf("AR")).toBe("rtl");
+        expect(directionOf("he-il")).toBe("rtl");
+        expect(directionOf("ES-mx")).toBe("ltr");
+    });
+
+    it("answers for a tag `Intl.Locale` cannot parse", () => {
+        // `normalizeLocaleTag` passes these through untouched rather than
+        // rejecting them, so direction has to cope with whatever survives.
+        expect(directionOf("he_IL")).toBe("rtl");
+        expect(directionOf("ar_Arab_EG")).toBe("rtl");
+        expect(directionOf("en_US")).toBe("ltr");
+    });
+
+    it("defaults to left-to-right for nonsense and for nothing at all", () => {
+        expect(directionOf("")).toBe("ltr");
+        expect(directionOf("   ")).toBe("ltr");
+        expect(directionOf("!!!")).toBe("ltr");
+        expect(directionOf("not-a-language")).toBe("ltr");
+    });
+
+    it("makes the two pseudo-locales differ in direction and nothing else", () => {
+        // Both are `en-…`, so neither resolves from its script. The carve-out
+        // is what the right-to-left pseudo-locale is.
+        expect(directionOf(PSEUDO_LOCALE)).toBe("ltr");
+        expect(directionOf(PSEUDO_RTL_LOCALE)).toBe("rtl");
+        expect(directionOf("en-xb")).toBe("rtl");
+    });
+});
+
+describe("stripBidiIsolates", () => {
+    it("removes Fluent's isolation marks", () => {
+        expect(stripBidiIsolates("Show ⁨3⁩ responses")).toBe(
+            "Show 3 responses",
+        );
+    });
+
+    it("removes the directional marks the RTL pseudo-locale adds", () => {
+        expect(stripBidiIsolates("‏»Çórréçţ«‏")).toBe("»Çórréçţ«");
+    });
+
+    it("leaves text carrying none of them untouched", () => {
+        expect(stripBidiIsolates("Max credit available: 80%")).toBe(
+            "Max credit available: 80%",
+        );
+    });
+});

--- a/packages/i18n/test/direction.test.ts
+++ b/packages/i18n/test/direction.test.ts
@@ -70,13 +70,13 @@ describe("directionOf", () => {
 
 describe("stripBidiIsolates", () => {
     it("removes Fluent's isolation marks", () => {
-        expect(stripBidiIsolates("Show ⁨3⁩ responses")).toBe(
+        expect(stripBidiIsolates("Show \u20683\u2069 responses")).toBe(
             "Show 3 responses",
         );
     });
 
     it("removes the directional marks the RTL pseudo-locale adds", () => {
-        expect(stripBidiIsolates("‏»Çórréçţ«‏")).toBe("»Çórréçţ«");
+        expect(stripBidiIsolates("\u200F»Çórréçţ«\u200F")).toBe("»Çórréçţ«");
     });
 
     it("leaves text carrying none of them untouched", () => {

--- a/packages/i18n/test/localeData.test.ts
+++ b/packages/i18n/test/localeData.test.ts
@@ -59,6 +59,20 @@ describe("createTranslatorFromLocaleData", () => {
         expect(t("noun.circle", undefined, "circle")).toBe("circle");
     });
 
+    it("never isolates a placeable, even in a translated language", () => {
+        // The opposite answer to `createChromeTranslator`'s, pinned as exact
+        // bytes: what this translator renders becomes state variables an
+        // author interpolates and an `<award>` compares, where an invisible
+        // U+2068/U+2069 is a silent wrong answer. A future "consistency"
+        // change that passed `useIsolating` here the way the chrome does
+        // would corrupt every parameterized content string.
+        const t = createTranslatorFromLocaleData({
+            locale: "es",
+            resources: { es: "count-items = { $count } elementos" },
+        });
+        expect(t("count-items", { count: 3 })).toBe("3 elementos");
+    });
+
     it("translates for a locale other than the one the payload asked for", () => {
         // A nested `<document lang>` differing from the host's request.
         const localeData = { locale: "en", resources: ES };

--- a/packages/i18n/test/pseudo.test.ts
+++ b/packages/i18n/test/pseudo.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { PSEUDO_LOCALE, pseudoLocalize } from "../src/pseudo";
+import {
+    PSEUDO_LOCALE,
+    PSEUDO_RTL_BRACKETS,
+    PSEUDO_RTL_LOCALE,
+    pseudoLocalize,
+} from "../src/pseudo";
+import { stripBidiIsolates } from "../src/direction";
 import { createTranslator } from "../src/translator";
 import { catalogParseErrors, extractKeys } from "../scripts/catalogUtils";
 
@@ -87,5 +93,39 @@ describe("pseudoLocalize", () => {
             brackets: ["[", "]"],
         });
         expect(pseudo.trim()).toBe("greeting = [Ĥí]");
+    });
+});
+
+describe("the right-to-left pseudo-locale", () => {
+    it("renders the same text as the left-to-right one", () => {
+        // The whole design: `en-XB` is a direction fixture, not a second
+        // vocabulary. A difference between an `en-XA` run and an `en-XB` run
+        // has to be a difference in layout, so the text must not vary.
+        const ltr = pseudoLocalize(SOURCE);
+        const rtl = pseudoLocalize(SOURCE, { brackets: PSEUDO_RTL_BRACKETS });
+        expect(stripBidiIsolates(rtl)).toBe(ltr);
+    });
+
+    it("adds only invisible marks, inside the brackets", () => {
+        const t = createTranslator([PSEUDO_RTL_LOCALE], {
+            [PSEUDO_RTL_LOCALE]: pseudoLocalize(SOURCE, {
+                brackets: PSEUDO_RTL_BRACKETS,
+            }),
+        });
+        const greeting = t("greeting");
+        // Still bracketed and still readable — the marks sit outside the `»`,
+        // so a truncation check reads exactly as it does under `en-XA`.
+        expect(greeting).toContain("»");
+        expect(greeting).toContain("Ĥéļļó");
+        expect(stripBidiIsolates(greeting).startsWith("»")).toBe(true);
+        expect(stripBidiIsolates(greeting).endsWith("«")).toBe(true);
+    });
+
+    it("is still a catalog with the same keys", () => {
+        const pseudo = pseudoLocalize(SOURCE, {
+            brackets: PSEUDO_RTL_BRACKETS,
+        });
+        expect(catalogParseErrors(pseudo)).toEqual([]);
+        expect(extractKeys(pseudo)).toEqual(extractKeys(SOURCE));
     });
 });

--- a/packages/i18n/test/pseudo.test.ts
+++ b/packages/i18n/test/pseudo.test.ts
@@ -106,7 +106,7 @@ describe("the right-to-left pseudo-locale", () => {
         expect(stripBidiIsolates(rtl)).toBe(ltr);
     });
 
-    it("adds only invisible marks, inside the brackets", () => {
+    it("adds only invisible marks, outside the brackets", () => {
         const t = createTranslator([PSEUDO_RTL_LOCALE], {
             [PSEUDO_RTL_LOCALE]: pseudoLocalize(SOURCE, {
                 brackets: PSEUDO_RTL_BRACKETS,

--- a/packages/i18n/test/pseudo.test.ts
+++ b/packages/i18n/test/pseudo.test.ts
@@ -119,6 +119,13 @@ describe("the right-to-left pseudo-locale", () => {
         expect(greeting).toContain("Ĥéļļó");
         expect(stripBidiIsolates(greeting).startsWith("»")).toBe(true);
         expect(stripBidiIsolates(greeting).endsWith("«")).toBe(true);
+        // And *outside* pinned on the raw bytes — the mark precedes the
+        // opener and follows the closer, on the face turned towards the
+        // sentence. The assertions above would all still pass with the marks
+        // inside the brackets, where they would sit against the value's own
+        // strong Latin letters and resolve nothing.
+        expect(greeting.startsWith("\u200F»")).toBe(true);
+        expect(greeting.endsWith("«\u200F")).toBe(true);
     });
 
     it("is still a catalog with the same keys", () => {

--- a/packages/i18n/test/translator.test.ts
+++ b/packages/i18n/test/translator.test.ts
@@ -86,8 +86,11 @@ describe("createTranslator", () => {
     });
 
     it("does not insert bidi isolation marks by default", () => {
-        // Doenet compares and hashes rendered strings, so U+2068/U+2069 around
-        // every placeable would be a silent behavior change.
+        // Off unless a caller asks, because the caller is what knows whether
+        // its output is only looked at: the chrome turns it on for every
+        // language but English, and the worker's content translator never
+        // does — what it renders becomes state variables that get compared
+        // and hashed.
         const t = createTranslator(["en"], { en: EN });
         expect(t("count-items", { count: 3 })).not.toMatch(/[⁦-⁩]/);
 

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -5,7 +5,7 @@ import {
 } from "../tagSpecific/utils/listItemNumberAlignment";
 
 /** Any of the four Unicode bidi isolates Fluent wraps a placeable in. */
-const ISOLATE = /[⁦-⁩]/;
+const ISOLATE = /[\u2066-\u2069]/;
 
 // Covers both halves of the split: chrome, which follows the reader's
 // `uiLocale`, and worker-computed content, which follows the document's.
@@ -464,6 +464,15 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             render({ doenetML: solution, documentLocale: "es", uiLocale: RTL });
 
             cy.get(".doenet-viewer").should("have.attr", "dir", "ltr");
+            // The wrapper around the viewer is the chrome's root, and carries
+            // the reader's tag. `closest` because it is the nearest ancestor
+            // with a theme; nothing inside `.doenet-viewer` has one.
+            cy.get(".doenet-viewer")
+                .closest("[data-theme]")
+                .should("have.attr", "lang", RTL)
+                .should("have.attr", "dir", "rtl");
+            // And the keyboard tray, which is outside the React tree entirely
+            // and so has to be told rather than inherit.
             cy.get("#virtual-keyboard-tray").should("have.attr", "dir", "rtl");
         });
 

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -560,6 +560,33 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
                 .should("have.attr", "dir", "ltr")
                 .should("have.attr", "lang", "en");
         });
+
+        it("re-declares a pretzel's answer label in a right-to-left document", () => {
+            // The same mixed-heading shape as a hint, at a different renderer:
+            // the "Answer" label and its colon are the reader's English, the
+            // answer beside them is the author's. Without the re-declaration
+            // the colon lands on the wrong end of the label. `uiLocale` is
+            // explicit because with nothing configured the chrome follows the
+            // document — and then the two directions agree and nothing needs
+            // saying.
+            render({
+                doenetML: `
+                <pretzel name="pz">
+                  <problem><statement>1</statement><answer>1</answer></problem>
+                  <problem><statement>2</statement><answer>2</answer></problem>
+                </pretzel>
+                <p name="ready">ready</p>`,
+                documentLocale: RTL,
+                uiLocale: "en",
+            });
+
+            cy.get("#ready").should("have.text", "ready");
+            cy.get('[data-test="pretzel-row-answer"] > span')
+                .first()
+                .should("contain.text", "Answer")
+                .should("have.attr", "dir", "ltr")
+                .should("have.attr", "lang", "en");
+        });
     });
 
     describe("pseudo-locale", () => {

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -1,3 +1,8 @@
+import { plainTextIncluding, stripBidiIsolates } from "../utils/bidi";
+
+/** Any of the four Unicode bidi isolates Fluent wraps a placeable in. */
+const ISOLATE = /[⁦-⁩]/;
+
 // Covers both halves of the split: chrome, which follows the reader's
 // `uiLocale`, and worker-computed content, which follows the document's.
 describe("Translation Tests", { tags: ["@group5"] }, function () {
@@ -63,6 +68,32 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         cy.get("#sol_button").should("contain.text", "(clic para abrir)");
     });
 
+    it("isolates an interpolated value in translated chrome", () => {
+        // Pinned in the DOM, not only at the translator, and pinned as the
+        // presence of the marks rather than their absence: every other
+        // assertion in this file strips them, so nothing else here would
+        // notice if isolation were turned back off.
+        //
+        // This is what keeps a Latin identifier from visually scrambling the
+        // Arabic around it once a right-to-left catalog lands.
+        render({ doenetML: problem, documentLocale: "es" });
+
+        cy.get("[data-test=attempts-remaining]")
+            .invoke("text")
+            .should("match", ISOLATE);
+    });
+
+    it("leaves English free of isolation marks", () => {
+        // The invariant every phase has held: with nothing configured, the
+        // output is byte-identical to what it replaced.
+        render({ doenetML: problem });
+
+        cy.get("[data-test=attempts-remaining]")
+            .invoke("text")
+            .should("contain", "2 attempts remaining")
+            .should("not.match", ISOLATE);
+    });
+
     it("translates the check-work widget for the document's language", () => {
         // The whole widget follows the document, so a `documentLocale` with no
         // `uiLocale` moves it. The plural form is the target language's, not a
@@ -70,17 +101,17 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
         // it.
         render({ doenetML: problem, documentLocale: "es" });
 
+        // The count is a placeable, so the rendered text carries isolation
+        // marks on either side of it in every language but English.
         cy.get("[data-test=attempts-remaining]").should(
-            "contain.text",
-            "quedan 2 intentos",
+            plainTextIncluding("quedan 2 intentos"),
         );
 
         submitWrongAnswer();
 
         cy.get("#prob_button").should("contain.text", "Incorrecto");
         cy.get("[data-test=attempts-remaining]").should(
-            "contain.text",
-            "queda 1 intento",
+            plainTextIncluding("queda 1 intento"),
         );
     });
 
@@ -91,8 +122,7 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
 
         cy.get(".doenet-viewer").should("have.attr", "lang", "es");
         cy.get("[data-test=attempts-remaining]").should(
-            "contain.text",
-            "quedan 2 intentos",
+            plainTextIncluding("quedan 2 intentos"),
         );
     });
 
@@ -339,11 +369,17 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
          * Through `should` rather than `then`, so it retries: the records
          * arrive with the core's first result, which is not tied to any
          * element being on screen.
+         *
+         * Bidi marks are stripped because a diagnostic in any language but
+         * English isolates its placeables, and the ignored attributes here are
+         * one. The comparison is exact once they are out.
          */
         function shouldHaveDiagnostic(field, value) {
             cy.window().should((win) => {
                 const diagnostics = win.returnDiagnostics1?.() ?? [];
-                expect(diagnostics.map((d) => d[field])).to.include(value);
+                expect(
+                    diagnostics.map((d) => stripBidiIsolates(String(d[field]))),
+                ).to.include(value);
             });
         }
 

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -1,4 +1,5 @@
 import { plainTextIncluding, stripBidiIsolates } from "../utils/bidi";
+import { verifyListItemNumbersAlign } from "../tagSpecific/utils/listItemNumberAlignment";
 
 /** Any of the four Unicode bidi isolates Fluent wraps a placeable in. */
 const ISOLATE = /[⁦-⁩]/;
@@ -415,6 +416,129 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
 
             cy.get("#ready").should("have.text", "ready");
             shouldHaveDiagnostic("code", "doenet-i0001");
+        });
+    });
+
+    describe("direction", () => {
+        // `en-XB` renders exactly the text `en-XA` does and differs only in
+        // being right-to-left, so anything that moves between the two runs
+        // moved because of the layout and not because the words changed.
+        // Everything here would otherwise have to wait on an Arabic catalog.
+        const RTL = "en-XB";
+
+        /**
+         * Sections numbered as list items — the hanging-number layout that has
+         * been the recurring alignment hotspot. Items of deliberately
+         * different lengths, since the whole risk is that the number's
+         * position ends up depending on the content beside it.
+         */
+        const listItems = `
+        <problems name="problems">
+          <problem name="p1"><p>short</p></problem>
+          <problem name="p2"><p>a rather longer line of text that will wrap around onto a second line</p></problem>
+          <problem name="p3"><p>medium length</p></problem>
+        </problems>
+        <p name="ready">ready</p>`;
+
+        it("labels the document with its direction, beside its language", () => {
+            render({ doenetML: solution, documentLocale: RTL });
+
+            cy.get(".doenet-viewer").should("have.attr", "lang", RTL);
+            cy.get(".doenet-viewer").should("have.attr", "dir", "rtl");
+        });
+
+        it("says left-to-right for a left-to-right language", () => {
+            // Not merely absent: an explicit `ltr` is what stops a
+            // right-to-left host page from turning an English activity around.
+            render({ doenetML: solution, documentLocale: "es" });
+
+            cy.get(".doenet-viewer").should("have.attr", "dir", "ltr");
+        });
+
+        it("turns the chrome without turning the content", () => {
+            // The two locales are separate attributes for this case: a reader
+            // whose language runs the other way from the activity's.
+            render({ doenetML: solution, documentLocale: "es", uiLocale: RTL });
+
+            cy.get(".doenet-viewer").should("have.attr", "dir", "ltr");
+            cy.get("#virtual-keyboard-tray").should("have.attr", "dir", "rtl");
+        });
+
+        it("keeps the notation left-to-right inside a right-to-left document", () => {
+            // The reason this is a `dir` attribute per island rather than one
+            // on the wrapper: mathematics does not mirror.
+            render({
+                doenetML: `
+                <graph name="g"><point name="P">(1,2)</point></graph>
+                <p><mathInput name="mi" /></p>
+                <p><slider name="s" from="0" to="10" /></p>
+                <p name="ready">ready</p>`,
+                documentLocale: RTL,
+            });
+
+            cy.get("#ready").should("have.text", "ready");
+            cy.get(".doenet-viewer").should("have.attr", "dir", "rtl");
+            // Asserting the *computed* direction, so an island that stopped
+            // being pinned would fail here even if some ancestor still said
+            // `ltr` for another reason.
+            cy.get(".jxgbox").should(($el) => {
+                expect(getComputedStyle($el[0]).direction).to.equal("ltr");
+            });
+            cy.get("#mi .mq-editable-field").should(($el) => {
+                expect(getComputedStyle($el[0]).direction).to.equal("ltr");
+            });
+            cy.get("#s").should(($el) => {
+                expect(getComputedStyle($el[0]).direction).to.equal("ltr");
+            });
+            cy.get(".virtual-keyboard").should(($el) => {
+                expect(getComputedStyle($el[0]).direction).to.equal("ltr");
+            });
+        });
+
+        it("hangs list-item numbers off the side the text starts from", () => {
+            // The layout that has been reworked five times. Asserted as the
+            // outcome — sibling numbers line up — rather than as a technique,
+            // and measured from the starting edge so it means the same thing
+            // in both directions.
+            render({ doenetML: listItems, documentLocale: RTL });
+
+            cy.get("#ready").should("have.text", "ready");
+            verifyListItemNumbersAlign(["p1", "p2", "p3"], {
+                label: "right-to-left document",
+            });
+            // And the numbers really are on the other side: each item's
+            // content starts to the right of where its box ends on the left.
+            cy.get("#p1").should(($el) => {
+                const box = $el[0].getBoundingClientRect();
+                const range = document.createRange();
+                range.selectNodeContents($el[0]);
+                const content = range.getBoundingClientRect();
+                expect(
+                    box.right - content.right,
+                    "gutter is on the right",
+                ).to.be.greaterThan(1);
+            });
+        });
+
+        it("still hangs them off the left in a left-to-right document", () => {
+            // The mirror of the assertion above, so a change that fixed one
+            // direction by breaking the other cannot pass.
+            render({ doenetML: listItems, documentLocale: "es" });
+
+            cy.get("#ready").should("have.text", "ready");
+            verifyListItemNumbersAlign(["p1", "p2", "p3"], {
+                label: "left-to-right document",
+            });
+            cy.get("#p1").should(($el) => {
+                const box = $el[0].getBoundingClientRect();
+                const range = document.createRange();
+                range.selectNodeContents($el[0]);
+                const content = range.getBoundingClientRect();
+                expect(
+                    content.left - box.left,
+                    "gutter is on the left",
+                ).to.be.greaterThan(1);
+            });
         });
     });
 

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -534,6 +534,32 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             });
             verifyListItemNumberGutterSide("p1", "ltr");
         });
+
+        it("re-declares chrome inside a nested right-to-left document", () => {
+            // A nested `<document lang>` turns its own subtree around, so it
+            // is what the chrome drawn inside *it* has to agree with — not the
+            // activity, which is still left-to-right here and would report no
+            // disagreement at all.
+            render({
+                doenetML: `
+                <document lang="en">
+                  <document name="inner" lang="${RTL}">
+                    <solution name="sol"><p>answer</p></solution>
+                  </document>
+                </document>`,
+            });
+
+            cy.get(".doenet-viewer").should("have.attr", "dir", "ltr");
+            cy.get("#inner").should("have.attr", "dir", "rtl");
+            // The disclosure label is the reader's English inside that
+            // right-to-left box, so it says so on its own span. The icon
+            // beside it is an `<svg>`, so this is the only span in the
+            // heading.
+            cy.get("#sol_button span")
+                .should("contain.text", "(click to open)")
+                .should("have.attr", "dir", "ltr")
+                .should("have.attr", "lang", "en");
+        });
     });
 
     describe("pseudo-locale", () => {

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -1,5 +1,8 @@
 import { plainTextIncluding, stripBidiIsolates } from "../utils/bidi";
-import { verifyListItemNumbersAlign } from "../tagSpecific/utils/listItemNumberAlignment";
+import {
+    verifyListItemNumberGutterSide,
+    verifyListItemNumbersAlign,
+} from "../tagSpecific/utils/listItemNumberAlignment";
 
 /** Any of the four Unicode bidi isolates Fluent wraps a placeable in. */
 const ISOLATE = /[⁦-⁩]/;
@@ -506,18 +509,9 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             verifyListItemNumbersAlign(["p1", "p2", "p3"], {
                 label: "right-to-left document",
             });
-            // And the numbers really are on the other side: each item's
-            // content starts to the right of where its box ends on the left.
-            cy.get("#p1").should(($el) => {
-                const box = $el[0].getBoundingClientRect();
-                const range = document.createRange();
-                range.selectNodeContents($el[0]);
-                const content = range.getBoundingClientRect();
-                expect(
-                    box.right - content.right,
-                    "gutter is on the right",
-                ).to.be.greaterThan(1);
-            });
+            // And the numbers really are on the other side: aligning with each
+            // other is something a uniformly wrong layout would also manage.
+            verifyListItemNumberGutterSide("p1", "rtl");
         });
 
         it("still hangs them off the left in a left-to-right document", () => {
@@ -529,16 +523,7 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             verifyListItemNumbersAlign(["p1", "p2", "p3"], {
                 label: "left-to-right document",
             });
-            cy.get("#p1").should(($el) => {
-                const box = $el[0].getBoundingClientRect();
-                const range = document.createRange();
-                range.selectNodeContents($el[0]);
-                const content = range.getBoundingClientRect();
-                expect(
-                    content.left - box.left,
-                    "gutter is on the left",
-                ).to.be.greaterThan(1);
-            });
+            verifyListItemNumberGutterSide("p1", "ltr");
         });
     });
 

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -484,6 +484,8 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
                 <graph name="g"><point name="P">(1,2)</point></graph>
                 <p><mathInput name="mi" /></p>
                 <p><slider name="s" from="0" to="10" /></p>
+                <p><subsetOfRealsInput name="sori" /></p>
+                <orbitalDiagramInput name="od" />
                 <p name="ready">ready</p>`,
                 documentLocale: RTL,
             });
@@ -492,7 +494,9 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             cy.get(".doenet-viewer").should("have.attr", "dir", "rtl");
             // Asserting the *computed* direction, so an island that stopped
             // being pinned would fail here even if some ancestor still said
-            // `ltr` for another reason.
+            // `ltr` for another reason. The slider, number line and orbital
+            // diagram are the `ltrIslandProps()` sites; the rest pin
+            // themselves.
             cy.get(".jxgbox").should(($el) => {
                 expect(getComputedStyle($el[0]).direction).to.equal("ltr");
             });
@@ -500,6 +504,12 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
                 expect(getComputedStyle($el[0]).direction).to.equal("ltr");
             });
             cy.get("#s").should(($el) => {
+                expect(getComputedStyle($el[0]).direction).to.equal("ltr");
+            });
+            cy.get("#sori").should(($el) => {
+                expect(getComputedStyle($el[0]).direction).to.equal("ltr");
+            });
+            cy.get("#od").should(($el) => {
                 expect(getComputedStyle($el[0]).direction).to.equal("ltr");
             });
             cy.get(".virtual-keyboard").should(($el) => {

--- a/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/i18n.cy.js
@@ -507,6 +507,29 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
             });
         });
 
+        it("keeps the math input's preview left-to-right too", () => {
+            // The preview draws the same notation as the field it previews,
+            // and its popover does not portal — so inside a right-to-left
+            // document this div is the sharp case among the islands: it is
+            // the scroll container for a long expression, and an RTL scroll
+            // container opens at the tail with `scrollLeft` running from the
+            // negatives up to zero, which inverts the renderer's Home/End
+            // handling.
+            render({
+                doenetML: `
+                <p><mathInput name="mi" showPreview /></p>
+                <p name="ready">ready</p>`,
+                documentLocale: RTL,
+            });
+
+            cy.get("#ready").should("have.text", "ready");
+            cy.get("#mi textarea").type("x+1", { force: true });
+            cy.get("#mi [data-test='MathInput Preview']").should("be.visible");
+            cy.get("#mi-preview").should(($el) => {
+                expect(getComputedStyle($el[0]).direction).to.equal("ltr");
+            });
+        });
+
         it("hangs list-item numbers off the side the text starts from", () => {
             // The layout that has been reworked five times. Asserted as the
             // outcome — sibling numbers line up — rather than as a technique,
@@ -559,6 +582,32 @@ describe("Translation Tests", { tags: ["@group5"] }, function () {
                 .should("contain.text", "(click to open)")
                 .should("have.attr", "dir", "ltr")
                 .should("have.attr", "lang", "en");
+        });
+
+        it("republishes the direction at every level of nesting", () => {
+            // Doubly nested: the middle document turns the subtree around and
+            // the innermost turns it back. Chrome compares itself against the
+            // box *nearest* to it, so the innermost document's disclosure
+            // label — English chrome in an English box — has nothing to
+            // re-declare, even though the document around that box runs the
+            // other way. A `dir` on it here would mean the innermost document
+            // failed to republish what it had just declared.
+            render({
+                doenetML: `
+                <document lang="en">
+                  <document name="mid" lang="${RTL}">
+                    <document name="inner" lang="en">
+                      <solution name="sol"><p>answer</p></solution>
+                    </document>
+                  </document>
+                </document>`,
+            });
+
+            cy.get("#mid").should("have.attr", "dir", "rtl");
+            cy.get("#inner").should("have.attr", "dir", "ltr");
+            cy.get("#sol_button span")
+                .should("contain.text", "(click to open)")
+                .should("not.have.attr", "dir");
         });
 
         it("re-declares a pretzel's answer label in a right-to-left document", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/slider.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/slider.cy.js
@@ -436,4 +436,48 @@ describe("Slider Tag Tests", { tags: ["@group1"] }, function () {
             ).eq(6);
         });
     });
+
+    it("sizes an authored percentage width against the column", () => {
+        // The track is pinned to `dir="ltr"` so a right-to-left document does
+        // not mirror it, and a pinned block needs a width of its own or it
+        // fills the column and strands its contents against the far edge.
+        // Taking that width shrink-to-fit would resolve an authored percentage
+        // against the widget's own content instead of the column — which is a
+        // regression in both directions, so it is guarded here rather than
+        // among the direction tests.
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <slider name="sPx" from="0" to="10" />
+  <slider name="sPct" from="0" to="10" width="50%" />
+  <p name="ready">ready</p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ready").should("have.text", "ready");
+
+        // A few px of slack throughout: the range input's thumb overhangs the
+        // track it is measured with.
+        cy.get("#sPx").should(($el) => {
+            expect($el[0].getBoundingClientRect().width).to.be.closeTo(300, 4);
+        });
+
+        cy.get(".doenet-viewer").then(($viewer) => {
+            const style = getComputedStyle($viewer[0]);
+            const columnWidth =
+                $viewer[0].getBoundingClientRect().width -
+                parseFloat(style.paddingInlineStart) -
+                parseFloat(style.paddingInlineEnd);
+            cy.get("#sPct").should(($el) => {
+                expect($el[0].getBoundingClientRect().width).to.be.closeTo(
+                    columnWidth / 2,
+                    4,
+                );
+            });
+        });
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemNumberAlignment.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemNumberAlignment.js
@@ -1,64 +1,74 @@
 import { cesc } from "@doenet/utils";
 
 /**
- * Return the viewport-x of the left edge of an element's rendered CONTENT,
- * excluding the CSS `::before` section-number marker.
+ * Return the viewport-x of an element's rendered CONTENT on the side the text
+ * starts from, excluding the CSS `::before` section-number marker.
  *
  * The section number ("1.", "2.", …) is a `::before` pseudo-element. Pseudo
  * elements are not part of the DOM, so they have no `getBoundingClientRect()`.
  * A `Range` over the element's contents measures only the real (text / replaced)
- * content, so its left edge is the content's hanging-indent position.
+ * content, so its starting edge is the content's hanging-indent position.
+ *
+ * The *starting* edge, not the left one: in a right-to-left document the text
+ * begins at the right, the number hangs off that side, and every item's left
+ * edge instead varies with how wide its content happens to be. Measuring the
+ * left edge there would compare the ragged ends of the lines and report drift
+ * that is not a bug — or, worse, miss real drift because two different content
+ * widths happened to cancel it out.
  *
  * In every list-item layout the number and the content share the same layout
- * row / columns, so if the content's left edge is identical across sibling list
- * items then their numbers line up at the decimal too. Measuring rendered
+ * row / columns, so if the content's starting edge is identical across sibling
+ * list items then their numbers line up at the decimal too. Measuring rendered
  * geometry this way is technique-independent (it works for flex, grid, or
  * absolute positioning) — unlike computed-style assertions, which are identical
  * on the (buggy) flex layout even when the rendered numbers are visibly
  * misaligned. That is the gap that let issue #1482 through the existing suite.
  */
-function measureContentLeft(el) {
+function measureContentStart(el) {
     const doc = el.ownerDocument;
     const range = doc.createRange();
     range.selectNodeContents(el);
-    return range.getBoundingClientRect().left;
+    const rect = range.getBoundingClientRect();
+    const rtl = doc.defaultView.getComputedStyle(el).direction === "rtl";
+    return rtl ? rect.right : rect.left;
 }
 
 /**
  * Assert that a set of sibling list items render their content — and therefore
  * their section numbers — at the same horizontal position, i.e. the numbers
- * line up at the decimal and no content is shifted right.
+ * line up at the decimal and no content is shifted inward.
  *
  * This is the outcome-based regression guard for #1482 and the recurring
  * list-item-alignment regressions. It is deliberately technique-independent so
- * it survives a change of layout technique (e.g. flex -> grid).
+ * it survives a change of layout technique (e.g. flex -> grid), and
+ * direction-independent so it survives the document being right-to-left.
  *
  * @param {string[]} ids Doenet component ids of the sibling list items.
  * @param {Object} [options]
- * @param {number} [options.maxDriftPx=1.5] Allowed left-edge drift in px.
+ * @param {number} [options.maxDriftPx=1.5] Allowed start-edge drift in px.
  * @param {string} [options.label] Optional label for the assertion message.
  */
 export function verifyListItemNumbersAlign(
     ids,
     { maxDriftPx = 1.5, label = "" } = {},
 ) {
-    const lefts = [];
+    const starts = [];
     ids.forEach((id) => {
         cy.get(`#${cesc(id)}`)
             .should("be.visible")
             .then(($el) => {
-                lefts.push(measureContentLeft($el[0]));
+                starts.push(measureContentStart($el[0]));
             });
     });
     cy.then(() => {
-        const min = Math.min(...lefts);
-        const max = Math.max(...lefts);
+        const min = Math.min(...starts);
+        const max = Math.max(...starts);
         const detail = ids
-            .map((id, i) => `${id}=${lefts[i].toFixed(2)}`)
+            .map((id, i) => `${id}=${starts[i].toFixed(2)}`)
             .join(", ");
         expect(
             max - min,
-            `list-item content-left drift ${label} [${detail}]`,
+            `list-item content-start drift ${label} [${detail}]`,
         ).to.be.lessThan(maxDriftPx);
     });
 }

--- a/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemNumberAlignment.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemNumberAlignment.js
@@ -72,3 +72,36 @@ export function verifyListItemNumbersAlign(
         ).to.be.lessThan(maxDriftPx);
     });
 }
+
+/**
+ * Assert that a list item's number hangs in the gutter on the side the text
+ * starts from, i.e. that its content is inset from that edge of its own box.
+ *
+ * {@link verifyListItemNumbersAlign} only says the siblings agree with each
+ * other, which a layout that put every number on the wrong side would satisfy
+ * too. This says *which* side, so the two together pin the layout in either
+ * direction.
+ *
+ * @param {string} id Doenet component id of the list item.
+ * @param {"ltr"|"rtl"} direction The direction the document is laid out in.
+ * @param {number} [minGutterPx=1] Smallest inset that counts as a gutter.
+ */
+export function verifyListItemNumberGutterSide(id, direction, minGutterPx = 1) {
+    cy.get(`#${cesc(id)}`).should(($el) => {
+        const el = $el[0];
+        const box = el.getBoundingClientRect();
+        // From the element's own document: `document` in a spec file is the
+        // Cypress runner's, not the application's.
+        const range = el.ownerDocument.createRange();
+        range.selectNodeContents(el);
+        const content = range.getBoundingClientRect();
+        const rtl = direction === "rtl";
+        const gutter = rtl
+            ? box.right - content.right
+            : content.left - box.left;
+        expect(
+            gutter,
+            `${id} gutter is on the ${rtl ? "right" : "left"}`,
+        ).to.be.greaterThan(minGutterPx);
+    });
+}

--- a/packages/test-cypress/cypress/e2e/utils/bidi.js
+++ b/packages/test-cypress/cypress/e2e/utils/bidi.js
@@ -1,0 +1,22 @@
+import { stripBidiIsolates } from "@doenet/i18n";
+
+export { stripBidiIsolates };
+
+/**
+ * A `.should()` callback asserting the subject's text contains `text`, once the
+ * invisible bidi formatting characters are taken out.
+ *
+ * The chrome wraps every placeable in U+2068/U+2069 in every language but
+ * English, so `should("contain.text", "quedan 2 intentos")` no longer matches:
+ * the marks land *inside* the string, on either side of the count. They render
+ * as nothing, so a failure diff shows two strings that look identical — which
+ * is why an assertion on translated chrome has to say out loud that it is
+ * ignoring them.
+ *
+ * Assert against English if what you mean to pin is the exact bytes.
+ */
+export function plainTextIncluding(text) {
+    return ($el) => {
+        expect(stripBidiIsolates($el.text())).to.include(text);
+    };
+}

--- a/packages/test-cypress/package.json
+++ b/packages/test-cypress/package.json
@@ -57,6 +57,7 @@
     },
     "dependencies": {
         "@doenet/doenetml-prototype": "*",
+        "@doenet/i18n": "*",
         "@doenet/utils": "^*",
         "vite": "^*"
     },

--- a/packages/ui-components/src/components/style.css
+++ b/packages/ui-components/src/components/style.css
@@ -81,19 +81,18 @@
     &:not(.vertical) {
         flex-direction: row;
         .doenet-button {
-            margin-left: 0;
-            margin-right: 0;
+            margin-inline: 0;
             /* Remove border radius on all but the first and last buttons */
             &:not(:first-child):not(:last-child) {
                 border-radius: 0;
             }
             &:first-child {
-                border-top-right-radius: 0;
-                border-bottom-right-radius: 0;
+                border-start-end-radius: 0;
+                border-end-end-radius: 0;
             }
             &:last-child {
-                border-top-left-radius: 0;
-                border-bottom-left-radius: 0;
+                border-start-start-radius: 0;
+                border-end-start-radius: 0;
             }
         }
     }
@@ -108,12 +107,12 @@
             border-radius: 0;
         }
         &:first-child {
-            border-bottom-left-radius: 0;
-            border-bottom-right-radius: 0;
+            border-end-start-radius: 0;
+            border-end-end-radius: 0;
         }
         &:last-child {
-            border-top-left-radius: 0;
-            border-top-right-radius: 0;
+            border-start-start-radius: 0;
+            border-start-end-radius: 0;
         }
     }
 }
@@ -206,14 +205,14 @@
 
     svg {
         flex-shrink: 0;
-        margin-left: 1px;
+        margin-inline-start: 1px;
     }
 
     &.vertical {
         width: 100%;
         height: 10px;
         svg {
-            margin-left: 0;
+            margin-inline-start: 0;
             margin-top: 0.5px;
         }
     }

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -59,20 +59,23 @@ Tailwind base is purposely not included because we want all styles to be prefixe
     background-color: var(--kb-tray-bg);
 
     .close-keyboard-button {
-        @apply absolute top-0 right-0 m-2 rounded;
+        @apply absolute top-0 end-0 m-2 rounded;
         @apply hover:bg-slate-300 active:bg-slate-400;
         @apply w-6 h-6 flex items-center justify-center text-2xl;
     }
 
     /*
-     * Right-edge footprint of this button (w-12 + me-4 = 4rem) is mirrored
+     * Inline-end footprint of this button (w-12 + me-4 = 4rem) is mirrored
      * by `--keyboard-tab-reserve-width` in
      * `packages/doenetml/src/EditorViewer/editor-viewer.css` so the editor
-     * footer can shift its rightmost element inward to clear it. Keep the
-     * two values in sync.
+     * footer can shift its last element inward to clear it. Keep the two
+     * values in sync — and keep both on the *same* axis. `end-0` here pairs
+     * with `margin-inline-end` there; making one logical and leaving the
+     * other physical would send the tab and the space reserved for it to
+     * opposite edges under `rtl`, which is worse than either alone.
      */
     .open-keyboard-button {
-        @apply absolute top-[-1.5rem] right-0 rounded-t me-4;
+        @apply absolute top-[-1.5rem] end-0 rounded-t me-4;
         @apply border-b-black border-b;
         @apply hover:bg-slate-300 active:bg-slate-400;
         @apply w-12 h-[1.5rem] flex items-center justify-center;

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { OnClick } from "./keyboard";
 import { ManagedKeyboard } from "./managed-keyboard";
 import classNames from "classnames";
-import type { Translator } from "@doenet/i18n";
+import type { Direction, Translator } from "@doenet/i18n";
 import "./keyboard-tray.css";
 
 /**
@@ -39,6 +39,7 @@ export function KeyboardTray({
     onClick,
     theme,
     translate,
+    direction,
 }: {
     onClick: OnClick;
     theme?: "dark" | "light";
@@ -49,6 +50,16 @@ export function KeyboardTray({
      * so a host that never configured a locale is unaffected.
      */
     translate?: Translator;
+    /**
+     * The reader's writing direction. Passed in for the same reason
+     * `translate` is: this renders into its own root on `document.body` and
+     * inherits nothing from the viewer that owns it.
+     *
+     * It governs the tray's own chrome — where the open/close tab sits, which
+     * end the close button is on. The keys themselves stay left-to-right;
+     * `keyboard.css` pins them, because they are notation.
+     */
+    direction?: Direction;
 }) {
     const [open, setOpen] = React.useState(false);
     const t = translate ?? untranslated;
@@ -59,6 +70,7 @@ export function KeyboardTray({
         <div
             id="virtual-keyboard-tray"
             data-theme={theme}
+            dir={direction}
             className={classNames({ open })}
             onMouseDown={() => {
                 // The mousedown event appears to precede a blur event on a mathInput,

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
@@ -15,8 +15,9 @@
  * tray around them is right-to-left. Every row is a flex row and every region a
  * grid, both of which reverse under `rtl`, so an Arabic reader would otherwise
  * get a mirrored QWERTY and a numeric pad running 3-2-1. The cursor keys are
- * the sharpest case: `.key-left` has to move the caret the way the math field
- * lays the expression out, which is always left.
+ * the sharpest case: `.key-left` sends MathQuill a `Left` keystroke whatever
+ * the CSS says, so a reversed row would leave the `←` key sitting on the right
+ * and moving the caret the other way.
  *
  * Stated here rather than as a `dir` attribute because `Keyboard` returns a
  * different element per style; one rule covers all of them. The tab strip is

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
@@ -10,6 +10,24 @@
     @apply bg-slate-200 border-slate-200 hover:bg-slate-300 hover:border-slate-300 active:bg-slate-400 active:border-slate-400 active:text-slate-50;
 }
 
+/*
+ * The keys are mathematical notation, so they stay left-to-right even when the
+ * tray around them is right-to-left. Every row is a flex row and every region a
+ * grid, both of which reverse under `rtl`, so an Arabic reader would otherwise
+ * get a mirrored QWERTY and a numeric pad running 3-2-1. The cursor keys are
+ * the sharpest case: `.key-left` has to move the caret the way the math field
+ * lays the expression out, which is always left.
+ *
+ * Stated here rather than as a `dir` attribute because `Keyboard` returns a
+ * different element per style; one rule covers all of them. The tab strip is
+ * included: its labels are `123`, `f(x)`, `ABC`, `αβγ` and `$%∞`, none of which
+ * is prose.
+ */
+.virtual-keyboard,
+.virtual-keyboard-tab-list {
+    direction: ltr;
+}
+
 .virtual-keyboard {
     @apply flex gap-y-1 justify-center max-w-2xl sm:gap-y-2 gap-x-3;
     @apply flex-wrap sm:flex-nowrap;

--- a/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { IframeMessage } from "./external-virtual-keyboard";
 import { UniqueKeyboardTray } from "./unique-keyboard-tray";
 import { KeyCommand } from "./keys";
-import type { Translator } from "@doenet/i18n";
+import type { Direction, Translator } from "@doenet/i18n";
 
 /**
  * Virtual keyboard that can be made aware of an externally provided virtual keyboard (e.g., when used
@@ -14,6 +14,7 @@ export function ExternalAwareVirtualKeyboard({
     onClick = () => {},
     theme,
     translate,
+    direction,
     ownerRef,
 }: {
     /**
@@ -36,6 +37,12 @@ export function ExternalAwareVirtualKeyboard({
      * omitted.
      */
     translate?: Translator;
+    /**
+     * Writing direction for the tray's own chrome. Defaults to left-to-right
+     * when omitted. The keys stay left-to-right regardless — they are
+     * mathematical notation.
+     */
+    direction?: Direction;
     /**
      * Element whose focus should be treated as this keyboard instance being
      * active when a document-wide shared tray is used.
@@ -82,6 +89,7 @@ export function ExternalAwareVirtualKeyboard({
             ownerRef={ownerRef}
             theme={theme}
             translate={translate}
+            direction={direction}
         />
     );
 }

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -4,7 +4,7 @@ import { OnClick } from "./keyboard";
 import { KeyboardTray } from "./keyboard-tray";
 import { MathJaxContext } from "@doenet/utils/mathjax";
 import { mathjaxConfig } from "@doenet/utils";
-import type { Translator } from "@doenet/i18n";
+import type { Direction, Translator } from "@doenet/i18n";
 
 type VirtualKeyboardState = {
     count: number;
@@ -15,6 +15,12 @@ type VirtualKeyboardState = {
         onClick: OnClick;
         theme?: "dark" | "light";
         translate?: Translator;
+        /**
+         * The reader's writing direction, for the tray's own chrome. Prop-drilled
+         * for the same reason `translate` is: the tray lives in its own React
+         * root on `document.body` and inherits nothing from any viewer.
+         */
+        direction?: Direction;
         ownerRef: React.RefObject<HTMLElement | null>;
     }[];
     lastRenderedTranslate?: Translator;
@@ -88,8 +94,8 @@ function getActiveRegistration() {
  * The registration whose settings the tray should reflect: the one whose owner
  * is focused, else the last one that was, else the most recent registration.
  *
- * The tray is shared by every viewer on the page, so which viewer's `theme`
- * and `translate` it shows is a question about focus.
+ * The tray is shared by every viewer on the page, so which viewer's `theme`,
+ * `translate` and `direction` it shows is a question about focus.
  */
 function getTrayRegistration():
     VirtualKeyboardState["registrations"][number] | undefined {
@@ -114,6 +120,7 @@ function rerenderTray() {
     const registration = getTrayRegistration();
     const theme = registration?.theme;
     const translate = registration?.translate;
+    const direction = registration?.direction;
     // The focusin listener fires on every focus change anywhere in the
     // document. Skip the React re-render when what the tray already shows is
     // correct — reconciling the MathJaxContext + tray subtree on every focus
@@ -124,13 +131,21 @@ function rerenderTray() {
     // before comparing so they compare equal. The translator has no DOM
     // counterpart to read back, so the last one rendered is recorded instead;
     // it is memoized per locale, making identity a sound comparison.
+    // `dir` is read back off the DOM the same way `data-theme` is. It has to be
+    // part of this comparison: moving focus between two viewers whose readers
+    // differ only in direction would otherwise leave the tray facing the way
+    // the previous one did.
     const trayEl = getTrayElement();
     if (trayEl) {
         const currentTheme =
             (trayEl.getAttribute("data-theme") as
                 "dark" | "light" | null | undefined) ?? undefined;
+        const currentDirection =
+            (trayEl.getAttribute("dir") as Direction | null | undefined) ??
+            undefined;
         if (
             currentTheme === theme &&
+            currentDirection === direction &&
             virtualKeyboardState.lastRenderedTranslate === translate
         ) {
             return;
@@ -138,19 +153,21 @@ function rerenderTray() {
     }
     virtualKeyboardState.lastRenderedTranslate = translate;
     virtualKeyboardState.keyboardReactRoot?.render(
-        renderTray(theme, translate),
+        renderTray(theme, translate, direction),
     );
 }
 
 function renderTray(
     theme: "dark" | "light" | undefined,
     translate: Translator | undefined,
+    direction: Direction | undefined,
 ) {
     return (
         <MathJaxContext config={mathjaxConfig} version={4}>
             <KeyboardTray
                 theme={theme}
                 translate={translate}
+                direction={direction}
                 onClick={(e) => {
                     // Route key events only to the active (focused) owner.
                     getActiveRegistration()?.onClick(e);
@@ -167,12 +184,15 @@ function renderTray(
 export function UniqueKeyboardTray({
     onClick,
     theme,
+    direction,
     translate,
     ownerRef,
 }: {
     onClick: OnClick;
     theme?: "dark" | "light";
     translate?: Translator;
+    /** The reader's writing direction, for the tray's own chrome. */
+    direction?: Direction;
     ownerRef: React.RefObject<HTMLElement | null>;
 }) {
     // Allocate a stable registration ID for this instance using a lazy useState
@@ -211,6 +231,7 @@ export function UniqueKeyboardTray({
             onClick,
             theme,
             translate,
+            direction,
             ownerRef,
         });
         rerenderTray();
@@ -265,10 +286,11 @@ export function UniqueKeyboardTray({
             registration.onClick = onClick;
             registration.theme = theme;
             registration.translate = translate;
+            registration.direction = direction;
             registration.ownerRef = ownerRef;
             rerenderTray();
         }
-    }, [onClick, ownerRef, theme, translate]);
+    }, [onClick, ownerRef, theme, translate, direction]);
 
     // This component doesn't render anything directly. Instead it relies on a common instance of the keyboard tray already existing.
     return null;


### PR DESCRIPTION
Closes #1614. Part of #861.

DoenetML emitted no `dir` anywhere, and a browser will not infer one from `lang`. An Arabic document rendered right-to-left text in a left-to-right box: punctuation landed on the wrong end, and a run mixing Arabic with a Latin identifier came out in the wrong visual order. The stylesheets were written in left and right throughout, so every indent, gutter and hanging list number pointed away from the text it belonged to.

This is **Deliverable 1: the mechanics, with no right-to-left catalog.** Arabic follows as Deliverable 2, the remaining six (Persian, Hebrew, Urdu, Pashto, Sindhi, Uyghur) as Deliverable 3. The layout work is identical for all seven, so it is done once here, and it is verifiable on its own so it did not wait on translation.

## Reviewing this

Thirteen commits, each independently sensible, ordered so that everything changing no DOM lands first:

1. **`c8af8546b`** — `directionOf` and the `en-XB` fixture. No consumers.
2. **`0a5a77b4d`** — the isolation flip. The riskiest one; alone so it reverts cleanly.
3. **`333f7cf04`** — the left-to-right pins. Inert today.
4. **`904715ffe`** — logical CSS. Inert today.
5. **`49a57d645`** — emitting `dir`. First change to rendered DOM.
6. **`2017a8cb7`** — tests, harness, README, changeset.
7. **`26bc95687`** — the first review pass: the two chrome surfaces the fifth commit missed (a solution's heading and a collapsible section's, which draw the same string a hint does), and three helpers standing in for code that had been written out more than once.
8. **`9326ff8c4`** — the second review pass: comments corrected against what the code does, the invisible bidi characters respelled as escapes, and one repeated `::before` rule folded together.
9. **`84b9c8d46`** — the third review pass: the one regression the second pass documented instead of fixing, now fixed and measured.
10. **`6184a02ce`** — the fourth review pass: the nested-document case below, which the fifth commit declared but never published.
11. **`a60d63ee7`** — the fifth review pass: three more in-document chrome surfaces the re-declaration had not reached — a pretzel's answer label with its trailing colon, the summary-statistics caption, and the math input preview's parse-error message, whose Ariakit popover does *not* portal — plus the tooltip exemption written down: Ariakit portals tooltips to `document.body`, so they are never inside the document's box at all.
12. **`aebb853ec`** — the sixth review pass: the last notation island — the math input's *preview*, whose non-portaling popover made the div that scrolls a long expression an RTL scroll container (it opened at the tail, and `scrollLeft`'s negative range turned the renderer's Home/End into two ways of showing the same end); a doubly-nested-document test pinning that every nested document republishes the direction it declares; and the English layout measured against `main` by bounding rect across twenty-odd converted surfaces, pixel-identical throughout.
13. **`fbe673ad5`** — the seventh review pass: three invariants the tests held only in prose, now held by assertions — the `en-XB` mark's outside-the-bracket placement pinned on raw bytes (every existing assertion also passed with the marks inside, the exact mistake an earlier pass made); the worker translator's freedom from isolation pinned byte-exactly in a *translated* language, not only as the shared factory's default; and the number line and orbital diagram asserted left-to-right beside the slider, covering all of `ltrIslandProps()`'s sites.

## The decisions worth arguing with

**Direction is computed, not recorded.** `directionOf(tag)` answers for any BCP-47 tag, not only the ones with a catalog — `lang` accepts whatever an author types, and `<document lang="ar">` has to lay out right-to-left whether or not `locales/ar/` exists. It keys on script, because that is what decides: Punjabi is left-to-right in Gurmukhi and right-to-left in Arabic. Deliberately not `Intl.Locale.prototype.getTextInfo()`, which is too new and throws on exactly the tags `normalizeLocaleTag` is written to tolerate.

**Two roots carry `dir`, not one**, because the reader's language and the content's need not agree. A nested `<document lang>` needs no new state variable: `renderedLang` is set exactly when the language changes, so where it is absent the direction cannot have changed either — which keeps this whole deliverable out of `doenetml-worker-javascript`.

**"The document" a piece of chrome compares itself against is the nearest one, not the activity.** Chrome drawn inside the content re-declares itself only where its direction disagrees with the box it sits in, so the value it compares against has to be republished wherever that box changes — which is at every nested `<document lang>`, not only at the viewer. Publishing it once from the outermost document left an English hint inside `<document lang="ar">` finding no disagreement and saying nothing, in exactly the case this mechanism exists for.

**Isolation is on for chrome, off for content.** What the chrome renders is looked at and discarded. What the worker renders becomes state variables an author interpolates, an `<award>` compares against a response, and `answer.js` folds into a SHA-1 of the dependency graph, where an invisible character is a silent wrong answer.

**English is excluded, and the reason is not principled** — it is written down as such in `packages/i18n/README.md` rather than dressed up as policy. Isolation protects a sentence whose placeable runs the other way, which has nothing to do with whether the sentence is English; an English UI naming an Arabic answer still gets none. English is excluded because the assertion corpus compares it as plain text.

**Author-facing physical attributes stay physical.** `halign`, `labelPosition`, `<sideBySide>` margins, a cell's `right`, a row's `left`. Filed as #1627, which records the sharper point: under `rtl` these do not merely fail to mirror, they mislead — DOM order puts `labelPosition="left"` on the right while the margin beside it moves the other way.

## Notation does not mirror

Pinned left-to-right: the JSXGraph board and prefigure SVG (both write `text-anchor: start|end`, which resolves against the computed direction), MathQuill (no `direction` declaration anywhere, inline siblings in source order, physical kerns), the matrix input (a `<table>` reverses its columns), the slider (a native range input reverses its track), the number line, the orbital diagrams, the math input's preview (its popover does not portal, and the div that scrolls a long expression must not become an RTL scroll container — `scrollLeft` there runs from the negatives up to zero, inverting the Home/End handling), and CodeMirror. The spreadsheet is the exception to the attribute: Handsontable reads the inherited direction through its own `layoutDirection` option, so it is told rather than styled. **MathJax needs nothing** — its v4 CHTML already pins `direction: ltr` on `mjx-math`, verified against the build actually loaded rather than assumed — but only on the mathematics itself, which is why the preview's scroll container still needed a pin of its own.

Everything else mirrors: the paginator, prose, the feedback heading, the click-to-toggle text on a hint, a solution and a collapsible section, the graph-controls panel, the editor chrome.

Two subtleties found while checking by hand rather than by reasoning:

- A pinned *block* stretches full-width and then left-aligns its contents, which stranded the slider's track across the page from its own label. A width of its own lets the surrounding direction place the box while its insides keep running the other way. The pin and the width travel together as `ltrIslandProps()`, so the half that is easy to forget cannot be left off. It shrink-wraps by default, which is what a widget drawn at its own intrinsic size wants — but shrink-to-fit also resolves a percentage *inside* the island against the island rather than the column, so a widget the author can size passes its own width instead and stretches to fill it. That is the slider: `<slider width="50%" />` is half the column, in both directions, and `slider.cy.js` now measures it.
- The keyboard tab is portaled to `document.body` while the editor footer reserves space for it. Converting either side alone would have sent the gap and the button it clears to opposite edges — worse than converting neither. They move together.

## Testing it without a catalog

`en-XB` renders visually identical text to `en-XA` and differs only in direction — plus a right-to-left mark against the outer face of each bracket, which renders no glyph and exists so a value's trailing punctuation resolves the way it would in a real RTL sentence. A difference between the two runs is therefore a difference in layout and nothing else. Deliberately not a text transform: Android's U+202E override demonstrates bidi rather than testing a layout, and look-alike glyphs would cost the accented text its readability and break the hard-coded-English sweep.

`verifyListItemNumbersAlign` measured each item's left edge, which is the wrong edge in a right-to-left document — there the numbers hang off the right and the left edge varies with how wide each line happens to be. It now measures the edge the text starts from, and both directions are asserted so a change that fixed one by breaking the other cannot pass. `verifyListItemNumberGutterSide` beside it says *which* side, since agreeing with each other is something a uniformly wrong layout would also manage.

## Verification

- `@doenet/i18n` (240) and `@doenet/doenetml` (114) unit tests green, `npm run lint:i18n` green.
- Component suite green (80/80). E2E: `DocViewer/i18n.cy.js` (36), plus `problem`, `sectioning`, `slider`, `subsetofrealsinput`, `matrixinput`, `booleaninput`, `choiceinput`, `mathinput`, `graph`, `graphicControls`, `spreadsheet`, `hint`, `paginator`, `answer`, `documentLang`.
- Rendered `en` and `en-XB` side by side: right-to-left lays out correctly with the notation unmirrored, and left-to-right is pixel-identical to before. The slider fix was measured the same way — a default and a `width="50%"` slider in each direction, screenshotted and measured, before and after.
- The English layout was then measured against `main` outright: one page rendering the converted surfaces — hanging list numbers, checkbox and radio markers, labeled text/math inputs, the matrix, a default and a percentage-width slider, the number line, the orbital diagram, the graph and its navigation widget, hint and solution headings, side-by-side panels, a pretzel row, the keyboard tab — compared by bounding rect between the two builds. Every content rect is pixel-identical; the only widths that differ are the invisible island wrappers, which now shrink-wrap by design.

**One pre-existing flake**, not a regression: `DoenetEditor.diagnosticHoverLocale` "follows a language chosen after the editor is already up" failed 1 run in 3, which is #1612, filed before this work.

## Trying it

`packages/doenetml/dev/main.tsx` now suggests `en-XB` and `ar` alongside `en-XA`. `ar` is a real right-to-left tag with no catalog — it turns the page around and leaves the words in English, which is the state a reader who asks for Arabic gets today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






