### PR TITLE
Deprecate the `description` attribute in favor of a `<shortDescription>` child

### DIFF
--- a/.changeset/deprecate-description-attribute.md
+++ b/.changeset/deprecate-description-attribute.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Warn that the `description` attribute is deprecated in favor of a `<shortDescription>` child.
+
+`<image description="A tree" />` has quietly gone on working since version 0.6: normalization rewrites the attribute into a `<shortDescription>` child, so it still supplies the alt text. But the attribute is in neither the schema nor the documentation, which left old source being carried forward with no indication that it is writing something no longer supported. It now says so, on all ten components that accepted it — `<image>`, `<video>`, `<graph>`, `<answer>` and the `<*Input>`s — and keeps working exactly as before.

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
@@ -99,6 +99,36 @@ describe("Warning Tests @group4", async () => {
         ).eq(true);
     });
 
+    it("Deprecated description attribute names the component it was written on", async () => {
+        // `descriptionAttributeSugar` covers ten component types and puts the
+        // one the attribute was written on into the message, so exercise a
+        // couple of them together. `<image>` is covered in `image.test.ts`,
+        // which also checks that the rewritten child still supplies the alt
+        // text.
+        const { core } = await createTestCore({
+            doenetML: `
+<mathInput description="Enter a number" />
+<graph description="A graph" />
+            `,
+        });
+
+        const diagnosticsByType = getDiagnosticsByType(core);
+
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(diagnosticsByType.warnings.length).eq(2);
+
+        expect(
+            diagnosticsByType.warnings.map((warning) => warning.message),
+        ).contains(
+            "[deprecation] Attribute `description` on `<mathInput>` is deprecated; use a `<shortDescription>` child instead.",
+        );
+        expect(
+            diagnosticsByType.warnings.map((warning) => warning.message),
+        ).contains(
+            "[deprecation] Attribute `description` on `<graph>` is deprecated; use a `<shortDescription>` child instead.",
+        );
+    });
+
     it("From state variable definitions", async () => {
         let { core } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
@@ -355,6 +355,42 @@ describe("Image tag tests @group3", async () => {
         ).eq("description");
     });
 
+    it("deprecated `description` attribute still becomes the short description, with a warning", async () => {
+        // A leftover from version 0.6: absent from the schema and the docs, so
+        // the only source still using it is old source being carried forward.
+        // `descriptionAttributeSugar` rewrites it to a `<shortDescription>`
+        // child and warns, rather than the deprecation registry, which has no
+        // rule shape for an attribute that becomes a child.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<image name="image1" description="A tree" />
+            `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("image1")].stateValues
+                .shortDescription,
+        ).eq("A tree");
+
+        let diagnosticsByType = getDiagnosticsByType(core);
+
+        // The short description is supplied, so no accessibility diagnostic.
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(diagnosticsByType.accessibility.length).eq(0);
+        expect(diagnosticsByType.warnings.length).eq(1);
+        expect(diagnosticsByType.warnings[0].code).eq("doenet-w0120");
+        expect(diagnosticsByType.warnings[0].args).eqls({
+            attribute: "description",
+            child: "shortDescription",
+            component: "image",
+        });
+        expect(diagnosticsByType.warnings[0].message).eq(
+            "[deprecation] Attribute `description` on `<image>` is deprecated; use a `<shortDescription>` child instead.",
+        );
+    });
+
     it("license codes derive names and urls", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/i18n/diagnostic-codes.lock.json
+++ b/packages/i18n/diagnostic-codes.lock.json
@@ -212,5 +212,6 @@
     "doenet-w0116": "schema-attribute-value-not-allowed",
     "doenet-w0117": "matches-pattern-parameter-not-in-pattern",
     "doenet-w0118": "prefigure-grid-spacing-too-fine",
-    "doenet-w0119": "graph-grid-invalid"
+    "doenet-w0119": "graph-grid-invalid",
+    "doenet-w0120": "deprecated-attribute-to-child"
 }

--- a/packages/i18n/locales/en/diagnostics.ftl
+++ b/packages/i18n/locales/en/diagnostics.ftl
@@ -723,7 +723,7 @@ external-doenetml-type-mismatch = Invalid DoenetML retrieved from { $attribute }
 # as written. $component is `none` for a rename that applies to every component
 # accepting the attribute, where naming one would be wrong.
 #
-# The `[deprecation]` opening is a literal marker shared by all three messages,
+# The `[deprecation]` opening is a literal marker shared by all four messages,
 # not a word: leave it as it is.
 
 deprecated-attribute-renamed =
@@ -739,6 +739,12 @@ deprecated-attribute-renamed-conflict =
     }
 
 deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` on `<{ $component }>` is deprecated and ignored.
+
+# An attribute replaced by a child element rather than by another attribute:
+# $attribute and $component stay as written, and so does $child, which is the
+# tag name of the child to write instead.
+
+deprecated-attribute-to-child = [deprecation] Attribute `{ $attribute }` on `<{ $component }>` is deprecated; use a `<{ $child }>` child instead.
 
 
 ## Language coverage

--- a/packages/i18n/src/diagnostics.ts
+++ b/packages/i18n/src/diagnostics.ts
@@ -204,6 +204,7 @@ export const DIAGNOSTIC_CODES = {
     "doenet-w0117": "matches-pattern-parameter-not-in-pattern",
     "doenet-w0118": "prefigure-grid-spacing-too-fine",
     "doenet-w0119": "graph-grid-invalid",
+    "doenet-w0120": "deprecated-attribute-to-child",
 
     "doenet-e0001": "pretzel-circuit-first-problem-distractor",
     "doenet-e0002": "component-type-invalid",

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -475,6 +475,7 @@ export type MessageKey =
     | "deprecated-attribute-renamed"
     | "deprecated-attribute-renamed-conflict"
     | "deprecated-attribute-ignored"
+    | "deprecated-attribute-to-child"
     | "pluralize-english-only"
     | "schema-element-unrecognized"
     | "schema-element-not-allowed-at-root"
@@ -1038,6 +1039,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "deprecated-attribute-renamed",
     "deprecated-attribute-renamed-conflict",
     "deprecated-attribute-ignored",
+    "deprecated-attribute-to-child",
     "pluralize-english-only",
     "schema-element-unrecognized",
     "schema-element-not-allowed-at-root",

--- a/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
+++ b/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
@@ -1,6 +1,14 @@
 import { codedDastError } from "../../coded-dast-error";
 import { DastElement, DastError } from "../../types";
 
+/** The deprecated attribute this sugar consumes. */
+const ATTRIBUTE_NAME = "description";
+/**
+ * The child it becomes. Named once so the element that is inserted, the
+ * warning's English, and the argument a translation reads cannot drift apart.
+ */
+const CHILD_NAME = "shortDescription";
+
 /**
  * If there is a `description` attribute, turn it into a `<shortDescription>` child.
  *
@@ -38,13 +46,13 @@ export function descriptionAttributeSugar(node: DastElement) {
         );
     }
 
-    const descriptionAttribute = node.attributes["description"];
+    const descriptionAttribute = node.attributes[ATTRIBUTE_NAME];
 
     if (descriptionAttribute) {
-        delete node.attributes["description"];
+        delete node.attributes[ATTRIBUTE_NAME];
         const shortDescriptionChild: DastElement = {
             type: "element",
-            name: "shortDescription",
+            name: CHILD_NAME,
             children: descriptionAttribute.children,
             position: descriptionAttribute.position,
             source_doc: descriptionAttribute.source_doc,
@@ -53,11 +61,11 @@ export function descriptionAttributeSugar(node: DastElement) {
         const deprecation: DastError = codedDastError({
             code: "doenet-w0120",
             error_type: "warning",
-            message: `[deprecation] Attribute \`description\` on \`<${node.name}>\` is deprecated; use a \`<shortDescription>\` child instead.`,
+            message: `[deprecation] Attribute \`${ATTRIBUTE_NAME}\` on \`<${node.name}>\` is deprecated; use a \`<${CHILD_NAME}>\` child instead.`,
             args: {
-                attribute: "description",
-                child: "shortDescription",
-                // The component the author actually wrote, since this sugar
+                attribute: ATTRIBUTE_NAME,
+                child: CHILD_NAME,
+                // The component the attribute was written on, since this sugar
                 // covers ten of them.
                 component: node.name,
             },

--- a/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
+++ b/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
@@ -10,9 +10,9 @@ import { DastElement, DastError } from "../../types";
  *
  * The warning is emitted here rather than from `DEPRECATION_REGISTRY`, which
  * knows how to rename an attribute and how to drop one but not how to turn one
- * into a child. Teaching it that shape would put the knowledge of which child
- * `description` becomes in two places, since this function still has to do the
- * splice. Sugar emitting its own coded diagnostics is established — see
+ * into a child. Teaching it that shape would split the knowledge of which child
+ * `description` becomes across two places, since this function still has to
+ * insert it. Sugar emitting its own coded diagnostics is established — see
  * `answerSugar` — and `convertNormalizedDast` lifts a warning node into a
  * diagnostic wherever in the tree it sits, so it need not be hoisted to the
  * `<document>` the way the deprecation pass hoists its own.
@@ -50,8 +50,6 @@ export function descriptionAttributeSugar(node: DastElement) {
             source_doc: descriptionAttribute.source_doc,
             attributes: {},
         };
-        node.children.splice(0, 0, shortDescriptionChild);
-
         const deprecation: DastError = codedDastError({
             code: "doenet-w0120",
             error_type: "warning",
@@ -66,6 +64,7 @@ export function descriptionAttributeSugar(node: DastElement) {
             position: descriptionAttribute.position ?? node.position,
             source_doc: descriptionAttribute.source_doc ?? node.source_doc,
         });
-        node.children.unshift(deprecation);
+
+        node.children.unshift(deprecation, shortDescriptionChild);
     }
 }

--- a/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
+++ b/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
@@ -1,7 +1,21 @@
-import { DastElement } from "../../types";
+import { codedDastError } from "../../coded-dast-error";
+import { DastElement, DastError } from "../../types";
 
 /**
  * If there is a `description` attribute, turn it into a `<shortDescription>` child.
+ *
+ * The attribute is a leftover from version 0.6: it is in neither the schema nor
+ * the documentation, so the only authors reaching it are ones carrying old
+ * source forward. It still works, and warns.
+ *
+ * The warning is emitted here rather than from `DEPRECATION_REGISTRY`, which
+ * knows how to rename an attribute and how to drop one but not how to turn one
+ * into a child. Teaching it that shape would put the knowledge of which child
+ * `description` becomes in two places, since this function still has to do the
+ * splice. Sugar emitting its own coded diagnostics is established — see
+ * `answerSugar` — and `convertNormalizedDast` lifts a warning node into a
+ * diagnostic wherever in the tree it sits, so it need not be hoisted to the
+ * `<document>` the way the deprecation pass hoists its own.
  */
 export function descriptionAttributeSugar(node: DastElement) {
     if (
@@ -37,5 +51,21 @@ export function descriptionAttributeSugar(node: DastElement) {
             attributes: {},
         };
         node.children.splice(0, 0, shortDescriptionChild);
+
+        const deprecation: DastError = codedDastError({
+            code: "doenet-w0120",
+            error_type: "warning",
+            message: `[deprecation] Attribute \`description\` on \`<${node.name}>\` is deprecated; use a \`<shortDescription>\` child instead.`,
+            args: {
+                attribute: "description",
+                child: "shortDescription",
+                // The component the author actually wrote, since this sugar
+                // covers ten of them.
+                component: node.name,
+            },
+            position: descriptionAttribute.position ?? node.position,
+            source_doc: descriptionAttribute.source_doc ?? node.source_doc,
+        });
+        node.children.unshift(deprecation);
     }
 }

--- a/packages/parser/test/coded-dast-errors.test.ts
+++ b/packages/parser/test/coded-dast-errors.test.ts
@@ -208,8 +208,13 @@ describe("Coded DAST errors render to the English the parser wrote", () => {
             ),
             // An attribute that is dropped rather than renamed.
             ...normalizedErrors(`<description weight="2">hi</description>`),
+            // An attribute replaced by a child element, warned about by the
+            // sugar that rewrites it rather than by the deprecation registry.
+            ...normalizedErrors(
+                `<image description="a tree" source="t.png" />`,
+            ),
         ];
-        expect(codedErrors(errors).length).toBe(4);
+        expect(codedErrors(errors).length).toBe(5);
         expectRoundTrip(errors);
     });
 


### PR DESCRIPTION
`<image description="A tree" />` has quietly gone on working since version 0.6: `descriptionAttributeSugar` rewrites the attribute into a `<shortDescription>` child, so it still supplies the alt text. But the attribute is in neither the schema nor the documentation, so the only source still reaching it is old source being carried forward — with nothing to say it is writing something no longer supported.

It now warns, on all ten components that accepted it (`<image>`, `<video>`, `<graph>`, `<answer>` and the `<*Input>`s), and keeps working exactly as before:

> [deprecation] Attribute `description` on `<image>` is deprecated; use a `<shortDescription>` child instead.

## Why the warning comes from the sugar

`DEPRECATION_REGISTRY` knows how to rename an attribute and how to drop one, but not how to turn one into a child. Teaching it that shape would split the knowledge of which child `description` becomes across two places, since `descriptionAttributeSugar` still has to insert it. Sugar emitting its own coded diagnostics is established — see `answerSugar` — and `convertNormalizedDast` lifts a warning node into a diagnostic wherever in the tree it sits, so it need not be hoisted to the `<document>` the way the deprecation pass hoists its own.

`doenet-w0120` / `deprecated-attribute-to-child` is a new message rather than a reuse of `deprecated-attribute-renamed`, whose sentence is about an attribute replacing an attribute. It names the component the attribute was written on, since this sugar covers ten of them.

## Notes

- Nothing in the repo authored `description="…"` — no docs, tests, or `v06-to-v07` output — so there was no churn to fix up.
- Since the attribute is absent from the generated schema, the LSP already reported it as unrecognized (`doenet-w0115`); in the editor authors will now see both that and the deprecation, the same doubling that already exists for other deprecated attributes.
- The sugar matches the attribute name exactly, as it always has, so `<image Description="A tree" />` is untouched: no `<shortDescription>` child and no deprecation warning, just the invalid-attribute report it gets today. The deprecation pass, by contrast, matches case-insensitively. Left as is here — making the sugar case-insensitive would start accepting spellings that do not work today, which is a change of its own.

## Testing

- `packages/parser/test/coded-dast-errors.test.ts`: added `<image description="a tree" …>` to the `deprecated attributes` case, which pins the parser's hand-written English to the catalog and satisfies that file's "every code is exercised" assertion.
- `packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts`: a new test asserting the round trip end to end — `shortDescription` is still `"A tree"`, no accessibility diagnostic, and one warning with the code, its three args, and the exact message.
- `packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts`: a second test alongside the existing deprecation-warning tests, covering `<mathInput>` and `<graph>` together, which pins the component name the message interpolates rather than leaving `<image>` as the only case.
- Checked by hand that each of the remaining components emits exactly one warning and no errors, and that the `<answer>` and `<fractionInput>` sugars that run after this one are undisturbed by the inserted warning node.
- Suites run: `packages/parser` (297 passed), `image.test.ts` (14 passed), `src/test/diagnostics` (98 passed, 3 pre-existing skips), `npm run lint:i18n -w @doenet/i18n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

