### PR TITLE
fix: give inline choiceInput options a text accessible name

### DIFF
--- a/.changeset/inline-choice-input-option-accessible-name.md
+++ b/.changeset/inline-choice-input-option-accessible-name.md
@@ -8,10 +8,11 @@
 
 Viewer: announce inline `<choiceInput>` options by their text, not "[object Object]".
 
-The inline choice input passes each choice's rendered content to react-select as
+The inline choice input passed each choice's rendered content to react-select as
 the option label. React-select stringifies that label for the announcements it
 writes to its aria-live region (and for typeahead filtering), so screen readers
-heard "[object Object], 1 of 3" instead of the choice text.
+heard "[object Object], 1 of 3" instead of the choice text, and typing to filter
+the list matched nothing.
 
 Each option now carries its plain text alongside the rendered content: the text
 supplies the accessible name and the filter string, while the rendered content —

--- a/.changeset/inline-choice-input-option-accessible-name.md
+++ b/.changeset/inline-choice-input-option-accessible-name.md
@@ -20,6 +20,7 @@ which may contain math, images, or styled text — is still what is drawn in the
 menu and in the displayed value.
 
 With `selectMultiple`, the button that removes a selected choice was likewise
-named "Remove [object Object]"; it is now named after the choice text too.
+named "Remove [object Object]"; it is now named after the choice text too, in
+the reader's language.
 
 Closes #1613.

--- a/.changeset/inline-choice-input-option-accessible-name.md
+++ b/.changeset/inline-choice-input-option-accessible-name.md
@@ -1,0 +1,21 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Viewer: announce inline `<choiceInput>` options by their text, not "[object Object]".
+
+The inline choice input passes each choice's rendered content to react-select as
+the option label. React-select stringifies that label for the announcements it
+writes to its aria-live region (and for typeahead filtering), so screen readers
+heard "[object Object], 1 of 3" instead of the choice text.
+
+Each option now carries its plain text alongside the rendered content: the text
+supplies the accessible name and the filter string, while the rendered content —
+which may contain math, images, or styled text — is still what is drawn in the
+menu and in the displayed value.
+
+Closes #1613.

--- a/.changeset/inline-choice-input-option-accessible-name.md
+++ b/.changeset/inline-choice-input-option-accessible-name.md
@@ -19,4 +19,7 @@ supplies the accessible name and the filter string, while the rendered content â
 which may contain math, images, or styled text â€” is still what is drawn in the
 menu and in the displayed value.
 
+With `selectMultiple`, the button that removes a selected choice was likewise
+named "Remove [object Object]"; it is now named after the choice text too.
+
 Closes #1613.

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -21,7 +21,7 @@ import { DescriptionPopover } from "./utils/Description";
 import { addValidationStateToShortDescription } from "./utils/validationState";
 import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
-import { useContentT } from "../../utils/i18n";
+import { useContentT, useT } from "../../utils/i18n";
 
 // type guard
 const isMultiValue = <T,>(
@@ -95,6 +95,8 @@ interface ChoiceInputSVs {
 export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
     let { id, SVs, actions, children, ignoreUpdate, callAction } =
         useDoenetRenderer<ChoiceInputSVs>(props);
+
+    const t = useT();
 
     // The check-work button and the validation state announced on the input
     // both follow the document's language, not the reader's — see
@@ -295,13 +297,19 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             // remove button. react-select names that button
             // `Remove ${children}`, where `children` is the rendered choice
             // node — which stringifies to "[object Object]" (#1613). Name it
-            // from the choice's text instead.
+            // from the choice's text instead, in the reader's language: the
+            // name is addressed to whoever is looking at the screen, so it
+            // takes `useT` rather than `useContentT`.
             MultiValueRemove: (props: any) => (
                 <components.MultiValueRemove
                     {...props}
                     innerProps={{
                         ...props.innerProps,
-                        "aria-label": `Remove ${props.data.label}`,
+                        "aria-label": t(
+                            "choice-input-remove-choice",
+                            { choice: props.data.label },
+                            `Remove ${props.data.label}`,
+                        ),
                     }}
                 />
             ),
@@ -310,7 +318,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 <components.Input {...props} aria-details={descriptionId} />
             ),
         }),
-        [descriptionId],
+        [descriptionId, t],
     );
 
     if (SVs.inline) {

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -33,16 +33,19 @@ const isMultiValue = <T,>(
 /**
  * An option of the inline (react-select) choice input.
  *
- * - `label` is the rendered choice content (a React node), used for display.
- * - `text` is the choice's plain text, used for the accessible name that
- *   react-select puts in its aria-live region (and for typeahead filtering).
- *   Without it, react-select would stringify `label` and announce
- *   "[object Object]" to screen readers (#1613).
+ * - `label` is the choice's plain text. As in react-select's own option shape,
+ *   it must be a string: react-select interpolates it into the announcements it
+ *   writes to its aria-live region and matches typeahead input against it. When
+ *   it held a React node instead, screen readers heard "[object Object]"
+ *   (#1613).
+ * - `content` is the rendered choice content (a React node) — which may contain
+ *   math, images, or styled text — and is what is actually drawn in the menu
+ *   and in the displayed value.
  */
 type Option = {
     value: number;
-    label: any;
-    text: string;
+    label: string;
+    content: React.ReactNode;
     isDisabled: boolean;
 };
 
@@ -278,11 +281,8 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             inOption: !!props.isSelected,
                         }}
                     >
