### PR TITLE
fix: let screen readers read a list marker when the item starts with a <p>

### DIFF
--- a/.changeset/list-item-paragraph-aria-roles.md
+++ b/.changeset/list-item-paragraph-aria-roles.md
@@ -1,0 +1,24 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Viewer: let screen readers read the list marker of an item that starts with a `<p>`.
+
+A `<p>` renders as `<div class="para">`, and any wrapper element between the
+`<li>` and its text stops a screen reader from folding the item's `::marker`
+into the item's own text. VoiceOver then landed on the marker as a separate
+object and announced "list marker" rather than "1. Apples, 1 of 3", so an
+ordered list whose items each held a `<p>` lost its numbering out loud. The
+paragraph that leads a list item is now presentational, which restores the
+accessibility tree a plain `<li>Apples</li>` produces.
+
+Paragraphs are also exposed as paragraphs now, in and out of lists: a `<div>`
+carries no paragraph semantics on its own, so every `<p>` beyond the leading
+one in a list item gets an explicit `paragraph` role. Nothing about the visual
+layout changes.
+
+Closes #662.

--- a/.changeset/list-item-paragraph-aria-roles.md
+++ b/.changeset/list-item-paragraph-aria-roles.md
@@ -16,9 +16,9 @@ ordered list whose items each held a `<p>` lost its numbering out loud. The
 paragraph that leads a list item is now presentational, which restores the
 accessibility tree a plain `<li>Apples</li>` produces.
 
