### PR TITLE
Seed catalogs for ten more sub-Saharan African languages

### DIFF
--- a/.changeset/seed-more-sub-saharan-african-languages.md
+++ b/.changeset/seed-more-sub-saharan-african-languages.md
@@ -1,0 +1,38 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Add message catalogs for Wolof, Bambara, Akan, Ewe, Lingala, Shona, Southern Sotho, Setswana, Tigrinya and Ganda.
+
+Each covers all four namespaces — the viewer chrome, the editor and language-server surfaces, the prose the core computes into a document, and the warnings and errors. `documentLocale="sn"` and `<document lang="lg">` work with nothing configured, and all ten reach `<document lang>`'s autocomplete, eight of them labelled with their endonym beside the English name.
+
+All ten also carry `deprecated-attribute-to-child`, the diagnostic added alongside them, so no locale in the batch lands already one key behind.
+
+These are **unreviewed machine-generated seeds**, and every file says so in its header. Nothing falls back silently: a key a translation is missing renders in English, which is what makes seeding safe.
+
+This is the second sub-Saharan batch, and it goes back for the two largest things the first one left out: **Bantu south of the equator**, which the first reached only through Swahili, Zulu, Xhosa, Kinyarwanda and Nyanja, and **francophone West and Central Africa**, which it did not reach at all.
+
+Five of the ten agree an adjective with its noun's **class**, and they use the `$gender` argument as a class token exactly the way `locales/sw` does — the whole reason that argument was named for a position rather than for a case. What is worth reading is how differently five languages do the same thing:
+
+- **Shona** does not bolt a prefix onto an unchanged stem. In class 5 the stem's own first consonant changes with the prefix, so «-tema» is «dema», «-chena» is «jena» and «-kobvu» is «gobvu». The table cannot be derived from the stems and is written out in the header.
+- **Luganda** carries six classes, the widest table here, because its own geometry words land where the others' do not: «olunyiriri», a line, is class 11, and «akasaale», a ray, and «akatonnyeze», a point, are class 12 — the diminutive, which is where a small thing goes whether or not it is small on purpose.
+- **Southern Sotho** and **Setswana** additionally need a qualificative *particle* — «mola *o* motenya» — and both leave it out on purpose, because the same string is what `backgroundColor` reports standing alone, where a bare particle would be a fragment. That is the trade `locales/sw` already makes with its associative.
+- **Lingala** is the case where the device barely reaches. Its inventory of true adjectives is small and no colour word is in it — most of them are invariable French loans, and the three native ones are cited in one shape — so the concord touches two adjective stems and one participle and no more. Recording that is the point: a smaller table here is a fact about Lingala, not an unfinished one.
+
+**Tigrinya** is the one that uses `$gender` for a gender. It is Semitic, the agreement is internal rather than suffixed — «ጸሊም» → «ጸላም», «ረጒድ» → «ረጓድ» — and it is also the only language in the batch whose adjectives *precede* the noun, so its composition messages keep the English order while the other nine invert it. Its Ge'ez runs left to right, so `direction.ts` needs nothing.
+
+The four West African languages are the batch's counterweight, and they answer one question four ways: **what does a description do when the language inflects nothing?** **Wolof** has noun classes and still ignores `$gender`, because the class in Wolof rides on the determiner and the relative marker and never on the adjective. **Bambara** marks an adjective with the qualifier suffix `-man` rather than agreement. **Akan** and **Ewe** mark nothing at all on the adjective and put it after the noun.
+
+Plurals split the batch too. CLDR gives Wolof and Bambara one category each, and Akan and Ewe have two that no counted message here can use — an Ewe noun takes no plural after a numeral, and the two nouns Akan counts carry their plural prefix in the singular already — so all four drop their selects rather than write a `[one]` that repeats its `[other]`. The five Bantu languages keep theirs and change the noun inside them, except that in Shona and Luganda it is decided per message by the class of the noun being counted: Shona's «edzo» is class 5 and takes «ma-», while «mhinduro» is class 9 and its plural is spelled the same; Luganda's «akabonero» becomes «obubonero», while «okumenya» is a class 15 verbal noun with no plural at all and «amagezi» is class 6 and already plural. So in both, some counted messages keep their selects and the rest drop them.
+
+**Akan needs an alias, and Fante deliberately does not get one.** `ak` is the macrolanguage and the catalog is Asante Twi. `tw` is the retired code for Twi and the tag an author is as likely to type, and `Intl.getCanonicalLocales` leaves it alone rather than rewriting it the way it rewrites `iw` and `in` — so `negotiate.ts` maps `tw` to `ak`, the second entry `LANGUAGE_ALIASES` has ever needed. Fante is left out for the reason Nynorsk is: it is a written standard of its own, and answering `fat` with an Asante Twi catalog would be a substitution rather than a canonicalization. `negotiate.test.ts` holds both halves against the real roster.
+
+**Chemistry.** All ten leave the 118 element names and the 12 anion names to fall back to English, and unlike the batches before them they split no ways at all: every one is the school-system case. Secondary science is taught in English across Ghana, Zimbabwe, Botswana, Lesotho, Uganda, Eritrea and Tigray, and in French across Senegal, Mali and both Congos, so in all ten the fallback *is* the curriculum. That is a fact about ten education ministries rather than about ten languages.
+
+**Naming.** `lg` appears in the roster as **Ganda**, `st` as **Southern Sotho** and `tn` as **Tswana**, because `Intl.DisplayNames` renders them that way and `supportedLocales.ts` is derived rather than hand-written — the same split `ny` already has between Nyanja and Chichewa. All three catalogs' headers say so.
+
+Setswana and Southern Sotho are close enough to raise the question of why they are two files: they are two standard languages with two orthographies and two vocabularies, and `locales/tn` writes «kgotsa», «boammaaruri» and «-hibidu» where `locales/st` writes «kapa», «nnete» and «-fubedu». That is the same reason `hr` is a directory of its own rather than a script of `sr`.

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
@@ -306,6 +306,34 @@ describe("style descriptions follow the document locale @group4", () => {
         expect(values.fd).eq("mga tuldok nga asul");
     });
 
+    it("agrees each Luganda word with its own noun's class", async () => {
+        const values = await descriptions(styled, names, "lg");
+        // Luganda carries six noun classes, and this fixture reaches three of
+        // them: «olunyiriri» a line is class 11, «ekyenkanyi» a square is class
+        // 7 and «enkulungo» a circle is class 9. The same adjective stems come
+        // out «olunene»/«olumyufu» on the line and «enjjuvu» on the circle,
+        // which is what would break if `noun-gender` were flattened to one
+        // answer.
+        //
+        // «olukugiro», the border, is class 11 like the line, so `bd` and `st`
+        // agree here — the two are the same string for a reason rather than by
+        // accident, and the circle standing beside them in `sh` is what shows
+        // the border is not taking the shape's class.
+        //
+        // Only the three colours with a native adjective stem inflect; the
+        // rest are invariable nouns («bbululu», «kiragala») and stay put in
+        // every position, which is why the square shows its class in its own
+        // prefix and nowhere else.
+        expect(values.st).eq("olunene olumyufu olw'obutundutundu");
+        expect(values.stn).eq("olunyiriri olunene olumyufu olw'obutundutundu");
+        expect(values.pt).eq("ekyenkanyi kiragala");
+        expect(values.sh).eq(
+            "enkulungo enjjuvu bbululu n'obutonnyeze n'olukugiro olunene olumyufu olw'obutundutundu",
+        );
+        expect(values.bd).eq("olunene olumyufu olw'obutundutundu");
+        expect(values.fd).eq("obutonnyeze bbululu");
+    });
+
     it("falls back to English for a locale with no catalog", async () => {
         // `qaa` is in the ISO 639-3 private-use range, so it can never gain a
         // catalog and this stays a test of the fallback rather than of which

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -66,26 +66,28 @@ locales/<locale>/
   editor.ftl        # editor and LSP surfaces                — uiLocale
 ```
 
-English is the source of truth. Every translation — `af`, `am`, `ar`, `as`,
-`az`, `be`, `bg`, `bn`, `br`, `ca`, `ceb`, `cs`, `cy`, `da`, `de`, `el`, `es`,
-`et`, `eu`, `fa`, `fi`, `fil`, `fo`, `fr`, `ga`, `gd`, `gl`, `gu`, `ha`, `haw`,
-`he`, `hi`, `hnj`, `hr`, `hu`, `hy`, `id`, `ig`, `is`, `it`, `ja`, `jv`, `ka`,
-`kk`, `km`, `kn`, `ko`, `ky`, `lo`, `lt`, `lv`, `mg`, `mi`, `mk`, `ml`, `mn`,
-`mr`, `ms`, `mt`, `my`, `nb`, `ne`, `nl`, `ny`, `om`, `or`, `pa`, `pl`, `ps`,
-`pt`, `ro`, `ru`, `rw`, `sd`, `si`, `sk`, `sl`, `sm`, `so`, `sq`, `sr`, `su`,
-`sv`, `sw`, `ta`, `te`, `tg`, `th`, `tk`, `tr`, `tt`, `ug`, `uk`, `ur`, `uz`,
-`vi`, `xh`, `yo`, `zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed
-machine-generated seed**, which each file's own header says at the
-top, and which is what #1521's translation platform is for. None has
-been read by a speaker. Correcting one needs no permission and no coordination:
-a wrong string is just wrong, and the English is one key away.
+English is the source of truth. Every translation — `af`, `ak`, `am`, `ar`,
+`as`, `az`, `be`, `bg`, `bm`, `bn`, `br`, `ca`, `ceb`, `cs`, `cy`, `da`, `de`,
+`ee`, `el`, `es`, `et`, `eu`, `fa`, `fi`, `fil`, `fo`, `fr`, `ga`, `gd`, `gl`,
+`gu`, `ha`, `haw`, `he`, `hi`, `hnj`, `hr`, `hu`, `hy`, `id`, `ig`, `is`, `it`,
+`ja`, `jv`, `ka`, `kk`, `km`, `kn`, `ko`, `ky`, `lg`, `ln`, `lo`, `lt`, `lv`,
+`mg`, `mi`, `mk`, `ml`, `mn`, `mr`, `ms`, `mt`, `my`, `nb`, `ne`, `nl`, `ny`,
+`om`, `or`, `pa`, `pl`, `ps`, `pt`, `ro`, `ru`, `rw`, `sd`, `si`, `sk`, `sl`,
+`sm`, `sn`, `so`, `sq`, `sr`, `st`, `su`, `sv`, `sw`, `ta`, `te`, `tg`, `th`,
+`ti`, `tk`, `tn`, `tr`, `tt`, `ug`, `uk`, `ur`, `uz`, `vi`, `wo`, `xh`, `yo`,
+`zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed machine-generated seed**, which
+each file's own header says at the top, and which is what #1521's translation
+platform is for. None has been read by a speaker. Correcting one needs no
+permission and no coordination: a wrong string is just wrong, and the English
+is one key away.
 
-Twenty-nine of them are deliberately partial, all in the same place: Somali,
+Thirty-nine of them are deliberately partial, all in the same place: Somali,
 Hmong Njua, Amharic, Assamese, Nepali, Burmese, Pashto, Sindhi, Uyghur,
 Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa, Kinyarwanda, Nyanja,
 Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano, Malagasy, Māori,
-Samoan and Hawaiian leave `element-name` and `element-anion-name` out, so those
-130 keys fall back to English and `lint:i18n` reports the gap.
+Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona, Southern Sotho,
+Setswana, Tigrinya and Ganda leave `element-name` and `element-anion-name`
+out, so those 130 keys fall back to English and `lint:i18n` reports the gap.
 The first nine have no settled chemical nomenclature to seed from, and
 inventing one would be worse than the English a student meets in their own
 textbook. Kannada has two — native coinages reaching a dozen elements and
@@ -95,7 +97,7 @@ current one is English: Punjabi secondary chemistry uses the English terms, the
 Philippines teaches science in English from the intermediate grades, and
 Vietnamese school chemistry has moved from the transliterated names to the
 IUPAC forms, so in each case the fallback is already what the curriculum uses.
-The eight from the sub-Saharan batch are that same case for a different
+The eight from the first sub-Saharan batch are that same case for a different
 reason: secondary science is taught in English, French or Afrikaans across all
 of them, so the fallback *is* the curriculum. Afrikaans and Swahili are the two
 of that batch that do have a settled list and supply it.
@@ -121,6 +123,16 @@ Indonesian-language textbooks, so the scientific names are the Indonesian ones
 known long before the elements were — «wesi» and «beusi» for iron, «walirang»
 for sulfur, «warangan» for arsenic — which is where the two catalogs differ
 from `id` and from each other.
+
+All ten of the second sub-Saharan batch — Wolof, Bambara, Akan, Ewe, Lingala,
+Shona, Southern Sotho, Setswana, Tigrinya and Ganda — are partial too, and
+unlike the batches above them they split no ways at all: every one of the ten
+is the school-system case. Secondary science is taught in English across
+Ghana, Zimbabwe, Botswana, Lesotho, Uganda, Eritrea and Tigray, and in French
+across Senegal, Mali and both Congos, so in all ten the fallback *is* the
+curriculum. That is a fact about ten education ministries rather than about ten
+languages, which is why it reads as one sentence here and takes a sentence of
+its own in each catalog's header.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -230,6 +242,41 @@ deployment that wants krama or lemes supplies its own catalog as
 `localeResources`, which wins over the shipped one; correcting these files
 sentence by sentence toward a different level is what would leave the locale in
 two registers at once.
+
+The second sub-Saharan batch adds three naming cases and no direction case:
+nine of the ten are Latin-script, and Tigrinya's Ge'ez runs left to right, so
+none of them needs anything from `direction.ts`.
+
+`lg` appears in `<document lang>`'s autocomplete as **Ganda** rather than
+Luganda, for the same reason Chichewa appears as Nyanja: `Intl.DisplayNames`
+renders it that way and `supportedLocales.ts` is derived rather than
+hand-written. `st` is likewise **Southern Sotho** and not Sesotho, and `tn` is
+**Tswana** and not Setswana. In all three the two names are one language, and
+all three catalogs' headers say so.
+
+`ak` is the macrolanguage, and the catalog is written in **Asante Twi** — the
+variety Ghanaian schooling and publishing use and what CLDR fills a bare `ak`
+in as. It is the one locale in this batch that needs an entry in
+`LANGUAGE_ALIASES`, and it is the Norwegian case a second time: `tw` is the
+retired code for Twi, `Intl.getCanonicalLocales` leaves it alone rather than
+rewriting it the way it rewrites `iw` and `in`, and a hand-typed
+`<document lang="tw">` would otherwise fall to English with nothing to say why.
+So `negotiate.ts` maps `tw` to `ak`. Fante is deliberately left out, exactly as
+Nynorsk is: it is a written standard of its own, and answering `fat` with an
+Asante Twi catalog would be a substitution rather than a canonicalization.
+`negotiate.test.ts` holds both halves against the real roster.
+
+None of the other nine needs an alias — `wo-SN`, `bm-ML`, `ee-GH`, `ee-TG`,
+`ln-CD`, `sn-ZW`, `st-LS`, `st-ZA`, `tn-BW`, `ti-ER`, `ti-ET` and `lg-UG` all
+filter to their catalogs unaided.
+
+Setswana and Southern Sotho are close enough that it is worth recording why
+they are two files rather than one with a script tag: they are two standard
+languages with two orthographies and two vocabularies. `locales/tn` writes
+«kgotsa» where `locales/st` writes «kapa», «boammaaruri» where it writes
+«nnete», and «-hibidu» where it writes «-fubedu». Copying either over the other
+would be wrong in both, which is the same reason `hr` is a directory of its own
+rather than a script of `sr`.
 
 A catalog's **comments are in English** whatever it translates into: its
 header, its `##` group headings, and the notes explaining a wording choice.

--- a/packages/i18n/locales/ak/chrome.ftl
+++ b/packages/i18n/locales/ak/chrome.ftl
@@ -1,0 +1,142 @@
+# Akan viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Asante Twi, as `content.ftl`'s header sets out.
+#
+# Akan has two plural categories, and CLDR puts **zero** in the `one` branch
+# with it — so nothing here can lean on the category to say "no ...". A noun
+# marks its plural with a prefix rather than a suffix: «kratafa» a page,
+# «nkratafa» pages. But the two nouns these messages count — «mmɔdenbɔ» an
+# attempt, «mmuaeɛ» an answer — carry that prefix in the singular already and
+# have one shape for both numbers, so the selects are dropped and a `[one]`
+# differing from its `[other]` would be wrong rather than merely redundant.
+# `attempts-remaining` keeps its `[0]` branch, which is an exact-value match
+# ahead of the category and says «biara nka ho» instead of counting to zero.
+
+
+## Answer submission
+
+answer-checking = Ɛrehwɛ...
+answer-submitting = Ɛrema akɔ...
+
+answer-checking-status = Ɛrehwɛ mmuaeɛ no
+answer-submitting-status = Ɛrema mmuaeɛ no akɔ
+
+answer-correct = Ɛteɛ
+answer-incorrect = Ɛnteɛ
+
+answer-response-saved = Wɔakora Mmuaeɛ No So
+
+answer-percent-credit = { $percent }% Nsɛkyerɛ
+answer-percent-correct = { $percent }% Ɛteɛ
+answer-percent-short = { $percent } %
+
+max-credit-available = Nsɛkyerɛ kɛseɛ a wobɛnya: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] mmɔdenbɔ biara nka ho
+       *[other] mmɔdenbɔ { $count } na aka
+    }
+
+validation-correct = (Ɛteɛ)
+validation-incorrect = (Ɛnteɛ)
+validation-partially-correct = (Ɛfã teɛ)
+
+answer-show-responses = Kyerɛ mmuaeɛ { $count } a wɔde maa { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Nsɛm a Ɛfiri Mu
+
+collapsible-click-to-open = (mia na bue)
+collapsible-click-to-close = (mia na to mu)
+
+collapsible-initializing = Ɛrefiri aseɛ...
+
+footnote-show = Kyerɛ ase nkaeɛ
+footnote-hide = Fa ase nkaeɛ sie
+
+description-more-information = nsɛm foforɔ
+
+
+## Controls
+
+slider-previous = Akyire
+slider-next = Anim
+
+keyboard-open = Bue Kiibɔɔd
+keyboard-close = To Kiibɔɔd Mu
+
+choice-input-remove-choice = Yi { $choice } firi mu
+
+matrix-remove-row = Yi santene firi mu
+matrix-add-row = Fa santene ka ho
+matrix-remove-column = Yi adum firi mu
+matrix-add-column = Fa adum ka ho
+
+subset-add-remove-points = Fa pɔint ka ho/Yi firi mu
+subset-toggle-points-intervals = Sesa pɔint ne ntam
+subset-move-points = Twe Pɔint No
+subset-clear = Popa
+
+# A `box` here is one orbital, drawn as a square: «adaka».
+orbital-add-row = Fa Santene Ka Ho
+orbital-remove-row = Yi Santene Firi Mu
+orbital-add-box = Fa Adaka Ka Ho
+orbital-remove-box = Yi Adaka Firi Mu
+orbital-add-up-arrow = Fa Bɛmma A Ɛkyerɛ Soro Ka Ho
+orbital-add-down-arrow = Fa Bɛmma A Ɛkyerɛ Fam Ka Ho
+orbital-remove-arrow = Yi Bɛmma Firi Mu
+
+orbital-row-label = Santene { $row } din
+
+pretzel-answer = Mmuaeɛ
+
+summary-statistics-caption = { $column } ho akontabuo tiawa
+
+
+## Math input
+
+math-input-preview-region = akontabuo nkyerɛwee ho nhwɛ
+math-input-preview = Nhwɛ
+math-input-invalid-expression = Nkyerɛwee no nteɛ:
+
+
+## Document status
+
+viewer-initializing = Ɛrefiri aseɛ...
+
+
+## Errors
+
+error-heading = Mfomsoɔ
+
+error-found-at =
+    { $span ->
+        [line] Wohunuu no wɔ layin { $startLine } so.
+       *[lines] Wohunuu no wɔ layin { $startLine }–{ $endLine } so.
+    }
+
+document-contains-errors = Mfomsoɔ wɔ krataa yi mu!
+
+diagnostic-heading-error = Mfomsoɔ
+diagnostic-heading-warning = Kɔkɔbɔ
+diagnostic-heading-information = Nsɛm
+diagnostic-heading-hint = Akwankyerɛ
+
+accessibility-heading-level-1 = WCAG AA Nhyehyɛeɛ A Wɔabu So
+accessibility-heading-level-2 = Nkɔmu-kwan ho kɔkɔbɔ
+
+something-went-wrong = Biribi ansi yie.
+
+renderer-load-failed = ɔkyerɛfoɔ baako antumi amma. Yɛsrɛ wo, san fa kratafa no bra.
+
+core-start-failed = Krataa kyerɛfoɔ no antumi anfiri aseɛ. Yɛsrɛ wo, san fa kratafa no bra.

--- a/packages/i18n/locales/ak/content.ftl
+++ b/packages/i18n/locales/ak/content.ftl
@@ -1,0 +1,254 @@
+# Akan content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `ak` is the macrolanguage, and the catalog is written in **Asante Twi**, the
+# variety Ghanaian schooling and publishing use most and the one CLDR fills a
+# bare `ak` in as. `tw` — the retired code for Twi — reaches this file through
+# `LANGUAGE_ALIASES` in `negotiate.ts`, because nothing canonicalizes it on its
+# own. Fante readers arriving under `fat` reach English rather than this, and
+# deliberately so: a second catalog beside this one is the answer, not a
+# widening of this one.
+#
+# Akan has no grammatical gender, no article and no case, so `$gender` and
+# `$role` go unused here exactly as they do in English.
+#
+# Adjectives follow the noun — «nsensanee kɛseɛ kɔkɔɔ» — so the composition
+# messages put the noun first and keep the English order among the adjectives
+# themselves.
+#
+# The geometric nouns are the Twi ones Ghanaian school mathematics uses, and
+# they are built rather than borrowed: «ahinasa» a triangle, «ahinanan» a
+# four-sided figure, «ahinapii» a polygon, all on «ahina», a side. Where no
+# such word has settled the catalog borrows and spells the loan the way Twi
+# writes it — «vɛkta», «parabola», «fankshɔn».
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black = tuntum
+    .white = fitaa
+    .gray = nsõ
+    .red = kɔkɔɔ
+    .orange = ankaa
+    .yellow = akokɔsradeɛ
+    .green = ahabammono
+    .cyan = siyan
+    .blue = bruu
+    .purple = beredum
+    .pink = pinki
+    .brown = dɔteɛ
+
+line-width =
+    .thick = kɛseɛ
+    .thin = ketewa
+
+# Written as «a ɛwɔ …» relative phrases rather than as adjectives, so that they
+# can close the description. `style-stroke` puts them last for that reason.
+line-style =
+    .dashed = a ɛwɔ ntwaa
+    .dotted = a ɛwɔ nsɛnkyerɛnne
+
+fill-style =
+    .horizontal = nsensanee a ɛdeda hɔ
+    .vertical = nsensanee a ɛgyina
+    .diagonal = nsensanee a ɛkyea
+    .backdiagonal = nsensanee a ɛkyea kɔ akyire
+    .dots = nsɛnkyerɛnne
+    .diamonds = daemɔn
+
+noun =
+    .line = nsensanee
+    .line-segment = nsensanee fã
+    .ray = nsensanee-kwan
+    .vector = vɛkta
+    .curve = nkyea
+    .function = fankshɔn
+    .parabola = parabola
+    .polyline = nsensanee pii
+    .polygon = ahinapii
+    .triangle = ahinasa
+    .rectangle = ahinanan tenten
+    .circle = kanko
+    .region = beaeɛ
+    .point = pɔint
+    .square = ahinanan pɛ
+    .diamond = daemɔn
+    .cross = mmeamudua
+    .plus = kabom sɛnkyerɛnne
+
+# The side count follows the adjectives, behind «a ɛwɔ», because Twi closes a
+# noun phrase with a relative rather than opening one: «ahinapii pɛpɛɛpɛ kɔkɔɔ
+# a ɛwɔ ahina 5».
+noun-regular-polygon =
+    { $part ->
+        [tail] a ɛwɔ ahina { $numSides }
+       *[head] ahinapii pɛpɛɛpɛ
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = a wɔahyɛ mu ma
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } a ɛwɔ { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } a ɛwɔ { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } a ɛwɔ { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Twi has no article and joins the complement with the invariable «a ɛwɔ», so
+# all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] a ɛwɔ ano { $border }
+        [and] a ɛwɔ ano { $border }
+        [and-article] a ɛwɔ ano { $border }
+       *[with] a ɛwɔ ano { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = a wɔnhyɛɛ mu ma
+
+style-text =
+    { $parts ->
+        [background] { $color } wɔ akyire { $background } so
+       *[plain] { $color }
+    }
+
+style-background-none = biara nni hɔ
+
+
+## Boolean words
+
+boolean-true = nokware
+boolean-false = atorɔ
+
+
+## Answer buttons
+
+answer-submit-label = Hwɛ Adwuma No
+answer-submit-label-no-correctness = Fa Mmuaeɛ No Kɔ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Dwumadie
+    .aside = Nkyɛn asɛm
+    .cascade = Nsuotene
+    .definition = Nkyerɛaseɛ
+    .example = Nhwɛsoɔ
+    .exercise = Nsɔhwɛ
+    .exercises = Nsɔhwɛ
+    .given-answer = Mmuaeɛ
+    .note = Nkaeɛ
+    .objectives = Botaeɛ
+    .paragraphs = Nkyekyɛmu
+    .part = Ɔfa
+    .problem = Ɔhaw
+    .problems = Nhaw
+    .proof = Adanseɛ
+    .question = Asɛmmisa
+    .section = Ɔfa
+    .solution = Nsɛmmuaeɛ
+    .task = Adwuma
+    .theorem = Teɔrɛm
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Akwankyerɛ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabo { $enumeration }
+        [numbered-title] Tabo { $enumeration }{ ": " }
+        [unnumbered-title] Tabo{ ": " }
+       *[unnumbered] Tabo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Mfoni { $enumeration }
+        [numbered-caption] Mfoni { $enumeration }{ ": " }
+        [unnumbered-caption] Mfoni{ ": " }
+       *[unnumbered] Mfoni
+    }
+
+
+## Paginator controls
+
+paginator-previous = Deɛ ɛdi kan
+paginator-next = Deɛ ɛdi soɔ
+paginator-page = Kratafa
+
+paginator-page-status = { $pageLabel } { $currentPage } wɔ { $numPages } mu
+
+
+## Piecewise functions
+
+piecewise-condition-or = anaasɛ
+piecewise-condition-if = sɛ
+piecewise-condition-otherwise = sɛ ɛnte saa a
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Ghanaian secondary science is
+# taught in English throughout, so a student meeting these words meets them in
+# English already, and the seed has no settled Twi list to reproduce. A speaker
+# adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kemikal Sɛnkyerɛnne A Ɛnteɛ
+chemistry-invalid-ionic-compound = Ayɔn Nkabom A Ɛnteɛ

--- a/packages/i18n/locales/ak/diagnostics.ftl
+++ b/packages/i18n/locales/ak/diagnostics.ftl
@@ -1,0 +1,618 @@
+# Akan diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Asante Twi, as `content.ftl`'s header sets out.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Twi verb takes no number from its
+# subject, and the argument is a list either way. So those selects are dropped
+# and the count argument goes unused.
+#
+# A line of the author's source is a «layin»; «nsensanee», which `content.ftl`
+# uses, is the geometric line a document draws.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = Sɛ wɔka awieeɛ pɔint mmienu no ho asɛm a, wɔmfa { $attributes } nyɛ hwee
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = Sɛ wɔka awieeɛ pɔint ne mfimfini pɔint nyinaa ho asɛm a, wɔmfa { $attributes } nyɛ hwee
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset nyɛ hwee sɛ mfimfini pɔint nni hɔ a
+
+## `<line>`
+
+line-points-undetermined-dimensions = Nsensanee no fa pɔint a wɔnhunu wɔn tɛtrɛtɛ so.
+
+line-points-too-few-dimensions = Ɛsɛ sɛ nsensanee no fa pɔint a wɔwɔ tɛtrɛtɛ mmienu firi aseɛ so.
+
+line-points-depend-on-variables = Nsensanee no fa pɔint a wɔgyina nsakraeɛ so: { $variables }.
+
+line-equation-invalid-format = Nhyehyɛeɛ no nteɛ mma nsensanee kyekyeremu wɔ nsakraeɛ { $variable1 } ne { $variable2 } mu.
+
+## `<ray>`
+
+ray-overprescribed-through = Wɔde through, endpoint ne direction nyinaa akyerɛ nsensanee-kwan no. Wɔmfa through a wɔkaeɛ no nyɛ hwee.
+
+ray-dimension-mismatch = numDimensions nhyia wɔ nsensanee-kwan no mu.
+
+## `<vector>`
+
+vector-overprescribed-head = Wɔde head, tail ne displacement nyinaa akyerɛ vɛkta no. Wɔmfa head a wɔkaeɛ no nyɛ hwee.
+
+vector-dimension-mismatch = numDimensions nhyia wɔ vɛkta no mu.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ɛntumi ntwe nkɔ `<{ $component }>` so ɛfiri sɛ ɔnni tebea nsakraeɛ nearestPoint.
+
+constrain-to-without-nearest-point = Ɛntumi nkyekyere nkɔ `<{ $component }>` so ɛfiri sɛ ɔnni tebea nsakraeɛ nearestPoint.
+
+constrain-to-interior-without-nearest-point = Ɛntumi nkyekyere nkɔ `<{ $component }>` mu ɛfiri sɛ ɔnni tebea nsakraeɛ nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = Wɔmfa labelPosition nyɛ hwee wɔ choiceInput a ɛnyɛ layin baako so
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Wɔmfa indɛks a wɔkaeɛ nyɛ hwee wɔ choiceInput ho ɛfiri sɛ indɛks dodoɔ ne choice mma dodoɔ nhyia.
+
+pretzel-indices-count-mismatch = Wɔmfa indɛks a wɔkaeɛ nyɛ hwee wɔ problem ho ɛfiri sɛ indɛks dodoɔ ne problem mma dodoɔ nhyia.
+
+shuffle-indices-count-mismatch = Wɔmfa indɛks a wɔkaeɛ nyɛ hwee wɔ shuffle ho ɛfiri sɛ indɛks dodoɔ ne nneɛma dodoɔ nhyia.
+
+indices-ignored-out-of-range = Wɔmfa indɛks a wɔkaeɛ nyɛ hwee wɔ { $component } ho ɛfiri sɛ indɛks bi wɔ ɛfa a wɔatwa no akyi.
+
+pretzel-indices-repeated = Wɔmfa indɛks a wɔkaeɛ nyɛ hwee wɔ pretzel ho ɛfiri sɛ wɔasan aka indɛks bi.
+
+pretzel-circuit-first-index = Wɔmfa indɛks a wɔkaeɛ nyɛ hwee wɔ pretzel circuit mu ɛfiri sɛ ɛsɛ sɛ indɛks a ɛdi kan yɛ 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Sɛ `<{ $component }>` bɛyɛ adwuma ne nkyerɛwee suban mma a, ɛsɛ sɛ wɔka su `type` ho asɛm.
+
+invalid-type-defaulting-to-math = type { $type } nteɛ mma adeɛ { $component }. Ɛsɛ sɛ ɛyɛ math, text, number anaa boolean. Wɔde math sisi ananmu.
+
+string-not-valid-component-to-arrange = Nkyerɛwee "{ $value }" nyɛ { $component } adeɛ a ɛteɛ. Wɔmfa nyɛ hwee.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } nteɛ, wɔde number sisi type ananmu.
+
+invalid-variable-value = Nsakraeɛ gyinaboɔ nteɛ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Ɛsɛ sɛ suban indɛks { $index } yɛ nɔma
+
+variant-index-must-be-integer = Ɛsɛ sɛ suban indɛks { $index } yɛ nɔma mua
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Wɔnyɛɛ `<{ $component }>` a nsusuiɛ pɔtee wɔ mu bi da. Wɔde tɛtrɛtɛ no si nkyɛmu so.
+
+side-by-side-absolute-margins = Wɔnyɛɛ `<{ $component }>` a nsusuiɛ pɔtee wɔ mu bi da. Wɔde nkyɛn no si nkyɛmu so.
+
+side-by-side-no-block-child = `<{ $component }>` nteɛ: ɛsɛ sɛ ɛwɔ blɔk suban ɔba baako firi aseɛ.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Wɔmfa su `for` a ɛwɔ mfoni `<label>` so nyɛ hwee.
+
+label-for-must-resolve-to-one = Ɛsɛ sɛ su `for` a ɛwɔ `<label>` so kyerɛ adeɛ baako pɛ.
+
+label-for-unresolved = Su `for` a ɛwɔ `<label>` so antumi ankyerɛ adeɛ biara.
+
+label-for-answer-with-authored-inputs = Su `for` a ɛwɔ `<label>` so kyerɛ `<answer>` a ɔwɔ nsɛm-hyɛmu a wɔatwerɛ; kyerɛ nsɛm-hyɛmu no ankasa.
+
+label-for-answer-without-input = Su `for` a ɛwɔ `<label>` so kyerɛ `<answer>` a ɔnni nsɛm-hyɛmu a wɔbɛto no din.
+
+label-for-must-reference-input-or-answer = Ɛsɛ sɛ su `for` a ɛwɔ `<label>` so kyerɛ nsɛm-hyɛmu anaa mmuaeɛ.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Nkɔmu-kwan ho nti, ɛsɛ sɛ `<{ $component }>` wɔ nkyerɛaseɛ tiawa anaasɛ wɔka sɛ ɔyɛ nsiesie deɛ.
+
+accessibility-video-short-description = Nkɔmu-kwan ho nti, ɛsɛ sɛ `<video>` wɔ nkyerɛaseɛ tiawa.
+
+accessibility-input-short-description-or-label = Nkɔmu-kwan ho nti, ɛsɛ sɛ `<{ $component }>` wɔ nkyerɛaseɛ tiawa anaa din.
+
+accessibility-answer-input-short-description-or-label = Nkɔmu-kwan ho nti, ɛsɛ sɛ `<answer>` a ɔbɔ nsɛm-hyɛmu wɔ nkyerɛaseɛ tiawa anaa din.
+
+accessibility-short-description-contains-math = Ɛnsɛ sɛ akontabuo nneɛma sɛ `<{ $component }>` wɔ nkyerɛaseɛ tiawa no mu. Fa nsɛm ka akontabuo biara ho asɛm.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } nsonsonoeɛ no nnɔɔso mma ɔfa ti nkyerɛwee (esum tebea) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ɛsɛ sɛ ɛyɛ { $threshold }:1 firi aseɛ).
+       *[other] { $colorName } nsonsonoeɛ no nnɔɔso mma ɔfa ti nkyerɛwee ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ɛsɛ sɛ ɛyɛ { $threshold }:1 firi aseɛ).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wɔnyɛɛ `<circle>` a ɛfa pɔint { $count } so bi da wɔ berɛ a saa pɔint no nni nɔma gyinaboɔ.
+
+circle-too-many-through-points = Ɛntumi mmu kanko a ɛfa pɔint 3 boro so ho akontaa.
+
+circle-overprescribed-radius-center-points = Ɛntumi mmu kanko a wɔaka ne rediɔs, ne mfimfini ne pɔint a ɛfa so nyinaa ho asɛm ho akontaa.
+
+circle-center-with-multiple-points = Ɛntumi mmu kanko a wɔaka ne mfimfini ho asɛm na ɛfa pɔint 1 boro so ho akontaa.
+
+circle-radius-too-small = Ɛntumi mmu kanko ho akontaa: ɛfiri sɛ pɔint mmienu no ntam kwan yɛ { $distance }, rediɔs { $radius } a wɔkaeɛ no sua dodo.
+
+circle-radius-with-many-points = Ɛntumi mmɔ kanko a ɛfa pɔint mmienu boro so a rediɔs a wɔkaeɛ ka ho.
+
+circle-invalid-center-or-through-points = Kanko no mfimfini anaa pɔint a ɛfa so no nteɛ.
+
+circle-radius-center-with-multiple-points = Ɛntumi mmu kanko a wɔaka ne mfimfini ho asɛm na ɛfa pɔint 1 boro so no rediɔs ho akontaa.
+
+circle-change-radius-non-numerical = Ɛntumi nsesa kanko a ɛfa pɔint a wɔnni nɔma gyinaboɔ so no rediɔs
+
+circle-radius-with-points-non-numerical = Ɛntumi mmɔ kanko a ɛfa pɔint baako boro so a rediɔs a wɔkaeɛ ka ho wɔ berɛ a nɔma gyinaboɔ nni hɔ.
+
+circle-change-center-non-numerical = Wɔnsesaa kanko a ɛfa pɔint a wɔnni nɔma gyinaboɔ so no mfimfini bi da.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Fankshɔn no beaeɛ tɛtrɛtɛ nnɔɔso. Beaeɛ no wɔ ntam { $intervals } nanso fankshɔn no wɔ nsɛm-hyɛmu { $inputs }.
+
+function-domain-invalid-format = Fankshɔn beaeɛ nhyehyɛeɛ nteɛ.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Wɔmfa fankshɔn no soro pɔint a ɛnyɛ nɔma no nyɛ hwee.
+        [minimum] Wɔmfa fankshɔn no fam pɔint a ɛnyɛ nɔma no nyɛ hwee.
+        [extremum] Wɔmfa fankshɔn no ano pɔint a ɛnyɛ nɔma no nyɛ hwee.
+        [point] Wɔmfa fankshɔn no pɔint a ɛnyɛ nɔma no nyɛ hwee.
+        [slope] Wɔmfa fankshɔn no nkyeaeɛ a ɛnyɛ nɔma no nyɛ hwee.
+       *[other] Wɔmfa fankshɔn no { $type } a ɛnyɛ nɔma no nyɛ hwee.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Wɔmfa fankshɔn no soro pɔint a hwee nni mu no nyɛ hwee.
+        [minimum] Wɔmfa fankshɔn no fam pɔint a hwee nni mu no nyɛ hwee.
+        [extremum] Wɔmfa fankshɔn no ano pɔint a hwee nni mu no nyɛ hwee.
+        [point] Wɔmfa fankshɔn no pɔint a hwee nni mu no nyɛ hwee.
+       *[other] Wɔmfa fankshɔn no { $type } a hwee nni mu no nyɛ hwee.
+    }
+
+function-points-too-close = Fankshɔn no wɔ pɔint mmienu a ɛbɛn ho dodo. Wɔntumi nkyerɛ fankshɔn no aseɛ.
+
+function-iterates-input-output-mismatch = Fankshɔn no tumi san yɛ ne ho bio bere a nsɛm-hyɛmu dodoɔ ne deɛ ɛfiri mu ba dodoɔ yɛ pɛ. Fankshɔn yi wɔ nsɛm-hyɛmu { $inputs } ne deɛ ɛfiri mu ba { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Nsatoa no tenten nteɛ. Ɛsɛ sɛ ɛyɛ nɔma mua a ɛnyɛ fam-nɔma.
+
+sequence-invalid-step = Nsatoa no anammɔn nteɛ. Wɔ { $type } suban nsatoa mu no, ɛsɛ sɛ ɛyɛ nɔma.
+
+sequence-invalid-endpoint-number = Nɔma nsatoa no "{ $attribute }" nteɛ. Ɛsɛ sɛ ɛyɛ nɔma.
+
+sequence-invalid-endpoint-letters = Nkyerɛwde nsatoa no "{ $attribute }" nteɛ. Ɛsɛ sɛ ɛyɛ nkyerɛwde.
+
+sequence-invalid-endpoint = Nsatoa no "{ $attribute }" nteɛ.
+
+select-from-sequence-coprime-not-numbers = Wɔmfa coprime nyɛ hwee ɛfiri sɛ ɛnyɛ nɔma na wɔreyi
+
+select-from-sequence-coprime-with-exclude-combinations = Wɔmfa coprime nyɛ hwee ɛfiri sɛ wɔaka excludeCombinations ho asɛm
+
+## Resolving a `target`
+
+target-not-found = target nteɛ wɔ `<{ $source }>` mu: wɔanhunu deɛ ɛkyerɛ no.
+
+target-state-variable-not-found = target nteɛ wɔ `<{ $source }>` mu: wɔanhunu tebea nsakraeɛ a ne din yɛ "{ $property }" wɔ `<{ $component }>` mu.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Ɛsɛ sɛ `<odeSystem>` nsakraeɛ no yɛ soronko firi nsakraeɛ a ɛgyina ne ho so no ho.
+
+ode-system-duplicate-variable-names = Ɛntumi nkyerɛ ODE RHS fankshɔn aseɛ berɛ a nsakraeɛ din bi asan aba.
+
+ode-system-rhs-function-error = Ɛntumi nkyerɛ ODE RHS fankshɔn aseɛ. Mfomsoɔ sii berɛ a wɔrebɔ mathjs fankshɔn no.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ɛntumi nkyerɛ nsensanee { $count } ntam kɔn aseɛ
+
+angle-invalid-through-point = Pɔint no nteɛ wɔ `<angle>` through mu
+
+parabola-vertex-too-many-points = Wɔnyɛɛ parabola a ɔwɔ soro pɔint na ɛfa pɔint 1 boro so bi da.
+
+parabola-too-many-points = Wɔnyɛɛ parabola a ɛfa pɔint 3 boro so bi da.
+
+intersection-too-many-items = Wɔnyɛɛ nneɛma mmienu boro so ntwitwaeɛ bi da
+
+## Other math components
+
+ionic-compound-not-two-ions = Wɔnyɛɛ ayɔn nkabom a ɛboro ayɔn mmienu so bi da.
+
+ionic-compound-needs-cation-and-anion = Wɔyɛɛ ayɔn nkabom maa katayɔn baako ne anayɔn baako pɛ.
+
+solve-equations-cannot-evaluate = Ɛntumi nnyina kyekyeremu no ano ɛfiri sɛ wɔantumi ammu ho akontaa: { $equation }
+
+math-operators-operand-number-required = Ɛsɛ sɛ wɔka operandNumber ho asɛm berɛ a wɔreyi akontabuo adwumayɛfoɔ.
+
+eigen-decomposition-failed = Ɛntumi mmu matriks no eigen gyinaboɔ ho akontaa
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: paramɛta { $parameters } nni nhyehyɛeɛ no mu, enti wɔbɛhyia hwee daa.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ɛntumi nkyerɛ grid="{ $grid }" aseɛ. Ɛsɛ sɛ ɛyɛ none, medium, dense, anaa nɔma pɔsitif mmienu a ntam da wɔn ntam, sɛ grid="1 0.5". Wɔntwe girid biara.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure kyerɛfoɔ no nnye xLabelPosition="left" ntom; nifa fa nneyɛeɛ na ɛreyɛ adwuma.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure kyerɛfoɔ no nnye yLabelPosition="bottom" ntom; soro fa nneyɛeɛ na ɛreyɛ adwuma.
+
+prefigure-invalid-axis-bounds = `<graph>`: aksis ano nteɛ mma prefigure nsakraeɛ; bbox (-10,-10,10,10) na ɛreyɛ adwuma.
+
+prefigure-invalid-width = `<graph>`: tɛtrɛtɛ no nteɛ mma prefigure nsakraeɛ; mfoni tɛtrɛtɛ 425 na ɛreyɛ adwuma.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio nteɛ mma prefigure nsakraeɛ; nsusuiɛ 1 na ɛreyɛ adwuma.
+
+prefigure-grid-spacing-too-fine = `<graph>`: girid ntam no sua dodo mma aksis ano no; wɔgyaee girid wɔ prefigure kyerɛfoɔ no mu.
+
+prefigure-annotations-not-rendered = `<graph>`: wɔrenkyerɛ nkaeɛ berɛ a PreFigure kyerɛfoɔ nyɛ adwuma.
+
+multiple-annotations-children = Wɔhunuu `<annotations>` mma pii wɔ `<graph>` mu; wɔmfa wɔn nyinaa nyɛ hwee gye deɛ ɔtwa toɔ.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ɛntumi ntrɛ anaa ɛnkopi adeɛ suban a wɔnnim: { $type }.
+
+copy-prop-not-found = Wɔanhunu su { $property } wɔ { $component } suban adeɛ so
+
+collect-no-source = Wɔanhunu fibea biara mma collect.
+
+collect-invalid-component-type = Ɛntumi mmoaboa `<{ $component }>` suban nneɛma ano ɛfiri sɛ ɛyɛ adeɛ suban a ɛnteɛ.
+
+reference-index-unavailable = Ɛntumi nkyerɛ indɛks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ɛntumi mfrɛ { $action } wɔ adeɛ `{ $reference }` so
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Nsɛm no nhyehyɛeɛ nteɛ. Santene no tenten nyɛ pɛ. Wɔhunuu no wɔ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Adum din bi asan aba nsɛm no mu. Wɔhunuu no wɔ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Adum din bi nni nsɛm no mu. Wɔhunuu no wɔ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Mmuaeɛ yi award baako gyina mmuaeɛ a answer tagi no ankasa de kɔeɛ so, na ɛno bɛma nneyɛeɛ a wɔnhwɛ kwan aba.
+
+answer-max-num-attempts-in-section-wide-check-work = Sɛ wode `maxNumAttempts` si `<answer>` a ɛwɔ adaka a `sectionWideCheckWork` wɔ so mu so a, ɛnyɛ hwee, ɛfiri sɛ saa adaka no na ɛhwɛ mmɔdenbɔ dodoɔ so. Fa `maxNumAttempts` si adaka no ankasa so.
+
+nested-section-wide-check-work-max-num-attempts = Sɛ wode `maxNumAttempts` si adaka a `sectionWideCheckWork` wɔ so a ɛwɔ adaka foforɔ a `sectionWideCheckWork` nso wɔ so mu so a, ɛnyɛ hwee, ɛfiri sɛ adaka a ɛwɔ akyire no na ɛhwɛ mmɔdenbɔ dodoɔ so. Fa `maxNumAttempts` si adaka a ɛwɔ akyire no so.
+
+answer-attributes-need-symbolic-equality = Su { $attributes } renyɛ hwee sɛ wɔansi symbolicEquality a.
+
+answer-invalid-type = Suban no nteɛ mma mmuaeɛ no: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ɛfiri sɛ adeɛ `<{ $component }>` nni din no, wɔntumi mfa nyɛ module su
+
+module-attribute-name-already-defined = Wɔntumi mfa adeɛ `<{ $component } name="{ $name }">` nyɛ module su ɛfiri sɛ adeɛ suban `<module>` wɔ su a ne din yɛ "{ $name }" dada.
+
+conditional-content-condition-ignored = Wɔmfa su `condition` nyɛ hwee wɔ adeɛ `<conditionalContent>` a ɔwɔ case anaa else mma so.
+
+slider-markers-type-mismatch = Nsɛnkyerɛnne suban ne slider suban nhyia.
+
+pretzel-problem-needs-statement-and-answer = pretzel nteɛ: ɛsɛ sɛ `<problem>` biara wɔ `<statement>` baako ne `<answer>` baako.
+
+pretzel-circuit-first-problem-distractor = pretzel nteɛ: wɔ mode="circuit" mu no, `<problem>` a ɛdi kan no ntumi nyɛ nnaadaa deɛ.
+
+## Attribute values
+
+attribute-invalid-values = Gyinaboɔ { $values } nteɛ mma su `{ $attribute }`; wɔmfa nyɛ hwee.
+
+attribute-must-be-references = Gyinaboɔ `{ $value }` nteɛ mma su `{ $attribute }`. Ɛsɛ sɛ su no yɛ nkyerɛ a ɛfiri `$` aseɛ.
+
+math-input-invalid-function-names = <mathInput>: wɔmfa fankshɔn din a ɛnteɛ a ɛwɔ { $attribute } mu nyɛ hwee: { $names }. Ɛsɛ sɛ din biara kyerɛ-fa wɔ nkyerɛwde 2 firi aseɛ (nkyerɛwde anaa nsensanee); `|<mathspeak alternative>` bɛtumi adi akyire.
+
+## Building components from the source
+
+component-type-invalid = Adeɛ suban no nteɛ: `<{ $componentType }>`
+
+attribute-repeated = Wɔntumi nsan nka su { $attribute } bio.
+
+attribute-invalid-for-component = Su "{ $attribute }" nteɛ mma `<{ $componentType }>` suban adeɛ.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Nsiesie nkyerɛaseɛ { $styleNumber } nsonsonoeɛ nnɔɔso mma { $context ->
+        [text-on-background] nkyerɛwee kɔla ne akyire kɔla
+        [high-contrast] nsonsonoeɛ kɛseɛ kɔla ne asaase no
+        [line] nsensanee kɔla ne asaase no
+        [marker] nsɛnkyerɛnne kɔla ne asaase no
+       *[text-on-canvas] nkyerɛwee kɔla ne asaase no
+    }{ $mode ->
+        [dark] { " (esum tebea)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ɛsɛ sɛ ɛyɛ { $threshold }:1 firi aseɛ).
+
+style-definition-dark-mode-text-background-contrast =
+    Ɛwom sɛ nsiesie nkyerɛaseɛ { $styleNumber } kaa kɔla a nsonsonoeɛ dɔɔso wɔ hann tebea mu ho asɛm deɛ, nanso esum tebea kɔla a ɛfiri mu baeɛ no nsonsonoeɛ nnɔɔso mma nkyerɛwee kɔla ne akyire kɔla ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ɛsɛ sɛ ɛyɛ { $threshold }:1 firi aseɛ). { $suggestion ->
+        [available] Sɛ wopɛ sɛ nsonsonoeɛ dɔɔso wɔ esum tebea mu a, ma hann tebea nsonsonoeɛ no nkɔ soro (sɛ nhwɛsoɔ, si { $lightAttribute }="{ $lightColor }") anaasɛ sesa esum tebea kɔla no (sɛ nhwɛsoɔ, si { $darkAttribute }="{ $darkColor }").
+       *[none] Sɛ wopɛ sɛ nsonsonoeɛ dɔɔso wɔ esum tebea mu a, ma hann tebea nsonsonoeɛ no nkɔ soro anaasɛ sesa kɔla a ɛfiri mu ba no wɔ textColorDarkMode ne/anaa backgroundColorDarkMode mu.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Ɛwom sɛ nsiesie nkyerɛaseɛ { $styleNumber } kaa nkyerɛwee kɔla a nsonsonoeɛ dɔɔso wɔ hann tebea mu ho asɛm deɛ, nanso esum tebea nkyerɛwee kɔla a ɛfiri mu baeɛ no nsonsonoeɛ nnɔɔso wɔ asaase no so ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ɛsɛ sɛ ɛyɛ { $threshold }:1 firi aseɛ). { $suggestion ->
+        [available] Sɛ wopɛ sɛ nsonsonoeɛ dɔɔso wɔ esum tebea mu a, ma hann tebea nsonsonoeɛ no nkɔ soro (sɛ nhwɛsoɔ, si textColor="{ $lightColor }") anaasɛ sesa esum tebea kɔla no (sɛ nhwɛsoɔ, si textColorDarkMode="{ $darkColor }").
+       *[none] Sɛ wopɛ sɛ nsonsonoeɛ dɔɔso wɔ esum tebea mu a, ma hann tebea nsonsonoeɛ no nkɔ soro anaasɛ sesa kɔla a ɛfiri mu ba no wɔ textColorDarkMode mu.
+    }
+
+section-multiple-style-palettes = Ɔfa bi tumi yi <stylePalette> baako pɛ; deɛ ɔtwa toɔ na ɛyɛ adwuma.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ɛntumi nhunu { $component } suban soronko ɛfiri sɛ numToSelect nyɛ nɔma mua a ɛnyɛ fam-nɔma.
+
+variant-num-to-select-not-constant-number = ɛntumi nhunu { $component } suban soronko ɛfiri sɛ numToSelect nyɛ nɔma a ɛsesa.
+
+variant-with-replacement-not-constant-boolean = ɛntumi nhunu { $component } suban soronko ɛfiri sɛ withReplacement nyɛ buulian a ɛnsesa.
+
+variant-select-weight-disables-unique = Sɛ ɔyi bi wɔ selectWeight anaa selectForVariants a, wɔto select suban soronko no mu
+
+variant-coprime-undetermined = ɛntumi nhunu { $component } suban soronko ɛfiri sɛ ɛntumi nsi so dua sɛ coprime yɛ atorɔ daa.
+
+variant-attribute-not-constant = ɛntumi nhunu { $component } suban soronko ɛfiri sɛ { $attribute } nnyina pintinn.
+
+variant-attribute-not-number = ɛntumi nhunu { $component } suban soronko ɛfiri sɛ { $attribute } nyɛ nɔma.
+
+variant-attribute-wrong-type-for-sequence =
+    ɛntumi nhunu { $component } { $type } suban soronko ɛfiri sɛ { $attribute } nyɛ { $expected ->
+        [letters-combination] nkyerɛwde nkabom
+        [math-expression] akontabuo nkyerɛwee a ɛteɛ
+        [integer] nɔma mua
+       *[number] nɔma
+    }.
+
+variant-length-not-integer = ɛntumi nhunu { $component } suban soronko ɛfiri sɛ length nyɛ nɔma mua.
+
+variant-sort-not-implemented = wɔnyɛɛ { $component } suban soronko a sort ka ho bi da
+
+variant-exclude-combinations-not-implemented = wɔnyɛɛ { $component } suban soronko a excludeCombinations ka ho bi da
+
+variant-math-exclude-not-implemented = wɔnyɛɛ { $component } math suban soronko a exclude ka ho bi da
+
+variant-non-constant-exclude-not-implemented = wɔnyɛɛ { $component } suban soronko a exclude a ɛnnyina pintinn ka ho bi da
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure kyerɛfoɔ no nnye ntom; wɔtoo aseni no twene.
+
+prefigure-descendant-invalid-geometry = { $subject }: sukuu-nsusuiɛ a ɛnni ano anaa ɛnwieeɛ; wɔtoo aseni no twene.
+
+prefigure-curve-label-omitted = { $subject }: din nnyɛ adwuma wɔ nkyea nneɛma a wɔasesa so; wɔgyaee din no.
+
+prefigure-curve-unsupported-definition-type = { $subject }: nkyea fankshɔn nkyerɛaseɛ suban '{ $definitionType }' nnye ntom; wɔtoo aseni no twene.
+
+prefigure-region-flip-functions-unsupported = { $subject }: su flipFunctions a ɛwɔ regionBetweenCurves so nnye ntom; wɔtoo aseni no twene.
+
+prefigure-region-non-formula-child = { $subject }: formula suban mma fankshɔn nko ara na wɔgye tom wɔ regionBetweenCurves mu; wɔtoo aseni no twene.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' nnye ntom mma { $labelKind ->
+        [line-family] nsensanee abusua din
+       *[point] pɔint din
+    }; PreFigure nhyehyɛeɛ na ɛreyɛ adwuma.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure nnye mahyɛ-suban '{ $fillStyle }' ntom; ɛsan kɔ kɔla baako mahyɛ so.
+
+prefigure-line-style-unknown = { $subject }: wɔnnim nsensanee suban '{ $lineStyle }' na wɔgyaee wɔ PreFigure adwuma mu.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wɔde nsɛnkyerɛnne suban '{ $markerStyle }' ahyia PreFigure suban 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure nnye nsɛnkyerɛnne suban '{ $markerStyle }' ntom; suban a ɛwɔ hɔ dada na ɛreyɛ adwuma.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` nteɛ; ɛntumi nhunu deɛ ɛkyerɛ. Wɔgyaee nkaeɛ no.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` kyerɛɛ nneɛma pii; deɛ ɛdi kan na ɛreyɛ adwuma.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` nteɛ; deɛ ɛkyerɛ no wɔ graf a ɛkura no akyi. Wɔgyaee nkaeɛ no.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` nteɛ; deɛ ɛkyerɛ no nyɛ mfoni adeɛ a wɔgye tom wɔ prefigure nsakraeɛ mu. Wɔgyaee nkaeɛ no.
+
+annotation-text-missing = `<annotation>`: `text` nni hɔ anaa hwee nni mu; nkyerɛwee a hwee nni mu na ɛreba.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wɔahunu kanko-gyinabea.
+       *[other] Wɔahunu kanko-gyinabea a ɛfa adeɛ `<{ $componentType }>` ho.
+    }
+
+reference-no-referent = Wɔanhunu biribiara mmaa nkyerɛ: `{ $reference }`
+
+reference-multiple-referents = Wɔhunuu nneɛma pii maa nkyerɛ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Nhyehyɛeɛ no nteɛ mma `<{ $componentType }>` su { $attribute }.
+
+children-invalid = Mma no nteɛ mma `<{ $componentType }>`: Wɔhunuu mma a wɔnteɛ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Gyinaboɔ `{ $value }` nteɛ mma su `{ $attribute }`, gyinaboɔ `{ $default }` na ɛreyɛ adwuma
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Wɔanhunu DoenetML nkyerɛaseɛ { $version }.
+       *[other] Wɔanhunu DoenetML nkyerɛaseɛ { $version }. Ɛsan kɔ nkyerɛaseɛ { $fallback } so
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML nteɛ: { $content }
+
+parse-tag-missing-close-tag = DoenetML nteɛ: Tagi `{ $tag }` nni to-mu tagi. Na wɔhwɛ kwan sɛ tagi a ɛto ne ho mu anaa tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML nteɛ: Mfomsoɔ wɔ tagi `<{ $tagName }>` mu
+
+parse-attribute-missing-value = DoenetML nteɛ: Ɛte sɛ deɛ su `{ $attribute }` a ɛnteɛ no nni gyinaboɔ.
+
+parse-attribute-invalid = DoenetML nteɛ: Su `{ $attribute }` nteɛ
+
+parse-attribute-value-invalid = DoenetML nteɛ: Su gyinaboɔ `{ $value }` nteɛ
+
+parse-attribute-value-quote-mismatch = DoenetML nteɛ: Su gyinaboɔ `{ $value }` nteɛ. Kasa-nsɛnkyerɛnne no nhyia. Ɛte sɛ deɛ `{ $quote }` ayera
+
+parse-open-tag-name-missing = DoenetML nteɛ: Wɔhunuu tagi a ɛnni din, sɛ `<`
+
+parse-tag-not-closed = DoenetML nteɛ: Wɔanto tagi `{ $tag }` mu (ɛte sɛ deɛ `>` ayera).
+
+parse-self-closing-tag-name-missing = DoenetML nteɛ: Wɔhunuu tagi a ɛnni din `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML nteɛ: Wɔanto tagi `{ $tag }` mu (ɛte sɛ deɛ `/>` ayera).
+
+parse-tag-invalid-attributes = DoenetML nteɛ: Tagi `{ $tag }` nteɛ. Ebia su a ɛnteɛ wɔ mu.
+
+parse-close-tag-name-missing = DoenetML nteɛ: Wɔhunuu to-mu tagi a ɛnni din, sɛ `</`
+
+parse-attribute-value-unquoted = Ɛsɛ sɛ su gyinaboɔ hyɛ kasa-nsɛnkyerɛnne mu: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML nteɛ: Wɔhunuu to-mu tagi `{ $tag }`, nanso bue-tagi a ɛne no hyia nni hɔ
+
+parse-close-tag-mismatched = DoenetML nteɛ: To-mu tagi no nhyia. Na wɔhwɛ kwan `</{ $expected }>`. Wɔhunuu `{ $found }`
+
+parser-node-unconvertible = Wɔantumi ansesa nɔdi { $node } ankɔ Dast nɔdi mu.
+
+## Names
+
+name-attribute-invalid =
+    Su name='{ $name }' nteɛ. { $reason ->
+        [characters] Din tumi nya nkyerɛwde, nɔma, ase-nsensanee anaa nsensanee nko ara.
+       *[start] Ɛsɛ sɛ din firi nkyerɛwde aseɛ.
+    }
+
+component-name-invalid-start = Adeɛ din "{ $name }" nteɛ. Ɛsɛ sɛ din firi nkyerɛwde aseɛ.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Ɛsɛ sɛ videoWatched suban mmuaeɛ wɔ su video
+
+answer-video-watched-video-not-reference = Ɛsɛ sɛ videoWatched suban mmuaeɛ wɔ su video a ɛyɛ nkyerɛ
+
+answer-name-not-single-text = Ɛsɛ sɛ mmuaeɛ su name wɔ text ɔba baako pɛ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ɛntumi nnya abɔntene DoenetML ɛfiri sɛ ɛsan kɔ ne ho so dodo. So nkyerɛ kanko bi wɔ hɔ?
+
+external-doenetml-unavailable = Ɛntumi nnya DoenetML mfiri { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML a wɔnyaa no firii { $attribute }="{ $uri }" nteɛ: ɔne adeɛ suban "{ $componentType }" nhyia
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Su `{ $from }` abɔ dada; fa `{ $to }` si ananmu.
+       *[other] [deprecation] Su `{ $from }` a ɛwɔ `<{ $component }>` so abɔ dada; fa `{ $to }` si ananmu.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Su `{ $from }` abɔ dada na wɔmfa nyɛ hwee ɛfiri sɛ wɔaka `{ $to }` nso ho asɛm.
+       *[other] [deprecation] Su `{ $from }` a ɛwɔ `<{ $component }>` so abɔ dada na wɔmfa nyɛ hwee ɛfiri sɛ wɔaka `{ $to }` nso ho asɛm.
+    }
+
+deprecated-attribute-ignored = [deprecation] Su `{ $attribute }` a ɛwɔ `<{ $component }>` so abɔ dada na wɔmfa nyɛ hwee.
+
+deprecated-attribute-to-child = [deprecation] Su `{ $attribute }` a ɛwɔ `<{ $component }>` so abɔ dada; fa `<{ $child }>` ba si ananmu.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` tumi yɛ dodoɔ wɔ Borɔfo nko ara mu, enti ne nkyerɛwee no ka hɔ saa ara wɔ krataa a wɔtwerɛeɛ wɔ { $locale } mu. Twerɛ dodoɔ suban no ankasa, anaasɛ fa si su `pluralForm` mu.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Adeɛ `<{ $tag }>` nyɛ Doenet adeɛ a wɔnim.
+
+schema-element-not-allowed-at-root = Wɔmma adeɛ `<{ $tag }>` ho kwan wɔ krataa no ntini so.
+
+schema-element-not-allowed-inside = Wɔmma adeɛ `<{ $tag }>` ho kwan wɔ `<{ $parent }>` mu.
+
+schema-attribute-unrecognized = Adeɛ `<{ $tag }>` nni su a ne din yɛ `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Ɛsɛ sɛ adeɛ `<{ $tag }>` su `{ $attribute }` yɛ nhwehwɛmu a adeɛ biara a ɛwɔ mu yɛ yeinom bi: { $allowed }
+       *[other] Ɛsɛ sɛ adeɛ `<{ $tag }>` su `{ $attribute }` yɛ yeinom bi: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Suban din no nteɛ mma select. Suban din { $variantName } wɔ ɔyi { $numOptions } mu nanso dodoɔ a wɔbɛyi yɛ { $numToSelect }.
+
+select-variant-name-without-options = Wɔkaa suban bi ho asɛm maa select nanso wɔanka ɔyi biara ho asɛm mmaa suban din a ɛbɛtumi aba: { $variantName }.
+
+select-variant-name-not-possible = Suban din { $variantName } a wɔkaa ho asɛm maa select no nyɛ suban din a ɛbɛtumi aba.
+
+select-too-few-options = Ɛntumi nyi nneɛma { $numToSelect } mfiri { $numOptions } pɛ mu.
+
+select-from-sequence-too-few-values = Ɛntumi nyi gyinaboɔ { $numToSelect } mfiri nsatoa a ne tenten yɛ { $length } mu.
+
+select-from-sequence-indices-count-mismatch = Ɛsɛ sɛ indɛks dodoɔ a wɔkaa ho asɛm maa select no ne dodoɔ a wɔbɛyi hyia
+
+select-from-sequence-indices-not-integers = Ɛsɛ sɛ indɛks a wɔkaa ho asɛm maa select nyinaa yɛ nɔma mua
+
+select-from-sequence-index-excluded = Wɔkaa selectfromsequence indɛks a wɔayi afiri mu ho asɛm
+
+select-from-sequence-indices-excluded-combination = Wɔkaa selectfromsequence indɛks a na ɛyɛ nkabom a wɔayi afiri mu ho asɛm
+
+select-from-sequence-coprime-not-positive-integers = Ɛntumi nyi nɔma a wɔne wɔn ho nni kwan nkabom ɛfiri sɛ ɛnyɛ nɔma mua pɔsitif na wɔreyi.
+
+select-from-sequence-coprime-common-factor = Ɛntumi nyi nɔma a wɔne wɔn ho nni kwan. Gyinaboɔ a ɛbɛtumi aba nyinaa wɔ ɔkyɛfoɔ baako. (Ɛsɛ sɛ gyinaboɔ a wɔkaa ho asɛm wɔ "from" anaa "to" mu no ne "step" nni kwan.)
+
+select-from-sequence-coprime-single-number = Ɛntumi nyi nɔma a wɔne wɔn ho nni kwan nkabom mfiri nɔma baako a ɛnyɛ 1 mu.
+
+select-from-sequence-excluded-too-many-combinations = Wɔayi nkabom no 70% boro so afiri selectFromSequence mu
+
+select-from-sequence-coprime-none-found = Wɔantumi anyi nɔma a wɔne wɔn ho nni kwan. Gyinaboɔ a ɛbɛtumi aba nyinaa wɔ ɔkyɛfoɔ baako.
+
+select-from-sequence-too-few-unique-values = Ɛntumi nyi gyinaboɔ soronko { $numToSelect } mfiri nsatoa a ne tenten yɛ { $numPossibleValues } mu
+
+select-prime-numbers-too-few-values = Ɛntumi nyi gyinaboɔ { $numToSelect } mfiri nɔma a wɔnkyɛ no nhwehwɛmu a ne tenten yɛ { $numValues } mu
+
+select-prime-numbers-values-count-mismatch = Ɛsɛ sɛ gyinaboɔ dodoɔ a wɔkaa ho asɛm maa select no ne dodoɔ a wɔbɛyi hyia
+
+select-prime-numbers-values-not-prime = Ɛsɛ sɛ gyinaboɔ a wɔkaa ho asɛm maa select prime number nyinaa wɔ nɔma a wɔnkyɛ no nhwehwɛmu mu
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers gyinaboɔ a wɔkaa ho asɛm no na ɛyɛ nkabom a wɔayi afiri mu
+
+select-prime-numbers-excluded-too-many-combinations = Wɔayi nkabom no 70% boro so afiri selectPrimeNumbers mu
+
+select-random-combination-fluke = Ɛnnyɛ deɛ ɛtaa si, nanso wɔantumi anyi gyinaboɔ a wɔfa no kwa nkabom
+
+select-random-value-fluke = Ɛnnyɛ deɛ ɛtaa si, nanso wɔantumi anyi gyinaboɔ a wɔfa no kwa

--- a/packages/i18n/locales/ak/editor.ftl
+++ b/packages/i18n/locales/ak/editor.ftl
@@ -1,0 +1,210 @@
+# Akan editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Asante Twi, as `content.ftl`'s header sets out.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# The nouns the counted messages here count are invariable for number, so those
+# selects are dropped — the same reason `chrome.ftl` gives.
+#
+# A line of the author's source is called a «layin», the loan the editor's own
+# users say, and not «nsensanee», which `content.ftl` keeps for the geometric
+# line a document draws.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] San Yɛ
+       *[update] Yɛ No Foforɔ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Kyerɛfoɔ No
+       *[other] { $word } Kyerɛfoɔ No { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Suban
+editor-variant-filter = Yi mu...
+editor-variant-next = Yi suban a ɛdi soɔ
+editor-variant-previous = Yi suban a ɛdi kan
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wɔahunu WCAG AA nkɔmu-kwan ho mmara a wɔabu so. Mia na { $action ->
+            [close] to
+           *[open] bue
+        } nkɔmu-kwan amanneɛbɔ no mu.
+        [advisories] Mia na { $action ->
+            [close] to
+           *[open] bue
+        } nkɔmu-kwan amanneɛbɔ no mu. Wɔanhunu WCAG AA mmara a wɔabu so biara, nanso afotuo foforɔ wɔ nkɔmu-kwan ho.
+       *[clean] Mia na { $action ->
+            [close] to
+           *[open] bue
+        } nkɔmu-kwan amanneɛbɔ no mu. Wɔanhunu nkɔmu-kwan ho ɔhaw biara.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wɔahunu WCAG AA nkɔmu-kwan ho mmara a wɔabu so. Wɔahunu WCAG AA mmara a wɔabu so { $count }. Mia na { $action ->
+            [close] to
+           *[open] bue
+        } nkɔmu-kwan amanneɛbɔ no mu.
+        [advisories] Wɔanhunu WCAG AA mmara a wɔabu so biara. Wɔahunu nkɔmu-kwan ho afotuo foforɔ { $count }. Mia na { $action ->
+            [close] to
+           *[open] bue
+        } nkɔmu-kwan amanneɛbɔ no mu.
+       *[clean] Wɔanhunu WCAG AA mmara a wɔabu so biara. Mia na { $action ->
+            [close] to
+           *[open] bue
+        } nkɔmu-kwan amanneɛbɔ no mu.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML nkyerɛaseɛ { $version }
+
+editor-tab-help = Mmoa a ɛfata asɛm no
+editor-tab-help-short = Asɛm
+editor-tab-errors = Mfomsoɔ
+editor-tab-warnings = Kɔkɔbɔ
+editor-tab-info = Nsɛm
+editor-tab-accessibility = Nkɔmu-kwan
+editor-tab-responses = Mmuaeɛ a wɔde kɔeɛ
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Nkyerɛwfoɔ nhyehyɛeɛ
+editor-format-as-doenetml = Hyehyɛ no sɛ DoenetML
+editor-format-as-xml = Hyehyɛ no sɛ XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Layin #{ $line }
+
+editor-no-errors = Mfomsoɔ Biara Nni Hɔ
+editor-no-warnings = Kɔkɔbɔ Biara Nni Hɔ
+editor-no-info = Nsɛm Ho Nhwehwɛmu Biara Nni Hɔ
+
+editor-show-info-annotations = Kyerɛ nsɛm ho nhwehwɛmu wɔ nkyerɛwfoɔ no mu
+editor-show-accessibility-annotations = Kyerɛ nkɔmu-kwan ho nhwehwɛmu wɔ nkyerɛwfoɔ no mu
+
+editor-accessibility-learn-more = Sua sɛdeɛ Doenet di nkɔmu-kwan ho dwuma
+
+editor-accessibility-violations-heading = Nkɔmu-kwan mmara a wɔabu so ({ $standard })
+
+editor-accessibility-other-heading = Nkɔmu-kwan ho nsɛm foforɔ
+editor-none-found = Wɔanhunu biribiara
+
+
+## Submitted responses
+
+editor-no-responses = Wɔmmfaa mmuaeɛ biara nkɔeɛ
+editor-response-answer-id = Mmuaeɛ Din
+editor-response-response = Mmuaeɛ
+editor-response-credit = Nsɛkyerɛ
+editor-response-submitted = Wɔde kɔeɛ
+
+
+## The context-help panel
+
+help-placeholder = Fa kɔɔsɔ no si tagi din, su anaa { $ref } so na woanya nkyerɛkyerɛmu.
+
+help-unsupported-ref-chain = Wɔntumi nyɛ nkyerɛ a ɛwɔ afaafa pii sɛ { $example } ho adwuma bi da.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Wɔanhunu biribiara mmaa nkyerɛ: { $ref }.
+        [multiple] Wɔhunuu nneɛma pii maa nkyerɛ: { $ref }.
+       *[indeterminate] Wɔantumi anhunu deɛ { $ref } kyerɛ.
+    }
+
+help-learn-about-references = Sua nkyerɛ ho ade →
+help-reference-page = Nkyerɛ kratafa →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } mu
+       *[top] Soro pɛɛ
+    }{ $allowed ->
+        [none] { " — biribiara nkɔ ha." }
+        [text] { " — twerɛ nkyerɛwee wɔ ha." }
+        [text-and-components] { " — twerɛ nkyerɛwee wɔ ha, anaasɛ sɔ yeinom hwɛ:" }
+       *[components] { " — nneɛma a wobɛtumi asɔ ahwɛ:" }
+    }
+
+help-suggestions-footer = Mia { $shortcut } na woahunu nneɛma { $total } nyinaa.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } yɛ { $target } ho nkyerɛ.
+       *[other] { $ref } yɛ { $target } ho nkyerɛ (layin { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } na ɔtoo no din sɛ { $role }.
+       *[other] { $owner } na ɔtoo no din wɔ layin { $line } so sɛ { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } yɛ { $element } su { $property } ho nkyerɛ.
+       *[other] { $ref } yɛ { $element } su { $property } ho nkyerɛ (layin { $line }).
+    }
+
+help-kind-attribute = su
+help-kind-snippet = nkyerɛwee sini
+help-kind-array-entry = tabo mu adeɛ
+
+help-default = Deɛ ɛwɔ hɔ dada:
+help-active-default = Deɛ ɛwɔ hɔ dada a ɛreyɛ adwuma:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Gyinaboɔ a wɔma ho kwan (baako ma adeɛ biara):
+       *[other] Gyinaboɔ a wɔma ho kwan:
+    }
+
+help-suggested-values = Gyinaboɔ a wɔkamfo kyerɛ:
+
+help-inserts = Ɛde ba mu:
+
+help-coordinates = Nkyerɛbea:
+
+help-type = Suban:
+
+help-resolved-style = Nsiesieɛ a wɔahunu (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fankshɔn din a wɔahunu:
+help-reset-list = Nhwehwɛmu a ɛsan yɛ foforɔ wɔ ha:
+help-added-on-input = Deɛ wɔde kaa ho wɔ ha:
+help-removed-on-input = Deɛ wɔyii firi mu wɔ ha:
+
+help-reset-overrides = { $reset } sene { $additional } ne { $removed } so.

--- a/packages/i18n/locales/bm/chrome.ftl
+++ b/packages/i18n/locales/bm/chrome.ftl
@@ -1,0 +1,138 @@
+# Bambara viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# CLDR gives Bambara one plural category. Bambara does mark plural, with the
+# suffix `-w`, but not after a numeral: «sɛbɛnnisɛn fila», never «sɛbɛnnisɛnw
+# fila». So a counted noun in these messages is invariable, the selects are
+# dropped, and a `[one]` differing from its `[other]` would be wrong rather
+# than merely redundant. `attempts-remaining` keeps its `[0]` branch, which is
+# an exact-value match rather than a plural category and says «si tɛ» instead
+# of counting to zero.
+
+
+## Answer submission
+
+answer-checking = A bɛ sɛgɛsɛgɛ...
+answer-submitting = A bɛ ci...
+
+answer-checking-status = Jaabi bɛ sɛgɛsɛgɛ
+answer-submitting-status = Jaabi bɛ ci
+
+answer-correct = A bɛnna
+answer-incorrect = A ma bɛn
+
+answer-response-saved = Jaabi Marala
+
+answer-percent-credit = Nɔgɔya { $percent }%
+answer-percent-correct = { $percent }% Bɛnnen
+answer-percent-short = { $percent } %
+
+max-credit-available = Nɔgɔya belebele min bɛ sɔrɔ: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] cɛsiri si tɛ yen tugun
+       *[other] cɛsiri { $count } tora
+    }
+
+validation-correct = (A bɛnna)
+validation-incorrect = (A ma bɛn)
+validation-partially-correct = (A bɛnna dɔɔni)
+
+answer-show-responses = { $answerId } ka jaabi { $count } jira
+
+
+## Disclosure panels
+
+feedback-heading = Kɔsegin
+
+collapsible-click-to-open = (digi walasa k'a da wuli)
+collapsible-click-to-close = (digi walasa k'a datugu)
+
+collapsible-initializing = A bɛ daminɛ...
+
+footnote-show = Duguma-sɛbɛnni jira
+footnote-hide = Duguma-sɛbɛnni dogo
+
+description-more-information = kunnafoni wɛrɛw
+
+
+## Controls
+
+slider-previous = Kɔfɛta
+slider-next = Nata
+
+keyboard-open = Kilabɔri Da Wuli
+keyboard-close = Kilabɔri Datugu
+
+choice-input-remove-choice = { $choice } bɔ
+
+matrix-remove-row = Layini bɔ
+matrix-add-row = Layini fara
+matrix-remove-column = Kolɔni bɔ
+matrix-add-column = Kolɔni fara
+
+subset-add-remove-points = Pɔnw fara/bɔ
+subset-toggle-points-intervals = Pɔnw ni ɛntɛrɛvaliw falen-falen
+subset-move-points = Pɔnw Yɛlɛma
+subset-clear = Jɔsi
+
+# A `box` here is one orbital, drawn as a square: «kɛsu».
+orbital-add-row = Layini Fara
+orbital-remove-row = Layini Bɔ
+orbital-add-box = Kɛsu Fara
+orbital-remove-box = Kɛsu Bɔ
+orbital-add-up-arrow = Sanfɛ-Bina Fara
+orbital-add-down-arrow = Dugumafɛ-Bina Fara
+orbital-remove-arrow = Bina Bɔ
+
+orbital-row-label = Layini { $row } tɔgɔ
+
+pretzel-answer = Jaabi
+
+summary-statistics-caption = { $column } ka jatebɔ surunman
+
+
+## Math input
+
+math-input-preview-region = matematiki fɔcogo ɲɛfɔli
+math-input-preview = Ɲɛfɔli
+math-input-invalid-expression = Fɔcogo tɛ ɲɛ:
+
+
+## Document status
+
+viewer-initializing = A bɛ daminɛ...
+
+
+## Errors
+
+error-heading = Fili
+
+error-found-at =
+    { $span ->
+        [line] A sɔrɔla liɲi { $startLine } kan.
+       *[lines] A sɔrɔla liɲi { $startLine }–{ $endLine } kan.
+    }
+
+document-contains-errors = Filiw bɛ nin sɛbɛn kɔnɔ!
+
+diagnostic-heading-error = Fili
+diagnostic-heading-warning = Lasɔmini
+diagnostic-heading-information = Kunnafoni
+diagnostic-heading-hint = Ladilikan
+
+accessibility-heading-level-1 = WCAG AA Sɔrɔliya Tiɲɛni
+accessibility-heading-level-2 = Sɔrɔliya lasɔmini
+
+something-went-wrong = Fɛn dɔ ma taa a cogo la.
+
+renderer-load-failed = jirali fɛn kelen ma se ka don. Aw ka sɛbɛnnisɛn lasegin.
+
+core-start-failed = Sɛbɛn jirala ma se ka daminɛ. Aw ka sɛbɛnnisɛn lasegin.

--- a/packages/i18n/locales/bm/content.ftl
+++ b/packages/i18n/locales/bm/content.ftl
@@ -1,0 +1,251 @@
+# Bambara content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Bambara has no grammatical gender, no article and no case, so `$gender` and
+# `$role` go unused here exactly as they do in English.
+#
+# What it does have is a **qualifier suffix**: an adjective following a noun
+# takes `-man` — «liɲi finman», «liɲi bonman» — and the same stem standing on
+# its own as a noun does not. Every adjective in this catalog is written in the
+# qualifier form, because every one of them is said of something: even where
+# `lineColorDescription` reports a colour alone, what it reports is the colour
+# *of a line*. `style-background-none` is the one string that is not a
+# qualifier and so has no suffix.
+#
+# Adjectives follow the noun, so the composition messages put the noun first
+# and keep the English order among the adjectives themselves.
+#
+# The mathematical nouns lean on the French loans Malian schooling supplies —
+# «liɲi», «sɛrɛkili», «fɔnksiyɔn» — spelled the way Bambara writes them rather
+# than the way French does. Where Bambara has its own word it is used: «yɔrɔ» a
+# region, «kuruwa» a cross, «jate» a number.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black = finman
+    .white = jɛman
+    .gray = bugurilama
+    .red = bilenman
+    .orange = lenburulama
+    .yellow = nɛrɛmugulama
+    .green = binkɛnɛlama
+    .cyan = siyan
+    .blue = bulama
+    .purple = wulenfinman
+    .pink = wulenɲɛman
+    .brown = bɔgɔlama
+
+line-width =
+    .thick = bonman
+    .thin = misɛnman
+
+# Written as «ni …» phrases rather than as qualifiers, so that they take no
+# `-man` and can close the description. `style-stroke` puts them last.
+line-style =
+    .dashed = ni tirɛw ye
+    .dotted = ni pɔnw ye
+
+fill-style =
+    .horizontal = liɲi dalenw
+    .vertical = liɲi jɔlenw
+    .diagonal = liɲi jɛngɛlenw
+    .backdiagonal = liɲi jɛngɛlen kɔfɛtaw
+    .dots = pɔnw
+    .diamonds = losanziw
+
+noun =
+    .line = liɲi
+    .line-segment = liɲi tilayɔrɔ
+    .ray = reyɔn
+    .vector = wɛkitɛri
+    .curve = kurubu
+    .function = fɔnksiyɔn
+    .parabola = parabɔli
+    .polyline = liɲi kuruma
+    .polygon = poligɔni
+    .triangle = tiriyanguli
+    .rectangle = rɛktangili
+    .circle = sɛrɛkili
+    .region = yɔrɔ
+    .point = pɔn
+    .square = kare
+    .diamond = losanzi
+    .cross = kuruwa
+    .plus = fara-taamasere
+
+# The side count follows the qualifiers, behind «min kɛrɛ … ye», because
+# Bambara closes a noun phrase with a relative rather than opening one.
+noun-regular-polygon =
+    { $part ->
+        [tail] min kɛrɛ { $numSides } ye
+       *[head] poligɔni bɛnnen
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = falen
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ni { $pattern } ye
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ni { $pattern } ye
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ni { $pattern } ye
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Bambara has no article and joins the complement with the invariable «ni …
+# ye», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] ni dancɛ { $border } ye
+        [and] ni dancɛ { $border } ye
+        [and-article] ni dancɛ { $border } ye
+       *[with] ni dancɛ { $border } ye
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = falenbali
+
+style-text =
+    { $parts ->
+        [background] { $color } kɔkanna { $background } kan
+       *[plain] { $color }
+    }
+
+style-background-none = foyi tɛ
+
+
+## Boolean words
+
+boolean-true = tiɲɛ
+boolean-false = galon
+
+
+## Answer buttons
+
+answer-submit-label = Baara Sɛgɛsɛgɛ
+answer-submit-label-no-correctness = Jaabi Ci
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Baara
+    .aside = Kɛrɛfɛ kuma
+    .cascade = Kaskadi
+    .definition = Kɔrɔfɔli
+    .example = Misali
+    .exercise = Ekizɛrisi
+    .exercises = Ekizɛrisiw
+    .given-answer = Jaabi
+    .note = Kɔlɔsili
+    .objectives = Laɲiniw
+    .paragraphs = Paragarafuw
+    .part = Tilayɔrɔ
+    .problem = Gɛlɛya
+    .problems = Gɛlɛyaw
+    .proof = Dalilu
+    .question = Ɲininkali
+    .section = Yɔrɔ
+    .solution = Ɲɛnabɔli
+    .task = Baara
+    .theorem = Teyorɛmu
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Ladilikan
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabali { $enumeration }
+        [numbered-title] Tabali { $enumeration }{ ": " }
+        [unnumbered-title] Tabali{ ": " }
+       *[unnumbered] Tabali
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ja { $enumeration }
+        [numbered-caption] Ja { $enumeration }{ ": " }
+        [unnumbered-caption] Ja{ ": " }
+       *[unnumbered] Ja
+    }
+
+
+## Paginator controls
+
+paginator-previous = Kɔfɛta
+paginator-next = Nata
+paginator-page = Sɛbɛnnisɛn
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = walima
+piecewise-condition-if = ni
+piecewise-condition-otherwise = n'o tɛ
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Malian secondary science is
+# taught in French, so a student meeting these words meets them in a European
+# language already — and the seed has no settled Bambara list to reproduce. A
+# speaker adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simi Taamasere Tɛ Ɲɛ
+chemistry-invalid-ionic-compound = Iyɔn Fɛn-Fara Tɛ Ɲɛ

--- a/packages/i18n/locales/bm/diagnostics.ftl
+++ b/packages/i18n/locales/bm/diagnostics.ftl
@@ -1,0 +1,617 @@
+# Bambara diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Bambara verb takes no number from its
+# subject, and the argument is a list either way. So those selects are dropped
+# and the count argument goes unused.
+#
+# The technical vocabulary is the French-derived one Malian schooling supplies
+# — «fɔnksiyɔn», «endɛsi», «wariyabili» — beside the Bambara words for the
+# things that are not technical: «liɲi» a line, «hakɛ» a value, «tɔgɔ» a name.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } tɛ jateminɛ ni dan-pɔn fila fɔra
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } tɛ jateminɛ ni dan-pɔn ni cɛmancɛ-pɔn bɛɛ fɔra
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset tɛ foyi kɛ ni cɛmancɛ-pɔn tɛ yen
+
+## `<line>`
+
+line-points-undetermined-dimensions = Liɲi bɛ tɛmɛ pɔn minnu kan, olu bonya ma jateminɛ.
+
+line-points-too-few-dimensions = Liɲi ka kan ka tɛmɛ pɔn minnu kan, olu ka kan ka kɛ bonya fila ye a dɔgɔyalenba.
+
+line-points-depend-on-variables = Liɲi bɛ tɛmɛ pɔn minnu kan, olu bɛ wariyabiliw kan: { $variables }.
+
+line-equation-invalid-format = Cogoya tɛ ɲɛ liɲi ekuwasiyɔn na wariyabili { $variable1 } ni { $variable2 } la.
+
+## `<ray>`
+
+ray-overprescribed-through = Reyɔn fɔra ni through, endpoint ani direction bɛɛ ye. through fɔlen tɛ jateminɛ.
+
+ray-dimension-mismatch = numDimensions ma bɛn reyɔn kɔnɔ.
+
+## `<vector>`
+
+vector-overprescribed-head = Wɛkitɛri fɔra ni head, tail ani displacement bɛɛ ye. head fɔlen tɛ jateminɛ.
+
+vector-dimension-mismatch = numDimensions ma bɛn wɛkitɛri kɔnɔ.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = A tɛ se ka sama `<{ $component }>` ma sabu cogoya-wariyabili nearestPoint t'a la.
+
+constrain-to-without-nearest-point = A tɛ se ka siri `<{ $component }>` la sabu cogoya-wariyabili nearestPoint t'a la.
+
+constrain-to-interior-without-nearest-point = A tɛ se ka siri `<{ $component }>` kɔnɔ sabu cogoya-wariyabili nearestPoint t'a la.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition tɛ jateminɛ choiceInput min tɛ liɲi kelen ye
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Endɛsi fɔlenw tɛ jateminɛ choiceInput na sabu endɛsi hakɛ ma bɛn choice den hakɛ ma.
+
+pretzel-indices-count-mismatch = Endɛsi fɔlenw tɛ jateminɛ problem na sabu endɛsi hakɛ ma bɛn problem den hakɛ ma.
+
+shuffle-indices-count-mismatch = Endɛsi fɔlenw tɛ jateminɛ shuffle na sabu endɛsi hakɛ ma bɛn elemanti hakɛ ma.
+
+indices-ignored-out-of-range = Endɛsi fɔlenw tɛ jateminɛ { $component } na sabu endɛsi dɔw bɛ dancɛ kɔfɛ.
+
+pretzel-indices-repeated = Endɛsi fɔlenw tɛ jateminɛ pretzel na sabu endɛsi dɔw seginna.
+
+pretzel-circuit-first-index = Endɛsi fɔlenw tɛ jateminɛ pretzel na circuit cogoya la sabu endɛsi fɔlɔ ka kan ka kɛ 1 ye.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Walasa `<{ $component }>` ka baara kɛ ni sɛbɛnni suguya denw ye, atiribi `type` ka kan ka fɔ.
+
+invalid-type-defaulting-to-math = type { $type } tɛ ɲɛ elemanti { $component } ma. A ka kan ka kɛ math, text, number walima boolean dɔ ye. A bilala math la.
+
+string-not-valid-component-to-arrange = Sɛbɛnni "{ $value }" tɛ { $component } elemanti bɛnnen ye. A tɛ jateminɛ.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } tɛ ɲɛ, type bilala number la.
+
+invalid-variable-value = Wariyabili hakɛ tɛ ɲɛ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Cogoya endɛsi { $index } ka kan ka kɛ jate ye
+
+variant-index-must-be-integer = Cogoya endɛsi { $index } ka kan ka kɛ jate dafalen ye
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ma labɛn ni sumani jɔlenw ye. Bonyaw bilala tilancɛ la.
+
+side-by-side-absolute-margins = `<{ $component }>` ma labɛn ni sumani jɔlenw ye. Dafɛlaw bilala tilancɛ la.
+
+side-by-side-no-block-child = `<{ $component }>` tɛ ɲɛ: bloki suguya den kelen ka kan ka kɛ a la a dɔgɔyalenba.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atiribi `for` tɛ jateminɛ ja `<label>` kan.
+
+label-for-must-resolve-to-one = Atiribi `for` min bɛ `<label>` la, o ka kan ka elemanti kelen dɔrɔn jira.
+
+label-for-unresolved = Atiribi `for` min bɛ `<label>` la, o ma se ka elemanti si jira.
+
+label-for-answer-with-authored-inputs = Atiribi `for` min bɛ `<label>` la, o bɛ `<answer>` yira min donyɔrɔw sɛbɛnna; donyɔrɔ yɛrɛ yira.
+
+label-for-answer-without-input = Atiribi `for` min bɛ `<label>` la, o bɛ `<answer>` yira min donyɔrɔ tɛ tɔgɔ da.
+
+label-for-must-reference-input-or-answer = Atiribi `for` min bɛ `<label>` la, o ka kan ka donyɔrɔ walima jaabi yira.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Sɔrɔliya kama, `<{ $component }>` ka kan ka kɛ ni ɲɛfɔli surunman ye walima k'a fɔ ko masiri lo.
+
+accessibility-video-short-description = Sɔrɔliya kama, `<video>` ka kan ka kɛ ni ɲɛfɔli surunman ye.
+
+accessibility-input-short-description-or-label = Sɔrɔliya kama, `<{ $component }>` ka kan ka kɛ ni ɲɛfɔli surunman walima tɔgɔ ye.
+
+accessibility-answer-input-short-description-or-label = Sɔrɔliya kama, `<answer>` min bɛ donyɔrɔ da, o ka kan ka kɛ ni ɲɛfɔli surunman walima tɔgɔ ye.
+
+accessibility-short-description-contains-math = Ɲɛfɔli surunman man kan ka kɛ ni matematiki elemantiw ye i n'a fɔ `<{ $component }>`. Matematiki bɛɛ ɲɛfɔ ni kumaw ye.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } danfaralikɛ man ca yɔrɔ kuncɛ sɛbɛnni kama (dibi cogoya) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ka kan ka kɛ { $threshold }:1 ye a dɔgɔyalenba).
+       *[other] { $colorName } danfaralikɛ man ca yɔrɔ kuncɛ sɛbɛnni kama ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ka kan ka kɛ { $threshold }:1 ye a dɔgɔyalenba).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` min bɛ tɛmɛ pɔn { $count } kan, o ma labɛn fɔlɔ ni jate hakɛ tɛ pɔn olu la.
+
+circle-too-many-through-points = A tɛ se ka sɛrɛkili jate min bɛ tɛmɛ pɔn 3 ni kɔ kan.
+
+circle-overprescribed-radius-center-points = A tɛ se ka sɛrɛkili jate ni reyɔn, cɛmancɛ ani tɛmɛ-pɔnw bɛɛ fɔra.
+
+circle-center-with-multiple-points = A tɛ se ka sɛrɛkili jate min cɛmancɛ fɔra ani min bɛ tɛmɛ pɔn 1 ni kɔ kan.
+
+circle-radius-too-small = A tɛ se ka sɛrɛkili jate: sabu pɔn fila ni ɲɔgɔn cɛ ye { $distance } ye, reyɔn { $radius } fɔlen ka dɔgɔ kojugu.
+
+circle-radius-with-many-points = A tɛ se ka sɛrɛkili da min bɛ tɛmɛ pɔn fila ni kɔ kan ni reyɔn fɔlen ye.
+
+circle-invalid-center-or-through-points = Sɛrɛkili cɛmancɛ walima a tɛmɛ-pɔnw tɛ ɲɛ.
+
+circle-radius-center-with-multiple-points = A tɛ se ka sɛrɛkili reyɔn jate min cɛmancɛ fɔra ani min bɛ tɛmɛ pɔn 1 ni kɔ kan.
+
+circle-change-radius-non-numerical = A tɛ se ka sɛrɛkili reyɔn yɛlɛma min bɛ tɛmɛ pɔn kan minnu jate hakɛ tɛ yen
+
+circle-radius-with-points-non-numerical = A tɛ se ka sɛrɛkili da min bɛ tɛmɛ pɔn kelen ni kɔ kan ni reyɔn fɔlen ye ni jate hakɛ tɛ yen.
+
+circle-change-center-non-numerical = Sɛrɛkili cɛmancɛ yɛlɛmani ma labɛn fɔlɔ min bɛ tɛmɛ pɔn kan minnu jate hakɛ tɛ yen.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Fɔnksiyɔn dancɛ bonyaw man ca. Dancɛ ɛntɛrɛvali hakɛ ye { $intervals } ye nka fɔnksiyɔn donyɔrɔ hakɛ ye { $inputs } ye.
+
+function-domain-invalid-format = Fɔnksiyɔn dancɛ cogoya tɛ ɲɛ.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Fɔnksiyɔn sanfɛ-dan min tɛ jate ye, o tɛ jateminɛ.
+        [minimum] Fɔnksiyɔn dugumafɛ-dan min tɛ jate ye, o tɛ jateminɛ.
+        [extremum] Fɔnksiyɔn dan min tɛ jate ye, o tɛ jateminɛ.
+        [point] Fɔnksiyɔn pɔn min tɛ jate ye, o tɛ jateminɛ.
+        [slope] Fɔnksiyɔn jɛngɛnni min tɛ jate ye, o tɛ jateminɛ.
+       *[other] Fɔnksiyɔn { $type } min tɛ jate ye, o tɛ jateminɛ.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Fɔnksiyɔn sanfɛ-dan lankolon tɛ jateminɛ.
+        [minimum] Fɔnksiyɔn dugumafɛ-dan lankolon tɛ jateminɛ.
+        [extremum] Fɔnksiyɔn dan lankolon tɛ jateminɛ.
+        [point] Fɔnksiyɔn pɔn lankolon tɛ jateminɛ.
+       *[other] Fɔnksiyɔn { $type } lankolon tɛ jateminɛ.
+    }
+
+function-points-too-close = Fɔnksiyɔn pɔn fila ka surun ɲɔgɔn na kojugu. Fɔnksiyɔn tɛ se ka kɔrɔfɔ.
+
+function-iterates-input-output-mismatch = Fɔnksiyɔn seginni bɛ se ka kɛ dɔrɔn ni donyɔrɔ hakɛ ni bɔyɔrɔ hakɛ bɛnna. Nin fɔnksiyɔn donyɔrɔ ye { $inputs } ye, a bɔyɔrɔ ye { $outputs } ye.
+
+## `<sequence>`
+
+sequence-invalid-length = Sekansi janya tɛ ɲɛ. A ka kan ka kɛ jate dafalen ye min tɛ dɔgɔya-jate ye.
+
+sequence-invalid-step = Sekansi taama tɛ ɲɛ. { $type } suguya sekansi la, a ka kan ka kɛ jate ye.
+
+sequence-invalid-endpoint-number = Jate sekansi ka "{ $attribute }" tɛ ɲɛ. A ka kan ka kɛ jate ye.
+
+sequence-invalid-endpoint-letters = Sɛbɛnden sekansi ka "{ $attribute }" tɛ ɲɛ. A ka kan ka kɛ sɛbɛndenw ye.
+
+sequence-invalid-endpoint = Sekansi ka "{ $attribute }" tɛ ɲɛ.
+
+select-from-sequence-coprime-not-numbers = coprime tɛ jateminɛ sabu jate tɛ minnu bɛ sugandi
+
+select-from-sequence-coprime-with-exclude-combinations = coprime tɛ jateminɛ sabu excludeCombinations fɔra
+
+## Resolving a `target`
+
+target-not-found = target tɛ ɲɛ `<{ $source }>` la: laɲini ma sɔrɔ.
+
+target-state-variable-not-found = target tɛ ɲɛ `<{ $source }>` la: cogoya-wariyabili min tɔgɔ ye "{ $property }", o ma sɔrɔ `<{ $component }>` la.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` wariyabiliw ka kan ka danfara wariyabili yɛrɛmahɔrɔn na.
+
+ode-system-duplicate-variable-names = ODE RHS fɔnksiyɔnw tɛ se ka kɔrɔfɔ ni wariyabili tɔgɔ seginlenw bɛ yen.
+
+ode-system-rhs-function-error = ODE RHS fɔnksiyɔn tɛ se ka kɔrɔfɔ. Fili kɛra mathjs fɔnksiyɔn dabɔli la.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Liɲi { $count } cɛ kɔrɔnnin tɛ se ka kɔrɔfɔ
+
+angle-invalid-through-point = Pɔn tɛ ɲɛ `<angle>` ka through kɔnɔ
+
+parabola-vertex-too-many-points = Parabɔli min kuncɛ bɛ yen ani min bɛ tɛmɛ pɔn 1 ni kɔ kan, o ma labɛn fɔlɔ.
+
+parabola-too-many-points = Parabɔli min bɛ tɛmɛ pɔn 3 ni kɔ kan, o ma labɛn fɔlɔ.
+
+intersection-too-many-items = Fɛn fila ni kɔ ka tɛmɛsira ma labɛn fɔlɔ
+
+## Other math components
+
+ionic-compound-not-two-ions = Iyɔn fɛn-fara min bɛ tɛmɛ iyɔn fila kan, o ma labɛn fɔlɔ.
+
+ionic-compound-needs-cation-and-anion = Iyɔn fɛn-fara labɛnna katiyɔn kelen ni aniyɔn kelen dɔrɔn kama.
+
+solve-equations-cannot-evaluate = Ekuwasiyɔn tɛ se ka ɲɛnabɔ sabu a ma se ka jate: { $equation }
+
+math-operators-operand-number-required = operandNumber ka kan ka fɔ ni matematiki baarafɛn bɛ bɔ.
+
+eigen-decomposition-failed = Matirisi ka eigen hakɛw tɛ se ka jate
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: paramɛtiri { $parameters } tɛ cogoya kɔnɔ, o de kama u bɛna bɛn lankolon ma tuma bɛɛ.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" tɛ se ka kɔrɔfɔ. A ka kan ka kɛ none, medium, dense, walima jate jɔlen fila ye minnu tilalen don ni funtan ye, i n'a fɔ grid="1 0.5". Girize si tɛ ja.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" tɛ dɛmɛ sɔrɔ prefigure jirala la; kinifɛ cogoya de bɛ baara kɛ.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" tɛ dɛmɛ sɔrɔ prefigure jirala la; sanfɛ cogoya de bɛ baara kɛ.
+
+prefigure-invalid-axis-bounds = `<graph>`: aksi dancɛw tɛ ɲɛ prefigure yɛlɛmani kama; bbox bilalen (-10,-10,10,10) de bɛ baara kɛ.
+
+prefigure-invalid-width = `<graph>`: bonya tɛ ɲɛ prefigure yɛlɛmani kama; ja bonya bilalen 425 de bɛ baara kɛ.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio tɛ ɲɛ prefigure yɛlɛmani kama; rapɔri bilalen 1 de bɛ baara kɛ.
+
+prefigure-grid-spacing-too-fine = `<graph>`: girize cɛtigɛw ka misɛn kojugu aksi dancɛw kama; girize bilala prefigure jirala la.
+
+prefigure-annotations-not-rendered = `<graph>`: kɔlɔsiliw tɛna jira ni PreFigure jirala tɛ baara la.
+
+multiple-annotations-children = `<annotations>` den caman sɔrɔla `<graph>` kɔnɔ; u bɛɛ tɛ jateminɛ fo laban.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Elemanti suguya lɔnbali tɛ se ka yɛlɛma walima ka kopi kɛ: { $type }.
+
+copy-prop-not-found = Atiribi { $property } ma sɔrɔ { $component } suguya elemanti la
+
+collect-no-source = Sɔrɔyɔrɔ si ma sɔrɔ collect kama.
+
+collect-invalid-component-type = `<{ $component }>` suguya elemantiw tɛ se ka lajɛ sabu elemanti suguya tɛ ɲɛ.
+
+reference-index-unavailable = Endɛsi `{ $reference }` tɛ se ka yira
+
+## `<callAction>`
+
+component-action-unavailable = { $action } tɛ se ka wele elemanti `{ $reference }` kan
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Kunnafoni cogoya tɛ ɲɛ. Layiniw janya ma bɛn ɲɔgɔn ma. A sɔrɔla componentIdx :{ $componentIdx } la
+
+data-frame-duplicate-column-names = Kunnafoni kɔnɔ kolɔni tɔgɔ dɔw seginna. A sɔrɔla componentIdx :{ $componentIdx } la
+
+data-frame-missing-column-name = Kolɔni tɔgɔ tɛ kunnafoni na. A sɔrɔla componentIdx :{ $componentIdx } la
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Nin jaabi ka award kelen bɛ jaabi kan answer tagi yɛrɛ ye min ci, o bɛna cogoya kɔnɔnata lase.
+
+answer-max-num-attempts-in-section-wide-check-work = `maxNumAttempts` bilali `<answer>` kan min bɛ minɛn kɔnɔ min bɛ ni `sectionWideCheckWork` ye, o tɛ foyi kɛ, sabu o minɛn de bɛ cɛsiri hakɛ mara. `maxNumAttempts` bila minɛn yɛrɛ kan.
+
+nested-section-wide-check-work-max-num-attempts = `maxNumAttempts` bilali minɛn kan min bɛ ni `sectionWideCheckWork` ye ani min bɛ minɛn wɛrɛ kɔnɔ min fana bɛ ni `sectionWideCheckWork` ye, o tɛ foyi kɛ, sabu kɛnɛma minɛn de bɛ cɛsiri hakɛ mara. `maxNumAttempts` bila kɛnɛma minɛn kan.
+
+answer-attributes-need-symbolic-equality = Atiribi { $attributes } tɛna foyi kɛ ni symbolicEquality ma bila.
+
+answer-invalid-type = Suguya tɛ ɲɛ jaabi la: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sabu elemanti `<{ $component }>` tɔgɔ tɛ yen, a tɛ se ka kɛ module atiribi ye
+
+module-attribute-name-already-defined = Elemanti `<{ $component } name="{ $name }">` tɛ se ka kɛ module atiribi ye sabu elemanti suguya `<module>` bɛ ni atiribi ye kaban min tɔgɔ ye "{ $name }".
+
+conditional-content-condition-ignored = Atiribi `condition` tɛ jateminɛ elemanti `<conditionalContent>` kan min bɛ ni case walima else denw ye.
+
+slider-markers-type-mismatch = Taamasiɲɛw suguya ma bɛn slider suguya ma.
+
+pretzel-problem-needs-statement-and-answer = pretzel tɛ ɲɛ: `<problem>` kelen-kelen bɛɛ ka kan ka kɛ ni `<statement>` kelen ni `<answer>` kelen ye.
+
+pretzel-circuit-first-problem-distractor = pretzel tɛ ɲɛ: mode="circuit" la, `<problem>` fɔlɔ tɛ se ka kɛ nɛgɛnnikɛlan ye.
+
+## Attribute values
+
+attribute-invalid-values = Hakɛ { $values } tɛ ɲɛ atiribi `{ $attribute }` la; u tɛ jateminɛ.
+
+attribute-must-be-references = Hakɛ `{ $value }` tɛ ɲɛ atiribi `{ $attribute }` la. Atiribi ka kan ka kɛ yiraliw ye minnu bɛ daminɛ ni `$` ye.
+
+math-input-invalid-function-names = <mathInput>: fɔnksiyɔn tɔgɔ minnu tɛ ɲɛ { $attribute } kɔnɔ, olu tɛ jateminɛ: { $names }. Tɔgɔ kelen-kelen bɛɛ jirali yɔrɔ ka kan ka kɛ sɛbɛnden 2 ye a dɔgɔyalenba (sɛbɛnden walima jɛngɛn); `|<mathspeak alternative>` bɛ se ka tugu a kɔ ni a diyara.
+
+## Building components from the source
+
+component-type-invalid = Elemanti suguya tɛ ɲɛ: `<{ $componentType }>`
+
+attribute-repeated = Atiribi { $attribute } tɛ se ka segin.
+
+attribute-invalid-for-component = Atiribi "{ $attribute }" tɛ ɲɛ `<{ $componentType }>` suguya elemanti la.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Cogoya kɔrɔfɔli { $styleNumber } danfaralikɛ man ca { $context ->
+        [text-on-background] sɛbɛnni kulɛri ni kɔkanna kulɛri cɛ
+        [high-contrast] danfaralikɛ-caman kulɛri ni jayɔrɔ cɛ
+        [line] liɲi kulɛri ni jayɔrɔ cɛ
+        [marker] taamasiɲɛ kulɛri ni jayɔrɔ cɛ
+       *[text-on-canvas] sɛbɛnni kulɛri ni jayɔrɔ cɛ
+    }{ $mode ->
+        [dark] { " (dibi cogoya)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ka kan ka kɛ { $threshold }:1 ye a dɔgɔyalenba).
+
+style-definition-dark-mode-text-background-contrast =
+    Hali ni cogoya kɔrɔfɔli { $styleNumber } ye kulɛriw fɔ minnu danfaralikɛ ka ca yeelen cogoya la, dibi cogoya kulɛri minnu bɔra olu la, olu danfaralikɛ man ca sɛbɛnni kulɛri ni kɔkanna kulɛri cɛ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ka kan ka kɛ { $threshold }:1 ye a dɔgɔyalenba). { $suggestion ->
+        [available] Walasa danfaralikɛ ka ca dibi cogoya la, yeelen cogoya danfaralikɛ caya (misali la { $lightAttribute }="{ $lightColor }" bila) walima dibi cogoya kulɛri yɛlɛma (misali la { $darkAttribute }="{ $darkColor }" bila).
+       *[none] Walasa danfaralikɛ ka ca dibi cogoya la, yeelen cogoya danfaralikɛ caya walima kulɛri bɔlenw yɛlɛma ni textColorDarkMode ni/walima backgroundColorDarkMode ye.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Hali ni cogoya kɔrɔfɔli { $styleNumber } ye sɛbɛnni kulɛri fɔ min danfaralikɛ ka ca yeelen cogoya la, dibi cogoya sɛbɛnni kulɛri min bɔra o la, o danfaralikɛ man ca jayɔrɔ kama ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ka kan ka kɛ { $threshold }:1 ye a dɔgɔyalenba). { $suggestion ->
+        [available] Walasa danfaralikɛ ka ca dibi cogoya la, yeelen cogoya danfaralikɛ caya (misali la textColor="{ $lightColor }" bila) walima dibi cogoya kulɛri yɛlɛma (misali la textColorDarkMode="{ $darkColor }" bila).
+       *[none] Walasa danfaralikɛ ka ca dibi cogoya la, yeelen cogoya danfaralikɛ caya walima kulɛri bɔlen yɛlɛma ni textColorDarkMode ye.
+    }
+
+section-multiple-style-palettes = Yɔrɔ bɛ se ka <stylePalette> kelen dɔrɔn sugandi; laban de bɛ baara kɛ.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } cogoya danmakɛɲɛnenw tɛ se ka jateminɛ sabu numToSelect tɛ jate dafalen ye min tɛ dɔgɔya-jate ye.
+
+variant-num-to-select-not-constant-number = { $component } cogoya danmakɛɲɛnenw tɛ se ka jateminɛ sabu numToSelect tɛ jate basigilen ye.
+
+variant-with-replacement-not-constant-boolean = { $component } cogoya danmakɛɲɛnenw tɛ se ka jateminɛ sabu withReplacement tɛ buleyan basigilen ye.
+
+variant-select-weight-disables-unique = select cogoya danmakɛɲɛnenw bɛ faga ni sugandili dɔ bɛ ni selectWeight walima selectForVariants ye
+
+variant-coprime-undetermined = { $component } cogoya danmakɛɲɛnenw tɛ se ka jateminɛ sabu a tɛ se ka jɛya ko coprime ye galon ye tuma bɛɛ.
+
+variant-attribute-not-constant = { $component } cogoya danmakɛɲɛnenw tɛ se ka jateminɛ sabu { $attribute } ma basigi.
+
+variant-attribute-not-number = { $component } cogoya danmakɛɲɛnenw tɛ se ka jateminɛ sabu { $attribute } tɛ jate ye.
+
+variant-attribute-wrong-type-for-sequence =
+    { $component } cogoya danmakɛɲɛnen { $type } suguya tɛ se ka jateminɛ sabu { $attribute } tɛ { $expected ->
+        [letters-combination] sɛbɛndenw
+        [math-expression] matematiki fɔcogo bɛnnen
+        [integer] jate dafalen
+       *[number] jate
+    } ye.
+
+variant-length-not-integer = { $component } cogoya danmakɛɲɛnenw tɛ se ka jateminɛ sabu length tɛ jate dafalen ye.
+
+variant-sort-not-implemented = { $component } cogoya danmakɛɲɛnenw ni sort ye, olu ma labɛn fɔlɔ
+
+variant-exclude-combinations-not-implemented = { $component } cogoya danmakɛɲɛnenw ni excludeCombinations ye, olu ma labɛn fɔlɔ
+
+variant-math-exclude-not-implemented = { $component } cogoya danmakɛɲɛnen math suguya ni exclude ye, olu ma labɛn fɔlɔ
+
+variant-non-constant-exclude-not-implemented = { $component } cogoya danmakɛɲɛnenw ni exclude basigibali ye, olu ma labɛn fɔlɔ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: a tɛ dɛmɛ sɔrɔ graph prefigure jirala la; bɔnsɔn tɛmɛna.
+
+prefigure-descendant-invalid-geometry = { $subject }: seyomɛtiri dan tɛ min na walima min ma dafa; bɔnsɔn tɛmɛna.
+
+prefigure-curve-label-omitted = { $subject }: tɔgɔw tɛ dɛmɛ sɔrɔ kurubu elemanti yɛlɛmalenw kan; tɔgɔ bilala.
+
+prefigure-curve-unsupported-definition-type = { $subject }: kurubu fɔnksiyɔn kɔrɔfɔli suguya '{ $definitionType }' tɛ dɛmɛ sɔrɔ; bɔnsɔn tɛmɛna.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atiribi flipFunctions min bɛ regionBetweenCurves la, o tɛ dɛmɛ sɔrɔ; bɔnsɔn tɛmɛna.
+
+prefigure-region-non-formula-child = { $subject }: formula suguya den fɔnksiyɔnw dɔrɔn de bɛ dɛmɛ sɔrɔ regionBetweenCurves la; bɔnsɔn tɛmɛna.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' tɛ dɛmɛ sɔrɔ { $labelKind ->
+        [line-family] liɲi somɔgɔw tɔgɔ
+       *[point] pɔn tɔgɔ
+    } kama; PreFigure ka bilali de bɛ baara kɛ.
+
+prefigure-fill-style-unsupported = { $subject }: falen cogoya '{ $fillStyle }' tɛ dɛmɛ sɔrɔ PreFigure fɛ; a bɛ segin kulɛri kelen falen kan.
+
+prefigure-line-style-unknown = { $subject }: liɲi cogoya '{ $lineStyle }' ma lɔn wa a bilala PreFigure bɔyɔrɔ la.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: taamasiɲɛ cogoya '{ $markerStyle }' bɛnna PreFigure cogoya 'diamond' ma.
+
+prefigure-marker-style-unsupported = { $subject }: taamasiɲɛ cogoya '{ $markerStyle }' tɛ dɛmɛ sɔrɔ PreFigure fɛ; cogoya bilalen de bɛ baara kɛ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` tɛ ɲɛ; laɲini tɛ se ka jateminɛ. Kɔlɔsili bilala.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ye laɲini caman fɔ; laɲini fɔlɔ de bɛ baara kɛ.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` tɛ ɲɛ; laɲini bɛ graf kɔfɛ min b'a mara. Kɔlɔsili bilala.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` tɛ ɲɛ; laɲini tɛ ja fɛn ye min bɛ dɛmɛ sɔrɔ prefigure yɛlɛmani na. Kɔlɔsili bilala.
+
+annotation-text-missing = `<annotation>`: `text` tɛ yen walima a lankolon don; sɛbɛnni lankolon de bɛ bɔ.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Kuruma-jɔyɔrɔ sɔrɔla.
+       *[other] Kuruma-jɔyɔrɔ sɔrɔla min bɛ elemanti `<{ $componentType }>` la.
+    }
+
+reference-no-referent = Foyi ma sɔrɔ yirali la: `{ $reference }`
+
+reference-multiple-referents = Fɛn caman sɔrɔla yirali la: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Cogoya tɛ ɲɛ `<{ $componentType }>` ka atiribi { $attribute } la.
+
+children-invalid = Denw tɛ ɲɛ `<{ $componentType }>` la: Den bɛnbaliw sɔrɔla: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Hakɛ `{ $value }` tɛ ɲɛ atiribi `{ $attribute }` la, hakɛ `{ $default }` de bɛ baara kɛ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML cogoya { $version } ma sɔrɔ.
+       *[other] DoenetML cogoya { $version } ma sɔrɔ. A bɛ segin cogoya { $fallback } kan
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML tɛ ɲɛ: { $content }
+
+parse-tag-missing-close-tag = DoenetML tɛ ɲɛ: Tagi `{ $tag }` datugu-tagi tɛ yen. Tagi min bɛ a yɛrɛ datugu walima tagi `</{ $tagName }>` de tun bɛ makɔnɔ.
+
+parse-tag-error = DoenetML tɛ ɲɛ: Fili bɛ tagi `<{ $tagName }>` la
+
+parse-attribute-missing-value = DoenetML tɛ ɲɛ: Atiribi `{ $attribute }` min tɛ ɲɛ, a bɛ i n'a fɔ hakɛ t'a la.
+
+parse-attribute-invalid = DoenetML tɛ ɲɛ: Atiribi `{ $attribute }` tɛ ɲɛ
+
+parse-attribute-value-invalid = DoenetML tɛ ɲɛ: Atiribi hakɛ `{ $value }` tɛ ɲɛ
+
+parse-attribute-value-quote-mismatch = DoenetML tɛ ɲɛ: Atiribi hakɛ `{ $value }` tɛ ɲɛ. Kuma-taamasereɲɛw ma bɛn. A bɛ i n'a fɔ `{ $quote }` tununna
+
+parse-open-tag-name-missing = DoenetML tɛ ɲɛ: Tagi sɔrɔla min tɔgɔ tɛ yen, misali la `<`
+
+parse-tag-not-closed = DoenetML tɛ ɲɛ: Tagi `{ $tag }` ma datugu (a bɛ i n'a fɔ `>` tununna).
+
+parse-self-closing-tag-name-missing = DoenetML tɛ ɲɛ: Tagi sɔrɔla min tɔgɔ tɛ yen `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML tɛ ɲɛ: Tagi `{ $tag }` ma datugu (a bɛ i n'a fɔ `/>` tununna).
+
+parse-tag-invalid-attributes = DoenetML tɛ ɲɛ: Tagi `{ $tag }` tɛ ɲɛ. A bɛ se ka kɛ ni atiribi bɛnbaliw ye.
+
+parse-close-tag-name-missing = DoenetML tɛ ɲɛ: Datugu-tagi sɔrɔla min tɔgɔ tɛ yen, misali la `</`
+
+parse-attribute-value-unquoted = Atiribi hakɛw ka kan ka bila kuma-taamasereɲɛw cɛ: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML tɛ ɲɛ: Datugu-tagi `{ $tag }` sɔrɔla, nka a da-wuli-tagi tɛ yen
+
+parse-close-tag-mismatched = DoenetML tɛ ɲɛ: Datugu-tagi ma bɛn. `</{ $expected }>` tun bɛ makɔnɔ. `{ $found }` de sɔrɔla
+
+parser-node-unconvertible = Nɔdi { $node } ma se ka yɛlɛma Dast nɔdi ye.
+
+## Names
+
+name-attribute-invalid =
+    Atiribi name='{ $name }' tɛ ɲɛ. { $reason ->
+        [characters] Tɔgɔw bɛ se ka kɛ ni sɛbɛndenw, jatew, duguma-jɛngɛnw walima jɛngɛnw dɔrɔn ye.
+       *[start] Tɔgɔw ka kan ka daminɛ ni sɛbɛnden ye.
+    }
+
+component-name-invalid-start = Elemanti tɔgɔ "{ $name }" tɛ ɲɛ. Tɔgɔw ka kan ka daminɛ ni sɛbɛnden ye.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched suguya jaabi ka kan ka kɛ ni atiribi video ye
+
+answer-video-watched-video-not-reference = videoWatched suguya jaabi ka kan ka kɛ ni atiribi video ye min ye yirali ye
+
+answer-name-not-single-text = Jaabi ka atiribi name ka kan ka kɛ ni text den kelen dɔrɔn ye
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Kɛnɛma DoenetML tɛ se ka sɔrɔ sabu seginni ka ca kojugu. Yali yirali kuruma dɔ bɛ yen wa?
+
+external-doenetml-unavailable = DoenetML tɛ se ka sɔrɔ { $attribute }="{ $uri }" la
+
+external-doenetml-type-mismatch = DoenetML min sɔrɔla { $attribute }="{ $uri }" la, o tɛ ɲɛ: a ma bɛn elemanti suguya "{ $componentType }" ma
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atiribi `{ $from }` kɔrɔla; `{ $to }` de kɛ a nɔ na.
+       *[other] [deprecation] Atiribi `{ $from }` min bɛ `<{ $component }>` la, o kɔrɔla; `{ $to }` de kɛ a nɔ na.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atiribi `{ $from }` kɔrɔla wa a tɛ jateminɛ sabu `{ $to }` fana fɔra.
+       *[other] [deprecation] Atiribi `{ $from }` min bɛ `<{ $component }>` la, o kɔrɔla wa a tɛ jateminɛ sabu `{ $to }` fana fɔra.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atiribi `{ $attribute }` min bɛ `<{ $component }>` la, o kɔrɔla wa a tɛ jateminɛ.
+
+deprecated-attribute-to-child = [deprecation] Atiribi `{ $attribute }` min bɛ `<{ $component }>` la, o kɔrɔla; den `<{ $child }>` de kɛ a nɔ na.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` bɛ se ka caya-cogoya kɛ Angilɛkan dɔrɔn na, o de kama a sɛbɛnni tora i n'a fɔ a bɛ cogo min na sɛbɛn kɔnɔ min sɛbɛnna { $locale } la. Caya-cogoya sɛbɛn i yɛrɛ ma, walima a bila atiribi `pluralForm` la.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemanti `<{ $tag }>` tɛ Doenet elemanti lɔnnen ye.
+
+schema-element-not-allowed-at-root = Elemanti `<{ $tag }>` tɛ daga sɛbɛn juu la.
+
+schema-element-not-allowed-inside = Elemanti `<{ $tag }>` tɛ daga `<{ $parent }>` kɔnɔ.
+
+schema-attribute-unrecognized = Elemanti `<{ $tag }>` atiribi tɛ yen min tɔgɔ ye `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Elemanti `<{ $tag }>` ka atiribi `{ $attribute }` ka kan ka kɛ lisi ye min fɛn kelen-kelen bɛɛ ye ninnu dɔ ye: { $allowed }
+       *[other] Elemanti `<{ $tag }>` ka atiribi `{ $attribute }` ka kan ka kɛ ninnu dɔ ye: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Cogoya tɔgɔ tɛ ɲɛ select la. Cogoya tɔgɔ { $variantName } bɛ sugandili { $numOptions } la nka sugandi hakɛ ye { $numToSelect } ye.
+
+select-variant-name-without-options = Cogoya dɔw fɔra select kama nka sugandili si ma fɔ cogoya tɔgɔ bɛnnen kama: { $variantName }.
+
+select-variant-name-not-possible = Cogoya tɔgɔ { $variantName } min fɔra select kama, o tɛ cogoya tɔgɔ bɛnnen ye.
+
+select-too-few-options = Elemanti { $numToSelect } tɛ se ka sugandi { $numOptions } dɔrɔn na.
+
+select-from-sequence-too-few-values = Hakɛ { $numToSelect } tɛ se ka sugandi sekansi la min janya ye { $length } ye.
+
+select-from-sequence-indices-count-mismatch = Endɛsi hakɛ min fɔra select kama, o ka kan ka bɛn sugandi hakɛ ma
+
+select-from-sequence-indices-not-integers = Endɛsi minnu bɛɛ fɔra select kama, olu ka kan ka kɛ jate dafalenw ye
+
+select-from-sequence-index-excluded = selectfromsequence endɛsi bɔlen dɔ fɔra
+
+select-from-sequence-indices-excluded-combination = selectfromsequence endɛsiw fɔra minnu tun ye faralen bɔlen ye
+
+select-from-sequence-coprime-not-positive-integers = Jate bɔɲɔgɔnkow faralenw tɛ se ka sugandi sabu jate dafalen jɔlenw tɛ minnu bɛ sugandi.
+
+select-from-sequence-coprime-common-factor = Jate bɔɲɔgɔnkow tɛ se ka sugandi. Hakɛ bɛnnenw bɛɛ bɛ ni tilanlan kelen ye. ("from" walima "to" hakɛ fɔlenw ka kan ka kɛ bɔɲɔgɔnkow ye "step" fɛ.)
+
+select-from-sequence-coprime-single-number = Jate bɔɲɔgɔnkow faralenw tɛ se ka sugandi jate kelen na min tɛ 1 ye.
+
+select-from-sequence-excluded-too-many-combinations = Faralenw 70% ni kɔ bɔra selectFromSequence la
+
+select-from-sequence-coprime-none-found = Jate bɔɲɔgɔnkow ma se ka sugandi. Hakɛ bɛnnenw bɛɛ bɛ ni tilanlan kelen ye.
+
+select-from-sequence-too-few-unique-values = Hakɛ danmakɛɲɛnen { $numToSelect } tɛ se ka sugandi sekansi la min janya ye { $numPossibleValues } ye
+
+select-prime-numbers-too-few-values = Hakɛ { $numToSelect } tɛ se ka sugandi jate tilabaliw lisi la min janya ye { $numValues } ye
+
+select-prime-numbers-values-count-mismatch = Hakɛ hakɛ min fɔra select kama, o ka kan ka bɛn sugandi hakɛ ma
+
+select-prime-numbers-values-not-prime = Hakɛ minnu bɛɛ fɔra select prime number kama, olu ka kan ka kɛ jate tilabaliw lisi kɔnɔ
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers hakɛ fɔlenw tun ye faralen bɔlen ye
+
+select-prime-numbers-excluded-too-many-combinations = Faralenw 70% ni kɔ bɔra selectPrimeNumbers la
+
+select-random-combination-fluke = Ni a ma deli ka kɛ, hakɛ kɛrɛnkɛrɛnbaliw faralen ma se ka sugandi
+
+select-random-value-fluke = Ni a ma deli ka kɛ, hakɛ kɛrɛnkɛrɛnbali ma se ka sugandi

--- a/packages/i18n/locales/bm/editor.ftl
+++ b/packages/i18n/locales/bm/editor.ftl
@@ -1,0 +1,204 @@
+# Bambara editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# A counted noun in Bambara takes no plural suffix, so the counted messages
+# drop their selects.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Lasegin
+       *[update] Kura Don
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Jirala { $word }
+       *[other] Jirala { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Cogoya
+editor-variant-filter = Woloma...
+editor-variant-next = Cogoya nata sugandi
+editor-variant-previous = Cogoya kɔfɛta sugandi
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA sɔrɔliya tiɲɛni ye sɔrɔ. Digi walasa sɔrɔliya rapɔri ka { $action ->
+            [close] datugu
+           *[open] da wuli
+        }.
+        [advisories] Digi walasa sɔrɔliya rapɔri ka { $action ->
+            [close] datugu
+           *[open] da wuli
+        }. WCAG AA tiɲɛni si ma sɔrɔ, nka ladilikan wɛrɛw bɛ sɔrɔliya kan.
+       *[clean] Digi walasa sɔrɔliya rapɔri ka { $action ->
+            [close] datugu
+           *[open] da wuli
+        }. Sɔrɔliya gɛlɛya si ma sɔrɔ.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA sɔrɔliya tiɲɛni ye sɔrɔ. WCAG AA tiɲɛni { $count } sɔrɔla. Digi walasa sɔrɔliya rapɔri ka { $action ->
+            [close] datugu
+           *[open] da wuli
+        }.
+        [advisories] WCAG AA tiɲɛni si ma sɔrɔ. Sɔrɔliya ladilikan wɛrɛ { $count } sɔrɔla. Digi walasa sɔrɔliya rapɔri ka { $action ->
+            [close] datugu
+           *[open] da wuli
+        }.
+       *[clean] WCAG AA tiɲɛni si ma sɔrɔ. Digi walasa sɔrɔliya rapɔri ka { $action ->
+            [close] datugu
+           *[open] da wuli
+        }.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML cogoya { $version }
+
+editor-tab-help = Dɛmɛ min bɛ bɛn kuma ma
+editor-tab-help-short = Kuma
+editor-tab-errors = Filiw
+editor-tab-warnings = Lasɔminiw
+editor-tab-info = Kunnafoni
+editor-tab-accessibility = Sɔrɔliya
+editor-tab-responses = Jaabi cilenw
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Sɛbɛnnikɛla sugandiliw
+editor-format-as-doenetml = A labɛn i n'a fɔ DoenetML
+editor-format-as-xml = A labɛn i n'a fɔ XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Liɲi #{ $line }
+
+editor-no-errors = Fili Tɛ Yen
+editor-no-warnings = Lasɔmini Tɛ Yen
+editor-no-info = Kunnafoni Sɛgɛsɛgɛli Tɛ Yen
+
+editor-show-info-annotations = Kunnafoni sɛgɛsɛgɛliw jira sɛbɛnnikɛla kɔnɔ
+editor-show-accessibility-annotations = Sɔrɔliya sɛgɛsɛgɛliw jira sɛbɛnnikɛla kɔnɔ
+
+editor-accessibility-learn-more = Doenet bɛ sɔrɔliya ɲɛnabɔ cogo min na, o kalan
+
+editor-accessibility-violations-heading = Sɔrɔliya tiɲɛniw ({ $standard })
+
+editor-accessibility-other-heading = Sɔrɔliya gɛlɛya wɛrɛw
+editor-none-found = Foyi ma sɔrɔ
+
+
+## Submitted responses
+
+editor-no-responses = Jaabi si ma ci fɔlɔ
+editor-response-answer-id = Jaabi Tɔgɔ
+editor-response-response = Jaabi
+editor-response-credit = Nɔgɔya
+editor-response-submitted = A cila
+
+
+## The context-help panel
+
+help-placeholder = Kurusɔrɔ bila tagi tɔgɔ, atiribi walima { $ref } kan walasa ka sɛbɛnw sɔrɔ.
+
+help-unsupported-ref-chain = Yirali caman ta i n'a fɔ { $example } ka dɛmɛ ma se fɔlɔ.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Foyi ma sɔrɔ yirali la: { $ref }.
+        [multiple] Fɛn caman sɔrɔla yirali la: { $ref }.
+       *[indeterminate] { $ref } bɛ min yira, o ma se ka jateminɛ.
+    }
+
+help-learn-about-references = Yiraliw kalan →
+help-reference-page = Yirali sɛbɛnnisɛn →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } kɔnɔ
+       *[top] Sanfɛ yɔrɔ la
+    }{ $allowed ->
+        [none] { " — foyi tɛ don yan." }
+        [text] { " — sɛbɛnni kɛ yan." }
+        [text-and-components] { " — sɛbɛnni kɛ yan, walima a lajɛ:" }
+       *[components] { " — fɛn minnu bɛ se ka lajɛ:" }
+    }
+
+help-suggestions-footer = { $shortcut } digi walasa ka elemanti { $total } bɛɛ ye.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ye { $target } yirali ye.
+       *[other] { $ref } ye { $target } yirali ye (liɲi { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } y'a tɔgɔ da ko { $role }.
+       *[other] { $owner } y'a tɔgɔ da liɲi { $line } kan ko { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ye { $element } ka atiribi { $property } yirali ye.
+       *[other] { $ref } ye { $element } ka atiribi { $property } yirali ye (liɲi { $line }).
+    }
+
+help-kind-attribute = atiribi
+help-kind-snippet = sɛbɛn tilancɛ
+help-kind-array-entry = tabali donyɔrɔ
+
+help-default = Bilalen:
+help-active-default = Bilalen baaralen:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Hakɛ dagalenw (kelen elemanti kelen-kelen bɛɛ la):
+       *[other] Hakɛ dagalenw:
+    }
+
+help-suggested-values = Hakɛ laadilenw:
+
+help-inserts = A bɛ don:
+
+help-coordinates = Kɔɔridɔne:
+
+help-type = Suguya:
+
+help-resolved-style = Cogoya jateminɛna (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fɔnksiyɔn tɔgɔ jateminɛnaw:
+help-reset-list = Lisi min bɛ lasegin nin donni na:
+help-added-on-input = Min farala nin donni kan:
+help-removed-on-input = Min bɔra nin donni na:
+
+help-reset-overrides = { $reset } bɛ tɛmɛ { $additional } ni { $removed } kan.

--- a/packages/i18n/locales/ee/chrome.ftl
+++ b/packages/i18n/locales/ee/chrome.ftl
@@ -1,0 +1,141 @@
+# Ewe viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `ɖ`, `ƒ`, `ɣ`, `ŋ`, `ɔ`, `ɛ` and `ʋ` are letters of the alphabet, as
+# `content.ftl`'s header sets out; so are the tone marks.
+#
+# CLDR gives Ewe two plural categories. Ewe marks its plural with the suffix
+# `-wo`, but not after a numeral: «axa eve», never «axawo eve». So a counted
+# noun in these messages is invariable, the selects are dropped, and a `[one]`
+# differing from its `[other]` would be wrong rather than merely redundant.
+# `attempts-remaining` keeps its `[0]` branch, which is an exact-value match
+# rather than a plural category and says «ɖeke mesusɔ o» instead of counting to
+# zero.
+
+
+## Answer submission
+
+answer-checking = Ele kpɔkpɔm...
+answer-submitting = Ele ɖoɖom ɖa...
+
+answer-checking-status = Ele ŋuɖoɖoa kpɔm
+answer-submitting-status = Ele ŋuɖoɖoa ɖom ɖa
+
+answer-correct = Esɔ
+answer-incorrect = Mesɔ o
+
+answer-response-saved = Woɖo Ŋuɖoɖoa Ɖi
+
+answer-percent-credit = Dzesi { $percent }%
+answer-percent-correct = { $percent }% Sɔ
+answer-percent-short = { $percent } %
+
+max-credit-available = Dzesi gãtɔ si woate ŋu axɔ: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] agbagbadzedze aɖeke mesusɔ o
+       *[other] agbagbadzedze { $count } susɔ
+    }
+
+validation-correct = (Esɔ)
+validation-incorrect = (Mesɔ o)
+validation-partially-correct = (Esɔ le akpa aɖe me)
+
+answer-show-responses = Fia ŋuɖoɖo { $count } si woɖo ɖe { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Nyaŋuɖoɖo
+
+collapsible-click-to-open = (zi edzi be nàʋui)
+collapsible-click-to-close = (zi edzi be nàtui)
+
+collapsible-initializing = Ele gɔmedzedzem...
+
+footnote-show = Fia afɔnuŋɔŋlɔ
+footnote-hide = Ɣla afɔnuŋɔŋlɔ
+
+description-more-information = nyatakaka bubuwo
+
+
+## Controls
+
+slider-previous = Megbe
+slider-next = Ŋgɔ
+
+keyboard-open = Ʋu Fɛŋlɔdzesiawo
+keyboard-close = Tu Fɛŋlɔdzesiawo
+
+choice-input-remove-choice = Ɖe { $choice } ɖa
+
+matrix-remove-row = Ɖe fli ɖa
+matrix-add-row = Tsɔ fli kpe ɖe eŋu
+matrix-remove-column = Ɖe sɔti ɖa
+matrix-add-column = Tsɔ sɔti kpe ɖe eŋu
+
+subset-add-remove-points = Tsɔ nɔƒe kpe ɖe eŋu/Ɖe wo ɖa
+subset-toggle-points-intervals = Trɔ le nɔƒewo kple dometsotsowo dome
+subset-move-points = Ʋu Nɔƒeawo
+subset-clear = Tutu
+
+# A `box` here is one orbital, drawn as a square: «aɖaka».
+orbital-add-row = Tsɔ Fli Kpe Ɖe Eŋu
+orbital-remove-row = Ɖe Fli Ɖa
+orbital-add-box = Tsɔ Aɖaka Kpe Ɖe Eŋu
+orbital-remove-box = Ɖe Aɖaka Ɖa
+orbital-add-up-arrow = Tsɔ Aŋutrɔ Dziyimetɔ Kpe Ɖe Eŋu
+orbital-add-down-arrow = Tsɔ Aŋutrɔ Anyiyimetɔ Kpe Ɖe Eŋu
+orbital-remove-arrow = Ɖe Aŋutrɔ Ɖa
+
+orbital-row-label = Fli { $row } ƒe ŋkɔ
+
+pretzel-answer = Ŋuɖoɖo
+
+summary-statistics-caption = { $column } ƒe akɔntabubu kpuiwo
+
+
+## Math input
+
+math-input-preview-region = akɔntabubu nyagbe ƒe ŋgɔdokpɔ
+math-input-preview = Ŋgɔdokpɔ
+math-input-invalid-expression = Nyagbea mesɔ o:
+
+
+## Document status
+
+viewer-initializing = Ele gɔmedzedzem...
+
+
+## Errors
+
+error-heading = Vodada
+
+error-found-at =
+    { $span ->
+        [line] Wokpɔe le fli { $startLine } dzi.
+       *[lines] Wokpɔe le fli { $startLine }–{ $endLine } dzi.
+    }
+
+document-contains-errors = Vodadawo le agbalẽ sia me!
+
+diagnostic-heading-error = Vodada
+diagnostic-heading-warning = Nuxlɔ̃ame
+diagnostic-heading-information = Nyatakaka
+diagnostic-heading-hint = Mɔfiame
+
+accessibility-heading-level-1 = WCAG AA Sedzimawɔmawɔ le Ŋudɔwɔwɔ Ŋu
+accessibility-heading-level-2 = Ŋudɔwɔwɔ ŋuti nuxlɔ̃ame
+
+something-went-wrong = Nane meyi edzi nyuie o.
+
+renderer-load-failed = nufiala ɖeka mete ŋu va o. Taflatse gaʋu axaa.
+
+core-start-failed = Agbalẽ kpɔla la mete ŋu dze egɔme o. Taflatse gaʋu axaa.

--- a/packages/i18n/locales/ee/content.ftl
+++ b/packages/i18n/locales/ee/content.ftl
@@ -1,0 +1,253 @@
+# Ewe content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Ewe has no grammatical gender, no article and no case, so `$gender` and
+# `$role` go unused here exactly as they do in English.
+#
+# Adjectives follow the noun — «fli lolo dzĩ» — so the composition messages put
+# the noun first and keep the English order among the adjectives themselves.
+#
+# **The letters are letters.** `ɖ`, `ƒ`, `ɣ`, `ŋ`, `ɔ`, `ɛ` and `ʋ` are not
+# decorated Latin letters that a plainer spelling could stand in for: «ɖe» and
+# «de» are different words, and so are «ƒe» and «fe». The tone marks in «dzĩ»
+# and «ãtɔ» are the same kind of thing. Stripping any of them is a
+# mis-spelling, not a simplification.
+#
+# The colour words are the point where this seed is thinnest, and it is worth
+# saying which are which. «yibɔ», «ɣi» and «dzĩ» — black, white, red — are
+# Ewe's own basic terms. The rest are loans spelled the way Ewe writes loans,
+# because Ewe names most other colours by comparing them to a thing («amagbe»,
+# green, is a green leaf) and a seed cannot tell which comparison a school
+# textbook settled on. A speaker should expect to replace most of this block.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black = yibɔ
+    .white = ɣi
+    .gray = afi
+    .red = dzĩ
+    .orange = ɔrenj
+    .yellow = ɣiɖeɖi
+    .green = amagbe
+    .cyan = siyan
+    .blue = blɔ
+    .purple = pɔpul
+    .pink = piŋk
+    .brown = anyigbatɔ
+
+line-width =
+    .thick = lolo
+    .thin = sue
+
+# Written as «kple …» phrases rather than as adjectives, so that they can close
+# the description. `style-stroke` puts them last for that reason.
+line-style =
+    .dashed = kple fli kakɛwo
+    .dotted = kple dzesi sueawo
+
+fill-style =
+    .horizontal = fli mlɔamlɔwo
+    .vertical = fli tsitrewo
+    .diagonal = fli dzeŋgɔwo
+    .backdiagonal = fli dzeŋgɔ megbetɔwo
+    .dots = dzesi sueawo
+    .diamonds = adzagbawo
+
+noun =
+    .line = fli
+    .line-segment = fli akpa
+    .ray = fli mɔ
+    .vector = vɛkta
+    .curve = fli gobɛ
+    .function = dɔwɔfia
+    .parabola = parabola
+    .polyline = fli geɖe
+    .polygon = axa geɖe
+    .triangle = dzogoe etɔ̃
+    .rectangle = dzogoe ene didi
+    .circle = nugogo
+    .region = nuto
+    .point = nɔƒe
+    .square = dzogoe ene sɔsɔ
+    .diamond = adzagba
+    .cross = atitsoga
+    .plus = tsɔkpe dzesi
+
+# The side count follows the adjectives, behind «si le», because Ewe closes a
+# noun phrase with a relative rather than opening one: «axa geɖe sɔsɔ dzĩ si le
+# axa 5».
+noun-regular-polygon =
+    { $part ->
+        [tail] si le axa { $numSides }
+       *[head] axa geɖe sɔsɔ
+    }
+
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = si me yɔ
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } kple { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } kple { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kple { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Ewe has no article and joins the complement with the invariable «kple», so
+# all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] kple liƒo { $border }
+        [and] kple liƒo { $border }
+        [and-article] kple liƒo { $border }
+       *[with] kple liƒo { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = si me meyɔ o
+
+style-text =
+    { $parts ->
+        [background] { $color } le megbenu { $background } dzi
+       *[plain] { $color }
+    }
+
+style-background-none = ɖeke meli o
+
+
+## Boolean words
+
+boolean-true = nyateƒe
+boolean-false = alakpa
+
+
+## Answer buttons
+
+answer-submit-label = Do Dɔa Kpɔ
+answer-submit-label-no-correctness = Ɖo Ŋuɖoɖoa Ɖa
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Dɔwɔwɔ
+    .aside = Axadzinya
+    .cascade = Tsidzadza
+    .definition = Gɔmeɖeɖe
+    .example = Kpɔɖeŋu
+    .exercise = Dɔdasi
+    .exercises = Dɔdasiwo
+    .given-answer = Ŋuɖoɖo
+    .note = Ŋkuɖodzinu
+    .objectives = Taɖodzinuwo
+    .paragraphs = Memamawo
+    .part = Akpa
+    .problem = Kuxi
+    .problems = Kuxiwo
+    .proof = Kpeɖodzi
+    .question = Nyabiase
+    .section = Memama
+    .solution = Kuxikakaɖeŋu
+    .task = Dɔ
+    .theorem = Teorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Mɔfiame
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Kplɔ̃ { $enumeration }
+        [numbered-title] Kplɔ̃ { $enumeration }{ ": " }
+        [unnumbered-title] Kplɔ̃{ ": " }
+       *[unnumbered] Kplɔ̃
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Nɔnɔmetata { $enumeration }
+        [numbered-caption] Nɔnɔmetata { $enumeration }{ ": " }
+        [unnumbered-caption] Nɔnɔmetata{ ": " }
+       *[unnumbered] Nɔnɔmetata
+    }
+
+
+## Paginator controls
+
+paginator-previous = Do ŋgɔ
+paginator-next = Emegbetɔ
+paginator-page = Axa
+
+paginator-page-status = { $pageLabel } { $currentPage } le { $numPages } dome
+
+
+## Piecewise functions
+
+piecewise-condition-or = alo
+piecewise-condition-if = ne
+piecewise-condition-otherwise = ne menye nenema o
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Ghanaian and Togolese
+# secondary science is taught in English and in French respectively, so a
+# student meeting these words meets them in a European language already — and a
+# seed that guessed would have to guess twice, once for each school system. A
+# speaker adding a list should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kemikal Dzesi Si Mesɔ O
+chemistry-invalid-ionic-compound = Ion Nutsotso Si Mesɔ O

--- a/packages/i18n/locales/ee/diagnostics.ftl
+++ b/packages/i18n/locales/ee/diagnostics.ftl
@@ -1,0 +1,616 @@
+# Ewe diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Ewe verb takes no number from its
+# subject, and the argument is a list either way. So those selects are dropped
+# and the count argument goes unused.
+#
+# `ɖ`, `ƒ`, `ɣ`, `ŋ`, `ɔ`, `ɛ` and `ʋ` are letters of the alphabet, as
+# `content.ftl`'s header sets out; so are the tone marks.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = Womebua { $attributes } ŋu o ne woɖo nuwuwu nɔƒe eveawo
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = Womebua { $attributes } ŋu o ne woɖo nuwuwu nɔƒe kple titina nɔƒe siaa
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset mewɔa naneke o ne titina nɔƒe meli o
+
+## `<line>`
+
+line-points-undetermined-dimensions = Flia to nɔƒe siwo ƒe lolome womenya o dzi.
+
+line-points-too-few-dimensions = Ele be flia nato nɔƒe siwo si lolome eve ya teti le dzi.
+
+line-points-depend-on-variables = Flia to nɔƒe siwo nɔ tɔtrɔnuwo dzi la dzi: { $variables }.
+
+line-equation-invalid-format = Ɖoɖoa mesɔ na fli ƒe sɔsɔmenya le tɔtrɔnu { $variable1 } kple { $variable2 } me o.
+
+## `<ray>`
+
+ray-overprescribed-through = Woɖo fli mɔ la kple through, endpoint kple direction siaa. Womebua through si woɖo la ŋu o.
+
+ray-dimension-mismatch = numDimensions mesɔ le fli mɔ la me o.
+
+## `<vector>`
+
+vector-overprescribed-head = Woɖo vɛkta la kple head, tail kple displacement siaa. Womebua head si woɖo la ŋu o.
+
+vector-dimension-mismatch = numDimensions mesɔ le vɛkta la me o.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Mate ŋu ahe ayi `<{ $component }>` gbɔ o elabena nɔnɔme tɔtrɔnu nearestPoint mele esi o.
+
+constrain-to-without-nearest-point = Mate ŋu abla ɖe `<{ $component }>` ŋu o elabena nɔnɔme tɔtrɔnu nearestPoint mele esi o.
+
+constrain-to-interior-without-nearest-point = Mate ŋu abla ɖe `<{ $component }>` me o elabena nɔnɔme tɔtrɔnu nearestPoint mele esi o.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = Womebua labelPosition ŋu le choiceInput si menye fli ɖeka o la me o
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Womebua indɛks siwo woɖo na choiceInput ŋu o elabena indɛks ƒe agbɔsɔsɔ kple choice viwo ƒe agbɔsɔsɔ mesɔ o.
+
+pretzel-indices-count-mismatch = Womebua indɛks siwo woɖo na problem ŋu o elabena indɛks ƒe agbɔsɔsɔ kple problem viwo ƒe agbɔsɔsɔ mesɔ o.
+
+shuffle-indices-count-mismatch = Womebua indɛks siwo woɖo na shuffle ŋu o elabena indɛks ƒe agbɔsɔsɔ kple nuawo ƒe agbɔsɔsɔ mesɔ o.
+
+indices-ignored-out-of-range = Womebua indɛks siwo woɖo na { $component } ŋu o elabena indɛks aɖewo le liƒoa godo.
+
+pretzel-indices-repeated = Womebua indɛks siwo woɖo na pretzel ŋu o elabena wogagblɔ indɛks aɖewo.
+
+pretzel-circuit-first-index = Womebua indɛks siwo woɖo na pretzel le circuit me ŋu o elabena ele be indɛks gbãtɔ nanye 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Be `<{ $component }>` nawɔ dɔ kple nuŋɔŋlɔ ƒomevi viwo la, ele be woaɖo nɔnɔme `type`.
+
+invalid-type-defaulting-to-math = type { $type } mesɔ na nu { $component } o. Ele be wòanye math, text, number alo boolean dometɔ ɖeka. Wotsɔ math ɖo eteƒe.
+
+string-not-valid-component-to-arrange = Nuŋɔŋlɔ "{ $value }" menye { $component } nu si sɔ o. Womebua eŋu o.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } mesɔ o, wotsɔ number ɖo type teƒe.
+
+invalid-variable-value = Tɔtrɔnu ƒe home mesɔ o: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Ele be nɔnɔme indɛks { $index } nanye xexlẽdzesi
+
+variant-index-must-be-integer = Ele be nɔnɔme indɛks { $index } nanye xexlẽdzesi blibo
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Womewɔ `<{ $component }>` kple nudidi tututuwo o. Wotsɔ akpa ɖo keklẽmeawo teƒe.
+
+side-by-side-absolute-margins = Womewɔ `<{ $component }>` kple nudidi tututuwo o. Wotsɔ akpa ɖo axadzinuawo teƒe.
+
+side-by-side-no-block-child = `<{ $component }>` mesɔ o: ele be blɔk ƒomevi vi ɖeka ya teti nanɔ eŋu.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Womebua nɔnɔme `for` si le nɔnɔmetata ƒe `<label>` dzi ŋu o.
+
+label-for-must-resolve-to-one = Ele be nɔnɔme `for` si le `<label>` dzi la nafia nu ɖeka pɛ.
+
+label-for-unresolved = Nɔnɔme `for` si le `<label>` dzi la mete ŋu fia nu aɖeke o.
+
+label-for-answer-with-authored-inputs = Nɔnɔme `for` si le `<label>` dzi la fia `<answer>` si si nudede siwo woŋlɔ le; fia nudedea ŋutɔ.
+
+label-for-answer-without-input = Nɔnɔme `for` si le `<label>` dzi la fia `<answer>` si si nudede si woana ŋkɔ mele o.
+
+label-for-must-reference-input-or-answer = Ele be nɔnɔme `for` si le `<label>` dzi la nafia nudede alo ŋuɖoɖo.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Le ŋudɔwɔwɔ ta la, ele be numeɖeɖe kpui nanɔ `<{ $component }>` ŋu alo woagblɔ be atsyɔ̃ɖoɖo ko wònye.
+
+accessibility-video-short-description = Le ŋudɔwɔwɔ ta la, ele be numeɖeɖe kpui nanɔ `<video>` ŋu.
+
+accessibility-input-short-description-or-label = Le ŋudɔwɔwɔ ta la, ele be numeɖeɖe kpui alo ŋkɔ nanɔ `<{ $component }>` ŋu.
+
+accessibility-answer-input-short-description-or-label = Le ŋudɔwɔwɔ ta la, ele be numeɖeɖe kpui alo ŋkɔ nanɔ `<answer>` si wɔa nudede la ŋu.
+
+accessibility-short-description-contains-math = Mele be akɔntabubu nuwo abe `<{ $component }>` ene nanɔ numeɖeɖe kpui la me o. Ɖe akɔntabubu ɖe sia ɖe me kple nyawo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ƒe vovototo mesɔ gbɔ na memama ƒe tanya ŋɔŋlɔ o (viviti nɔnɔme) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ele be wòanye { $threshold }:1 ya teti).
+       *[other] { $colorName } ƒe vovototo mesɔ gbɔ na memama ƒe tanya ŋɔŋlɔ o ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ele be wòanye { $threshold }:1 ya teti).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Womewɔ `<circle>` si to nɔƒe { $count } dzi la haɖe o ne xexlẽdzesi ƒe home mele nɔƒe mawo si o.
+
+circle-too-many-through-points = Mate ŋu abu nugogo si to nɔƒe 3 wu dzi la ŋu o.
+
+circle-overprescribed-radius-center-points = Mate ŋu abu nugogo si si titinamɔ, titina kple totonɔƒewo katã le la ŋu o.
+
+circle-center-with-multiple-points = Mate ŋu abu nugogo si si titina si woɖo le eye wòto nɔƒe 1 wu dzi la ŋu o.
+
+circle-radius-too-small = Mate ŋu abu nugogoa ŋu o: elabena didi si le nɔƒe eveawo dome nye { $distance }, titinamɔ { $radius } si woɖo la le sue akpa.
+
+circle-radius-with-many-points = Mate ŋu awɔ nugogo si to nɔƒe eve wu dzi kple titinamɔ si woɖo o.
+
+circle-invalid-center-or-through-points = Nugogoa ƒe titina alo eƒe totonɔƒewo mesɔ o.
+
+circle-radius-center-with-multiple-points = Mate ŋu abu nugogo si si titina si woɖo le eye wòto nɔƒe 1 wu dzi la ƒe titinamɔ ŋu o.
+
+circle-change-radius-non-numerical = Mate ŋu atrɔ nugogo si to nɔƒe siwo si xexlẽdzesi ƒe home mele o dzi la ƒe titinamɔ o
+
+circle-radius-with-points-non-numerical = Mate ŋu awɔ nugogo si to nɔƒe ɖeka wu dzi kple titinamɔ si woɖo ne xexlẽdzesi ƒe home meli o.
+
+circle-change-center-non-numerical = Womewɔ nugogo si to nɔƒe siwo si xexlẽdzesi ƒe home mele o dzi la ƒe titina tɔtrɔ haɖe o.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Dɔwɔfia ƒe nuto ƒe lolome mesɔ gbɔ o. Dometsotso { $intervals } le nutoa si gake nudede { $inputs } le dɔwɔfia la si.
+
+function-domain-invalid-format = Dɔwɔfia ƒe nuto ƒe ɖoɖo mesɔ o.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Womebua dɔwɔfia ƒe kɔkɔƒe si menye xexlẽdzesi o la ŋu o.
+        [minimum] Womebua dɔwɔfia ƒe bɔbɔƒe si menye xexlẽdzesi o la ŋu o.
+        [extremum] Womebua dɔwɔfia ƒe nuwuƒe si menye xexlẽdzesi o la ŋu o.
+        [point] Womebua dɔwɔfia ƒe nɔƒe si menye xexlẽdzesi o la ŋu o.
+        [slope] Womebua dɔwɔfia ƒe dzedzeme si menye xexlẽdzesi o la ŋu o.
+       *[other] Womebua dɔwɔfia ƒe { $type } si menye xexlẽdzesi o la ŋu o.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Womebua dɔwɔfia ƒe kɔkɔƒe ƒuƒlu la ŋu o.
+        [minimum] Womebua dɔwɔfia ƒe bɔbɔƒe ƒuƒlu la ŋu o.
+        [extremum] Womebua dɔwɔfia ƒe nuwuƒe ƒuƒlu la ŋu o.
+        [point] Womebua dɔwɔfia ƒe nɔƒe ƒuƒlu la ŋu o.
+       *[other] Womebua dɔwɔfia ƒe { $type } ƒuƒlu la ŋu o.
+    }
+
+function-points-too-close = Nɔƒe eve siwo te ɖe wo nɔewo ŋu akpa le dɔwɔfia la si. Womate ŋu aɖe dɔwɔfia la gɔme o.
+
+function-iterates-input-output-mismatch = Dɔwɔfia ate ŋu agagbugbɔ awɔ dɔ ne nudedewo ƒe agbɔsɔsɔ kple nu siwo doa go la ƒe agbɔsɔsɔ sɔ ko. Nudede { $inputs } kple nu si doa go { $outputs } le dɔwɔfia sia si.
+
+## `<sequence>`
+
+sequence-invalid-length = Ɖoɖoa ƒe didime mesɔ o. Ele be wòanye xexlẽdzesi blibo si menye ɖoɖodzesi o.
+
+sequence-invalid-step = Ɖoɖoa ƒe afɔɖeɖe mesɔ o. Le { $type } ƒomevi ɖoɖo me la, ele be wòanye xexlẽdzesi.
+
+sequence-invalid-endpoint-number = Xexlẽdzesi ɖoɖo ƒe "{ $attribute }" mesɔ o. Ele be wòanye xexlẽdzesi.
+
+sequence-invalid-endpoint-letters = Ŋɔŋlɔdzesi ɖoɖo ƒe "{ $attribute }" mesɔ o. Ele be wòanye ŋɔŋlɔdzesiwo.
+
+sequence-invalid-endpoint = Ɖoɖoa ƒe "{ $attribute }" mesɔ o.
+
+select-from-sequence-coprime-not-numbers = Womebua coprime ŋu o elabena menye xexlẽdzesiwo wole tiam o
+
+select-from-sequence-coprime-with-exclude-combinations = Womebua coprime ŋu o elabena woɖo excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = target mesɔ le `<{ $source }>` me o: womekpɔ taɖodzinua o.
+
+target-state-variable-not-found = target mesɔ le `<{ $source }>` me o: womekpɔ nɔnɔme tɔtrɔnu si ŋkɔe nye "{ $property }" le `<{ $component }>` me o.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Ele be `<odeSystem>` ƒe tɔtrɔnuwo nato vovo tso tɔtrɔnu si le eɖokui si la gbɔ.
+
+ode-system-duplicate-variable-names = Mate ŋu aɖe ODE RHS dɔwɔfiawo gɔme ne wogagblɔ tɔtrɔnu ƒe ŋkɔ aɖewo o.
+
+ode-system-rhs-function-error = Mate ŋu aɖe ODE RHS dɔwɔfia gɔme o. Vodada dzɔ esime wole mathjs dɔwɔfia wɔm.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Mate ŋu aɖe dzogoe si le fli { $count } dome la gɔme o
+
+angle-invalid-through-point = Nɔƒea mesɔ le `<angle>` ƒe through me o
+
+parabola-vertex-too-many-points = Womewɔ parabola si si kɔkɔƒe le eye wòto nɔƒe 1 wu dzi la haɖe o.
+
+parabola-too-many-points = Womewɔ parabola si to nɔƒe 3 wu dzi la haɖe o.
+
+intersection-too-many-items = Womewɔ nu eve wu ƒe godoƒe haɖe o
+
+## Other math components
+
+ionic-compound-not-two-ions = Womewɔ ion nutsotso si wu ion eve la haɖe o.
+
+ionic-compound-needs-cation-and-anion = Wowɔ ion nutsotso na kation ɖeka kple anion ɖeka ko.
+
+solve-equations-cannot-evaluate = Mate ŋu akpɔ sɔsɔmenya la gbɔ o elabena womete ŋu bu eŋu o: { $equation }
+
+math-operators-operand-number-required = Ele be woaɖo operandNumber ne wole akɔntabubu dɔwɔnu ɖem do goe.
+
+eigen-decomposition-failed = Mate ŋu abu matriks la ƒe eigen homewo ŋu o
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: paramɛta { $parameters } medze le ɖoɖoa me o, eya ta woasɔ kple ƒuƒlu ɣesiaɣi.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: mate ŋu ase grid="{ $grid }" gɔme o. Ele be wòanye none, medium, dense, alo xexlẽdzesi eve nyuiwo siwo dome ɖe le, abe grid="1 0.5" ene. Womata girid aɖeke o.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure kpɔla la mexɔa xLabelPosition="left" o; ɖusime ƒe nɔnɔme dzie wowɔa dɔ le.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure kpɔla la mexɔa yLabelPosition="bottom" o; tame ƒe nɔnɔme dzie wowɔa dɔ le.
+
+prefigure-invalid-axis-bounds = `<graph>`: aksis ƒe liƒowo mesɔ na prefigure tɔtrɔ o; bbox (-10,-10,10,10) dzie wowɔ dɔ le.
+
+prefigure-invalid-width = `<graph>`: keklẽme la mesɔ na prefigure tɔtrɔ o; nɔnɔmetata ƒe keklẽme 425 dzie wowɔ dɔ le.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio mesɔ na prefigure tɔtrɔ o; sɔsɔme 1 dzie wowɔ dɔ le.
+
+prefigure-grid-spacing-too-fine = `<graph>`: girid ƒe dometsotsowo le sue akpa na aksis ƒe liƒowo; woɖe asi le girid ŋu le prefigure kpɔla la me.
+
+prefigure-annotations-not-rendered = `<graph>`: womafia ŋkuɖodzinuwo o ne womele PreFigure kpɔla la ŋu dɔ wɔm o.
+
+multiple-annotations-children = Wokpɔ `<annotations>` vi geɖe le `<graph>` me; womebua wo katã ŋu o negbe mamlɛtɔ ko.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Mate ŋu akeke alo agbugbɔ aŋlɔ nu ƒomevi si womenya o: { $type }.
+
+copy-prop-not-found = Womekpɔ nɔnɔme { $property } le { $component } ƒomevi nu la ŋu o
+
+collect-no-source = Womekpɔ dzɔtsoƒe aɖeke na collect o.
+
+collect-invalid-component-type = Mate ŋu aƒo `<{ $component }>` ƒomevi nuwo nu ƒu o elabena nu ƒomevi si mesɔ o wònye.
+
+reference-index-unavailable = Mate ŋu afia indɛks `{ $reference }` o
+
+## `<callAction>`
+
+component-action-unavailable = Mate ŋu ayɔ { $action } le nu `{ $reference }` dzi o
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Nyatakakawo ƒe nɔnɔme mesɔ o. Fliawo ƒe didime mesɔ o. Wokpɔe le componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Wogagblɔ sɔti ƒe ŋkɔ aɖewo le nyatakakawo me. Wokpɔe le componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Sɔti ƒe ŋkɔ aɖe mele nyatakakawo ŋu o. Wokpɔe le componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ŋuɖoɖo sia ƒe award ɖeka nɔ ŋuɖoɖo si answer tagi la ŋutɔ ɖo ɖa la dzi, eye esia ahe nɔnɔme si womekpɔ mɔ na o vɛ.
+
+answer-max-num-attempts-in-section-wide-check-work = `maxNumAttempts` dada ɖe `<answer>` si le nudzraɖoƒe si si `sectionWideCheckWork` le me dzi mewɔa naneke o, elabena nudzraɖoƒe ma ŋutɔe kpɔa agbagbadzedzewo ƒe agbɔsɔsɔ dzi. Da `maxNumAttempts` ɖe nudzraɖoƒea ŋutɔ dzi.
+
+nested-section-wide-check-work-max-num-attempts = `maxNumAttempts` dada ɖe nudzraɖoƒe si si `sectionWideCheckWork` le eye wòle nudzraɖoƒe bubu si si `sectionWideCheckWork` hã le me dzi mewɔa naneke o, elabena nudzraɖoƒe si le gota la ŋutɔe kpɔa agbagbadzedzewo ƒe agbɔsɔsɔ dzi. Da `maxNumAttempts` ɖe nudzraɖoƒe si le gota la dzi.
+
+answer-attributes-need-symbolic-equality = Nɔnɔme { $attributes } mawɔ naneke o ne womeɖo symbolicEquality o.
+
+answer-invalid-type = Ƒomevia mesɔ na ŋuɖoɖoa o: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Esi ŋkɔ mele nu `<{ $component }>` ŋu o ta la, womate ŋu awɔ eŋu dɔ abe module ƒe nɔnɔme ene o
+
+module-attribute-name-already-defined = Womate ŋu awɔ nu `<{ $component } name="{ $name }">` ŋu dɔ abe module ƒe nɔnɔme ene o elabena nɔnɔme si ŋkɔe nye "{ $name }" xoxo le nu ƒomevi `<module>` si.
+
+conditional-content-condition-ignored = Womebua nɔnɔme `condition` ŋu le nu `<conditionalContent>` si si case alo else viwo le la dzi o.
+
+slider-markers-type-mismatch = Dzesiawo ƒe ƒomevi kple slider ƒe ƒomevi mesɔ o.
+
+pretzel-problem-needs-statement-and-answer = pretzel mesɔ o: ele be `<statement>` ɖeka kple `<answer>` ɖeka nanɔ `<problem>` ɖe sia ɖe si.
+
+pretzel-circuit-first-problem-distractor = pretzel mesɔ o: le mode="circuit" me la, `<problem>` gbãtɔ mate ŋu anye nublanuinu o.
+
+## Attribute values
+
+attribute-invalid-values = Home { $values } mesɔ na nɔnɔme `{ $attribute }` o; womebua wo ŋu o.
+
+attribute-must-be-references = Home `{ $value }` mesɔ na nɔnɔme `{ $attribute }` o. Ele be nɔnɔmea nanye asifiafia siwo dzea egɔme kple `$`.
+
+math-input-invalid-function-names = <mathInput>: womebua dɔwɔfia ƒe ŋkɔ siwo mesɔ o le { $attribute } me ŋu o: { $names }. Ele be ŋɔŋlɔdzesi 2 ya teti nanɔ ŋkɔ ɖe sia ɖe ƒe fiafia me (ŋɔŋlɔdzesi alo fli); `|<mathspeak alternative>` ate ŋu akplɔe ɖo.
+
+## Building components from the source
+
+component-type-invalid = Nu ƒomevia mesɔ o: `<{ $componentType }>`
+
+attribute-repeated = Womate ŋu agagblɔ nɔnɔme { $attribute } o.
+
+attribute-invalid-for-component = Nɔnɔme "{ $attribute }" mesɔ na `<{ $componentType }>` ƒomevi nu o.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Nɔnɔme gɔmeɖeɖe { $styleNumber } ƒe vovototo mesɔ gbɔ na { $context ->
+        [text-on-background] nuŋɔŋlɔ ƒe amadede kple megbenu ƒe amadede
+        [high-contrast] vovototo gã ƒe amadede kple nuŋlɔƒea
+        [line] fli ƒe amadede kple nuŋlɔƒea
+        [marker] dzesi ƒe amadede kple nuŋlɔƒea
+       *[text-on-canvas] nuŋɔŋlɔ ƒe amadede kple nuŋlɔƒea
+    }{ $mode ->
+        [dark] { " (viviti nɔnɔme)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ele be wòanye { $threshold }:1 ya teti).
+
+style-definition-dark-mode-text-background-contrast =
+    Togbɔ be nɔnɔme gɔmeɖeɖe { $styleNumber } ɖo amadede siwo ƒe vovototo sɔ gbɔ le kekeli nɔnɔme me hã la, viviti nɔnɔme ƒe amadede siwo do tso eme la ƒe vovototo mesɔ gbɔ na nuŋɔŋlɔ ƒe amadede kple megbenu ƒe amadede o ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ele be wòanye { $threshold }:1 ya teti). { $suggestion ->
+        [available] Be vovototo nasɔ gbɔ le viviti nɔnɔme me la, dzi kekeli nɔnɔme ƒe vovototo ɖe edzi (kpɔɖeŋu, ɖo { $lightAttribute }="{ $lightColor }") alo trɔ viviti nɔnɔme ƒe amadede (kpɔɖeŋu, ɖo { $darkAttribute }="{ $darkColor }").
+       *[none] Be vovototo nasɔ gbɔ le viviti nɔnɔme me la, dzi kekeli nɔnɔme ƒe vovototo ɖe edzi alo trɔ amadede siwo do tso eme la kple textColorDarkMode kple/alo backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Togbɔ be nɔnɔme gɔmeɖeɖe { $styleNumber } ɖo nuŋɔŋlɔ ƒe amadede si ƒe vovototo sɔ gbɔ le kekeli nɔnɔme me hã la, viviti nɔnɔme ƒe nuŋɔŋlɔ amadede si do tso eme la ƒe vovototo mesɔ gbɔ le nuŋlɔƒea ŋu o ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ele be wòanye { $threshold }:1 ya teti). { $suggestion ->
+        [available] Be vovototo nasɔ gbɔ le viviti nɔnɔme me la, dzi kekeli nɔnɔme ƒe vovototo ɖe edzi (kpɔɖeŋu, ɖo textColor="{ $lightColor }") alo trɔ viviti nɔnɔme ƒe amadede (kpɔɖeŋu, ɖo textColorDarkMode="{ $darkColor }").
+       *[none] Be vovototo nasɔ gbɔ le viviti nɔnɔme me la, dzi kekeli nɔnɔme ƒe vovototo ɖe edzi alo trɔ amadede si do tso eme la kple textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Memama ate ŋu atia <stylePalette> ɖeka ko; mamlɛtɔ dzie wowɔa dɔ le.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = mate ŋu akpɔ { $component } ƒe nɔnɔme tɔxɛwo o elabena numToSelect menye xexlẽdzesi blibo si menye ɖoɖodzesi o.
+
+variant-num-to-select-not-constant-number = mate ŋu akpɔ { $component } ƒe nɔnɔme tɔxɛwo o elabena numToSelect menye xexlẽdzesi si metrɔna o.
+
+variant-with-replacement-not-constant-boolean = mate ŋu akpɔ { $component } ƒe nɔnɔme tɔxɛwo o elabena withReplacement menye bulian si metrɔna o.
+
+variant-select-weight-disables-unique = Wotsia select ƒe nɔnɔme tɔxɛwo nu ne tiatia aɖe si selectWeight alo selectForVariants li
+
+variant-coprime-undetermined = mate ŋu akpɔ { $component } ƒe nɔnɔme tɔxɛwo o elabena mate ŋu aka ɖe edzi be coprime nye alakpa ɣesiaɣi o.
+
+variant-attribute-not-constant = mate ŋu akpɔ { $component } ƒe nɔnɔme tɔxɛwo o elabena { $attribute } meli ke o.
+
+variant-attribute-not-number = mate ŋu akpɔ { $component } ƒe nɔnɔme tɔxɛwo o elabena { $attribute } menye xexlẽdzesi o.
+
+variant-attribute-wrong-type-for-sequence =
+    mate ŋu akpɔ { $component } ƒe { $type } ƒomevi nɔnɔme tɔxɛwo o elabena { $attribute } menye { $expected ->
+        [letters-combination] ŋɔŋlɔdzesiwo ƒe ƒoƒuƒu
+        [math-expression] akɔntabubu nyagbe si sɔ
+        [integer] xexlẽdzesi blibo
+       *[number] xexlẽdzesi
+    } o.
+
+variant-length-not-integer = mate ŋu akpɔ { $component } ƒe nɔnɔme tɔxɛwo o elabena length menye xexlẽdzesi blibo o.
+
+variant-sort-not-implemented = womewɔ { $component } ƒe nɔnɔme tɔxɛ siwo si sort le haɖe o
+
+variant-exclude-combinations-not-implemented = womewɔ { $component } ƒe nɔnɔme tɔxɛ siwo si excludeCombinations le haɖe o
+
+variant-math-exclude-not-implemented = womewɔ { $component } ƒe math ƒomevi nɔnɔme tɔxɛ siwo si exclude le haɖe o
+
+variant-non-constant-exclude-not-implemented = womewɔ { $component } ƒe nɔnɔme tɔxɛ siwo si exclude si meli ke o le haɖe o
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: graph prefigure kpɔla la mexɔnɛ o; woto dzidzimevia dzi.
+
+prefigure-descendant-invalid-geometry = { $subject }: nudidi si nu meli na o alo si mede blibo o; woto dzidzimevia dzi.
+
+prefigure-curve-label-omitted = { $subject }: ŋkɔwo mewɔa dɔ le fli gobɛ nu siwo wotrɔ la dzi o; woɖe asi le ŋkɔa ŋu.
+
+prefigure-curve-unsupported-definition-type = { $subject }: fli gobɛ dɔwɔfia ƒe gɔmeɖeɖe ƒomevi '{ $definitionType }' mexɔ o; woto dzidzimevia dzi.
+
+prefigure-region-flip-functions-unsupported = { $subject }: nɔnɔme flipFunctions si le regionBetweenCurves dzi la mexɔ o; woto dzidzimevia dzi.
+
+prefigure-region-non-formula-child = { $subject }: formula ƒomevi vi dɔwɔfiawo koe woxɔna le regionBetweenCurves me; woto dzidzimevia dzi.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' mexɔ na { $labelKind ->
+        [line-family] fli ƒomea ƒe ŋkɔ
+       *[point] nɔƒe ƒe ŋkɔ
+    } o; PreFigure ƒe ɖoɖo si li xoxo dzie wowɔ dɔ le.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure mexɔa yɔyɔ nɔnɔme '{ $fillStyle }' o; egatrɔ yi amadede ɖeka ƒe yɔyɔ dzi.
+
+prefigure-line-style-unknown = { $subject }: womenya fli nɔnɔme '{ $lineStyle }' o eye woɖe asi le eŋu le PreFigure ƒe dɔwɔwɔ me.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wotsɔ dzesi nɔnɔme '{ $markerStyle }' sɔ kple PreFigure ƒe nɔnɔme 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure mexɔa dzesi nɔnɔme '{ $markerStyle }' o; nɔnɔme si li xoxo dzie wowɔ dɔ le.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` mesɔ o; mate ŋu akpɔ taɖodzinua o. Woɖe asi le ŋkuɖodzinua ŋu.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ɖo taɖodzinu geɖe; taɖodzinu gbãtɔ dzie wowɔ dɔ le.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` mesɔ o; taɖodzinua le graf si lée ɖe asi la godo. Woɖe asi le ŋkuɖodzinua ŋu.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` mesɔ o; taɖodzinua menye nɔnɔmetata nu si woxɔna le prefigure tɔtrɔ me o. Woɖe asi le ŋkuɖodzinua ŋu.
+
+annotation-text-missing = `<annotation>`: `text` meli o alo ƒuƒlu wònye; nuŋɔŋlɔ ƒuƒlue wodo goe.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wokpɔ nɔnɔ-ɖe-nɔewo-dzi gogloe.
+       *[other] Wokpɔ nɔnɔ-ɖe-nɔewo-dzi gogloe si ku ɖe nu `<{ $componentType }>` ŋu.
+    }
+
+reference-no-referent = Womekpɔ naneke na asifiafia sia o: `{ $reference }`
+
+reference-multiple-referents = Wokpɔ nu geɖe na asifiafia sia: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Ɖoɖoa mesɔ na `<{ $componentType }>` ƒe nɔnɔme { $attribute } o.
+
+children-invalid = Viawo mesɔ na `<{ $componentType }>` o: Wokpɔ vi siwo mesɔ o: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Home `{ $value }` mesɔ na nɔnɔme `{ $attribute }` o, home `{ $default }` dzie wowɔ dɔ le
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Womekpɔ DoenetML tata { $version } o.
+       *[other] Womekpɔ DoenetML tata { $version } o. Egatrɔ yi tata { $fallback } dzi
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML mesɔ o: { $content }
+
+parse-tag-missing-close-tag = DoenetML mesɔ o: Tugbaɖoɖo tagi mele `{ $tag }` ŋu o. Wokpɔ mɔ na tagi si tua eɖokui alo tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML mesɔ o: Vodada le tagi `<{ $tagName }>` me
+
+parse-attribute-missing-value = DoenetML mesɔ o: Edze abe home mele nɔnɔme `{ $attribute }` si mesɔ o la ŋu o ene.
+
+parse-attribute-invalid = DoenetML mesɔ o: Nɔnɔme `{ $attribute }` mesɔ o
+
+parse-attribute-value-invalid = DoenetML mesɔ o: Nɔnɔme ƒe home `{ $value }` mesɔ o
+
+parse-attribute-value-quote-mismatch = DoenetML mesɔ o: Nɔnɔme ƒe home `{ $value }` mesɔ o. Nyagbɔgblɔ dzesiawo mesɔ o. Edze abe `{ $quote }` bu ene
+
+parse-open-tag-name-missing = DoenetML mesɔ o: Wokpɔ tagi si si ŋkɔ mele o, abe `<` ene
+
+parse-tag-not-closed = DoenetML mesɔ o: Wometu tagi `{ $tag }` nu o (edze abe `>` bu ene).
+
+parse-self-closing-tag-name-missing = DoenetML mesɔ o: Wokpɔ tagi si si ŋkɔ mele o `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML mesɔ o: Wometu tagi `{ $tag }` nu o (edze abe `/>` bu ene).
+
+parse-tag-invalid-attributes = DoenetML mesɔ o: Tagi `{ $tag }` mesɔ o. Ɖewohĩ nɔnɔme siwo mesɔ o le eŋu.
+
+parse-close-tag-name-missing = DoenetML mesɔ o: Wokpɔ tugbaɖoɖo tagi si si ŋkɔ mele o, abe `</` ene
+
+parse-attribute-value-unquoted = Ele be nɔnɔme ƒe homewo nanɔ nyagbɔgblɔ dzesiwo dome: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML mesɔ o: Wokpɔ tugbaɖoɖo tagi `{ $tag }`, gake ʋuʋu tagi si sɔ kplii meli o
+
+parse-close-tag-mismatched = DoenetML mesɔ o: Tugbaɖoɖo tagi la mesɔ o. Wokpɔ mɔ na `</{ $expected }>`. Wokpɔ `{ $found }`
+
+parser-node-unconvertible = Womete ŋu trɔ nɔdi { $node } wòzu Dast nɔdi o.
+
+## Names
+
+name-attribute-invalid =
+    Nɔnɔme name='{ $name }' mesɔ o. { $reason ->
+        [characters] Ŋkɔwo ate ŋu anye ŋɔŋlɔdzesiwo, xexlẽdzesiwo, ete fliwo alo fliwo ko.
+       *[start] Ele be ŋkɔwo nadze egɔme kple ŋɔŋlɔdzesi.
+    }
+
+component-name-invalid-start = Nu ƒe ŋkɔ "{ $name }" mesɔ o. Ele be ŋkɔwo nadze egɔme kple ŋɔŋlɔdzesi.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Ele be nɔnɔme video nanɔ videoWatched ƒomevi ŋuɖoɖo ŋu
+
+answer-video-watched-video-not-reference = Ele be nɔnɔme video si nye asifiafia nanɔ videoWatched ƒomevi ŋuɖoɖo ŋu
+
+answer-name-not-single-text = Ele be text vi ɖeka pɛ ko nanɔ ŋuɖoɖo ƒe nɔnɔme name ŋu
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Mate ŋu axɔ gota DoenetML o elabena egbugbɔ ɖe eɖokui dzi zi geɖe akpa. Ɖe asifiafia gogloe aɖe li mahã?
+
+external-doenetml-unavailable = Mate ŋu axɔ DoenetML tso { $attribute }="{ $uri }" o
+
+external-doenetml-type-mismatch = DoenetML si woxɔ tso { $attribute }="{ $uri }" la mesɔ o: mesɔ kple nu ƒomevi "{ $componentType }" o
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Nɔnɔme `{ $from }` do xoxo; zã `{ $to }` boŋ.
+       *[other] [deprecation] Nɔnɔme `{ $from }` si le `<{ $component }>` dzi la do xoxo; zã `{ $to }` boŋ.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Nɔnɔme `{ $from }` do xoxo eye womebua eŋu o elabena woɖo `{ $to }` hã.
+       *[other] [deprecation] Nɔnɔme `{ $from }` si le `<{ $component }>` dzi la do xoxo eye womebua eŋu o elabena woɖo `{ $to }` hã.
+    }
+
+deprecated-attribute-ignored = [deprecation] Nɔnɔme `{ $attribute }` si le `<{ $component }>` dzi la do xoxo eye womebua eŋu o.
+
+deprecated-attribute-to-child = [deprecation] Nɔnɔme `{ $attribute }` si le `<{ $component }>` dzi la do xoxo; zã `<{ $child }>` vi la boŋ.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ate ŋu awɔ agbɔsɔsɔ le Eŋlisigbe me ko, eya ta eƒe nuŋɔŋlɔ tsi anyi abe ale si wòle ene le agbalẽ si woŋlɔ le { $locale } me la me. Ŋlɔ agbɔsɔsɔ ƒe nɔnɔmea ŋutɔ, alo tsɔe da ɖe nɔnɔme `pluralForm` me.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Nu `<{ $tag }>` menye Doenet nu si wonya o.
+
+schema-element-not-allowed-at-root = Womeɖe mɔ na nu `<{ $tag }>` le agbalẽa ƒe kegli dzi o.
+
+schema-element-not-allowed-inside = Womeɖe mɔ na nu `<{ $tag }>` le `<{ $parent }>` me o.
+
+schema-attribute-unrecognized = Nɔnɔme si ŋkɔe nye `{ $attribute }` mele nu `<{ $tag }>` si o.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Ele be nu `<{ $tag }>` ƒe nɔnɔme `{ $attribute }` nanye nuŋɔŋlɔ si me nu ɖe sia ɖe nye esiawo dometɔ ɖeka: { $allowed }
+       *[other] Ele be nu `<{ $tag }>` ƒe nɔnɔme `{ $attribute }` nanye esiawo dometɔ ɖeka: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nɔnɔmea ƒe ŋkɔ mesɔ na select o. Nɔnɔme ƒe ŋkɔ { $variantName } dze le tiatia { $numOptions } me gake agbɔsɔsɔ si woatia nye { $numToSelect }.
+
+select-variant-name-without-options = Woɖo nɔnɔme aɖewo na select gake womeɖo tiatia aɖeke na nɔnɔme ƒe ŋkɔ si ate ŋu ava o: { $variantName }.
+
+select-variant-name-not-possible = Nɔnɔme ƒe ŋkɔ { $variantName } si woɖo na select la menye nɔnɔme ƒe ŋkɔ si ate ŋu ava o.
+
+select-too-few-options = Mate ŋu atia nu { $numToSelect } le { $numOptions } ko me o.
+
+select-from-sequence-too-few-values = Mate ŋu atia home { $numToSelect } le ɖoɖo si ƒe didime nye { $length } me o.
+
+select-from-sequence-indices-count-mismatch = Ele be indɛks siwo woɖo na select ƒe agbɔsɔsɔ nasɔ kple agbɔsɔsɔ si woatia
+
+select-from-sequence-indices-not-integers = Ele be indɛks siwo katã woɖo na select nanye xexlẽdzesi blibowo
+
+select-from-sequence-index-excluded = Woɖo selectfromsequence indɛks si woɖe ɖa
+
+select-from-sequence-indices-excluded-combination = Woɖo selectfromsequence indɛks siwo nye ƒoƒu si woɖe ɖa
+
+select-from-sequence-coprime-not-positive-integers = Mate ŋu atia xexlẽdzesi siwo mema wo nɔewo o ƒe ƒoƒuwo o elabena menye xexlẽdzesi blibo nyuiwo wole tiam o.
+
+select-from-sequence-coprime-common-factor = Mate ŋu atia xexlẽdzesi siwo mema wo nɔewo o. Nu ɖeka mã home siwo katã ate ŋu ava. (Ele be home siwo woɖo na "from" alo "to" la nagbe "step" mama.)
+
+select-from-sequence-coprime-single-number = Mate ŋu atia xexlẽdzesi siwo mema wo nɔewo o ƒe ƒoƒuwo tso xexlẽdzesi ɖeka si menye 1 o me o.
+
+select-from-sequence-excluded-too-many-combinations = Woɖe ƒoƒuawo ƒe akpa 70% wu ɖa le selectFromSequence me
+
+select-from-sequence-coprime-none-found = Womete ŋu tia xexlẽdzesi siwo mema wo nɔewo o o. Nu ɖeka mã home siwo katã ate ŋu ava.
+
+select-from-sequence-too-few-unique-values = Mate ŋu atia home tɔxɛ { $numToSelect } le ɖoɖo si ƒe didime nye { $numPossibleValues } me o
+
+select-prime-numbers-too-few-values = Mate ŋu atia home { $numToSelect } le xexlẽdzesi mamamawo ƒe nuŋɔŋlɔ si ƒe didime nye { $numValues } me o
+
+select-prime-numbers-values-count-mismatch = Ele be home siwo woɖo na select ƒe agbɔsɔsɔ nasɔ kple agbɔsɔsɔ si woatia
+
+select-prime-numbers-values-not-prime = Ele be home siwo katã woɖo na select prime number nanɔ xexlẽdzesi mamamawo ƒe nuŋɔŋlɔ la me
+
+select-prime-numbers-values-excluded-combination = Home siwo woɖo na selectPrimeNumbers la nye ƒoƒu si woɖe ɖa
+
+select-prime-numbers-excluded-too-many-combinations = Woɖe ƒoƒuawo ƒe akpa 70% wu ɖa le selectPrimeNumbers me
+
+select-random-combination-fluke = Le nu si medzɔna zi geɖe o ta la, womete ŋu tia home tiatiamanɔmee ƒe ƒoƒu o
+
+select-random-value-fluke = Le nu si medzɔna zi geɖe o ta la, womete ŋu tia home tiatiamanɔmee o

--- a/packages/i18n/locales/ee/editor.ftl
+++ b/packages/i18n/locales/ee/editor.ftl
@@ -1,0 +1,204 @@
+# Ewe editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# A counted noun in Ewe takes no plural suffix, so the counted messages drop
+# their selects.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Gaɖoe Ɖe Egɔme
+       *[update] Wɔe Yeyee
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Kpɔla la
+       *[other] { $word } Kpɔla la { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Nɔnɔme
+editor-variant-filter = Tia...
+editor-variant-next = Tia nɔnɔme si kplɔe ɖo
+editor-variant-previous = Tia nɔnɔme si do ŋgɔ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wokpɔ WCAG AA ŋudɔwɔwɔ ƒe sedzimawɔmawɔ. Zi edzi be nàtu ŋudɔwɔwɔ nyatakaka la { $action ->
+            [close] nu
+           *[open] ʋu
+        }.
+        [advisories] Zi edzi be nà{ $action ->
+            [close] tu
+           *[open] ʋu
+        } ŋudɔwɔwɔ nyatakaka la. Womekpɔ WCAG AA sedzimawɔmawɔ aɖeke o, gake aɖaŋuɖoɖo bubuwo li le ŋudɔwɔwɔ ŋu.
+       *[clean] Zi edzi be nà{ $action ->
+            [close] tu
+           *[open] ʋu
+        } ŋudɔwɔwɔ nyatakaka la. Womekpɔ ŋudɔwɔwɔ ƒe kuxi aɖeke o.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wokpɔ WCAG AA ŋudɔwɔwɔ ƒe sedzimawɔmawɔ. Wokpɔ WCAG AA sedzimawɔmawɔ { $count }. Zi edzi be nà{ $action ->
+            [close] tu
+           *[open] ʋu
+        } ŋudɔwɔwɔ nyatakaka la.
+        [advisories] Womekpɔ WCAG AA sedzimawɔmawɔ aɖeke o. Wokpɔ ŋudɔwɔwɔ ŋuti aɖaŋuɖoɖo bubu { $count }. Zi edzi be nà{ $action ->
+            [close] tu
+           *[open] ʋu
+        } ŋudɔwɔwɔ nyatakaka la.
+       *[clean] Womekpɔ WCAG AA sedzimawɔmawɔ aɖeke o. Zi edzi be nà{ $action ->
+            [close] tu
+           *[open] ʋu
+        } ŋudɔwɔwɔ nyatakaka la.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML tata { $version }
+
+editor-tab-help = Kpekpeɖeŋu si sɔ kple nyaa
+editor-tab-help-short = Nyaa
+editor-tab-errors = Vodadawo
+editor-tab-warnings = Nuxlɔ̃amewo
+editor-tab-info = Nyatakaka
+editor-tab-accessibility = Ŋudɔwɔwɔ
+editor-tab-responses = Ŋuɖoɖo siwo woɖo ɖa
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Nuŋlɔla ƒe tiatiawo
+editor-format-as-doenetml = Ɖoe ɖe ɖoɖo nu abe DoenetML ene
+editor-format-as-xml = Ɖoe ɖe ɖoɖo nu abe XML ene
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Fli #{ $line }
+
+editor-no-errors = Vodada Aɖeke Meli O
+editor-no-warnings = Nuxlɔ̃ame Aɖeke Meli O
+editor-no-info = Nyatakaka Ŋuti Nudidi Aɖeke Meli O
+
+editor-show-info-annotations = Fia nyatakaka ŋuti nudidiwo le nuŋlɔla la me
+editor-show-accessibility-annotations = Fia ŋudɔwɔwɔ ŋuti nudidiwo le nuŋlɔla la me
+
+editor-accessibility-learn-more = Srɔ̃ ale si Doenet léa ŋudɔwɔwɔ me ɖe asi
+
+editor-accessibility-violations-heading = Ŋudɔwɔwɔ ƒe sedzimawɔmawɔwo ({ $standard })
+
+editor-accessibility-other-heading = Ŋudɔwɔwɔ ŋuti kuxi bubuwo
+editor-none-found = Womekpɔ naneke o
+
+
+## Submitted responses
+
+editor-no-responses = Womeɖo ŋuɖoɖo aɖeke ɖa haɖe o
+editor-response-answer-id = Ŋuɖoɖoa ƒe Ŋkɔ
+editor-response-response = Ŋuɖoɖo
+editor-response-credit = Dzesi
+editor-response-submitted = Woɖoe ɖa
+
+
+## The context-help panel
+
+help-placeholder = Tsɔ asinudzesia da ɖe tagi ƒe ŋkɔ, nɔnɔme alo { $ref } dzi be nàkpɔ nuŋlɔɖiwo.
+
+help-unsupported-ref-chain = Womete ŋu wɔ dɔ kple asifiafia si me akpa geɖe le abe { $example } ene haɖe o.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Womekpɔ naneke na asifiafia sia o: { $ref }.
+        [multiple] Wokpɔ nu geɖe na asifiafia sia: { $ref }.
+       *[indeterminate] Womete ŋu kpɔ nu si { $ref } fia o.
+    }
+
+help-learn-about-references = Srɔ̃ nu tso asifiafiawo ŋu →
+help-reference-page = Asifiafia ƒe axa →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Le { $element } me
+       *[top] Le tame ke
+    }{ $allowed ->
+        [none] { " — naneke meyi afi sia o." }
+        [text] { " — ŋlɔ nya ɖe afi sia." }
+        [text-and-components] { " — ŋlɔ nya ɖe afi sia, alo dze agbagba kple:" }
+       *[components] { " — nu siwo nàte ŋu adze agbagba:" }
+    }
+
+help-suggestions-footer = Zi { $shortcut } dzi be nàkpɔ nu { $total } katã.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } nye { $target } ƒe asifiafia.
+       *[other] { $ref } nye { $target } ƒe asifiafia (fli { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } na ŋkɔe be { $role }.
+       *[other] { $owner } na ŋkɔe le fli { $line } dzi be { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } nye { $element } ƒe nɔnɔme { $property } ƒe asifiafia.
+       *[other] { $ref } nye { $element } ƒe nɔnɔme { $property } ƒe asifiafia (fli { $line }).
+    }
+
+help-kind-attribute = nɔnɔme
+help-kind-snippet = nuŋɔŋlɔ kpui
+help-kind-array-entry = kplɔ̃ me nu
+
+help-default = Nu si li xoxo:
+help-active-default = Nu si li xoxo eye wòle dɔ wɔm:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Home siwo woɖe mɔ na (ɖeka na nu ɖe sia ɖe):
+       *[other] Home siwo woɖe mɔ na:
+    }
+
+help-suggested-values = Home siwo woɖo ɖa:
+
+help-inserts = Etsɔa esiawo dea eme:
+
+help-coordinates = Nɔƒefiadzesiwo:
+
+help-type = Ƒomevi:
+
+help-resolved-style = Nɔnɔme si wokpɔ (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Dɔwɔfia ƒe ŋkɔ siwo wokpɔ:
+help-reset-list = Nuŋɔŋlɔ si wogaɖoa ɖe egɔme le afi sia:
+help-added-on-input = Nu si wotsɔ kpe ɖe eŋu le afi sia:
+help-removed-on-input = Nu si woɖe ɖa le afi sia:
+
+help-reset-overrides = { $reset } ƒua { $additional } kple { $removed } ta.

--- a/packages/i18n/locales/lg/chrome.ftl
+++ b/packages/i18n/locales/lg/chrome.ftl
@@ -1,0 +1,143 @@
+# Luganda viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Luganda has two plural categories, and a noun marks number with a class
+# prefix rather than a suffix — «omulundi» one time, «emirundi» several;
+# «eky'okuddamu» one answer, «eby'okuddamu» several — and it keeps doing so
+# after a numeral. So the selects are kept and the noun changes shape inside
+# them. `attempts-remaining` also keeps its `[0]` branch, an exact-value match
+# rather than a plural category, which says «tewali» instead of counting to
+# zero.
+
+
+## Answer submission
+
+answer-checking = Ekebera...
+answer-submitting = Eweereza...
+
+answer-checking-status = Ekebera eky'okuddamu
+answer-submitting-status = Eweereza eky'okuddamu
+
+answer-correct = Kituufu
+answer-incorrect = Si kituufu
+
+answer-response-saved = Eky'okuddamu Kitereddwa
+
+answer-percent-credit = Amanya { $percent }%
+answer-percent-correct = { $percent }% Kituufu
+answer-percent-short = { $percent } %
+
+max-credit-available = Amanya agasinga agasoboka: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] tewali mulundi gusigadde
+        [one] omulundi { $count } gusigadde
+       *[other] emirundi { $count } gisigadde
+    }
+
+validation-correct = (Kituufu)
+validation-incorrect = (Si kituufu)
+validation-partially-correct = (Kituufu mu kitundu)
+
+answer-show-responses =
+    { $count ->
+        [one] Laga eky'okuddamu { $count } ekya { $answerId }
+       *[other] Laga eby'okuddamu { $count } ebya { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Okuddamu kw'Omusomesa
+
+collapsible-click-to-open = (nyiga okuggulawo)
+collapsible-click-to-close = (nyiga okuggalawo)
+
+collapsible-initializing = Etandika...
+
+footnote-show = Laga ekiwandiiko eky'emmanga
+footnote-hide = Kweka ekiwandiiko eky'emmanga
+
+description-more-information = ebirala ebikwata ku kino
+
+
+## Controls
+
+slider-previous = Ekiyise
+slider-next = Ekiddako
+
+keyboard-open = Ggulawo Kiibbodi
+keyboard-close = Ggalawo Kiibbodi
+
+choice-input-remove-choice = Ggyawo { $choice }
+
+matrix-remove-row = Ggyawo olunyiriri olugalamidde
+matrix-add-row = Yongerako olunyiriri olugalamidde
+matrix-remove-column = Ggyawo olunyiriri oluyimiridde
+matrix-add-column = Yongerako olunyiriri oluyimiridde
+
+subset-add-remove-points = Yongerako/Ggyawo obutonnyeze
+subset-toggle-points-intervals = Kyusa wakati w'obutonnyeze n'ebbanga
+subset-move-points = Situla Obutonnyeze
+subset-clear = Sangula
+
+# A `box` here is one orbital, drawn as a square: «akasanduuko».
+orbital-add-row = Yongerako Olunyiriri
+orbital-remove-row = Ggyawo Olunyiriri
+orbital-add-box = Yongerako Akasanduuko
+orbital-remove-box = Ggyawo Akasanduuko
+orbital-add-up-arrow = Yongerako Akasaale Akatunuulidde Waggulu
+orbital-add-down-arrow = Yongerako Akasaale Akatunuulidde Wansi
+orbital-remove-arrow = Ggyawo Akasaale
+
+orbital-row-label = Erinnya ly'olunyiriri { $row }
+
+pretzel-answer = Eky'okuddamu
+
+summary-statistics-caption = Enkomerero y'ebibalo bya { $column }
+
+
+## Math input
+
+math-input-preview-region = okulaba mu maaso ng'ebigambo by'okubala
+math-input-preview = Okulaba mu maaso
+math-input-invalid-expression = Ebigambo tebituufu:
+
+
+## Document status
+
+viewer-initializing = Etandika...
+
+
+## Errors
+
+error-heading = Ensobi
+
+error-found-at =
+    { $span ->
+        [line] Kizuuliddwa ku lunyiriri { $startLine }.
+       *[lines] Kizuuliddwa ku nnyiriri { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Ekiwandiiko kino kirimu ensobi!
+
+diagnostic-heading-error = Ensobi
+diagnostic-heading-warning = Okulabula
+diagnostic-heading-information = Ebiwandiiko
+diagnostic-heading-hint = Amagezi
+
+accessibility-heading-level-1 = Okumenya Etteeka lya WCAG AA ery'Okutuukirira
+accessibility-heading-level-2 = Okulabula ku kutuukirira
+
+something-went-wrong = Waliwo ekitagenze bulungi.
+
+renderer-load-failed = omulaga omu tegusobodde kutandika. Ddamu ozzeemu olupapula.
+
+core-start-failed = Omulaga w'ekiwandiiko tasobodde kutandika. Ddamu ozzeemu olupapula.

--- a/packages/i18n/locales/lg/content.ftl
+++ b/packages/i18n/locales/lg/content.ftl
@@ -1,0 +1,346 @@
+# Luganda content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# The roster calls this language **Ganda**, which is what `Intl.DisplayNames`
+# renders `lg` as and so what `<document lang>`'s autocomplete offers. Luganda
+# is the name its speakers use, and the two are one language — the same split
+# `ny` has, where the roster says Nyanja and the speakers say Chichewa.
+#
+# Luganda has no masculine or feminine, and it agrees an adjective with its
+# noun's **class**, so this catalog reads `$gender` as the class token rather
+# than as a gender — the same device `locales/sw` uses. `noun-gender` answers
+# `c3`, `c5`, `c7`, `c9`, `c11` or `c12`, and every adjective that carries a
+# concord selects on it.
+#
+# Six classes is the widest table in this batch, and the reason is that
+# Luganda's own geometry words land in classes the other Bantu catalogs here
+# never need: «olunyiriri», a line, is class 11, and «akasaale», a ray, and
+# «akatonnyeze», a point, are class 12 — the diminutive, which is where a small
+# thing goes whether or not it is small on purpose.
+#
+#           c3 (omu-)   c5 (eri-)    c7 (eki-)    c9 (en-)     c11 (olu-)   c12 (aka-)
+#   -ddugavu omuddugavu eriddugavu   ekiddugavu   enzirugavu   oluddugavu   akaddugavu
+#   -yeru    omweru     eryeru       ekyeru       enjeru       olweru       akeeru
+#   -myufu   omumyufu   erimyufu     ekimyufu     emmyufu      olumyufu     akamyufu
+#   -nene    omunene    erinene      ekinene      ennene       olunene      akanene
+#   -tono    omutono    eritono      ekitono      entono       olutono      akatono
+#   -jjuvu   omujjuvu   erijjuvu     ekijjuvu     enjjuvu      olujjuvu     akajjuvu
+#
+# The initial vowel is part of the word, not an article: «omuddugavu» is one
+# word and dropping the «o» does not make it indefinite, it makes it wrong.
+#
+# `c9` is the default, because that is the class a loanword joins — and an
+# author's own `markerStyleWord`, which this catalog has never seen, is a
+# loanword as far as it is concerned.
+#
+# Only the three colours with a native adjective stem inflect. The rest are
+# invariable nouns, joined attributively with the associative of the class
+# («olunyiriri olunene *olwa* kiragala»). The associative is computable from
+# `$gender`, but the same string is what `backgroundColor` reports standing
+# alone, where a bare associative would be ungrammatical, and nothing in
+# `$role` tells the two apart. So the colour nouns are written bare — the same
+# trade `locales/sw` makes.
+#
+# Adjectives follow the noun, so the composition messages put the noun first.
+# `$role` goes unused: Luganda marks no case.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [c3] omuddugavu
+            [c5] eriddugavu
+            [c7] ekiddugavu
+            [c11] oluddugavu
+            [c12] akaddugavu
+           *[c9] enzirugavu
+        }
+    .white =
+        { $gender ->
+            [c3] omweru
+            [c5] eryeru
+            [c7] ekyeru
+            [c11] olweru
+            [c12] akeeru
+           *[c9] enjeru
+        }
+    .gray = kiwuka
+    .red =
+        { $gender ->
+            [c3] omumyufu
+            [c5] erimyufu
+            [c7] ekimyufu
+            [c11] olumyufu
+            [c12] akamyufu
+           *[c9] emmyufu
+        }
+    .orange = mucungwa
+    .yellow = kyenvu
+    .green = kiragala
+    .cyan = sayani
+    .blue = bbululu
+    .purple = kakobe
+    .pink = pinki
+    .brown = kikanvu
+
+line-width =
+    .thick =
+        { $gender ->
+            [c3] omunene
+            [c5] erinene
+            [c7] ekinene
+            [c11] olunene
+            [c12] akanene
+           *[c9] ennene
+        }
+    .thin =
+        { $gender ->
+            [c3] omutono
+            [c5] eritono
+            [c7] ekitono
+            [c11] olutono
+            [c12] akatono
+           *[c9] entono
+        }
+
+# Written as invariable «olwa …» phrases rather than as adjectives, so that
+# they agree with nothing and can close the description. `style-stroke` puts
+# them last for that reason.
+line-style =
+    .dashed = olw'obutundutundu
+    .dotted = olw'obutonnyeze
+
+fill-style =
+    .horizontal = ennyiriri ezigalamidde
+    .vertical = ennyiriri eziyimiridde
+    .diagonal = ennyiriri ezisenzeeko
+    .backdiagonal = ennyiriri ezisenzeeko emabega
+    .dots = obutonnyeze
+    .diamonds = daayimondi
+
+noun =
+    .line = olunyiriri
+    .line-segment = ekitundu ky'olunyiriri
+    .ray = akasaale
+    .vector = vekita
+    .curve = ekikoona
+    .function = omulimu
+    .parabola = paraboola
+    .polyline = ennyiriri ez'awamu
+    .polygon = poligoni
+    .triangle = ekisatu
+    .rectangle = eky'enjuyi ennya
+    .circle = enkulungo
+    .region = ekitundu
+    .point = akatonnyeze
+    .square = ekyenkanyi
+    .diamond = daayimondi
+    .cross = omusaalaba
+    .plus = akabonero k'okugatta
+
+# The side count goes in the tail, behind the adjectives, because «erina
+# enjuyi 5» is a relative clause and Luganda closes a noun phrase with one
+# rather than opening one.
+noun-regular-polygon =
+    { $part ->
+        [tail] erina enjuyi { $numSides }
+       *[head] poligoni enkanyi
+    }
+
+noun-gender =
+    { $noun ->
+        [line] c11
+        [polyline] c11
+        [border] c11
+        [ray] c12
+        [point] c12
+        [line-segment] c7
+        [region] c7
+        [triangle] c7
+        [rectangle] c7
+        [square] c7
+        [fill] c7
+        [cross] c3
+        [function] c3
+        [text] c5
+       *[other] c9
+    }
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c3] omujjuvu
+        [c5] erijjuvu
+        [c7] ekijjuvu
+        [c11] olujjuvu
+        [c12] akajjuvu
+       *[c9] enjjuvu
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } n'{ $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } n'{ $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } n'{ $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «olukugiro» is class 11 and leads its own adjectives, so the border's words
+# agree with it and not with the shape it surrounds. Luganda has no article, so
+# the two `-article` branches read like the two without, and the complement is
+# joined with the invariable «ne» — «n'» before a vowel — whether it is the
+# first clause or a further one, so `[and]` reads like `[with]` as well. All
+# four end up the same string.
+style-border-clause =
+    { $parts ->
+        [with-article] n'olukugiro { $border }
+        [and] n'olukugiro { $border }
+        [and-article] n'olukugiro { $border }
+       *[with] n'olukugiro { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = tejjuzibbwa
+
+style-text =
+    { $parts ->
+        [background] { $color } ku mabega { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = tewali
+
+
+## Boolean words
+
+boolean-true = kituufu
+boolean-false = bulimba
+
+
+## Answer buttons
+
+answer-submit-label = Kebera Omulimu
+answer-submit-label-no-correctness = Weereza Eky'okuddamu
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Omulimu
+    .aside = Ekigambo eky'oku ludda
+    .cascade = Kasukeedi
+    .definition = Ennyinyonnyola
+    .example = Ekyokulabirako
+    .exercise = Okwegezaamu
+    .exercises = Okwegezaamu
+    .given-answer = Eky'okuddamu
+    .note = Ekijjukizo
+    .objectives = Ebiruubirirwa
+    .paragraphs = Obutundu
+    .part = Ekitundu
+    .problem = Ekizibu
+    .problems = Ebizibu
+    .proof = Obukakafu
+    .question = Ekibuuzo
+    .section = Ekitundu
+    .solution = Eky'okugonjoola
+    .task = Omulimu
+    .theorem = Tiyoremu
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Amagezi
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Ttebulo { $enumeration }
+        [numbered-title] Ttebulo { $enumeration }{ ": " }
+        [unnumbered-title] Ttebulo{ ": " }
+       *[unnumbered] Ttebulo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ekifaananyi { $enumeration }
+        [numbered-caption] Ekifaananyi { $enumeration }{ ": " }
+        [unnumbered-caption] Ekifaananyi{ ": " }
+       *[unnumbered] Ekifaananyi
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ekiyise
+paginator-next = Ekiddako
+paginator-page = Olupapula
+
+paginator-page-status = { $pageLabel } { $currentPage } ku { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = oba
+piecewise-condition-if = singa
+piecewise-condition-otherwise = bwe kitaba bwe kityo
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Ugandan secondary science is
+# taught in English, so a student meeting these words meets them in English
+# already, and the seed has no settled Luganda list to reproduce. A speaker
+# adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Akabonero ka Kemikaali Akatatuufu
+chemistry-invalid-ionic-compound = Ekitabuliddwa kya Ayoni Ekitatuufu

--- a/packages/i18n/locales/lg/diagnostics.ftl
+++ b/packages/i18n/locales/lg/diagnostics.ftl
@@ -1,0 +1,613 @@
+# Luganda diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Luganda verb takes its subject concord
+# from the noun class rather than from the count, and the argument is a list
+# either way. So those selects are dropped and the count argument goes unused.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } tebifaayo ng'obutonnyeze bwombi obw'enkomerero bulagiddwa
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } tebifaayo ng'akatonnyeze k'enkomerero n'akatonnyeze ak'omu makkati byombi bilagiddwa
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset tekikola nga tewali katonnyeze ak'omu makkati
+
+## `<line>`
+
+line-points-undetermined-dimensions = Olunyiriri luyita mu butonnyeze obutamanyiddwa obunene bwabwo.
+
+line-points-too-few-dimensions = Olunyiriri lulina okuyita mu butonnyeze obulina waakiri obunene bubiri.
+
+line-points-depend-on-variables = Olunyiriri luyita mu butonnyeze obwesigama ku bikyukakyuka: { $variables }.
+
+line-equation-invalid-format = Endabika tetuufu ku kwenkanya kw'olunyiriri mu bikyukakyuka { $variable1 } ne { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Akasaale kalagiddwa ne through, endpoint ne direction byonna wamu. through elagiddwa tefaayo.
+
+ray-dimension-mismatch = numDimensions tekituukagana mu kasaale.
+
+## `<vector>`
+
+vector-overprescribed-head = Vekita elagiddwa ne head, tail ne displacement byonna wamu. head elagiddwa tefaayo.
+
+vector-dimension-mismatch = numDimensions tekituukagana mu vekita.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Tekisoboka kusikirizibwa ku `<{ $component }>` kubanga terina kikyukakyuka ky'embeera nearestPoint.
+
+constrain-to-without-nearest-point = Tekisoboka kukwatibwa ku `<{ $component }>` kubanga terina kikyukakyuka ky'embeera nearestPoint.
+
+constrain-to-interior-without-nearest-point = Tekisoboka kukwatibwa munda mu `<{ $component }>` kubanga terina kikyukakyuka ky'embeera nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition tefaayo ku choiceInput etali ya lunyiriri lumu
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Obubonero obulagiddwa ku choiceInput tebufaayo kubanga omuwendo gw'obubonero tegutuukagana n'omuwendo gw'abaana ba choice.
+
+pretzel-indices-count-mismatch = Obubonero obulagiddwa ku problem tebufaayo kubanga omuwendo gw'obubonero tegutuukagana n'omuwendo gw'abaana ba problem.
+
+shuffle-indices-count-mismatch = Obubonero obulagiddwa ku shuffle tebufaayo kubanga omuwendo gw'obubonero tegutuukagana n'omuwendo gw'ebintu.
+
+indices-ignored-out-of-range = Obubonero obulagiddwa ku { $component } tebufaayo kubanga obumu ku bubonero buli ebweru w'ekigero.
+
+pretzel-indices-repeated = Obubonero obulagiddwa ku pretzel tebufaayo kubanga obumu ku bubonero buddiŋŋanyiziddwa.
+
+pretzel-circuit-first-index = Obubonero obulagiddwa ku pretzel mu mutindo circuit tebufaayo kubanga akabonero akasooka kalina okuba 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` okukola n'abaana ab'ekika ky'ebigambo, engeri `type` erina okulagibwa.
+
+invalid-type-defaulting-to-math = type { $type } tetuufu ku kintu { $component }. Erina okuba emu ku math, text, number oba boolean. Eteekebwako math.
+
+string-not-valid-component-to-arrange = Ebigambo "{ $value }" si kintu kya { $component } ekituufu. Tekifaayo.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } tetuufu, type eteekebwako number.
+
+invalid-variable-value = Omuwendo gw'ekikyukakyuka si mutuufu: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Akabonero k'engeri { $index } kalina okuba omuwendo
+
+variant-index-must-be-integer = Akabonero k'engeri { $index } kalina okuba omuwendo omulamba
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` tekikoleddwa n'ebipimo ebikakafu. Obugazi buteekebwako mu bitundu.
+
+side-by-side-absolute-margins = `<{ $component }>` tekikoleddwa n'ebipimo ebikakafu. Ensalo ziteekebwako mu bitundu.
+
+side-by-side-no-block-child = `<{ $component }>` tetuufu: kirina okuba n'omwana omu waakiri ow'ekika kya bbulooka.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Engeri `for` ku `<label>` ey'ekifaananyi tefaayo.
+
+label-for-must-resolve-to-one = Engeri `for` ku `<label>` erina okulaga ekintu kimu kyokka.
+
+label-for-unresolved = Engeri `for` ku `<label>` teyasobodde kulaga kintu kyonna.
+
+label-for-answer-with-authored-inputs = Engeri `for` ku `<label>` eraga `<answer>` erina ebiyingizibwa ebiwandiikiddwa; laga ekiyingizibwa kyennyini.
+
+label-for-answer-without-input = Engeri `for` ku `<label>` eraga `<answer>` etalina kiyingizibwa kya kutuuma.
+
+label-for-must-reference-input-or-answer = Engeri `for` ku `<label>` erina okulaga ekiyingizibwa oba eky'okuddamu.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Olw'okutuukirira, `<{ $component }>` kirina okuba n'ennyinyonnyola empi oba kirageddwa nga kya kuwoomya.
+
+accessibility-video-short-description = Olw'okutuukirira, `<video>` erina okuba n'ennyinyonnyola empi.
+
+accessibility-input-short-description-or-label = Olw'okutuukirira, `<{ $component }>` kirina okuba n'ennyinyonnyola empi oba erinnya.
+
+accessibility-answer-input-short-description-or-label = Olw'okutuukirira, `<answer>` ekola ekiyingizibwa erina okuba n'ennyinyonnyola empi oba erinnya.
+
+accessibility-short-description-contains-math = Ennyinyonnyola empi terina kubaamu bintu bya kubala nga `<{ $component }>`. Nnyonnyola okubala kwonna n'ebigambo.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } terina njawulo emala ku bigambo by'omutwe gw'ekitundu (embeera ey'ekizikiza) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaaga waakiri { $threshold }:1).
+       *[other] { $colorName } terina njawulo emala ku bigambo by'omutwe gw'ekitundu ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaaga waakiri { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` eyita mu butonnyeze { $count } tennakolebwa ng'obutonnyeze obwo tebulina miwendo gya kubala.
+
+circle-too-many-through-points = Tekisoboka kubala nkulungo eyita mu butonnyeze obusukka mu 3.
+
+circle-overprescribed-radius-center-points = Tekisoboka kubala nkulungo erina lediyaasi, wakati n'obutonnyeze obw'okuyitamu byonna nga bilagiddwa.
+
+circle-center-with-multiple-points = Tekisoboka kubala nkulungo erina wakati alagiddwa nga eyita mu butonnyeze obusukka mu 1.
+
+circle-radius-too-small = Tekisoboka kubala nkulungo: olw'okuba ebbanga wakati w'obutonnyeze bwombi ni { $distance }, lediyaasi { $radius } elagiddwa ntono nnyo.
+
+circle-radius-with-many-points = Tekisoboka kukola nkulungo eyita mu butonnyeze obusukka mu bubiri erina lediyaasi elagiddwa.
+
+circle-invalid-center-or-through-points = Wakati w'enkulungo oba obutonnyeze bwayo obw'okuyitamu si butuufu.
+
+circle-radius-center-with-multiple-points = Tekisoboka kubala lediyaasi y'enkulungo erina wakati alagiddwa nga eyita mu butonnyeze obusukka mu 1.
+
+circle-change-radius-non-numerical = Tekisoboka kukyusa lediyaasi y'enkulungo eyita mu butonnyeze obutalina miwendo gya kubala
+
+circle-radius-with-points-non-numerical = Tekisoboka kukola nkulungo eyita mu butonnyeze obusukka mu bumu erina lediyaasi elagiddwa nga tewali miwendo gya kubala.
+
+circle-change-center-non-numerical = Okukyusa wakati w'enkulungo eyita mu butonnyeze obutalina miwendo gya kubala tekunnakolebwa.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Obunene bw'ekitundu ky'omulimu tebumala. Ekitundu kirina amabanga { $intervals } naye omulimu gulina ebiyingizibwa { $inputs }.
+
+function-domain-invalid-format = Endabika y'ekitundu ky'omulimu tetuufu.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Enkomerero ya waggulu ey'omulimu etali ya kubala tefaayo.
+        [minimum] Enkomerero ya wansi ey'omulimu etali ya kubala tefaayo.
+        [extremum] Enkomerero y'omulimu etali ya kubala tefaayo.
+        [point] Akatonnyeze k'omulimu akatali ka kubala tekafaayo.
+        [slope] Okusenza kw'omulimu okutali kwa kubala tekufaayo.
+       *[other] { $type } ey'omulimu etali ya kubala tefaayo.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Enkomerero ya waggulu ey'omulimu enkalu tefaayo.
+        [minimum] Enkomerero ya wansi ey'omulimu enkalu tefaayo.
+        [extremum] Enkomerero y'omulimu enkalu tefaayo.
+        [point] Akatonnyeze k'omulimu akakalu tekafaayo.
+       *[other] { $type } ey'omulimu enkalu tefaayo.
+    }
+
+function-points-too-close = Omulimu gulina obutonnyeze bubiri obuli kumpi nnyo. Omulimu tegusobola kunnyonnyolwa.
+
+function-iterates-input-output-mismatch = Okuddiŋŋana kw'omulimu kusoboka bwe kuba nti omuwendo gw'ebiyingizibwa gwenkanankana n'omuwendo gw'ebifuluma. Omulimu guno gulina ebiyingizibwa { $inputs } n'ebifuluma { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Obuwanvu bw'olusa si butuufu. Bulina okuba omuwendo omulamba ogutali wansi wa zeero.
+
+sequence-invalid-step = Ekigere ky'olusa si kituufu. Mu lusa olw'ekika { $type } kirina okuba omuwendo.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ey'olusa lw'emiwendo si ntuufu. Erina okuba omuwendo.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ey'olusa lw'ennukuta si ntuufu. Erina okuba ennukuta.
+
+sequence-invalid-endpoint = "{ $attribute }" ey'olusa si ntuufu.
+
+select-from-sequence-coprime-not-numbers = coprime tefaayo kubanga si miwendo egirondebwa
+
+select-from-sequence-coprime-with-exclude-combinations = coprime tefaayo kubanga excludeCombinations elagiddwa
+
+## Resolving a `target`
+
+target-not-found = target tetuufu ku `<{ $source }>`: ekigendererwa tekizuuliddwa.
+
+target-state-variable-not-found = target tetuufu ku `<{ $source }>`: ekikyukakyuka ky'embeera ekiyitibwa "{ $property }" tekizuuliddwa ku `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Ebikyukakyuka bya `<odeSystem>` birina okwawukana ku kikyukakyuka ekyetwala.
+
+ode-system-duplicate-variable-names = Tekisoboka kunnyonnyola mirimu gya ODE RHS egirina amannya g'ebikyukakyuka agaddiŋŋanyiziddwa.
+
+ode-system-rhs-function-error = Tekisoboka kunnyonnyola mulimu gwa ODE RHS. Ensobi mu kukola omulimu gwa mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Tekisoboka kunnyonnyola nsonda wakati w'ennyiriri { $count }
+
+angle-invalid-through-point = Akatonnyeze tekatuufu mu through eya `<angle>`
+
+parabola-vertex-too-many-points = Paraboola erina enkomerero eyita mu butonnyeze obusukka mu 1 tennakolebwa.
+
+parabola-too-many-points = Paraboola eyita mu butonnyeze obusukka mu 3 tennakolebwa.
+
+intersection-too-many-items = Okusisinkana kw'ebintu ebisukka mu bibiri tekunnakolebwa
+
+## Other math components
+
+ionic-compound-not-two-ions = Ekitabuliddwa kya ayoni ekisukka mu ayoni bbiri tekinnakolebwa.
+
+ionic-compound-needs-cation-and-anion = Ekitabuliddwa kya ayoni kikoleddwa ku katiyoni emu ne anayoni emu zokka.
+
+solve-equations-cannot-evaluate = Tekisoboka kugonjoola kwenkanya kubanga okwenkanya tekusobodde kubalibwa: { $equation }
+
+math-operators-operand-number-required = operandNumber erina okulagibwa nga eggyibwako operandi ey'okubala.
+
+eigen-decomposition-failed = Tekisoboka kubala miwendo gya eigen egya matiriki
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameeta { $parameters } tezirabika mu ndabika, bwe kityo zijja kutuukagana n'obwereere buli kiseera.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: tekisoboka kutegeera grid="{ $grid }". Erina okuba none, medium, dense, oba emiwendo ebiri emirungi egyawuliddwa n'ekifo, nga grid="1 0.5". Tewali giriidi ekubibwa.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" tewagirwa mu mulaga wa prefigure; embeera ey'oku ddyo ekozesebwa.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" tewagirwa mu mulaga wa prefigure; embeera ey'oku ntikko ekozesebwa.
+
+prefigure-invalid-axis-bounds = `<graph>`: ensalo z'akasaale si ntuufu ku nkyukakyuka ya prefigure; bbox (-10,-10,10,10) ekozesebwa.
+
+prefigure-invalid-width = `<graph>`: obugazi si butuufu ku nkyukakyuka ya prefigure; obugazi bw'ekifaananyi 425 bukozesebwa.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio si ntuufu ku nkyukakyuka ya prefigure; ekigero 1 kikozesebwa.
+
+prefigure-grid-spacing-too-fine = `<graph>`: amabanga ga giriidi matono nnyo ku nsalo z'akasaale; giriidi elekeddwa mu mulaga wa prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: ebijjukizo tebijja kulagibwa ng'omulaga wa PreFigure takozesebwa.
+
+multiple-annotations-children = Abaana bangi aba `<annotations>` bazuuliddwa mu `<graph>`; bonna tebafaayo okuggyako ow'enkomerero.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Tekisoboka kugaziya oba kukoppa kika kya kintu ekitamanyiddwa: { $type }.
+
+copy-prop-not-found = Engeri { $property } tezuuliddwa ku kintu eky'ekika { $component }
+
+collect-no-source = Tewali nsibuko ezuuliddwa ku collect.
+
+collect-invalid-component-type = Tekisoboka kukuŋŋaanya bintu bya kika `<{ $component }>` kubanga kika kya kintu ekitali kituufu.
+
+reference-index-unavailable = Tekisoboka kulaga kabonero `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Tekisoboka kuyita { $action } ku kintu `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Endabika ya data si ntuufu. Ennyiriri zirina obuwanvu obutatuukagana. Kizuuliddwa ku componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data erina amannya g'ennyiriri eziyimiridde agaddiŋŋanyiziddwa. Kizuuliddwa ku componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data ebulwako erinnya ly'olunyiriri oluyimiridde. Kizuuliddwa ku componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = award emu ey'eky'okuddamu kino yesigama ku ky'okuddamu ekyaweerezebwa tagi answer yennyini, era ekyo kijja kuleeta embeera etasuubirwa.
+
+answer-max-num-attempts-in-section-wide-check-work = Okuteeka `maxNumAttempts` ku `<answer>` eri munda mu kisenge ekirina `sectionWideCheckWork` tekikola kintu, kubanga ekisenge ekyo kye kifuga omuwendo gw'emirundi. Teeka `maxNumAttempts` ku kisenge kyennyini.
+
+nested-section-wide-check-work-max-num-attempts = Okuteeka `maxNumAttempts` ku kisenge ekirina `sectionWideCheckWork` ekiri munda mu kisenge ekirala ekirina `sectionWideCheckWork` tekikola kintu, kubanga ekisenge eky'ebweru kye kifuga omuwendo gw'emirundi. Teeka `maxNumAttempts` ku kisenge eky'ebweru.
+
+answer-attributes-need-symbolic-equality = Engeri { $attributes } tezijja kukola kintu nga symbolicEquality teteekeddwako.
+
+answer-invalid-type = Ekika tekituufu ku ky'okuddamu: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Olw'okuba ekintu `<{ $component }>` tekirina linnya, tekisobola kukozesebwa nga ngeri ya module
+
+module-attribute-name-already-defined = Ekintu `<{ $component } name="{ $name }">` tekisobola kukozesebwa nga ngeri ya module kubanga ekika ky'ekintu `<module>` kirina dda engeri eyitibwa "{ $name }".
+
+conditional-content-condition-ignored = Engeri `condition` tefaayo ku kintu `<conditionalContent>` ekirina abaana ba case oba else.
+
+slider-markers-type-mismatch = Ekika ky'obubonero tekituukagana n'ekika kya slider.
+
+pretzel-problem-needs-statement-and-answer = pretzel tetuufu: buli `<problem>` erina okuba n'`<statement>` emu n'`<answer>` emu.
+
+pretzel-circuit-first-problem-distractor = pretzel tetuufu: mu mode="circuit", `<problem>` esooka tesobola kuba ya kubuzaabuza.
+
+## Attribute values
+
+attribute-invalid-values = Emiwendo { $values } si mituufu ku ngeri `{ $attribute }`; tegifaayo.
+
+attribute-must-be-references = Omuwendo `{ $value }` si mutuufu ku ngeri `{ $attribute }`. Engeri erina okukolebwa n'obulaga obutandika ne `$`.
+
+math-input-invalid-function-names = <mathInput>: amannya g'emirimu agatali matuufu mu { $attribute } tegafaayo: { $names }. Ekitundu ekiraga ekya buli linnya kirina okuba n'ennukuta 2 waakiri (ennukuta oba akalago); `|<mathspeak alternative>` esobola okugoberera.
+
+## Building components from the source
+
+component-type-invalid = Ekika ky'ekintu tekituufu: `<{ $componentType }>`
+
+attribute-repeated = Engeri { $attribute } tesobola kuddiŋŋanyizibwa.
+
+attribute-invalid-for-component = Engeri "{ $attribute }" tetuufu ku kintu eky'ekika `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Ennyinyonnyola y'endabika { $styleNumber } terina njawulo emala ku { $context ->
+        [text-on-background] langi y'ebigambo ku langi y'emabega
+        [high-contrast] langi ey'enjawulo ennene ku lubaawo
+        [line] langi y'olunyiriri ku lubaawo
+        [marker] langi y'akabonero ku lubaawo
+       *[text-on-canvas] langi y'ebigambo ku lubaawo
+    }{ $mode ->
+        [dark] { " (embeera ey'ekizikiza)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaaga waakiri { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Wadde ennyinyonnyola y'endabika { $styleNumber } yalaga langi eziwa enjawulo emala mu mbeera ey'omusana, langi ez'embeera ey'ekizikiza ezivaamu tezirina njawulo emala ku langi y'ebigambo ku langi y'emabega ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaaga waakiri { $threshold }:1). { $suggestion ->
+        [available] Okukakasa enjawulo emala mu mbeera ey'ekizikiza, yongera enjawulo ey'embeera ey'omusana (ng'ekyokulabirako teeka { $lightAttribute }="{ $lightColor }") oba kyusa langi ey'embeera ey'ekizikiza (ng'ekyokulabirako teeka { $darkAttribute }="{ $darkColor }").
+       *[none] Okukakasa enjawulo emala mu mbeera ey'ekizikiza, yongera enjawulo ey'embeera ey'omusana oba kyusa langi ezivaamu ne textColorDarkMode ne/oba backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Wadde ennyinyonnyola y'endabika { $styleNumber } yalaga langi y'ebigambo ewa enjawulo emala mu mbeera ey'omusana, langi y'ebigambo ey'embeera ey'ekizikiza evaamu terina njawulo emala ku lubaawo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kyetaaga waakiri { $threshold }:1). { $suggestion ->
+        [available] Okukakasa enjawulo emala mu mbeera ey'ekizikiza, yongera enjawulo ey'embeera ey'omusana (ng'ekyokulabirako teeka textColor="{ $lightColor }") oba kyusa langi ey'embeera ey'ekizikiza (ng'ekyokulabirako teeka textColorDarkMode="{ $darkColor }").
+       *[none] Okukakasa enjawulo emala mu mbeera ey'ekizikiza, yongera enjawulo ey'embeera ey'omusana oba kyusa langi evaamu ne textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Ekitundu kisobola kulonda <stylePalette> emu yokka; ey'enkomerero ye ekozesebwa.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = tekisoboka kunnyonnyola ngeri za njawulo eza { $component } kubanga numToSelect si muwendo mulamba ogutali wansi wa zeero.
+
+variant-num-to-select-not-constant-number = tekisoboka kunnyonnyola ngeri za njawulo eza { $component } kubanga numToSelect si muwendo ogutakyuka.
+
+variant-with-replacement-not-constant-boolean = tekisoboka kunnyonnyola ngeri za njawulo eza { $component } kubanga withReplacement si buliyaani etakyuka.
+
+variant-select-weight-disables-unique = Engeri za njawulo eza select ziggalwawo bwe wabaawo okulonda okulina selectWeight oba selectForVariants ekulagiddwa
+
+variant-coprime-undetermined = tekisoboka kunnyonnyola ngeri za njawulo eza { $component } kubanga tekisoboka kukakasa nti coprime bulimba buli kiseera.
+
+variant-attribute-not-constant = tekisoboka kunnyonnyola ngeri za njawulo eza { $component } kubanga { $attribute } tenywevu.
+
+variant-attribute-not-number = tekisoboka kunnyonnyola ngeri za njawulo eza { $component } kubanga { $attribute } si muwendo.
+
+variant-attribute-wrong-type-for-sequence =
+    tekisoboka kunnyonnyola ngeri za njawulo eza { $component } ez'ekika { $type } kubanga { $attribute } si { $expected ->
+        [letters-combination] ntabula ya nnukuta
+        [math-expression] bigambo bya kubala ebituufu
+        [integer] muwendo mulamba
+       *[number] muwendo
+    }.
+
+variant-length-not-integer = tekisoboka kunnyonnyola ngeri za njawulo eza { $component } kubanga length si muwendo mulamba.
+
+variant-sort-not-implemented = engeri za njawulo eza { $component } ezirina sort tezinnakolebwa
+
+variant-exclude-combinations-not-implemented = engeri za njawulo eza { $component } ezirina excludeCombinations tezinnakolebwa
+
+variant-math-exclude-not-implemented = engeri za njawulo eza { $component } ez'ekika math ezirina exclude tezinnakolebwa
+
+variant-non-constant-exclude-not-implemented = engeri za njawulo eza { $component } ezirina exclude etanywevu tezinnakolebwa
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: tekiwagirwa mu mulaga wa graph prefigure; omuzzukulu abuukiddwa.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiyomeetule etaliiko nsalo oba etatuukiridde; omuzzukulu abuukiddwa.
+
+prefigure-curve-label-omitted = { $subject }: amannya tegawagirwa ku bintu bya kikoona ebikyusiddwa; erinnya lirekeddwa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ekika ky'ennyinyonnyola y'omulimu gw'ekikoona '{ $definitionType }' tekiwagirwa; omuzzukulu abuukiddwa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: engeri flipFunctions ku regionBetweenCurves tewagirwa; omuzzukulu abuukiddwa.
+
+prefigure-region-non-formula-child = { $subject }: emirimu gy'abaana ab'ekika formula gyokka gye giwagirwa ku regionBetweenCurves; omuzzukulu abuukiddwa.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' tewagirwa ku { $labelKind ->
+        [line-family] erinnya ly'ekika ky'olunyiriri
+       *[point] erinnya ly'akatonnyeze
+    }; entegeka ya PreFigure ekozesebwa.
+
+prefigure-fill-style-unsupported = { $subject }: endabika y'okujjuza '{ $fillStyle }' tewagirwa PreFigure; edda ku kujjuza kwa langi emu.
+
+prefigure-line-style-unknown = { $subject }: endabika y'olunyiriri '{ $lineStyle }' temanyiddwa era erekeddwa mu bivaamu bya PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: endabika y'akabonero '{ $markerStyle }' egeraageranyiziddwa n'endabika ya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: endabika y'akabonero '{ $markerStyle }' tewagirwa PreFigure; endabika eriwo edda ekozesebwa.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` tetuufu; ekigendererwa tekisobola kumanyibwa. Ekijjukizo kirekeddwa.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` yalaga ebigendererwa bingi; ekigendererwa ekisooka kye kikozesebwa.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` tetuufu; ekigendererwa kiri ebweru wa girafu ekikirimu. Ekijjukizo kirekeddwa.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` tetuufu; ekigendererwa si kintu kya kifaananyi ekiwagirwa mu nkyukakyuka ya prefigure. Ekijjukizo kirekeddwa.
+
+annotation-text-missing = `<annotation>`: `text` tewali oba nkalu; ebigambo ebikalu bye bifulumizibwa.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Okwesigama okwetooloola kuzuuliddwa.
+       *[other] Okwesigama okwetooloola okuzingiramu ekintu `<{ $componentType }>` kuzuuliddwa.
+    }
+
+reference-no-referent = Tewali kizuuliddwa ku kulaga: `{ $reference }`
+
+reference-multiple-referents = Ebintu bingi bizuuliddwa ku kulaga: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Endabika tetuufu ku ngeri { $attribute } eya `<{ $componentType }>`.
+
+children-invalid = Abaana si batuufu ku `<{ $componentType }>`: Abaana abatali batuufu bazuuliddwa: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Omuwendo `{ $value }` si mutuufu ku ngeri `{ $attribute }`, omuwendo `{ $default }` gukozesebwa
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML engeri { $version } tezuuliddwa.
+       *[other] DoenetML engeri { $version } tezuuliddwa. Edda ku ngeri { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML tetuufu: { $content }
+
+parse-tag-missing-close-tag = DoenetML tetuufu: Tagi `{ $tag }` terina tagi ya kuggalawo. Twali tusuubira tagi eyeeggalawo oba tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML tetuufu: Ensobi mu tagi `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML tetuufu: Engeri `{ $attribute }` etali ntuufu erabika ng'ebulwako omuwendo.
+
+parse-attribute-invalid = DoenetML tetuufu: Engeri `{ $attribute }` tetuufu
+
+parse-attribute-value-invalid = DoenetML tetuufu: Omuwendo gw'engeri `{ $value }` si mutuufu
+
+parse-attribute-value-quote-mismatch = DoenetML tetuufu: Omuwendo gw'engeri `{ $value }` si mutuufu. Obubonero bw'ebigambo tebutuukagana. Kirabika `{ $quote }` ebuze
+
+parse-open-tag-name-missing = DoenetML tetuufu: Tagi etaliiko linnya ezuuliddwa, ng'ekyokulabirako `<`
+
+parse-tag-not-closed = DoenetML tetuufu: Tagi `{ $tag }` teggaliddwawo (kirabika `>` ebuze).
+
+parse-self-closing-tag-name-missing = DoenetML tetuufu: Tagi etaliiko linnya ezuuliddwa `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML tetuufu: Tagi `{ $tag }` teggaliddwawo (kirabika `/>` ebuze).
+
+parse-tag-invalid-attributes = DoenetML tetuufu: Tagi `{ $tag }` tetuufu. Oboolyawo erina engeri ezitali ntuufu.
+
+parse-close-tag-name-missing = DoenetML tetuufu: Tagi ey'okuggalawo etaliiko linnya ezuuliddwa, ng'ekyokulabirako `</`
+
+parse-attribute-value-unquoted = Emiwendo gy'engeri girina okuteekebwa munda mu bubonero bw'ebigambo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML tetuufu: Tagi ey'okuggalawo `{ $tag }` ezuuliddwa, naye tewali tagi ya kuggulawo etuukagana nayo
+
+parse-close-tag-mismatched = DoenetML tetuufu: Tagi ey'okuggalawo tetuukagana. Twali tusuubira `</{ $expected }>`. Kizuuliddwa `{ $found }`
+
+parser-node-unconvertible = Tekisobose kukyusa nnoodi { $node } okufuuka nnoodi ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    Engeri name='{ $name }' tetuufu. { $reason ->
+        [characters] Amannya gasobola okuba n'ennukuta, emiwendo, obulago obw'omunda oba obulago bwokka.
+       *[start] Amannya galina okutandika n'ennukuta.
+    }
+
+component-name-invalid-start = Erinnya ly'ekintu "{ $name }" si ttuufu. Amannya galina okutandika n'ennukuta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Eky'okuddamu eky'ekika videoWatched kirina okuba n'engeri video
+
+answer-video-watched-video-not-reference = Eky'okuddamu eky'ekika videoWatched kirina okuba n'engeri video eri okulaga
+
+answer-name-not-single-text = Engeri name ey'eky'okuddamu erina okuba n'omwana text omu yekka
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Tekisoboka kufuna DoenetML ey'ebweru olw'okuddiŋŋana okungi ennyo. Waliwo okulaga okwetooloola?
+
+external-doenetml-unavailable = Tekisoboka kufuna DoenetML okuva ku { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML eyafunibwa okuva ku { $attribute }="{ $uri }" si ntuufu: tetuukagana n'ekika ky'ekintu "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Engeri `{ $from }` ekaddiye; kozesa `{ $to }`.
+       *[other] [deprecation] Engeri `{ $from }` ku `<{ $component }>` ekaddiye; kozesa `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Engeri `{ $from }` ekaddiye era tefaayo kubanga `{ $to }` nayo elagiddwa.
+       *[other] [deprecation] Engeri `{ $from }` ku `<{ $component }>` ekaddiye era tefaayo kubanga `{ $to }` nayo elagiddwa.
+    }
+
+deprecated-attribute-ignored = [deprecation] Engeri `{ $attribute }` ku `<{ $component }>` ekaddiye era tefaayo.
+
+deprecated-attribute-to-child = [deprecation] Engeri `{ $attribute }` ku `<{ $component }>` ekaddiye; kozesa omwana `<{ $child }>`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` esobola okukola obungi mu Lungereza kyokka, bwe kityo ebigambo byayo bisigala nga bwe biri mu kiwandiiko ekyawandiikibwa mu { $locale }. Wandiika endabika y'obungi ggwe kennyini, oba gitekeko ku ngeri `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ekintu `<{ $tag }>` si kintu kya Doenet ekimanyiddwa.
+
+schema-element-not-allowed-at-root = Ekintu `<{ $tag }>` tekikkirizibwa ku musingi gw'ekiwandiiko.
+
+schema-element-not-allowed-inside = Ekintu `<{ $tag }>` tekikkirizibwa munda mu `<{ $parent }>`.
+
+schema-attribute-unrecognized = Ekintu `<{ $tag }>` tekirina ngeri eyitibwa `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Engeri `{ $attribute }` ey'ekintu `<{ $tag }>` erina okuba olukalala nga buli kintu kirimu kimu ku bino: { $allowed }
+       *[other] Engeri `{ $attribute }` ey'ekintu `<{ $tag }>` erina okuba kimu ku bino: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Erinnya ly'engeri si ttuufu ku select. Erinnya ly'engeri { $variantName } lirabika mu bulonzi { $numOptions } naye omuwendo gw'okulonda ni { $numToSelect }.
+
+select-variant-name-without-options = Engeri ezimu zilagiddwa ku select naye tewali kulonda kulagiddwa ku rinnya ly'engeri erisoboka: { $variantName }.
+
+select-variant-name-not-possible = Erinnya ly'engeri { $variantName } eryalagiddwa ku select si rinnya lya ngeri erisoboka.
+
+select-too-few-options = Tekisoboka kulonda bintu { $numToSelect } okuva mu { $numOptions } byokka.
+
+select-from-sequence-too-few-values = Tekisoboka kulonda miwendo { $numToSelect } mu lusa olulina obuwanvu { $length }.
+
+select-from-sequence-indices-count-mismatch = Omuwendo gw'obubonero obulagiddwa ku select gulina okutuukagana n'omuwendo gw'okulonda
+
+select-from-sequence-indices-not-integers = Obubonero bwonna obulagiddwa ku select bulina okuba emiwendo emiramba
+
+select-from-sequence-index-excluded = Akabonero ka selectfromsequence akaggyiddwawo kalagiddwa
+
+select-from-sequence-indices-excluded-combination = Obubonero bwa selectfromsequence obwali ntabula eyaggyibwawo bulagiddwa
+
+select-from-sequence-coprime-not-positive-integers = Tekisoboka kulonda ntabula za miwendo egitagabana kubanga si miwendo mirungi mirambe egirondebwa.
+
+select-from-sequence-coprime-common-factor = Tekisoboka kulonda miwendo egitagabana. Emiwendo gyonna egisoboka gigabana omugabanya gumu. (Emiwendo egilagiddwa egya "from" oba "to" girina obutagabana ne "step".)
+
+select-from-sequence-coprime-single-number = Tekisoboka kulonda ntabula za miwendo egitagabana okuva ku muwendo gumu ogutali 1.
+
+select-from-sequence-excluded-too-many-combinations = Okusukka mu 70% ez'entabula ziggyiddwawo mu selectFromSequence
+
+select-from-sequence-coprime-none-found = Tekisobose kulonda miwendo egitagabana. Emiwendo gyonna egisoboka gigabana omugabanya gumu.
+
+select-from-sequence-too-few-unique-values = Tekisoboka kulonda miwendo egy'enjawulo { $numToSelect } mu lusa olulina obuwanvu { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Tekisoboka kulonda miwendo { $numToSelect } mu lukalala lw'emiwendo egy'obusika olulina obuwanvu { $numValues }
+
+select-prime-numbers-values-count-mismatch = Omuwendo gw'emiwendo egilagiddwa ku select gulina okutuukagana n'omuwendo gw'okulonda
+
+select-prime-numbers-values-not-prime = Emiwendo gyonna egilagiddwa ku select prime number girina okuba mu lukalala lw'emiwendo egy'obusika
+
+select-prime-numbers-values-excluded-combination = Emiwendo gya selectPrimeNumbers egyalagiddwa gyali ntabula eyaggyibwawo
+
+select-prime-numbers-excluded-too-many-combinations = Okusukka mu 70% ez'entabula ziggyiddwawo mu selectPrimeNumbers
+
+select-random-combination-fluke = Mu ngeri etatera kubaawo, tekisobose kulonda ntabula ya miwendo egitalondeddwa
+
+select-random-value-fluke = Mu ngeri etatera kubaawo, tekisobose kulonda muwendo ogutalondeddwa

--- a/packages/i18n/locales/lg/editor.ftl
+++ b/packages/i18n/locales/lg/editor.ftl
@@ -1,0 +1,214 @@
+# Luganda editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Luganda marks number with a class prefix and keeps doing so after a numeral,
+# so a counted message keeps its select where the noun it counts has a plural
+# to change into: `help-coordinates` does, «akabonero» becoming «obubonero».
+# `editor-accessibility-label` does not, and both of its counted nouns are the
+# reason rather than one of them: «okumenya», a violation, is the class 15
+# verbal noun and has no plural at all, and «amagezi», advice, is already
+# class 6 and counts without changing. So both of its selects are dropped
+# rather than written as a `[one]` that repeats its `[other]`.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Zzaawo
+       *[update] Longoosa
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Omulaga
+       *[other] { $word } Omulaga { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Engeri
+editor-variant-filter = Londa...
+editor-variant-next = Londa engeri eddako
+editor-variant-previous = Londa engeri eyise
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Okumenya etteeka lya WCAG AA ery'okutuukirira kuzuuliddwa. Nyiga o{ $action ->
+            [close] ggalewo
+           *[open] ggulewo
+        } alipoota y'okutuukirira.
+        [advisories] Nyiga o{ $action ->
+            [close] ggalewo
+           *[open] ggulewo
+        } alipoota y'okutuukirira. Tewali kumenya WCAG AA okuzuuliddwa, naye waliwo amagezi amalala ku kutuukirira.
+       *[clean] Nyiga o{ $action ->
+            [close] ggalewo
+           *[open] ggulewo
+        } alipoota y'okutuukirira. Tewali kizibu kya kutuukirira ekizuuliddwa.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Okumenya etteeka lya WCAG AA ery'okutuukirira kuzuuliddwa. Okumenya { $count } okwa WCAG AA kuzuuliddwa. Nyiga o{ $action ->
+            [close] ggalewo
+           *[open] ggulewo
+        } alipoota y'okutuukirira.
+        [advisories] Tewali kumenya WCAG AA okuzuuliddwa. Amagezi { $count } amalala ag'okutuukirira gazuuliddwa. Nyiga o{ $action ->
+            [close] ggalewo
+           *[open] ggulewo
+        } alipoota y'okutuukirira.
+       *[clean] Tewali kumenya WCAG AA okuzuuliddwa. Nyiga o{ $action ->
+            [close] ggalewo
+           *[open] ggulewo
+        } alipoota y'okutuukirira.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML engeri { $version }
+
+editor-tab-help = Obuyambi obutuukira ku kifo
+editor-tab-help-short = Ekifo
+editor-tab-errors = Ensobi
+editor-tab-warnings = Okulabula
+editor-tab-info = Ebiwandiiko
+editor-tab-accessibility = Okutuukirira
+editor-tab-responses = Eby'okuddamu ebiweereddwa
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Obulonzi bw'omuwandiisi
+editor-format-as-doenetml = Tegeka nga DoenetML
+editor-format-as-xml = Tegeka nga XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Olunyiriri #{ $line }
+
+editor-no-errors = Tewali Nsobi
+editor-no-warnings = Tewali Kulabula
+editor-no-info = Tewali Kukebera kwa Biwandiiko
+
+editor-show-info-annotations = Laga okukebera kw'ebiwandiiko mu muwandiisi
+editor-show-accessibility-annotations = Laga okukebera kw'okutuukirira mu muwandiisi
+
+editor-accessibility-learn-more = Yiga engeri Doenet gy'ekwatamu okutuukirira
+
+editor-accessibility-violations-heading = Okumenya etteeka ly'okutuukirira ({ $standard })
+
+editor-accessibility-other-heading = Ebizibu ebirala eby'okutuukirira
+editor-none-found = Tewali kizuuliddwa
+
+
+## Submitted responses
+
+editor-no-responses = Tewali ky'okuddamu kiweereddwa kati
+editor-response-answer-id = Erinnya ly'Eky'okuddamu
+editor-response-response = Eky'okuddamu
+editor-response-credit = Amanya
+editor-response-submitted = Kiweereddwa
+
+
+## The context-help panel
+
+help-placeholder = Teeka akabonero ku linnya lya tagi, engeri oba { $ref } okufuna ebiwandiiko.
+
+help-unsupported-ref-chain = Obuyambi ku bulaga obw'ebitundu bingi nga { $example } tebunnaba kubaawo.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Tewali kizuuliddwa ku kulaga: { $ref }.
+        [multiple] Ebintu bingi bizuuliddwa ku kulaga: { $ref }.
+       *[indeterminate] Ekyo { $ref } ky'eraga tekimanyiddwa.
+    }
+
+help-learn-about-references = Yiga ku bulaga →
+help-reference-page = Olupapula lw'obulaga →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Munda mu { $element }
+       *[top] Ku mutindo ogwa waggulu
+    }{ $allowed ->
+        [none] { " — tewali kiyingira wano." }
+        [text] { " — wandiika ebigambo wano." }
+        [text-and-components] { " — wandiika ebigambo wano, oba gezaako:" }
+       *[components] { " — ebintu by'oyinza okugezaako:" }
+    }
+
+help-suggestions-footer = Nyiga { $shortcut } okulaba ebintu byonna { $total }.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } kwe kulaga okwa { $target }.
+       *[other] { $ref } kwe kulaga okwa { $target } (olunyiriri { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } yakituuma { $role }.
+       *[other] { $owner } yakituuma { $role } ku lunyiriri { $line }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } kwe kulaga okw'engeri { $property } eya { $element }.
+       *[other] { $ref } kwe kulaga okw'engeri { $property } eya { $element } (olunyiriri { $line }).
+    }
+
+help-kind-attribute = engeri
+help-kind-snippet = akatundu k'ebigambo
+help-kind-array-entry = ekiyingizibwa mu ttebulo
+
+help-default = Ekiriwo edda:
+help-active-default = Ekiriwo edda era ekikola:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Emiwendo egikkirizibwa (gumu ku buli kintu):
+       *[other] Emiwendo egikkirizibwa:
+    }
+
+help-suggested-values = Emiwendo egiwabulwa:
+
+help-inserts = Kiyingiza:
+
+help-coordinates =
+    { $count ->
+        [one] Akabonero k'ekifo:
+       *[other] Obubonero bw'ebifo:
+    }
+
+help-type = Ekika:
+
+help-resolved-style = Endabika emanyiddwa (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Amannya g'emirimu agamanyiddwa:
+help-reset-list = Olukalala oluzzibwawo ku kuyingiza kuno:
+help-added-on-input = Ekyongeddwako ku kuyingiza kuno:
+help-removed-on-input = Ekiggiddwawo ku kuyingiza kuno:
+
+help-reset-overrides = { $reset } esinga { $additional } ne { $removed }.

--- a/packages/i18n/locales/ln/chrome.ftl
+++ b/packages/i18n/locales/ln/chrome.ftl
@@ -1,0 +1,144 @@
+# Lingala viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Lingala has two plural categories, and CLDR puts **zero** in the `one` branch
+# with it, so nothing here can lean on the category to say "no ...". A noun
+# marks number by changing its class prefix rather than by taking a suffix —
+# «momekano» one attempt, «mimekano» several; «eyano» one answer, «biyano»
+# several — and it keeps doing so after a numeral. So the selects are kept and
+# the noun changes shape inside them, which is the same reason the Slavic
+# catalogs keep theirs. `attempts-remaining` still writes its own `[0]` branch,
+# an exact-value match ahead of the category.
+
+
+## Answer submission
+
+answer-checking = Ezali kotala...
+answer-submitting = Ezali kotinda...
+
+answer-checking-status = Ezali kotala eyano
+answer-submitting-status = Ezali kotinda eyano
+
+answer-correct = Ebongi
+answer-incorrect = Ebongi te
+
+answer-response-saved = Eyano Ebombami
+
+answer-percent-credit = Motuya { $percent }%
+answer-percent-correct = { $percent }% Ebongi
+answer-percent-short = { $percent } %
+
+max-credit-available = Motuya monene oyo ekoki kozwama: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] momekano moko etikali te
+        [one] momekano { $count } etikali
+       *[other] mimekano { $count } etikali
+    }
+
+validation-correct = (Ebongi)
+validation-incorrect = (Ebongi te)
+validation-partially-correct = (Ebongi na ndambo)
+
+answer-show-responses =
+    { $count ->
+        [one] Lakisá eyano { $count } ya { $answerId }
+       *[other] Lakisá biyano { $count } ya { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Eyano ya Molakisi
+
+collapsible-click-to-open = (finá mpo na kofungola)
+collapsible-click-to-close = (finá mpo na kokanga)
+
+collapsible-initializing = Ezali kobanda...
+
+footnote-show = Lakisá liyebisi ya nse
+footnote-hide = Bombá liyebisi ya nse
+
+description-more-information = basango mosusu
+
+
+## Controls
+
+slider-previous = Eleki
+slider-next = Elandi
+
+keyboard-open = Fungolá Klavye
+keyboard-close = Kangá Klavye
+
+choice-input-remove-choice = Longolá { $choice }
+
+matrix-remove-row = Longolá molɔngɔ ya kolala
+matrix-add-row = Bakisá molɔngɔ ya kolala
+matrix-remove-column = Longolá molɔngɔ ya kotɛlɛma
+matrix-add-column = Bakisá molɔngɔ ya kotɛlɛma
+
+subset-add-remove-points = Bakisá/Longolá matono
+subset-toggle-points-intervals = Bongolá kati ya matono na bantaka
+subset-move-points = Longolá Matono
+subset-clear = Pɛtolá
+
+# A `box` here is one orbital, drawn as a square: «sanduku».
+orbital-add-row = Bakisá Molɔngɔ
+orbital-remove-row = Longolá Molɔngɔ
+orbital-add-box = Bakisá Sanduku
+orbital-remove-box = Longolá Sanduku
+orbital-add-up-arrow = Bakisá Likula ya Likolo
+orbital-add-down-arrow = Bakisá Likula ya Nse
+orbital-remove-arrow = Longolá Likula
+
+orbital-row-label = Nkombo ya molɔngɔ { $row }
+
+pretzel-answer = Eyano
+
+summary-statistics-caption = Motango mokuse ya { $column }
+
+
+## Math input
+
+math-input-preview-region = botali liboso ya maloba ya matematiki
+math-input-preview = Botali liboso
+math-input-invalid-expression = Maloba ebongi te:
+
+
+## Document status
+
+viewer-initializing = Ezali kobanda...
+
+
+## Errors
+
+error-heading = Libunga
+
+error-found-at =
+    { $span ->
+        [line] Emonani na molɔngɔ { $startLine }.
+       *[lines] Emonani na milɔngɔ { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Mokanda oyo ezali na mabunga!
+
+diagnostic-heading-error = Libunga
+diagnostic-heading-warning = Likebisi
+diagnostic-heading-information = Sango
+diagnostic-heading-hint = Toli
+
+accessibility-heading-level-1 = Kobuka Mibeko ya WCAG AA mpo na Bokɔti
+accessibility-heading-level-2 = Likebisi mpo na bokɔti
+
+something-went-wrong = Eloko moko esalemi malamu te.
+
+renderer-load-failed = molakisi moko ekokaki kokɔta te. Zongisá lokasa.
+
+core-start-failed = Molakisi ya mokanda akokaki kobanda te. Zongisá lokasa.

--- a/packages/i18n/locales/ln/content.ftl
+++ b/packages/i18n/locales/ln/content.ftl
@@ -1,0 +1,302 @@
+# Lingala content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Lingala has no masculine or feminine, and it agrees an adjective with its
+# noun's **class**, so this catalog reads `$gender` as the class token rather
+# than as a gender — the same device `locales/sw` uses, and for the same
+# reason: a token set is a token set. `noun-gender` answers `c3`, `c5`, `c7` or
+# `c9`, and the adjectives that carry a concord select on it.
+#
+# The concords this catalog writes out:
+#
+#          c3 (mo-/mi-)  c5 (li-/ma-)  c7 (e-/bi-)  c9 (N-)
+#   -nene   monene        linene        enene        enene
+#   -kɛ     mokɛ          likɛ          ekɛ          ekɛ
+#   -tondi  motondi       litondi       etondi       etondi
+#
+# Two adjective stems and one participle is all it reaches, and that is the
+# difference from Swahili worth recording: Lingala's inventory of true
+# adjectives — the stems that take a concord at all — is small, and every
+# colour in this catalog is outside it.
+# The colours are French loans, which is what Kinshasa and Brazzaville say, and
+# a loan is invariable. So `color` selects on nothing, and the three native
+# colour words that do exist — «moindo», «mpɛmbɛ», «motane» — are written in
+# the c3 shape they are usually cited in rather than inflected, because the
+# same string is what `backgroundColor` reports standing alone.
+#
+# Adjectives follow the noun, so the composition messages put the noun first.
+# `$role` goes unused: Lingala marks no case, and the three clause positions
+# each arrive with the class of their own noun already set.
+#
+# `c9` is the default, because that is the class a loanword joins — and an
+# author's own `markerStyleWord`, which this catalog has never seen, is a
+# loanword as far as it is concerned.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+# Invariable: the three native words are cited in their c3 shape, and the rest
+# are French loans, which do not change shape for anything.
+color =
+    .black = moindo
+    .white = mpɛmbɛ
+    .gray = gri
+    .red = motane
+    .orange = oranje
+    .yellow = jonɛ
+    .green = vɛrɛ
+    .cyan = siyan
+    .blue = blɛ
+    .purple = violɛ
+    .pink = rozɛ
+    .brown = marɔ
+
+line-width =
+    .thick =
+        { $gender ->
+            [c3] monene
+            [c5] linene
+            [c7] enene
+           *[c9] enene
+        }
+    .thin =
+        { $gender ->
+            [c3] mokɛ
+            [c5] likɛ
+            [c7] ekɛ
+           *[c9] ekɛ
+        }
+
+# Written as invariable «na …» phrases rather than as adjectives, so that they
+# agree with nothing and can close the description. `style-stroke` puts them
+# last for that reason.
+line-style =
+    .dashed = na bantɔkɔ
+    .dotted = na bapwɛ
+
+fill-style =
+    .horizontal = milɔngɔ ya kolala
+    .vertical = milɔngɔ ya kotɛlɛma
+    .diagonal = milɔngɔ ya ngwɛ
+    .backdiagonal = milɔngɔ ya ngwɛ ya nsima
+    .dots = bapwɛ
+    .diamonds = balozanje
+
+noun =
+    .line = molɔngɔ
+    .line-segment = eteni ya molɔngɔ
+    .ray = mwinda
+    .vector = vɛktɛrɛ
+    .curve = kurbɛ
+    .function = fɔnksiɔ
+    .parabola = parabolɛ
+    .polyline = milɔngɔ ebele
+    .polygon = poligonɛ
+    .triangle = triangle
+    .rectangle = rɛktangle
+    .circle = sɛrkɛlɛ
+    .region = etuka
+    .point = litono
+    .square = karé
+    .diamond = lozanje
+    .cross = ekulusu
+    .plus = elembo ya kobakisa
+
+# The side count goes in the tail, behind the adjectives, because «oyo ezali na
+# mipanzi 5» is a relative clause and Lingala closes a noun phrase with one
+# rather than opening one.
+noun-regular-polygon =
+    { $part ->
+        [tail] oyo ezali na mipanzi { $numSides }
+       *[head] poligonɛ ya bokokani
+    }
+
+# The noun class, which is what an adjective agrees with. `c9` is the default
+# and the class of every loanword, including a word an author supplies.
+noun-gender =
+    { $noun ->
+        [line] c3
+        [ray] c3
+        [polyline] c3
+        [border] c3
+        [point] c5
+        [region] c7
+        [line-segment] c7
+        [fill] c7
+        [text] c5
+       *[other] c9
+    }
+
+
+## Style composition
+
+# The dash pattern is a «na …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c3] motondi
+        [c5] litondi
+        [c7] etondi
+       *[c9] etondi
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } na { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } na { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «ndelo» leads its own adjectives, so the border's words agree with it and not
+# with the shape it surrounds. Lingala has no article and joins a complement
+# with the invariable «na», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] na ndelo { $border }
+        [and] na ndelo { $border }
+        [and-article] na ndelo { $border }
+       *[with] na ndelo { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = etondi te
+
+style-text =
+    { $parts ->
+        [background] { $color } likolo ya nsima { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = eloko te
+
+
+## Boolean words
+
+boolean-true = solo
+boolean-false = lokuta
+
+
+## Answer buttons
+
+answer-submit-label = Talá Mosala
+answer-submit-label-no-correctness = Tinda Eyano
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Mosala
+    .aside = Liloba ya pembeni
+    .cascade = Kaskadɛ
+    .definition = Ndimbola
+    .example = Ndakisa
+    .exercise = Momekano
+    .exercises = Mimekano
+    .given-answer = Eyano
+    .note = Likanisi
+    .objectives = Mikano
+    .paragraphs = Biteni
+    .part = Eteni
+    .problem = Mokakatano
+    .problems = Mikakatano
+    .proof = Elembeteli
+    .question = Motuna
+    .section = Eteni
+    .solution = Bosili
+    .task = Mosala
+    .theorem = Teorɛmɛ
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Toli
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabelo { $enumeration }
+        [numbered-title] Tabelo { $enumeration }{ ": " }
+        [unnumbered-title] Tabelo{ ": " }
+       *[unnumbered] Tabelo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Elilingi { $enumeration }
+        [numbered-caption] Elilingi { $enumeration }{ ": " }
+        [unnumbered-caption] Elilingi{ ": " }
+       *[unnumbered] Elilingi
+    }
+
+
+## Paginator controls
+
+paginator-previous = Eleki
+paginator-next = Elandi
+paginator-page = Lokasa
+
+paginator-page-status = { $pageLabel } { $currentPage } na kati ya { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = to
+piecewise-condition-if = soki
+piecewise-condition-otherwise = soki te
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Secondary science in both
+# Congos is taught in French, so a student meeting these words meets them in a
+# European language already, and the seed has no settled Lingala list to
+# reproduce. A speaker adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Elembo ya Shimi Ebongi Te
+chemistry-invalid-ionic-compound = Bosangani ya Ioni Ebongi Te

--- a/packages/i18n/locales/ln/diagnostics.ftl
+++ b/packages/i18n/locales/ln/diagnostics.ftl
@@ -1,0 +1,618 @@
+# Lingala diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Lingala verb takes its subject concord
+# from the noun class rather than from the count, and the argument is a list
+# either way. So those selects are dropped and the count argument goes unused.
+#
+# The technical vocabulary is the French-derived one Kinshasa and Brazzaville
+# schooling supplies — «fɔnksiɔ», «indɛkse», «variablɛ» — beside the Lingala
+# words for the things that are not technical: «molɔngɔ» a line, «motuya» a
+# value, «nkombo» a name.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } etalelami te soki matono mibale ya nsuka elimbolami
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } etalelami te soki litono ya nsuka mpe litono ya katikati nyonso mibale elimbolami
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset esalaka eloko te soki litono ya katikati ezali te
+
+## `<line>`
+
+line-points-undetermined-dimensions = Molɔngɔ eleki na matono oyo bonene na yango eyebani te.
+
+line-points-too-few-dimensions = Molɔngɔ esengeli koleka na matono oyo ezali na bonene mibale ata.
+
+line-points-depend-on-variables = Molɔngɔ eleki na matono oyo etali bavariablɛ: { $variables }.
+
+line-equation-invalid-format = Lolenge ebongi te mpo na ekwasiɔ ya molɔngɔ na bavariablɛ { $variable1 } mpe { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Mwinda elimbolami na through, endpoint mpe direction nyonso misato. through oyo elimbolami etalelami te.
+
+ray-dimension-mismatch = numDimensions ekokani te na kati ya mwinda.
+
+## `<vector>`
+
+vector-overprescribed-head = Vɛktɛrɛ elimbolami na head, tail mpe displacement nyonso misato. head oyo elimbolami etalelami te.
+
+vector-dimension-mismatch = numDimensions ekokani te na kati ya vɛktɛrɛ.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ekoki kobendama epai ya `<{ $component }>` te mpo ezali na variablɛ ya ezaleli nearestPoint te.
+
+constrain-to-without-nearest-point = Ekoki kokangama na `<{ $component }>` te mpo ezali na variablɛ ya ezaleli nearestPoint te.
+
+constrain-to-interior-without-nearest-point = Ekoki kokangama na kati ya `<{ $component }>` te mpo ezali na variablɛ ya ezaleli nearestPoint te.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition etalelami te na choiceInput oyo ezali na molɔngɔ moko te
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ba-indɛkse oyo elimbolami mpo na choiceInput etalelami te mpo motango ya ba-indɛkse ekokani te na motango ya bana choice.
+
+pretzel-indices-count-mismatch = Ba-indɛkse oyo elimbolami mpo na problem etalelami te mpo motango ya ba-indɛkse ekokani te na motango ya bana problem.
+
+shuffle-indices-count-mismatch = Ba-indɛkse oyo elimbolami mpo na shuffle etalelami te mpo motango ya ba-indɛkse ekokani te na motango ya biloko.
+
+indices-ignored-out-of-range = Ba-indɛkse oyo elimbolami mpo na { $component } etalelami te mpo ba-indɛkse mosusu ezali libanda ya ndelo.
+
+pretzel-indices-repeated = Ba-indɛkse oyo elimbolami mpo na pretzel etalelami te mpo ba-indɛkse mosusu ezongelami.
+
+pretzel-circuit-first-index = Ba-indɛkse oyo elimbolami mpo na pretzel na modi circuit etalelami te mpo indɛkse ya liboso esengeli kozala 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Mpo `<{ $component }>` esala na bana ya lolenge ya makomi, ezalela `type` esengeli kolimbolama.
+
+invalid-type-defaulting-to-math = type { $type } ebongi te mpo na eloko { $component }. Esengeli kozala moko ya math, text, number to boolean. Ezali kotiama math.
+
+string-not-valid-component-to-arrange = Makomi "{ $value }" ezali eloko ya { $component } ya malamu te. Etalelami te.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } ebongi te, type ezali kotiama number.
+
+invalid-variable-value = Motuya ya variablɛ ebongi te: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indɛkse ya lolenge { $index } esengeli kozala motango
+
+variant-index-must-be-integer = Indɛkse ya lolenge { $index } esengeli kozala motango mobimba
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` esalemi na bomeki ya solosolo te. Bonene ezali kotiama na ndambo.
+
+side-by-side-absolute-margins = `<{ $component }>` esalemi na bomeki ya solosolo te. Bandelo ezali kotiama na ndambo.
+
+side-by-side-no-block-child = `<{ $component }>` ebongi te: esengeli kozala na mwana moko ata ya lolenge ya blɔ.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ezalela `for` na `<label>` ya elilingi etalelami te.
+
+label-for-must-resolve-to-one = Ezalela `for` na `<label>` esengeli kolakisa eloko moko kaka.
+
+label-for-unresolved = Ezalela `for` na `<label>` ekokaki kolakisa eloko moko te.
+
+label-for-answer-with-authored-inputs = Ezalela `for` na `<label>` ezali kolakisa `<answer>` oyo ezali na ba-ekɔteli oyo ekomami; lakisá ekɔteli yango moko.
+
+label-for-answer-without-input = Ezalela `for` na `<label>` ezali kolakisa `<answer>` oyo ezali na ekɔteli ya kopesa nkombo te.
+
+label-for-must-reference-input-or-answer = Ezalela `for` na `<label>` esengeli kolakisa ekɔteli to eyano.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Mpo na bokɔti, `<{ $component }>` esengeli kozala na ndimbola mokuse to elimbolama lokola ya kobongisa.
+
+accessibility-video-short-description = Mpo na bokɔti, `<video>` esengeli kozala na ndimbola mokuse.
+
+accessibility-input-short-description-or-label = Mpo na bokɔti, `<{ $component }>` esengeli kozala na ndimbola mokuse to nkombo.
+
+accessibility-answer-input-short-description-or-label = Mpo na bokɔti, `<answer>` oyo ezali kosala ekɔteli esengeli kozala na ndimbola mokuse to nkombo.
+
+accessibility-short-description-contains-math = Ndimbola mokuse esengeli kozala na biloko ya matematiki lokola `<{ $component }>` te. Limbolá matematiki nyonso na maloba.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ezali na bokeseni ekoki te mpo na makomi ya motó ya eteni (modi ya molili) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; esengeli kozala ata { $threshold }:1).
+       *[other] { $colorName } ezali na bokeseni ekoki te mpo na makomi ya motó ya eteni ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; esengeli kozala ata { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` oyo eleki na matono { $count } esalemi naino te soki matono yango ezali na mituya ya motango te.
+
+circle-too-many-through-points = Ekoki kotánga sɛrkɛlɛ oyo eleki na matono koleka 3 te.
+
+circle-overprescribed-radius-center-points = Ekoki kotánga sɛrkɛlɛ oyo ezali na rɛyɔ, katikati mpe matono ya koleka nyonso elimbolami te.
+
+circle-center-with-multiple-points = Ekoki kotánga sɛrkɛlɛ oyo katikati na yango elimbolami mpe oyo eleki na matono koleka 1 te.
+
+circle-radius-too-small = Ekoki kotánga sɛrkɛlɛ te: lokola ntaka kati ya matono mibale ezali { $distance }, rɛyɔ { $radius } oyo elimbolami ezali moke mingi.
+
+circle-radius-with-many-points = Ekoki kosala sɛrkɛlɛ oyo eleki na matono koleka mibale na rɛyɔ oyo elimbolami te.
+
+circle-invalid-center-or-through-points = Katikati ya sɛrkɛlɛ to matono ya koleka na yango ebongi te.
+
+circle-radius-center-with-multiple-points = Ekoki kotánga rɛyɔ ya sɛrkɛlɛ oyo katikati na yango elimbolami mpe oyo eleki na matono koleka 1 te.
+
+circle-change-radius-non-numerical = Ekoki kobongola rɛyɔ ya sɛrkɛlɛ oyo eleki na matono oyo ezali na mituya ya motango te
+
+circle-radius-with-points-non-numerical = Ekoki kosala sɛrkɛlɛ oyo eleki na litono koleka moko na rɛyɔ oyo elimbolami soki mituya ya motango ezali te.
+
+circle-change-center-non-numerical = Kobongola katikati ya sɛrkɛlɛ oyo eleki na matono oyo ezali na mituya ya motango te esalemi naino te.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Bonene ya etuka ya fɔnksiɔ ekoki te. Etuka ezali na bantaka { $intervals } kasi fɔnksiɔ ezali na ba-ekɔteli { $inputs }.
+
+function-domain-invalid-format = Lolenge ya etuka ya fɔnksiɔ ebongi te.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Nsɔngɛ ya likolo ya fɔnksiɔ oyo ezali motango te etalelami te.
+        [minimum] Nsɔngɛ ya nse ya fɔnksiɔ oyo ezali motango te etalelami te.
+        [extremum] Nsɔngɛ ya fɔnksiɔ oyo ezali motango te etalelami te.
+        [point] Litono ya fɔnksiɔ oyo ezali motango te etalelami te.
+        [slope] Ngwɛ ya fɔnksiɔ oyo ezali motango te etalelami te.
+       *[other] { $type } ya fɔnksiɔ oyo ezali motango te etalelami te.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Nsɔngɛ ya likolo ya fɔnksiɔ oyo ezali polele etalelami te.
+        [minimum] Nsɔngɛ ya nse ya fɔnksiɔ oyo ezali polele etalelami te.
+        [extremum] Nsɔngɛ ya fɔnksiɔ oyo ezali polele etalelami te.
+        [point] Litono ya fɔnksiɔ oyo ezali polele etalelami te.
+       *[other] { $type } ya fɔnksiɔ oyo ezali polele etalelami te.
+    }
+
+function-points-too-close = Fɔnksiɔ ezali na matono mibale oyo ezali penepene mingi. Fɔnksiɔ ekoki kolimbolama te.
+
+function-iterates-input-output-mismatch = Bozongeli ya fɔnksiɔ ekoki kosalema kaka soki motango ya ba-ekɔteli ekokani na motango ya ba-ebimeli. Fɔnksiɔ oyo ezali na ba-ekɔteli { $inputs } mpe ba-ebimeli { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Bolai ya molɔngɔ ebongi te. Esengeli kozala motango mobimba oyo ezali na nse ya zero te.
+
+sequence-invalid-step = Litambe ya molɔngɔ ebongi te. Na molɔngɔ ya lolenge { $type } esengeli kozala motango.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ya molɔngɔ ya mitango ebongi te. Esengeli kozala motango.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ya molɔngɔ ya balɛtrɛ ebongi te. Esengeli kozala balɛtrɛ.
+
+sequence-invalid-endpoint = "{ $attribute }" ya molɔngɔ ebongi te.
+
+select-from-sequence-coprime-not-numbers = coprime etalelami te mpo ezali mitango te oyo eponami
+
+select-from-sequence-coprime-with-exclude-combinations = coprime etalelami te mpo excludeCombinations elimbolami
+
+## Resolving a `target`
+
+target-not-found = target ebongi te mpo na `<{ $source }>`: eloko oyo elukami emonani te.
+
+target-state-variable-not-found = target ebongi te mpo na `<{ $source }>`: variablɛ ya ezaleli oyo nkombo na yango ezali "{ $property }" emonani te na `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Bavariablɛ ya `<odeSystem>` esengeli kokesana na variablɛ ya bomoko.
+
+ode-system-duplicate-variable-names = Ekoki kolimbola ba-fɔnksiɔ ya ODE RHS te soki bankombo ya bavariablɛ ezongelami.
+
+ode-system-rhs-function-error = Ekoki kolimbola fɔnksiɔ ya ODE RHS te. Libunga esalemi na kosala fɔnksiɔ ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ekoki kolimbola angle kati ya milɔngɔ { $count } te
+
+angle-invalid-through-point = Litono ebongi te na through ya `<angle>`
+
+parabola-vertex-too-many-points = Parabolɛ oyo ezali na nsɔngɛ mpe eleki na matono koleka 1 esalemi naino te.
+
+parabola-too-many-points = Parabolɛ oyo eleki na matono koleka 3 esalemi naino te.
+
+intersection-too-many-items = Bokutani ya biloko koleka mibale esalemi naino te
+
+## Other math components
+
+ionic-compound-not-two-ions = Bosangani ya ioni oyo eleki ba-ioni mibale esalemi naino te.
+
+ionic-compound-needs-cation-and-anion = Bosangani ya ioni esalemi kaka mpo na kation moko mpe anion moko.
+
+solve-equations-cannot-evaluate = Ekoki kosilisa ekwasiɔ te mpo ekwasiɔ ekokaki kotángama te: { $equation }
+
+math-operators-operand-number-required = operandNumber esengeli kolimbolama ntango ezali kobimisa operandɛ ya matematiki.
+
+eigen-decomposition-failed = Ekoki kotánga mituya eigen ya matrisɛ te
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: baparamɛtrɛ { $parameters } ezali na kati ya lolenge te, yango wana ekokokana na polele ntango nyonso.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ekoki kolimbola grid="{ $grid }" te. Esengeli kozala none, medium, dense, to mitango mibale ya malamu oyo ekabolami na esika mpamba, lokola grid="1 0.5". Grilɛ moko te ezali kosalema.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" endimami te na molakisi ya prefigure; ezaleli ya ngámbo ya mobali ezali kosalelama.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" endimami te na molakisi ya prefigure; ezaleli ya likolo ezali kosalelama.
+
+prefigure-invalid-axis-bounds = `<graph>`: bandelo ya aksɛ ebongi te mpo na bobongoli ya prefigure; bbox (-10,-10,10,10) ezali kosalelama.
+
+prefigure-invalid-width = `<graph>`: bonene ebongi te mpo na bobongoli ya prefigure; bonene ya elilingi 425 ezali kosalelama.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio ebongi te mpo na bobongoli ya prefigure; bokokani 1 ezali kosalelama.
+
+prefigure-grid-spacing-too-fine = `<graph>`: bantaka ya grilɛ ezali mikemike mingi mpo na bandelo ya aksɛ; grilɛ etikali na molakisi ya prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: makanisi ekolakisama te soki molakisi ya PreFigure esalelami te.
+
+multiple-annotations-children = Bana `<annotations>` ebele emonani na `<graph>`; nyonso etalelami te longola kaka ya nsuka.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ekoki kotanda to kokopi lolenge ya eloko oyo eyebani te: { $type }.
+
+copy-prop-not-found = Ezalela { $property } emonani te na eloko ya lolenge { $component }
+
+collect-no-source = Esika ya kozwa emonani te mpo na collect.
+
+collect-invalid-component-type = Ekoki koyanganisa biloko ya lolenge `<{ $component }>` te mpo ezali lolenge ya eloko oyo ebongi te.
+
+reference-index-unavailable = Ekoki kolakisa indɛkse `{ $reference }` te
+
+## `<callAction>`
+
+component-action-unavailable = Ekoki kobenga { $action } na eloko `{ $reference }` te
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Lolenge ya ba-donɛ ebongi te. Milɔngɔ ezali na bolai ekokani te. Emonani na componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Ba-donɛ ezali na bankombo ya milɔngɔ ya kotɛlɛma oyo ezongelami. Emonani na componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Ba-donɛ ezangi nkombo ya molɔngɔ ya kotɛlɛma. Emonani na componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = award moko ya eyano oyo etali eyano oyo tagi answer yango moko etindaki, mpe yango ekobimisa ezaleli oyo ezelami te.
+
+answer-max-num-attempts-in-section-wide-check-work = Kotia `maxNumAttempts` na `<answer>` oyo ezali na kati ya libenga oyo ezali na `sectionWideCheckWork` esalaka eloko te, mpo libenga yango nde ezali kotala motango ya mimekano. Tiá `maxNumAttempts` na libenga yango.
+
+nested-section-wide-check-work-max-num-attempts = Kotia `maxNumAttempts` na libenga oyo ezali na `sectionWideCheckWork` mpe ezali na kati ya libenga mosusu oyo ezali na `sectionWideCheckWork` esalaka eloko te, mpo libenga ya libanda nde ezali kotala motango ya mimekano. Tiá `maxNumAttempts` na libenga ya libanda.
+
+answer-attributes-need-symbolic-equality = Bizalela { $attributes } ekosala eloko te soki symbolicEquality etiami te.
+
+answer-invalid-type = Lolenge ebongi te mpo na eyano: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Lokola eloko `<{ $component }>` ezali na nkombo te, ekoki kosalelama lokola ezalela ya module te
+
+module-attribute-name-already-defined = Eloko `<{ $component } name="{ $name }">` ekoki kosalelama lokola ezalela ya module te mpo lolenge ya eloko `<module>` esili kozala na ezalela oyo nkombo na yango ezali "{ $name }".
+
+conditional-content-condition-ignored = Ezalela `condition` etalelami te na eloko `<conditionalContent>` oyo ezali na bana case to else.
+
+slider-markers-type-mismatch = Lolenge ya bilembo ekokani te na lolenge ya slider.
+
+pretzel-problem-needs-statement-and-answer = pretzel ebongi te: `<problem>` mokomoko esengeli kozala na `<statement>` moko mpe `<answer>` moko.
+
+pretzel-circuit-first-problem-distractor = pretzel ebongi te: na mode="circuit", `<problem>` ya liboso ekoki kozala ya kobungisa nzela te.
+
+## Attribute values
+
+attribute-invalid-values = Mituya { $values } ebongi te mpo na ezalela `{ $attribute }`; etalelami te.
+
+attribute-must-be-references = Motuya `{ $value }` ebongi te mpo na ezalela `{ $attribute }`. Ezalela esengeli kozala balakisi oyo ebandaka na `$`.
+
+math-input-invalid-function-names = <mathInput>: bankombo ya fɔnksiɔ oyo ebongi te na { $attribute } etalelami te: { $names }. Eteni ya bolakisi ya nkombo mokomoko esengeli kozala na balɛtrɛ 2 ata (balɛtrɛ to bantɔkɔ); `|<mathspeak alternative>` ekoki kolanda.
+
+## Building components from the source
+
+component-type-invalid = Lolenge ya eloko ebongi te: `<{ $componentType }>`
+
+attribute-repeated = Ezalela { $attribute } ekoki kozongelama te.
+
+attribute-invalid-for-component = Ezalela "{ $attribute }" ebongi te mpo na eloko ya lolenge `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Ndimbola ya lolenge { $styleNumber } ezali na bokeseni ekoki te mpo na { $context ->
+        [text-on-background] langi ya makomi likolo ya langi ya nsima
+        [high-contrast] langi ya bokeseni monene likolo ya etanda
+        [line] langi ya molɔngɔ likolo ya etanda
+        [marker] langi ya elembo likolo ya etanda
+       *[text-on-canvas] langi ya makomi likolo ya etanda
+    }{ $mode ->
+        [dark] { " (modi ya molili)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; esengeli kozala ata { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Atako ndimbola ya lolenge { $styleNumber } elimbolaki balangi oyo epesaka bokeseni ekoki na modi ya pole, balangi ya modi ya molili oyo ebimi na yango ezali na bokeseni ekoki te mpo na langi ya makomi likolo ya langi ya nsima ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; esengeli kozala ata { $threshold }:1). { $suggestion ->
+        [available] Mpo bokeseni ekoka na modi ya molili, bakisá bokeseni ya modi ya pole (ndakisa tiá { $lightAttribute }="{ $lightColor }") to bongolá langi ya modi ya molili (ndakisa tiá { $darkAttribute }="{ $darkColor }").
+       *[none] Mpo bokeseni ekoka na modi ya molili, bakisá bokeseni ya modi ya pole to bongolá balangi oyo ebimi na yango na textColorDarkMode mpe/to backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Atako ndimbola ya lolenge { $styleNumber } elimbolaki langi ya makomi oyo epesaka bokeseni ekoki na modi ya pole, langi ya makomi ya modi ya molili oyo ebimi na yango ezali na bokeseni ekoki te likolo ya etanda ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; esengeli kozala ata { $threshold }:1). { $suggestion ->
+        [available] Mpo bokeseni ekoka na modi ya molili, bakisá bokeseni ya modi ya pole (ndakisa tiá textColor="{ $lightColor }") to bongolá langi ya modi ya molili (ndakisa tiá textColorDarkMode="{ $darkColor }").
+       *[none] Mpo bokeseni ekoka na modi ya molili, bakisá bokeseni ya modi ya pole to bongolá langi oyo ebimi na yango na textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Eteni ekoki kopona kaka <stylePalette> moko; ya nsuka ezali kosalelama.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ekoki koyeba balolenge ya bokeseni ya { $component } te mpo numToSelect ezali motango mobimba oyo ezali na nse ya zero te.
+
+variant-num-to-select-not-constant-number = ekoki koyeba balolenge ya bokeseni ya { $component } te mpo numToSelect ezali motango oyo ebongwanaka te.
+
+variant-with-replacement-not-constant-boolean = ekoki koyeba balolenge ya bokeseni ya { $component } te mpo withReplacement ezali bulean oyo ebongwanaka te.
+
+variant-select-weight-disables-unique = Balolenge ya bokeseni ya select ekangami soki bopono moko ezali na selectWeight to selectForVariants
+
+variant-coprime-undetermined = ekoki koyeba balolenge ya bokeseni ya { $component } te mpo ekoki kondimisa te ete coprime ezali lokuta ntango nyonso.
+
+variant-attribute-not-constant = ekoki koyeba balolenge ya bokeseni ya { $component } te mpo { $attribute } ezali makasi te.
+
+variant-attribute-not-number = ekoki koyeba balolenge ya bokeseni ya { $component } te mpo { $attribute } ezali motango te.
+
+variant-attribute-wrong-type-for-sequence =
+    ekoki koyeba balolenge ya bokeseni ya { $component } ya lolenge { $type } te mpo { $attribute } ezali { $expected ->
+        [letters-combination] bosangani ya balɛtrɛ
+        [math-expression] maloba ya matematiki ya malamu
+        [integer] motango mobimba
+       *[number] motango
+    } te.
+
+variant-length-not-integer = ekoki koyeba balolenge ya bokeseni ya { $component } te mpo length ezali motango mobimba te.
+
+variant-sort-not-implemented = balolenge ya bokeseni ya { $component } oyo ezali na sort esalemi naino te
+
+variant-exclude-combinations-not-implemented = balolenge ya bokeseni ya { $component } oyo ezali na excludeCombinations esalemi naino te
+
+variant-math-exclude-not-implemented = balolenge ya bokeseni ya { $component } ya lolenge math oyo ezali na exclude esalemi naino te
+
+variant-non-constant-exclude-not-implemented = balolenge ya bokeseni ya { $component } oyo ezali na exclude oyo ezali makasi te esalemi naino te
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: endimami te na molakisi ya graph prefigure; mokitani elekisami.
+
+prefigure-descendant-invalid-geometry = { $subject }: jeometri oyo ezali na nsuka te to esili te; mokitani elekisami.
+
+prefigure-curve-label-omitted = { $subject }: bankombo endimami te na biloko ya kurbɛ oyo ebongolami; nkombo etikali.
+
+prefigure-curve-unsupported-definition-type = { $subject }: lolenge ya ndimbola ya fɔnksiɔ ya kurbɛ '{ $definitionType }' endimami te; mokitani elekisami.
+
+prefigure-region-flip-functions-unsupported = { $subject }: ezalela flipFunctions na regionBetweenCurves endimami te; mokitani elekisami.
+
+prefigure-region-non-formula-child = { $subject }: kaka ba-fɔnksiɔ bana ya lolenge formula nde endimami na regionBetweenCurves; mokitani elekisami.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' endimami te mpo na { $labelKind ->
+        [line-family] nkombo ya libota ya molɔngɔ
+       *[point] nkombo ya litono
+    }; bobongisi ya PreFigure ezali kosalelama.
+
+prefigure-fill-style-unsupported = { $subject }: lolenge ya kotondisa '{ $fillStyle }' endimami te na PreFigure; ezali kozonga na kotondisa na langi moko.
+
+prefigure-line-style-unknown = { $subject }: lolenge ya molɔngɔ '{ $lineStyle }' eyebani te mpe etikali na mosala ya PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: lolenge ya elembo '{ $markerStyle }' ekokanisami na lolenge ya PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: lolenge ya elembo '{ $markerStyle }' endimami te na PreFigure; lolenge ya ebandeli ezali kosalelama.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ebongi te; eloko oyo elukami eyebani te. Likanisi etikali.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` elimbolaki biloko ebele; ya liboso ezali kosalelama.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ebongi te; eloko oyo elukami ezali libanda ya grafi oyo ebombi yango. Likanisi etikali.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ebongi te; eloko oyo elukami ezali eloko ya elilingi oyo endimami na bobongoli ya prefigure te. Likanisi etikali.
+
+annotation-text-missing = `<annotation>`: `text` ezali te to ezali polele; makomi ya polele nde ebimi.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Botali ya zɛlɔ emonani.
+       *[other] Botali ya zɛlɔ oyo etali eloko `<{ $componentType }>` emonani.
+    }
+
+reference-no-referent = Eloko moko te emonani mpo na elakisi: `{ $reference }`
+
+reference-multiple-referents = Biloko ebele emonani mpo na elakisi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Lolenge ebongi te mpo na ezalela { $attribute } ya `<{ $componentType }>`.
+
+children-invalid = Bana ebongi te mpo na `<{ $componentType }>`: Bana oyo ebongi te emonani: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Motuya `{ $value }` ebongi te mpo na ezalela `{ $attribute }`, motuya `{ $default }` ezali kosalelama
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML lolenge { $version } emonani te.
+       *[other] DoenetML lolenge { $version } emonani te. Ezali kozonga na lolenge { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ebongi te: { $content }
+
+parse-tag-missing-close-tag = DoenetML ebongi te: Tagi `{ $tag }` ezali na tagi ya kokanga te. Ezelamaki tagi oyo emikangaka to tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ebongi te: Libunga na tagi `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ebongi te: Ezalela `{ $attribute }` oyo ebongi te emonani lokola ezangi motuya.
+
+parse-attribute-invalid = DoenetML ebongi te: Ezalela `{ $attribute }` ebongi te
+
+parse-attribute-value-invalid = DoenetML ebongi te: Motuya ya ezalela `{ $value }` ebongi te
+
+parse-attribute-value-quote-mismatch = DoenetML ebongi te: Motuya ya ezalela `{ $value }` ebongi te. Bilembo ya maloba ekokani te. Emonani lokola `{ $quote }` ezangi
+
+parse-open-tag-name-missing = DoenetML ebongi te: Tagi oyo ezali na nkombo te emonani, ndakisa `<`
+
+parse-tag-not-closed = DoenetML ebongi te: Tagi `{ $tag }` ekangami te (emonani lokola `>` ezangi).
+
+parse-self-closing-tag-name-missing = DoenetML ebongi te: Tagi oyo ezali na nkombo te emonani `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ebongi te: Tagi `{ $tag }` ekangami te (emonani lokola `/>` ezangi).
+
+parse-tag-invalid-attributes = DoenetML ebongi te: Tagi `{ $tag }` ebongi te. Mbala mosusu ezali na bizalela oyo ebongi te.
+
+parse-close-tag-name-missing = DoenetML ebongi te: Tagi ya kokanga oyo ezali na nkombo te emonani, ndakisa `</`
+
+parse-attribute-value-unquoted = Mituya ya bizalela esengeli kotiama na kati ya bilembo ya maloba: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ebongi te: Tagi ya kokanga `{ $tag }` emonani, kasi tagi ya kofungola oyo ekokani ezali te
+
+parse-close-tag-mismatched = DoenetML ebongi te: Tagi ya kokanga ekokani te. Ezelamaki `</{ $expected }>`. Emonani `{ $found }`
+
+parser-node-unconvertible = Ekokaki kobongola nɔdi { $node } na nɔdi ya Dast te.
+
+## Names
+
+name-attribute-invalid =
+    Ezalela name='{ $name }' ebongi te. { $reason ->
+        [characters] Bankombo ekoki kozala kaka na balɛtrɛ, mitango, bantɔkɔ ya nse to bantɔkɔ.
+       *[start] Bankombo esengeli kobanda na lɛtrɛ.
+    }
+
+component-name-invalid-start = Nkombo ya eloko "{ $name }" ebongi te. Bankombo esengeli kobanda na lɛtrɛ.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Eyano ya lolenge videoWatched esengeli kozala na ezalela video
+
+answer-video-watched-video-not-reference = Eyano ya lolenge videoWatched esengeli kozala na ezalela video oyo ezali elakisi
+
+answer-name-not-single-text = Ezalela name ya eyano esengeli kozala na mwana text moko kaka
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ekoki kozwa DoenetML ya libanda te mpo bozongeli ezali mingi mingi. Elakisi ya zɛlɔ ezali?
+
+external-doenetml-unavailable = Ekoki kozwa DoenetML uta na { $attribute }="{ $uri }" te
+
+external-doenetml-type-mismatch = DoenetML oyo ezwami uta na { $attribute }="{ $uri }" ebongi te: ekokani te na lolenge ya eloko "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Ezalela `{ $from }` eleki ntango; salelá `{ $to }`.
+       *[other] [deprecation] Ezalela `{ $from }` na `<{ $component }>` eleki ntango; salelá `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Ezalela `{ $from }` eleki ntango mpe etalelami te mpo `{ $to }` mpe elimbolami.
+       *[other] [deprecation] Ezalela `{ $from }` na `<{ $component }>` eleki ntango mpe etalelami te mpo `{ $to }` mpe elimbolami.
+    }
+
+deprecated-attribute-ignored = [deprecation] Ezalela `{ $attribute }` na `<{ $component }>` eleki ntango mpe etalelami te.
+
+deprecated-attribute-to-child = [deprecation] Ezalela `{ $attribute }` na `<{ $component }>` eleki ntango; salelá mwana `<{ $child }>`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ekoki kosala motango ebele kaka na Lingelesi, yango wana makomi na yango etikali ndenge ezali na mokanda oyo ekomami na { $locale }. Komá lolenge ya motango ebele yo moko, to tiá yango na ezalela `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Eloko `<{ $tag }>` ezali eloko ya Doenet oyo eyebani te.
+
+schema-element-not-allowed-at-root = Eloko `<{ $tag }>` epesameli nzela te na mosisa ya mokanda.
+
+schema-element-not-allowed-inside = Eloko `<{ $tag }>` epesameli nzela te na kati ya `<{ $parent }>`.
+
+schema-attribute-unrecognized = Eloko `<{ $tag }>` ezali na ezalela oyo nkombo na yango ezali `{ $attribute }` te.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Ezalela `{ $attribute }` ya eloko `<{ $tag }>` esengeli kozala molɔngɔ oyo eloko mokomoko ezali moko ya: { $allowed }
+       *[other] Ezalela `{ $attribute }` ya eloko `<{ $tag }>` esengeli kozala moko ya: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nkombo ya lolenge ebongi te mpo na select. Nkombo ya lolenge { $variantName } emonani na baponi { $numOptions } kasi motango ya kopona ezali { $numToSelect }.
+
+select-variant-name-without-options = Balolenge mosusu elimbolami mpo na select kasi bopono moko te elimbolami mpo na nkombo ya lolenge oyo ekoki kozala: { $variantName }.
+
+select-variant-name-not-possible = Nkombo ya lolenge { $variantName } oyo elimbolami mpo na select ezali nkombo ya lolenge oyo ekoki kozala te.
+
+select-too-few-options = Ekoki kopona biloko { $numToSelect } na kati ya { $numOptions } kaka te.
+
+select-from-sequence-too-few-values = Ekoki kopona mituya { $numToSelect } na molɔngɔ oyo bolai na yango ezali { $length } te.
+
+select-from-sequence-indices-count-mismatch = Motango ya ba-indɛkse oyo elimbolami mpo na select esengeli kokokana na motango ya kopona
+
+select-from-sequence-indices-not-integers = Ba-indɛkse nyonso oyo elimbolami mpo na select esengeli kozala mitango mibimba
+
+select-from-sequence-index-excluded = Indɛkse ya selectfromsequence oyo elongolami elimbolami
+
+select-from-sequence-indices-excluded-combination = Ba-indɛkse ya selectfromsequence oyo ezalaki bosangani oyo elongolami elimbolami
+
+select-from-sequence-coprime-not-positive-integers = Ekoki kopona bosangani ya mitango ya bokabwani te mpo ezali mitango mibimba ya malamu te oyo eponami.
+
+select-from-sequence-coprime-common-factor = Ekoki kopona mitango ya bokabwani te. Mituya nyonso oyo ekoki kozala ezali na mokaboli moko. (Mituya oyo elimbolami ya "from" to "to" esengeli kozala na bokabwani na "step".)
+
+select-from-sequence-coprime-single-number = Ekoki kopona bosangani ya mitango ya bokabwani na motango moko oyo ezali 1 te.
+
+select-from-sequence-excluded-too-many-combinations = Koleka 70% ya bosangani elongolami na selectFromSequence
+
+select-from-sequence-coprime-none-found = Ekokaki kopona mitango ya bokabwani te. Mituya nyonso oyo ekoki kozala ezali na mokaboli moko.
+
+select-from-sequence-too-few-unique-values = Ekoki kopona mituya ya bokeseni { $numToSelect } na molɔngɔ oyo bolai na yango ezali { $numPossibleValues } te
+
+select-prime-numbers-too-few-values = Ekoki kopona mituya { $numToSelect } na molɔngɔ ya mitango ya nkónzi oyo bolai na yango ezali { $numValues } te
+
+select-prime-numbers-values-count-mismatch = Motango ya mituya oyo elimbolami mpo na select esengeli kokokana na motango ya kopona
+
+select-prime-numbers-values-not-prime = Mituya nyonso oyo elimbolami mpo na select prime number esengeli kozala na molɔngɔ ya mitango ya nkónzi
+
+select-prime-numbers-values-excluded-combination = Mituya ya selectPrimeNumbers oyo elimbolami ezalaki bosangani oyo elongolami
+
+select-prime-numbers-excluded-too-many-combinations = Koleka 70% ya bosangani elongolami na selectPrimeNumbers
+
+select-random-combination-fluke = Na likambo oyo esalemaka mingi te, ekokaki kopona bosangani ya mituya ya mbalakaka te
+
+select-random-value-fluke = Na likambo oyo esalemaka mingi te, ekokaki kopona motuya ya mbalakaka te

--- a/packages/i18n/locales/ln/editor.ftl
+++ b/packages/i18n/locales/ln/editor.ftl
@@ -1,0 +1,214 @@
+# Lingala editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Lingala marks number by changing a noun's class prefix, and keeps doing so
+# after a numeral, so the counted messages keep their selects.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Zongisá
+       *[update] Bongisá
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Molakisi
+       *[other] { $word } Molakisi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Lolenge
+editor-variant-filter = Poná...
+editor-variant-next = Poná lolenge oyo elandi
+editor-variant-previous = Poná lolenge oyo eleki
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Kobuka mibeko ya WCAG AA mpo na bokɔti emonani. Finá mpo na { $action ->
+            [close] kokanga
+           *[open] kofungola
+        } lapolo ya bokɔti.
+        [advisories] Finá mpo na { $action ->
+            [close] kokanga
+           *[open] kofungola
+        } lapolo ya bokɔti. Kobuka mibeko ya WCAG AA emonani te, kasi batoli mosusu ezali mpo na bokɔti.
+       *[clean] Finá mpo na { $action ->
+            [close] kokanga
+           *[open] kofungola
+        } lapolo ya bokɔti. Mokakatano moko te ya bokɔti emonani.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Kobuka mibeko ya WCAG AA mpo na bokɔti emonani. { $count ->
+            [one] Kobuka mobeko { $count } ya WCAG AA emonani
+           *[other] Kobuka mibeko { $count } ya WCAG AA emonani
+        }. Finá mpo na { $action ->
+            [close] kokanga
+           *[open] kofungola
+        } lapolo ya bokɔti.
+        [advisories] Kobuka mibeko ya WCAG AA emonani te. { $count ->
+            [one] Toli { $count } ya kobakisa mpo na bokɔti emonani
+           *[other] Batoli { $count } ya kobakisa mpo na bokɔti emonani
+        }. Finá mpo na { $action ->
+            [close] kokanga
+           *[open] kofungola
+        } lapolo ya bokɔti.
+       *[clean] Kobuka mibeko ya WCAG AA emonani te. Finá mpo na { $action ->
+            [close] kokanga
+           *[open] kofungola
+        } lapolo ya bokɔti.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML lolenge { $version }
+
+editor-tab-help = Lisalisi oyo ebongi na esika
+editor-tab-help-short = Esika
+editor-tab-errors = Mabunga
+editor-tab-warnings = Makebisi
+editor-tab-info = Basango
+editor-tab-accessibility = Bokɔti
+editor-tab-responses = Biyano oyo etindami
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Baponi ya mokomi
+editor-format-as-doenetml = Bongisá lokola DoenetML
+editor-format-as-xml = Bongisá lokola XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Molɔngɔ #{ $line }
+
+editor-no-errors = Libunga Moko Te
+editor-no-warnings = Likebisi Moko Te
+editor-no-info = Botali ya Basango Moko Te
+
+editor-show-info-annotations = Lakisá botali ya basango na mokomi
+editor-show-accessibility-annotations = Lakisá botali ya bokɔti na mokomi
+
+editor-accessibility-learn-more = Yekolá ndenge Doenet asalaka na bokɔti
+
+editor-accessibility-violations-heading = Kobuka mibeko ya bokɔti ({ $standard })
+
+editor-accessibility-other-heading = Mikakatano mosusu ya bokɔti
+editor-none-found = Eloko moko te emonani
+
+
+## Submitted responses
+
+editor-no-responses = Eyano moko etindami naino te
+editor-response-answer-id = Nkombo ya Eyano
+editor-response-response = Eyano
+editor-response-credit = Motuya
+editor-response-submitted = Etindami
+
+
+## The context-help panel
+
+help-placeholder = Tiá elembo likolo ya nkombo ya tagi, ezalela to { $ref } mpo na kozwa mikanda.
+
+help-unsupported-ref-chain = Lisalisi mpo na balakisi ya biteni ebele lokola { $example } ezali naino te.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Eloko moko te emonani mpo na elakisi: { $ref }.
+        [multiple] Biloko ebele emonani mpo na elakisi: { $ref }.
+       *[indeterminate] Eloko oyo { $ref } elakisi eyebani te.
+    }
+
+help-learn-about-references = Yekolá makambo ya balakisi →
+help-reference-page = Lokasa ya balakisi →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Na kati ya { $element }
+       *[top] Na likolo
+    }{ $allowed ->
+        [none] { " — eloko moko te ekɔti awa." }
+        [text] { " — komá makomi awa." }
+        [text-and-components] { " — komá makomi awa, to meká:" }
+       *[components] { " — biloko ya komeka:" }
+    }
+
+help-suggestions-footer = Finá { $shortcut } mpo na kotala biloko { $total } nyonso.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ezali elakisi ya { $target }.
+       *[other] { $ref } ezali elakisi ya { $target } (molɔngɔ { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } apesi yango nkombo { $role }.
+       *[other] { $owner } apesi yango nkombo { $role } na molɔngɔ { $line }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ezali elakisi ya ezalela { $property } ya { $element }.
+       *[other] { $ref } ezali elakisi ya ezalela { $property } ya { $element } (molɔngɔ { $line }).
+    }
+
+help-kind-attribute = ezalela
+help-kind-snippet = eteni ya makomi
+help-kind-array-entry = ekɔteli ya tabelo
+
+help-default = Oyo ezali wana:
+help-active-default = Oyo ezali wana mpe ezali kosala:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Mituya oyo epesameli nzela (moko na eloko mokomoko):
+       *[other] Mituya oyo epesameli nzela:
+    }
+
+help-suggested-values = Mituya oyo epesami likanisi:
+
+help-inserts = Ekɔtisaka:
+
+help-coordinates =
+    { $count ->
+        [one] Elembo ya esika:
+       *[other] Bilembo ya esika:
+    }
+
+help-type = Lolenge:
+
+help-resolved-style = Lolenge oyo eyebani (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Bankombo ya fɔnksiɔ oyo eyebani:
+help-reset-list = Molɔngɔ oyo ezongisami na ekɔteli oyo:
+help-added-on-input = Oyo ebakisami na ekɔteli oyo:
+help-removed-on-input = Oyo elongolami na ekɔteli oyo:
+
+help-reset-overrides = { $reset } eleki { $additional } mpe { $removed }.

--- a/packages/i18n/locales/sn/chrome.ftl
+++ b/packages/i18n/locales/sn/chrome.ftl
@@ -1,0 +1,142 @@
+# Shona viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Shona has two plural categories, and whether a counted noun changes shape
+# depends on which class it is in — which is why the two counted messages here
+# do different things. «edzo», an attempt, is class 5 and takes «ma-» in the
+# plural, so `attempts-remaining` keeps its select. «mhinduro», an answer, is
+# class 9, whose plural is class 10 and identical to it, so
+# `answer-show-responses` drops its select rather than writing a `[one]` that
+# repeats its `[other]`.
+#
+# `attempts-remaining` also keeps its `[0]` branch, an exact-value match rather
+# than a plural category, which says «hapana» instead of counting to zero.
+
+
+## Answer submission
+
+answer-checking = Iri kuongorora...
+answer-submitting = Iri kutumira...
+
+answer-checking-status = Iri kuongorora mhinduro
+answer-submitting-status = Iri kutumira mhinduro
+
+answer-correct = Yakarurama
+answer-incorrect = Haina kururama
+
+answer-response-saved = Mhinduro Yachengetwa
+
+answer-percent-credit = Mamakisi { $percent }%
+answer-percent-correct = { $percent }% Yakarurama
+answer-percent-short = { $percent } %
+
+max-credit-available = Mamakisi epamusoro anowanikwa: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] hapana edzo yasara
+        [one] edzo { $count } yasara
+       *[other] maedzo { $count } asara
+    }
+
+validation-correct = (Yakarurama)
+validation-incorrect = (Haina kururama)
+validation-partially-correct = (Yakarurama pane zvimwe)
+
+answer-show-responses = Ratidza mhinduro { $count } dza{ $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Mhinduro yeMudzidzisi
+
+collapsible-click-to-open = (dzvanya kuti uvhure)
+collapsible-click-to-close = (dzvanya kuti uvhare)
+
+collapsible-initializing = Iri kutanga...
+
+footnote-show = Ratidza cherechedzo yepasi
+footnote-hide = Vanza cherechedzo yepasi
+
+description-more-information = mamwe mashoko
+
+
+## Controls
+
+slider-previous = Yapfuura
+slider-next = Inotevera
+
+keyboard-open = Vhura Kibhodhi
+keyboard-close = Vhara Kibhodhi
+
+choice-input-remove-choice = Bvisa { $choice }
+
+matrix-remove-row = Bvisa mutsara wakarara
+matrix-add-row = Wedzera mutsara wakarara
+matrix-remove-column = Bvisa mutsara wakamira
+matrix-add-column = Wedzera mutsara wakamira
+
+subset-add-remove-points = Wedzera/Bvisa mapoindi
+subset-toggle-points-intervals = Chinjanisa pakati pemapoindi nenhambo
+subset-move-points = Fambisa Mapoindi
+subset-clear = Dzima
+
+# A `box` here is one orbital, drawn as a square: «bhokisi».
+orbital-add-row = Wedzera Mutsara
+orbital-remove-row = Bvisa Mutsara
+orbital-add-box = Wedzera Bhokisi
+orbital-remove-box = Bvisa Bhokisi
+orbital-add-up-arrow = Wedzera Museve Wekumusoro
+orbital-add-down-arrow = Wedzera Museve Wepasi
+orbital-remove-arrow = Bvisa Museve
+
+orbital-row-label = Zita remutsara { $row }
+
+pretzel-answer = Mhinduro
+
+summary-statistics-caption = Pfupiso yehuwandu hwe{ $column }
+
+
+## Math input
+
+math-input-preview-region = pfungwa yekutarisa kwechirevo chemasvomhu
+math-input-preview = Tarisa
+math-input-invalid-expression = Chirevo hachina kururama:
+
+
+## Document status
+
+viewer-initializing = Iri kutanga...
+
+
+## Errors
+
+error-heading = Kukanganisa
+
+error-found-at =
+    { $span ->
+        [line] Yawanikwa pamutsara { $startLine }.
+       *[lines] Yawanikwa pamitsara { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Gwaro rino rine zvikanganiso!
+
+diagnostic-heading-error = Kukanganisa
+diagnostic-heading-warning = Yambiro
+diagnostic-heading-information = Ruzivo
+diagnostic-heading-hint = Zano
+
+accessibility-heading-level-1 = Kutyorwa kweWCAG AA kweKuwanikwa
+accessibility-heading-level-2 = Yambiro yekuwanikwa
+
+something-went-wrong = Pane chakakanganisika.
+
+renderer-load-failed = muratidzi mumwe wakundikana kurodha. Ndapota dzokorora peji.
+
+core-start-failed = Muratidzi wegwaro haana kukwanisa kutanga. Ndapota dzokorora peji.

--- a/packages/i18n/locales/sn/content.ftl
+++ b/packages/i18n/locales/sn/content.ftl
@@ -1,0 +1,326 @@
+# Shona content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Shona has no masculine or feminine, and it agrees an adjective with its
+# noun's **class**, so this catalog reads `$gender` as the class token rather
+# than as a gender — the same device `locales/sw` uses. `noun-gender` answers
+# `c3`, `c5`, `c7` or `c9`, and every adjective that carries a concord selects
+# on it.
+#
+# What is worth reading closely is *how* Shona marks the concord, because it is
+# not a prefix bolted onto an unchanged stem. In class 5 the stem's own first
+# consonant changes with it — «-tema» becomes «dema», «-chena» becomes «jena»,
+# «-kobvu» becomes «gobvu» — so the table below is not derivable from the
+# stems and has to be written out:
+#
+#           c3 (mu-/mi-)  c5 (ma-)   c7 (chi-/zvi-)  c9 (N-)
+#   -tema    mutema        dema       chitema         nhema
+#   -chena   muchena       jena       chichena        chena
+#   -tsvuku  mutsvuku      dzvuku     chitsvuku       tsvuku
+#   -kobvu   mukobvu       gobvu      chikobvu        hobvu
+#   -tete    mutete        dete       chitete         tete
+#   -zadzwa  wakazadzwa    rakazadzwa chakazadzwa     yakazadzwa
+#
+# `c9` is the default, because that is the class a loanword joins — and an
+# author's own `markerStyleWord`, which this catalog has never seen, is a
+# loanword as far as it is concerned.
+#
+# Only the three colours with a native adjective stem inflect — black, white
+# and red; the two stems below them in the table are the widths. The rest are
+# invariable nouns, and attributively Shona joins them with the associative of
+# the class («mutsara mukobvu *we*girini»). The associative is computable from
+# `$gender`, but the same string is what `backgroundColor` reports standing
+# alone, where a bare associative would be ungrammatical, and nothing in
+# `$role` tells the two apart. So the colour nouns are written bare, which is
+# what a label says in Shona anyway. This is the same trade `locales/sw` makes,
+# and for the same reason.
+#
+# Adjectives follow the noun, so the composition messages put the noun first.
+# `$role` goes unused: Shona marks no case.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [c3] mutema
+            [c5] dema
+            [c7] chitema
+           *[c9] nhema
+        }
+    .white =
+        { $gender ->
+            [c3] muchena
+            [c5] jena
+            [c7] chichena
+           *[c9] chena
+        }
+    .gray = girei
+    .red =
+        { $gender ->
+            [c3] mutsvuku
+            [c5] dzvuku
+            [c7] chitsvuku
+           *[c9] tsvuku
+        }
+    .orange = orenji
+    .yellow = yero
+    .green = girini
+    .cyan = sayani
+    .blue = bhuruu
+    .purple = pepuru
+    .pink = pingi
+    .brown = bhurauni
+
+line-width =
+    .thick =
+        { $gender ->
+            [c3] mukobvu
+            [c5] gobvu
+            [c7] chikobvu
+           *[c9] hobvu
+        }
+    .thin =
+        { $gender ->
+            [c3] mutete
+            [c5] dete
+            [c7] chitete
+           *[c9] tete
+        }
+
+# Written as invariable «ane …» phrases rather than as adjectives, so that they
+# agree with nothing and can close the description. `style-stroke` puts them
+# last for that reason.
+line-style =
+    .dashed = ane zvidimbu
+    .dotted = ane madotsi
+
+fill-style =
+    .horizontal = mitsara yakarara
+    .vertical = mitsara yakamira
+    .diagonal = mitsara yakatsveyama
+    .backdiagonal = mitsara yakatsveyama kumashure
+    .dots = madotsi
+    .diamonds = madhaimondi
+
+noun =
+    .line = mutsara
+    .line-segment = chidimbu chemutsara
+    .ray = mwaranzi
+    .vector = vhekita
+    .curve = chikombamiro
+    .function = basa
+    .parabola = parabhora
+    .polyline = mitsara yakabatana
+    .polygon = poligoni
+    .triangle = tirayangoni
+    .rectangle = rekitangoni
+    .circle = denderedzwa
+    .region = nzvimbo
+    .point = poindi
+    .square = sikweya
+    .diamond = dhaimondi
+    .cross = muchinjikwa
+    .plus = chiratidzo chekuwedzera
+
+# The side count goes in the tail, behind the adjectives, because «ine mativi
+# 5» is a relative phrase and Shona closes a noun phrase with it rather than
+# opening one.
+noun-regular-polygon =
+    { $part ->
+        [tail] ine mativi { $numSides }
+       *[head] poligoni yakaenzana
+    }
+
+noun-gender =
+    { $noun ->
+        [line] c3
+        [ray] c3
+        [cross] c3
+        [border] c3
+        [line-segment] c7
+        [region] c9
+        [circle] c5
+        [fill] c7
+        [text] c5
+       *[other] c9
+    }
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c3] wakazadzwa
+        [c5] rakazadzwa
+        [c7] chakazadzwa
+       *[c9] yakazadzwa
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ne{ $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ne{ $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ne{ $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «muganhu» is class 3 and leads its own adjectives, so the border's words
+# agree with it and not with the shape it surrounds. Shona has no article, so
+# the two `-article` branches read like the two without, and «une» — a relative
+# «having» rather than a conjunction — opens the clause wherever it lands, so
+# `[and]` reads like `[with]` as well. All four end up the same string.
+style-border-clause =
+    { $parts ->
+        [with-article] une muganhu { $border }
+        [and] une muganhu { $border }
+        [and-article] une muganhu { $border }
+       *[with] une muganhu { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = isina kuzadzwa
+
+style-text =
+    { $parts ->
+        [background] { $color } pamusoro pechigadziko { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = hapana
+
+
+## Boolean words
+
+boolean-true = chokwadi
+# «nhema» is also the class 9 word for black, three blocks above this one; the
+# word for a falsehood here is «manyepo», which is not.
+boolean-false = manyepo
+
+
+## Answer buttons
+
+answer-submit-label = Ongorora Basa
+answer-submit-label-no-correctness = Tumira Mhinduro
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Chiitiko
+    .aside = Rutivi
+    .cascade = Kasikedhi
+    .definition = Tsanangudzo
+    .example = Muenzaniso
+    .exercise = Kudzidzira
+    .exercises = Kudzidzira
+    .given-answer = Mhinduro
+    .note = Cherechedzo
+    .objectives = Zvinangwa
+    .paragraphs = Ndima
+    .part = Chikamu
+    .problem = Dambudziko
+    .problems = Matambudziko
+    .proof = Uchapupu
+    .question = Mubvunzo
+    .section = Chikamu
+    .solution = Gadziriso
+    .task = Basa
+    .theorem = Tiyoremu
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Zano
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tafura { $enumeration }
+        [numbered-title] Tafura { $enumeration }{ ": " }
+        [unnumbered-title] Tafura{ ": " }
+       *[unnumbered] Tafura
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Mufananidzo { $enumeration }
+        [numbered-caption] Mufananidzo { $enumeration }{ ": " }
+        [unnumbered-caption] Mufananidzo{ ": " }
+       *[unnumbered] Mufananidzo
+    }
+
+
+## Paginator controls
+
+paginator-previous = Yapfuura
+paginator-next = Inotevera
+paginator-page = Peji
+
+paginator-page-status = { $pageLabel } { $currentPage } pa{ $numPages }
+
+
+## Piecewise functions
+
+# Shona says «kana» for both "if" and "or", so the disjunction is written
+# «kana kuti» to keep the two apart where a branch shows them side by side.
+piecewise-condition-or = kana kuti
+piecewise-condition-if = kana
+piecewise-condition-otherwise = kana zvisina kudaro
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Zimbabwean secondary science
+# is taught in English, so a student meeting these words meets them in English
+# already, and the seed has no settled Shona list to reproduce. A speaker
+# adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Chiratidzo cheKemisitiri Chisiri Icho
+chemistry-invalid-ionic-compound = Musanganiswa weIoni Usiri Iwo

--- a/packages/i18n/locales/sn/diagnostics.ftl
+++ b/packages/i18n/locales/sn/diagnostics.ftl
@@ -1,0 +1,613 @@
+# Shona diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Shona verb takes its subject concord
+# from the noun class rather than from the count, and the argument is a list
+# either way. So those selects are dropped and the count argument goes unused.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } zvinofuratirwa kana mapoindi ekupedzisira maviri atsanangurwa
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } zvinofuratirwa kana poindi rekupedzisira nepoindi repakati zvese zvatsanangurwa
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset haina basa pasina poindi repakati
+
+## `<line>`
+
+line-points-undetermined-dimensions = Mutsara unopfuura nemumapoindi ane madimensheni asingazivikanwi.
+
+line-points-too-few-dimensions = Mutsara unofanira kupfuura nemumapoindi ane madimensheni maviri zvirinani.
+
+line-points-depend-on-variables = Mutsara unopfuura nemumapoindi anotsamira pazvinochinja: { $variables }.
+
+line-equation-invalid-format = Chimiro hachina kururama pamuenzaniso wemutsara muzvinochinja { $variable1 } ne{ $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Mwaranzi wakatsanangurwa ne through, endpoint ne direction zvese. through yakatsanangurwa inofuratirwa.
+
+ray-dimension-mismatch = numDimensions hazvienderani mumwaranzi.
+
+## `<vector>`
+
+vector-overprescribed-head = Vhekita rakatsanangurwa ne head, tail ne displacement zvese. head yakatsanangurwa inofuratirwa.
+
+vector-dimension-mismatch = numDimensions hazvienderani muvhekita.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Hazvigoni kukwevewa ku`<{ $component }>` nekuti haina chinochinja chemamiriro nearestPoint.
+
+constrain-to-without-nearest-point = Hazvigoni kusungwa ku`<{ $component }>` nekuti haina chinochinja chemamiriro nearestPoint.
+
+constrain-to-interior-without-nearest-point = Hazvigoni kusungwa mukati me`<{ $component }>` nekuti haina chinochinja chemamiriro nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition inofuratirwa pachoiceInput isiri yemutsara mumwe
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Zvinongedzo zvakatsanangurwa pachoiceInput zvinofuratirwa nekuti huwandu hwezvinongedzo hahuenderani nehuwandu hwevana vechoice.
+
+pretzel-indices-count-mismatch = Zvinongedzo zvakatsanangurwa paproblem zvinofuratirwa nekuti huwandu hwezvinongedzo hahuenderani nehuwandu hwevana veproblem.
+
+shuffle-indices-count-mismatch = Zvinongedzo zvakatsanangurwa pashuffle zvinofuratirwa nekuti huwandu hwezvinongedzo hahuenderani nehuwandu hwezvinhu.
+
+indices-ignored-out-of-range = Zvinongedzo zvakatsanangurwa pa{ $component } zvinofuratirwa nekuti zvimwe zvinongedzo zviri kunze kwenhambo.
+
+pretzel-indices-repeated = Zvinongedzo zvakatsanangurwa papretzel zvinofuratirwa nekuti zvimwe zvinongedzo zvakadzokororwa.
+
+pretzel-circuit-first-index = Zvinongedzo zvakatsanangurwa papretzel mumodhi circuit zvinofuratirwa nekuti chinongedzo chekutanga chinofanira kuva 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Kuti `<{ $component }>` ishande nevana verudzi rwezvinyorwa, chimiro `type` chinofanira kutsanangurwa.
+
+invalid-type-defaulting-to-math = type { $type } haina kururama pachinhu { $component }. Inofanira kuva imwe ye math, text, number kana boolean. Iri kuiswa math.
+
+string-not-valid-component-to-arrange = Zvinyorwa "{ $value }" hachisi chinhu che{ $component } chakakodzera. Chinofuratirwa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } haina kururama, type iri kuiswa number.
+
+invalid-variable-value = Kukosha kwechinochinja hakuna kururama: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Chinongedzo chemhando { $index } chinofanira kuva nhamba
+
+variant-index-must-be-integer = Chinongedzo chemhando { $index } chinofanira kuva nhamba yakazara
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` haina kugadzirwa nezviyero zvakatarwa. Upamhi huri kuiswa muzvikamu.
+
+side-by-side-absolute-margins = `<{ $component }>` haina kugadzirwa nezviyero zvakatarwa. Miganhu iri kuiswa muzvikamu.
+
+side-by-side-no-block-child = `<{ $component }>` haina kururama: inofanira kuva nemwana mumwe zvirinani werudzi rwebhuroko.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Chimiro `for` pa`<label>` yemufananidzo chinofuratirwa.
+
+label-for-must-resolve-to-one = Chimiro `for` pa`<label>` chinofanira kunongedza chinhu chimwe chete.
+
+label-for-unresolved = Chimiro `for` pa`<label>` hachina kukwanisa kunongedza chinhu chero chipi.
+
+label-for-answer-with-authored-inputs = Chimiro `for` pa`<label>` chinonongedza `<answer>` ine zvipinzwa zvakanyorwa; nongedza chipinzwa pachacho.
+
+label-for-answer-without-input = Chimiro `for` pa`<label>` chinonongedza `<answer>` isina chipinzwa chekutumidza.
+
+label-for-must-reference-input-or-answer = Chimiro `for` pa`<label>` chinofanira kunongedza chipinzwa kana mhinduro.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Nekuda kwekuwanikwa, `<{ $component }>` inofanira kuva netsanangudzo pfupi kana kutsanangurwa sechishongedzo.
+
+accessibility-video-short-description = Nekuda kwekuwanikwa, `<video>` inofanira kuva netsanangudzo pfupi.
+
+accessibility-input-short-description-or-label = Nekuda kwekuwanikwa, `<{ $component }>` inofanira kuva netsanangudzo pfupi kana zita.
+
+accessibility-answer-input-short-description-or-label = Nekuda kwekuwanikwa, `<answer>` inogadzira chipinzwa inofanira kuva netsanangudzo pfupi kana zita.
+
+accessibility-short-description-contains-math = Tsanangudzo pfupi haifaniri kuva nezvinhu zvemasvomhu se`<{ $component }>`. Tsanangura masvomhu ese nemazwi.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ine musiyano usingakwani pazvinyorwa zvemusoro wechikamu (modhi yerima) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; inoda { $threshold }:1 zvirinani).
+       *[other] { $colorName } ine musiyano usingakwani pazvinyorwa zvemusoro wechikamu ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; inoda { $threshold }:1 zvirinani).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` inopfuura nemumapoindi { $count } haisati yagadzirwa kana mapoindi iwayo asina kukosha kwenhamba.
+
+circle-too-many-through-points = Hazvigoni kuverenga denderedzwa rinopfuura nemumapoindi anopfuura 3.
+
+circle-overprescribed-radius-center-points = Hazvigoni kuverenga denderedzwa rine rediyasi, pakati nemapoindi ekupfuura zvese zvakatsanangurwa.
+
+circle-center-with-multiple-points = Hazvigoni kuverenga denderedzwa rine pakati pakatsanangurwa rinopfuura nemumapoindi anopfuura 1.
+
+circle-radius-too-small = Hazvigoni kuverenga denderedzwa: sezvo nhambo iri pakati pemapoindi maviri iri { $distance }, rediyasi { $radius } yakatsanangurwa idiki kwazvo.
+
+circle-radius-with-many-points = Hazvigoni kugadzira denderedzwa rinopfuura nemumapoindi anopfuura maviri rine rediyasi yakatsanangurwa.
+
+circle-invalid-center-or-through-points = Pakati pedenderedzwa kana mapoindi aro ekupfuura hazvina kururama.
+
+circle-radius-center-with-multiple-points = Hazvigoni kuverenga rediyasi yedenderedzwa rine pakati pakatsanangurwa rinopfuura nemumapoindi anopfuura 1.
+
+circle-change-radius-non-numerical = Hazvigoni kuchinja rediyasi yedenderedzwa rinopfuura nemumapoindi asina kukosha kwenhamba
+
+circle-radius-with-points-non-numerical = Hazvigoni kugadzira denderedzwa rinopfuura nemumapoindi anopfuura rimwe rine rediyasi yakatsanangurwa pasina kukosha kwenhamba.
+
+circle-change-center-non-numerical = Kuchinja pakati pedenderedzwa rinopfuura nemumapoindi asina kukosha kwenhamba hakusati kwagadzirwa.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Madimensheni edomeni yebasa haakwani. Domeni ine nhambo { $intervals } asi basa rine zvipinzwa { $inputs }.
+
+function-domain-invalid-format = Chimiro chedomeni yebasa hachina kururama.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Musoro wepamusoro webasa usiri wenhamba uri kufuratirwa.
+        [minimum] Musoro wepasi webasa usiri wenhamba uri kufuratirwa.
+        [extremum] Musoro webasa usiri wenhamba uri kufuratirwa.
+        [point] Poindi rebasa risiri renhamba riri kufuratirwa.
+        [slope] Kutsveyama kwebasa kusiri kwenhamba kuri kufuratirwa.
+       *[other] { $type } yebasa isiri yenhamba iri kufuratirwa.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Musoro wepamusoro webasa usina chinhu uri kufuratirwa.
+        [minimum] Musoro wepasi webasa usina chinhu uri kufuratirwa.
+        [extremum] Musoro webasa usina chinhu uri kufuratirwa.
+        [point] Poindi rebasa risina chinhu riri kufuratirwa.
+       *[other] { $type } yebasa isina chinhu iri kufuratirwa.
+    }
+
+function-points-too-close = Basa rine mapoindi maviri ari pedyo kwazvo. Basa harigoni kutsanangurwa.
+
+function-iterates-input-output-mismatch = Kudzokororwa kwebasa kunogona chete kana huwandu hwezvipinzwa huchienderana nehuwandu hwezvinobuda. Basa iri rine zvipinzwa { $inputs } nezvinobuda { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Urefu hweteedzano hahuna kururama. Hunofanira kuva nhamba yakazara isiri pasi pezero.
+
+sequence-invalid-step = Danho reteedzano harina kururama. Muteedzano yerudzi { $type } rinofanira kuva nhamba.
+
+sequence-invalid-endpoint-number = "{ $attribute }" yeteedzano yenhamba haina kururama. Inofanira kuva nhamba.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" yeteedzano yemavara haina kururama. Inofanira kuva mavara.
+
+sequence-invalid-endpoint = "{ $attribute }" yeteedzano haina kururama.
+
+select-from-sequence-coprime-not-numbers = coprime iri kufuratirwa nekuti hadzisi nhamba dziri kusarudzwa
+
+select-from-sequence-coprime-with-exclude-combinations = coprime iri kufuratirwa nekuti excludeCombinations yakatsanangurwa
+
+## Resolving a `target`
+
+target-not-found = target haina kururama pa`<{ $source }>`: chinangwa hachina kuwanikwa.
+
+target-state-variable-not-found = target haina kururama pa`<{ $source }>`: chinochinja chemamiriro chine zita "{ $property }" hachina kuwanikwa pa`<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Zvinochinja zve`<odeSystem>` zvinofanira kusiyana nechinochinja chakazvimirira.
+
+ode-system-duplicate-variable-names = Hazvigoni kutsanangura mabasa eODE RHS ane mazita ezvinochinja akadzokororwa.
+
+ode-system-rhs-function-error = Hazvigoni kutsanangura basa reODE RHS. Kukanganisa pakugadzira basa remathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Hazvigoni kutsanangura kona pakati pemitsara { $count }
+
+angle-invalid-through-point = Poindi harina kururama muthrough ye`<angle>`
+
+parabola-vertex-too-many-points = Parabhora ine musoro inopfuura nemumapoindi anopfuura 1 haisati yagadzirwa.
+
+parabola-too-many-points = Parabhora inopfuura nemumapoindi anopfuura 3 haisati yagadzirwa.
+
+intersection-too-many-items = Kusangana kwezvinhu zvinopfuura zviviri hakusati kwagadzirwa
+
+## Other math components
+
+ionic-compound-not-two-ions = Musanganiswa weioni unopfuura maioni maviri hausati wagadzirwa.
+
+ionic-compound-needs-cation-and-anion = Musanganiswa weioni wakagadzirirwa kateni imwe neanioni imwe chete.
+
+solve-equations-cannot-evaluate = Hazvigoni kugadzirisa muenzaniso nekuti muenzaniso hauna kukwanisa kuverengwa: { $equation }
+
+math-operators-operand-number-required = operandNumber inofanira kutsanangurwa pakubudisa opharendi yemasvomhu.
+
+eigen-decomposition-failed = Hazvigoni kuverenga kukosha kweeigen kwematiriki
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: paramita { $parameters } hadzisi mumufananidzo, saka dzichaenderana nepasina nguva dzese.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: hazvigoni kududzira grid="{ $grid }". Inofanira kuva none, medium, dense, kana nhamba mbiri dzakanaka dzakaparadzaniswa nenzvimbo, se grid="1 0.5". Hapana girini riri kudhirowewa.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" haitsigirwe mumuratidzi weprefigure; maitiro erutivi rwerudyi ari kushandiswa.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" haitsigirwe mumuratidzi weprefigure; maitiro erutivi rwepamusoro ari kushandiswa.
+
+prefigure-invalid-axis-bounds = `<graph>`: miganhu yeakisi haina kururama pakushandurwa kweprefigure; bbox (-10,-10,10,10) iri kushandiswa.
+
+prefigure-invalid-width = `<graph>`: upamhi hahuna kururama pakushandurwa kweprefigure; upamhi hwemufananidzo 425 huri kushandiswa.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio haina kururama pakushandurwa kweprefigure; chiyero 1 chiri kushandiswa.
+
+prefigure-grid-spacing-too-fine = `<graph>`: nhambo dzegirini idiki kwazvo pamiganhu yeakisi; girini rakasiiwa mumuratidzi weprefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: zvicherechedzo hazvizoratidzwe kana muratidzi wePreFigure usiri kushandiswa.
+
+multiple-annotations-children = Vana `<annotations>` vakawanda vakawanikwa mu`<graph>`; vese vanofuratirwa kunze kwewekupedzisira.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Hazvigoni kuwedzera kana kukopa rudzi rwechinhu rusingazivikanwi: { $type }.
+
+copy-prop-not-found = Chimiro { $property } hachina kuwanikwa pachinhu cherudzi { $component }
+
+collect-no-source = Hapana chinobva chakawanikwa pacollect.
+
+collect-invalid-component-type = Hazvigoni kuunganidza zvinhu zverudzi `<{ $component }>` nekuti irudzi rwechinhu rusina kururama.
+
+reference-index-unavailable = Hazvigoni kunongedza chinongedzo `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Hazvigoni kudaidza { $action } pachinhu `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Chimiro chedata hachina kururama. Mitsara ine urefu husingaenderani. Zvakawanikwa pacomponentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data rine mazita emitsara yakamira akadzokororwa. Zvakawanikwa pacomponentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data harina zita remutsara wakamira. Zvakawanikwa pacomponentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Imwe award yemhinduro iyi inotsamira pamhinduro yakatumirwa netagi answer pachayo, izvo zvichaunza maitiro asingatarisirwi.
+
+answer-max-num-attempts-in-section-wide-check-work = Kuisa `maxNumAttempts` pa`<answer>` iri mukati mechigadziko chine `sectionWideCheckWork` hakuna basa, nekuti chigadziko ichocho ndicho chinodzora huwandu hwemaedzo. Isa `maxNumAttempts` pachigadziko pachacho.
+
+nested-section-wide-check-work-max-num-attempts = Kuisa `maxNumAttempts` pachigadziko chine `sectionWideCheckWork` chiri mukati mechimwe chigadziko chine `sectionWideCheckWork` hakuna basa, nekuti chigadziko chekunze ndicho chinodzora huwandu hwemaedzo. Isa `maxNumAttempts` pachigadziko chekunze.
+
+answer-attributes-need-symbolic-equality = Zvimiro { $attributes } hazvizovi nebasa kana symbolicEquality isina kuiswa.
+
+answer-invalid-type = Rudzi haruna kururama pamhinduro: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sezvo chinhu `<{ $component }>` chisina zita, hachigoni kushandiswa sechimiro chemodule
+
+module-attribute-name-already-defined = Chinhu `<{ $component } name="{ $name }">` hachigoni kushandiswa sechimiro chemodule nekuti rudzi rwechinhu `<module>` rwatova nechimiro chine zita "{ $name }".
+
+conditional-content-condition-ignored = Chimiro `condition` chinofuratirwa pachinhu `<conditionalContent>` chine vana case kana else.
+
+slider-markers-type-mismatch = Rudzi rwezviratidzo haruenderani nerudzi rweslider.
+
+pretzel-problem-needs-statement-and-answer = pretzel haina kururama: `<problem>` yega yega inofanira kuva ne`<statement>` imwe ne`<answer>` imwe.
+
+pretzel-circuit-first-problem-distractor = pretzel haina kururama: mumode="circuit", `<problem>` yekutanga haigoni kuva yekutsausa.
+
+## Attribute values
+
+attribute-invalid-values = Kukosha { $values } hakuna kururama pachimiro `{ $attribute }`; kunofuratirwa.
+
+attribute-must-be-references = Kukosha `{ $value }` hakuna kururama pachimiro `{ $attribute }`. Chimiro chinofanira kuumbwa nezvinongedzo zvinotanga ne`$`.
+
+math-input-invalid-function-names = <mathInput>: mazita emabasa asina kururama mu{ $attribute } ari kufuratirwa: { $names }. Chikamu chekuratidza chezita rimwe nerimwe chinofanira kuva nemavara 2 zvirinani (mavara kana mitsara); chiwedzero `|<mathspeak alternative>` chinogona kutevera.
+
+## Building components from the source
+
+component-type-invalid = Rudzi rwechinhu haruna kururama: `<{ $componentType }>`
+
+attribute-repeated = Chimiro { $attribute } hachigoni kudzokororwa.
+
+attribute-invalid-for-component = Chimiro "{ $attribute }" hachina kururama pachinhu cherudzi `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Tsanangudzo yechimiro { $styleNumber } ine musiyano usingakwani pa{ $context ->
+        [text-on-background] ruvara rwezvinyorwa pamusoro peruvara rwechigadziko
+        [high-contrast] ruvara rwemusiyano mukuru pamusoro pekenvasi
+        [line] ruvara rwemutsara pamusoro pekenvasi
+        [marker] ruvara rwechiratidzo pamusoro pekenvasi
+       *[text-on-canvas] ruvara rwezvinyorwa pamusoro pekenvasi
+    }{ $mode ->
+        [dark] { " (modhi yerima)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; inoda { $threshold }:1 zvirinani).
+
+style-definition-dark-mode-text-background-contrast =
+    Kunyange tsanangudzo yechimiro { $styleNumber } yakatsanangura mavara anopa musiyano wakakwana pamodhi yechiedza, mavara emodhi yerima anobva paari ane musiyano usingakwani paruvara rwezvinyorwa pamusoro peruvara rwechigadziko ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; inoda { $threshold }:1 zvirinani). { $suggestion ->
+        [available] Kuti musiyano ukwane mumodhi yerima, wedzera musiyano wemodhi yechiedza (semuenzaniso isa { $lightAttribute }="{ $lightColor }") kana chinja ruvara rwemodhi yerima (semuenzaniso isa { $darkAttribute }="{ $darkColor }").
+       *[none] Kuti musiyano ukwane mumodhi yerima, wedzera musiyano wemodhi yechiedza kana chinja mavara anobva paari ne textColorDarkMode ne/kana backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Kunyange tsanangudzo yechimiro { $styleNumber } yakatsanangura ruvara rwezvinyorwa runopa musiyano wakakwana pamodhi yechiedza, ruvara rwezvinyorwa rwemodhi yerima runobva parwuri rune musiyano usingakwani pamusoro pekenvasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; inoda { $threshold }:1 zvirinani). { $suggestion ->
+        [available] Kuti musiyano ukwane mumodhi yerima, wedzera musiyano wemodhi yechiedza (semuenzaniso isa textColor="{ $lightColor }") kana chinja ruvara rwemodhi yerima (semuenzaniso isa textColorDarkMode="{ $darkColor }").
+       *[none] Kuti musiyano ukwane mumodhi yerima, wedzera musiyano wemodhi yechiedza kana chinja ruvara runobva parwuri ne textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Chikamu chinogona kusarudza <stylePalette> imwe chete; yekupedzisira iri kushandiswa.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = hazvigoni kutsanangura mhando dzakasiyana dze{ $component } nekuti numToSelect haisi nhamba yakazara isiri pasi pezero.
+
+variant-num-to-select-not-constant-number = hazvigoni kutsanangura mhando dzakasiyana dze{ $component } nekuti numToSelect haisi nhamba isingachinji.
+
+variant-with-replacement-not-constant-boolean = hazvigoni kutsanangura mhando dzakasiyana dze{ $component } nekuti withReplacement haisi bhuriyani isingachinji.
+
+variant-select-weight-disables-unique = Mhando dzakasiyana dzeselect dzinodzimwa kana paine sarudzo ine selectWeight kana selectForVariants yakatsanangurwa
+
+variant-coprime-undetermined = hazvigoni kutsanangura mhando dzakasiyana dze{ $component } nekuti hazvigoni kuvimbisa kuti coprime manyepo nguva dzese.
+
+variant-attribute-not-constant = hazvigoni kutsanangura mhando dzakasiyana dze{ $component } nekuti { $attribute } haina kusimba.
+
+variant-attribute-not-number = hazvigoni kutsanangura mhando dzakasiyana dze{ $component } nekuti { $attribute } haisi nhamba.
+
+variant-attribute-wrong-type-for-sequence =
+    hazvigoni kutsanangura mhando dzakasiyana dze{ $component } dzerudzi { $type } nekuti { $attribute } haisi { $expected ->
+        [letters-combination] musanganiswa wemavara
+        [math-expression] chirevo chemasvomhu chakakodzera
+        [integer] nhamba yakazara
+       *[number] nhamba
+    }.
+
+variant-length-not-integer = hazvigoni kutsanangura mhando dzakasiyana dze{ $component } nekuti length haisi nhamba yakazara.
+
+variant-sort-not-implemented = mhando dzakasiyana dze{ $component } dzine sort hadzisati dzagadzirwa
+
+variant-exclude-combinations-not-implemented = mhando dzakasiyana dze{ $component } dzine excludeCombinations hadzisati dzagadzirwa
+
+variant-math-exclude-not-implemented = mhando dzakasiyana dze{ $component } dzerudzi math dzine exclude hadzisati dzagadzirwa
+
+variant-non-constant-exclude-not-implemented = mhando dzakasiyana dze{ $component } dzine exclude isina kusimba hadzisati dzagadzirwa
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: hazvitsigirwe mumuratidzi wegraph prefigure; mwana asvetukwa.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiyometiri isina magumo kana isina kukwana; mwana asvetukwa.
+
+prefigure-curve-label-omitted = { $subject }: mazita haatsigirwe pazvinhu zvechikombamiro zvakashandurwa; zita rasiiwa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: rudzi rwetsanangudzo yebasa rechikombamiro '{ $definitionType }' harutsigirwe; mwana asvetukwa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: chimiro flipFunctions paregionBetweenCurves hachitsigirwe; mwana asvetukwa.
+
+prefigure-region-non-formula-child = { $subject }: mabasa evana verudzi formula chete ndiwo anotsigirwa paregionBetweenCurves; mwana asvetukwa.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' haitsigirwe pa{ $labelKind ->
+        [line-family] zita remhuri yemutsara
+       *[point] zita repoindi
+    }; kurongwa kwePreFigure kuri kushandiswa.
+
+prefigure-fill-style-unsupported = { $subject }: chimiro chekuzadza '{ $fillStyle }' hachitsigirwe nePreFigure; iri kudzokera kukuzadza neruvara rumwe.
+
+prefigure-line-style-unknown = { $subject }: chimiro chemutsara '{ $lineStyle }' hachizivikanwi uye chasiiwa muzvinobuda zvePreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: chimiro chechiratidzo '{ $markerStyle }' chakaenzaniswa nechimiro chePreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: chimiro chechiratidzo '{ $markerStyle }' hachitsigirwe nePreFigure; chimiro chiripo kare chiri kushandiswa.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` haina kururama; chinangwa hachigoni kuzivikanwa. Chicherechedzo chasiiwa.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` yakatsanangura zvinangwa zvakawanda; chinangwa chekutanga chiri kushandiswa.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` haina kururama; chinangwa chiri kunze kwegirafu rinochichengeta. Chicherechedzo chasiiwa.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` haina kururama; chinangwa hachisi chinhu chemufananidzo chinotsigirwa mukushandurwa kweprefigure. Chicherechedzo chasiiwa.
+
+annotation-text-missing = `<annotation>`: `text` haipo kana haina chinhu; zvinyorwa zvisina chinhu zviri kubudiswa.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Kutsamira kwakatenderera kwaonekwa.
+       *[other] Kutsamira kwakatenderera kunosanganisira chinhu `<{ $componentType }>` kwaonekwa.
+    }
+
+reference-no-referent = Hapana chakawanikwa pachinongedzo: `{ $reference }`
+
+reference-multiple-referents = Zvinhu zvakawanda zvakawanikwa pachinongedzo: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Chimiro hachina kururama pachimiro { $attribute } che`<{ $componentType }>`.
+
+children-invalid = Vana havana kururama pa`<{ $componentType }>`: Vana vasina kururama vakawanikwa: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Kukosha `{ $value }` hakuna kururama pachimiro `{ $attribute }`, kukosha `{ $default }` kuri kushandiswa
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML vhezheni { $version } haina kuwanikwa.
+       *[other] DoenetML vhezheni { $version } haina kuwanikwa. Iri kudzokera kuvhezheni { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML haina kururama: { $content }
+
+parse-tag-missing-close-tag = DoenetML haina kururama: Tagi `{ $tag }` haina tagi yekuvhara. Paitarisirwa tagi inozvivhara kana tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML haina kururama: Kukanganisa mutagi `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML haina kururama: Chimiro `{ $attribute }` chisina kururama chinoita sechisina kukosha.
+
+parse-attribute-invalid = DoenetML haina kururama: Chimiro `{ $attribute }` hachina kururama
+
+parse-attribute-value-invalid = DoenetML haina kururama: Kukosha kwechimiro `{ $value }` hakuna kururama
+
+parse-attribute-value-quote-mismatch = DoenetML haina kururama: Kukosha kwechimiro `{ $value }` hakuna kururama. Zviratidzo zvemashoko hazvienderani. Zvinoita se`{ $quote }` yakashaikwa
+
+parse-open-tag-name-missing = DoenetML haina kururama: Tagi isina zita yakawanikwa, semuenzaniso `<`
+
+parse-tag-not-closed = DoenetML haina kururama: Tagi `{ $tag }` haina kuvharwa (zvinoita se`>` yakashaikwa).
+
+parse-self-closing-tag-name-missing = DoenetML haina kururama: Tagi isina zita yakawanikwa `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML haina kururama: Tagi `{ $tag }` haina kuvharwa (zvinoita se`/>` yakashaikwa).
+
+parse-tag-invalid-attributes = DoenetML haina kururama: Tagi `{ $tag }` haina kururama. Ingave ine zvimiro zvisina kururama.
+
+parse-close-tag-name-missing = DoenetML haina kururama: Tagi yekuvhara isina zita yakawanikwa, semuenzaniso `</`
+
+parse-attribute-value-unquoted = Kukosha kwezvimiro kunofanira kuiswa mukati mezviratidzo zvemashoko: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML haina kururama: Tagi yekuvhara `{ $tag }` yakawanikwa, asi hapana tagi yekuvhura inoenderana
+
+parse-close-tag-mismatched = DoenetML haina kururama: Tagi yekuvhara haienderani. Paitarisirwa `</{ $expected }>`. Pakawanikwa `{ $found }`
+
+parser-node-unconvertible = Hazvina kukwanisa kushandura nodhi { $node } kuita nodhi yeDast.
+
+## Names
+
+name-attribute-invalid =
+    Chimiro name='{ $name }' hachina kururama. { $reason ->
+        [characters] Mazita anogona kuva nemavara, nhamba, mitsara yepasi kana mitsara chete.
+       *[start] Mazita anofanira kutanga nevara.
+    }
+
+component-name-invalid-start = Zita rechinhu "{ $name }" harina kururama. Mazita anofanira kutanga nevara.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Mhinduro yerudzi videoWatched inofanira kuva nechimiro video
+
+answer-video-watched-video-not-reference = Mhinduro yerudzi videoWatched inofanira kuva nechimiro video chiri chinongedzo
+
+answer-name-not-single-text = Chimiro name chemhinduro chinofanira kuva nemwana text mumwe chete
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Hazvigoni kuwana DoenetML yekunze nekuda kwekudzokorora kwakawandisa. Ko paine chinongedzo chakatenderera here?
+
+external-doenetml-unavailable = Hazvigoni kuwana DoenetML kubva ku{ $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML yakawanikwa kubva ku{ $attribute }="{ $uri }" haina kururama: haienderani nerudzi rwechinhu "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Chimiro `{ $from }` chapfuura nenguva; shandisa `{ $to }`.
+       *[other] [deprecation] Chimiro `{ $from }` pa`<{ $component }>` chapfuura nenguva; shandisa `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Chimiro `{ $from }` chapfuura nenguva uye chinofuratirwa nekuti `{ $to }` chakatsanangurwawo.
+       *[other] [deprecation] Chimiro `{ $from }` pa`<{ $component }>` chapfuura nenguva uye chinofuratirwa nekuti `{ $to }` chakatsanangurwawo.
+    }
+
+deprecated-attribute-ignored = [deprecation] Chimiro `{ $attribute }` pa`<{ $component }>` chapfuura nenguva uye chinofuratirwa.
+
+deprecated-attribute-to-child = [deprecation] Chimiro `{ $attribute }` pa`<{ $component }>` chapfuura nenguva; shandisa mwana `<{ $child }>`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` inogona kuita huwandu muChirungu chete, saka zvinyorwa zvayo zvinosara sezvazviri mugwaro rakanyorwa mu{ $locale }. Nyora chimiro chehuwandu iwe pachako, kana uchiise pachimiro `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Chinhu `<{ $tag }>` hachisi chinhu cheDoenet chinozivikanwa.
+
+schema-element-not-allowed-at-root = Chinhu `<{ $tag }>` hachibvumirwi pamudzi wegwaro.
+
+schema-element-not-allowed-inside = Chinhu `<{ $tag }>` hachibvumirwi mukati me`<{ $parent }>`.
+
+schema-attribute-unrecognized = Chinhu `<{ $tag }>` hachina chimiro chine zita `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Chimiro `{ $attribute }` chechinhu `<{ $tag }>` chinofanira kuva runyorwa rune chinhu chimwe nechimwe chiri chimwe che: { $allowed }
+       *[other] Chimiro `{ $attribute }` chechinhu `<{ $tag }>` chinofanira kuva chimwe che: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Zita remhando harina kururama paselect. Zita remhando { $variantName } rinowanikwa musarudzo { $numOptions } asi huwandu hwekusarudza i{ $numToSelect }.
+
+select-variant-name-without-options = Dzimwe mhando dzakatsanangurwa paselect asi hapana sarudzo yakatsanangurwa pazita remhando rinogoneka: { $variantName }.
+
+select-variant-name-not-possible = Zita remhando { $variantName } rakatsanangurwa paselect harisi zita remhando rinogoneka.
+
+select-too-few-options = Hazvigoni kusarudza zvinhu { $numToSelect } kubva pa{ $numOptions } chete.
+
+select-from-sequence-too-few-values = Hazvigoni kusarudza kukosha { $numToSelect } kubva muteedzano ine urefu { $length }.
+
+select-from-sequence-indices-count-mismatch = Huwandu hwezvinongedzo zvakatsanangurwa paselect hunofanira kuenderana nehuwandu hwekusarudza
+
+select-from-sequence-indices-not-integers = Zvinongedzo zvese zvakatsanangurwa paselect zvinofanira kuva nhamba dzakazara
+
+select-from-sequence-index-excluded = Chinongedzo cheselectfromsequence chakabviswa chakatsanangurwa
+
+select-from-sequence-indices-excluded-combination = Zvinongedzo zveselectfromsequence zvakanga zviri musanganiswa wakabviswa zvakatsanangurwa
+
+select-from-sequence-coprime-not-positive-integers = Hazvigoni kusarudza misanganiswa yenhamba dzisingagoverani nekuti hadzisi nhamba dzakazara dziri pamusoro pezero dziri kusarudzwa.
+
+select-from-sequence-coprime-common-factor = Hazvigoni kusarudza nhamba dzisingagoverani. Kukosha kwese kunogoneka kunogovana chigoveso chimwe. (Kukosha kwakatsanangurwa kwe"from" kana "to" kunofanira kusagoverana ne"step".)
+
+select-from-sequence-coprime-single-number = Hazvigoni kusarudza misanganiswa yenhamba dzisingagoverani kubva panhamba imwe isiri 1.
+
+select-from-sequence-excluded-too-many-combinations = Anopfuura 70% emisanganiswa akabviswa muselectFromSequence
+
+select-from-sequence-coprime-none-found = Hazvina kukwanisa kusarudza nhamba dzisingagoverani. Kukosha kwese kunogoneka kunogovana chigoveso chimwe.
+
+select-from-sequence-too-few-unique-values = Hazvigoni kusarudza kukosha kwakasiyana { $numToSelect } kubva muteedzano ine urefu { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Hazvigoni kusarudza kukosha { $numToSelect } kubva murunyorwa rwenhamba dzeprime rune urefu { $numValues }
+
+select-prime-numbers-values-count-mismatch = Huwandu hwekukosha kwakatsanangurwa paselect hunofanira kuenderana nehuwandu hwekusarudza
+
+select-prime-numbers-values-not-prime = Kukosha kwese kwakatsanangurwa paselect prime number kunofanira kuva murunyorwa rwenhamba dzeprime
+
+select-prime-numbers-values-excluded-combination = Kukosha kweselectPrimeNumbers kwakatsanangurwa kwakanga kuri musanganiswa wakabviswa
+
+select-prime-numbers-excluded-too-many-combinations = Anopfuura 70% emisanganiswa akabviswa muselectPrimeNumbers
+
+select-random-combination-fluke = Nenzira isingawanzoitiki, hazvina kukwanisa kusarudza musanganiswa wekukosha kwehuchapu
+
+select-random-value-fluke = Nenzira isingawanzoitiki, hazvina kukwanisa kusarudza kukosha kwehuchapu

--- a/packages/i18n/locales/sn/editor.ftl
+++ b/packages/i18n/locales/sn/editor.ftl
@@ -1,0 +1,209 @@
+# Shona editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Whether a counted noun changes shape depends on its class, as `chrome.ftl`'s
+# header sets out, and here none of them does, so all three selects are
+# dropped. `help-coordinates` counts «makoodhineti», a loan cited in one shape
+# for both numbers. `editor-accessibility-label` counts «kutyorwa», the class
+# 15 verbal noun for a violation, which has no plural at all, and «mazano»,
+# which is already the class 6 plural and is what the message says at any
+# count.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Dzosera
+       *[update] Vandudza
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Muratidzi
+       *[other] { $word } Muratidzi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Mhando
+editor-variant-filter = Sefa...
+editor-variant-next = Sarudza mhando inotevera
+editor-variant-previous = Sarudza mhando yapfuura
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Kutyorwa kweWCAG AA kwekuwanikwa kwaonekwa. Dzvanya kuti { $action ->
+            [close] uvhare
+           *[open] uvhure
+        } mushumo wekuwanikwa.
+        [advisories] Dzvanya kuti { $action ->
+            [close] uvhare
+           *[open] uvhure
+        } mushumo wekuwanikwa. Hapana kutyorwa kweWCAG AA kwakawanikwa, asi pane mamwe mazano ekuwanikwa.
+       *[clean] Dzvanya kuti { $action ->
+            [close] uvhare
+           *[open] uvhure
+        } mushumo wekuwanikwa. Hapana dambudziko rekuwanikwa rakawanikwa.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Kutyorwa kweWCAG AA kwekuwanikwa kwaonekwa. Kutyorwa kweWCAG AA { $count } kwakawanikwa. Dzvanya kuti { $action ->
+            [close] uvhare
+           *[open] uvhure
+        } mushumo wekuwanikwa.
+        [advisories] Hapana kutyorwa kweWCAG AA kwakaonekwa. Mamwe mazano ekuwanikwa { $count } akawanikwa. Dzvanya kuti { $action ->
+            [close] uvhare
+           *[open] uvhure
+        } mushumo wekuwanikwa.
+       *[clean] Hapana kutyorwa kweWCAG AA kwakaonekwa. Dzvanya kuti { $action ->
+            [close] uvhare
+           *[open] uvhure
+        } mushumo wekuwanikwa.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML vhezheni { $version }
+
+editor-tab-help = Rubatsiro runoenderana nenzvimbo
+editor-tab-help-short = Nzvimbo
+editor-tab-errors = Zvikanganiso
+editor-tab-warnings = Yambiro
+editor-tab-info = Ruzivo
+editor-tab-accessibility = Kuwanikwa
+editor-tab-responses = Mhinduro dzakatumirwa
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Sarudzo dzemunyori
+editor-format-as-doenetml = Gadzira seDoenetML
+editor-format-as-xml = Gadzira seXML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Mutsara #{ $line }
+
+editor-no-errors = Hapana Zvikanganiso
+editor-no-warnings = Hapana Yambiro
+editor-no-info = Hapana Ongororo yeRuzivo
+
+editor-show-info-annotations = Ratidza ongororo dzeruzivo mumunyori
+editor-show-accessibility-annotations = Ratidza ongororo dzekuwanikwa mumunyori
+
+editor-accessibility-learn-more = Dzidza kuti Doenet inobata sei kuwanikwa
+
+editor-accessibility-violations-heading = Kutyorwa kwekuwanikwa ({ $standard })
+
+editor-accessibility-other-heading = Mamwe matambudziko ekuwanikwa
+editor-none-found = Hapana chakawanikwa
+
+
+## Submitted responses
+
+editor-no-responses = Hapana mhinduro yakatumirwa parizvino
+editor-response-answer-id = Zita reMhinduro
+editor-response-response = Mhinduro
+editor-response-credit = Mamakisi
+editor-response-submitted = Yakatumirwa
+
+
+## The context-help panel
+
+help-placeholder = Isa chiratidzo pamusoro pezita retagi, chimiro kana { $ref } kuti uwane magwaro.
+
+help-unsupported-ref-chain = Rubatsiro rwezvinongedzo zvine zvikamu zvakawanda se{ $example } haruna kutsigirwa.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Hapana chakawanikwa pachinongedzo: { $ref }.
+        [multiple] Zvinhu zvakawanda zvakawanikwa pachinongedzo: { $ref }.
+       *[indeterminate] Zvinonongedzwa ne{ $ref } hazvina kuzivikanwa.
+    }
+
+help-learn-about-references = Dzidza nezvezvinongedzo →
+help-reference-page = Peji rezvinongedzo →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Mukati me{ $element }
+       *[top] Pamusoro-soro
+    }{ $allowed ->
+        [none] { " — hapana chinopinda pano." }
+        [text] { " — nyora zvinyorwa pano." }
+        [text-and-components] { " — nyora zvinyorwa pano, kana edza:" }
+       *[components] { " — zvinhu zvekuedza:" }
+    }
+
+help-suggestions-footer = Dzvanya { $shortcut } kuti uone zvinhu { $total } zvese.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } chinongedzo che{ $target }.
+       *[other] { $ref } chinongedzo che{ $target } (mutsara { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } akachitumidza kuti { $role }.
+       *[other] { $owner } akachitumidza pamutsara { $line } kuti { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } chinongedzo chechimiro { $property } che{ $element }.
+       *[other] { $ref } chinongedzo chechimiro { $property } che{ $element } (mutsara { $line }).
+    }
+
+help-kind-attribute = chimiro
+help-kind-snippet = chidimbu chezvinyorwa
+help-kind-array-entry = chipinzwa chetafura
+
+help-default = Chiripo kare:
+help-active-default = Chiripo kare chiri kushanda:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Kukosha kunobvumirwa (kumwe pachinhu chimwe nechimwe):
+       *[other] Kukosha kunobvumirwa:
+    }
+
+help-suggested-values = Kukosha kunokurudzirwa:
+
+help-inserts = Inoisa:
+
+help-coordinates = Makoodhineti:
+
+help-type = Rudzi:
+
+help-resolved-style = Chimiro chakazivikanwa (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Mazita emabasa akazivikanwa:
+help-reset-list = Runyorwa runodzoserwa pachipinzwa ichi:
+help-added-on-input = Zvakawedzerwa pachipinzwa ichi:
+help-removed-on-input = Zvakabviswa pachipinzwa ichi:
+
+help-reset-overrides = { $reset } inopfuura { $additional } ne{ $removed }.

--- a/packages/i18n/locales/st/chrome.ftl
+++ b/packages/i18n/locales/st/chrome.ftl
@@ -1,0 +1,143 @@
+# Southern Sotho viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Sesotho has two plural categories, and a noun marks number with a class
+# prefix rather than a suffix — «teko» one attempt, «diteko» several; «karabo»
+# one answer, «dikarabo» several — and it keeps doing so after a numeral. So
+# the selects are kept and the noun changes shape inside them, which is the
+# same reason the Slavic catalogs keep theirs. `attempts-remaining` also keeps
+# its `[0]` branch, an exact-value match rather than a plural category, which
+# says «ha ho» instead of counting to zero.
+
+
+## Answer submission
+
+answer-checking = Ea hlahloba...
+answer-submitting = Ea romela...
+
+answer-checking-status = E hlahloba karabo
+answer-submitting-status = E romela karabo
+
+answer-correct = E nepahetse
+answer-incorrect = Ha e a nepahala
+
+answer-response-saved = Karabo e Bolokiloe
+
+answer-percent-credit = Matshwao { $percent }%
+answer-percent-correct = { $percent }% E nepahetse
+answer-percent-short = { $percent } %
+
+max-credit-available = Matshwao a maholo a fumanehang: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] ha ho teko e setseng
+        [one] teko e { $count } e setse
+       *[other] diteko tse { $count } di setse
+    }
+
+validation-correct = (E nepahetse)
+validation-incorrect = (Ha e a nepahala)
+validation-partially-correct = (E nepahetse karolwana)
+
+answer-show-responses =
+    { $count ->
+        [one] Bontsha karabo e { $count } ho { $answerId }
+       *[other] Bontsha dikarabo tse { $count } ho { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Maikutlo
+
+collapsible-click-to-open = (tobetsa ho bula)
+collapsible-click-to-close = (tobetsa ho koala)
+
+collapsible-initializing = Ea qala...
+
+footnote-show = Bontsha tlhaloso ya tlase
+footnote-hide = Pata tlhaloso ya tlase
+
+description-more-information = tlhahisoleseding e nngwe
+
+
+## Controls
+
+slider-previous = E fetileng
+slider-next = E latelang
+
+keyboard-open = Bula Keyboard
+keyboard-close = Koala Keyboard
+
+choice-input-remove-choice = Tlosa { $choice }
+
+matrix-remove-row = Tlosa mola o robetseng
+matrix-add-row = Eketsa mola o robetseng
+matrix-remove-column = Tlosa mola o emeng
+matrix-add-column = Eketsa mola o emeng
+
+subset-add-remove-points = Eketsa/Tlosa dintlha
+subset-toggle-points-intervals = Fetola pakeng tsa dintlha le dikgeo
+subset-move-points = Sutumetsa Dintlha
+subset-clear = Hlakola
+
+# A `box` here is one orbital, drawn as a square: «lebokose».
+orbital-add-row = Eketsa Mola
+orbital-remove-row = Tlosa Mola
+orbital-add-box = Eketsa Lebokose
+orbital-remove-box = Tlosa Lebokose
+orbital-add-up-arrow = Eketsa Motsu o Lebileng Hodimo
+orbital-add-down-arrow = Eketsa Motsu o Lebileng Tlase
+orbital-remove-arrow = Tlosa Motsu
+
+orbital-row-label = Lebitso la mola { $row }
+
+pretzel-answer = Karabo
+
+summary-statistics-caption = Kakaretso ya dipalopalo tsa { $column }
+
+
+## Math input
+
+math-input-preview-region = ponelopele ya polelo ya dipalo
+math-input-preview = Ponelopele
+math-input-invalid-expression = Polelo ha e a nepahala:
+
+
+## Document status
+
+viewer-initializing = Ea qala...
+
+
+## Errors
+
+error-heading = Phoso
+
+error-found-at =
+    { $span ->
+        [line] E fumanwe moleng wa { $startLine }.
+       *[lines] E fumanwe melaneng ya { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Tokomane ena e na le diphoso!
+
+diagnostic-heading-error = Phoso
+diagnostic-heading-warning = Temoso
+diagnostic-heading-information = Tlhahisoleseding
+diagnostic-heading-hint = Keletso
+
+accessibility-heading-level-1 = Tlolo ya WCAG AA ya Phihlelelo
+accessibility-heading-level-2 = Temoso ya phihlelelo
+
+something-went-wrong = Ho na le se sa tsamayang hantle.
+
+renderer-load-failed = mmontshi o le mong ha oa kgona ho kenella. Ka kopo nchafatsa leqephe.
+
+core-start-failed = Mmontshi wa tokomane ha a kgonang ho qala. Ka kopo nchafatsa leqephe.

--- a/packages/i18n/locales/st/content.ftl
+++ b/packages/i18n/locales/st/content.ftl
@@ -1,0 +1,333 @@
+# Southern Sotho content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# The roster calls this language **Southern Sotho**, which is what
+# `Intl.DisplayNames` renders `st` as and so what `<document lang>`'s
+# autocomplete offers. Sesotho is the name its speakers use, and the two are
+# one language — the same split `ny` has between Nyanja and Chichewa.
+#
+# Sesotho has no masculine or feminine, and it agrees an adjective with its
+# noun's **class**, so this catalog reads `$gender` as the class token rather
+# than as a gender — the same device `locales/sw` uses. `noun-gender` answers
+# `c3`, `c5`, `c7` or `c9`, and every adjective that carries a concord selects
+# on it.
+#
+# The concords this catalog writes out:
+#
+#           c3 (mo-/me-)  c5 (le-/ma-)  c7 (se-/di-)  c9 (N-)
+#   -tšo     motšo         letšo         setšo         ntšo
+#   -tšweu   motšweu       letšweu       setšweu       tšweu
+#   -fubedu  mofubedu      lefubedu      sefubedu      khubedu
+#   -tenya   motenya       letenya       setenya       tenya
+#   -sesane  mosesane      lesesane      sesesane      sesane
+#
+# **The qualificative particle is left out on purpose**, and that is the one
+# thing a speaker will notice first. Sesotho joins an adjective to its noun
+# with a particle agreeing in class as well — «mola *o* motenya», «ntlha *e*
+# ntšo» — and the particle is computable from `$gender`. It is left out because
+# the same string is also what `backgroundColor` and `lineColorDescription`
+# report standing alone, where a bare particle would be a fragment, and nothing
+# in `$role` tells the two positions apart. Restoring it belongs in
+# `style-with-noun`, where the noun is in hand; this is the same trade
+# `locales/sw` makes with its associative.
+#
+# `style-filled-word` is the one entry that does carry a concord in front of
+# it — «o tletseng», «se tletseng» — and it is not the particle being restored
+# there: «tletseng» is a relative verb form, and its relative concord is part
+# of the word rather than a linker that could be dropped. It selects on
+# `$gender` like the adjectives do.
+#
+# Adjectives follow the noun, so the composition messages put the noun first.
+# `$role` goes unused: Sesotho marks no case.
+#
+# `c9` is the default, because that is the class a loanword joins — and an
+# author's own `markerStyleWord`, which this catalog has never seen, is a
+# loanword as far as it is concerned.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+# Only the three with a native adjective stem inflect. The rest are invariable
+# loans and do not change shape for anything.
+color =
+    .black =
+        { $gender ->
+            [c3] motšo
+            [c5] letšo
+            [c7] setšo
+           *[c9] ntšo
+        }
+    .white =
+        { $gender ->
+            [c3] motšweu
+            [c5] letšweu
+            [c7] setšweu
+           *[c9] tšweu
+        }
+    .gray = boputswa
+    .red =
+        { $gender ->
+            [c3] mofubedu
+            [c5] lefubedu
+            [c7] sefubedu
+           *[c9] khubedu
+        }
+    .orange = lamunu
+    .yellow = mosehla
+    .green = botala
+    .cyan = sayane
+    .blue = boputsoa
+    .purple = perese
+    .pink = pinki
+    .brown = sootho
+
+line-width =
+    .thick =
+        { $gender ->
+            [c3] motenya
+            [c5] letenya
+            [c7] setenya
+           *[c9] tenya
+        }
+    .thin =
+        { $gender ->
+            [c3] mosesane
+            [c5] lesesane
+            [c7] sesesane
+           *[c9] sesane
+        }
+
+# Written as invariable «ka …» phrases rather than as adjectives, so that they
+# agree with nothing and can close the description. `style-stroke` puts them
+# last for that reason.
+line-style =
+    .dashed = ka dikgaolo
+    .dotted = ka dintlha
+
+fill-style =
+    .horizontal = mela e robetseng
+    .vertical = mela e emeng
+    .diagonal = mela e sekameng
+    .backdiagonal = mela e sekameng morao
+    .dots = dintlha
+    .diamonds = ditaemane
+
+noun =
+    .line = mola
+    .line-segment = karolo ya mola
+    .ray = lesedi
+    .vector = vektoro
+    .curve = kobeho
+    .function = tshebetso
+    .parabola = parabola
+    .polyline = mokoloko wa mela
+    .polygon = polikone
+    .triangle = khutlotharo
+    .rectangle = khutlonne
+    .circle = sedikadikwe
+    .region = sebaka
+    .point = ntlha
+    .square = sekwere
+    .diamond = taemane
+    .cross = sefapano
+    .plus = letshwao la ho eketsa
+
+# The side count goes in the tail, behind the adjectives, because «e nang le
+# mahlakore a 5» is a relative clause and Sesotho closes a noun phrase with one
+# rather than opening one.
+noun-regular-polygon =
+    { $part ->
+        [tail] e nang le mahlakore a { $numSides }
+       *[head] polikone e lekanang
+    }
+
+noun-gender =
+    { $noun ->
+        [line] c3
+        [polyline] c3
+        [border] c3
+        [ray] c5
+        [line-segment] c7
+        [region] c7
+        [circle] c7
+        [square] c7
+        [cross] c7
+        [fill] c7
+        [text] c5
+       *[other] c9
+    }
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c3] o tletseng
+        [c5] le tletseng
+        [c7] se tletseng
+       *[c9] e tletseng
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ka { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ka { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ka { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «moedi» is class 3 and leads its own adjectives, so the border's words agree
+# with it and not with the shape it surrounds. Sesotho has no article, so the
+# two `-article` branches read like the two without, and the complement is
+# joined with the invariable «ka» whether it is the first clause or a further
+# one, so `[and]` reads like `[with]` as well. All four end up the same string.
+style-border-clause =
+    { $parts ->
+        [with-article] ka moedi { $border }
+        [and] ka moedi { $border }
+        [and-article] ka moedi { $border }
+       *[with] ka moedi { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = e sa tlalang
+
+style-text =
+    { $parts ->
+        [background] { $color } holim'a bokamorao { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ha ho letho
+
+
+## Boolean words
+
+boolean-true = nnete
+boolean-false = leshano
+
+
+## Answer buttons
+
+answer-submit-label = Hlahloba Mosebetsi
+answer-submit-label-no-correctness = Romela Karabo
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Mosebetsi
+    .aside = Tlhaloso ka thoko
+    .cascade = Kaskade
+    .definition = Tlhaloso
+    .example = Mohlala
+    .exercise = Boitlwaetso
+    .exercises = Boitlwaetso
+    .given-answer = Karabo
+    .note = Tlhokomediso
+    .objectives = Merero
+    .paragraphs = Dirapa
+    .part = Karolo
+    .problem = Bothata
+    .problems = Mathata
+    .proof = Bopaki
+    .question = Potso
+    .section = Karolo
+    .solution = Tharollo
+    .task = Mosebetsi
+    .theorem = Thiorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Keletso
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tafole { $enumeration }
+        [numbered-title] Tafole { $enumeration }{ ": " }
+        [unnumbered-title] Tafole{ ": " }
+       *[unnumbered] Tafole
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Setshwantsho { $enumeration }
+        [numbered-caption] Setshwantsho { $enumeration }{ ": " }
+        [unnumbered-caption] Setshwantsho{ ": " }
+       *[unnumbered] Setshwantsho
+    }
+
+
+## Paginator controls
+
+paginator-previous = E fetileng
+paginator-next = E latelang
+paginator-page = Leqephe
+
+paginator-page-status = { $pageLabel } { $currentPage } ho { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = kapa
+piecewise-condition-if = ha
+piecewise-condition-otherwise = ho seng joalo
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Secondary science in Lesotho
+# and in the Free State is taught in English, so a student meeting these words
+# meets them in English already, and the seed has no settled Sesotho list to
+# reproduce. A speaker adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Letshwao la Khemistri le sa Nepahalang
+chemistry-invalid-ionic-compound = Motswako wa Ione o sa Nepahalang

--- a/packages/i18n/locales/st/diagnostics.ftl
+++ b/packages/i18n/locales/st/diagnostics.ftl
@@ -1,0 +1,613 @@
+# Southern Sotho diagnostics. Translated from `locales/en/diagnostics.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Sesotho verb takes its subject concord
+# from the noun class rather than from the count, and the argument is a list
+# either way. So those selects are dropped and the count argument goes unused.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } ha e nahanelwe ha dintlha tse pedi tsa pheletso di boletswe
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } ha e nahanelwe ha ntlha ya pheletso le ntlha ya bohareng di boletswe ka bobedi
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ha e na tshusumetso ha ho se na ntlha ya bohareng
+
+## `<line>`
+
+line-points-undetermined-dimensions = Mola o feta dintlheng tse nang le bophara bo sa tsejweng.
+
+line-points-too-few-dimensions = Mola o tshwanetse ho feta dintlheng tse nang le bophara bo bobedi bonyane.
+
+line-points-depend-on-variables = Mola o feta dintlheng tse itshetlehileng ho diphetoho: { $variables }.
+
+line-equation-invalid-format = Sebopeho ha se a nepahala bakeng sa equation ya mola ho diphetoho { $variable1 } le { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Lesedi le boletswe ka through, endpoint le direction ka bonngwe. through e boletsweng ha e nahanelwe.
+
+ray-dimension-mismatch = numDimensions ha e tsamaellane ka hare ho lesedi.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektoro e boletswe ka head, tail le displacement ka bonngwe. head e boletsweng ha e nahanelwe.
+
+vector-dimension-mismatch = numDimensions ha e tsamaellane ka hare ho vektoro.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ha e kgone ho huelwa ho `<{ $component }>` hobane ha e na phetoho ya boemo nearestPoint.
+
+constrain-to-without-nearest-point = Ha e kgone ho tlangwa ho `<{ $component }>` hobane ha e na phetoho ya boemo nearestPoint.
+
+constrain-to-interior-without-nearest-point = Ha e kgone ho tlangwa ka hare ho `<{ $component }>` hobane ha e na phetoho ya boemo nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ha e nahanelwe ho choiceInput e seng ya mola o le mong
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Disupo tse boletsweng bakeng sa choiceInput ha di nahanelwe hobane palo ya disupo ha e tsamaellane le palo ya bana ba choice.
+
+pretzel-indices-count-mismatch = Disupo tse boletsweng bakeng sa problem ha di nahanelwe hobane palo ya disupo ha e tsamaellane le palo ya bana ba problem.
+
+shuffle-indices-count-mismatch = Disupo tse boletsweng bakeng sa shuffle ha di nahanelwe hobane palo ya disupo ha e tsamaellane le palo ya dintho.
+
+indices-ignored-out-of-range = Disupo tse boletsweng bakeng sa { $component } ha di nahanelwe hobane disupo tse ding di ka ntle ho sebaka.
+
+pretzel-indices-repeated = Disupo tse boletsweng bakeng sa pretzel ha di nahanelwe hobane disupo tse ding di pheta-phetilwe.
+
+pretzel-circuit-first-index = Disupo tse boletsweng bakeng sa pretzel mokgweng wa circuit ha di nahanelwe hobane sesupo sa pele se tshwanetse ho ba 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Hore `<{ $component }>` e sebetse le bana ba mofuta wa mongolo, tshobotsi `type` e tshwanetse ho boleloa.
+
+invalid-type-defaulting-to-math = type { $type } ha e a nepahala bakeng sa ntho { $component }. E tshwanetse ho ba e nngwe ya math, text, number kapa boolean. E behwa math.
+
+string-not-valid-component-to-arrange = Mongolo "{ $value }" ha se ntho ya { $component } e nepahetseng. Ha e nahanelwe.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } ha e a nepahala, type e behwa number.
+
+invalid-variable-value = Boleng ba phetoho ha bo a nepahala: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Sesupo sa mofuta { $index } se tshwanetse ho ba palo
+
+variant-index-must-be-integer = Sesupo sa mofuta { $index } se tshwanetse ho ba palo e felletseng
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ha e a etswa ka ditekanyo tse tiileng. Bophara bo behwa ka dikarolo.
+
+side-by-side-absolute-margins = `<{ $component }>` ha e a etswa ka ditekanyo tse tiileng. Meedi e behwa ka dikarolo.
+
+side-by-side-no-block-child = `<{ $component }>` ha e a nepahala: e tshwanetse ho ba le ngwana a le mong bonyane wa mofuta wa bolokwe.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Tshobotsi `for` ho `<label>` ya setshwantsho ha e nahanelwe.
+
+label-for-must-resolve-to-one = Tshobotsi `for` ho `<label>` e tshwanetse ho supa ntho e le nngwe feela.
+
+label-for-unresolved = Tshobotsi `for` ho `<label>` ha e a kgona ho supa ntho leha e le efe.
+
+label-for-answer-with-authored-inputs = Tshobotsi `for` ho `<label>` e supa `<answer>` e nang le dikenyo tse ngotsweng; supa kenyo ka boyona.
+
+label-for-answer-without-input = Tshobotsi `for` ho `<label>` e supa `<answer>` e se nang kenyo ya ho rehwa lebitso.
+
+label-for-must-reference-input-or-answer = Tshobotsi `for` ho `<label>` e tshwanetse ho supa kenyo kapa karabo.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Bakeng sa phihlelelo, `<{ $component }>` e tshwanetse ho ba le tlhaloso e kgutshwane kapa e boleloe e le ya mokgabiso.
+
+accessibility-video-short-description = Bakeng sa phihlelelo, `<video>` e tshwanetse ho ba le tlhaloso e kgutshwane.
+
+accessibility-input-short-description-or-label = Bakeng sa phihlelelo, `<{ $component }>` e tshwanetse ho ba le tlhaloso e kgutshwane kapa lebitso.
+
+accessibility-answer-input-short-description-or-label = Bakeng sa phihlelelo, `<answer>` e etsang kenyo e tshwanetse ho ba le tlhaloso e kgutshwane kapa lebitso.
+
+accessibility-short-description-contains-math = Tlhaloso e kgutshwane ha ea lokela ho ba le dintho tsa dipalo jwaloka `<{ $component }>`. Hlalosa dipalo tsohle ka mantswe.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } e na le phapang e sa lekaneng bakeng sa mongolo wa sehlooho sa karolo (mokgwa o lefifi) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e hloka bonyane { $threshold }:1).
+       *[other] { $colorName } e na le phapang e sa lekaneng bakeng sa mongolo wa sehlooho sa karolo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e hloka bonyane { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` e fetang dintlheng tse { $count } ha e eso etswe ha dintlha tseo di se na boleng ba dipalo.
+
+circle-too-many-through-points = Ha e kgone ho bala sedikadikwe se fetang dintlheng tse fetang 3.
+
+circle-overprescribed-radius-center-points = Ha e kgone ho bala sedikadikwe se nang le radiase, bohareng le dintlha tsa ho feta tsohle di boletswe.
+
+circle-center-with-multiple-points = Ha e kgone ho bala sedikadikwe se nang le bohareng bo boletsweng se fetang dintlheng tse fetang 1.
+
+circle-radius-too-small = Ha e kgone ho bala sedikadikwe: kaha sebaka pakeng tsa dintlha tse pedi ke { $distance }, radiase { $radius } e boletsweng e nyenyane haholo.
+
+circle-radius-with-many-points = Ha e kgone ho etsa sedikadikwe se fetang dintlheng tse fetang tse pedi se nang le radiase e boletsweng.
+
+circle-invalid-center-or-through-points = Bohareng ba sedikadikwe kapa dintlha tsa sona tsa ho feta ha di a nepahala.
+
+circle-radius-center-with-multiple-points = Ha e kgone ho bala radiase ya sedikadikwe se nang le bohareng bo boletsweng se fetang dintlheng tse fetang 1.
+
+circle-change-radius-non-numerical = Ha e kgone ho fetola radiase ya sedikadikwe se fetang dintlheng tse se nang boleng ba dipalo
+
+circle-radius-with-points-non-numerical = Ha e kgone ho etsa sedikadikwe se fetang dintlheng tse fetang e le nngwe se nang le radiase e boletsweng ha ho se na boleng ba dipalo.
+
+circle-change-center-non-numerical = Ho fetola bohareng ba sedikadikwe se fetang dintlheng tse se nang boleng ba dipalo ha ho eso etswe.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Bophara ba lebala la tshebetso ha bo lekane. Lebala le na le dikgeo tse { $intervals } empa tshebetso e na le dikenyo tse { $inputs }.
+
+function-domain-invalid-format = Sebopeho sa lebala la tshebetso ha se a nepahala.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ntlha e phahameng ya tshebetso e seng ya dipalo ha e nahanelwe.
+        [minimum] Ntlha e tlase ya tshebetso e seng ya dipalo ha e nahanelwe.
+        [extremum] Ntlha ya pheletso ya tshebetso e seng ya dipalo ha e nahanelwe.
+        [point] Ntlha ya tshebetso e seng ya dipalo ha e nahanelwe.
+        [slope] Tshekamo ya tshebetso e seng ya dipalo ha e nahanelwe.
+       *[other] { $type } ya tshebetso e seng ya dipalo ha e nahanelwe.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ntlha e phahameng ya tshebetso e se nang letho ha e nahanelwe.
+        [minimum] Ntlha e tlase ya tshebetso e se nang letho ha e nahanelwe.
+        [extremum] Ntlha ya pheletso ya tshebetso e se nang letho ha e nahanelwe.
+        [point] Ntlha ya tshebetso e se nang letho ha e nahanelwe.
+       *[other] { $type } ya tshebetso e se nang letho ha e nahanelwe.
+    }
+
+function-points-too-close = Tshebetso e na le dintlha tse pedi tse haufi haholo. Tshebetso ha e kgone ho hlaloswa.
+
+function-iterates-input-output-mismatch = Ho pheta-pheta tshebetso ho kgonahala feela ha palo ya dikenyo e lekana le palo ya diphello. Tshebetso ena e na le dikenyo tse { $inputs } le diphello tse { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Bolelele ba tatellano ha bo a nepahala. Bo tshwanetse ho ba palo e felletseng e seng ka tlase ho zero.
+
+sequence-invalid-step = Mohato wa tatellano ha o a nepahala. Tatellanong ya mofuta { $type } o tshwanetse ho ba palo.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ya tatellano ya dipalo ha e a nepahala. E tshwanetse ho ba palo.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ya tatellano ya ditlhaku ha e a nepahala. E tshwanetse ho ba ditlhaku.
+
+sequence-invalid-endpoint = "{ $attribute }" ya tatellano ha e a nepahala.
+
+select-from-sequence-coprime-not-numbers = coprime ha e nahanelwe hobane ha se dipalo tse kgethwang
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ha e nahanelwe hobane excludeCombinations e boletswe
+
+## Resolving a `target`
+
+target-not-found = target ha e a nepahala bakeng sa `<{ $source }>`: sepheo ha se a fumanwa.
+
+target-state-variable-not-found = target ha e a nepahala bakeng sa `<{ $source }>`: phetoho ya boemo e nang le lebitso "{ $property }" ha e a fumanwa ho `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Diphetoho tsa `<odeSystem>` di tshwanetse ho fapana le phetoho e ikemetseng.
+
+ode-system-duplicate-variable-names = Ha e kgone ho hlalosa ditshebetso tsa ODE RHS tse nang le mabitso a diphetoho a pheta-phetilweng.
+
+ode-system-rhs-function-error = Ha e kgone ho hlalosa tshebetso ya ODE RHS. Phoso ha ho etswa tshebetso ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ha e kgone ho hlalosa kgutlo pakeng tsa mela e { $count }
+
+angle-invalid-through-point = Ntlha ha e a nepahala ho through ya `<angle>`
+
+parabola-vertex-too-many-points = Parabola e nang le ntlha e phahameng e fetang dintlheng tse fetang 1 ha e eso etswe.
+
+parabola-too-many-points = Parabola e fetang dintlheng tse fetang 3 ha e eso etswe.
+
+intersection-too-many-items = Kopano ya dintho tse fetang tse pedi ha e eso etswe
+
+## Other math components
+
+ionic-compound-not-two-ions = Motswako wa ione o fetang di-ione tse pedi ha o eso etswe.
+
+ionic-compound-needs-cation-and-anion = Motswako wa ione o etseditswe cation e le nngwe le anion e le nngwe feela.
+
+solve-equations-cannot-evaluate = Ha e kgone ho rarolla equation hobane equation ha e a kgona ho balwa: { $equation }
+
+math-operators-operand-number-required = operandNumber e tshwanetse ho boleloa ha ho ntshuwa operand ya dipalo.
+
+eigen-decomposition-failed = Ha e kgone ho bala boleng ba eigen ba matrix
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: diparamethara { $parameters } ha di hlahe sebopehong, kahoo di tla tsamaellana le lefeela kamehla.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ha e kgone ho hlalosa grid="{ $grid }". E tshwanetse ho ba none, medium, dense, kapa dipalo tse pedi tse ntle tse arotsweng ka sebaka, jwaloka grid="1 0.5". Ha ho grid e takwang.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ha e tshehetswe mmontshing wa prefigure; boitshwaro ba lehlakoreng le letona bo sebediswa.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ha e tshehetswe mmontshing wa prefigure; boitshwaro ba hodimo bo sebediswa.
+
+prefigure-invalid-axis-bounds = `<graph>`: meedi ya axis ha e a nepahala bakeng sa phetoho ya prefigure; bbox (-10,-10,10,10) e sebediswa.
+
+prefigure-invalid-width = `<graph>`: bophara ha bo a nepahala bakeng sa phetoho ya prefigure; bophara ba setshwantsho 425 bo sebediswa.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio ha e a nepahala bakeng sa phetoho ya prefigure; tekanyo 1 e sebediswa.
+
+prefigure-grid-spacing-too-fine = `<graph>`: dikgeo tsa grid di nyenyane haholo bakeng sa meedi ya axis; grid e siilwe mmontshing wa prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: dintlha tsa tlatsetso di ke ke tsa bontshwa ha mmontshi wa PreFigure a sa sebediswe.
+
+multiple-annotations-children = Bana ba bangata ba `<annotations>` ba fumanwe ho `<graph>`; bohle ha ba nahanelwe ntle le wa ho qetela.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ha e kgone ho atolosa kapa ho kopitsa mofuta wa ntho o sa tsejweng: { $type }.
+
+copy-prop-not-found = Tshobotsi { $property } ha e a fumanwa nthong ya mofuta { $component }
+
+collect-no-source = Ha ho mohlodi o fumanweng bakeng sa collect.
+
+collect-invalid-component-type = Ha e kgone ho bokella dintho tsa mofuta `<{ $component }>` hobane ke mofuta wa ntho o sa nepahalang.
+
+reference-index-unavailable = Ha e kgone ho supa sesupo `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ha e kgone ho bitsa { $action } nthong `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Sebopeho sa data ha se a nepahala. Mela e na le bolelele bo sa tsamaellaneng. E fumanwe ho componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data e na le mabitso a mela e emeng a pheta-phetilweng. E fumanwe ho componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data e haelloa ke lebitso la mola o emeng. E fumanwe ho componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = award e le nngwe ya karabo ena e itshetlehile ka karabo e rometsweng ke tagi answer ka boyona, mme seo se tla baka boitshwaro bo sa lebellwang.
+
+answer-max-num-attempts-in-section-wide-check-work = Ho beha `maxNumAttempts` ho `<answer>` e ka hare ho setshelo se nang le `sectionWideCheckWork` ha ho na tshusumetso, hobane setshelo seo ke sona se laolang palo ya diteko. Beha `maxNumAttempts` setshelong ka bosona.
+
+nested-section-wide-check-work-max-num-attempts = Ho beha `maxNumAttempts` setshelong se nang le `sectionWideCheckWork` se ka hare ho setshelo se seng se nang le `sectionWideCheckWork` ha ho na tshusumetso, hobane setshelo sa ka ntle ke sona se laolang palo ya diteko. Beha `maxNumAttempts` setshelong sa ka ntle.
+
+answer-attributes-need-symbolic-equality = Ditshobotsi { $attributes } di ke ke tsa ba le tshusumetso ha symbolicEquality e sa behwa.
+
+answer-invalid-type = Mofuta ha o a nepahala bakeng sa karabo: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Kaha ntho `<{ $component }>` ha e na lebitso, e ke ke ya sebediswa e le tshobotsi ya module
+
+module-attribute-name-already-defined = Ntho `<{ $component } name="{ $name }">` e ke ke ya sebediswa e le tshobotsi ya module hobane mofuta wa ntho `<module>` o se o na le tshobotsi e nang le lebitso "{ $name }".
+
+conditional-content-condition-ignored = Tshobotsi `condition` ha e nahanelwe nthong `<conditionalContent>` e nang le bana ba case kapa else.
+
+slider-markers-type-mismatch = Mofuta wa matshwao ha o tsamaellane le mofuta wa slider.
+
+pretzel-problem-needs-statement-and-answer = pretzel ha e a nepahala: `<problem>` e nngwe le e nngwe e tshwanetse ho ba le `<statement>` e le nngwe le `<answer>` e le nngwe.
+
+pretzel-circuit-first-problem-distractor = pretzel ha e a nepahala: ho mode="circuit", `<problem>` ya pele e ke ke ya ba ya ho kgelosa.
+
+## Attribute values
+
+attribute-invalid-values = Boleng { $values } ha bo a nepahala bakeng sa tshobotsi `{ $attribute }`; ha bo nahanelwe.
+
+attribute-must-be-references = Boleng `{ $value }` ha bo a nepahala bakeng sa tshobotsi `{ $attribute }`. Tshobotsi e tshwanetse ho etswa ka disupo tse qalang ka `$`.
+
+math-input-invalid-function-names = <mathInput>: mabitso a ditshebetso a sa nepahalang ho { $attribute } ha a nahanelwe: { $names }. Karolo e bontshwang ya lebitso le leng le le leng e tshwanetse ho ba le ditlhaku tse 2 bonyane (ditlhaku kapa mela); tlatsetso `|<mathspeak alternative>` e ka latela.
+
+## Building components from the source
+
+component-type-invalid = Mofuta wa ntho ha o a nepahala: `<{ $componentType }>`
+
+attribute-repeated = Tshobotsi { $attribute } e ke ke ya pheta-phetwa.
+
+attribute-invalid-for-component = Tshobotsi "{ $attribute }" ha e a nepahala bakeng sa ntho ya mofuta `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Tlhaloso ya setaele { $styleNumber } e na le phapang e sa lekaneng bakeng sa { $context ->
+        [text-on-background] mmala wa mongolo kgahlano le mmala wa bokamorao
+        [high-contrast] mmala wa phapang e phahameng kgahlano le lesela
+        [line] mmala wa mola kgahlano le lesela
+        [marker] mmala wa letshwao kgahlano le lesela
+       *[text-on-canvas] mmala wa mongolo kgahlano le lesela
+    }{ $mode ->
+        [dark] { " (mokgwa o lefifi)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e hloka bonyane { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Le hoja tlhaloso ya setaele { $styleNumber } e boletse mebala e fanang ka phapang e lekaneng mokgweng o kganyang, mebala ya mokgwa o lefifi e tswang ho yona e na le phapang e sa lekaneng bakeng sa mmala wa mongolo kgahlano le mmala wa bokamorao ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e hloka bonyane { $threshold }:1). { $suggestion ->
+        [available] Ho netefatsa phapang e lekaneng mokgweng o lefifi, eketsa phapang ya mokgwa o kganyang (mohlala beha { $lightAttribute }="{ $lightColor }") kapa fetola mmala wa mokgwa o lefifi (mohlala beha { $darkAttribute }="{ $darkColor }").
+       *[none] Ho netefatsa phapang e lekaneng mokgweng o lefifi, eketsa phapang ya mokgwa o kganyang kapa fetola mebala e tswang ho yona ka textColorDarkMode le/kapa backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Le hoja tlhaloso ya setaele { $styleNumber } e boletse mmala wa mongolo o fanang ka phapang e lekaneng mokgweng o kganyang, mmala wa mongolo wa mokgwa o lefifi o tswang ho ona o na le phapang e sa lekaneng kgahlano le lesela ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e hloka bonyane { $threshold }:1). { $suggestion ->
+        [available] Ho netefatsa phapang e lekaneng mokgweng o lefifi, eketsa phapang ya mokgwa o kganyang (mohlala beha textColor="{ $lightColor }") kapa fetola mmala wa mokgwa o lefifi (mohlala beha textColorDarkMode="{ $darkColor }").
+       *[none] Ho netefatsa phapang e lekaneng mokgweng o lefifi, eketsa phapang ya mokgwa o kganyang kapa fetola mmala o tswang ho ona ka textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Karolo e ka kgetha <stylePalette> e le nngwe feela; ya ho qetela e sebediswa.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ha e kgone ho hlalosa mefuta e ikgethang ya { $component } hobane numToSelect ha se palo e felletseng e seng ka tlase ho zero.
+
+variant-num-to-select-not-constant-number = ha e kgone ho hlalosa mefuta e ikgethang ya { $component } hobane numToSelect ha se palo e sa fetoheng.
+
+variant-with-replacement-not-constant-boolean = ha e kgone ho hlalosa mefuta e ikgethang ya { $component } hobane withReplacement ha se boolean e sa fetoheng.
+
+variant-select-weight-disables-unique = Mefuta e ikgethang ya select e a tinywa ha ho na le kgetho e nang le selectWeight kapa selectForVariants e boletsweng
+
+variant-coprime-undetermined = ha e kgone ho hlalosa mefuta e ikgethang ya { $component } hobane ha e kgone ho netefatsa hore coprime ke leshano kamehla.
+
+variant-attribute-not-constant = ha e kgone ho hlalosa mefuta e ikgethang ya { $component } hobane { $attribute } ha e tsitsa.
+
+variant-attribute-not-number = ha e kgone ho hlalosa mefuta e ikgethang ya { $component } hobane { $attribute } ha se palo.
+
+variant-attribute-wrong-type-for-sequence =
+    ha e kgone ho hlalosa mefuta e ikgethang ya { $component } ya mofuta { $type } hobane { $attribute } ha se { $expected ->
+        [letters-combination] motswako wa ditlhaku
+        [math-expression] polelo ya dipalo e nepahetseng
+        [integer] palo e felletseng
+       *[number] palo
+    }.
+
+variant-length-not-integer = ha e kgone ho hlalosa mefuta e ikgethang ya { $component } hobane length ha se palo e felletseng.
+
+variant-sort-not-implemented = mefuta e ikgethang ya { $component } e nang le sort ha e eso etswe
+
+variant-exclude-combinations-not-implemented = mefuta e ikgethang ya { $component } e nang le excludeCombinations ha e eso etswe
+
+variant-math-exclude-not-implemented = mefuta e ikgethang ya { $component } ya mofuta math e nang le exclude ha e eso etswe
+
+variant-non-constant-exclude-not-implemented = mefuta e ikgethang ya { $component } e nang le exclude e sa tsitsang ha e eso etswe
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ha e tshehetswe mmontshing wa graph prefigure; setloholo se tlolilwe.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometry e se nang moedi kapa e sa phethahalang; setloholo se tlolilwe.
+
+prefigure-curve-label-omitted = { $subject }: mabitso ha a tshehetswe dinthong tsa kobeho tse fetotsweng; lebitso le siilwe.
+
+prefigure-curve-unsupported-definition-type = { $subject }: mofuta wa tlhaloso ya tshebetso ya kobeho '{ $definitionType }' ha o tshehetswe; setloholo se tlolilwe.
+
+prefigure-region-flip-functions-unsupported = { $subject }: tshobotsi flipFunctions ho regionBetweenCurves ha e tshehetswe; setloholo se tlolilwe.
+
+prefigure-region-non-formula-child = { $subject }: ditshebetso tsa bana ba mofuta formula feela ke tse tshehetswang ho regionBetweenCurves; setloholo se tlolilwe.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ha e tshehetswe bakeng sa { $labelKind ->
+        [line-family] lebitso la lelapa la mola
+       *[point] lebitso la ntlha
+    }; tlhophiso ya PreFigure e sebediswa.
+
+prefigure-fill-style-unsupported = { $subject }: setaele sa ho tlatsa '{ $fillStyle }' ha se tshehetswe ke PreFigure; e khutlela ho tlatsa ka mmala o le mong.
+
+prefigure-line-style-unknown = { $subject }: setaele sa mola '{ $lineStyle }' ha se tsejwe mme se siilwe diphellong tsa PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: setaele sa letshwao '{ $markerStyle }' se tsamaellanngwe le setaele sa PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: setaele sa letshwao '{ $markerStyle }' ha se tshehetswe ke PreFigure; setaele se teng ka tlwaelo se sebediswa.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ha e a nepahala; sepheo ha se kgone ho tsejwa. Ntlha ya tlatsetso e siilwe.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` e boletse dipheo tse ngata; sepheo sa pele se sebediswa.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ha e a nepahala; sepheo se ka ntle ho kerafo e se tshwereng. Ntlha ya tlatsetso e siilwe.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ha e a nepahala; sepheo ha se ntho ya setshwantsho e tshehetswang phetohong ya prefigure. Ntlha ya tlatsetso e siilwe.
+
+annotation-text-missing = `<annotation>`: `text` ha e yo kapa ha e na letho; mongolo o se nang letho o ntshuwa.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Boitshetleho bo potolohang bo fumanwe.
+       *[other] Boitshetleho bo potolohang bo amang ntho `<{ $componentType }>` bo fumanwe.
+    }
+
+reference-no-referent = Ha ho letho le fumanweng bakeng sa sesupo: `{ $reference }`
+
+reference-multiple-referents = Dintho tse ngata di fumanwe bakeng sa sesupo: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Sebopeho ha se a nepahala bakeng sa tshobotsi { $attribute } ya `<{ $componentType }>`.
+
+children-invalid = Bana ha ba a nepahala bakeng sa `<{ $componentType }>`: Bana ba sa nepahalang ba fumanwe: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Boleng `{ $value }` ha bo a nepahala bakeng sa tshobotsi `{ $attribute }`, boleng `{ $default }` bo sebediswa
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML mofuta { $version } ha o a fumanwa.
+       *[other] DoenetML mofuta { $version } ha o a fumanwa. E khutlela mofuteng { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ha e a nepahala: { $content }
+
+parse-tag-missing-close-tag = DoenetML ha e a nepahala: Tagi `{ $tag }` ha e na tagi ya ho koala. Ho ne ho lebelletswe tagi e ikwalang kapa tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ha e a nepahala: Phoso tagi ya `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ha e a nepahala: Tshobotsi `{ $attribute }` e sa nepahalang e bonahala e haelloa ke boleng.
+
+parse-attribute-invalid = DoenetML ha e a nepahala: Tshobotsi `{ $attribute }` ha e a nepahala
+
+parse-attribute-value-invalid = DoenetML ha e a nepahala: Boleng ba tshobotsi `{ $value }` ha bo a nepahala
+
+parse-attribute-value-quote-mismatch = DoenetML ha e a nepahala: Boleng ba tshobotsi `{ $value }` ha bo a nepahala. Matshwao a mantswe ha a tsamaellane. Ho bonahala `{ $quote }` e haellwa
+
+parse-open-tag-name-missing = DoenetML ha e a nepahala: Ho fumanwe tagi e se nang lebitso, mohlala `<`
+
+parse-tag-not-closed = DoenetML ha e a nepahala: Tagi `{ $tag }` ha e a kwalwa (ho bonahala `>` e haellwa).
+
+parse-self-closing-tag-name-missing = DoenetML ha e a nepahala: Ho fumanwe tagi e se nang lebitso `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ha e a nepahala: Tagi `{ $tag }` ha e a kwalwa (ho bonahala `/>` e haellwa).
+
+parse-tag-invalid-attributes = DoenetML ha e a nepahala: Tagi `{ $tag }` ha e a nepahala. Mohlomong e na le ditshobotsi tse sa nepahalang.
+
+parse-close-tag-name-missing = DoenetML ha e a nepahala: Ho fumanwe tagi ya ho koala e se nang lebitso, mohlala `</`
+
+parse-attribute-value-unquoted = Boleng ba ditshobotsi bo tshwanetse ho behwa ka hare ho matshwao a mantswe: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ha e a nepahala: Ho fumanwe tagi ya ho koala `{ $tag }`, empa ha ho na tagi ya ho bula e tsamaellanang
+
+parse-close-tag-mismatched = DoenetML ha e a nepahala: Tagi ya ho koala ha e tsamaellane. Ho ne ho lebelletswe `</{ $expected }>`. Ho fumanwe `{ $found }`
+
+parser-node-unconvertible = Ha ho a kgoneha ho fetola node { $node } ho ba node ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    Tshobotsi name='{ $name }' ha e a nepahala. { $reason ->
+        [characters] Mabitso a ka ba le ditlhaku, dipalo, mela ya tlase kapa mela feela.
+       *[start] Mabitso a tshwanetse ho qala ka tlhaku.
+    }
+
+component-name-invalid-start = Lebitso la ntho "{ $name }" ha le a nepahala. Mabitso a tshwanetse ho qala ka tlhaku.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Karabo ya mofuta videoWatched e tshwanetse ho ba le tshobotsi video
+
+answer-video-watched-video-not-reference = Karabo ya mofuta videoWatched e tshwanetse ho ba le tshobotsi video e leng sesupo
+
+answer-name-not-single-text = Tshobotsi name ya karabo e tshwanetse ho ba le ngwana a le mong feela wa text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ha e kgone ho fumana DoenetML ya ka ntle ka lebaka la ho pheta-pheta ho hongata haholo. Na ho na le sesupo se potolohang?
+
+external-doenetml-unavailable = Ha e kgone ho fumana DoenetML ho tswa ho { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML e fumanweng ho tswa ho { $attribute }="{ $uri }" ha e a nepahala: ha e tsamaellane le mofuta wa ntho "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Tshobotsi `{ $from }` e felletswe ke nako; sebedisa `{ $to }`.
+       *[other] [deprecation] Tshobotsi `{ $from }` ho `<{ $component }>` e felletswe ke nako; sebedisa `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Tshobotsi `{ $from }` e felletswe ke nako mme ha e nahanelwe hobane `{ $to }` le yona e boletswe.
+       *[other] [deprecation] Tshobotsi `{ $from }` ho `<{ $component }>` e felletswe ke nako mme ha e nahanelwe hobane `{ $to }` le yona e boletswe.
+    }
+
+deprecated-attribute-ignored = [deprecation] Tshobotsi `{ $attribute }` ho `<{ $component }>` e felletswe ke nako mme ha e nahanelwe.
+
+deprecated-attribute-to-child = [deprecation] Tshobotsi `{ $attribute }` ho `<{ $component }>` e felletswe ke nako; sebedisa ngwana `<{ $child }>`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` e ka etsa bongata ka Senyesemane feela, kahoo mongolo wa yona o sala jwalokaha o le jwalo tokomaneng e ngotsweng ka { $locale }. Ngola sebopeho sa bongata ka bowena, kapa se behe tshobotsing `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ntho `<{ $tag }>` ha se ntho ya Doenet e tsejwang.
+
+schema-element-not-allowed-at-root = Ntho `<{ $tag }>` ha e dumellwe motsong wa tokomane.
+
+schema-element-not-allowed-inside = Ntho `<{ $tag }>` ha e dumellwe ka hare ho `<{ $parent }>`.
+
+schema-attribute-unrecognized = Ntho `<{ $tag }>` ha e na tshobotsi e nang le lebitso `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Tshobotsi `{ $attribute }` ya ntho `<{ $tag }>` e tshwanetse ho ba lethathamo leo ntho e nngwe le e nngwe ho lona e leng e nngwe ya: { $allowed }
+       *[other] Tshobotsi `{ $attribute }` ya ntho `<{ $tag }>` e tshwanetse ho ba e nngwe ya: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Lebitso la mofuta ha le a nepahala bakeng sa select. Lebitso la mofuta { $variantName } le hlaha dikgethong tse { $numOptions } empa palo ya ho kgetha ke { $numToSelect }.
+
+select-variant-name-without-options = Mefuta e meng e boletswe bakeng sa select empa ha ho kgetho e boletsweng bakeng sa lebitso la mofuta le kgonahalang: { $variantName }.
+
+select-variant-name-not-possible = Lebitso la mofuta { $variantName } le boletsweng bakeng sa select ha se lebitso la mofuta le kgonahalang.
+
+select-too-few-options = Ha e kgone ho kgetha dintho tse { $numToSelect } ho tswa ho { $numOptions } feela.
+
+select-from-sequence-too-few-values = Ha e kgone ho kgetha boleng bo { $numToSelect } tatellanong e nang le bolelele ba { $length }.
+
+select-from-sequence-indices-count-mismatch = Palo ya disupo tse boletsweng bakeng sa select e tshwanetse ho tsamaellana le palo ya ho kgetha
+
+select-from-sequence-indices-not-integers = Disupo tsohle tse boletsweng bakeng sa select di tshwanetse ho ba dipalo tse felletseng
+
+select-from-sequence-index-excluded = Ho boletswe sesupo sa selectfromsequence se tlositsweng
+
+select-from-sequence-indices-excluded-combination = Ho boletswe disupo tsa selectfromsequence tse neng di le motswako o tlositsweng
+
+select-from-sequence-coprime-not-positive-integers = Ha e kgone ho kgetha metswako ya dipalo tse sa arolelaneng hobane ha se dipalo tse felletseng tse ka hodima zero tse kgethwang.
+
+select-from-sequence-coprime-common-factor = Ha e kgone ho kgetha dipalo tse sa arolelaneng. Boleng bohle bo kgonahalang bo arolelana kgaolo e le nngwe. (Boleng bo boletsweng ba "from" kapa "to" bo tshwanetse ho se arolelane le "step".)
+
+select-from-sequence-coprime-single-number = Ha e kgone ho kgetha metswako ya dipalo tse sa arolelaneng ho tswa palong e le nngwe e seng 1.
+
+select-from-sequence-excluded-too-many-combinations = Ho feta 70% ya metswako e tlositswe ho selectFromSequence
+
+select-from-sequence-coprime-none-found = Ha ho a kgoneha ho kgetha dipalo tse sa arolelaneng. Boleng bohle bo kgonahalang bo arolelana kgaolo e le nngwe.
+
+select-from-sequence-too-few-unique-values = Ha e kgone ho kgetha boleng bo ikgethang bo { $numToSelect } tatellanong e nang le bolelele ba { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Ha e kgone ho kgetha boleng bo { $numToSelect } lethathamong la dipalo tsa prime le nang le bolelele ba { $numValues }
+
+select-prime-numbers-values-count-mismatch = Palo ya boleng bo boletsweng bakeng sa select e tshwanetse ho tsamaellana le palo ya ho kgetha
+
+select-prime-numbers-values-not-prime = Boleng bohle bo boletsweng bakeng sa select prime number bo tshwanetse ho ba lethathamong la dipalo tsa prime
+
+select-prime-numbers-values-excluded-combination = Boleng ba selectPrimeNumbers bo boletsweng bo ne bo le motswako o tlositsweng
+
+select-prime-numbers-excluded-too-many-combinations = Ho feta 70% ya metswako e tlositswe ho selectPrimeNumbers
+
+select-random-combination-fluke = Ka tsela e sa tlwaelehang, ha ho a kgoneha ho kgetha motswako wa boleng bo sa reroang
+
+select-random-value-fluke = Ka tsela e sa tlwaelehang, ha ho a kgoneha ho kgetha boleng bo sa reroang

--- a/packages/i18n/locales/st/editor.ftl
+++ b/packages/i18n/locales/st/editor.ftl
@@ -1,0 +1,214 @@
+# Southern Sotho editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Sesotho marks number with a class prefix and keeps doing so after a numeral,
+# so the counted messages keep their selects.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Khutlisetsa
+       *[update] Nchafatsa
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Mmontshi
+       *[other] { $word } Mmontshi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Mofuta
+editor-variant-filter = Sefa...
+editor-variant-next = Kgetha mofuta o latelang
+editor-variant-previous = Kgetha mofuta o fetileng
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Tlolo ya WCAG AA ya phihlelelo e fumanwe. Tobetsa ho { $action ->
+            [close] koala
+           *[open] bula
+        } tlaleho ya phihlelelo.
+        [advisories] Tobetsa ho { $action ->
+            [close] koala
+           *[open] bula
+        } tlaleho ya phihlelelo. Ha ho tlolo ya WCAG AA e fumanweng, empa ho na le dikeletso tse ding tsa phihlelelo.
+       *[clean] Tobetsa ho { $action ->
+            [close] koala
+           *[open] bula
+        } tlaleho ya phihlelelo. Ha ho bothata ba phihlelelo bo fumanweng.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Tlolo ya WCAG AA ya phihlelelo e fumanwe. { $count ->
+            [one] Tlolo e { $count } ya WCAG AA e fumanwe
+           *[other] Ditlolo tse { $count } tsa WCAG AA di fumanwe
+        }. Tobetsa ho { $action ->
+            [close] koala
+           *[open] bula
+        } tlaleho ya phihlelelo.
+        [advisories] Ha ho tlolo ya WCAG AA e fumanweng. { $count ->
+            [one] Keletso e { $count } e nngwe ya phihlelelo e fumanwe
+           *[other] Dikeletso tse { $count } tse ding tsa phihlelelo di fumanwe
+        }. Tobetsa ho { $action ->
+            [close] koala
+           *[open] bula
+        } tlaleho ya phihlelelo.
+       *[clean] Ha ho tlolo ya WCAG AA e fumanweng. Tobetsa ho { $action ->
+            [close] koala
+           *[open] bula
+        } tlaleho ya phihlelelo.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML mofuta { $version }
+
+editor-tab-help = Thuso e tsamaellanang le moo o leng teng
+editor-tab-help-short = Moo o leng teng
+editor-tab-errors = Diphoso
+editor-tab-warnings = Ditemoso
+editor-tab-info = Tlhahisoleseding
+editor-tab-accessibility = Phihlelelo
+editor-tab-responses = Dikarabo tse rometsweng
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Dikgetho tsa mongodi
+editor-format-as-doenetml = Hlophisa jwaloka DoenetML
+editor-format-as-xml = Hlophisa jwaloka XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Mola #{ $line }
+
+editor-no-errors = Ha ho Diphoso
+editor-no-warnings = Ha ho Ditemoso
+editor-no-info = Ha ho Tlhahlobo ya Tlhahisoleseding
+
+editor-show-info-annotations = Bontsha ditlhahlobo tsa tlhahisoleseding ho mongodi
+editor-show-accessibility-annotations = Bontsha ditlhahlobo tsa phihlelelo ho mongodi
+
+editor-accessibility-learn-more = Ithute kamoo Doenet e sebetsanang le phihlelelo
+
+editor-accessibility-violations-heading = Ditlolo tsa phihlelelo ({ $standard })
+
+editor-accessibility-other-heading = Mathata a mang a phihlelelo
+editor-none-found = Ha ho letho le fumanweng
+
+
+## Submitted responses
+
+editor-no-responses = Ha ho karabo e rometsweng ho fihlela jwale
+editor-response-answer-id = Lebitso la Karabo
+editor-response-response = Karabo
+editor-response-credit = Matshwao
+editor-response-submitted = E rometswe
+
+
+## The context-help panel
+
+help-placeholder = Beha sesupo hodima lebitso la tagi, tshobotsi kapa { $ref } ho fumana ditokomane.
+
+help-unsupported-ref-chain = Thuso bakeng sa disupo tsa dikarolo tse ngata jwaloka { $example } ha e eso be teng.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ha ho letho le fumanweng bakeng sa sesupo: { $ref }.
+        [multiple] Dintho tse ngata di fumanwe bakeng sa sesupo: { $ref }.
+       *[indeterminate] Seo { $ref } e se supang ha se a tsejwa.
+    }
+
+help-learn-about-references = Ithute ka disupo →
+help-reference-page = Leqephe la disupo →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ka hare ho { $element }
+       *[top] Boemong bo hodimo
+    }{ $allowed ->
+        [none] { " — ha ho letho le kenang mona." }
+        [text] { " — ngola mongolo mona." }
+        [text-and-components] { " — ngola mongolo mona, kapa leka:" }
+       *[components] { " — dintho tseo o ka di lekang:" }
+    }
+
+help-suggestions-footer = Tobetsa { $shortcut } ho bona dintho tsohle tse { $total }.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ke sesupo sa { $target }.
+       *[other] { $ref } ke sesupo sa { $target } (mola { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } o e reile lebitso la { $role }.
+       *[other] { $owner } o e reile lebitso la { $role } moleng wa { $line }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ke sesupo sa tshobotsi { $property } ya { $element }.
+       *[other] { $ref } ke sesupo sa tshobotsi { $property } ya { $element } (mola { $line }).
+    }
+
+help-kind-attribute = tshobotsi
+help-kind-snippet = karolwana ya mongolo
+help-kind-array-entry = kenyo ya lethathamo
+
+help-default = E teng ka tlwaelo:
+help-active-default = E teng ka tlwaelo mme e sebetsa:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Boleng bo dumelletsweng (bo le bong ntho ka nngwe):
+       *[other] Boleng bo dumelletsweng:
+    }
+
+help-suggested-values = Boleng bo kgothaletswang:
+
+help-inserts = E kenya:
+
+help-coordinates =
+    { $count ->
+        [one] Sesupanepo:
+       *[other] Disupanepo:
+    }
+
+help-type = Mofuta:
+
+help-resolved-style = Setaele se tsejwang (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Mabitso a tshebetso a tsejwang:
+help-reset-list = Lethathamo le khutlisetswang kenyong ena:
+help-added-on-input = Se ekeditsweng kenyong ena:
+help-removed-on-input = Se tlositsweng kenyong ena:
+
+help-reset-overrides = { $reset } e feta { $additional } le { $removed }.

--- a/packages/i18n/locales/ti/chrome.ftl
+++ b/packages/i18n/locales/ti/chrome.ftl
@@ -1,0 +1,145 @@
+# Tigrinya viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Tigrinya has two plural categories, and CLDR puts **zero** in the `one`
+# branch with it, so nothing here can lean on the category to say "no ...".
+# A noun does change shape for the plural — «ፈተነ» one attempt, «ፈተነታት»
+# several — so the selects are kept and the noun changes inside them.
+# `attempts-remaining` writes its own `[0]` branch, an exact-value match ahead
+# of the category, which says «የልቦን» instead of counting to zero.
+#
+# The script is Ge'ez and reads left to right; nothing here needs a direction
+# mark.
+
+
+## Answer submission
+
+answer-checking = ይምርምር ኣሎ...
+answer-submitting = ይልእኽ ኣሎ...
+
+answer-checking-status = መልሲ ይምርምር ኣሎ
+answer-submitting-status = መልሲ ይልእኽ ኣሎ
+
+answer-correct = ቅኑዕ
+answer-incorrect = ጌጋ
+
+answer-response-saved = መልሲ ተዓቂቡ
+
+answer-percent-credit = ነጥቢ { $percent }%
+answer-percent-correct = { $percent }% ቅኑዕ
+answer-percent-short = { $percent } %
+
+max-credit-available = ዝለዓለ ክርከብ ዝኽእል ነጥቢ፡ { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] ዝተረፈ ፈተነ የልቦን
+        [one] { $count } ፈተነ ተሪፉ
+       *[other] { $count } ፈተነታት ተሪፈን
+    }
+
+validation-correct = (ቅኑዕ)
+validation-incorrect = (ጌጋ)
+validation-partially-correct = (ብኸፊል ቅኑዕ)
+
+answer-show-responses =
+    { $count ->
+        [one] { $count } መልሲ ናብ { $answerId } ኣርኢ
+       *[other] { $count } መልስታት ናብ { $answerId } ኣርኢ
+    }
+
+
+## Disclosure panels
+
+feedback-heading = ግብረ-መልሲ
+
+collapsible-click-to-open = (ንምኽፋት ጠውቕ)
+collapsible-click-to-close = (ንምዕጻው ጠውቕ)
+
+collapsible-initializing = ይጅምር ኣሎ...
+
+footnote-show = እግረ-ጽሑፍ ኣርኢ
+footnote-hide = እግረ-ጽሑፍ ሕባእ
+
+description-more-information = ተወሳኺ ሓበሬታ
+
+
+## Controls
+
+slider-previous = ዝሓለፈ
+slider-next = ዝቕጽል
+
+keyboard-open = ኪቦርድ ክፈት
+keyboard-close = ኪቦርድ ዕጾ
+
+choice-input-remove-choice = { $choice } ኣወግድ
+
+matrix-remove-row = መስርዕ ኣወግድ
+matrix-add-row = መስርዕ ወስኽ
+matrix-remove-column = ዓምዲ ኣወግድ
+matrix-add-column = ዓምዲ ወስኽ
+
+subset-add-remove-points = ነጥብታት ወስኽ/ኣወግድ
+subset-toggle-points-intervals = ኣብ መንጎ ነጥብታትን ክፍተታትን ቀያይር
+subset-move-points = ነጥብታት ኣንቀሳቕስ
+subset-clear = ኣጽሪ
+
+# A `box` here is one orbital, drawn as a square: «ሳጹን».
+orbital-add-row = መስርዕ ወስኽ
+orbital-remove-row = መስርዕ ኣወግድ
+orbital-add-box = ሳጹን ወስኽ
+orbital-remove-box = ሳጹን ኣወግድ
+orbital-add-up-arrow = ናብ ላዕሊ ዘመልክት ኮፍታ ወስኽ
+orbital-add-down-arrow = ናብ ታሕቲ ዘመልክት ኮፍታ ወስኽ
+orbital-remove-arrow = ኮፍታ ኣወግድ
+
+orbital-row-label = ስም መስርዕ { $row }
+
+pretzel-answer = መልሲ
+
+summary-statistics-caption = ጽማቝ ስታቲስቲክስ { $column }
+
+
+## Math input
+
+math-input-preview-region = ቅድመ-ትርኢት ናይ ሒሳብ መግለጺ
+math-input-preview = ቅድመ-ትርኢት
+math-input-invalid-expression = ዘይቅቡል መግለጺ፡
+
+
+## Document status
+
+viewer-initializing = ይጅምር ኣሎ...
+
+
+## Errors
+
+error-heading = ጌጋ
+
+error-found-at =
+    { $span ->
+        [line] ኣብ መስመር { $startLine } ተረኺቡ።
+       *[lines] ኣብ መስመራት { $startLine }–{ $endLine } ተረኺቡ።
+    }
+
+document-contains-errors = እዚ ሰነድ ጌጋታት ኣለውዎ!
+
+diagnostic-heading-error = ጌጋ
+diagnostic-heading-warning = መጠንቀቕታ
+diagnostic-heading-information = ሓበሬታ
+diagnostic-heading-hint = ፍንጪ
+
+accessibility-heading-level-1 = ጥሕሰት ተበጻሕነት WCAG AA
+accessibility-heading-level-2 = መጠንቀቕታ ተበጻሕነት
+
+something-went-wrong = ገለ ጌጋ ኣጋጢሙ።
+
+renderer-load-failed = ሓደ ኣርኣዪ ክጽዕን ኣይከኣለን። በጃኹም ገጽ ደጊምኩም ጽዓኑ።
+
+core-start-failed = ኣርኣዪ ሰነድ ክጅምር ኣይከኣለን። በጃኹም ገጽ ደጊምኩም ጽዓኑ።

--- a/packages/i18n/locales/ti/content.ftl
+++ b/packages/i18n/locales/ti/content.ftl
@@ -1,0 +1,288 @@
+# Tigrinya content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Tigrinya is the one language in this batch that uses `$gender` for what the
+# argument is named after. It is Semitic, it marks masculine and feminine on
+# the noun, and an adjective agrees with the noun it describes: «ጸሊም መስመር» but
+# «ጸላም ነጥቢ». So the tokens here are `m` and `f`, the same ones `locales/ar` and
+# `locales/es` use, and `m` is the default.
+#
+# The agreement is internal rather than suffixed — «ጸሊም» becomes «ጸላም»,
+# «ቀይሕ» becomes «ቀያሕ», «ረጒድ» becomes «ረጓድ» — so the feminine cannot be
+# derived from the masculine by a rule and each pair is written out.
+#
+# **Adjectives precede the noun**, which is the other thing that sets this
+# catalog apart from the rest of the batch: every other language seeded
+# alongside it puts them after. So the composition messages keep the English
+# order, with the description first and the noun behind it.
+#
+# `$role` goes unused. Tigrinya does mark the three clause positions, but with
+# a preposition or a prefix on the noun — «ኣብ ቀይሕ ድሕረ-ባይታ» — and neither ever
+# touches the adjective in front of it, so no branch here would differ.
+#
+# The script is Ge'ez and reads left to right, so nothing in `direction.ts`
+# treats it specially.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [f] ጸላም
+           *[m] ጸሊም
+        }
+    .white = ጻዕዳ
+    .gray = ሓሙኽሽታይ
+    .red =
+        { $gender ->
+            [f] ቀያሕ
+           *[m] ቀይሕ
+        }
+    .orange = ብርቱኳናይ
+    .yellow = ብጫ
+    .green = ቀጠልያ
+    .cyan = ሳያን
+    .blue = ሰማያዊ
+    .purple = ወይናይ
+    .pink = ሮዛ
+    .brown = ቡናዊ
+
+line-width =
+    .thick =
+        { $gender ->
+            [f] ረጓድ
+           *[m] ረጒድ
+        }
+    .thin =
+        { $gender ->
+            [f] ቀጣን
+           *[m] ቀጢን
+        }
+
+# Written as «ብ …» phrases rather than as adjectives, so that they agree with
+# nothing. They close the description, which is why `style-stroke` moves them
+# behind the colour.
+line-style =
+    .dashed = ብስንጥቕ
+    .dotted = ብነጥብታት
+
+fill-style =
+    .horizontal = ደቀኛ መስመራት
+    .vertical = ቀጥ ዝበሉ መስመራት
+    .diagonal = ሰያፍ መስመራት
+    .backdiagonal = ንድሕሪት ዝሰየፉ መስመራት
+    .dots = ነጥብታት
+    .diamonds = ኣልማዛት
+
+noun =
+    .line = መስመር
+    .line-segment = ክፍሊ መስመር
+    .ray = ጩራ
+    .vector = ቬክተር
+    .curve = ጥውይዋይ
+    .function = ተግባር
+    .parabola = ፓራቦላ
+    .polyline = ብዙሕ መስመር
+    .polygon = ፖሊጎን
+    .triangle = ሰለስተ ኩርናዕ
+    .rectangle = ኣርባዕተ ኩርናዕ
+    .circle = ክቢ
+    .region = ከባቢ
+    .point = ነጥቢ
+    .square = ካሬ
+    .diamond = ኣልማዝ
+    .cross = መስቀል
+    .plus = ምልክት ምድማር
+
+# Tigrinya folds the side count into the head, in front of the noun, the way
+# English does — «5 ጎድኒ ዘለዎ ስሩዕ ፖሊጎን» — so there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] { $numSides } ጎድኒ ዘለዎ ስሩዕ ፖሊጎን
+    }
+
+noun-gender =
+    { $noun ->
+        [point] f
+        [circle] f
+        [parabola] f
+        [curve] f
+        [region] f
+        [background] f
+       *[other] m
+    }
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The adjectives lead and the noun follows, as in English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word =
+    { $gender ->
+        [f] ምልእቲ
+       *[m] ምሉእ
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ምስ { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } ምስ { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } ምስ { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+# «ዶብ» is masculine and leads its own adjectives, so the border's words agree
+# with it and not with the shape it surrounds. Tigrinya has no indefinite
+# article, so the two `-article` branches read like the two without.
+style-border-clause =
+    { $parts ->
+        [with-article] ምስ { $border } ዶብ
+        [and] ከምኡ'ውን { $border } ዶብ
+        [and-article] ከምኡ'ውን { $border } ዶብ
+       *[with] ምስ { $border } ዶብ
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = ዘይመልአ
+
+style-text =
+    { $parts ->
+        [background] { $color } ምስ { $background } ድሕረ-ባይታ
+       *[plain] { $color }
+    }
+
+style-background-none = የልቦን
+
+
+## Boolean words
+
+boolean-true = ሓቂ
+boolean-false = ሓሶት
+
+
+## Answer buttons
+
+answer-submit-label = ስራሕ ኣረጋግጽ
+answer-submit-label-no-correctness = መልሲ ልኣኽ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = ንጥፈት
+    .aside = ጎድናዊ ሓሳብ
+    .cascade = ካስኬድ
+    .definition = ትርጉም
+    .example = ኣብነት
+    .exercise = ልምምድ
+    .exercises = ልምምዳት
+    .given-answer = መልሲ
+    .note = መዘኻኸሪ
+    .objectives = ዕላማታት
+    .paragraphs = ሕጡበ-ጽሑፋት
+    .part = ክፋል
+    .problem = ጸገም
+    .problems = ጸገማት
+    .proof = መርትዖ
+    .question = ሕቶ
+    .section = ክፍሊ
+    .solution = መፍትሒ
+    .task = ዕማም
+    .theorem = ቲዮረም
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = ፍንጪ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] ሰንጠረዥ { $enumeration }
+        [numbered-title] ሰንጠረዥ { $enumeration }{ ": " }
+        [unnumbered-title] ሰንጠረዥ{ ": " }
+       *[unnumbered] ሰንጠረዥ
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] ስእሊ { $enumeration }
+        [numbered-caption] ስእሊ { $enumeration }{ ": " }
+        [unnumbered-caption] ስእሊ{ ": " }
+       *[unnumbered] ስእሊ
+    }
+
+
+## Paginator controls
+
+paginator-previous = ዝሓለፈ
+paginator-next = ዝቕጽል
+paginator-page = ገጽ
+
+paginator-page-status = { $pageLabel } { $currentPage } ካብ { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ወይ
+piecewise-condition-if = እንተ
+piecewise-condition-otherwise = እንተዘይኮይኑ
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Secondary science in Eritrea
+# and in Tigray is taught in English, so a student meeting these words meets
+# them in English already, and the seed has no settled Tigrinya list to
+# reproduce — an unreviewed guess written in Ge'ez, which the reader cannot
+# check against the English beside it, would be worse than the English. A
+# speaker adding a list should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = ዘይቅቡል ኬሚካላዊ ምልክት
+chemistry-invalid-ionic-compound = ዘይቅቡል ኣዮናዊ ውህደት

--- a/packages/i18n/locales/ti/diagnostics.ftl
+++ b/packages/i18n/locales/ti/diagnostics.ftl
@@ -1,0 +1,617 @@
+# Tigrinya diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source. Ge'ez reads left to right, so those Latin runs need no direction
+# mark to sit where they are written.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — Tigrinya agrees its verb with a subject that
+# is a list either way, so those selects are dropped and the count argument
+# goes unused.
+#
+# The full stop is «።» and the comma «፡», which is why no sentence here ends in
+# a Latin period.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = ክልቲኦም መወዳእታ ነጥብታት ምስ ተገለጹ { $attributes } ኣይግድሱን
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = መወዳእታ ነጥብን ማእከላይ ነጥብን ክልቲኦም ምስ ተገለጹ { $attributes } ኣይግድሱን
+
+line-segment-midpoint-offset-without-midpoint = ማእከላይ ነጥቢ ብዘይብሉ midpointOffset ውጽኢት የብሉን
+
+## `<line>`
+
+line-points-undetermined-dimensions = እቲ መስመር ብዘይተፈልጠ ዓቐን ዘለዎም ነጥብታት ይሓልፍ።
+
+line-points-too-few-dimensions = እቲ መስመር እንተ ወሓደ ክልተ ዓቐን ብዘለዎም ነጥብታት ክሓልፍ ኣለዎ።
+
+line-points-depend-on-variables = እቲ መስመር ኣብ ተለዋወጥቲ ዝምርኮሱ ነጥብታት ይሓልፍ፡ { $variables }።
+
+line-equation-invalid-format = ኣብ ተለዋወጥቲ { $variable1 } ከምኡ'ውን { $variable2 } ንዘሎ ማዕረነት መስመር እቲ ቅርጺ ቅቡል ኣይኮነን።
+
+## `<ray>`
+
+ray-overprescribed-through = እቲ ጩራ ብ through፡ endpoint ከምኡ'ውን direction ብሓባር ተገሊጹ። እቲ እተገልጸ through ኣይግደስን።
+
+ray-dimension-mismatch = numDimensions ኣብቲ ጩራ ኣይሰማምዕን።
+
+## `<vector>`
+
+vector-overprescribed-head = እቲ ቬክተር ብ head፡ tail ከምኡ'ውን displacement ብሓባር ተገሊጹ። እቲ እተገልጸ head ኣይግደስን።
+
+vector-dimension-mismatch = numDimensions ኣብቲ ቬክተር ኣይሰማምዕን።
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = ናብ `<{ $component }>` ክስሓብ ኣይክእልን ምኽንያቱ ተለዋዋጢ ኩነታት nearestPoint የብሉን።
+
+constrain-to-without-nearest-point = ናብ `<{ $component }>` ክግደድ ኣይክእልን ምኽንያቱ ተለዋዋጢ ኩነታት nearestPoint የብሉን።
+
+constrain-to-interior-without-nearest-point = ኣብ ውሽጢ `<{ $component }>` ክግደድ ኣይክእልን ምኽንያቱ ተለዋዋጢ ኩነታት nearestPoint የብሉን።
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ኣብ ሓደ መስመር ዘይኮነ choiceInput labelPosition ኣይግደስን
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = ንchoiceInput እተገልጹ መወከሲታት ኣይግደሱን ምኽንያቱ ብዝሒ መወከሲታት ምስ ብዝሒ ደቂ choice ኣይሰማምዕን።
+
+pretzel-indices-count-mismatch = ንproblem እተገልጹ መወከሲታት ኣይግደሱን ምኽንያቱ ብዝሒ መወከሲታት ምስ ብዝሒ ደቂ problem ኣይሰማምዕን።
+
+shuffle-indices-count-mismatch = ንshuffle እተገልጹ መወከሲታት ኣይግደሱን ምኽንያቱ ብዝሒ መወከሲታት ምስ ብዝሒ ኣቕሑ ኣይሰማምዕን።
+
+indices-ignored-out-of-range = ን{ $component } እተገልጹ መወከሲታት ኣይግደሱን ምኽንያቱ ገለ መወከሲታት ካብ ዶብ ወጻኢ እዮም።
+
+pretzel-indices-repeated = ንpretzel እተገልጹ መወከሲታት ኣይግደሱን ምኽንያቱ ገለ መወከሲታት ተደጋጊሞም።
+
+pretzel-circuit-first-index = ኣብ circuit ዘሎ pretzel እተገልጹ መወከሲታት ኣይግደሱን ምኽንያቱ እቲ ቀዳማይ መወከሲ 1 ክኸውን ኣለዎ።
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` ምስ ናይ ጽሑፍ ዓይነት ደቂ ክሰርሕ እንተ ኾይኑ፡ ባህሪ `type` ክግለጽ ኣለዎ።
+
+invalid-type-defaulting-to-math = type { $type } ንኣቕሓ { $component } ቅቡል ኣይኮነን። ካብ math፡ text፡ number ወይ boolean ሓደ ክኸውን ኣለዎ። math ይቕመጥ ኣሎ።
+
+string-not-valid-component-to-arrange = ጽሑፍ "{ $value }" ቅቡል ናይ { $component } ኣቕሓ ኣይኮነን። ኣይግደስን።
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } ቅቡል ኣይኮነን፡ type ከም number ይቕመጥ ኣሎ።
+
+invalid-variable-value = ክብሪ ተለዋዋጢ ቅቡል ኣይኮነን፡ `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = መወከሲ ዓይነት { $index } ቁጽሪ ክኸውን ኣለዎ
+
+variant-index-must-be-integer = መወከሲ ዓይነት { $index } ምሉእ ቁጽሪ ክኸውን ኣለዎ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ብፍጹም መለክዒታት ኣይተሰርሐን። ስፍሓት ብመጠን ይቕመጥ ኣሎ።
+
+side-by-side-absolute-margins = `<{ $component }>` ብፍጹም መለክዒታት ኣይተሰርሐን። ወሰናት ብመጠን ይቕመጡ ኣለዉ።
+
+side-by-side-no-block-child = `<{ $component }>` ቅቡል ኣይኮነን፡ እንተ ወሓደ ሓደ ናይ ብሎክ ዓይነት ውሉድ ክህልዎ ኣለዎ።
+
+## `<label>`
+
+label-for-ignored-on-graphical = ኣብ ናይ ስእሊ `<label>` ዘሎ ባህሪ `for` ኣይግደስን።
+
+label-for-must-resolve-to-one = ኣብ `<label>` ዘሎ ባህሪ `for` ልክዕ ሓደ ኣቕሓ ጥራይ ክውክል ኣለዎ።
+
+label-for-unresolved = ኣብ `<label>` ዘሎ ባህሪ `for` ዝኾነ ኣቕሓ ክውክል ኣይከኣለን።
+
+label-for-answer-with-authored-inputs = ኣብ `<label>` ዘሎ ባህሪ `for` እተጻሕፉ ኣታዊታት ዘለዎ `<answer>` ይውክል፤ ነቲ ኣታዊ ባዕሉ ውከስ።
+
+label-for-answer-without-input = ኣብ `<label>` ዘሎ ባህሪ `for` ክሰመ ዝኽእል ኣታዊ ዘይብሉ `<answer>` ይውክል።
+
+label-for-must-reference-input-or-answer = ኣብ `<label>` ዘሎ ባህሪ `for` ኣታዊ ወይ መልሲ ክውክል ኣለዎ።
+
+## Accessibility
+
+accessibility-short-description-or-decorative = ንተበጻሕነት፡ `<{ $component }>` ሓጺር መግለጺ ክህልዎ ወይ ከም ናይ ስልማት ክግለጽ ኣለዎ።
+
+accessibility-video-short-description = ንተበጻሕነት፡ `<video>` ሓጺር መግለጺ ክህልዎ ኣለዎ።
+
+accessibility-input-short-description-or-label = ንተበጻሕነት፡ `<{ $component }>` ሓጺር መግለጺ ወይ ስም ክህልዎ ኣለዎ።
+
+accessibility-answer-input-short-description-or-label = ንተበጻሕነት፡ ኣታዊ ዝፈጥር `<answer>` ሓጺር መግለጺ ወይ ስም ክህልዎ ኣለዎ።
+
+accessibility-short-description-contains-math = ሓጺር መግለጺ ከም `<{ $component }>` ዝኣመሰሉ ናይ ሒሳብ ኣቕሑ ክህልዎ የብሉን። ንዝኾነ ሒሳብ ብቓላት ግለጾ።
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ንናይ ክፍሊ ኣርእስቲ ጽሑፍ እኹል ፍልልይ የብሉን (ጸላም ኩነታት) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ እንተ ወሓደ { $threshold }:1 የድሊ)።
+       *[other] { $colorName } ንናይ ክፍሊ ኣርእስቲ ጽሑፍ እኹል ፍልልይ የብሉን ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ እንተ ወሓደ { $threshold }:1 የድሊ)።
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = እቶም ነጥብታት ቁጽራዊ ክብሪ ምስ ዘይህልዎም፡ ብ { $count } ነጥብታት ዝሓልፍ `<circle>` ገና ኣይተተግበረን።
+
+circle-too-many-through-points = ካብ 3 ንላዕሊ ብዝኾኑ ነጥብታት ዝሓልፍ ክቢ ክሕሰብ ኣይክእልን።
+
+circle-overprescribed-radius-center-points = ራድየስ፡ ማእከልን መሕለፊ ነጥብታትን ኩሎም እተገልጹሉ ክቢ ክሕሰብ ኣይክእልን።
+
+circle-center-with-multiple-points = እተገልጸ ማእከል ዘለዎን ካብ 1 ንላዕሊ ብዝኾኑ ነጥብታት ዝሓልፍን ክቢ ክሕሰብ ኣይክእልን።
+
+circle-radius-too-small = ክቢ ክሕሰብ ኣይክእልን፡ ኣብ መንጎ እቶም ክልተ ነጥብታት ዘሎ ርሕቀት { $distance } ስለ ዝኾነ፡ እቲ እተገልጸ ራድየስ { $radius } ኣዝዩ ንእሽቶ እዩ።
+
+circle-radius-with-many-points = እተገልጸ ራድየስ ዘለዎን ካብ ክልተ ንላዕሊ ብዝኾኑ ነጥብታት ዝሓልፍን ክቢ ክፍጠር ኣይክእልን።
+
+circle-invalid-center-or-through-points = ማእከል ናይቲ ክቢ ወይ መሕለፊ ነጥብታቱ ቅቡላት ኣይኮኑን።
+
+circle-radius-center-with-multiple-points = እተገልጸ ማእከል ዘለዎን ካብ 1 ንላዕሊ ብዝኾኑ ነጥብታት ዝሓልፍን ክቢ ራድየሱ ክሕሰብ ኣይክእልን።
+
+circle-change-radius-non-numerical = ቁጽራዊ ክብሪ ብዘይብሎም ነጥብታት ዝሓልፍ ክቢ ራድየሱ ክቕየር ኣይክእልን
+
+circle-radius-with-points-non-numerical = ቁጽራዊ ክብሪ ኣብ ዘይብሉሉ፡ እተገልጸ ራድየስ ዘለዎን ካብ ሓደ ንላዕሊ ብዝኾኑ ነጥብታት ዝሓልፍን ክቢ ክፍጠር ኣይክእልን።
+
+circle-change-center-non-numerical = ቁጽራዊ ክብሪ ብዘይብሎም ነጥብታት ዝሓልፍ ክቢ ማእከሉ ምቕያር ገና ኣይተተግበረን።
+
+## `<function>`
+
+function-domain-insufficient-dimensions = ዓቐናት ናይቲ ናይ ተግባር መዳይ እኹላት ኣይኮኑን። እቲ መዳይ { $intervals } ክፍተታት ኣለዉዎ፡ እቲ ተግባር ግን { $inputs } ኣታዊታት ኣለዉዎ።
+
+function-domain-invalid-format = ቅርጺ ናይቲ ናይ ተግባር መዳይ ቅቡል ኣይኮነን።
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] ቁጽራዊ ዘይኮነ ላዕለዋይ ጫፍ ተግባር ኣይግደስን።
+        [minimum] ቁጽራዊ ዘይኮነ ታሕተዋይ ጫፍ ተግባር ኣይግደስን።
+        [extremum] ቁጽራዊ ዘይኮነ ጫፍ ተግባር ኣይግደስን።
+        [point] ቁጽራዊ ዘይኮነ ነጥቢ ተግባር ኣይግደስን።
+        [slope] ቁጽራዊ ዘይኮነ ትዅዑት ተግባር ኣይግደስን።
+       *[other] ቁጽራዊ ዘይኮነ { $type } ተግባር ኣይግደስን።
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] ባዶ ላዕለዋይ ጫፍ ተግባር ኣይግደስን።
+        [minimum] ባዶ ታሕተዋይ ጫፍ ተግባር ኣይግደስን።
+        [extremum] ባዶ ጫፍ ተግባር ኣይግደስን።
+        [point] ባዶ ነጥቢ ተግባር ኣይግደስን።
+       *[other] ባዶ { $type } ተግባር ኣይግደስን።
+    }
+
+function-points-too-close = እቲ ተግባር ኣዝዮም እተቐራረቡ ክልተ ነጥብታት ኣለዉዎ። እቲ ተግባር ክግለጽ ኣይክእልን።
+
+function-iterates-input-output-mismatch = ናይ ተግባር ድግማ ዝከኣል ብዝሒ ኣታዊታት ምስ ብዝሒ ውጽኢታት ምስ ዝመዓራረ ጥራይ እዩ። እዚ ተግባር { $inputs } ኣታዊታትን { $outputs } ውጽኢታትን ኣለዉዎ።
+
+## `<sequence>`
+
+sequence-invalid-length = ንውሓት ተርታ ቅቡል ኣይኮነን። ካብ ዜሮ ዘይትሕት ምሉእ ቁጽሪ ክኸውን ኣለዎ።
+
+sequence-invalid-step = ስጉምቲ ተርታ ቅቡል ኣይኮነን። ኣብ ናይ { $type } ዓይነት ተርታ ቁጽሪ ክኸውን ኣለዎ።
+
+sequence-invalid-endpoint-number = ናይ ቁጽሪ ተርታ "{ $attribute }" ቅቡል ኣይኮነን። ቁጽሪ ክኸውን ኣለዎ።
+
+sequence-invalid-endpoint-letters = ናይ ፊደላት ተርታ "{ $attribute }" ቅቡል ኣይኮነን። ፊደላት ክኸውን ኣለዎ።
+
+sequence-invalid-endpoint = ናይ ተርታ "{ $attribute }" ቅቡል ኣይኮነን።
+
+select-from-sequence-coprime-not-numbers = coprime ኣይግደስን ምኽንያቱ ዝምረጹ ቁጽርታት ኣይኮኑን
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ኣይግደስን ምኽንያቱ excludeCombinations ተገሊጹ
+
+## Resolving a `target`
+
+target-not-found = target ን`<{ $source }>` ቅቡል ኣይኮነን፡ እቲ ዕላማ ኣይተረኽበን።
+
+target-state-variable-not-found = target ን`<{ $source }>` ቅቡል ኣይኮነን፡ "{ $property }" ዝበሃል ተለዋዋጢ ኩነታት ኣብ `<{ $component }>` ኣይተረኽበን።
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = ተለዋወጥቲ `<odeSystem>` ካብቲ ናጻ ተለዋዋጢ ክፍለዩ ኣለዎም።
+
+ode-system-duplicate-variable-names = እተደጋገሙ ስማት ተለዋወጥቲ ዘለዉዎም ናይ ODE RHS ተግባራት ክግለጹ ኣይክእሉን።
+
+ode-system-rhs-function-error = ናይ ODE RHS ተግባር ክግለጽ ኣይክእልን። ናይ mathjs ተግባር ኣብ ምፍጣር ጌጋ ተፈጢሩ።
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = ኣብ መንጎ { $count } መስመራት ዘሎ መኣዝን ክግለጽ ኣይክእልን
+
+angle-invalid-through-point = ኣብ ናይ `<angle>` through ዘሎ ነጥቢ ቅቡል ኣይኮነን
+
+parabola-vertex-too-many-points = ጫፍ ዘለዋን ካብ 1 ንላዕሊ ብዝኾኑ ነጥብታት እትሓልፍን ፓራቦላ ገና ኣይተተግበረትን።
+
+parabola-too-many-points = ካብ 3 ንላዕሊ ብዝኾኑ ነጥብታት እትሓልፍ ፓራቦላ ገና ኣይተተግበረትን።
+
+intersection-too-many-items = ካብ ክልተ ንላዕሊ ናይ ዝኾኑ ኣቕሑ ምቅርራብ ገና ኣይተተግበረን
+
+## Other math components
+
+ionic-compound-not-two-ions = ካብ ክልተ ኣዮናት ንላዕሊ ዘለዎ ኣዮናዊ ውህደት ገና ኣይተተግበረን።
+
+ionic-compound-needs-cation-and-anion = ኣዮናዊ ውህደት ንሓደ ካትዮንን ሓደ ኣንዮንን ጥራይ እዩ እተተግበረ።
+
+solve-equations-cannot-evaluate = እቲ ማዕረነት ክሕሰብ ስለ ዘይከኣለ ክፍታሕ ኣይክእልን፡ { $equation }
+
+math-operators-operand-number-required = ናይ ሒሳብ ኦፐራንድ ኣብ ምውጻእ operandNumber ክግለጽ ኣለዎ።
+
+eigen-decomposition-failed = ናይ ማትሪክስ eigen ክብርታት ክሕሰቡ ኣይክእሉን
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`፡ መለክዒታት { $parameters } ኣብቲ ቅርጺ ኣይረኣዩን፡ ስለዚ ኩሉ ግዜ ምስ ባዶ ክሰማምዑ እዮም።
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`፡ grid="{ $grid }" ክትርጎም ኣይክእልን። none፡ medium፡ dense፡ ወይ ብጋግ እተፈላለዩ ክልተ ኣወንታዊ ቁጽርታት ክኸውን ኣለዎ፡ ከም grid="1 0.5"። ዝኾነ መርበብ ኣይስኣልን።
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`፡ xLabelPosition="left" ኣብ ናይ prefigure ኣርኣዪ ኣይድገፍን፤ ናይ የማን ኣቀማምጣ ይስራሓሉ።
+
+prefigure-y-label-position-unsupported = `<graph>`፡ yLabelPosition="bottom" ኣብ ናይ prefigure ኣርኣዪ ኣይድገፍን፤ ናይ ላዕሊ ኣቀማምጣ ይስራሓሉ።
+
+prefigure-invalid-axis-bounds = `<graph>`፡ ንprefigure ምቕያር ዶባት ኣኽሲስ ቅቡላት ኣይኮኑን፤ bbox (-10,-10,10,10) ይስራሓሉ።
+
+prefigure-invalid-width = `<graph>`፡ ንprefigure ምቕያር እቲ ስፍሓት ቅቡል ኣይኮነን፤ ናይ ስእሊ ስፍሓት 425 ይስራሓሉ።
+
+prefigure-invalid-aspect-ratio = `<graph>`፡ ንprefigure ምቕያር aspectRatio ቅቡል ኣይኮነን፤ መጠን 1 ይስራሓሉ።
+
+prefigure-grid-spacing-too-fine = `<graph>`፡ ናይ መርበብ ጋግ ንዶባት ኣኽሲስ ኣዝዩ ጸቢብ እዩ፤ መርበብ ኣብ ናይ prefigure ኣርኣዪ ተሪፉ።
+
+prefigure-annotations-not-rendered = `<graph>`፡ ናይ PreFigure ኣርኣዪ ኣብ ዘይስራሓሉ ጊዜ መብርሂታት ኣይረኣዩን።
+
+multiple-annotations-children = ኣብ `<graph>` ብዙሓት ደቂ `<annotations>` ተረኺቦም፤ ብዘይካ እቲ ናይ መወዳእታ ኩሎም ኣይግደሱን።
+
+## Referring to other components
+
+copy-unrecognized-component-type = ዘይተፈልጠ ዓይነት ኣቕሓ ክስፋሕ ወይ ክቕዳሕ ኣይክእልን፡ { $type }።
+
+copy-prop-not-found = ባህሪ { $property } ኣብ ናይ { $component } ዓይነት ኣቕሓ ኣይተረኽበን
+
+collect-no-source = ንcollect ዝኸውን ምንጪ ኣይተረኽበን።
+
+collect-invalid-component-type = ናይ `<{ $component }>` ዓይነት ኣቕሑ ክእከቡ ኣይክእሉን ምኽንያቱ ቅቡል ዘይኮነ ዓይነት ኣቕሓ እዩ።
+
+reference-index-unavailable = መወከሲ `{ $reference }` ክውከስ ኣይክእልን
+
+## `<callAction>`
+
+component-action-unavailable = ኣብ ኣቕሓ `{ $reference }` { $action } ክጽዋዕ ኣይክእልን
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = ቅርጺ ዳታ ቅቡል ኣይኮነን። መስርዓት ዘይመዓራረ ንውሓት ኣለዎም። ኣብ componentIdx :{ $componentIdx } ተረኺቡ
+
+data-frame-duplicate-column-names = እቲ ዳታ እተደጋገሙ ስማት ዓምዲ ኣለዉዎ። ኣብ componentIdx :{ $componentIdx } ተረኺቡ
+
+data-frame-missing-column-name = እቲ ዳታ ስም ዓምዲ ይጎድሎ። ኣብ componentIdx :{ $componentIdx } ተረኺቡ
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ሓደ ካብ award ናይዚ መልሲ ኣብቲ ናይ answer ታግ ባዕሉ ዝለኣኾ መልሲ ይምርኮስ፡ እዚ ድማ ዘይተጸበኻዮ ባህሪ ከምጽእ እዩ።
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` ኣብ ዘለዎ ኮንተይነር ውሽጢ ንዘሎ `<answer>` `maxNumAttempts` ምቕማጥ ውጽኢት የብሉን፡ ምኽንያቱ ብዝሒ ፈተነታት ብእቲ ኮንተይነር እዩ ዝቆጻጸር። ኣብ ክንድኡ `maxNumAttempts` ኣብቲ ኮንተይነር ኣቐምጥ።
+
+nested-section-wide-check-work-max-num-attempts = `sectionWideCheckWork` ኣብ ዘለዎ ካልእ ኮንተይነር ውሽጢ ንዘሎ፡ ንሱ'ውን `sectionWideCheckWork` ዘለዎ ኮንተይነር `maxNumAttempts` ምቕማጥ ውጽኢት የብሉን፡ ምኽንያቱ ብዝሒ ፈተነታት ብእቲ ናይ ደገ ኮንተይነር እዩ ዝቆጻጸር። ኣብ ክንድኡ `maxNumAttempts` ኣብቲ ናይ ደገ ኮንተይነር ኣቐምጥ።
+
+answer-attributes-need-symbolic-equality = symbolicEquality እንተ ዘይተቐሚጡ ባህርያት { $attributes } ውጽኢት ኣይህልዎምን።
+
+answer-invalid-type = ንመልሲ እቲ ዓይነት ቅቡል ኣይኮነን፡ { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = ኣቕሓ `<{ $component }>` ስም ስለ ዘይብሉ፡ ከም ናይ module ባህሪ ክውዕል ኣይክእልን
+
+module-attribute-name-already-defined = ኣቕሓ `<{ $component } name="{ $name }">` ከም ናይ module ባህሪ ክውዕል ኣይክእልን ምኽንያቱ ናይ ኣቕሓ ዓይነት `<module>` "{ $name }" ዝበሃል ባህሪ ኣቐዲሙ ኣለዎ።
+
+conditional-content-condition-ignored = case ወይ else ደቂ ኣብ ዘለዎ ኣቕሓ `<conditionalContent>` ባህሪ `condition` ኣይግደስን።
+
+slider-markers-type-mismatch = ዓይነት ምልክታት ምስ ዓይነት slider ኣይሰማምዕን።
+
+pretzel-problem-needs-statement-and-answer = pretzel ቅቡል ኣይኮነን፡ ነፍሲ ወከፍ `<problem>` ሓደ `<statement>` ከምኡ'ውን ሓደ `<answer>` ክህልዎ ኣለዎ።
+
+pretzel-circuit-first-problem-distractor = pretzel ቅቡል ኣይኮነን፡ ኣብ mode="circuit"፡ እቲ ቀዳማይ `<problem>` መስሓቲ ክኸውን ኣይክእልን።
+
+## Attribute values
+
+attribute-invalid-values = ክብርታት { $values } ንባህሪ `{ $attribute }` ቅቡላት ኣይኮኑን፤ ኣይግደሱን።
+
+attribute-must-be-references = ክብሪ `{ $value }` ንባህሪ `{ $attribute }` ቅቡል ኣይኮነን። እቲ ባህሪ ብ`$` ካብ ዝጅምሩ መወከሲታት ክቐውም ኣለዎ።
+
+math-input-invalid-function-names = <mathInput>፡ ኣብ { $attribute } ዘለዉ ቅቡላት ዘይኮኑ ስማት ተግባር ኣይግደሱን፡ { $names }። ናይ ነፍሲ ወከፍ ስም ዝረአ ክፋል እንተ ወሓደ 2 ፊደላት ክህልዎ ኣለዎ (ፊደላት ወይ መስመራት)፤ ናይ ምርጫ መጠቓለሊ `|<mathspeak alternative>` ክስዕብ ይኽእል።
+
+## Building components from the source
+
+component-type-invalid = ዓይነት ኣቕሓ ቅቡል ኣይኮነን፡ `<{ $componentType }>`
+
+attribute-repeated = ባህሪ { $attribute } ክድገም ኣይክእልን።
+
+attribute-invalid-for-component = ባህሪ "{ $attribute }" ንናይ `<{ $componentType }>` ዓይነት ኣቕሓ ቅቡል ኣይኮነን።
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    ናይ ቅዲ ትርጉም { $styleNumber } ን{ $context ->
+        [text-on-background] ሕብሪ ጽሑፍ ኣንጻር ሕብሪ ድሕረ-ባይታ
+        [high-contrast] ሕብሪ ዓቢ ፍልልይ ኣንጻር እቲ ሸራ
+        [line] ሕብሪ መስመር ኣንጻር እቲ ሸራ
+        [marker] ሕብሪ ምልክት ኣንጻር እቲ ሸራ
+       *[text-on-canvas] ሕብሪ ጽሑፍ ኣንጻር እቲ ሸራ
+    } እኹል ፍልልይ የብሉን{ $mode ->
+        [dark] { " (ጸላም ኩነታት)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ እንተ ወሓደ { $threshold }:1 የድሊ)።
+
+style-definition-dark-mode-text-background-contrast =
+    ናይ ቅዲ ትርጉም { $styleNumber } ኣብ ብሩህ ኩነታት እኹል ፍልልይ ዝህቡ ሕብርታት እኳ እንተ ገለጸ፡ ካብኣቶም ዝወጹ ናይ ጸላም ኩነታት ሕብርታት ንሕብሪ ጽሑፍ ኣንጻር ሕብሪ ድሕረ-ባይታ እኹል ፍልልይ የብሎምን ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ እንተ ወሓደ { $threshold }:1 የድሊ)። { $suggestion ->
+        [available] ኣብ ጸላም ኩነታት እኹል ፍልልይ ንምርግጋጽ፡ ናይ ብሩህ ኩነታት ፍልልይ ወስኽ (ንኣብነት { $lightAttribute }="{ $lightColor }" ኣቐምጥ) ወይ ናይ ጸላም ኩነታት ሕብሪ ቀይር (ንኣብነት { $darkAttribute }="{ $darkColor }" ኣቐምጥ)።
+       *[none] ኣብ ጸላም ኩነታት እኹል ፍልልይ ንምርግጋጽ፡ ናይ ብሩህ ኩነታት ፍልልይ ወስኽ ወይ እቶም ዝወጹ ሕብርታት ብtextColorDarkMode ከምኡ'ውን/ወይ backgroundColorDarkMode ቀይር።
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    ናይ ቅዲ ትርጉም { $styleNumber } ኣብ ብሩህ ኩነታት እኹል ፍልልይ ዝህብ ሕብሪ ጽሑፍ እኳ እንተ ገለጸ፡ ካብኡ ዝወጸ ናይ ጸላም ኩነታት ሕብሪ ጽሑፍ ኣንጻር እቲ ሸራ እኹል ፍልልይ የብሉን ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1፤ እንተ ወሓደ { $threshold }:1 የድሊ)። { $suggestion ->
+        [available] ኣብ ጸላም ኩነታት እኹል ፍልልይ ንምርግጋጽ፡ ናይ ብሩህ ኩነታት ፍልልይ ወስኽ (ንኣብነት textColor="{ $lightColor }" ኣቐምጥ) ወይ ናይ ጸላም ኩነታት ሕብሪ ቀይር (ንኣብነት textColorDarkMode="{ $darkColor }" ኣቐምጥ)።
+       *[none] ኣብ ጸላም ኩነታት እኹል ፍልልይ ንምርግጋጽ፡ ናይ ብሩህ ኩነታት ፍልልይ ወስኽ ወይ እቲ ዝወጸ ሕብሪ ብtextColorDarkMode ቀይር።
+    }
+
+section-multiple-style-palettes = ሓደ ክፍሊ ሓደ <stylePalette> ጥራይ ክመርጽ ይኽእል፤ እቲ ናይ መወዳእታ ይስራሓሉ።
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = numToSelect ካብ ዜሮ ዘይትሕት ምሉእ ቁጽሪ ስለ ዘይኮነ ናይ { $component } ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-num-to-select-not-constant-number = numToSelect ዘይቀያየር ቁጽሪ ስለ ዘይኮነ ናይ { $component } ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-with-replacement-not-constant-boolean = withReplacement ዘይቀያየር ቡሊያን ስለ ዘይኮነ ናይ { $component } ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-select-weight-disables-unique = selectWeight ወይ selectForVariants እተገልጸሉ ምርጫ እንተ ሃልዩ ናይ select ፍሉያት ዓይነታት ይዕጸዉ
+
+variant-coprime-undetermined = coprime ኩሉ ግዜ ሓሶት ምዃኑ ከረጋግጽ ስለ ዘይክእል ናይ { $component } ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-attribute-not-constant = { $attribute } ስለ ዘይተረጋገአ ናይ { $component } ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-attribute-not-number = { $attribute } ቁጽሪ ስለ ዘይኮነ ናይ { $component } ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-attribute-wrong-type-for-sequence =
+    { $attribute } { $expected ->
+        [letters-combination] ናይ ፊደላት ጥርናፈ
+        [math-expression] ቅቡል ናይ ሒሳብ መግለጺ
+        [integer] ምሉእ ቁጽሪ
+       *[number] ቁጽሪ
+    } ስለ ዘይኮነ ናይ { $component } ናይ { $type } ዓይነት ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-length-not-integer = length ምሉእ ቁጽሪ ስለ ዘይኮነ ናይ { $component } ፍሉያት ዓይነታት ክግለጹ ኣይክእሉን።
+
+variant-sort-not-implemented = sort ዘለዎም ናይ { $component } ፍሉያት ዓይነታት ገና ኣይተተግበሩን
+
+variant-exclude-combinations-not-implemented = excludeCombinations ዘለዎም ናይ { $component } ፍሉያት ዓይነታት ገና ኣይተተግበሩን
+
+variant-math-exclude-not-implemented = exclude ዘለዎም ናይ { $component } ናይ math ዓይነት ፍሉያት ዓይነታት ገና ኣይተተግበሩን
+
+variant-non-constant-exclude-not-implemented = ዘይተረጋገአ exclude ዘለዎም ናይ { $component } ፍሉያት ዓይነታት ገና ኣይተተግበሩን
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }፡ ኣብ ናይ graph prefigure ኣርኣዪ ኣይድገፍን፤ እቲ ወራሲ ተሓሊፉ።
+
+prefigure-descendant-invalid-geometry = { $subject }፡ ዶብ ዘይብሉ ወይ ዘይተማልአ ጂኦሜትሪ፤ እቲ ወራሲ ተሓሊፉ።
+
+prefigure-curve-label-omitted = { $subject }፡ ኣብ እተቐየሩ ናይ ጥውይዋይ ኣቕሑ ስማት ኣይድገፉን፤ እቲ ስም ተሪፉ።
+
+prefigure-curve-unsupported-definition-type = { $subject }፡ ናይ ጥውይዋይ ተግባር ትርጉም ዓይነት '{ $definitionType }' ኣይድገፍን፤ እቲ ወራሲ ተሓሊፉ።
+
+prefigure-region-flip-functions-unsupported = { $subject }፡ ኣብ regionBetweenCurves ዘሎ ባህሪ flipFunctions ኣይድገፍን፤ እቲ ወራሲ ተሓሊፉ።
+
+prefigure-region-non-formula-child = { $subject }፡ ኣብ regionBetweenCurves ናይ formula ዓይነት ደቂ ተግባራት ጥራይ እዮም ዝድገፉ፤ እቲ ወራሲ ተሓሊፉ።
+
+prefigure-label-position-unsupported =
+    { $subject }፡ labelPosition '{ $labelPosition }' ን{ $labelKind ->
+        [line-family] ስም ስድራ መስመር
+       *[point] ስም ነጥቢ
+    } ኣይድገፍን፤ ናይ PreFigure ኣቀማምጣ ይስራሓሉ።
+
+prefigure-fill-style-unsupported = { $subject }፡ ናይ መመልኢ ቅዲ '{ $fillStyle }' ብPreFigure ኣይድገፍን፤ ናብ ናይ ሓደ ሕብሪ መመልኢ ይምለስ።
+
+prefigure-line-style-unknown = { $subject }፡ ናይ መስመር ቅዲ '{ $lineStyle }' ኣይተፈልጠን፡ ኣብ ውጽኢት PreFigure ተሪፉ።
+
+prefigure-marker-style-mapped-to-diamond = { $subject }፡ ናይ ምልክት ቅዲ '{ $markerStyle }' ምስ ናይ PreFigure ቅዲ 'diamond' ተዛሚዱ።
+
+prefigure-marker-style-unsupported = { $subject }፡ ናይ ምልክት ቅዲ '{ $markerStyle }' ብPreFigure ኣይድገፍን፤ እቲ ቀዳምነት ዘለዎ ቅዲ ይስራሓሉ።
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`፡ `ref` ቅቡል ኣይኮነን፤ እቲ ዕላማ ክፍለጥ ኣይክእልን። እቲ መብርሂ ተሪፉ።
+
+annotation-ref-multiple-targets = `<annotation>`፡ `ref` ብዙሓት ዕላማታት ገሊጹ፤ እቲ ቀዳማይ ዕላማ ይስራሓሉ።
+
+annotation-ref-outside-graph = `<annotation>`፡ `ref` ቅቡል ኣይኮነን፤ እቲ ዕላማ ካብቲ ዝሓዞ ግራፍ ወጻኢ እዩ። እቲ መብርሂ ተሪፉ።
+
+annotation-ref-unsupported-target = `<annotation>`፡ `ref` ቅቡል ኣይኮነን፤ እቲ ዕላማ ኣብ ናይ prefigure ምቕያር ዝድገፍ ናይ ስእሊ ኣቕሓ ኣይኮነን። እቲ መብርሂ ተሪፉ።
+
+annotation-text-missing = `<annotation>`፡ `text` የልቦን ወይ ባዶ እዩ፤ ባዶ ጽሑፍ ይወጽእ።
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] ዑደታዊ ምምርኳስ ተረኺቡ።
+       *[other] ንኣቕሓ `<{ $componentType }>` ዘሳትፍ ዑደታዊ ምምርኳስ ተረኺቡ።
+    }
+
+reference-no-referent = ንመወከሲ ዝኾነ ኣይተረኽበን፡ `{ $reference }`
+
+reference-multiple-referents = ንመወከሲ ብዙሓት ተረኺበን፡ `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = ናይ `<{ $componentType }>` ባህሪ { $attribute } ቅርጺ ቅቡል ኣይኮነን።
+
+children-invalid = ን`<{ $componentType }>` እቶም ደቂ ቅቡላት ኣይኮኑን፡ ቅቡላት ዘይኮኑ ደቂ ተረኺቦም፡ { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = ክብሪ `{ $value }` ንባህሪ `{ $attribute }` ቅቡል ኣይኮነን፡ ክብሪ `{ $default }` ይስራሓሉ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML ስሪት { $version } ኣይተረኽበን።
+       *[other] DoenetML ስሪት { $version } ኣይተረኽበን። ናብ ስሪት { $fallback } ይምለስ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ቅቡል ኣይኮነን፡ { $content }
+
+parse-tag-missing-close-tag = DoenetML ቅቡል ኣይኮነን፡ ታግ `{ $tag }` መዕጸዊ ታግ የብሉን። ባዕሉ ዝዕጾ ታግ ወይ ታግ `</{ $tagName }>` ተጸቢና።
+
+parse-tag-error = DoenetML ቅቡል ኣይኮነን፡ ኣብ ታግ `<{ $tagName }>` ጌጋ
+
+parse-attribute-missing-value = DoenetML ቅቡል ኣይኮነን፡ ቅቡል ዘይኮነ ባህሪ `{ $attribute }` ክብሪ ዝጎደሎ ይመስል።
+
+parse-attribute-invalid = DoenetML ቅቡል ኣይኮነን፡ ባህሪ `{ $attribute }` ቅቡል ኣይኮነን
+
+parse-attribute-value-invalid = DoenetML ቅቡል ኣይኮነን፡ ናይ ባህሪ ክብሪ `{ $value }` ቅቡል ኣይኮነን
+
+parse-attribute-value-quote-mismatch = DoenetML ቅቡል ኣይኮነን፡ ናይ ባህሪ ክብሪ `{ $value }` ቅቡል ኣይኮነን። ናይ ጥቕሲ ምልክታት ኣይሰማምዑን። `{ $quote }` ዝጎደለ ይመስል
+
+parse-open-tag-name-missing = DoenetML ቅቡል ኣይኮነን፡ ስም ዘይብሉ ታግ ተረኺቡ፡ ንኣብነት `<`
+
+parse-tag-not-closed = DoenetML ቅቡል ኣይኮነን፡ ታግ `{ $tag }` ኣይተዓጸወን (`>` ዝጎደለ ይመስል)።
+
+parse-self-closing-tag-name-missing = DoenetML ቅቡል ኣይኮነን፡ ስም ዘይብሉ ታግ ተረኺቡ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ቅቡል ኣይኮነን፡ ታግ `{ $tag }` ኣይተዓጸወን (`/>` ዝጎደለ ይመስል)።
+
+parse-tag-invalid-attributes = DoenetML ቅቡል ኣይኮነን፡ ታግ `{ $tag }` ቅቡል ኣይኮነን። ምናልባት ቅቡላት ዘይኮኑ ባህርያት ኣለዉዎ።
+
+parse-close-tag-name-missing = DoenetML ቅቡል ኣይኮነን፡ ስም ዘይብሉ መዕጸዊ ታግ ተረኺቡ፡ ንኣብነት `</`
+
+parse-attribute-value-unquoted = ናይ ባህሪ ክብርታት ኣብ ውሽጢ ናይ ጥቕሲ ምልክታት ክቕመጡ ኣለዎም፡ `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ቅቡል ኣይኮነን፡ መዕጸዊ ታግ `{ $tag }` ተረኺቡ፡ ግን ዝሰማማዕ መኽፈቲ ታግ የልቦን
+
+parse-close-tag-mismatched = DoenetML ቅቡል ኣይኮነን፡ እቲ መዕጸዊ ታግ ኣይሰማምዕን። `</{ $expected }>` ተጸቢና። `{ $found }` ተረኺቡ
+
+parser-node-unconvertible = ኖድ { $node } ናብ ናይ Dast ኖድ ክቕየር ኣይከኣለን።
+
+## Names
+
+name-attribute-invalid =
+    ባህሪ name='{ $name }' ቅቡል ኣይኮነን። { $reason ->
+        [characters] ስማት ፊደላት፡ ቁጽርታት፡ ታሕተዎት መስመራት ወይ መስመራት ጥራይ ክህልዎም ይኽእል።
+       *[start] ስማት ብፊደል ክጅምሩ ኣለዎም።
+    }
+
+component-name-invalid-start = ስም ኣቕሓ "{ $name }" ቅቡል ኣይኮነን። ስማት ብፊደል ክጅምሩ ኣለዎም።
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = ናይ videoWatched ዓይነት መልሲ ባህሪ video ክህልዎ ኣለዎ
+
+answer-video-watched-video-not-reference = ናይ videoWatched ዓይነት መልሲ መወከሲ ዝኾነ ባህሪ video ክህልዎ ኣለዎ
+
+answer-name-not-single-text = ናይ መልሲ ባህሪ name ሓደ text ውሉድ ጥራይ ክህልዎ ኣለዎ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = ብዙሕ ደረጃ ድግማ ስለ ዘሎ ናይ ደገ DoenetML ክርከብ ኣይክእልን። ዑደታዊ መወከሲ ኣሎ ድዩ?
+
+external-doenetml-unavailable = ካብ { $attribute }="{ $uri }" DoenetML ክርከብ ኣይክእልን
+
+external-doenetml-type-mismatch = ካብ { $attribute }="{ $uri }" እተረኽበ DoenetML ቅቡል ኣይኮነን፡ ምስ ናይ ኣቕሓ ዓይነት "{ $componentType }" ኣይሰማምዕን
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] ባህሪ `{ $from }` ግዜኡ ሓሊፉ፤ ኣብ ክንድኡ `{ $to }` ተጠቐም።
+       *[other] [deprecation] ኣብ `<{ $component }>` ዘሎ ባህሪ `{ $from }` ግዜኡ ሓሊፉ፤ ኣብ ክንድኡ `{ $to }` ተጠቐም።
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] ባህሪ `{ $from }` ግዜኡ ሓሊፉ፡ `{ $to }` እውን ስለ እተገልጸ ኣይግደስን።
+       *[other] [deprecation] ኣብ `<{ $component }>` ዘሎ ባህሪ `{ $from }` ግዜኡ ሓሊፉ፡ `{ $to }` እውን ስለ እተገልጸ ኣይግደስን።
+    }
+
+deprecated-attribute-ignored = [deprecation] ኣብ `<{ $component }>` ዘሎ ባህሪ `{ $attribute }` ግዜኡ ሓሊፉ፡ ኣይግደስን።
+
+deprecated-attribute-to-child = [deprecation] ኣብ `<{ $component }>` ዘሎ ባህሪ `{ $attribute }` ግዜኡ ሓሊፉ፤ ኣብ ክንድኡ ውሉድ `<{ $child }>` ተጠቐም።
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ብእንግሊዝኛ ጥራይ ብዙሕነት ክገብር ይኽእል፡ ስለዚ ኣብ { $locale } እተጻሕፈ ሰነድ ጽሑፉ ከምዘሎ ይተርፍ። ናይ ብዙሕነት ቅርጺ ባዕልኻ ጽሓፍ፡ ወይ ኣብ ባህሪ `pluralForm` ኣቐምጦ።
+
+
+## Checking against the schema
+
+schema-element-unrecognized = ኣቕሓ `<{ $tag }>` ዝፍለጥ ናይ Doenet ኣቕሓ ኣይኮነን።
+
+schema-element-not-allowed-at-root = ኣቕሓ `<{ $tag }>` ኣብ መሰረት እቲ ሰነድ ኣይፍቀድን።
+
+schema-element-not-allowed-inside = ኣቕሓ `<{ $tag }>` ኣብ ውሽጢ `<{ $parent }>` ኣይፍቀድን።
+
+schema-attribute-unrecognized = ኣቕሓ `<{ $tag }>` `{ $attribute }` ዝበሃል ባህሪ የብሉን።
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] ናይ ኣቕሓ `<{ $tag }>` ባህሪ `{ $attribute }` ነፍሲ ወከፍ ኣቕሓኡ ካብዞም ሓደ ዝኾነ ዝርዝር ክኸውን ኣለዎ፡ { $allowed }
+       *[other] ናይ ኣቕሓ `<{ $tag }>` ባህሪ `{ $attribute }` ካብዞም ሓደ ክኸውን ኣለዎ፡ { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = ንselect ስም ዓይነት ቅቡል ኣይኮነን። ስም ዓይነት { $variantName } ኣብ { $numOptions } ምርጫታት ይረአ፡ ብዝሒ ምርጫ ግን { $numToSelect } እዩ።
+
+select-variant-name-without-options = ንselect ገለ ዓይነታት ተገሊጾም፡ ግን ክኸውን ንዝኽእል ስም ዓይነት ዝኾነ ምርጫ ኣይተገልጸን፡ { $variantName }።
+
+select-variant-name-not-possible = ንselect እተገልጸ ስም ዓይነት { $variantName } ክኸውን ዝኽእል ስም ዓይነት ኣይኮነን።
+
+select-too-few-options = ካብ { $numOptions } ጥራይ { $numToSelect } ኣቕሑ ክምረጹ ኣይክእሉን።
+
+select-from-sequence-too-few-values = ንውሓቱ { $length } ካብ ዝኾነ ተርታ { $numToSelect } ክብርታት ክምረጹ ኣይክእሉን።
+
+select-from-sequence-indices-count-mismatch = ንselect እተገልጸ ብዝሒ መወከሲታት ምስ ብዝሒ ምርጫ ክሰማማዕ ኣለዎ
+
+select-from-sequence-indices-not-integers = ንselect እተገልጹ ኩሎም መወከሲታት ምሉኣት ቁጽርታት ክኾኑ ኣለዎም
+
+select-from-sequence-index-excluded = እተወገደ ናይ selectfromsequence መወከሲ ተገሊጹ
+
+select-from-sequence-indices-excluded-combination = እተወገደ ጥርናፈ ዝነበሩ ናይ selectfromsequence መወከሲታት ተገሊጾም
+
+select-from-sequence-coprime-not-positive-integers = ዝምረጹ ኣወንታዊ ምሉኣት ቁጽርታት ስለ ዘይኮኑ ናይ ተጻመድቲ ቁጽርታት ጥርናፈታት ክምረጹ ኣይክእሉን።
+
+select-from-sequence-coprime-common-factor = ተጻመድቲ ቁጽርታት ክምረጹ ኣይክእሉን። ኩሎም ክኾኑ ዝኽእሉ ክብርታት ሓደ መማቐሊ የካፍሉ። (እተገልጹ ናይ "from" ወይ "to" ክብርታት ምስ "step" ተጻመድቲ ክኾኑ ኣለዎም።)
+
+select-from-sequence-coprime-single-number = 1 ካብ ዘይኮነ ሓደ ቁጽሪ ናይ ተጻመድቲ ቁጽርታት ጥርናፈታት ክምረጹ ኣይክእሉን።
+
+select-from-sequence-excluded-too-many-combinations = ኣብ selectFromSequence ካብ 70% ንላዕሊ ጥርናፈታት ተወጊዶም
+
+select-from-sequence-coprime-none-found = ተጻመድቲ ቁጽርታት ክምረጹ ኣይከኣሉን። ኩሎም ክኾኑ ዝኽእሉ ክብርታት ሓደ መማቐሊ የካፍሉ።
+
+select-from-sequence-too-few-unique-values = ንውሓቱ { $numPossibleValues } ካብ ዝኾነ ተርታ { $numToSelect } ፍሉያት ክብርታት ክምረጹ ኣይክእሉን
+
+select-prime-numbers-too-few-values = ንውሓቱ { $numValues } ካብ ዝኾነ ናይ ቀዳማይ ቁጽርታት ዝርዝር { $numToSelect } ክብርታት ክምረጹ ኣይክእሉን
+
+select-prime-numbers-values-count-mismatch = ንselect እተገልጸ ብዝሒ ክብርታት ምስ ብዝሒ ምርጫ ክሰማማዕ ኣለዎ
+
+select-prime-numbers-values-not-prime = ንselect prime number እተገልጹ ኩሎም ክብርታት ኣብቲ ናይ ቀዳማይ ቁጽርታት ዝርዝር ክህልዉ ኣለዎም
+
+select-prime-numbers-values-excluded-combination = እተገልጹ ናይ selectPrimeNumbers ክብርታት እተወገደ ጥርናፈ ነይሮም
+
+select-prime-numbers-excluded-too-many-combinations = ኣብ selectPrimeNumbers ካብ 70% ንላዕሊ ጥርናፈታት ተወጊዶም
+
+select-random-combination-fluke = ብዘይልሙድ ኩነት፡ ናይ ዘይተወሰኑ ክብርታት ጥርናፈ ክምረጽ ኣይከኣለን
+
+select-random-value-fluke = ብዘይልሙድ ኩነት፡ ዘይተወሰነ ክብሪ ክምረጽ ኣይከኣለን

--- a/packages/i18n/locales/ti/editor.ftl
+++ b/packages/i18n/locales/ti/editor.ftl
@@ -1,0 +1,217 @@
+# Tigrinya editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written. They are Latin letters
+# in the middle of Ge'ez, which is what a Tigrinya developer reads on screen
+# anyway; the script is left to right, so no direction mark is needed to keep
+# them in place.
+#
+# Tigrinya marks the plural on the noun, so the counted messages keep their
+# selects.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] እንደገና ኣቐምጥ
+       *[update] ኣሐድስ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] ኣርኣዪ { $word }
+       *[other] ኣርኣዪ { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = ዓይነት
+editor-variant-filter = ኣጻሪ...
+editor-variant-next = ዝቕጽል ዓይነት ምረጽ
+editor-variant-previous = ዝሓለፈ ዓይነት ምረጽ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] ጥሕሰት ተበጻሕነት WCAG AA ተረኺቡ። ጸብጻብ ተበጻሕነት ንም{ $action ->
+            [close] ዕጻው
+           *[open] ኽፋት
+        } ጠውቕ።
+        [advisories] ጸብጻብ ተበጻሕነት ንም{ $action ->
+            [close] ዕጻው
+           *[open] ኽፋት
+        } ጠውቕ። ጥሕሰት WCAG AA ኣይተረኽበን፡ ግን ተወሳኺ ምኽሪ ተበጻሕነት ኣሎ።
+       *[clean] ጸብጻብ ተበጻሕነት ንም{ $action ->
+            [close] ዕጻው
+           *[open] ኽፋት
+        } ጠውቕ። ዝኾነ ጸገም ተበጻሕነት ኣይተረኽበን።
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] ጥሕሰት ተበጻሕነት WCAG AA ተረኺቡ። { $count ->
+            [one] { $count } ጥሕሰት WCAG AA ተረኺቡ
+           *[other] { $count } ጥሕሰታት WCAG AA ተረኺበን
+        }። ጸብጻብ ተበጻሕነት ንም{ $action ->
+            [close] ዕጻው
+           *[open] ኽፋት
+        } ጠውቕ።
+        [advisories] ጥሕሰት WCAG AA ኣይተረኽበን። { $count ->
+            [one] { $count } ተወሳኺ ምኽሪ ተበጻሕነት ተረኺቡ
+           *[other] { $count } ተወሰኽቲ ምኽርታት ተበጻሕነት ተረኺበን
+        }። ጸብጻብ ተበጻሕነት ንም{ $action ->
+            [close] ዕጻው
+           *[open] ኽፋት
+        } ጠውቕ።
+       *[clean] ጥሕሰት WCAG AA ኣይተረኽበን። ጸብጻብ ተበጻሕነት ንም{ $action ->
+            [close] ዕጻው
+           *[open] ኽፋት
+        } ጠውቕ።
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML ስሪት { $version }
+
+editor-tab-help = ምስ ኩነታት ዝሰማማዕ ሓገዝ
+editor-tab-help-short = ኩነታት
+editor-tab-errors = ጌጋታት
+editor-tab-warnings = መጠንቀቕታታት
+editor-tab-info = ሓበሬታ
+editor-tab-accessibility = ተበጻሕነት
+editor-tab-responses = ዝተላእኩ መልስታት
+
+editor-tab-with-count = { $label }፡ { $count }
+
+editor-options = ምርጫታት ኣርታዒ
+editor-format-as-doenetml = ከም DoenetML ኣሰናዲ
+editor-format-as-xml = ከም XML ኣሰናዲ
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = መስመር #{ $line }
+
+editor-no-errors = ጌጋታት የልቦን
+editor-no-warnings = መጠንቀቕታታት የልቦን
+editor-no-info = ናይ ሓበሬታ ምርመራ የልቦን
+
+editor-show-info-annotations = ናይ ሓበሬታ ምርመራታት ኣብ ኣርታዒ ኣርኢ
+editor-show-accessibility-annotations = ናይ ተበጻሕነት ምርመራታት ኣብ ኣርታዒ ኣርኢ
+
+editor-accessibility-learn-more = Doenet ንተበጻሕነት ብኸመይ ከም ዝሕዞ ተማሃር
+
+editor-accessibility-violations-heading = ጥሕሰታት ተበጻሕነት ({ $standard })
+
+editor-accessibility-other-heading = ካልኦት ጸገማት ተበጻሕነት
+editor-none-found = ዝኾነ ኣይተረኽበን
+
+
+## Submitted responses
+
+editor-no-responses = ክሳብ ሕጂ ዝተላእከ መልሲ የልቦን
+editor-response-answer-id = መለለዪ መልሲ
+editor-response-response = መልሲ
+editor-response-credit = ነጥቢ
+editor-response-submitted = ተላኢኹ
+
+
+## The context-help panel
+
+help-placeholder = ሰነዳት ንምርካብ መርኣዪ ኣብ ልዕሊ ስም ታግ፡ ባህሪ ወይ { $ref } ኣቐምጥ።
+
+help-unsupported-ref-chain = ከም { $example } ንዝኣመሰሉ ብዙሕ ክፋል ዘለዎም መወከሲታት ዘሎ ሓገዝ ገና ኣይተደገፈን።
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ንመወከሲ { $ref } ዝኾነ ኣይተረኽበን።
+        [multiple] ንመወከሲ { $ref } ብዙሓት ተረኺበን።
+       *[indeterminate] { $ref } እንታይ ከም ዘመልክት ክፍለጥ ኣይከኣለን።
+    }
+
+help-learn-about-references = ብዛዕባ መወከሲታት ተማሃር →
+help-reference-page = ገጽ መወከሲ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] ኣብ ውሽጢ { $element }
+       *[top] ኣብ ላዕለዋይ ደረጃ
+    }{ $allowed ->
+        [none] { " — ኣብዚ ዝኣቱ የልቦን።" }
+        [text] { " — ኣብዚ ጽሑፍ ጽሓፍ።" }
+        [text-and-components] { " — ኣብዚ ጽሑፍ ጽሓፍ፡ ወይ እዚኣቶም ፈትን፡" }
+       *[components] { " — ክትፍትኖም እትኽእል፡" }
+    }
+
+help-suggestions-footer = ኩሎም { $total } ኣቕሑ ንምርኣይ { $shortcut } ጠውቕ።
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } መወከሲ ናይ { $target } እዩ።
+       *[other] { $ref } መወከሲ ናይ { $target } እዩ (መስመር { $line })።
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } ከም { $role } ሰይምዎ።
+       *[other] { $owner } ኣብ መስመር { $line } ከም { $role } ሰይምዎ።
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } መወከሲ ናይ ባህሪ { $property } ናይ { $element } እዩ።
+       *[other] { $ref } መወከሲ ናይ ባህሪ { $property } ናይ { $element } እዩ (መስመር { $line })።
+    }
+
+help-kind-attribute = ባህሪ
+help-kind-snippet = ቁራጽ ጽሑፍ
+help-kind-array-entry = ኣታዊ ሰንጠረዥ
+
+help-default = ቀዳምነት ዘለዎ፡
+help-active-default = ኣብ ስራሕ ዘሎ ቀዳምነት፡
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] ዝፍቀዱ ክብርታት (ሓደ ንነፍሲ ወከፍ ኣቕሓ)፡
+       *[other] ዝፍቀዱ ክብርታት፡
+    }
+
+help-suggested-values = ዝምከሩ ክብርታት፡
+
+help-inserts = የእቱ፡
+
+help-coordinates =
+    { $count ->
+        [one] መወከሲ ነጥቢ፡
+       *[other] መወከሲ ነጥብታት፡
+    }
+
+help-type = ዓይነት፡
+
+help-resolved-style = እተፈልጠ ቅዲ (styleNumber { $styleNumber })፡
+
+help-resolved-function-names = እተፈልጡ ስማት ተግባር፡
+help-reset-list = ኣብዚ ኣታዊ ዝምለስ ዝርዝር፡
+help-added-on-input = ኣብዚ ኣታዊ እተወሰኸ፡
+help-removed-on-input = ኣብዚ ኣታዊ እተወግደ፡
+
+help-reset-overrides = { $reset } ን{ $additional } ከምኡ'ውን ን{ $removed } ይስዕር።

--- a/packages/i18n/locales/tn/chrome.ftl
+++ b/packages/i18n/locales/tn/chrome.ftl
@@ -1,0 +1,142 @@
+# Setswana viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Setswana has two plural categories, and a noun marks number with a class
+# prefix rather than a suffix — «teko» one attempt, «diteko» several; «karabo»
+# one answer, «dikarabo» several — and it keeps doing so after a numeral. So
+# the selects are kept and the noun changes shape inside them.
+# `attempts-remaining` also keeps its `[0]` branch, an exact-value match rather
+# than a plural category, which says «ga go na» instead of counting to zero.
+
+
+## Answer submission
+
+answer-checking = E a tlhatlhoba...
+answer-submitting = E a romela...
+
+answer-checking-status = E tlhatlhoba karabo
+answer-submitting-status = E romela karabo
+
+answer-correct = E siame
+answer-incorrect = Ga e a siama
+
+answer-response-saved = Karabo e Bolokilwe
+
+answer-percent-credit = Matshwao { $percent }%
+answer-percent-correct = { $percent }% E siame
+answer-percent-short = { $percent } %
+
+max-credit-available = Matshwao a magolo a a leng teng: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] ga go na teko e e setseng
+        [one] teko e le { $count } e setse
+       *[other] diteko tse { $count } di setse
+    }
+
+validation-correct = (E siame)
+validation-incorrect = (Ga e a siama)
+validation-partially-correct = (E siame ka bontlhanngwe)
+
+answer-show-responses =
+    { $count ->
+        [one] Bontsha karabo e le { $count } ya { $answerId }
+       *[other] Bontsha dikarabo tse { $count } tsa { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Kakgelo
+
+collapsible-click-to-open = (tobetsa go bula)
+collapsible-click-to-close = (tobetsa go tswala)
+
+collapsible-initializing = E a simolola...
+
+footnote-show = Bontsha tlhaloso ya kwa tlase
+footnote-hide = Fitlha tlhaloso ya kwa tlase
+
+description-more-information = tshedimosetso e nngwe
+
+
+## Controls
+
+slider-previous = E e fetileng
+slider-next = E e latelang
+
+keyboard-open = Bula Keyboard
+keyboard-close = Tswala Keyboard
+
+choice-input-remove-choice = Ntsha { $choice }
+
+matrix-remove-row = Ntsha mola o o rapameng
+matrix-add-row = Oketsa mola o o rapameng
+matrix-remove-column = Ntsha mola o o emeng
+matrix-add-column = Oketsa mola o o emeng
+
+subset-add-remove-points = Oketsa/Ntsha dintlha
+subset-toggle-points-intervals = Fetola fa gare ga dintlha le dikgaoganyo
+subset-move-points = Sutisa Dintlha
+subset-clear = Phimola
+
+# A `box` here is one orbital, drawn as a square: «lebokoso».
+orbital-add-row = Oketsa Mola
+orbital-remove-row = Ntsha Mola
+orbital-add-box = Oketsa Lebokoso
+orbital-remove-box = Ntsha Lebokoso
+orbital-add-up-arrow = Oketsa Sekai se se Lebileng Godimo
+orbital-add-down-arrow = Oketsa Sekai se se Lebileng Tlase
+orbital-remove-arrow = Ntsha Sekai
+
+orbital-row-label = Leina la mola { $row }
+
+pretzel-answer = Karabo
+
+summary-statistics-caption = Tshobokanyo ya dipalopalo tsa { $column }
+
+
+## Math input
+
+math-input-preview-region = ponelopele ya polelo ya dipalo
+math-input-preview = Ponelopele
+math-input-invalid-expression = Polelo ga e a siama:
+
+
+## Document status
+
+viewer-initializing = E a simolola...
+
+
+## Errors
+
+error-heading = Phoso
+
+error-found-at =
+    { $span ->
+        [line] E fitlhetswe mo moleng wa { $startLine }.
+       *[lines] E fitlhetswe mo melaneng ya { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Lokwalo lo lo na le diphoso!
+
+diagnostic-heading-error = Phoso
+diagnostic-heading-warning = Tlhagiso
+diagnostic-heading-information = Tshedimosetso
+diagnostic-heading-hint = Kgakololo
+
+accessibility-heading-level-1 = Tlolo ya WCAG AA ya Tsenogo
+accessibility-heading-level-2 = Tlhagiso ya tsenogo
+
+something-went-wrong = Go na le se se sa tsamayang sentle.
+
+renderer-load-failed = mmontshi o le mongwe ga o a kgona go tsena. Tsweetswee ntshafatsa tsebe.
+
+core-start-failed = Mmontshi wa lokwalo ga a a kgona go simolola. Tsweetswee ntshafatsa tsebe.

--- a/packages/i18n/locales/tn/content.ftl
+++ b/packages/i18n/locales/tn/content.ftl
@@ -1,0 +1,328 @@
+# Setswana content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# The roster calls this language **Tswana**, which is what `Intl.DisplayNames`
+# renders `tn` as and so what `<document lang>`'s autocomplete offers. Setswana
+# is the name its speakers use, and the two are one language — the same split
+# `st` has between Southern Sotho and Sesotho, and `ny` between Nyanja and
+# Chichewa.
+#
+# Setswana has no masculine or feminine, and it agrees an adjective with its
+# noun's **class**, so this catalog reads `$gender` as the class token rather
+# than as a gender — the same device `locales/sw` uses. `noun-gender` answers
+# `c3`, `c5`, `c7` or `c9`, and every adjective that carries a concord selects
+# on it.
+#
+# The concords this catalog writes out:
+#
+#           c3 (mo-/me-)  c5 (le-/ma-)  c7 (se-/di-)  c9 (N-)
+#   -ntsho   montsho       lentsho       sentsho       ntsho
+#   -tshweu  motshweu      letshweu      setshweu      tshweu
+#   -hibidu  mohibidu      lehibidu      sehibidu      khibidu
+#   -kima    mokima        lekima        sekima        kima
+#   -sesane  mosesane      lesesane      sesesane      sesane
+#
+# The qualificative particle — «mola *o* mokima», «ntlha *e* ntsho» — is left
+# out for the reason `locales/st` gives at length: the same string is what
+# `backgroundColor` reports standing alone, where a bare particle would be a
+# fragment, and nothing in `$role` tells the two positions apart.
+#
+# `style-filled-word` is the one entry that does carry a concord in front of
+# it — «o o tletseng», «se se tletseng» — and it is not the particle being
+# restored there: «tletseng» is a relative verb form, and the concord is part
+# of the word rather than a linker that could be dropped. It selects on
+# `$gender` like the adjectives do.
+#
+# Setswana and Sesotho are close enough that a reader may wonder why they are
+# two catalogs. They are two standard languages with two orthographies, and
+# this file is where that shows: Setswana writes «kgotsa» where Sesotho writes
+# «kapa», «boammaaruri» where Sesotho writes «nnete», and «-hibidu» where
+# Sesotho writes «-fubedu». Copying either file over the other would be wrong
+# in both.
+#
+# Adjectives follow the noun, so the composition messages put the noun first.
+# `$role` goes unused: Setswana marks no case.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [c3] montsho
+            [c5] lentsho
+            [c7] sentsho
+           *[c9] ntsho
+        }
+    .white =
+        { $gender ->
+            [c3] motshweu
+            [c5] letshweu
+            [c7] setshweu
+           *[c9] tshweu
+        }
+    .gray = boputswa
+    .red =
+        { $gender ->
+            [c3] mohibidu
+            [c5] lehibidu
+            [c7] sehibidu
+           *[c9] khibidu
+        }
+    .orange = namune
+    .yellow = serolwana
+    .green = botala jwa tlhaga
+    .cyan = sayane
+    .blue = bolou
+    .purple = phepolo
+    .pink = pinki
+    .brown = borokwa
+
+line-width =
+    .thick =
+        { $gender ->
+            [c3] mokima
+            [c5] lekima
+            [c7] sekima
+           *[c9] kima
+        }
+    .thin =
+        { $gender ->
+            [c3] mosesane
+            [c5] lesesane
+            [c7] sesesane
+           *[c9] sesane
+        }
+
+# Written as invariable «ka …» phrases rather than as adjectives, so that they
+# agree with nothing and can close the description. `style-stroke` puts them
+# last for that reason.
+line-style =
+    .dashed = ka dikgaotso
+    .dotted = ka dintlha
+
+fill-style =
+    .horizontal = mela e e rapameng
+    .vertical = mela e e emeng
+    .diagonal = mela e e sekameng
+    .backdiagonal = mela e e sekameng morago
+    .dots = dintlha
+    .diamonds = ditaemane
+
+noun =
+    .line = mola
+    .line-segment = karolo ya mola
+    .ray = lesedi
+    .vector = vektara
+    .curve = kobamo
+    .function = tiro
+    .parabola = parabola
+    .polyline = letlhotlho la mela
+    .polygon = polikone
+    .triangle = khutlotharo
+    .rectangle = khutlonne
+    .circle = sedikadikwe
+    .region = lefelo
+    .point = ntlha
+    .square = khutlonne e e lekanang
+    .diamond = taemane
+    .cross = sefapaano
+    .plus = letshwao la go oketsa
+
+# The side count goes in the tail, behind the adjectives, because «e e nang le
+# matlhakore a le 5» is a relative clause and Setswana closes a noun phrase
+# with one rather than opening one.
+noun-regular-polygon =
+    { $part ->
+        [tail] e e nang le matlhakore a le { $numSides }
+       *[head] polikone e e lekalekanang
+    }
+
+noun-gender =
+    { $noun ->
+        [line] c3
+        [polyline] c3
+        [border] c3
+        [ray] c5
+        [line-segment] c7
+        [region] c5
+        [circle] c7
+        [cross] c7
+        [fill] c7
+        [text] c5
+       *[other] c9
+    }
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c3] o o tletseng
+        [c5] le le tletseng
+        [c7] se se tletseng
+       *[c9] e e tletseng
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ka { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ka { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ka { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «moedi» is class 3 and leads its own adjectives, so the border's words agree
+# with it and not with the shape it surrounds. Setswana has no article, so the
+# two `-article` branches read like the two without, and the complement is
+# joined with the invariable «ka» whether it is the first clause or a further
+# one, so `[and]` reads like `[with]` as well. All four end up the same string.
+style-border-clause =
+    { $parts ->
+        [with-article] ka moedi { $border }
+        [and] ka moedi { $border }
+        [and-article] ka moedi { $border }
+       *[with] ka moedi { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = e e sa tlalang
+
+style-text =
+    { $parts ->
+        [background] { $color } mo godimo ga bokamorago { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ga go na sepe
+
+
+## Boolean words
+
+boolean-true = boammaaruri
+boolean-false = maaka
+
+
+## Answer buttons
+
+answer-submit-label = Tlhatlhoba Tiro
+answer-submit-label-no-correctness = Romela Karabo
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Tiro
+    .aside = Tlhaloso ya ka thoko
+    .cascade = Kaskade
+    .definition = Tlhaloso
+    .example = Sekai
+    .exercise = Boitshidilo
+    .exercises = Boitshidilo
+    .given-answer = Karabo
+    .note = Tlhokomelo
+    .objectives = Maikaelelo
+    .paragraphs = Dirapa
+    .part = Karolo
+    .problem = Bothata
+    .problems = Mathata
+    .proof = Bosupi
+    .question = Potso
+    .section = Karolo
+    .solution = Tharabololo
+    .task = Tiro
+    .theorem = Thiorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Kgakololo
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tafole { $enumeration }
+        [numbered-title] Tafole { $enumeration }{ ": " }
+        [unnumbered-title] Tafole{ ": " }
+       *[unnumbered] Tafole
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Setshwantsho { $enumeration }
+        [numbered-caption] Setshwantsho { $enumeration }{ ": " }
+        [unnumbered-caption] Setshwantsho{ ": " }
+       *[unnumbered] Setshwantsho
+    }
+
+
+## Paginator controls
+
+paginator-previous = E e fetileng
+paginator-next = E e latelang
+paginator-page = Tsebe
+
+paginator-page-status = { $pageLabel } { $currentPage } mo go { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = kgotsa
+piecewise-condition-if = fa
+piecewise-condition-otherwise = fa go sa nna jalo
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Botswana teaches secondary
+# science in English, and so does the North West, so a student meeting these
+# words meets them in English already; the seed has no settled Setswana list to
+# reproduce. A speaker adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Letshwao la Khemisi le le sa Siamang
+chemistry-invalid-ionic-compound = Motswako wa Ione o o sa Siamang

--- a/packages/i18n/locales/tn/diagnostics.ftl
+++ b/packages/i18n/locales/tn/diagnostics.ftl
@@ -1,0 +1,613 @@
+# Setswana diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — the Setswana verb takes its subject concord
+# from the noun class rather than from the count, and the argument is a list
+# either way. So those selects are dropped and the count argument goes unused.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = { $attributes } ga e elwe tlhoko fa dintlha tse pedi tsa bokhutlo di tlhalositswe
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } ga e elwe tlhoko fa ntlha ya bokhutlo le ntlha ya bogareng ka bobedi di tlhalositswe
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ga e na tshusumetso fa go se na ntlha ya bogareng
+
+## `<line>`
+
+line-points-undetermined-dimensions = Mola o feta mo dintlheng tse di nang le bogolo jo bo sa itsiweng.
+
+line-points-too-few-dimensions = Mola o tshwanetse go feta mo dintlheng tse di nang le bogolo jo bobedi bonnye.
+
+line-points-depend-on-variables = Mola o feta mo dintlheng tse di ikaegileng ka diphetogo: { $variables }.
+
+line-equation-invalid-format = Sebopego ga se a siama mo equation ya mola mo diphetogong { $variable1 } le { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Lesedi le tlhalositswe ka through, endpoint le direction ka botlhe. through e e tlhalositsweng ga e elwe tlhoko.
+
+ray-dimension-mismatch = numDimensions ga e tsamaelane mo leseding.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektara e tlhalositswe ka head, tail le displacement ka botlhe. head e e tlhalositsweng ga e elwe tlhoko.
+
+vector-dimension-mismatch = numDimensions ga e tsamaelane mo vektareng.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ga e kgone go gogelwa kwa `<{ $component }>` ka gonne ga e na phetogo ya seemo nearestPoint.
+
+constrain-to-without-nearest-point = Ga e kgone go golegwa mo `<{ $component }>` ka gonne ga e na phetogo ya seemo nearestPoint.
+
+constrain-to-interior-without-nearest-point = Ga e kgone go golegwa mo teng ga `<{ $component }>` ka gonne ga e na phetogo ya seemo nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ga e elwe tlhoko mo choiceInput e e seng ya mola o le mongwe
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Disupo tse di tlhalositsweng mo choiceInput ga di elwe tlhoko ka gonne palo ya disupo ga e tsamaelane le palo ya bana ba choice.
+
+pretzel-indices-count-mismatch = Disupo tse di tlhalositsweng mo problem ga di elwe tlhoko ka gonne palo ya disupo ga e tsamaelane le palo ya bana ba problem.
+
+shuffle-indices-count-mismatch = Disupo tse di tlhalositsweng mo shuffle ga di elwe tlhoko ka gonne palo ya disupo ga e tsamaelane le palo ya dilo.
+
+indices-ignored-out-of-range = Disupo tse di tlhalositsweng mo { $component } ga di elwe tlhoko ka gonne disupo dingwe di kwa ntle ga selekanyo.
+
+pretzel-indices-repeated = Disupo tse di tlhalositsweng mo pretzel ga di elwe tlhoko ka gonne disupo dingwe di boeleditswe.
+
+pretzel-circuit-first-index = Disupo tse di tlhalositsweng mo pretzel mo mokgweng wa circuit ga di elwe tlhoko ka gonne sesupo sa ntlha se tshwanetse go nna 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Gore `<{ $component }>` e dire le bana ba mofuta wa mokwalo, tshiamelo `type` e tshwanetse go tlhalosiwa.
+
+invalid-type-defaulting-to-math = type { $type } ga e a siama mo selong { $component }. E tshwanetse go nna nngwe ya math, text, number kgotsa boolean. E bewa math.
+
+string-not-valid-component-to-arrange = Mokwalo "{ $value }" ga se selo sa { $component } se se siameng. Ga se elwe tlhoko.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } ga e a siama, type e bewa number.
+
+invalid-variable-value = Boleng jwa phetogo ga bo a siama: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Sesupo sa mofuta { $index } se tshwanetse go nna palo
+
+variant-index-must-be-integer = Sesupo sa mofuta { $index } se tshwanetse go nna palo e e feletseng
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ga e a dirwa ka dikelo tse di tiileng. Bophara bo bewa ka dikarolo.
+
+side-by-side-absolute-margins = `<{ $component }>` ga e a dirwa ka dikelo tse di tiileng. Melelwane e bewa ka dikarolo.
+
+side-by-side-no-block-child = `<{ $component }>` ga e a siama: e tshwanetse go nna le ngwana a le mongwe bonnye wa mofuta wa boloko.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Tshiamelo `for` mo `<label>` ya setshwantsho ga e elwe tlhoko.
+
+label-for-must-resolve-to-one = Tshiamelo `for` mo `<label>` e tshwanetse go supa selo se le sengwe fela.
+
+label-for-unresolved = Tshiamelo `for` mo `<label>` ga e a kgona go supa selo sepe.
+
+label-for-answer-with-authored-inputs = Tshiamelo `for` mo `<label>` e supa `<answer>` e e nang le ditsenyo tse di kwadilweng; supa tsenyo ka boyona.
+
+label-for-answer-without-input = Tshiamelo `for` mo `<label>` e supa `<answer>` e e senang tsenyo e e ka rewang leina.
+
+label-for-must-reference-input-or-answer = Tshiamelo `for` mo `<label>` e tshwanetse go supa tsenyo kgotsa karabo.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ka ntlha ya tsenogo, `<{ $component }>` e tshwanetse go nna le tlhaloso e khutshwane kgotsa e tlhalosiwe e le ya mokgabiso.
+
+accessibility-video-short-description = Ka ntlha ya tsenogo, `<video>` e tshwanetse go nna le tlhaloso e khutshwane.
+
+accessibility-input-short-description-or-label = Ka ntlha ya tsenogo, `<{ $component }>` e tshwanetse go nna le tlhaloso e khutshwane kgotsa leina.
+
+accessibility-answer-input-short-description-or-label = Ka ntlha ya tsenogo, `<answer>` e e dirang tsenyo e tshwanetse go nna le tlhaloso e khutshwane kgotsa leina.
+
+accessibility-short-description-contains-math = Tlhaloso e khutshwane ga e a tshwanela go nna le dilo tsa dipalo jaaka `<{ $component }>`. Tlhalosa dipalo tsotlhe ka mafoko.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } e na le pharologano e e sa lekaneng mo mokwalong wa setlhogo sa karolo (mokgwa o o lefifi) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e tlhoka bonnye { $threshold }:1).
+       *[other] { $colorName } e na le pharologano e e sa lekaneng mo mokwalong wa setlhogo sa karolo ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e tlhoka bonnye { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` e e fetang mo dintlheng tse { $count } ga e ise e dirwe fa dintlha tseo di se na boleng jwa dipalo.
+
+circle-too-many-through-points = Ga e kgone go bala sedikadikwe se se fetang mo dintlheng tse di fetang 3.
+
+circle-overprescribed-radius-center-points = Ga e kgone go bala sedikadikwe se se nang le radiase, bogare le dintlha tsa go feta tsotlhe di tlhalositswe.
+
+circle-center-with-multiple-points = Ga e kgone go bala sedikadikwe se se nang le bogare jo bo tlhalositsweng se se fetang mo dintlheng tse di fetang 1.
+
+circle-radius-too-small = Ga e kgone go bala sedikadikwe: ka gonne sekgala fa gare ga dintlha tse pedi ke { $distance }, radiase { $radius } e e tlhalositsweng e nnye thata.
+
+circle-radius-with-many-points = Ga e kgone go dira sedikadikwe se se fetang mo dintlheng tse di fetang tse pedi se se nang le radiase e e tlhalositsweng.
+
+circle-invalid-center-or-through-points = Bogare jwa sedikadikwe kgotsa dintlha tsa sona tsa go feta ga di a siama.
+
+circle-radius-center-with-multiple-points = Ga e kgone go bala radiase ya sedikadikwe se se nang le bogare jo bo tlhalositsweng se se fetang mo dintlheng tse di fetang 1.
+
+circle-change-radius-non-numerical = Ga e kgone go fetola radiase ya sedikadikwe se se fetang mo dintlheng tse di senang boleng jwa dipalo
+
+circle-radius-with-points-non-numerical = Ga e kgone go dira sedikadikwe se se fetang mo dintlheng tse di fetang e le nngwe se se nang le radiase e e tlhalositsweng fa go se na boleng jwa dipalo.
+
+circle-change-center-non-numerical = Go fetola bogare jwa sedikadikwe se se fetang mo dintlheng tse di senang boleng jwa dipalo ga go ise go dirwe.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Bogolo jwa lefelo la tiro ga bo a lekana. Lefelo le na le dikgaoganyo tse { $intervals } mme tiro e na le ditsenyo tse { $inputs }.
+
+function-domain-invalid-format = Sebopego sa lefelo la tiro ga se a siama.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ntlha e kgolo ya tiro e e seng ya dipalo ga e elwe tlhoko.
+        [minimum] Ntlha e nnye ya tiro e e seng ya dipalo ga e elwe tlhoko.
+        [extremum] Ntlha ya bokhutlo ya tiro e e seng ya dipalo ga e elwe tlhoko.
+        [point] Ntlha ya tiro e e seng ya dipalo ga e elwe tlhoko.
+        [slope] Sekamo sa tiro se se seng sa dipalo ga se elwe tlhoko.
+       *[other] { $type } ya tiro e e seng ya dipalo ga e elwe tlhoko.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ntlha e kgolo ya tiro e e senang sepe ga e elwe tlhoko.
+        [minimum] Ntlha e nnye ya tiro e e senang sepe ga e elwe tlhoko.
+        [extremum] Ntlha ya bokhutlo ya tiro e e senang sepe ga e elwe tlhoko.
+        [point] Ntlha ya tiro e e senang sepe ga e elwe tlhoko.
+       *[other] { $type } ya tiro e e senang sepe ga e elwe tlhoko.
+    }
+
+function-points-too-close = Tiro e na le dintlha tse pedi tse di gaufi thata. Tiro ga e kgone go tlhalosiwa.
+
+function-iterates-input-output-mismatch = Go boeletsa tiro go kgonagala fela fa palo ya ditsenyo e lekana le palo ya ditlhagiso. Tiro e e na le ditsenyo tse { $inputs } le ditlhagiso tse { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Boleele jwa tatelano ga bo a siama. Bo tshwanetse go nna palo e e feletseng e e seng kwa tlase ga zero.
+
+sequence-invalid-step = Kgato ya tatelano ga e a siama. Mo tatelanong ya mofuta { $type } e tshwanetse go nna palo.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ya tatelano ya dipalo ga e a siama. E tshwanetse go nna palo.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ya tatelano ya ditlhaka ga e a siama. E tshwanetse go nna ditlhaka.
+
+sequence-invalid-endpoint = "{ $attribute }" ya tatelano ga e a siama.
+
+select-from-sequence-coprime-not-numbers = coprime ga e elwe tlhoko ka gonne ga se dipalo tse di tlhophiwang
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ga e elwe tlhoko ka gonne excludeCombinations e tlhalositswe
+
+## Resolving a `target`
+
+target-not-found = target ga e a siama mo `<{ $source }>`: maikaelelo ga a a fitlhelwa.
+
+target-state-variable-not-found = target ga e a siama mo `<{ $source }>`: phetogo ya seemo e e nang le leina "{ $property }" ga e a fitlhelwa mo `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Diphetogo tsa `<odeSystem>` di tshwanetse go farologana le phetogo e e ikemetseng.
+
+ode-system-duplicate-variable-names = Ga e kgone go tlhalosa ditiro tsa ODE RHS tse di nang le maina a diphetogo a a boeleditsweng.
+
+ode-system-rhs-function-error = Ga e kgone go tlhalosa tiro ya ODE RHS. Phoso fa go dirwa tiro ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ga e kgone go tlhalosa sekhutlo fa gare ga mela e { $count }
+
+angle-invalid-through-point = Ntlha ga e a siama mo through ya `<angle>`
+
+parabola-vertex-too-many-points = Parabola e e nang le ntlha e kgolo e e fetang mo dintlheng tse di fetang 1 ga e ise e dirwe.
+
+parabola-too-many-points = Parabola e e fetang mo dintlheng tse di fetang 3 ga e ise e dirwe.
+
+intersection-too-many-items = Kgabaganyo ya dilo tse di fetang tse pedi ga e ise e dirwe
+
+## Other math components
+
+ionic-compound-not-two-ions = Motswako wa ione o o fetang di-ione tse pedi ga o ise o dirwe.
+
+ionic-compound-needs-cation-and-anion = Motswako wa ione o diretswe cation e le nngwe le anion e le nngwe fela.
+
+solve-equations-cannot-evaluate = Ga e kgone go rarabolola equation ka gonne equation ga e a kgona go balwa: { $equation }
+
+math-operators-operand-number-required = operandNumber e tshwanetse go tlhalosiwa fa go ntshiwa operand ya dipalo.
+
+eigen-decomposition-failed = Ga e kgone go bala boleng jwa eigen jwa matrix
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: diparamitara { $parameters } ga di tlhage mo sebopegong, ka jalo di tla tsamaelana le lefela ka metlha.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ga e kgone go tlhalosa grid="{ $grid }". E tshwanetse go nna none, medium, dense, kgotsa dipalo tse pedi tse di siameng tse di kgaogantsweng ka sebaka, jaaka grid="1 0.5". Ga go na grid e e gatisiwang.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ga e tshegediwe mo mmontshing wa prefigure; boitshwaro jwa lefelo la moja bo dirisiwa.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ga e tshegediwe mo mmontshing wa prefigure; boitshwaro jwa lefelo la godimo bo dirisiwa.
+
+prefigure-invalid-axis-bounds = `<graph>`: melelwane ya axis ga e a siama mo phetolong ya prefigure; bbox (-10,-10,10,10) e dirisiwa.
+
+prefigure-invalid-width = `<graph>`: bophara ga bo a siama mo phetolong ya prefigure; bophara jwa setshwantsho 425 bo dirisiwa.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio ga e a siama mo phetolong ya prefigure; selekanyo 1 se dirisiwa.
+
+prefigure-grid-spacing-too-fine = `<graph>`: dikgaoganyo tsa grid di nnye thata mo melelwaneng ya axis; grid e tlogetswe mo mmontshing wa prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: ditlhokomelo ga di kitla di bontshiwa fa mmontshi wa PreFigure a sa dirisiwe.
+
+multiple-annotations-children = Bana ba bantsi ba `<annotations>` ba fitlhetswe mo `<graph>`; botlhe ga ba elwe tlhoko fa e se wa bofelo.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ga e kgone go atolosa kgotsa go kopa mofuta wa selo o o sa itsiweng: { $type }.
+
+copy-prop-not-found = Tshiamelo { $property } ga e a fitlhelwa mo selong sa mofuta { $component }
+
+collect-no-source = Ga go na motswedi o o fitlhetsweng wa collect.
+
+collect-invalid-component-type = Ga e kgone go kokoanya dilo tsa mofuta `<{ $component }>` ka gonne ke mofuta wa selo o o sa siamang.
+
+reference-index-unavailable = Ga e kgone go supa sesupo `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ga e kgone go bitsa { $action } mo selong `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Sebopego sa data ga se a siama. Mela e na le boleele jo bo sa tsamaelaneng. E fitlhetswe mo componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data e na le maina a mela e e emeng a a boeleditsweng. E fitlhetswe mo componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data ga e na leina la mola o o emeng. E fitlhetswe mo componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = award e le nngwe ya karabo e e ikaegile ka karabo e e romilweng ke tagi answer ka boyona, mme seo se tla tlisa boitshwaro jo bo sa lebelelwang.
+
+answer-max-num-attempts-in-section-wide-check-work = Go baya `maxNumAttempts` mo `<answer>` e e mo teng ga sejana se se nang le `sectionWideCheckWork` ga go na tshusumetso, ka gonne sejana seo ke sona se se laolang palo ya diteko. Baya `maxNumAttempts` mo sejaneng ka bosona.
+
+nested-section-wide-check-work-max-num-attempts = Go baya `maxNumAttempts` mo sejaneng se se nang le `sectionWideCheckWork` se se mo teng ga sejana se sengwe se se nang le `sectionWideCheckWork` ga go na tshusumetso, ka gonne sejana sa kwa ntle ke sona se se laolang palo ya diteko. Baya `maxNumAttempts` mo sejaneng sa kwa ntle.
+
+answer-attributes-need-symbolic-equality = Ditshiamelo { $attributes } ga di kitla di nna le tshusumetso fa symbolicEquality e sa bewa.
+
+answer-invalid-type = Mofuta ga o a siama mo karabong: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ka gonne selo `<{ $component }>` ga se na leina, ga se kgone go dirisiwa e le tshiamelo ya module
+
+module-attribute-name-already-defined = Selo `<{ $component } name="{ $name }">` ga se kgone go dirisiwa e le tshiamelo ya module ka gonne mofuta wa selo `<module>` o setse o na le tshiamelo e e nang le leina "{ $name }".
+
+conditional-content-condition-ignored = Tshiamelo `condition` ga e elwe tlhoko mo selong `<conditionalContent>` se se nang le bana ba case kgotsa else.
+
+slider-markers-type-mismatch = Mofuta wa matshwao ga o tsamaelane le mofuta wa slider.
+
+pretzel-problem-needs-statement-and-answer = pretzel ga e a siama: `<problem>` nngwe le nngwe e tshwanetse go nna le `<statement>` e le nngwe le `<answer>` e le nngwe.
+
+pretzel-circuit-first-problem-distractor = pretzel ga e a siama: mo mode="circuit", `<problem>` ya ntlha ga e kgone go nna ya go tsietsa.
+
+## Attribute values
+
+attribute-invalid-values = Boleng { $values } ga bo a siama mo tshiamelong `{ $attribute }`; ga bo elwe tlhoko.
+
+attribute-must-be-references = Boleng `{ $value }` ga bo a siama mo tshiamelong `{ $attribute }`. Tshiamelo e tshwanetse go dirwa ka disupo tse di simololang ka `$`.
+
+math-input-invalid-function-names = <mathInput>: maina a ditiro a a sa siamang mo { $attribute } ga a elwe tlhoko: { $names }. Karolo e e bontshiwang ya leina lengwe le lengwe e tshwanetse go nna le ditlhaka tse 2 bonnye (ditlhaka kgotsa mela); tlatsetso `|<mathspeak alternative>` e ka latela.
+
+## Building components from the source
+
+component-type-invalid = Mofuta wa selo ga o a siama: `<{ $componentType }>`
+
+attribute-repeated = Tshiamelo { $attribute } ga e kgone go boelediwa.
+
+attribute-invalid-for-component = Tshiamelo "{ $attribute }" ga e a siama mo selong sa mofuta `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Tlhaloso ya setaele { $styleNumber } e na le pharologano e e sa lekaneng mo { $context ->
+        [text-on-background] mmala wa mokwalo kgatlhanong le mmala wa bokamorago
+        [high-contrast] mmala wa pharologano e kgolo kgatlhanong le lesela
+        [line] mmala wa mola kgatlhanong le lesela
+        [marker] mmala wa letshwao kgatlhanong le lesela
+       *[text-on-canvas] mmala wa mokwalo kgatlhanong le lesela
+    }{ $mode ->
+        [dark] { " (mokgwa o o lefifi)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e tlhoka bonnye { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Le fa tlhaloso ya setaele { $styleNumber } e tlhalositse mebala e e nang le pharologano e e lekaneng mo mokgweng o o phatsimang, mebala ya mokgwa o o lefifi e e tswang mo go yona e na le pharologano e e sa lekaneng mo mmaleng wa mokwalo kgatlhanong le mmala wa bokamorago ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e tlhoka bonnye { $threshold }:1). { $suggestion ->
+        [available] Go netefatsa pharologano e e lekaneng mo mokgweng o o lefifi, oketsa pharologano ya mokgwa o o phatsimang (sekai baya { $lightAttribute }="{ $lightColor }") kgotsa fetola mmala wa mokgwa o o lefifi (sekai baya { $darkAttribute }="{ $darkColor }").
+       *[none] Go netefatsa pharologano e e lekaneng mo mokgweng o o lefifi, oketsa pharologano ya mokgwa o o phatsimang kgotsa fetola mebala e e tswang mo go yona ka textColorDarkMode le/kgotsa backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Le fa tlhaloso ya setaele { $styleNumber } e tlhalositse mmala wa mokwalo o o nang le pharologano e e lekaneng mo mokgweng o o phatsimang, mmala wa mokwalo wa mokgwa o o lefifi o o tswang mo go ona o na le pharologano e e sa lekaneng kgatlhanong le lesela ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e tlhoka bonnye { $threshold }:1). { $suggestion ->
+        [available] Go netefatsa pharologano e e lekaneng mo mokgweng o o lefifi, oketsa pharologano ya mokgwa o o phatsimang (sekai baya textColor="{ $lightColor }") kgotsa fetola mmala wa mokgwa o o lefifi (sekai baya textColorDarkMode="{ $darkColor }").
+       *[none] Go netefatsa pharologano e e lekaneng mo mokgweng o o lefifi, oketsa pharologano ya mokgwa o o phatsimang kgotsa fetola mmala o o tswang mo go ona ka textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Karolo e ka tlhopha <stylePalette> e le nngwe fela; ya bofelo e dirisiwa.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ka gonne numToSelect ga se palo e e feletseng e e seng kwa tlase ga zero.
+
+variant-num-to-select-not-constant-number = ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ka gonne numToSelect ga se palo e e sa fetogeng.
+
+variant-with-replacement-not-constant-boolean = ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ka gonne withReplacement ga se boolean e e sa fetogeng.
+
+variant-select-weight-disables-unique = Mefuta e e ikgethileng ya select e a timiwa fa go na le kgetho e e nang le selectWeight kgotsa selectForVariants e e tlhalositsweng
+
+variant-coprime-undetermined = ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ka gonne ga e kgone go netefatsa gore coprime ke maaka ka metlha.
+
+variant-attribute-not-constant = ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ka gonne { $attribute } ga e a nitama.
+
+variant-attribute-not-number = ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ka gonne { $attribute } ga se palo.
+
+variant-attribute-wrong-type-for-sequence =
+    ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ya mofuta { $type } ka gonne { $attribute } ga se { $expected ->
+        [letters-combination] motswako wa ditlhaka
+        [math-expression] polelo ya dipalo e e siameng
+        [integer] palo e e feletseng
+       *[number] palo
+    }.
+
+variant-length-not-integer = ga e kgone go tlhalosa mefuta e e ikgethileng ya { $component } ka gonne length ga se palo e e feletseng.
+
+variant-sort-not-implemented = mefuta e e ikgethileng ya { $component } e e nang le sort ga e ise e dirwe
+
+variant-exclude-combinations-not-implemented = mefuta e e ikgethileng ya { $component } e e nang le excludeCombinations ga e ise e dirwe
+
+variant-math-exclude-not-implemented = mefuta e e ikgethileng ya { $component } ya mofuta math e e nang le exclude ga e ise e dirwe
+
+variant-non-constant-exclude-not-implemented = mefuta e e ikgethileng ya { $component } e e nang le exclude e e sa nitamang ga e ise e dirwe
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ga e tshegediwe mo mmontshing wa graph prefigure; setlogolo se tlodilwe.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometry e e senang molelwane kgotsa e e sa feleleng; setlogolo se tlodilwe.
+
+prefigure-curve-label-omitted = { $subject }: maina ga a tshegediwe mo dilong tsa kobamo tse di fetotsweng; leina le tlogetswe.
+
+prefigure-curve-unsupported-definition-type = { $subject }: mofuta wa tlhaloso ya tiro ya kobamo '{ $definitionType }' ga o tshegediwe; setlogolo se tlodilwe.
+
+prefigure-region-flip-functions-unsupported = { $subject }: tshiamelo flipFunctions mo regionBetweenCurves ga e tshegediwe; setlogolo se tlodilwe.
+
+prefigure-region-non-formula-child = { $subject }: ditiro tsa bana ba mofuta formula fela ke tse di tshegediwang mo regionBetweenCurves; setlogolo se tlodilwe.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ga e tshegediwe mo { $labelKind ->
+        [line-family] leina la lelapa la mola
+       *[point] leina la ntlha
+    }; thulaganyo ya PreFigure e dirisiwa.
+
+prefigure-fill-style-unsupported = { $subject }: setaele sa go tlatsa '{ $fillStyle }' ga se tshegediwe ke PreFigure; e boela mo go tlatseng ka mmala o le mongwe.
+
+prefigure-line-style-unknown = { $subject }: setaele sa mola '{ $lineStyle }' ga se itsiwe mme se tlogetswe mo ditlhagisong tsa PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: setaele sa letshwao '{ $markerStyle }' se tsamaelantswe le setaele sa PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: setaele sa letshwao '{ $markerStyle }' ga se tshegediwe ke PreFigure; setaele se se leng teng ka tlwaelo se dirisiwa.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ga e a siama; maikaelelo ga a kgone go itsiwe. Tlhokomelo e tlogetswe.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` e tlhalositse maikaelelo a mantsi; maikaelelo a ntlha a dirisiwa.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ga e a siama; maikaelelo a kwa ntle ga kerafo e e a tshotseng. Tlhokomelo e tlogetswe.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ga e a siama; maikaelelo ga se selo sa setshwantsho se se tshegediwang mo phetolong ya prefigure. Tlhokomelo e tlogetswe.
+
+annotation-text-missing = `<annotation>`: `text` ga e yo kgotsa ga e na sepe; mokwalo o o senang sepe o ntshiwa.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Boikaego jo bo dikologang bo fitlhetswe.
+       *[other] Boikaego jo bo dikologang jo bo amang selo `<{ $componentType }>` bo fitlhetswe.
+    }
+
+reference-no-referent = Ga go na sepe se se fitlhetsweng mo sesupong: `{ $reference }`
+
+reference-multiple-referents = Dilo tse dintsi di fitlhetswe mo sesupong: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Sebopego ga se a siama mo tshiamelong { $attribute } ya `<{ $componentType }>`.
+
+children-invalid = Bana ga ba a siama mo `<{ $componentType }>`: Bana ba ba sa siamang ba fitlhetswe: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Boleng `{ $value }` ga bo a siama mo tshiamelong `{ $attribute }`, boleng `{ $default }` bo dirisiwa
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML mofuta { $version } ga o a fitlhelwa.
+       *[other] DoenetML mofuta { $version } ga o a fitlhelwa. E boela mo mofuteng { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ga e a siama: { $content }
+
+parse-tag-missing-close-tag = DoenetML ga e a siama: Tagi `{ $tag }` ga e na tagi ya go tswala. Go ne go lebeletswe tagi e e itswalang kgotsa tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ga e a siama: Phoso mo taging `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ga e a siama: Tshiamelo `{ $attribute }` e e sa siamang e bonala e sena boleng.
+
+parse-attribute-invalid = DoenetML ga e a siama: Tshiamelo `{ $attribute }` ga e a siama
+
+parse-attribute-value-invalid = DoenetML ga e a siama: Boleng jwa tshiamelo `{ $value }` ga bo a siama
+
+parse-attribute-value-quote-mismatch = DoenetML ga e a siama: Boleng jwa tshiamelo `{ $value }` ga bo a siama. Matshwao a mafoko ga a tsamaelane. Go bonala `{ $quote }` e tlhaela
+
+parse-open-tag-name-missing = DoenetML ga e a siama: Go fitlhetswe tagi e e senang leina, sekai `<`
+
+parse-tag-not-closed = DoenetML ga e a siama: Tagi `{ $tag }` ga e a tswalwa (go bonala `>` e tlhaela).
+
+parse-self-closing-tag-name-missing = DoenetML ga e a siama: Go fitlhetswe tagi e e senang leina `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ga e a siama: Tagi `{ $tag }` ga e a tswalwa (go bonala `/>` e tlhaela).
+
+parse-tag-invalid-attributes = DoenetML ga e a siama: Tagi `{ $tag }` ga e a siama. Gongwe e na le ditshiamelo tse di sa siamang.
+
+parse-close-tag-name-missing = DoenetML ga e a siama: Go fitlhetswe tagi ya go tswala e e senang leina, sekai `</`
+
+parse-attribute-value-unquoted = Boleng jwa ditshiamelo bo tshwanetse go bewa mo gare ga matshwao a mafoko: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ga e a siama: Go fitlhetswe tagi ya go tswala `{ $tag }`, mme ga go na tagi ya go bula e e tsamaelanang
+
+parse-close-tag-mismatched = DoenetML ga e a siama: Tagi ya go tswala ga e tsamaelane. Go ne go lebeletswe `</{ $expected }>`. Go fitlhetswe `{ $found }`
+
+parser-node-unconvertible = Ga go a kgonagala go fetola node { $node } go nna node ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    Tshiamelo name='{ $name }' ga e a siama. { $reason ->
+        [characters] Maina a ka nna le ditlhaka, dipalo, mela ya kwa tlase kgotsa mela fela.
+       *[start] Maina a tshwanetse go simolola ka tlhaka.
+    }
+
+component-name-invalid-start = Leina la selo "{ $name }" ga le a siama. Maina a tshwanetse go simolola ka tlhaka.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Karabo ya mofuta videoWatched e tshwanetse go nna le tshiamelo video
+
+answer-video-watched-video-not-reference = Karabo ya mofuta videoWatched e tshwanetse go nna le tshiamelo video e e leng sesupo
+
+answer-name-not-single-text = Tshiamelo name ya karabo e tshwanetse go nna le ngwana a le mongwe fela wa text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ga e kgone go bona DoenetML ya kwa ntle ka ntlha ya go boeletsa mo gontsi thata. A go na le sesupo se se dikologang?
+
+external-doenetml-unavailable = Ga e kgone go bona DoenetML go tswa mo { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML e e bonweng go tswa mo { $attribute }="{ $uri }" ga e a siama: ga e tsamaelane le mofuta wa selo "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Tshiamelo `{ $from }` e feditswe ke nako; dirisa `{ $to }`.
+       *[other] [deprecation] Tshiamelo `{ $from }` mo `<{ $component }>` e feditswe ke nako; dirisa `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Tshiamelo `{ $from }` e feditswe ke nako mme ga e elwe tlhoko ka gonne `{ $to }` le yona e tlhalositswe.
+       *[other] [deprecation] Tshiamelo `{ $from }` mo `<{ $component }>` e feditswe ke nako mme ga e elwe tlhoko ka gonne `{ $to }` le yona e tlhalositswe.
+    }
+
+deprecated-attribute-ignored = [deprecation] Tshiamelo `{ $attribute }` mo `<{ $component }>` e feditswe ke nako mme ga e elwe tlhoko.
+
+deprecated-attribute-to-child = [deprecation] Tshiamelo `{ $attribute }` mo `<{ $component }>` e feditswe ke nako; dirisa ngwana `<{ $child }>`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` e ka dira bontsi ka Sekgoa fela, ka jalo mokwalo wa yona o sala jaaka o ntse mo lokwalong lo lo kwadilweng ka { $locale }. Kwala sebopego sa bontsi ka bowena, kgotsa se baye mo tshiamelong `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Selo `<{ $tag }>` ga se selo sa Doenet se se itsiweng.
+
+schema-element-not-allowed-at-root = Selo `<{ $tag }>` ga se letlelelwe mo moding wa lokwalo.
+
+schema-element-not-allowed-inside = Selo `<{ $tag }>` ga se letlelelwe mo teng ga `<{ $parent }>`.
+
+schema-attribute-unrecognized = Selo `<{ $tag }>` ga se na tshiamelo e e nang le leina `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Tshiamelo `{ $attribute }` ya selo `<{ $tag }>` e tshwanetse go nna lenaneo le selo sengwe le sengwe mo go lona e leng nngwe ya: { $allowed }
+       *[other] Tshiamelo `{ $attribute }` ya selo `<{ $tag }>` e tshwanetse go nna nngwe ya: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Leina la mofuta ga le a siama mo select. Leina la mofuta { $variantName } le tlhaga mo dikgethong tse { $numOptions } mme palo ya go tlhopha ke { $numToSelect }.
+
+select-variant-name-without-options = Mefuta mengwe e tlhalositswe mo select mme ga go na kgetho e e tlhalositsweng mo leineng la mofuta le le kgonagalang: { $variantName }.
+
+select-variant-name-not-possible = Leina la mofuta { $variantName } le le tlhalositsweng mo select ga se leina la mofuta le le kgonagalang.
+
+select-too-few-options = Ga e kgone go tlhopha dilo tse { $numToSelect } mo go { $numOptions } fela.
+
+select-from-sequence-too-few-values = Ga e kgone go tlhopha boleng jo { $numToSelect } mo tatelanong e e nang le boleele jwa { $length }.
+
+select-from-sequence-indices-count-mismatch = Palo ya disupo tse di tlhalositsweng mo select e tshwanetse go tsamaelana le palo ya go tlhopha
+
+select-from-sequence-indices-not-integers = Disupo tsotlhe tse di tlhalositsweng mo select di tshwanetse go nna dipalo tse di feletseng
+
+select-from-sequence-index-excluded = Go tlhalositswe sesupo sa selectfromsequence se se ntshitsweng
+
+select-from-sequence-indices-excluded-combination = Go tlhalositswe disupo tsa selectfromsequence tse di neng di le motswako o o ntshitsweng
+
+select-from-sequence-coprime-not-positive-integers = Ga e kgone go tlhopha metswako ya dipalo tse di sa kgaoganeng ka gonne ga se dipalo tse di feletseng tse di kwa godimo ga zero tse di tlhophiwang.
+
+select-from-sequence-coprime-common-factor = Ga e kgone go tlhopha dipalo tse di sa kgaoganeng. Boleng jotlhe jo bo kgonagalang bo abelana kgaolo e le nngwe. (Boleng jo bo tlhalositsweng jwa "from" kgotsa "to" bo tshwanetse go se abelane le "step".)
+
+select-from-sequence-coprime-single-number = Ga e kgone go tlhopha metswako ya dipalo tse di sa kgaoganeng mo palong e le nngwe e e seng 1.
+
+select-from-sequence-excluded-too-many-combinations = Go feta 70% ya metswako e ntshitswe mo selectFromSequence
+
+select-from-sequence-coprime-none-found = Ga go a kgonagala go tlhopha dipalo tse di sa kgaoganeng. Boleng jotlhe jo bo kgonagalang bo abelana kgaolo e le nngwe.
+
+select-from-sequence-too-few-unique-values = Ga e kgone go tlhopha boleng jo bo ikgethileng jo { $numToSelect } mo tatelanong e e nang le boleele jwa { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Ga e kgone go tlhopha boleng jo { $numToSelect } mo lenaneong la dipalo tsa prime le le nang le boleele jwa { $numValues }
+
+select-prime-numbers-values-count-mismatch = Palo ya boleng jo bo tlhalositsweng mo select e tshwanetse go tsamaelana le palo ya go tlhopha
+
+select-prime-numbers-values-not-prime = Boleng jotlhe jo bo tlhalositsweng mo select prime number bo tshwanetse go nna mo lenaneong la dipalo tsa prime
+
+select-prime-numbers-values-excluded-combination = Boleng jwa selectPrimeNumbers jo bo tlhalositsweng bo ne bo le motswako o o ntshitsweng
+
+select-prime-numbers-excluded-too-many-combinations = Go feta 70% ya metswako e ntshitswe mo selectPrimeNumbers
+
+select-random-combination-fluke = Ka tsela e e sa tlwaelegang, ga go a kgonagala go tlhopha motswako wa boleng jo bo sa rulaganngwang
+
+select-random-value-fluke = Ka tsela e e sa tlwaelegang, ga go a kgonagala go tlhopha boleng jo bo sa rulaganngwang

--- a/packages/i18n/locales/tn/editor.ftl
+++ b/packages/i18n/locales/tn/editor.ftl
@@ -1,0 +1,214 @@
+# Setswana editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Setswana marks number with a class prefix and keeps doing so after a numeral,
+# so the counted messages keep their selects.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Busetsa
+       *[update] Ntshafatsa
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Mmontshi
+       *[other] { $word } Mmontshi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Mofuta
+editor-variant-filter = Tlhopha...
+editor-variant-next = Tlhopha mofuta o o latelang
+editor-variant-previous = Tlhopha mofuta o o fetileng
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Tlolo ya WCAG AA ya tsenogo e fitlhetswe. Tobetsa go { $action ->
+            [close] tswala
+           *[open] bula
+        } pego ya tsenogo.
+        [advisories] Tobetsa go { $action ->
+            [close] tswala
+           *[open] bula
+        } pego ya tsenogo. Ga go na tlolo ya WCAG AA e e fitlhetsweng, mme go na le dikgakololo tse dingwe tsa tsenogo.
+       *[clean] Tobetsa go { $action ->
+            [close] tswala
+           *[open] bula
+        } pego ya tsenogo. Ga go na bothata jwa tsenogo jo bo fitlhetsweng.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Tlolo ya WCAG AA ya tsenogo e fitlhetswe. { $count ->
+            [one] Tlolo e le { $count } ya WCAG AA e fitlhetswe
+           *[other] Ditlolo tse { $count } tsa WCAG AA di fitlhetswe
+        }. Tobetsa go { $action ->
+            [close] tswala
+           *[open] bula
+        } pego ya tsenogo.
+        [advisories] Ga go na tlolo ya WCAG AA e e fitlhetsweng. { $count ->
+            [one] Kgakololo e le { $count } e nngwe ya tsenogo e fitlhetswe
+           *[other] Dikgakololo tse { $count } tse dingwe tsa tsenogo di fitlhetswe
+        }. Tobetsa go { $action ->
+            [close] tswala
+           *[open] bula
+        } pego ya tsenogo.
+       *[clean] Ga go na tlolo ya WCAG AA e e fitlhetsweng. Tobetsa go { $action ->
+            [close] tswala
+           *[open] bula
+        } pego ya tsenogo.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML mofuta { $version }
+
+editor-tab-help = Thuso e e tsamaelanang le lefelo
+editor-tab-help-short = Lefelo
+editor-tab-errors = Diphoso
+editor-tab-warnings = Ditlhagiso
+editor-tab-info = Tshedimosetso
+editor-tab-accessibility = Tsenogo
+editor-tab-responses = Dikarabo tse di romilweng
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Ditlhopho tsa mokwadi
+editor-format-as-doenetml = Rulaganya jaaka DoenetML
+editor-format-as-xml = Rulaganya jaaka XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Mola #{ $line }
+
+editor-no-errors = Ga go na Diphoso
+editor-no-warnings = Ga go na Ditlhagiso
+editor-no-info = Ga go na Tlhatlhobo ya Tshedimosetso
+
+editor-show-info-annotations = Bontsha ditlhatlhobo tsa tshedimosetso mo mokwading
+editor-show-accessibility-annotations = Bontsha ditlhatlhobo tsa tsenogo mo mokwading
+
+editor-accessibility-learn-more = Ithute ka fa Doenet e dirisanang ka teng le tsenogo
+
+editor-accessibility-violations-heading = Ditlolo tsa tsenogo ({ $standard })
+
+editor-accessibility-other-heading = Mathata a mangwe a tsenogo
+editor-none-found = Ga go na sepe se se fitlhetsweng
+
+
+## Submitted responses
+
+editor-no-responses = Ga go na karabo e e romilweng go fitlha jaanong
+editor-response-answer-id = Leina la Karabo
+editor-response-response = Karabo
+editor-response-credit = Matshwao
+editor-response-submitted = E romilwe
+
+
+## The context-help panel
+
+help-placeholder = Baya sesupo mo godimo ga leina la tagi, tshiamelo kgotsa { $ref } go bona dikwalo.
+
+help-unsupported-ref-chain = Thuso ya disupo tsa dikarolo tse dintsi jaaka { $example } ga e ise e nne teng.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ga go na sepe se se fitlhetsweng mo sesupong: { $ref }.
+        [multiple] Dilo tse dintsi di fitlhetswe mo sesupong: { $ref }.
+       *[indeterminate] Se { $ref } e se supang ga se itsiwe.
+    }
+
+help-learn-about-references = Ithute ka disupo →
+help-reference-page = Tsebe ya disupo →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Mo teng ga { $element }
+       *[top] Mo boemong jo bo kwa godimo
+    }{ $allowed ->
+        [none] { " — ga go sepe se se tsenang fano." }
+        [text] { " — kwala mokwalo fano." }
+        [text-and-components] { " — kwala mokwalo fano, kgotsa leka:" }
+       *[components] { " — dilo tse o ka di lekang:" }
+    }
+
+help-suggestions-footer = Tobetsa { $shortcut } go bona dilo tsotlhe tse { $total }.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ke sesupo sa { $target }.
+       *[other] { $ref } ke sesupo sa { $target } (mola { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } o e reile leina la { $role }.
+       *[other] { $owner } o e reile leina la { $role } mo moleng wa { $line }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ke sesupo sa tshiamelo { $property } ya { $element }.
+       *[other] { $ref } ke sesupo sa tshiamelo { $property } ya { $element } (mola { $line }).
+    }
+
+help-kind-attribute = tshiamelo
+help-kind-snippet = karolwana ya mokwalo
+help-kind-array-entry = tsenyo ya lenaneo
+
+help-default = E teng ka tlwaelo:
+help-active-default = E teng ka tlwaelo mme e a dira:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Boleng jo bo letleletsweng (bo le bongwe mo selong sengwe le sengwe):
+       *[other] Boleng jo bo letleletsweng:
+    }
+
+help-suggested-values = Boleng jo bo atlenegisitsweng:
+
+help-inserts = E tsenya:
+
+help-coordinates =
+    { $count ->
+        [one] Sesupanepo:
+       *[other] Disupanepo:
+    }
+
+help-type = Mofuta:
+
+help-resolved-style = Setaele se se itsiweng (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Maina a ditiro a a itsiweng:
+help-reset-list = Lenaneo le le busediwang mo tsenyong e:
+help-added-on-input = Se se okeditsweng mo tsenyong e:
+help-removed-on-input = Se se ntshitsweng mo tsenyong e:
+
+help-reset-overrides = { $reset } e feta { $additional } le { $removed }.

--- a/packages/i18n/locales/wo/chrome.ftl
+++ b/packages/i18n/locales/wo/chrome.ftl
@@ -1,0 +1,138 @@
+# Wolof viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# CLDR gives Wolof one plural category, and it is right to: number is marked on
+# the determiner and the class linker — «xët bi», «xët yi» — and the noun and
+# the numeral beside it do not change shape. So the counted messages drop their
+# selects, and a `[one]` differing from its `[other]` would be wrong rather
+# than merely redundant. `attempts-remaining` keeps its `[0]` branch, which is
+# an exact-value match rather than a plural category and says «amul» instead of
+# counting to zero.
+
+
+## Answer submission
+
+answer-checking = Mu ngi seetlu...
+answer-submitting = Mu ngi yónnee...
+
+answer-checking-status = Mu ngi seetlu tontu bi
+answer-submitting-status = Mu ngi yónnee tontu bi
+
+answer-correct = Baax na
+answer-incorrect = Baaxul
+
+answer-response-saved = Tontu bi Denc Nañu ko
+
+answer-percent-credit = { $percent }% Njariñ
+answer-percent-correct = { $percent }% Baax na
+answer-percent-short = { $percent } %
+
+max-credit-available = Njariñ gi gën a kawe: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] amul jéego bu des
+       *[other] { $count } jéego a des
+    }
+
+validation-correct = (Baax na)
+validation-incorrect = (Baaxul)
+validation-partially-correct = (Baax na ci lenn)
+
+answer-show-responses = Wone { $count } tontu ci { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Ndigal
+
+collapsible-click-to-open = (bësal ngir ubbi)
+collapsible-click-to-close = (bësal ngir tëj)
+
+collapsible-initializing = Mu ngi tàmbali...
+
+footnote-show = Wone nataalu suuf
+footnote-hide = Nëbb nataalu suuf
+
+description-more-information = xibaar yu gën a bare
+
+
+## Controls
+
+slider-previous = Bi jiitu
+slider-next = Bi ci topp
+
+keyboard-open = Ubbi Klaawiye bi
+keyboard-close = Tëj Klaawiye bi
+
+choice-input-remove-choice = Dindi { $choice }
+
+matrix-remove-row = Dindi ab rëdd
+matrix-add-row = Yokk ab rëdd
+matrix-remove-column = Dindi ab poto
+matrix-add-column = Yokk ab poto
+
+subset-add-remove-points = Yokk/Dindi ay poñ
+subset-toggle-points-intervals = Soppi diggante poñ ak enterwal
+subset-move-points = Toxal Poñ yi
+subset-clear = Far
+
+# A `box` here is one orbital, drawn as a square: «kees».
+orbital-add-row = Yokk Rëdd
+orbital-remove-row = Dindi Rëdd
+orbital-add-box = Yokk Kees
+orbital-remove-box = Dindi Kees
+orbital-add-up-arrow = Yokk Fetal bu Kaw
+orbital-add-down-arrow = Yokk Fetal bu Suuf
+orbital-remove-arrow = Dindi Fetal
+
+orbital-row-label = Turu rëdd { $row }
+
+pretzel-answer = Tontu
+
+summary-statistics-caption = Statistik yu gàttu yu { $column }
+
+
+## Math input
+
+math-input-preview-region = wonewaatu ekspresiyoŋu matematik
+math-input-preview = Wonewaat
+math-input-invalid-expression = Ekspresiyoŋ bi baaxul:
+
+
+## Document status
+
+viewer-initializing = Mu ngi tàmbali...
+
+
+## Errors
+
+error-heading = Njumte
+
+error-found-at =
+    { $span ->
+        [line] Gis nañu ko ci rëdd { $startLine }.
+       *[lines] Gis nañu ko ci rëdd { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokimaan bii am na ay njumte!
+
+diagnostic-heading-error = Njumte
+diagnostic-heading-warning = Artu
+diagnostic-heading-information = Xibaar
+diagnostic-heading-hint = Xelal
+
+accessibility-heading-level-1 = Moytu Jotewaay bu WCAG AA
+accessibility-heading-level-2 = Artu ci jotewaay
+
+something-went-wrong = Am na lu demul ni mu ware.
+
+renderer-load-failed = benn wonekaay yeggul. Nga jëmmali xët bi.
+
+core-start-failed = Wonekaayu dokimaan bi mënul tàmbali. Nga jëmmali xët bi.

--- a/packages/i18n/locales/wo/content.ftl
+++ b/packages/i18n/locales/wo/content.ftl
@@ -1,0 +1,264 @@
+# Wolof content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Wolof has noun classes, and the Bantu catalogs in this repository read
+# `$gender` as the class token for exactly that reason. Wolof is the case where
+# that device is *not* wanted, and it is worth saying why so nobody adds it:
+# the class in Wolof is carried by the determiner and the relative marker — bi,
+# gi, mi, si, wi, ki, li, ji — and never by the adjective. «rëdd wu réy», «poñ
+# bu xonq»: the adjective stem is the same in both, and only the linker in
+# front of it changes. So `$gender` goes unused here, as it does in English.
+#
+# What the adjective does need is that **linker**, and this catalog cannot
+# write it: the class belongs to the noun the phrase is being said of, and
+# `style-stroke` is composed before the noun is known — it is also what
+# `lineStyleDescription` reports standing alone, with no noun at all. Writing a
+# linker there would be wrong in half the places the string lands. So the
+# adjectives are written bare, which is what a label says in Wolof anyway, and
+# `style-with-noun` is where a corrected catalog would put the concord back
+# once the noun is in hand.
+#
+# Adjectives follow the noun, so the composition messages put the noun first
+# and keep the English order among the adjectives themselves.
+#
+# `$role` goes unused: Wolof marks no case, and a phrase behind a preposition
+# has the same shape as one standing alone.
+#
+# The mathematical nouns lean on French loans — «serkal», «wektëer»,
+# «poligon» — because that is the vocabulary Senegalese schooling supplies for
+# them. Where Wolof has its own word it is used: «rëdd» for line, «poñ» for
+# point, «xaaj» for section.
+#
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English — see the note above `ion-name-oxidation-state`.
+
+
+## Style vocabulary
+
+color =
+    .black = ñuul
+    .white = weex
+    .gray = gris
+    .red = xonq
+    .orange = oraas
+    .yellow = jaan
+    .green = wert
+    .cyan = siyaan
+    .blue = bulo
+    .purple = wiyole
+    .pink = roos
+    .brown = maroo
+
+line-width =
+    .thick = réy
+    .thin = sew
+
+# Written as «ak …» phrases rather than as adjectives, so that they take no
+# linker and can close the description. `style-stroke` puts them last.
+line-style =
+    .dashed = ak ay tiret
+    .dotted = ak ay poñ
+
+fill-style =
+    .horizontal = ay rëdd yu tëdd
+    .vertical = ay rëdd yu taxaw
+    .diagonal = ay rëdd yu jeng
+    .backdiagonal = ay rëdd yu jeng gannaaw
+    .dots = ay poñ
+    .diamonds = ay losaas
+
+noun =
+    .line = rëdd
+    .line-segment = dogu rëdd
+    .ray = reyoŋ
+    .vector = wektëer
+    .curve = kurb
+    .function = fonksiyoŋ
+    .parabola = parabol
+    .polyline = rëdd wu bare dog
+    .polygon = poligon
+    .triangle = triyangal
+    .rectangle = rektangal
+    .circle = serkal
+    .region = gox
+    .point = poñ
+    .square = kare
+    .diamond = losaas
+    .cross = kruwaa
+    .plus = màndarga plus
+
+# The side count follows the adjectives, behind «bu am», because Wolof closes a
+# noun phrase with a relative rather than opening one: «poligon bu yem bu xonq
+# bu am 5 wet».
+noun-regular-polygon =
+    { $part ->
+        [tail] bu am { $numSides } wet
+       *[head] poligon bu yem
+    }
+
+# Unused: the class lives on the determiner, not on the adjective.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun leads and its adjectives follow, with the noun's own relative
+# complement closing the phrase.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = feesal
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ak { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ak { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ak { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Wolof has no article, and the complement is joined with the invariable «ak»,
+# so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] ak wetu { $border }
+        [and] ak wetu { $border }
+        [and-article] ak wetu { $border }
+       *[with] ak wetu { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = feesalul
+
+style-text =
+    { $parts ->
+        [background] { $color } ci kaw ginnaaw { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = amul
+
+
+## Boolean words
+
+boolean-true = dëgg
+boolean-false = fen
+
+
+## Answer buttons
+
+answer-submit-label = Seetlu Liggéey bi
+answer-submit-label-no-correctness = Yónnee Tontu bi
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktiwite
+    .aside = Ci wet
+    .cascade = Kaskaad
+    .definition = Firnde
+    .example = Misaal
+    .exercise = Ekserkis
+    .exercises = Ekserkis
+    .given-answer = Tontu
+    .note = Xamle
+    .objectives = Jubluwaay
+    .paragraphs = Paragraf
+    .part = Cër
+    .problem = Jafe-jafe
+    .problems = Jafe-jafe
+    .proof = Firndeel
+    .question = Laaj
+    .section = Xaaj
+    .solution = Saafara
+    .task = Liggéey
+    .theorem = Teyoreem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Xelal
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabal { $enumeration }
+        [numbered-title] Tabal { $enumeration }{ ": " }
+        [unnumbered-title] Tabal{ ": " }
+       *[unnumbered] Tabal
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Nataal { $enumeration }
+        [numbered-caption] Nataal { $enumeration }{ ": " }
+        [unnumbered-caption] Nataal{ ": " }
+       *[unnumbered] Nataal
+    }
+
+
+## Paginator controls
+
+paginator-previous = Bi jiitu
+paginator-next = Bi ci topp
+paginator-page = Xët
+
+paginator-page-status = { $pageLabel } { $currentPage } ci { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = walla
+piecewise-condition-if = su
+piecewise-condition-otherwise = su dul loolu
+
+
+## Chemistry
+
+# The 118 element names and the 12 anion names are left out, so those keys fall
+# back to English and `lint:i18n` reports the gap. Senegalese secondary science
+# is taught in French, out of French-language textbooks, so a student meeting
+# these words meets them in a European language already — and the seed has no
+# settled Wolof list to reproduce. A speaker adding one should add it here.
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Màndarga Simi bu Baaxul
+chemistry-invalid-ionic-compound = Konpose Iyonik bu Baaxul

--- a/packages/i18n/locales/wo/diagnostics.ftl
+++ b/packages/i18n/locales/wo/diagnostics.ftl
@@ -1,0 +1,617 @@
+# Wolof diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Where English separates a singular from a plural only in the verb — "is
+# ignored" against "are ignored" — Wolof does not separate them at all: the
+# verb takes no number from its subject, and the argument is a list either way.
+# So those selects are dropped and the count argument goes unused.
+#
+# The technical vocabulary is the French-derived one Senegalese schooling uses
+# — «fonksiyoŋ», «endeks», «wariyaabal» — beside the Wolof words for the things
+# that are not technical: «rëdd» a line, «poñ» a point, «nattu» a value.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = Dees na bàyyi { $attributes } bu ñu wóorale ñaari poñ yu mujj yi
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = Dees na bàyyi { $attributes } bu ñu wóorale poñ bu mujj bi ak poñ bu digg bi ñoom ñaar
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset amul njariñ bu amul poñ bu digg
+
+## `<line>`
+
+line-points-undetermined-dimensions = Rëdd bi day jaar ci ay poñ yu amul dimãsiyoŋ yu wóor.
+
+line-points-too-few-dimensions = Rëdd bi war na jaar ci ay poñ yu am lu néew ñaari dimãsiyoŋ.
+
+line-points-depend-on-variables = Rëdd bi day jaar ci ay poñ yu sukkandiku ci wariyaabal yi: { $variables }.
+
+line-equation-invalid-format = Tegtal bi baaxul ngir ekuwasiyoŋu rëdd ci wariyaabal { $variable1 } ak { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Reyoŋ bi ñu ko wóorale through, endpoint ak direction ñoom ñett. Dees na bàyyi through bi ñu wóoral.
+
+ray-dimension-mismatch = numDimensions mengoowul ci reyoŋ bi.
+
+## `<vector>`
+
+vector-overprescribed-head = Wektëer bi ñu ko wóorale head, tail ak displacement ñoom ñett. Dees na bàyyi head bi ñu wóoral.
+
+vector-dimension-mismatch = numDimensions mengoowul ci wektëer bi.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Mënul jubbanti ci `<{ $component }>` ndaxte amul wariyaabalu doxin nearestPoint.
+
+constrain-to-without-nearest-point = Mënul tënk ci `<{ $component }>` ndaxte amul wariyaabalu doxin nearestPoint.
+
+constrain-to-interior-without-nearest-point = Mënul tënk ci biir `<{ $component }>` ndaxte amul wariyaabalu doxin nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = Dees na bàyyi labelPosition ci choiceInput bu nekkul ci benn rëdd
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Dees na bàyyi endeks yi ñu wóoral ci choiceInput ndaxte limu endeks yi mengoowul ak limu doom yu choice yi.
+
+pretzel-indices-count-mismatch = Dees na bàyyi endeks yi ñu wóoral ci problem ndaxte limu endeks yi mengoowul ak limu doom yu problem yi.
+
+shuffle-indices-count-mismatch = Dees na bàyyi endeks yi ñu wóoral ci shuffle ndaxte limu endeks yi mengoowul ak limu elemaa yi.
+
+indices-ignored-out-of-range = Dees na bàyyi endeks yi ñu wóoral ci { $component } ndaxte am na ay endeks yu génn diggante bi.
+
+pretzel-indices-repeated = Dees na bàyyi endeks yi ñu wóoral ci pretzel ndaxte am na ay endeks yu ñu waxaat.
+
+pretzel-circuit-first-index = Dees na bàyyi endeks yi ñu wóoral ci pretzel ci mood circuit ndaxte endeks bu njëkk bi war na doon 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ngir `<{ $component }>` liggéey ak ay doom yu xeetu mbind, sifaa `type` war na ñu ko wóoral.
+
+invalid-type-defaulting-to-math = type { $type } baaxul ngir elemaa { $component }. War na doon kenn ci math, text, number walla boolean. Dees na ko def math.
+
+string-not-valid-component-to-arrange = Mbind "{ $value }" du elemaa bu baax ci { $component }. Dees na ko bàyyi.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } baaxul, dees na def type number.
+
+invalid-variable-value = Nattu wariyaabal bi baaxul: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Endeksu sukkandiku { $index } war na doon nombar
+
+variant-index-must-be-integer = Endeksu sukkandiku { $index } war na doon nombar bu mat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` defaruñu ko ak natt yu wóoraale. Dees na def yaatuwaay yi ci wàll.
+
+side-by-side-absolute-margins = `<{ $component }>` defaruñu ko ak natt yu wóoraale. Dees na def wet yi ci wàll.
+
+side-by-side-no-block-child = `<{ $component }>` baaxul: war na am lu néew benn doom bu xeetu blook.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Dees na bàyyi sifaa `for` ci `<label>` bu grafik.
+
+label-for-must-resolve-to-one = Sifaa `for` ci `<label>` war na wóoral benn elemaa rekk.
+
+label-for-unresolved = Sifaa `for` ci `<label>` mënul wóoral benn elemaa.
+
+label-for-answer-with-authored-inputs = Sifaa `for` ci `<label>` day joxe ci `<answer>` bu am ay duggu yu ñu bind; joxeel ci duggu bi ci boppam.
+
+label-for-answer-without-input = Sifaa `for` ci `<label>` day joxe ci `<answer>` bu amul duggu bu ñu war a tudde.
+
+label-for-must-reference-input-or-answer = Sifaa `for` ci `<label>` war na joxe ci ab duggu walla ab tontu.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ngir jotewaay, `<{ $component }>` war na am ab leeral bu gàtt walla ñu wóoral ne ab taaral la.
+
+accessibility-video-short-description = Ngir jotewaay, `<video>` war na am ab leeral bu gàtt.
+
+accessibility-input-short-description-or-label = Ngir jotewaay, `<{ $component }>` war na am ab leeral bu gàtt walla ab tur.
+
+accessibility-answer-input-short-description-or-label = Ngir jotewaay, `<answer>` bu di sos ab duggu war na am ab leeral bu gàtt walla ab tur.
+
+accessibility-short-description-contains-math = Leeral bu gàtt bi warul am ay elemaa yu matematik ni `<{ $component }>`. Leeralal matematik bi ak baat.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } amul wutewaay bu doy ngir mbindu boppu xaaj (mood bu lëndëm) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; laaj na lu néew { $threshold }:1).
+       *[other] { $colorName } amul wutewaay bu doy ngir mbindu boppu xaaj ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; laaj na lu néew { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Defaruñu ba tey `<circle>` bu jaar ci { $count } poñ bu poñ yooyu amul nattu yu nombar.
+
+circle-too-many-through-points = Mënul waññ serkal bu jaar ci lu ëpp 3 poñ.
+
+circle-overprescribed-radius-center-points = Mënul waññ serkal bu am rayoŋ, digg ak poñ yu jaar ñoom ñépp ñu leen wóoral.
+
+circle-center-with-multiple-points = Mënul waññ serkal bu am digg bu ñu wóoral te di jaar ci lu ëpp 1 poñ.
+
+circle-radius-too-small = Mënul waññ serkal: ndaxte sori bi ci diggante ñaari poñ yooyu mooy { $distance }, rayoŋ { $radius } bi ñu wóoral dafa tuuti lool.
+
+circle-radius-with-many-points = Mënul sos serkal bu jaar ci lu ëpp ñaari poñ te am rayoŋ bu ñu wóoral.
+
+circle-invalid-center-or-through-points = Diggu serkal bi walla poñ yu mu jaar baaxul.
+
+circle-radius-center-with-multiple-points = Mënul waññ rayoŋu serkal bu am digg bu ñu wóoral te di jaar ci lu ëpp 1 poñ.
+
+circle-change-radius-non-numerical = Mënul soppi rayoŋu serkal bu jaar ci ay poñ yu amul nattu yu nombar
+
+circle-radius-with-points-non-numerical = Mënul sos serkal bu jaar ci lu ëpp benn poñ te am rayoŋ bu ñu wóoral bu amul nattu yu nombar.
+
+circle-change-center-non-numerical = Defaruñu ba tey soppi diggu serkal bu jaar ci ay poñ yu amul nattu yu nombar.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Dimãsiyoŋ yu domeenu fonksiyoŋ bi doyuñu. Domeen bi am na { $intervals } enterwal waaye fonksiyoŋ bi am na { $inputs } duggu.
+
+function-domain-invalid-format = Tegtalu domeenu fonksiyoŋ bi baaxul.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Dees na bàyyi kaw bu mag bu fonksiyoŋ bi bu nekkul nombar.
+        [minimum] Dees na bàyyi suuf bu mag bu fonksiyoŋ bi bu nekkul nombar.
+        [extremum] Dees na bàyyi jubluwaayu fonksiyoŋ bi bu nekkul nombar.
+        [point] Dees na bàyyi poñu fonksiyoŋ bi bu nekkul nombar.
+        [slope] Dees na bàyyi jengu fonksiyoŋ bi bu nekkul nombar.
+       *[other] Dees na bàyyi { $type } bu fonksiyoŋ bi bu nekkul nombar.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Dees na bàyyi kaw bu mag bu fonksiyoŋ bi bu neen.
+        [minimum] Dees na bàyyi suuf bu mag bu fonksiyoŋ bi bu neen.
+        [extremum] Dees na bàyyi jubluwaayu fonksiyoŋ bi bu neen.
+        [point] Dees na bàyyi poñu fonksiyoŋ bi bu neen.
+       *[other] Dees na bàyyi { $type } bu fonksiyoŋ bi bu neen.
+    }
+
+function-points-too-close = Fonksiyoŋ bi am na ñaari poñ yu jege lool. Mënuñu ko wóoral.
+
+function-iterates-input-output-mismatch = Delluwaatu fonksiyoŋ mën na am rekk su limu duggu yi tolloo ak limu génnu yi. Fonksiyoŋ bii am na { $inputs } duggu ak { $outputs } génn.
+
+## `<sequence>`
+
+sequence-invalid-length = Guddaayu ordër bi baaxul. War na doon nombar bu mat bu dul neexu.
+
+sequence-invalid-step = Jéegoy ordër bi baaxul. Ci ordëru xeetu { $type } war na doon nombar.
+
+sequence-invalid-endpoint-number = "{ $attribute }" bu ordëru nombar baaxul. War na doon nombar.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" bu ordëru araf baaxul. War na doon xeeti araf.
+
+sequence-invalid-endpoint = "{ $attribute }" bu ordër bi baaxul.
+
+select-from-sequence-coprime-not-numbers = Dees na bàyyi coprime ndaxte du ay nombar lañuy tànn
+
+select-from-sequence-coprime-with-exclude-combinations = Dees na bàyyi coprime ndaxte ñu wóoral na excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = target baaxul ci `<{ $source }>`: gisuñu jubluwaay bi.
+
+target-state-variable-not-found = target baaxul ci `<{ $source }>`: gisuñu wariyaabalu doxin bu tudd "{ $property }" ci `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Wariyaabal yu `<odeSystem>` war nañu wute ak wariyaabal bu temb bi.
+
+ode-system-duplicate-variable-names = Mënul wóoral fonksiyoŋ yu ODE RHS yu am turu wariyaabal yu ñu waxaat.
+
+ode-system-rhs-function-error = Mënul wóoral fonksiyoŋu ODE RHS. Njumte am na ci sosum fonksiyoŋu mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Mënul wóoral kornea ci { $count } rëdd
+
+angle-invalid-through-point = Poñ bi baaxul ci through bu `<angle>`
+
+parabola-vertex-too-many-points = Defaruñu ba tey parabol bu am kaw bu jaar ci lu ëpp 1 poñ.
+
+parabola-too-many-points = Defaruñu ba tey parabol bu jaar ci lu ëpp 3 poñ.
+
+intersection-too-many-items = Defaruñu ba tey jaxasoo bu lu ëpp ñaari mbir
+
+## Other math components
+
+ionic-compound-not-two-ions = Defaruñu ba tey konpose iyonik bu lu ëpp ñaari iyon.
+
+ionic-compound-needs-cation-and-anion = Konpose iyonik defaru nañu ko ngir benn katiyon ak benn aniyon rekk.
+
+solve-equations-cannot-evaluate = Mënul saafara ekuwasiyoŋ bi ndaxte mënuñu ko natt: { $equation }
+
+math-operators-operand-number-required = operandNumber war na ñu ko wóoral bu ñuy génne operãd bu matematik.
+
+eigen-decomposition-failed = Mënul waññ nattu yu eigen yu matriis bi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: paramet { $parameters } feeñuñu ci tegtal bi, kon dinañu mengoo ak neen saa su nekk.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: mënul firi grid="{ $grid }". War na doon none, medium, dense, walla ñaari nombar yu jub yu ñu xaajale ak ab bàyyi, ni grid="1 0.5". Dees na natt genn griy.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" jàppaguñu ko ci wonekaayu prefigure; doxinu wet gu ndeyjoor lees jëfandikoo.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" jàppaguñu ko ci wonekaayu prefigure; doxinu wet gu kaw lees jëfandikoo.
+
+prefigure-invalid-axis-bounds = `<graph>`: dig yu aks bi baaxuñu ngir soppim prefigure; bbox bu ndogal (-10,-10,10,10) lees jëfandikoo.
+
+prefigure-invalid-width = `<graph>`: yaatuwaay bi baaxul ngir soppim prefigure; yaatuwaayu nataal bu ndogal 425 lees jëfandikoo.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio baaxul ngir soppim prefigure; rapoor bu ndogal 1 lees jëfandikoo.
+
+prefigure-grid-spacing-too-fine = `<graph>`: diggante griy yi dafa xat lool ngir dig yu aks bi; bàyyi nañu griy bi ci wonekaayu prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: dees na wone ay xamle bu wonekaayu PreFigure jariñuwul.
+
+multiple-annotations-children = Gis nañu ay doom `<annotations>` yu bare ci `<graph>`; dees na leen bàyyi ñépp ba mu des bu mujj bi.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Mënul yaatal walla nataal xeetu elemaa bu ñu xamul: { $type }.
+
+copy-prop-not-found = Gisuñu sifaa { $property } ci elemaa bu xeetu { $component }
+
+collect-no-source = Gisuñu benn sos ngir collect.
+
+collect-invalid-component-type = Mënul dajale elemaa yu xeetu `<{ $component }>` ndaxte xeetu elemaa bu baaxul la.
+
+reference-index-unavailable = Mënul joxe ci endeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Mënul woo { $action } ci elemaa `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Melokaanu daata bi baaxul. Rëdd yi amuñu guddaay gu mengoo. Gis nañu ko ci componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Daata bi am na turu poto yu ñu waxaat. Gis nañu ko ci componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Daata bi amul turu poto. Gis nañu ko ci componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Benn award bu tontu bii day sukkandiku ci tontu bi tagi answer bi moom ci boppam yónnee, te loolu day indi doxin bu ñu séentuwul.
+
+answer-max-num-attempts-in-section-wide-check-work = Teg `maxNumAttempts` ci `<answer>` bu nekk ci biir dénkaan bu am `sectionWideCheckWork` amul njariñ, ndaxte dénkaan boobu moo yor limu jéego yi. Tegal `maxNumAttempts` ci dénkaan bi.
+
+nested-section-wide-check-work-max-num-attempts = Teg `maxNumAttempts` ci dénkaan bu am `sectionWideCheckWork` bu nekk ci biir beneen dénkaan bu am `sectionWideCheckWork` amul njariñ, ndaxte dénkaan bu biti bi moo yor limu jéego yi. Tegal `maxNumAttempts` ci dénkaan bu biti bi.
+
+answer-attributes-need-symbolic-equality = Sifaa { $attributes } dinañu amul njariñ bu symbolicEquality tegewul.
+
+answer-invalid-type = Xeet bi baaxul ngir tontu bi: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ndaxte elemaa `<{ $component }>` amul tur, mënuñu ko jëfandikoo ni sifaa bu module
+
+module-attribute-name-already-defined = Elemaa `<{ $component } name="{ $name }">` mënuñu ko jëfandikoo ni sifaa bu module ndaxte xeetu elemaa `<module>` am na ba noppi sifaa bu tudd "{ $name }".
+
+conditional-content-condition-ignored = Dees na bàyyi sifaa `condition` ci elemaa `<conditionalContent>` bu am ay doom case walla else.
+
+slider-markers-type-mismatch = Xeetu màndarga yi mengoowul ak xeetu slider bi.
+
+pretzel-problem-needs-statement-and-answer = pretzel baaxul: `<problem>` bu nekk war na am benn `<statement>` ak benn `<answer>`.
+
+pretzel-circuit-first-problem-distractor = pretzel baaxul: ci mode="circuit", `<problem>` bu njëkk bi mënul doon bu jaay-doole.
+
+## Attribute values
+
+attribute-invalid-values = Nattu { $values } baaxul ngir sifaa `{ $attribute }`; dees na leen bàyyi.
+
+attribute-must-be-references = Nattu `{ $value }` baaxul ngir sifaa `{ $attribute }`. Sifaa bi war na doon ay reyfeerãs yu tàmbalee ak `$`.
+
+math-input-invalid-function-names = <mathInput>: dees na bàyyi turu fonksiyoŋ yu baaxul ci { $attribute }: { $names }. Wàllu wone bu tur bu nekk war na am lu néew 2 araf (araf walla rëdd); tegtal `|<mathspeak alternative>` bu ñuy tànn mën na topp.
+
+## Building components from the source
+
+component-type-invalid = Xeetu elemaa bi baaxul: `<{ $componentType }>`
+
+attribute-repeated = Sifaa { $attribute } mënuñu koy waxaat.
+
+attribute-invalid-for-component = Sifaa "{ $attribute }" baaxul ngir elemaa bu xeetu `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Wóoralu estil { $styleNumber } amul wutewaay bu doy ngir { $context ->
+        [text-on-background] melokaanu mbind ci kanamu melokaanu ginnaaw
+        [high-contrast] melokaan bu am wutewaay bu kawe ci kanamu toileñ
+        [line] melokaanu rëdd ci kanamu toileñ
+        [marker] melokaanu màndarga ci kanamu toileñ
+       *[text-on-canvas] melokaanu mbind ci kanamu toileñ
+    }{ $mode ->
+        [dark] { " (mood bu lëndëm)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; laaj na lu néew { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Su fekkee ne wóoralu estil { $styleNumber } wóoral na ay melokaan yu jox wutewaay bu doy ci mood bu leer, melokaan yu mood bu lëndëm yi mu jur amuñu wutewaay bu doy ci melokaanu mbind ci kanamu melokaanu ginnaaw ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; laaj na lu néew { $threshold }:1). { $suggestion ->
+        [available] Ngir wóoral wutewaay bu doy ci mood bu lëndëm, yokkal wutewaayu mood bu leer (misaal tegal { $lightAttribute }="{ $lightColor }") walla soppil melokaanu mood bu lëndëm bi (misaal tegal { $darkAttribute }="{ $darkColor }").
+       *[none] Ngir wóoral wutewaay bu doy ci mood bu lëndëm, yokkal wutewaayu mood bu leer walla soppil melokaan yi mu jur ak textColorDarkMode ak/walla backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Su fekkee ne wóoralu estil { $styleNumber } wóoral na melokaanu mbind bu jox wutewaay bu doy ci mood bu leer, melokaanu mbind bu mood bu lëndëm bi mu jur amul wutewaay bu doy ci kanamu toileñ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; laaj na lu néew { $threshold }:1). { $suggestion ->
+        [available] Ngir wóoral wutewaay bu doy ci mood bu lëndëm, yokkal wutewaayu mood bu leer (misaal tegal textColor="{ $lightColor }") walla soppil melokaanu mood bu lëndëm bi (misaal tegal textColorDarkMode="{ $darkColor }").
+       *[none] Ngir wóoral wutewaay bu doy ci mood bu lëndëm, yokkal wutewaayu mood bu leer walla soppil melokaan bi mu jur ak textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Xaaj bi mën na tànn benn <stylePalette> rekk; bu mujj bi lees jëfandikoo.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = mënul wóoral sukkandiku yu wuute yu { $component } ndaxte numToSelect du nombar bu mat bu dul neexu.
+
+variant-num-to-select-not-constant-number = mënul wóoral sukkandiku yu wuute yu { $component } ndaxte numToSelect du nombar bu sax.
+
+variant-with-replacement-not-constant-boolean = mënul wóoral sukkandiku yu wuute yu { $component } ndaxte withReplacement du buleyaŋ bu sax.
+
+variant-select-weight-disables-unique = Sukkandiku yu wuute yu select dees na leen tëj su amee tànneef bu am selectWeight walla selectForVariants bu ñu wóoral
+
+variant-coprime-undetermined = mënul wóoral sukkandiku yu wuute yu { $component } ndaxte mënul wóoral ne coprime fen na saa su nekk.
+
+variant-attribute-not-constant = mënul wóoral sukkandiku yu wuute yu { $component } ndaxte { $attribute } saxul.
+
+variant-attribute-not-number = mënul wóoral sukkandiku yu wuute yu { $component } ndaxte { $attribute } du nombar.
+
+variant-attribute-wrong-type-for-sequence =
+    mënul wóoral sukkandiku yu wuute yu { $component } yu xeetu { $type } ndaxte { $attribute } du { $expected ->
+        [letters-combination] xeeti araf
+        [math-expression] ekspresiyoŋu matematik bu baax
+        [integer] nombar bu mat
+       *[number] nombar
+    }.
+
+variant-length-not-integer = mënul wóoral sukkandiku yu wuute yu { $component } ndaxte length du nombar bu mat.
+
+variant-sort-not-implemented = defaruñu ba tey sukkandiku yu wuute yu { $component } yu am sort
+
+variant-exclude-combinations-not-implemented = defaruñu ba tey sukkandiku yu wuute yu { $component } yu am excludeCombinations
+
+variant-math-exclude-not-implemented = defaruñu ba tey sukkandiku yu wuute yu { $component } yu xeetu math yu am exclude
+
+variant-non-constant-exclude-not-implemented = defaruñu ba tey sukkandiku yu wuute yu { $component } yu am exclude bu saxul
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: jàppaguñu ko ci wonekaayu graph prefigure; dees na tëb sët bi.
+
+prefigure-descendant-invalid-geometry = { $subject }: seometri bu amul àpp walla bu matul; dees na tëb sët bi.
+
+prefigure-curve-label-omitted = { $subject }: jàppaguñu ay tur ci elemaa yu kurb yi ñu soppi; bàyyi nañu turu bi.
+
+prefigure-curve-unsupported-definition-type = { $subject }: xeetu wóoralu fonksiyoŋu kurb '{ $definitionType }' jàppaguñu ko; dees na tëb sët bi.
+
+prefigure-region-flip-functions-unsupported = { $subject }: sifaa flipFunctions ci regionBetweenCurves jàppaguñu ko; dees na tëb sët bi.
+
+prefigure-region-non-formula-child = { $subject }: fonksiyoŋ yu doom yu xeetu formula rekk lañuy jàpp ci regionBetweenCurves; dees na tëb sët bi.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' jàppaguñu ko ngir { $labelKind ->
+        [line-family] turu mbootaayu rëdd
+       *[point] turu poñ
+    }; tegtal bu ndogal bu PreFigure lees jëfandikoo.
+
+prefigure-fill-style-unsupported = { $subject }: estilu feesal '{ $fillStyle }' PreFigure jàppul ko; dees na dellu ci feesal ak benn melokaan.
+
+prefigure-line-style-unknown = { $subject }: estilu rëdd '{ $lineStyle }' xamuñu ko te bàyyi nañu ko ci génnu PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: estilu màndarga '{ $markerStyle }' mengale nañu ko ak estilu PreFigure 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: estilu màndarga '{ $markerStyle }' PreFigure jàppul ko; estil bu ndogal lees jëfandikoo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` baaxul; mënul wóoral jubluwaay bi. Bàyyi nañu xamle bi.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` wóoral na ay jubluwaay yu bare; jubluwaay bu njëkk bi lees jëfandikoo.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` baaxul; jubluwaay bi génn na graf bi ko ëmb. Bàyyi nañu xamle bi.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` baaxul; jubluwaay bi du mbir mu grafik mu ñu jàpp ci soppim prefigure. Bàyyi nañu xamle bi.
+
+annotation-text-missing = `<annotation>`: `text` amul walla neen na; mbind mu neen lees génne.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Gis nañu sukkandiku bu wëng.
+       *[other] Gis nañu sukkandiku bu wëng bu jëmale ci elemaa `<{ $componentType }>`.
+    }
+
+reference-no-referent = Gisuñu dara ci reyfeerãs bi: `{ $reference }`
+
+reference-multiple-referents = Gis nañu ay lu bare ci reyfeerãs bi: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Tegtal bi baaxul ngir sifaa { $attribute } bu `<{ $componentType }>`.
+
+children-invalid = Doom yi baaxuñu ngir `<{ $componentType }>`: Gis nañu ay doom yu baaxul: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nattu `{ $value }` baaxul ngir sifaa `{ $attribute }`, nattu `{ $default }` lees jëfandikoo
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Gisuñu DoenetML wersiyoŋ { $version }.
+       *[other] Gisuñu DoenetML wersiyoŋ { $version }. Dees na dellu ci wersiyoŋ { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML baaxul: { $content }
+
+parse-tag-missing-close-tag = DoenetML baaxul: Tagi `{ $tag }` amul tagi bu tëj. Séentu nañu tagi bu tëju boppam walla tagi `</{ $tagName }>`.
+
+parse-tag-error = DoenetML baaxul: Njumte ci tagi `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML baaxul: Sifaa `{ $attribute }` bu baaxul mel na ni amul nattu.
+
+parse-attribute-invalid = DoenetML baaxul: Sifaa `{ $attribute }` baaxul
+
+parse-attribute-value-invalid = DoenetML baaxul: Nattu sifaa `{ $value }` baaxul
+
+parse-attribute-value-quote-mismatch = DoenetML baaxul: Nattu sifaa `{ $value }` baaxul. Màndarga yu wax yi mengoowuñu. Mel na ni `{ $quote }` ñàkk na
+
+parse-open-tag-name-missing = DoenetML baaxul: Gis nañu tagi bu amul turu tagi, misaal `<`
+
+parse-tag-not-closed = DoenetML baaxul: Tëjuñu tagi `{ $tag }` (mel na ni `>` ñàkk na).
+
+parse-self-closing-tag-name-missing = DoenetML baaxul: Gis nañu tagi bu amul turu tagi `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML baaxul: Tëjuñu tagi `{ $tag }` (mel na ni `/>` ñàkk na).
+
+parse-tag-invalid-attributes = DoenetML baaxul: Tagi `{ $tag }` baaxul. Mën na am ay sifaa yu baaxul.
+
+parse-close-tag-name-missing = DoenetML baaxul: Gis nañu tagi bu tëj bu amul turu tagi, misaal `</`
+
+parse-attribute-value-unquoted = Nattu sifaa yi war nañu nekk ci biir màndarga yu wax: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML baaxul: Gis nañu tagi bu tëj `{ $tag }`, waaye amul tagi bu ubbi bu ko mengoo
+
+parse-close-tag-mismatched = DoenetML baaxul: Tagi bu tëj bi mengoowul. Séentu nañu `</{ $expected }>`. Gis nañu `{ $found }`
+
+parser-node-unconvertible = Mënuñu soppi nod { $node } ci nodu Dast.
+
+## Names
+
+name-attribute-invalid =
+    Sifaa name='{ $name }' baaxul. { $reason ->
+        [characters] Tur yi mën nañu am araf, nombar, rëdd yu suuf walla rëdd rekk.
+       *[start] Tur yi war nañu tàmbalee ak araf.
+    }
+
+component-name-invalid-start = Turu elemaa "{ $name }" baaxul. Tur yi war nañu tàmbalee ak araf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Tontu bu xeetu videoWatched war na am sifaa video
+
+answer-video-watched-video-not-reference = Tontu bu xeetu videoWatched war na am sifaa video bu di reyfeerãs
+
+answer-name-not-single-text = Sifaa name bu tontu bi war na am benn doom text rekk
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Mënul am DoenetML bu biti ndaxte dellu yi dañoo bare lool. Ndax am na reyfeerãs bu wëng?
+
+external-doenetml-unavailable = Mënul am DoenetML bu jóge ci { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML bi ñu jële ci { $attribute }="{ $uri }" baaxul: mengoowul ak xeetu elemaa "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Sifaa `{ $from }` jeex na jamono; jëfandikool `{ $to }`.
+       *[other] [deprecation] Sifaa `{ $from }` ci `<{ $component }>` jeex na jamono; jëfandikool `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Sifaa `{ $from }` jeex na jamono te dees na ko bàyyi ndaxte `{ $to }` itam ñu wóoral na ko.
+       *[other] [deprecation] Sifaa `{ $from }` ci `<{ $component }>` jeex na jamono te dees na ko bàyyi ndaxte `{ $to }` itam ñu wóoral na ko.
+    }
+
+deprecated-attribute-ignored = [deprecation] Sifaa `{ $attribute }` ci `<{ $component }>` jeex na jamono te dees na ko bàyyi.
+
+deprecated-attribute-to-child = [deprecation] Sifaa `{ $attribute }` ci `<{ $component }>` jeex na jamono; jëfandikool doom bu `<{ $child }>`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` mën na def bare ci Angale rekk, kon mbindam mi des na ni mu mel ci dokimaan bu ñu bind ci { $locale }. Bindal melokaanu bare bi walla tegal ko ci sifaa `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemaa `<{ $tag }>` du elemaa bu Doenet xam.
+
+schema-element-not-allowed-at-root = Mayuñu elemaa `<{ $tag }>` ci reenu dokimaan bi.
+
+schema-element-not-allowed-inside = Mayuñu elemaa `<{ $tag }>` ci biir `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemaa `<{ $tag }>` amul sifaa bu tudd `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Sifaa `{ $attribute }` bu elemaa `<{ $tag }>` war na doon lim bu kenn ku ci nekk di kenn ci: { $allowed }
+       *[other] Sifaa `{ $attribute }` bu elemaa `<{ $tag }>` war na doon kenn ci: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Turu sukkandiku bi baaxul ngir select. Turu sukkandiku { $variantName } feeñ na ci { $numOptions } tànneef waaye limu tànn bi mooy { $numToSelect }.
+
+select-variant-name-without-options = Ñu wóoral na ay sukkandiku ngir select waaye wóoraluñu benn tànneef ngir turu sukkandiku bu mën a am: { $variantName }.
+
+select-variant-name-not-possible = Turu sukkandiku { $variantName } bi ñu wóoral ngir select du turu sukkandiku bu mën a am.
+
+select-too-few-options = Mënul tànn { $numToSelect } elemaa ci { $numOptions } rekk.
+
+select-from-sequence-too-few-values = Mënul tànn { $numToSelect } nattu ci ordër bu guddaayam di { $length }.
+
+select-from-sequence-indices-count-mismatch = Limu endeks yi ñu wóoral ngir select war na mengoo ak limu tànn bi
+
+select-from-sequence-indices-not-integers = Endeks yépp yi ñu wóoral ngir select war nañu doon nombar yu mat
+
+select-from-sequence-index-excluded = Ñu wóoral na endeksu selectfromsequence bu ñu génne
+
+select-from-sequence-indices-excluded-combination = Ñu wóoral na ay endeksu selectfromsequence yu nekkoon xeetu boole bu ñu génne
+
+select-from-sequence-coprime-not-positive-integers = Mënul tànn boole yu nombar yu bokk ndaxte du nombar yu mat yu jub lañuy tànn.
+
+select-from-sequence-coprime-common-factor = Mënul tànn nombar yu bokk. Nattu yépp yu mën a am dañoo bokk benn kalaam. (Nattu yi ñu wóoral ci "from" walla "to" war nañu bokk ak "step".)
+
+select-from-sequence-coprime-single-number = Mënul tànn boole yu nombar yu bokk ci benn nombar bu dul 1.
+
+select-from-sequence-excluded-too-many-combinations = Lu ëpp 70% ci boole yi génne nañu leen ci selectFromSequence
+
+select-from-sequence-coprime-none-found = Mënuñu tànn nombar yu bokk. Nattu yépp yu mën a am dañoo bokk benn kalaam.
+
+select-from-sequence-too-few-unique-values = Mënul tànn { $numToSelect } nattu yu wuute ci ordër bu guddaayam di { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Mënul tànn { $numToSelect } nattu ci limu nombar yu tasaaroo bu guddaayam di { $numValues }
+
+select-prime-numbers-values-count-mismatch = Limu nattu yi ñu wóoral ngir select war na mengoo ak limu tànn bi
+
+select-prime-numbers-values-not-prime = Nattu yépp yi ñu wóoral ngir select prime number war nañu nekk ci limu nombar yu tasaaroo
+
+select-prime-numbers-values-excluded-combination = Nattu yu selectPrimeNumbers yi ñu wóoral nekkoon nañu xeetu boole bu ñu génne
+
+select-prime-numbers-excluded-too-many-combinations = Lu ëpp 70% ci boole yi génne nañu leen ci selectPrimeNumbers
+
+select-random-combination-fluke = Ci lu jekkadi lool, mënuñu tànn boole bu nattu yu tegtalul
+
+select-random-value-fluke = Ci lu jekkadi lool, mënuñu tànn nattu bu tegtalul

--- a/packages/i18n/locales/wo/editor.ftl
+++ b/packages/i18n/locales/wo/editor.ftl
@@ -1,0 +1,203 @@
+# Wolof editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Wolof has one plural category, so the counted messages drop their selects.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Delloo
+       *[update] Yeesal
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Wonekaay bi
+       *[other] { $word } Wonekaay bi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Sukkandiku
+editor-variant-filter = Tànn...
+editor-variant-next = Tànn sukkandiku bi ci topp
+editor-variant-previous = Tànn sukkandiku bi jiitu
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Gis nañu moytu jotewaay bu WCAG AA. Bësal ngir { $action ->
+            [close] tëj
+           *[open] ubbi
+        } rapoor bu jotewaay bi.
+        [advisories] Bësal ngir { $action ->
+            [close] tëj
+           *[open] ubbi
+        } rapoor bu jotewaay bi. Gisuñu benn moytu WCAG AA, waaye am na ay xelal yu yokku ci jotewaay.
+       *[clean] Bësal ngir { $action ->
+            [close] tëj
+           *[open] ubbi
+        } rapoor bu jotewaay bi. Gisuñu benn jafe-jafe ci jotewaay.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Gis nañu moytu jotewaay bu WCAG AA. Gis nañu { $count } moytu WCAG AA. Bësal ngir { $action ->
+            [close] tëj
+           *[open] ubbi
+        } rapoor bu jotewaay bi.
+        [advisories] Gisuñu benn moytu WCAG AA. Gis nañu { $count } xelal yu yokku ci jotewaay. Bësal ngir { $action ->
+            [close] tëj
+           *[open] ubbi
+        } rapoor bu jotewaay bi.
+       *[clean] Gisuñu benn moytu WCAG AA. Bësal ngir { $action ->
+            [close] tëj
+           *[open] ubbi
+        } rapoor bu jotewaay bi.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML wersiyoŋ { $version }
+
+editor-tab-help = Ndimbal ci kàddu gi
+editor-tab-help-short = Kàddu
+editor-tab-errors = Njumte
+editor-tab-warnings = Artu
+editor-tab-info = Xibaar
+editor-tab-accessibility = Jotewaay
+editor-tab-responses = Tontu yi ñu yónnee
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Tànneefu editër bi
+editor-format-as-doenetml = Tegtal ni DoenetML
+editor-format-as-xml = Tegtal ni XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Rëdd #{ $line }
+
+editor-no-errors = Amul Njumte
+editor-no-warnings = Amul Artu
+editor-no-info = Amul Seetlu bu Xibaar
+
+editor-show-info-annotations = Wone seetlu yu xibaar ci editër bi
+editor-show-accessibility-annotations = Wone seetlu yu jotewaay ci editër bi
+
+editor-accessibility-learn-more = Jàng ni Doenet di topptoo jotewaay
+
+editor-accessibility-violations-heading = Moytu jotewaay ({ $standard })
+
+editor-accessibility-other-heading = Yeneen jafe-jafe yu jotewaay
+editor-none-found = Gisuñu dara
+
+
+## Submitted responses
+
+editor-no-responses = Yónneewuñu benn tontu ba tey
+editor-response-answer-id = Turu Tontu bi
+editor-response-response = Tontu
+editor-response-credit = Njariñ
+editor-response-submitted = Yónnee nañu ko
+
+
+## The context-help panel
+
+help-placeholder = Teg jumtukaay bi ci kaw turu tagi, sifaa walla { $ref } ngir am dokimaantasiyoŋ.
+
+help-unsupported-ref-chain = Ndimbal ci reyfeerãs yu bare cër ni { $example } jàppagul.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Gisuñu dara ci reyfeerãs bi: { $ref }.
+        [multiple] Gis nañu ay lu bare ci reyfeerãs bi: { $ref }.
+       *[indeterminate] Mënuñu wóoral lu { $ref } di tudd.
+    }
+
+help-learn-about-references = Jàng ci reyfeerãs yi →
+help-reference-page = Xëtu reyfeerãs →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ci biir { $element }
+       *[top] Ci kaw kaw
+    }{ $allowed ->
+        [none] { " — dara du fi dugg." }
+        [text] { " — bindal mbind fii." }
+        [text-and-components] { " — bindal mbind fii, walla jéemal:" }
+       *[components] { " — lu ngeen mën a jéem:" }
+    }
+
+help-suggestions-footer = Bësal { $shortcut } ngir gis { $total } elemaa yépp.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ab reyfeerãs la ci { $target }.
+       *[other] { $ref } ab reyfeerãs la ci { $target } (rëdd { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } moo ko tudde { $role }.
+       *[other] { $owner } moo ko tudde { $role } ci rëdd { $line }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ab reyfeerãs la ci sifaa { $property } bu { $element }.
+       *[other] { $ref } ab reyfeerãs la ci sifaa { $property } bu { $element } (rëdd { $line }).
+    }
+
+help-kind-attribute = sifaa
+help-kind-snippet = tuutal
+help-kind-array-entry = duggu tabalo
+
+help-default = Bu ndogal:
+help-active-default = Bu ndogal bi jariñu:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nattu yi ñu may (benn ci elemaa bu nekk):
+       *[other] Nattu yi ñu may:
+    }
+
+help-suggested-values = Nattu yi ñu digal:
+
+help-inserts = Dafay dugal:
+
+help-coordinates = Koordone:
+
+help-type = Xeet:
+
+help-resolved-style = Estil bi ñu wóoral (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Turu fonksiyoŋ yi ñu wóoral:
+help-reset-list = Lim bi ñuy delloo ci duggu bii:
+help-added-on-input = Li ñu yokk ci duggu bii:
+help-removed-on-input = Li ñu dindi ci duggu bii:
+
+help-reset-overrides = { $reset } dafay raw { $additional } ak { $removed }.

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -8,12 +8,14 @@
 export type SupportedLocale =
     | "en"
     | "af"
+    | "ak"
     | "am"
     | "ar"
     | "as"
     | "az"
     | "be"
     | "bg"
+    | "bm"
     | "bn"
     | "br"
     | "ca"
@@ -22,6 +24,7 @@ export type SupportedLocale =
     | "cy"
     | "da"
     | "de"
+    | "ee"
     | "el"
     | "es"
     | "et"
@@ -55,6 +58,8 @@ export type SupportedLocale =
     | "kn"
     | "ko"
     | "ky"
+    | "lg"
+    | "ln"
     | "lo"
     | "lt"
     | "lv"
@@ -85,9 +90,11 @@ export type SupportedLocale =
     | "sk"
     | "sl"
     | "sm"
+    | "sn"
     | "so"
     | "sq"
     | "sr"
+    | "st"
     | "su"
     | "sv"
     | "sw"
@@ -95,7 +102,9 @@ export type SupportedLocale =
     | "te"
     | "tg"
     | "th"
+    | "ti"
     | "tk"
+    | "tn"
     | "tr"
     | "tt"
     | "ug"
@@ -103,6 +112,7 @@ export type SupportedLocale =
     | "ur"
     | "uz"
     | "vi"
+    | "wo"
     | "xh"
     | "yo"
     | "zh-Hans"
@@ -152,6 +162,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Afrikaans",
         label: "Afrikaans",
     },
+    { locale: "ak", englishName: "Akan", endonym: "Akan", label: "Akan" },
     {
         locale: "am",
         englishName: "Amharic",
@@ -187,6 +198,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Bulgarian",
         endonym: "български",
         label: "Bulgarian (български)",
+    },
+    {
+        locale: "bm",
+        englishName: "Bambara",
+        endonym: "bamanakan",
+        label: "Bambara (bamanakan)",
     },
     {
         locale: "bn",
@@ -235,6 +252,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "German",
         endonym: "Deutsch",
         label: "German (Deutsch)",
+    },
+    {
+        locale: "ee",
+        englishName: "Ewe",
+        endonym: "eʋegbe",
+        label: "Ewe (eʋegbe)",
     },
     {
         locale: "el",
@@ -424,6 +447,18 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "кыргызча",
         label: "Kyrgyz (кыргызча)",
     },
+    {
+        locale: "lg",
+        englishName: "Ganda",
+        endonym: "Luganda",
+        label: "Ganda (Luganda)",
+    },
+    {
+        locale: "ln",
+        englishName: "Lingala",
+        endonym: "lingála",
+        label: "Lingala (lingála)",
+    },
     { locale: "lo", englishName: "Lao", endonym: "ລາວ", label: "Lao (ລາວ)" },
     {
         locale: "lt",
@@ -585,6 +620,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     },
     { locale: "sm", englishName: "Samoan", endonym: "Samoan", label: "Samoan" },
     {
+        locale: "sn",
+        englishName: "Shona",
+        endonym: "chiShona",
+        label: "Shona (chiShona)",
+    },
+    {
         locale: "so",
         englishName: "Somali",
         endonym: "Soomaali",
@@ -601,6 +642,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Serbian",
         endonym: "српски",
         label: "Serbian (српски)",
+    },
+    {
+        locale: "st",
+        englishName: "Southern Sotho",
+        endonym: "Sesotho",
+        label: "Southern Sotho (Sesotho)",
     },
     {
         locale: "su",
@@ -640,10 +687,22 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     },
     { locale: "th", englishName: "Thai", endonym: "ไทย", label: "Thai (ไทย)" },
     {
+        locale: "ti",
+        englishName: "Tigrinya",
+        endonym: "ትግርኛ",
+        label: "Tigrinya (ትግርኛ)",
+    },
+    {
         locale: "tk",
         englishName: "Turkmen",
         endonym: "türkmen dili",
         label: "Turkmen (türkmen dili)",
+    },
+    {
+        locale: "tn",
+        englishName: "Tswana",
+        endonym: "Setswana",
+        label: "Tswana (Setswana)",
     },
     {
         locale: "tr",
@@ -687,6 +746,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Tiếng Việt",
         label: "Vietnamese (Tiếng Việt)",
     },
+    { locale: "wo", englishName: "Wolof", endonym: "Wolof", label: "Wolof" },
     {
         locale: "xh",
         englishName: "Xhosa",

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -24,8 +24,15 @@ export type NegotiateLocalesOptions = {
  * and would fall to English with nothing to say why. `nn` is deliberately
  * absent: Nynorsk is a written standard of its own, and answering it with
  * Bokmål would be a substitution rather than a canonicalization.
+ *
+ * `tw` is the retired ISO 639-1 code for Twi, and `ak` — Akan, which Twi is a
+ * variety of — is the catalog it should reach. `Intl.getCanonicalLocales`
+ * leaves `tw` alone, so without this entry a hand-typed `<document lang="tw">`
+ * falls to English. `fat` is deliberately absent: Fante is a written standard
+ * of its own and `locales/ak` is written in Asante Twi, so answering Fante
+ * with it would be the substitution `nn` is kept out for.
  */
-const LANGUAGE_ALIASES: Record<string, string> = { no: "nb" };
+const LANGUAGE_ALIASES: Record<string, string> = { no: "nb", tw: "ak" };
 
 /** Rewrite a request's language subtag if it is one no catalog is named after. */
 function applyLanguageAlias(tag: string): string {

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -139,6 +139,29 @@ describe("negotiateLocales", () => {
     });
 
     /**
+     * Akan's catalog is named `ak` and is written in Asante Twi. `tw` is the
+     * retired code for Twi and the one an author is as likely to type;
+     * `Intl.getCanonicalLocales` leaves it alone, so nothing connects the two
+     * without the alias. Asserted against the real roster, so that removing the
+     * entry fails here rather than quietly serving English.
+     */
+    describe("Akan, whose catalog is named for the macrolanguage", () => {
+        it.each(["tw", "tw-GH", "ak", "ak-GH"])(
+            "serves Akan to %s",
+            (requested) => {
+                expect(negotiateLocales([requested], available)).toEqual([
+                    "ak",
+                    "en",
+                ]);
+            },
+        );
+
+        it("leaves Fante to fall back to English", () => {
+            expect(negotiateLocales(["fat"], available)).toEqual(["en"]);
+        });
+    });
+
+    /**
      * Filipino's catalog is named `fil`, and `tl` — the code an author is as
      * likely to type — needs no alias of its own: `Intl.Locale` canonicalizes
      * it, so `normalizeLocaleTag` has already rewritten it before negotiation

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -64968,6 +64968,10 @@
                             "description": "Afrikaans"
                         },
                         {
+                            "value": "ak",
+                            "description": "Akan"
+                        },
+                        {
                             "value": "am",
                             "description": "Amharic (አማርኛ)"
                         },
@@ -64990,6 +64994,10 @@
                         {
                             "value": "bg",
                             "description": "Bulgarian (български)"
+                        },
+                        {
+                            "value": "bm",
+                            "description": "Bambara (bamanakan)"
                         },
                         {
                             "value": "bn",
@@ -65022,6 +65030,10 @@
                         {
                             "value": "de",
                             "description": "German (Deutsch)"
+                        },
+                        {
+                            "value": "ee",
+                            "description": "Ewe (eʋegbe)"
                         },
                         {
                             "value": "el",
@@ -65156,6 +65168,14 @@
                             "description": "Kyrgyz (кыргызча)"
                         },
                         {
+                            "value": "lg",
+                            "description": "Ganda (Luganda)"
+                        },
+                        {
+                            "value": "ln",
+                            "description": "Lingala (lingála)"
+                        },
+                        {
                             "value": "lo",
                             "description": "Lao (ລາວ)"
                         },
@@ -65276,6 +65296,10 @@
                             "description": "Samoan"
                         },
                         {
+                            "value": "sn",
+                            "description": "Shona (chiShona)"
+                        },
+                        {
                             "value": "so",
                             "description": "Somali (Soomaali)"
                         },
@@ -65286,6 +65310,10 @@
                         {
                             "value": "sr",
                             "description": "Serbian (српски)"
+                        },
+                        {
+                            "value": "st",
+                            "description": "Southern Sotho (Sesotho)"
                         },
                         {
                             "value": "su",
@@ -65316,8 +65344,16 @@
                             "description": "Thai (ไทย)"
                         },
                         {
+                            "value": "ti",
+                            "description": "Tigrinya (ትግርኛ)"
+                        },
+                        {
                             "value": "tk",
                             "description": "Turkmen (türkmen dili)"
+                        },
+                        {
+                            "value": "tn",
+                            "description": "Tswana (Setswana)"
                         },
                         {
                             "value": "tr",
@@ -65346,6 +65382,10 @@
                         {
                             "value": "vi",
                             "description": "Vietnamese (Tiếng Việt)"
+                        },
+                        {
+                            "value": "wo",
+                            "description": "Wolof"
                         },
                         {
                             "value": "xh",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -963,6 +963,8 @@ describe("a phrase rendered in two positions", () => {
     const ceb = forLocale("ceb");
     const km = forLocale("km");
     const si = forLocale("si");
+    const lg = forLocale("lg");
+    const ti = forLocale("ti");
 
     const borderWords = { colorWord: "black", lineWidthWord: "thick" };
     const shapeWords = { ...borderWords, fillColorWord: "blue" };
@@ -1298,6 +1300,42 @@ describe("a phrase rendered in two positions", () => {
             textColor: "රතු",
             backgroundColor: "කහ",
             sentence: "කහ පසුබිමක් මත රතු",
+        });
+    });
+
+    // Luganda carries the widest concord table in the repository — six noun
+    // classes — and this case is here because the border and the shape it
+    // surrounds are in different ones: «olukugiro» is class 11 and takes
+    // «olu-», «enkulungo» is class 9 and takes «en-». The two adjectives are
+    // built from the same stems and come out spelled differently, which is
+    // exactly what would break if `noun-gender` were ever flattened.
+    it("agrees Luganda's border with its own class, not the shape's", () => {
+        expect(bothBorderForms(lg)).toEqual({
+            standalone: "olunene oluddugavu",
+            embedded:
+                "enkulungo enjjuvu bbululu n'olukugiro olunene oluddugavu",
+        });
+        expect(bothTextForms(lg)).toEqual({
+            textColor: "erimyufu",
+            backgroundColor: "kyenvu",
+            sentence: "erimyufu ku mabega kyenvu",
+        });
+    });
+
+    // Tigrinya is the only language in the sub-Saharan batch that uses
+    // `$gender` for a gender, and the only one there whose adjectives *precede*
+    // the noun. Both positions read alike, because Tigrinya marks a clause
+    // position on the noun rather than on the adjective in front of it — so
+    // what this pins is the agreement and the order, not a case.
+    it("puts Tigrinya's adjectives in front and agrees them for gender", () => {
+        expect(bothBorderForms(ti)).toEqual({
+            standalone: "ረጒድ ጸሊም",
+            embedded: "ምልእቲ ሰማያዊ ክቢ ምስ ረጒድ ጸሊም ዶብ",
+        });
+        expect(bothTextForms(ti)).toEqual({
+            textColor: "ቀይሕ",
+            backgroundColor: "ብጫ",
+            sentence: "ቀይሕ ምስ ብጫ ድሕረ-ባይታ",
         });
     });
 


### PR DESCRIPTION
Adds message catalogs for Wolof, Bambara, Akan, Ewe, Lingala, Shona, Southern Sotho, Setswana, Tigrinya and Ganda — all four namespaces each. `documentLocale="sn"` and `<document lang="lg">` work with nothing configured, and all ten reach `<document lang>`'s autocomplete, eight of them labelled with their endonym beside the English name.

Rebased onto `main` now that #1645 and #1647 have merged: the diff is this batch alone. Because #1647 added the `deprecated-attribute-to-child` diagnostic, all ten catalogs carry a translation of that key too, so no locale in the batch lands already one key behind.

These are **unreviewed machine-generated seeds**, and every file says so in its header. Nothing falls back silently: a key a translation is missing renders in English, which is what makes seeding safe.

## What the batch is about

This is the second sub-Saharan batch, and it goes back for the two largest things the first one left out: **Bantu south of the equator**, which the first reached only through Swahili, Zulu, Xhosa, Kinyarwanda and Nyanja, and **francophone West and Central Africa**, which it did not reach at all.

Five of the ten agree an adjective with its noun's **class**, reading `$gender` as a class token exactly the way `locales/sw` does — the whole reason that argument was named for a position rather than for a case. What is worth reading is how differently five languages do one thing:

- **Shona** does not bolt a prefix onto an unchanged stem. In class 5 the stem's own first consonant changes with the prefix, so «-tema» is «dema», «-chena» is «jena» and «-kobvu» is «gobvu». The table is not derivable from the stems and is written out in the header.
- **Luganda** carries six classes, the widest table in the repository, because its own geometry words land where the others' do not: «olunyiriri», a line, is class 11, and «akasaale», a ray, and «akatonnyeze», a point, are class 12 — the diminutive, which is where a small thing goes whether or not it is small on purpose.
- **Southern Sotho** and **Setswana** additionally need a qualificative particle — «mola *o* motenya» — and both leave it out on purpose, because the same string is what `backgroundColor` reports standing alone, where a bare particle would be a fragment, and nothing in `$role` tells the two positions apart. That is the trade `locales/sw` already makes with its associative.
- **Lingala** is where the device barely reaches: its inventory of true adjectives is small and no colour word is in it — most of them are invariable French loans, and the three native ones are cited in one shape — so the concord touches two adjective stems and one participle and no more. Recording that is the point — a smaller table is a fact about Lingala, not an unfinished one.

**Tigrinya** is the one that uses `$gender` for a gender. It is Semitic, the agreement is internal rather than suffixed — «ጸሊም» → «ጸላም», «ረጒድ» → «ረጓድ» — and it is also the only language here whose adjectives *precede* the noun, so its composition messages keep the English order while the other nine invert it. Its Ge'ez runs left to right, so `direction.ts` needs nothing.

The four West African languages answer one question four ways — **what does a description do when the language inflects nothing?** **Wolof** has noun classes and still ignores `$gender`, because the class rides on the determiner and the relative marker and never on the adjective. **Bambara** marks an adjective with the qualifier suffix `-man` rather than agreement. **Akan** and **Ewe** mark nothing at all and put the adjective after the noun.

## Plurals

CLDR gives Wolof and Bambara one category each. Akan and Ewe have two that no counted message here can use — an Ewe noun takes no plural after a numeral, and the two nouns Akan counts carry their plural prefix in the singular already — so all four drop their selects rather than write a `[one]` that repeats its `[other]`. The five Bantu languages keep theirs and change the noun inside them, except that in Shona and Luganda it is decided per message by the class of the noun being counted: Shona's «edzo» is class 5 and takes «ma-», while «mhinduro» is class 9 and its plural is spelled the same; Luganda's «akabonero» becomes «obubonero», while «okumenya» is a class 15 verbal noun with no plural at all and «amagezi» is class 6 and already plural. So in both, some counted messages keep their selects and the rest drop them.

## Akan needs an alias, and Fante deliberately does not get one

`ak` is the macrolanguage and the catalog is Asante Twi. `tw` is the retired code for Twi and the tag an author is as likely to type, and `Intl.getCanonicalLocales` leaves it alone rather than rewriting it the way it rewrites `iw` and `in` — so `negotiate.ts` maps `tw` to `ak`, the second entry `LANGUAGE_ALIASES` has ever needed. Fante is left out for the reason Nynorsk is: it is a written standard of its own, and answering `fat` with an Asante Twi catalog would be a substitution rather than a canonicalization.

## Chemistry

All ten leave the 118 element names and the 12 anion names to fall back to English, and unlike the batches before them they split no ways at all: every one is the school-system case. Secondary science is taught in English across Ghana, Zimbabwe, Botswana, Lesotho, Uganda, Eritrea and Tigray, and in French across Senegal, Mali and both Congos, so in all ten the fallback *is* the curriculum — a fact about ten education ministries rather than about ten languages.

## Naming

`lg` appears in the roster as **Ganda**, `st` as **Southern Sotho** and `tn` as **Tswana**, because `Intl.DisplayNames` renders them that way and `supportedLocales.ts` is derived rather than hand-written — the same split `ny` already has between Nyanja and Chichewa. All three catalogs' headers say so.

Setswana and Southern Sotho are close enough to raise why they are two files: they are two standard languages with two orthographies and two vocabularies, and `locales/tn` writes «kgotsa», «boammaaruri» and «-hibidu» where `locales/st` writes «kapa», «nnete» and «-fubedu». That is the same reason `hr` is a directory of its own rather than a script of `sr`.

## Tests

- `packages/i18n/test/negotiate.test.ts`: the `tw` → `ak` alias and the `fat` → English fallback, both against the real roster, so removing the alias fails here rather than quietly serving English.
- `packages/utils/test/styleDescriptions.test.ts`: Luganda in the two-position suite, pinning a border in class 11 beside a shape in class 9; and Tigrinya, pinning the gender agreement and the adjective-before-noun order.
- `packages/doenetml-worker-javascript/.../styleDescriptionLocale.test.ts`: Luganda through the whole worker path, where one fixture reaches three classes at once and the same adjective stems come out spelled differently in each.

## Docs

`packages/i18n/README.md` gains the ten codes in its roster, the chemistry paragraph for this batch, and the naming/alias section covering Ganda, Southern Sotho, Tswana, the `tw` alias and why `tn` and `st` are two directories.

## Regenerated

`supportedLocales.ts` (112 locales) and `doenet-schema.json`, via codegen → build i18n → build:schema → build static-assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




