### PR TITLE
fix: display the right choice when an inline choiceInput hides one

### DIFF
--- a/.changeset/inline-choice-input-hidden-choice-display.md
+++ b/.changeset/inline-choice-input-hidden-choice-display.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Viewer: show the right choice in an inline `<choiceInput>` that has a hidden choice.
+
+A hidden choice still occupies an index, but the inline input looked its selected
+choice up by position in the list of *visible* options. Every choice after a
+hidden one therefore displayed its neighbor's text — or, for the last choice,
+fell back to the placeholder as though nothing were selected. Only the display
+was wrong; the recorded answer was always correct.

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -207,34 +207,17 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         }
     }
 
-    if (SVs.hidden) {
-        return null;
-    }
-
-    let disabled = SVs.disabled;
-
-    let label: React.ReactNode = SVs.label;
-    const hasLabel =
-        typeof SVs.label === "string" ? SVs.label.trim() !== "" : !!SVs.label;
-    const labelId = `${id}-label`;
-    const inlineInputId = `${id}_input`;
-    if (SVs.labelHasLatex) {
-        label = (
-            <MathJax hideUntilTypeset={"first"} inline dynamic>
-                {label}
-            </MathJax>
-        );
-    }
-
-    let shortDescription = SVs.shortDescription || undefined;
-    const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
-    const inlineLabelledByIds = [
-        hasLabel ? labelId : null,
-        ...externalLabelRendererIds,
-    ]
-        .filter(Boolean)
-        .join(" ");
-
+    // The description and the `useMemo` below are derived before the
+    // `SVs.hidden` early return so that every hook runs on every render.
+    //
+    // Nothing reaches that state today: when `hidden` becomes true the worker
+    // drops the component from its parent's rendered children (see
+    // `returnActiveChildrenIndicesToRender` in the worker's `ChildMatcher`),
+    // so React unmounts the instance instead of re-rendering it past the
+    // return. But that is an invariant of the worker, not of this file, and a
+    // component that opts into `sendToRendererEvenIfHidden` does keep
+    // re-rendering while hidden — at which point a hook below the return
+    // changes the hook count and React throws.
     const descriptionChild =
         SVs.descriptionChildInd !== -1 && children[SVs.descriptionChildInd];
 
@@ -249,22 +232,6 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             </DescriptionPopover>
         );
     }
-
-    // For inline, the default is a small check work button,
-    // for non-inline, the default is a full check work button
-    const fullCheckWork = SVs.inline
-        ? SVs.forceFullCheckWorkButton
-        : SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton;
-
-    const checkWorkComponent = createCheckWorkComponent(
-        SVs,
-        id,
-        validationState,
-        submitActionWithPending,
-        fullCheckWork,
-        isPending,
-        tContent,
-    );
 
     const inlineSelectComponents = useMemo(
         () => ({
@@ -321,6 +288,50 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         [descriptionId, t],
     );
 
+    if (SVs.hidden) {
+        return null;
+    }
+
+    let disabled = SVs.disabled;
+
+    let label: React.ReactNode = SVs.label;
+    const hasLabel =
+        typeof SVs.label === "string" ? SVs.label.trim() !== "" : !!SVs.label;
+    const labelId = `${id}-label`;
+    const inlineInputId = `${id}_input`;
+    if (SVs.labelHasLatex) {
+        label = (
+            <MathJax hideUntilTypeset={"first"} inline dynamic>
+                {label}
+            </MathJax>
+        );
+    }
+
+    let shortDescription = SVs.shortDescription || undefined;
+    const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
+    const inlineLabelledByIds = [
+        hasLabel ? labelId : null,
+        ...externalLabelRendererIds,
+    ]
+        .filter(Boolean)
+        .join(" ");
+
+    // For inline, the default is a small check work button,
+    // for non-inline, the default is a full check work button
+    const fullCheckWork = SVs.inline
+        ? SVs.forceFullCheckWorkButton
+        : SVs.forceFullCheckWorkButton || !SVs.forceSmallCheckWorkButton;
+
+    const checkWorkComponent = createCheckWorkComponent(
+        SVs,
+        id,
+        validationState,
+        submitActionWithPending,
+        fullCheckWork,
+        isPending,
+        tContent,
+    );
+
     if (SVs.inline) {
         // since we color correctness for inline choiceInput,
         // modify shortDescription to include correctness state
@@ -353,8 +364,12 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             })
             .filter((opt) => opt !== null) as Option[];
 
+        // `value` is assigned before the hidden choices are filtered out, so it
+        // is an index into the full ordered list — which is also what
+        // `selectedIndices` holds. Look the option up by that key rather than
+        // by position in the filtered array, which a hidden choice shifts.
         const getOptionFromIndex = (index: number) => {
-            return choiceOptions[index - 1];
+            return choiceOptions.find((opt) => opt.value === index);
         };
 
         const valuePadding = "2px 0px 2px 6px";
@@ -524,9 +539,12 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                             menuPlacement="auto"
                             className={inputClasses}
                             onChange={onChangeHandlerInline}
-                            value={rendererSelectedIndices.map((ind) =>
-                                getOptionFromIndex(ind),
-                            )}
+                            // A selected choice that is now hidden has no
+                            // option to show, so it drops out of the value
+                            // rather than displacing the others.
+                            value={rendererSelectedIndices
+                                .map((ind) => getOptionFromIndex(ind))
+                                .filter((opt) => opt !== undefined)}
                             placeholder={SVs.placeHolder}
                             isDisabled={disabled}
                             isOptionDisabled={(opt) => !!opt.isDisabled}

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -207,8 +207,8 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         }
     }
 
