### PR TITLE
Add per-string translator comments to editor-variant-* messages

### DIFF
--- a/packages/i18n/locales/en/editor.ftl
+++ b/packages/i18n/locales/en/editor.ftl
@@ -54,9 +54,17 @@ editor-update-viewer-title =
 
 ## The variant picker
 
+# Label for the variant picker control itself (a noun, like a field label).
 editor-variant = Variant
+
+# Placeholder text shown in the empty filter input, before the user types
+# anything — not a button or instruction.
 editor-variant-filter = Filter...
+
+# Button/action label: advances to the next variant in the list.
 editor-variant-next = Select next variant
+
+# Button/action label: goes back to the previous variant in the list.
 editor-variant-previous = Select previous variant
 
 


### PR DESCRIPTION
## Summary
- Re-adds bound `#` comments to `editor-variant`, `editor-variant-filter`, `editor-variant-next`, and `editor-variant-previous` — this content was on the `editor-translator-comments` branch but didn't make it into the squash-merge of #1637. Test for #1521: the group `##` comment here is short, so the bound comment should have room to actually show in Weblate's string information panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