-Paragraphs are also exposed as paragraphs now, in and out of lists: a `<div>`
-carries no paragraph semantics on its own, so every `<p>` beyond the leading
-one in a list item gets an explicit `paragraph` role. Nothing about the visual
-layout changes.
+Paragraphs are also exposed as paragraphs now: a `<div>` carries no paragraph
+semantics on its own, so every `<p>` — outside a list, and every one in a list
+item beyond the leading one — gets an explicit `paragraph` role. Nothing about
+the visual layout changes.
 
 Closes #662.

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -10,6 +10,7 @@ import {
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { useContentT } from "../../utils/i18n";
+import type { PProps } from "./p";
 
 interface ListSVs {
     [key: string]: any;
@@ -146,7 +147,13 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
  *
  * Only a paragraph that leads the item is worth flagging: any other first
  * child (a figure, a nested list) sits between the marker and the text no
- * matter what role it carries.
+ * matter what role it carries. Whitespace-only text between the `<li>` and
+ * the paragraph is skipped, since it produces no accessibility node.
+ *
+ * The leading child is identified from the React tree, which does not know
+ * which children will render nothing: a hidden paragraph at the front of the
+ * item still counts as the leading one, so an item whose first visible
+ * content follows a `<p hide>` keeps the pre-existing behavior.
  */
 function markLeadingParagraphOfListItem(children: React.ReactNode[]) {
     const leadingInd = children.findIndex(
@@ -158,20 +165,17 @@ function markLeadingParagraphOfListItem(children: React.ReactNode[]) {
     const leadingChild = children[leadingInd];
 
     if (
-        leadingInd === -1 ||
-        !React.isValidElement<UseDoenetRendererProps>(leadingChild) ||
+        !React.isValidElement<PProps>(leadingChild) ||
         leadingChild.props.componentInstructions?.rendererType !== "p"
     ) {
         return children;
     }
 
-    return children.map((child, ind) =>
-        ind === leadingInd
-            ? React.cloneElement(leadingChild, {
-                  isLeadingListItemParagraph: true,
-              } as Partial<UseDoenetRendererProps>)
-            : child,
-    );
+    const markedChildren = [...children];
+    markedChildren[leadingInd] = React.cloneElement(leadingChild, {
+        isLeadingListItemParagraph: true,
+    });
+    return markedChildren;
 }
 
 const unnumberedStyles = ["disc", "circle", "square"];

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -149,6 +149,12 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
  * child (a figure, a nested list, or the `<span>` that
  * `addCommasForCompositeRanges` wraps around a composite's replacements) sits
  * between the marker and the text no matter what role the paragraph carries.
+ * Blink folds away a semantics-free *inline* generic, so a bare `<span>` around
+ * text is harmless — but the span around a composite's replacements holds the
+ * block-level `<div class="para">`, which keeps it in the tree as a `generic`
+ * node. Making the paragraph inside it presentational would only trade
+ * `generic > paragraph > text` for `generic > text`, which is the shape that is
+ * already broken; the paragraph keeps its `paragraph` role instead.
  *
  * Two kinds of child are skipped when looking for the leading one, because
  * neither reaches the accessibility tree: whitespace-only text (the

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -147,13 +147,13 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
  *
  * Only a paragraph that leads the item is worth flagging: any other first
  * child (a figure, a nested list) sits between the marker and the text no
- * matter what role it carries. Whitespace-only text between the `<li>` and
- * the paragraph is skipped, since it produces no accessibility node.
+ * matter what role it carries.
  *
- * The leading child is identified from the React tree, which does not know
- * which children will render nothing: a hidden paragraph at the front of the
- * item still counts as the leading one, so an item whose first visible
- * content follows a `<p hide>` keeps the pre-existing behavior.
+ * Two kinds of child are skipped when looking for the leading one, because
+ * neither reaches the accessibility tree: whitespace-only text (the
+ * indentation an author writes inside the `<li>`) and `null`, which is what
+ * the core sends for a child it does not render — a hidden child, most
+ * often a `<p hide>`.
  */
 function markLeadingParagraphOfListItem(children: React.ReactNode[]) {
     const leadingInd = children.findIndex(

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -74,7 +74,7 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
     if (SVs.item) {
         return (
             <li id={id} ref={ref}>
-                {children}
+                {markLeadingParagraphOfListItem(children)}
                 {checkWorkComponent}
             </li>
         );
@@ -131,6 +131,48 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
         );
     }
 });
+
+/**
+ * Flag the leading paragraph of a list item so that it renders as
+ * presentational.
+ *
+ * A screen reader folds a list item's `::marker` into the item's own text run
+ * only when that text is a direct child of the `<li>`. A paragraph wrapper
+ * makes the marker a separate object that VoiceOver lands on and announces as
+ * a bare "list marker" instead of "1. Apples, 1 of 3" — see issue #662. The
+ * leading paragraph therefore drops out of the accessibility tree; every later
+ * paragraph keeps its own node, since a reader still wants to be told where
+ * the next paragraph starts.
+ *
+ * Only a paragraph that leads the item is worth flagging: any other first
+ * child (a figure, a nested list) sits between the marker and the text no
+ * matter what role it carries.
+ */
+function markLeadingParagraphOfListItem(children: React.ReactNode[]) {
+    const leadingInd = children.findIndex(
+        (child) =>
+            React.isValidElement(child) ||
+            (typeof child === "string" && child.trim() !== ""),
+    );
+
+    const leadingChild = children[leadingInd];
+
+    if (
+        leadingInd === -1 ||
+        !React.isValidElement<UseDoenetRendererProps>(leadingChild) ||
+        leadingChild.props.componentInstructions?.rendererType !== "p"
+    ) {
+        return children;
+    }
+
+    return children.map((child, ind) =>
+        ind === leadingInd
+            ? React.cloneElement(leadingChild, {
+                  isLeadingListItemParagraph: true,
+              } as Partial<UseDoenetRendererProps>)
+            : child,
+    );
+}
 
 const unnumberedStyles = ["disc", "circle", "square"];
 

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -145,21 +145,24 @@ export default React.memo(function List(props: UseDoenetRendererProps) {
  * paragraph keeps its own node, since a reader still wants to be told where
  * the next paragraph starts.
  *
- * Only a paragraph that leads the item is worth flagging: any other first
- * child (a figure, a nested list) sits between the marker and the text no
- * matter what role it carries.
+ * Only a paragraph that leads the item is worth flagging: any other leading
+ * child (a figure, a nested list, or the `<span>` that
+ * `addCommasForCompositeRanges` wraps around a composite's replacements) sits
+ * between the marker and the text no matter what role the paragraph carries.
  *
  * Two kinds of child are skipped when looking for the leading one, because
  * neither reaches the accessibility tree: whitespace-only text (the
- * indentation an author writes inside the `<li>`) and `null`, which is what
- * the core sends for a child it does not render — a hidden child, most
- * often a `<p hide>`.
+ * indentation an author writes inside the `<li>`) and `null`, which stands for
+ * a child that is not rendered — the core sends it for a child it leaves out,
+ * most often a `<p hide>`, and `useDoenetRenderer` sends it for a child whose
+ * renderer has not finished loading yet (a later render then marks that child,
+ * since this runs on every render).
  */
 function markLeadingParagraphOfListItem(children: React.ReactNode[]) {
     const leadingInd = children.findIndex(
         (child) =>
-            React.isValidElement(child) ||
-            (typeof child === "string" && child.trim() !== ""),
+            child != null &&
+            !(typeof child === "string" && child.trim() === ""),
     );
 
     const leadingChild = children[leadingInd];

--- a/packages/doenetml/src/Viewer/renderers/p.tsx
+++ b/packages/doenetml/src/Viewer/renderers/p.tsx
@@ -20,7 +20,16 @@ interface PSVs {
     renderInlineForListItem: boolean;
 }
 
-export default React.memo(function P(props: UseDoenetRendererProps) {
+export type PProps = UseDoenetRendererProps & {
+    /**
+     * Set by the `<li>` renderer on the paragraph that leads a list item, so
+     * that the item's marker stays part of the item's text for screen readers.
+     * See `markLeadingParagraphOfListItem` in `list.tsx`.
+     */
+    isLeadingListItemParagraph?: boolean;
+};
+
+export default React.memo(function P(props: PProps) {
     let { id, SVs, children, actions, callAction } =
         useDoenetRenderer<PSVs>(props);
 
@@ -73,6 +82,13 @@ export default React.memo(function P(props: UseDoenetRendererProps) {
             id={id}
             ref={ref}
             className="para"
+            // A `<div>` is exposed as an anonymous `generic` node, so paragraphs
+            // are not announced as paragraphs without an explicit role. The one
+            // paragraph that leads a list item is presentational instead, to
+            // keep the item's marker readable — see `list.tsx`.
+            role={
+                props.isLeadingListItemParagraph ? "presentation" : "paragraph"
+            }
             // Keep paragraph spacing contract intact and only collapse the top
             // margin when this paragraph is first in a list-item container.
             style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}

--- a/packages/doenetml/src/Viewer/renderers/p.tsx
+++ b/packages/doenetml/src/Viewer/renderers/p.tsx
@@ -85,7 +85,13 @@ export default React.memo(function P(props: PProps) {
             // A `<div>` is exposed as an anonymous `generic` node, so paragraphs
             // are not announced as paragraphs without an explicit role. The one
             // paragraph that leads a list item is presentational instead, to
-            // keep the item's marker readable — see `list.tsx`.
+            // keep the item's marker readable — see `list.tsx`. That flag comes
+            // from the `<li>` renderer rather than from
+            // `SVs.renderInlineForListItem` below: the latter is the core's
+            // margin-collapsing signal, which answers a related but different
+            // question (it is set only for a section rendered as a list item,
+            // not for a plain `<li>`) and does not track what the renderer
+            // actually puts in the accessibility tree.
             role={
                 props.isLeadingListItemParagraph ? "presentation" : "paragraph"
             }

--- a/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
@@ -20,6 +20,7 @@ describe(
         beforeEach(() => {
             cy.clearIndexedDB();
             cy.visit("/");
+            cy.injectAxe();
         });
 
         function postDoenetML({ doenetML, settleSelector }) {
@@ -60,6 +61,28 @@ describe(
 
             cy.get("#firstPara").should("have.attr", "role", "presentation");
             cy.get("#secondPara").should("have.attr", "role", "paragraph");
+        });
+
+        it("leading paragraph is still found across whitespace, and the roles pass axe", () => {
+            // The shape authors actually write: the `<p>` is preceded by the
+            // whitespace that indents it, which produces no accessibility node
+            // and so must not count as the item's leading content.
+            postDoenetML({
+                settleSelector: "#firstPara",
+                doenetML: `<ul>
+  <li>
+    <p name="firstPara">Apples</p>
+    <p name="secondPara">More about apples</p>
+  </li>
+</ul>`,
+            });
+
+            cy.get("#firstPara").should("have.attr", "role", "presentation");
+            cy.get("#secondPara").should("have.attr", "role", "paragraph");
+
+            cy.checkAccessibility([".doenet-viewer"], {
+                onlyWarnImpacts: ["moderate", "minor"],
+            });
         });
 
         it("paragraph that does not lead its list item stays a paragraph", () => {

--- a/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
@@ -95,5 +95,20 @@ describe(
 
             cy.get("#trailingPara").should("have.attr", "role", "paragraph");
         });
+
+        it("hidden paragraph does not claim the lead of its list item", () => {
+            // The core sends `null` for a child it does not render, so a
+            // hidden paragraph never reaches the accessibility tree and must
+            // not take the leading role from the paragraph after it.
+            postDoenetML({
+                settleSelector: "#visiblePara",
+                doenetML: `<ol>
+  <li><p hide name="hiddenPara">Not shown</p><p name="visiblePara">Apples</p></li>
+</ol>`,
+            });
+
+            cy.get("#hiddenPara").should("not.exist");
+            cy.get("#visiblePara").should("have.attr", "role", "presentation");
+        });
     },
 );

--- a/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
@@ -97,11 +97,13 @@ describe(
         });
 
         it("content pulled in by a composite claims the lead of its list item", () => {
-            // A composite's replacements are wrapped in a `<span>` carrying
-            // the composite's name, and that wrapper keeps the marker out of
-            // the item's text run whatever role the paragraph inside it has.
-            // The paragraph after the wrapper does not lead the item, so it
-            // must stay a paragraph.
+            // A composite's replacements reach the `<li>` renderer as a nested
+            // array, and are wrapped in a `<span>` carrying the composite's
+            // name. That wrapper holds a block-level paragraph, so it survives
+            // in the accessibility tree and keeps the marker out of the item's
+            // text run whatever role the paragraph inside it has. Both the
+            // paragraph inside the wrapper and the one after it therefore stay
+            // paragraphs.
             postDoenetML({
                 settleSelector: "#after",
                 doenetML: `<p name="src">Apples</p>
@@ -110,7 +112,31 @@ describe(
 </ol>`,
             });
 
+            // Assert the wrapper is really there, so this stays a test of the
+            // composite shape rather than passing for an unrelated reason.
+            cy.get("#after")
+                .parent("li")
+                .children()
+                .first()
+                .should("match", "span")
+                .find(".para")
+                .should("have.attr", "role", "paragraph");
+
             cy.get("#after").should("have.attr", "role", "paragraph");
+        });
+
+        it("paragraph inside a leading section stays a paragraph", () => {
+            // The leading child is an element other than a paragraph, so
+            // nothing is made presentational: the section sits between the
+            // marker and the text however its contents are marked up.
+            postDoenetML({
+                settleSelector: "#inSection",
+                doenetML: `<ol>
+  <li><section name="sec"><p name="inSection">Apples</p></section></li>
+</ol>`,
+            });
+
+            cy.get("#inSection").should("have.attr", "role", "paragraph");
         });
 
         it("hidden paragraph does not claim the lead of its list item", () => {

--- a/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
@@ -96,6 +96,23 @@ describe(
             cy.get("#trailingPara").should("have.attr", "role", "paragraph");
         });
 
+        it("content pulled in by a composite claims the lead of its list item", () => {
+            // A composite's replacements are wrapped in a `<span>` carrying
+            // the composite's name, and that wrapper keeps the marker out of
+            // the item's text run whatever role the paragraph inside it has.
+            // The paragraph after the wrapper does not lead the item, so it
+            // must stay a paragraph.
+            postDoenetML({
+                settleSelector: "#after",
+                doenetML: `<p name="src">Apples</p>
+<ol>
+  <li>$src<p name="after">More about apples</p></li>
+</ol>`,
+            });
+
+            cy.get("#after").should("have.attr", "role", "paragraph");
+        });
+
         it("hidden paragraph does not claim the lead of its list item", () => {
             // The core sends `null` for a child it does not render, so a
             // hidden paragraph never reaches the accessibility tree and must

--- a/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js
@@ -1,0 +1,76 @@
+/**
+ * Accessibility coverage for the ARIA roles carried by `<p>`.
+ *
+ * A `<p>` renders as `<div class="para">`, which browsers expose as an
+ * anonymous `generic` node rather than a paragraph, so every paragraph
+ * carries an explicit `role="paragraph"`.
+ *
+ * The one exception is the paragraph that leads a list item. A screen reader
+ * folds a list item's `::marker` into the item's own text only when that text
+ * is a direct child of the `<li>`; a paragraph wrapper turns the marker into a
+ * separate object that gets announced as a bare "list marker" instead of
+ * "1. Apples, 1 of 3" (issue #662). That leading paragraph is therefore
+ * presentational, while later paragraphs in the same item keep their own node
+ * so a reader is still told where the next paragraph starts.
+ */
+describe(
+    "List item paragraph role accessibility checks",
+    { tags: ["@group5"] },
+    () => {
+        beforeEach(() => {
+            cy.clearIndexedDB();
+            cy.visit("/");
+        });
+
+        function postDoenetML({ doenetML, settleSelector }) {
+            cy.get("#testRunner_toggleControls").should("exist");
+            cy.window().then((win) => {
+                win.postMessage({ doenetML }, "*");
+            });
+            cy.get(settleSelector).should("exist");
+        }
+
+        it("paragraph outside a list item is exposed as a paragraph", () => {
+            postDoenetML({
+                settleSelector: "#para",
+                doenetML: `<p name="para">Hello</p>`,
+            });
+
+            cy.get("#para").should("have.attr", "role", "paragraph");
+        });
+
+        it("leading paragraph of a list item is presentational", () => {
+            postDoenetML({
+                settleSelector: "#firstPara",
+                doenetML: `<ol>
+  <li><p name="firstPara">Apples</p></li>
+</ol>`,
+            });
+
+            cy.get("#firstPara").should("have.attr", "role", "presentation");
+        });
+
+        it("later paragraphs of a list item stay paragraphs", () => {
+            postDoenetML({
+                settleSelector: "#firstPara",
+                doenetML: `<ol>
+  <li><p name="firstPara">Apples</p><p name="secondPara">More about apples</p></li>
+</ol>`,
+            });
+
+            cy.get("#firstPara").should("have.attr", "role", "presentation");
+            cy.get("#secondPara").should("have.attr", "role", "paragraph");
+        });
+
+        it("paragraph that does not lead its list item stays a paragraph", () => {
+            postDoenetML({
+                settleSelector: "#trailingPara",
+                doenetML: `<ol>
+  <li>Apples<p name="trailingPara">More about apples</p></li>
+</ol>`,
+            });
+
+            cy.get("#trailingPara").should("have.attr", "role", "paragraph");
+        });
+    },
+);


### PR DESCRIPTION
## Problem

`<ol><li><p>Apples</p></li>…</ol>` lost its numbering for screen-reader users: VoiceOver announced "You are currently on a list marker" instead of "1. Apples, 1 of 3". A plain `<li>Apples</li>` read correctly.

## Cause

A screen reader folds a list item's `::marker` into the item's own text only when that text is a **direct child** of the `<li>`. Any surviving wrapper node in between makes the marker a separate object to land on.

Dumping Chrome's accessibility tree (CDP `Accessibility.getFullAXTree`) over a matrix of list items shows the `ListMarker "1. "` node is present and unignored in *every* case — what actually varies is where the text sits:

| markup | listitem's children after the marker |
| --- | --- |
| `<li>Hello</li>` | `StaticText` ✅ |
| `<li><span>Hello</span></li>` | `StaticText` ✅ |
| `<li><p>Hello</p></li>` | `paragraph > StaticText` ❌ |
| `<li><div>Hello</div></li>` | `generic > StaticText` ❌ |
| `<li><em>Hello</em></li>` | `emphasis > StaticText` ❌ |

Doenet renders `<p>` as `<div class="para">`, which lands in the ❌ group as `generic > StaticText`. That also explains the reporter's observation that "most any tag inside the `<li>`" breaks it — more precisely, any tag that survives as an accessibility node. Blink folds away semantics-free *inline* generics like `<span>`, which is why those stay in the ✅ group.

## Fix

The paragraph that leads a list item now renders with `role="presentation"`, so it drops out of the accessibility tree and the item's text becomes a direct child of the `<li>` again.

Every other paragraph gains an explicit `role="paragraph"`. A `<div>` carries no paragraph semantics on its own, so Doenet's paragraphs were being exposed as anonymous `generic` nodes and were never announced as paragraphs — in or out of a list. Later paragraphs in a list item therefore keep their own node *and* are now properly announced, so a reader is still told where the next paragraph starts.

ARIA roles have no effect on layout. Margins and spacing are byte-for-byte what they were; verified computed `margin-top` is unchanged at 16px for paragraphs in and out of list items.

Verified against real viewer output — the accessibility tree for `<li><p>First para</p><p>Second para</p></li>` is now:

```
listitem
  ListMarker "1. "
  StaticText "First para"
  paragraph
    StaticText "Second para"
```

which matches the shape of the plain `<li>Plain text</li>` that already worked.

## Needs a VoiceOver check before merge

Everything above is Chrome's accessibility tree, captured on Linux. I could not run VoiceOver to confirm the announcement itself actually changes. The tree is now indistinguishable from the case reported as working, which is the best available evidence, but @virginiaMae or anyone on macOS should confirm that `<ol><li><p>Apples</p></li>…</ol>` now reads "1. Apples, 1 of 3" before this is trusted.

## Known limitations

- Items led by something other than a paragraph are unchanged — `<li><em>Hello</em></li>`, or an item starting with a figure or a nested list, still put a node between the marker and the text. Only the `<p>` case, which is what #662 reports and by far the most common, is addressed here.
- The leading paragraph is picked out of the React tree. Children that never reach the accessibility tree are skipped when looking for it: whitespace-only text (the indentation an author writes inside the `<li>`) and `null`, which is what the core sends for a child it does not render — so `<li><p hide>…</p><p>Apples</p></li>` is handled too, and the visible paragraph leads.
- An item whose content comes from a composite (`<li>$para</li>`, `<li><repeat>…</repeat></li>`) is unchanged. Those replacements reach the `<li>` renderer as a nested array and are wrapped in the `<span>` that carries the composite's name for name-anchored links. Blink folds away a semantics-free *inline* generic — which is why the `<span>` in the table above is in the ✅ group — but this one holds the block-level `<div class="para">`, so it survives as a `generic` node. Verified in the viewer: the item reads `generic > paragraph > text`, and making the paragraph presentational would only turn that into `generic > text`, which is the already-broken `<li><div>Hello</div></li>` row. The paragraph therefore keeps its `paragraph` role rather than being made presentational for no benefit. Fixing this case would mean making the composite `<span>` presentational as well, which affects every renderer that wraps composite replacements and is left for a follow-up.

## Testing

- New spec `packages/test-cypress/cypress/e2e/accessibility/listItemParagraphRoles.cy.js` (8 tests) covering each shape a child of an `<li>` can take: a paragraph outside a list, a leading paragraph, later paragraphs, a paragraph led by plain text, a paragraph led by a hidden paragraph (the `null` child), a paragraph led by composite-sourced content (the nested-array child — the spec also asserts the composite `<span>` is really present, so it cannot pass for an unrelated reason), a paragraph inside a leading section, and the indented `<li>` / `<p>` shape authors actually write (which also runs an axe check over the rendered list).
- Full `cypress/e2e/accessibility/` folder: 135 passing, including the axe-based specs.
- `tagSpecific/sectioning.cy.js`: 13 passing (3 pre-existing pending).

Closes #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