-    // The description and the `useMemo` below are derived before the
-    // `SVs.hidden` early return so that every hook runs on every render.
+    // The description and the `useMemo` that depends on it are computed above
+    // the `SVs.hidden` early return so that every hook runs on every render.
     //
     // Nothing reaches that state today: when `hidden` becomes true the worker
     // drops the component from its parent's rendered children (see
@@ -368,9 +368,9 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
         // is an index into the full ordered list — which is also what
         // `selectedIndices` holds. Look the option up by that key rather than
         // by position in the filtered array, which a hidden choice shifts.
-        const getOptionFromIndex = (index: number) => {
+        function getOptionFromIndex(index: number) {
             return choiceOptions.find((opt) => opt.value === index);
-        };
+        }
 
         const valuePadding = "2px 0px 2px 6px";
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1829,6 +1829,9 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get('#ci [class*="-singleValue"]').should("have.text", "mouse");
     });
 
+    // Coverage for the hide/show path, not a regression pin: hiding the
+    // component unmounts it, so this passes whether or not the renderer's
+    // hooks sit above its `hidden` early return.
     it("inline choiceInput survives being hidden and shown again", () => {
         cy.window().then(async (win) => {
             win.postMessage(
@@ -1852,7 +1855,7 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get("#ci").should("not.exist");
         cy.get("#b").click();
 
-        cy.log("It comes back working, rather than throwing on the re-render");
+        cy.log("It comes back working after the remount");
         cy.get("#ci").click();
         getOpenInlineChoiceMenu().within(() => {
             cy.contains("dog").click({ force: true });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1790,4 +1790,73 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
             "Remove banana",
         );
     });
+
+    it("inline choiceInput displays the selected choice when an earlier choice is hidden", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <choiceInput name="ci" inline placeholder="Choose animal">
+      <choice hide>cat</choice>
+      <choice>dog</choice>
+      <choice>mouse</choice>
+    </choiceInput>
+
+    <p name="p1">Selected value: $ci.selectedValue</p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.log("Select the choice right after the hidden one");
+        cy.get("#ci").click();
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("dog").click({ force: true });
+        });
+
+        // The hidden choice still occupies an index, so the selected index (2)
+        // is one past the selected option's position in the visible list.
+        cy.get("#p1").should("have.text", "Selected value: dog");
+        cy.get('#ci [class*="-singleValue"]').should("have.text", "dog");
+
+        cy.log("And the last choice, whose index runs past the visible list");
+        cy.get("#ci").click();
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("mouse").click({ force: true });
+        });
+        cy.get("#p1").should("have.text", "Selected value: mouse");
+        cy.get('#ci [class*="-singleValue"]').should("have.text", "mouse");
+    });
+
+    it("inline choiceInput survives being hidden and shown again", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <booleanInput name="b" />
+    <choiceInput name="ci" inline hide="$b" placeholder="Choose animal">
+      <choice>cat</choice>
+      <choice>dog</choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ci").should("exist");
+
+        cy.log("Hide it, then show it again");
+        cy.get("#b").click();
+        cy.get("#ci").should("not.exist");
+        cy.get("#b").click();
+
+        cy.log("It comes back working, rather than throwing on the re-render");
+        cy.get("#ci").click();
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("dog").click({ force: true });
+        });
+        cy.get('#ci [class*="-singleValue"]').should("have.text", "dog");
+    });
 });