-                        {/*
-                         * `children` is the rendered choice content supplied by
-                         * `formatOptionLabel`; `props.label` is the plain text
-                         * accessible name from `getOptionLabel`.
-                         */}
+                        {/* `children` is the rendered choice content that
+                         * react-select obtained from `formatOptionLabel`. */}
                         <div style={{ pointerEvents: "none" }}>
                             {props.children}
                         </div>
@@ -320,8 +320,10 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 }
                 return {
                     value: i + 1,
-                    label: child,
-                    text: SVs.choiceTexts?.[i] ?? "",
+                    // `choiceTexts` is in displayed order, like `choicesHidden`
+                    // and `choicesDisabled`, so it shares this index.
+                    label: SVs.choiceTexts[i],
+                    content: child,
                     isDisabled: !!SVs.choicesDisabled[i],
                 };
             })
@@ -449,27 +451,25 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                     <ChoiceInputInlineContext.Provider
                         value={{ isHidden: true, inOption: false }}
                     >
-                        {choiceOptions
-                            .filter((opt) => opt !== null)
-                            .map((opt) => (
-                                <div
-                                    key={opt.value}
-                                    style={{
-                                        whiteSpace: "nowrap", // Force single line
-                                        padding: valuePadding,
-                                    }}
-                                >
-                                    {opt.label}
+                        {choiceOptions.map((opt) => (
+                            <div
+                                key={opt.value}
+                                style={{
+                                    whiteSpace: "nowrap", // Force single line
+                                    padding: valuePadding,
+                                }}
+                            >
+                                {opt.content}
 
-                                    {/* Add buffer space for the Dropdown Arrow. */}
-                                    <span
-                                        style={{
-                                            display: "inline-block",
-                                            width: "30px",
-                                        }}
-                                    ></span>
-                                </div>
-                            ))}
+                                {/* Add buffer space for the Dropdown Arrow. */}
+                                <span
+                                    style={{
+                                        display: "inline-block",
+                                        width: "30px",
+                                    }}
+                                ></span>
+                            </div>
+                        ))}
                     </ChoiceInputInlineContext.Provider>
                 </div>
 
@@ -490,13 +490,16 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             styles={customStyles}
                             options={choiceOptions}
                             components={inlineSelectComponents}
