### PR TITLE
Minor bug fix -- adds consistent application of .trim() in breakstrings.js

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/commonsugar/breakstrings.js
+++ b/packages/doenetml-worker-javascript/src/components/commonsugar/breakstrings.js
@@ -221,7 +221,7 @@ export function breakEmbeddedStringsIntoParensPieces({
             continue;
         }
 
-        let s = component;
+        let s = component.trim();
 
         let beginInd = 0;
 
@@ -292,7 +292,7 @@ export function breakIntoPiecesBySpacesOutsideParens({ componentList }) {
             continue;
         }
 
-        let s = component;
+        let s = component.trim();
 
         let beginInd = 0;
 


### PR DESCRIPTION
# Summary

This PR fixes inconsistent whitespace handling when parsing tuple/list component strings in `breakstrings.js`.

Specifically, `.trim()` was added to several component string parsing paths in:
`packages/doenetml-worker-javascript/src/components/commonsugar/breakstrings.js`

This brings the implementation into alignment across related parsing functions, ensuring component strings are treated consistently regardless of surrounding whitespace.

## Motivation

[Issue #1617](https://github.com/Doenet/DoenetML/issues/1617) exposed cases where tuple/list parsing behavior differed depending on which helper function processed the input. Some code paths trimmed surrounding whitespace while others did not, leading to inconsistent parsing results and unexpected behavior.

By normalizing component strings with `.trim()` throughout the relevant parsing logic, tuple/list handling becomes more predictable and consistent.

Fixes #1617.

## Changes

- Added `.trim()` to several component string parsing operations in `breakstrings.js`
- Aligned whitespace handling across tuple/list parsing functions
- Removed inconsistencies between equivalent parsing paths
- Improved robustness when tuple/list components contain leading or trailing whitespace

## Impact

This is a low-risk change that affects preprocessing of component strings prior to parsing.

Expected benefits include:

- Consistent tuple/list parsing behavior
- Correct handling of leading/trailing whitespace across all parsing paths
- Resolution of Issue #1617
- Prevention of related whitespace-induced parsing bugs that could arise from inconsistent implementation details

## Testing

Verified that tuple/list expressions containing leading and trailing whitespace are parsed consistently across the affected code paths and produce the same results as equivalent trimmed inputs.