### PR DESCRIPTION
Follow-up to #1630, which noted both of these while reviewing the inline `<choiceInput>` renderer.

## The bug: a hidden choice shifts the displayed value

Each option's `value` is assigned *before* the hidden choices are filtered out, so it is a 1-based index into the full ordered list — the same thing `selectedIndices` holds. `getOptionFromIndex` nonetheless indexed the **filtered** array positionally:

```ts
const getOptionFromIndex = (index: number) => choiceOptions[index - 1];
```

So every choice after a hidden one resolved to its neighbor. With

```xml
<choiceInput inline name="ci">
  <choice hide>cat</choice>
  <choice>dog</choice>
  <choice>mouse</choice>
</choiceInput>
```

the visible options are `value: 2` and `value: 3`. Selecting **dog** put `selectedIndices = [2]`, which read `choiceOptions[1]` — and the closed select displayed **"mouse"**. Selecting **mouse** read `choiceOptions[2]`, found nothing, and fell back to the placeholder as though nothing were selected.

Only the display was affected. `selectedIndices`, `selectedValues`, and answer checking were all correct throughout, which is why the existing "hidden choice with inline choiceInput" spec missed it — that test asserts `$choiceInput1.selectedValue`, never what the closed select shows.

The fix looks the option up by the key that was assigned to it, and drops a selected-but-hidden choice from the value rather than letting it displace the others:

```ts
function getOptionFromIndex(index: number) {
    return choiceOptions.find((opt) => opt.value === index);
}
```

## Hardening: hooks above the `SVs.hidden` guard

`inlineSelectComponents` (a `useMemo`) sat below `if (SVs.hidden) return null`, along with the `descriptionId` derivation it depends on. Both are now hoisted above the guard so every hook runs on every render.

**This is hardening, not a fix — nothing reaches the bad state today.** When `hidden` becomes true the worker drops the component from its parent's rendered children (`returnActiveChildrenIndicesToRender`, `packages/doenetml-worker-javascript/src/core/ChildMatcher.ts:394`) and never sends the child a `hidden: true` state update, so React unmounts the instance instead of re-rendering it past the return. The guard is only ever reached on a first render.

Two things make it worth doing anyway:

- That is an invariant of the worker, not of this file. A component that sets `sendToRendererEvenIfHidden` *does* keep re-rendering while hidden, and then a hook below the guard changes the hook count and React throws. `Solution.js` is the only component that sets it today; `solution.tsx` correctly keeps all its hooks above its guard.
- The same shape exists in ten other renderers (`p.tsx`, `section.tsx`, `answer.tsx`, `booleanInput.tsx`, `list.tsx`, `containerBlock.tsx`, `containerInline.tsx`, `fractionInput.tsx`, `matrixInput.tsx`, `pretzel.tsx`), so this PR does not make the codebase consistent — it only stops this file from relying on the invariant. `section.tsx` is the interesting one: it renders the document root unconditionally, and is saved only by `Document.js` doing `delete attributes.hide`.

I've left the other ten alone rather than widen this PR. Happy to file that as its own issue if it's worth tracking.

## Tests

- `inline choiceInput displays the selected choice when an earlier choice is hidden` — new; pins the bug. Verified it **fails** against the pre-fix renderer and passes after.
- `inline choiceInput survives being hidden and shown again` — new; covers the hide/show remount path. Note this one passes with or without the hoist, for the unmount reason above; it is coverage, not a regression pin.

Full `build -> preview -> cypress run`: `tagSpecific/choiceinput.cy.js` 26/26, plus `tagSpecific/answer.cy.js` 34/34, `accessibility/basicTests.cy.js` 40/40, and `accessibility/darkModeVisibilityRegressions.cy.js` 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