-                            // react-select stringifies the result of
-                            // `getOptionLabel` for its aria-live announcements
-                            // and for typeahead filtering, so it must be text.
-                            // `formatOptionLabel` supplies the React content
-                            // actually rendered in the menu and in the value.
-                            getOptionLabel={(opt) => opt.text}
-                            formatOptionLabel={(opt) => opt.label}
+                            // `getOptionLabel` supplies the plain text that
+                            // react-select interpolates into its aria-live
+                            // announcements and matches typeahead input
+                            // against; `formatOptionLabel` supplies the React
+                            // content it renders in the menu and in the
+                            // displayed value. (`getOptionLabel` restates
+                            // react-select's default so that the two sit
+                            // together and neither is changed in isolation.)
+                            getOptionLabel={(opt) => opt.label}
+                            formatOptionLabel={(opt) => opt.content}
                             menuPortalTarget={menuPortalTarget}
                             menuPlacement="auto"
                             className={inputClasses}

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -41,6 +41,9 @@ const isMultiValue = <T,>(
  * - `content` is the rendered choice content (a React node) — which may contain
  *   math, images, or styled text — and is what is actually drawn in the menu
  *   and in the displayed value.
+ *
+ * The two are wired to react-select by the `getOptionLabel` and
+ * `formatOptionLabel` props of `<Select>` below.
  */
 type Option = {
     value: number;
@@ -270,10 +273,15 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             Option: (props: any) => (
                 <components.Option {...props}>
                     {/*
-                     * Render the option content with its style colors, except
-                     * for selected options, which are highlighted with a dark
-                     * background. There, the text color is left to react-select
-                     * (white) for contrast.
+                     * `props.children` is the option's `content`, which
+                     * react-select obtained from `formatOptionLabel`.
+                     * (`props.label` is the plain text used for announcements
+                     * and typeahead, not for display.)
+                     *
+                     * Render it with its style colors, except for selected
+                     * options, which are highlighted with a dark background.
+                     * There, the text color is left to react-select (white) for
+                     * contrast.
                      */}
                     <ChoiceInputInlineContext.Provider
                         value={{
@@ -281,8 +289,6 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             inOption: !!props.isSelected,
                         }}
                     >
-                        {/* `children` is the rendered choice content that
-                         * react-select obtained from `formatOptionLabel`. */}
                         <div style={{ pointerEvents: "none" }}>
                             {props.children}
                         </div>
@@ -490,14 +496,12 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             styles={customStyles}
                             options={choiceOptions}
                             components={inlineSelectComponents}
-                            // `getOptionLabel` supplies the plain text that
-                            // react-select interpolates into its aria-live
-                            // announcements and matches typeahead input
-                            // against; `formatOptionLabel` supplies the React
-                            // content it renders in the menu and in the
-                            // displayed value. (`getOptionLabel` restates
-                            // react-select's default so that the two sit
-                            // together and neither is changed in isolation.)
+                            // Keep an option's accessible name (`label`) and
+                            // its rendering (`content`) wired up together — see
+                            // the `Option` type. `getOptionLabel` restates
+                            // react-select's default, which makes a later
+                            // rename of `Option.label` a type error here rather
+                            // than a silent fallback to an undefined name.
                             getOptionLabel={(opt) => opt.label}
                             formatOptionLabel={(opt) => opt.content}
                             menuPortalTarget={menuPortalTarget}

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -33,17 +33,15 @@ const isMultiValue = <T,>(
 /**
  * An option of the inline (react-select) choice input.
  *
- * - `label` is the choice's plain text. As in react-select's own option shape,
- *   it must be a string: react-select interpolates it into the announcements it
- *   writes to its aria-live region and matches typeahead input against it. When
- *   it held a React node instead, screen readers heard "[object Object]"
- *   (#1613).
- * - `content` is the rendered choice content (a React node) — which may contain
- *   math, images, or styled text — and is what is actually drawn in the menu
- *   and in the displayed value.
+ * `label` must be a string, as in react-select's own option shape: react-select
+ * interpolates it into the announcements it writes to its aria-live region and
+ * matches typeahead input against it, so a React node there is announced as
+ * "[object Object]" (#1613). `content` carries the rendered choice — which may
+ * contain math, images, or styled text — and is what is actually drawn in the
+ * menu and in the displayed value.
  *
- * The two are wired to react-select by the `getOptionLabel` and
- * `formatOptionLabel` props of `<Select>` below.
+ * The `getOptionLabel` and `formatOptionLabel` props of `<Select>` below wire
+ * the two to react-select.
  */
 type Option = {
     value: number;
@@ -274,9 +272,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 <components.Option {...props}>
                     {/*
                      * `props.children` is the option's `content`, which
-                     * react-select obtained from `formatOptionLabel`.
-                     * (`props.label` is the plain text used for announcements
-                     * and typeahead, not for display.)
+                     * react-select took from `formatOptionLabel`.
                      *
                      * Render it with its style colors, except for selected
                      * options, which are highlighted with a dark background.
@@ -496,12 +492,10 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             styles={customStyles}
                             options={choiceOptions}
                             components={inlineSelectComponents}
-                            // Keep an option's accessible name (`label`) and
-                            // its rendering (`content`) wired up together — see
-                            // the `Option` type. `getOptionLabel` restates
-                            // react-select's default, which makes a later
-                            // rename of `Option.label` a type error here rather
-                            // than a silent fallback to an undefined name.
+                            // `getOptionLabel` restates react-select's default,
+                            // so that renaming `Option.label` becomes a type
+                            // error here rather than a silently undefined
+                            // accessible name.
                             getOptionLabel={(opt) => opt.label}
                             formatOptionLabel={(opt) => opt.content}
                             menuPortalTarget={menuPortalTarget}

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -291,6 +291,20 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                     </ChoiceInputInlineContext.Provider>
                 </components.Option>
             ),
+            // With `selectMultiple`, each selected choice becomes a chip with a
+            // remove button. react-select names that button
+            // `Remove ${children}`, where `children` is the rendered choice
+            // node — which stringifies to "[object Object]" (#1613). Name it
+            // from the choice's text instead.
+            MultiValueRemove: (props: any) => (
+                <components.MultiValueRemove
+                    {...props}
+                    innerProps={{
+                        ...props.innerProps,
+                        "aria-label": `Remove ${props.data.label}`,
+                    }}
+                />
+            ),
             // Add aria-details to the internal input used by react-select.
             Input: (props: any) => (
                 <components.Input {...props} aria-details={descriptionId} />

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -30,7 +30,21 @@ const isMultiValue = <T,>(
     return Array.isArray(val);
 };
 
-type Option = { value: number; label: any; isDisabled: boolean };
+/**
+ * An option of the inline (react-select) choice input.
+ *
+ * - `label` is the rendered choice content (a React node), used for display.
+ * - `text` is the choice's plain text, used for the accessible name that
+ *   react-select puts in its aria-live region (and for typeahead filtering).
+ *   Without it, react-select would stringify `label` and announce
+ *   "[object Object]" to screen readers (#1613).
+ */
+type Option = {
+    value: number;
+    label: any;
+    text: string;
+    isDisabled: boolean;
+};
 
 /**
  * The ChoiceInputInlineContext provides information about two modifications needed in descendants
@@ -63,6 +77,7 @@ interface ChoiceInputSVs {
     colorCorrectness: boolean;
     choiceChildIndices: any;
     choiceOrder: any;
+    choiceTexts: string[];
     choicesDisabled: any;
     choicesHidden: any;
     descriptionChildInd: any;
@@ -263,8 +278,13 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             inOption: !!props.isSelected,
                         }}
                     >
+                        {/*
+                         * `children` is the rendered choice content supplied by
+                         * `formatOptionLabel`; `props.label` is the plain text
+                         * accessible name from `getOptionLabel`.
+                         */}
                         <div style={{ pointerEvents: "none" }}>
-                            {props.label}
+                            {props.children}
                         </div>
                     </ChoiceInputInlineContext.Provider>
                 </components.Option>
@@ -301,6 +321,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 return {
                     value: i + 1,
                     label: child,
+                    text: SVs.choiceTexts?.[i] ?? "",
                     isDisabled: !!SVs.choicesDisabled[i],
                 };
             })
@@ -469,6 +490,13 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             styles={customStyles}
                             options={choiceOptions}
                             components={inlineSelectComponents}
+                            // react-select stringifies the result of
+                            // `getOptionLabel` for its aria-live announcements
+                            // and for typeahead filtering, so it must be text.
+                            // `formatOptionLabel` supplies the React content
+                            // actually rendered in the menu and in the value.
+                            getOptionLabel={(opt) => opt.text}
+                            formatOptionLabel={(opt) => opt.label}
                             menuPortalTarget={menuPortalTarget}
                             menuPlacement="auto"
                             className={inputClasses}

--- a/packages/i18n/locales/am/chrome.ftl
+++ b/packages/i18n/locales/am/chrome.ftl
@@ -74,6 +74,8 @@ slider-next = ቀጣይ
 keyboard-open = ቁልፍ ሰሌዳ ክፈት
 keyboard-close = ቁልፍ ሰሌዳ ዝጋ
 
+choice-input-remove-choice = { $choice } አስወግድ
+
 matrix-remove-row = ረድፍ አስወግድ
 matrix-add-row = ረድፍ ጨምር
 matrix-remove-column = ዓምድ አስወግድ

--- a/packages/i18n/locales/as/chrome.ftl
+++ b/packages/i18n/locales/as/chrome.ftl
@@ -74,6 +74,8 @@ slider-next = পৰৱৰ্তী
 keyboard-open = কীব'ৰ্ড খোলক
 keyboard-close = কীব'ৰ্ড বন্ধ কৰক
 
+choice-input-remove-choice = { $choice } আঁতৰাওক
+
 matrix-remove-row = শাৰী আঁতৰাওক
 matrix-add-row = শাৰী যোগ কৰক
 matrix-remove-column = স্তম্ভ আঁতৰাওক

--- a/packages/i18n/locales/bn/chrome.ftl
+++ b/packages/i18n/locales/bn/chrome.ftl
@@ -74,6 +74,8 @@ slider-next = পরবর্তী
 keyboard-open = কীবোর্ড খুলুন
 keyboard-close = কীবোর্ড বন্ধ করুন
 
+choice-input-remove-choice = { $choice } সরান
+
 matrix-remove-row = সারি সরান
 matrix-add-row = সারি যোগ করুন
 matrix-remove-column = কলাম সরান

--- a/packages/i18n/locales/de/chrome.ftl
+++ b/packages/i18n/locales/de/chrome.ftl
@@ -75,6 +75,8 @@ slider-next = Weiter
 keyboard-open = Tastatur öffnen
 keyboard-close = Tastatur schließen
 
+choice-input-remove-choice = { $choice } entfernen
+
 matrix-remove-row = Zeile entfernen
 matrix-add-row = Zeile hinzufügen
 matrix-remove-column = Spalte entfernen

--- a/packages/i18n/locales/en/chrome.ftl
+++ b/packages/i18n/locales/en/chrome.ftl
@@ -93,6 +93,12 @@ slider-next = Next
 keyboard-open = Open Keyboard
 keyboard-close = Close Keyboard
 
+# Accessible name of the button that drops one selected choice from an inline
+# `<choiceInput selectMultiple>`. The button itself is drawn as a bare cross,
+# so `$choice` — the choice's own text, which is never translated — is the
+# only thing that says which chip it belongs to.
+choice-input-remove-choice = Remove { $choice }
+
 # Accessible names of a matrix input's size controls, whose visible labels are
 # the symbols `r-` `r+` `c-` `c+`.
 matrix-remove-row = Remove row

--- a/packages/i18n/locales/es/chrome.ftl
+++ b/packages/i18n/locales/es/chrome.ftl
@@ -73,6 +73,8 @@ slider-next = Siguiente
 keyboard-open = Abrir el teclado
 keyboard-close = Cerrar el teclado
 
+choice-input-remove-choice = Eliminar { $choice }
+
 matrix-remove-row = Eliminar fila
 matrix-add-row = Añadir fila
 matrix-remove-column = Eliminar columna

--- a/packages/i18n/locales/fr/chrome.ftl
+++ b/packages/i18n/locales/fr/chrome.ftl
@@ -77,6 +77,8 @@ slider-next = Suiv.
 keyboard-open = Ouvrir le clavier
 keyboard-close = Fermer le clavier
 
+choice-input-remove-choice = Supprimer { $choice }
+
 matrix-remove-row = Supprimer une ligne
 matrix-add-row = Ajouter une ligne
 matrix-remove-column = Supprimer une colonne

--- a/packages/i18n/locales/hi/chrome.ftl
+++ b/packages/i18n/locales/hi/chrome.ftl
@@ -76,6 +76,8 @@ slider-next = अगला
 keyboard-open = कीबोर्ड खोलें
 keyboard-close = कीबोर्ड बंद करें
 
+choice-input-remove-choice = { $choice } हटाएँ
+
 matrix-remove-row = पंक्ति हटाएँ
 matrix-add-row = पंक्ति जोड़ें
 matrix-remove-column = स्तंभ हटाएँ

--- a/packages/i18n/locales/hnj/chrome.ftl
+++ b/packages/i18n/locales/hnj/chrome.ftl
@@ -77,6 +77,8 @@ slider-next = Tom ntej
 keyboard-open = Qhib lub keyboard
 keyboard-close = Kaw lub keyboard
 
+choice-input-remove-choice = Tshem kem { $choice }
+
 matrix-remove-row = Tshem kem kab
 matrix-add-row = Ntxiv kem kab
 matrix-remove-column = Tshem kem ncaj

--- a/packages/i18n/locales/id/chrome.ftl
+++ b/packages/i18n/locales/id/chrome.ftl
@@ -72,6 +72,8 @@ slider-next = Berikutnya
 keyboard-open = Buka papan ketik
 keyboard-close = Tutup papan ketik
 
+choice-input-remove-choice = Hapus { $choice }
+
 matrix-remove-row = Hapus baris
 matrix-add-row = Tambah baris
 matrix-remove-column = Hapus kolom

--- a/packages/i18n/locales/it/chrome.ftl
+++ b/packages/i18n/locales/it/chrome.ftl
@@ -74,6 +74,8 @@ slider-next = Succ.
 keyboard-open = Apri la tastiera
 keyboard-close = Chiudi la tastiera
 
+choice-input-remove-choice = Rimuovi { $choice }
+
 matrix-remove-row = Rimuovi riga
 matrix-add-row = Aggiungi riga
 matrix-remove-column = Rimuovi colonna

--- a/packages/i18n/locales/ja/chrome.ftl
+++ b/packages/i18n/locales/ja/chrome.ftl
@@ -79,6 +79,8 @@ slider-next = 次へ
 keyboard-open = キーボードを開く
 keyboard-close = キーボードを閉じる
 
+choice-input-remove-choice = { $choice } を削除
+
 matrix-remove-row = 行を削除
 matrix-add-row = 行を追加
 matrix-remove-column = 列を削除

--- a/packages/i18n/locales/ko/chrome.ftl
+++ b/packages/i18n/locales/ko/chrome.ftl
@@ -74,6 +74,8 @@ slider-next = 다음
 keyboard-open = 키보드 열기
 keyboard-close = 키보드 닫기
 
+choice-input-remove-choice = { $choice } 삭제
+
 matrix-remove-row = 행 삭제
 matrix-add-row = 행 추가
 matrix-remove-column = 열 삭제

--- a/packages/i18n/locales/mr/chrome.ftl
+++ b/packages/i18n/locales/mr/chrome.ftl
@@ -74,6 +74,8 @@ slider-next = पुढील
 keyboard-open = कीबोर्ड उघडा
 keyboard-close = कीबोर्ड बंद करा
 
+choice-input-remove-choice = { $choice } काढा
+
 matrix-remove-row = ओळ काढा
 matrix-add-row = ओळ जोडा
 matrix-remove-column = स्तंभ काढा

--- a/packages/i18n/locales/my/chrome.ftl
+++ b/packages/i18n/locales/my/chrome.ftl
@@ -77,6 +77,8 @@ slider-next = နောက်
 keyboard-open = ကီးဘုတ် ဖွင့်ရန်
 keyboard-close = ကီးဘုတ် ပိတ်ရန်
 
+choice-input-remove-choice = { $choice } ဖယ်ရန်
+
 matrix-remove-row = အတန်း ဖယ်ရန်
 matrix-add-row = အတန်း ထည့်ရန်
 matrix-remove-column = ကော်လံ ဖယ်ရန်

--- a/packages/i18n/locales/ne/chrome.ftl
+++ b/packages/i18n/locales/ne/chrome.ftl
@@ -75,6 +75,8 @@ slider-next = अर्को
 keyboard-open = किबोर्ड खोल्नुहोस्
 keyboard-close = किबोर्ड बन्द गर्नुहोस्
 
+choice-input-remove-choice = { $choice } हटाउनुहोस्
+
 matrix-remove-row = पङ्क्ति हटाउनुहोस्
 matrix-add-row = पङ्क्ति थप्नुहोस्
 matrix-remove-column = स्तम्भ हटाउनुहोस्

--- a/packages/i18n/locales/nl/chrome.ftl
+++ b/packages/i18n/locales/nl/chrome.ftl
@@ -75,6 +75,8 @@ slider-next = Volgende
 keyboard-open = Toetsenbord openen
 keyboard-close = Toetsenbord sluiten
 
+choice-input-remove-choice = { $choice } verwijderen
+
 matrix-remove-row = Rij verwijderen
 matrix-add-row = Rij toevoegen
 matrix-remove-column = Kolom verwijderen

--- a/packages/i18n/locales/pl/chrome.ftl
+++ b/packages/i18n/locales/pl/chrome.ftl
@@ -81,6 +81,8 @@ slider-next = Następny
 keyboard-open = Otwórz klawiaturę
 keyboard-close = Zamknij klawiaturę
 
+choice-input-remove-choice = Usuń { $choice }
+
 matrix-remove-row = Usuń wiersz
 matrix-add-row = Dodaj wiersz
 matrix-remove-column = Usuń kolumnę

--- a/packages/i18n/locales/pt/chrome.ftl
+++ b/packages/i18n/locales/pt/chrome.ftl
@@ -75,6 +75,8 @@ slider-next = Próximo
 keyboard-open = Abrir teclado
 keyboard-close = Fechar teclado
 
+choice-input-remove-choice = Remover { $choice }
+
 matrix-remove-row = Remover linha
 matrix-add-row = Adicionar linha
 matrix-remove-column = Remover coluna

--- a/packages/i18n/locales/ru/chrome.ftl
+++ b/packages/i18n/locales/ru/chrome.ftl
@@ -83,6 +83,8 @@ slider-next = Вперёд
 keyboard-open = Открыть клавиатуру
 keyboard-close = Закрыть клавиатуру
 
+choice-input-remove-choice = Удалить { $choice }
+
 matrix-remove-row = Удалить строку
 matrix-add-row = Добавить строку
 matrix-remove-column = Удалить столбец

--- a/packages/i18n/locales/so/chrome.ftl
+++ b/packages/i18n/locales/so/chrome.ftl
@@ -73,6 +73,8 @@ slider-next = Xiga
 keyboard-open = Fur kiiboodhka
 keyboard-close = Xir kiiboodhka
 
+choice-input-remove-choice = Ka saar { $choice }
+
 matrix-remove-row = Ka saar saf
 matrix-add-row = Ku dar saf
 matrix-remove-column = Ka saar tiir

--- a/packages/i18n/locales/tr/chrome.ftl
+++ b/packages/i18n/locales/tr/chrome.ftl
@@ -71,6 +71,8 @@ slider-next = Sonraki
 keyboard-open = Klavyeyi aç
 keyboard-close = Klavyeyi kapat
 
+choice-input-remove-choice = { $choice } sil
+
 matrix-remove-row = Satır sil
 matrix-add-row = Satır ekle
 matrix-remove-column = Sütun sil

--- a/packages/i18n/locales/vi/chrome.ftl
+++ b/packages/i18n/locales/vi/chrome.ftl
@@ -71,6 +71,8 @@ slider-next = Sau
 keyboard-open = Mở bàn phím
 keyboard-close = Đóng bàn phím
 
+choice-input-remove-choice = Xóa { $choice }
+
 matrix-remove-row = Xóa hàng
 matrix-add-row = Thêm hàng
 matrix-remove-column = Xóa cột

--- a/packages/i18n/locales/zh-Hans/chrome.ftl
+++ b/packages/i18n/locales/zh-Hans/chrome.ftl
@@ -84,6 +84,8 @@ slider-next = 下一个
 keyboard-open = 打开键盘
 keyboard-close = 关闭键盘
 
+choice-input-remove-choice = 删除 { $choice }
+
 matrix-remove-row = 删除行
 matrix-add-row = 添加行
 matrix-remove-column = 删除列

--- a/packages/i18n/locales/zh-Hant/chrome.ftl
+++ b/packages/i18n/locales/zh-Hant/chrome.ftl
@@ -89,6 +89,8 @@ slider-next = 下一個
 keyboard-open = 開啟鍵盤
 keyboard-close = 關閉鍵盤
 
+choice-input-remove-choice = 刪除 { $choice }
+
 # 列 is the row and 欄 the column — see the note on rows and columns above.
 matrix-remove-row = 刪除列
 matrix-add-row = 新增列

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -34,6 +34,7 @@ export type MessageKey =
     | "slider-next"
     | "keyboard-open"
     | "keyboard-close"
+    | "choice-input-remove-choice"
     | "matrix-remove-row"
     | "matrix-add-row"
     | "matrix-remove-column"
@@ -596,6 +597,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "slider-next",
     "keyboard-open",
     "keyboard-close",
+    "choice-input-remove-choice",
     "matrix-remove-row",
     "matrix-add-row",
     "matrix-remove-column",

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1742,13 +1742,13 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         getOpenInlineChoiceMenu().within(() => {
             cy.contains("choice").click({ force: true });
         });
-        cy.get("#aria-selection").should(
+        cy.get("#ci #aria-selection").should(
             "have.text",
             "option choice, selected.",
         );
 
         cy.log(
-            "The plain text is only an accessible name: the displayed value still renders the choice content, and only once",
+            "The displayed value renders the choice content once, not the plain text as well",
         );
         cy.get('#ci [class*="-singleValue"]').should("have.text", "choice");
     });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1694,7 +1694,11 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         getOpenInlineChoiceMenu().within(() => {
             cy.contains("apple").click({ force: true });
         });
-        cy.get("#ci").contains("apple").should("have.css", "color", green);
+        // Scope to the displayed value: `#ci` also holds react-select's
+        // visually hidden live region, which now names the choice too.
+        cy.get('#ci [class*="-singleValue"]')
+            .contains("apple")
+            .should("have.css", "color", green);
 
         cy.log(
             "Reopen the menu: the selected option uses white text for contrast",
@@ -1705,5 +1709,44 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
             cy.contains("banana").should("have.css", "color", red);
             cy.contains("cherry").should("have.css", "color", black);
         });
+    });
+
+    it("inline choiceInput exposes choice text to assistive technology", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <p>Some text leading into a
+    <choiceInput name="ci" inline placeholder="Choose word">
+      <choice>inline</choice>
+      <choice>choice</choice>
+      <choice>input</choice>
+    </choiceInput> showing the choices.
+    </p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.log(
+            "Typeahead filters on the choice text, not on '[object Object]'",
+        );
+        cy.get("#ci").click();
+        cy.get("#ci_input").type("cho");
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("choice").should("exist");
+            cy.contains("inline").should("not.exist");
+            cy.contains("input").should("not.exist");
+        });
+
+        cy.log("Selecting a choice announces its text in the live region");
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("choice").click({ force: true });
+        });
+        cy.get("#aria-selection").should(
+            "have.text",
+            "option choice, selected.",
+        );
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1746,5 +1746,10 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
             "have.text",
             "option choice, selected.",
         );
