### PR TITLE
Add translator-facing comments to editor-update-viewer strings

### DIFF
--- a/packages/i18n/locales/en/editor.ftl
+++ b/packages/i18n/locales/en/editor.ftl
@@ -33,12 +33,18 @@
 ## reference literally instead of falling back to English. This is the shape
 ## `paginator-page-status` already uses.
 
+# Button label. "Update" recompiles after a source edit; "Reset" reverts
+# only the document's live state to match — same button, different verb.
+# Keep both forms short enough to fit a toolbar button.
 editor-update-viewer =
     { $action ->
         [reset] Reset
        *[update] Update
     }
 
+# Tooltip on the button above. { $word } is that button's own current label
+# ("Update" or "Reset"), so this reads as e.g. "Update Viewer" or
+# "Reset Viewer". { $shortcut } appends the keyboard shortcut when one exists.
 editor-update-viewer-title =
     { $shortcut ->
         [none] { $word } Viewer


### PR DESCRIPTION
## Summary
- Add bound `#` comments to `editor-update-viewer` and `editor-update-viewer-title` in `editor.ftl`, testing whether Weblate surfaces these separately from (or concatenated with) the existing `##` group comment in the "Source string description" panel — part of the Weblate setup in #1521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