+
+        cy.log(
+            "The plain text is only an accessible name: the displayed value still renders the choice content, and only once",
+        );
+        cy.get('#ci [class*="-singleValue"]').should("have.text", "choice");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1752,4 +1752,42 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         );
         cy.get('#ci [class*="-singleValue"]').should("have.text", "choice");
     });
+
+    it("inline selectMultiple choiceInput names its remove buttons by choice text", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="ci" inline selectMultiple placeholder="Choose fruit">
+      <choice><text>apple</text></choice>
+      <choice><text>banana</text></choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ci").click();
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("banana").click({ force: true });
+        });
+
+        cy.log("Selecting a choice announces its text in the live region");
+        cy.get("#ci #aria-selection").should(
+            "have.text",
+            "option banana, selected.",
+        );
+
+        cy.log(
+            "The selected chip's remove button is named by the choice text, not '[object Object]'",
+        );
+        // The remove button is the only element react-select gives an
+        // `aria-label` inside the select.
+        cy.get('#ci [role="button"][aria-label]').should(
+            "have.attr",
+            "aria-label",
+            "Remove banana",
+        );
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1716,13 +1716,11 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
             win.postMessage(
                 {
                     doenetML: `
-    <p>Some text leading into a
     <choiceInput name="ci" inline placeholder="Choose word">
       <choice>inline</choice>
       <choice>choice</choice>
       <choice>input</choice>
-    </choiceInput> showing the choices.
-    </p>
+    </choiceInput>
     `,
                 },
                 "*",


### PR DESCRIPTION
Screen readers announced inline `<choiceInput>` options as `"[object Object], 1 of 3"` instead of the choice text.

## Root cause

`packages/doenetml/src/Viewer/renderers/choiceInput.tsx` built each react-select option as `{value, label: <rendered choice node>, isDisabled}`. react-select's default `getOptionLabel` returns `option.label`, and it interpolates that value into the strings it writes to its `aria-live` region — e.g. `` `option ${label}, selected.` `` on selection and `` `${label}, ${index} of ${count}.` `` as options are focused. A React element stringifies to `[object Object]`.

The same accessor drives typeahead filtering, so typing in the select filtered against `"[object object]"` and matched nothing.

## Fix

The option shape now follows react-select's own convention — `label` is a string — and the rendered node moves to a separate `content` field:

```ts
type Option = {
    value: number;
    label: string;          // plain text: accessible name + typeahead
    content: React.ReactNode; // rendered choice: math, styled text, images
    isDisabled: boolean;
};
```

- `label: SVs.choiceTexts[i]` — `choiceTexts` is an existing `forRenderer` state variable, already in displayed order (both it and the renderer index through `choiceOrder`, as `choicesHidden` and `choicesDisabled` already do).
- `getOptionLabel={(opt) => opt.label}` — supplies the accessible name and the filter string. This restates react-select's default; stating it keeps the accessor next to `formatOptionLabel` and turns a later rename of `Option.label` into a type error here rather than a silent fallback to an undefined accessible name.
- `formatOptionLabel={(opt) => opt.content}` — supplies the rendered content, which is still what is drawn in the menu and in the displayed value.
- The custom `Option` component renders `props.children` (the node from `formatOptionLabel`) rather than `props.label`, which is now the plain text.

The invisible ghost element that sizes the select renders `opt.content` for the same reason. (Its own `.filter(opt => opt !== null)` was dropped: `choiceOptions` is already filtered where it is built.)

Announcements become `option choice, selected.` on selection, and — on platforms where react-select emits the focus message, i.e. Apple devices/VoiceOver, which is where the issue was reported — "inline, 1 of 3" / "choice, 2 of 3" / "input, 3 of 3" as options are focused.

### `selectMultiple`

With `selectMultiple`, each selected choice renders as a chip with a remove button, and react-select names that button `` `Remove ${children}` `` — where `children` is whatever the value slot renders, i.e. the choice node. So its accessible name was literally `Remove [object Object]`, and moving the node to `formatOptionLabel` alone would have left it that way. A `MultiValueRemove` override now sets `aria-label` from the option's text: `Remove banana`.

That wording is the one string this PR authors rather than borrows, so it goes through the catalogs like every other name a renderer draws: `choice-input-remove-choice = Remove { $choice }` in `chrome.ftl`, reached with `useT()` rather than `useContentT()` because the name is addressed to whoever is reading the screen, not to the document's language (see the `useContentT` doc comment for that split). The choice text is a Fluent placeable, so a non-English catalog bidi-isolates it — which matters here, since the placeable is authored content and need not run the same way as the chrome around it. Machine-generated seeds added for all 24 translated locales, per `packages/i18n/README.md`.

### Non-text choices

`choiceTexts` comes from each `<choice>`'s `text` state variable, so it degrades sensibly for non-text content: `<choice><math>x^2</math></choice>` yields `"x²"` and `<choice><m>\frac{1}{2}</m></choice>` yields `"1/2"`. A choice whose only content has no `text` state variable — an `<image>`, say — yields `" "`, so its announcement is blank rather than named. That is a pre-existing limitation of `choiceTexts` (which is public and feeds answer matching), not a regression: before this PR that option announced `[object Object]`. Fixing it means giving `<image>` a `text` state variable, which is a separate change.

Only the inline rendering is affected. The non-inline rendering uses real radio/checkbox inputs whose labels wrap the rendered content, so its accessible names were already correct.

## Tests

Two new Cypress tests in `choiceinput.cy.js`.

The first uses the choices from the issue and checks that

- typeahead filters on the choice text (fails before the fix: nothing matched),
- react-select's live region reads `option choice, selected.` after a selection (before the fix: `option [object Object], selected.`),
- and the displayed value still renders the choice content, exactly once — a guard against a regression that rendered the plain text alongside, or instead of, the node.

The second covers `inline selectMultiple`: the live region names the selected choice, and the chip's remove button is named `Remove banana` (before the `MultiValueRemove` override: `Remove [object Object]`).

One existing assertion needed a tighter selector. `cy.get("#ci").contains("apple")` used to resolve to the displayed value span; now the visually hidden live region inside `#ci` also contains "apple" and comes first in document order. Scoped it to `#ci [class*="-singleValue"]`, matching the selector convention already used in `accessibility/darkModeVisibilityRegressions.cy.js`. (Adding `classNamePrefix` to the `<Select>` to get stabler selectors was tried and rejected — it breaks the `[class*="-menu"]` selector that spec relies on.)

Verified with the required `build -> preview -> cypress run` sequence: `tagSpecific/choiceinput.cy.js` 24/24, the full `accessibility/` directory (axe checks and dark-mode regressions) 127/127, and `DocViewer/i18n.cy.js` 36/36. Each new test was also confirmed to fail against a build without the fix. `npm run lint:i18n` and `npm run test -w @doenet/i18n` (240/240) cover the catalog addition. Earlier runs also covered `tagSpecific/answer.cy.js` 34/34.

## Out of scope

`getOptionFromIndex(index) => choiceOptions[index - 1]` indexes the *filtered* option list with a 1-based index into the *unfiltered* displayed order, so a hidden choice ahead of the selected one resolves the displayed value to the wrong option (or to `undefined`, which react-select's `cleanValue` drops). That is pre-existing on `main` and untouched here — this PR does not make it worse, since the live-region announcement uses the option object react-select itself passes to `onChange`, not this lookup. Worth a separate fix.

The rest of react-select's own screen-reader text — `option banana, selected.`, the results count, the initial-focus guidance — is hardcoded English inside the library. Translating it means supplying an `ariaLiveMessages` object for every one of them, which is a change of its own and touches every `<Select>` in the repo, not just this one.

Closes #1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

