### PR TITLE
Point Mac users at Option+I for the full component list

### DIFF
--- a/.changeset/context-help-mac-completion-shortcut.md
+++ b/.changeset/context-help-mac-completion-shortcut.md
@@ -14,5 +14,7 @@ every platform, but macOS claims Control+Space for "Select the previous input
 source", so the keystroke is swallowed before the editor sees it. CodeMirror
 ships mac-only alternates for that reason, and the panel now points at one of
 them (Option+I) when running on a Mac; other platforms still see Ctrl+Space.
+The authoring guides that point at the autocomplete menu name the Mac
+alternate too.
 
 Closes #1537.

--- a/.changeset/context-help-mac-completion-shortcut.md
+++ b/.changeset/context-help-mac-completion-shortcut.md
@@ -1,0 +1,18 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Context help now names the shortcut that works on a Mac: Option+I.
+
+The panel's "Press Ctrl+Space to see all N components" footer named a key
+combination Mac users cannot use. CodeMirror binds a literal Control+Space on
+every platform, but macOS claims Control+Space for "Select the previous input
+source", so the keystroke is swallowed before the editor sees it. CodeMirror
+ships mac-only alternates for that reason, and the panel now points at one of
+them (Option+I) when running on a Mac; other platforms still see Ctrl+Space.
+
+Closes #1537.

--- a/packages/docs-nextra/pages/guides/mathematical-questions.mdx
+++ b/packages/docs-nextra/pages/guides/mathematical-questions.mdx
@@ -28,7 +28,7 @@ A few things are worth noticing:
 - **Doenet accepts any equivalent form.** By default a math answer uses a numerical checker with a liberal notion of equality, so `2x{:dn}`, `x + x{:dn}`, and `2*x{:dn}` are all marked correct. The sections below show how to tighten that up.
 
 <Callout type="info">
-**Shortcut:** in the Doenet editor, open the autocomplete menu (**Ctrl+Space**) anywhere an `<answer>{:dn}` can go and choose the **`answer-labeled`** template. It drops in an `<answer>{:dn}` with an empty `<label>{:dn}`, ready for your question and answer.
+**Shortcut:** in the Doenet editor, open the autocomplete menu (**Ctrl+Space**, or **Option+I** on a Mac) anywhere an `<answer>{:dn}` can go and choose the **`answer-labeled`** template. It drops in an `<answer>{:dn}` with an empty `<label>{:dn}`, ready for your question and answer.
 </Callout>
 
 ---

--- a/packages/docs-nextra/pages/guides/multiple-choice-questions.mdx
+++ b/packages/docs-nextra/pages/guides/multiple-choice-questions.mdx
@@ -30,7 +30,7 @@ A few things are worth noticing:
 - **The `<label>{:dn}` is the question.** Putting the prompt in a `<label>{:dn}` makes it visible *and* ties it to the choices, so a screen reader announces the question when the reader reaches the input. When the question instead lives in the surrounding sentence, use a `<shortDescription>{:dn}` — see [Inline, inside a sentence](#inline-inside-a-sentence) below.
 
 <Callout type="info">
-**Shortcut:** in the Doenet editor, open the autocomplete menu (**Ctrl+Space**) anywhere an `<answer>{:dn}` can go and choose the **`multiple-choice-answer`** template. It drops in a filled-out `<answer>{:dn}` with a `<label>{:dn}` and five `<choice>{:dn}` elements for you to edit.
+**Shortcut:** in the Doenet editor, open the autocomplete menu (**Ctrl+Space**, or **Option+I** on a Mac) anywhere an `<answer>{:dn}` can go and choose the **`multiple-choice-answer`** template. It drops in a filled-out `<answer>{:dn}` with a `<label>{:dn}` and five `<choice>{:dn}` elements for you to edit.
 </Callout>
 
 Each section below takes this same basic recipe and adds a single attribute, showing what it changes.
@@ -91,7 +91,7 @@ Add `selectMultiple{:dn}` and the radio buttons become checkboxes: the reader ca
 By default this is all-or-nothing: to earn full credit the reader must check every choice marked `credit="1"{:dn}` and leave every other choice unchecked. Selecting one wrong option, or missing one correct option, scores 0. To soften that, add partial credit — next.
 
 <Callout type="info">
-**Shortcut:** the **`multiple-choice-select-multiple-answer`** template in the autocomplete menu (**Ctrl+Space**, where an `<answer>{:dn}` is allowed) drops in a `selectMultiple{:dn}` answer with two correct choices already marked, ready to edit.
+**Shortcut:** the **`multiple-choice-select-multiple-answer`** template in the autocomplete menu (**Ctrl+Space**, or **Option+I** on a Mac, where an `<answer>{:dn}` is allowed) drops in a `selectMultiple{:dn}` answer with two correct choices already marked, ready to edit.
 </Callout>
 
 ---
@@ -210,7 +210,7 @@ Put all three together (here with `shuffleOrder{:dn}` so the layout varies):
 Try it: pick a wrong option and it grays out while you keep going; reach the correct one and the question locks. The score reflects how many tries it took.
 
 <Callout type="info">
-**Shortcut:** the autocomplete menu (**Ctrl+Space**, where an `<answer>{:dn}` is allowed) includes an **`if-at-(immediate-feedback-assessment-technique)-answer`** template that drops in this exact combination of attributes, ready for you to fill in the question and choices.
+**Shortcut:** the autocomplete menu (**Ctrl+Space**, or **Option+I** on a Mac, where an `<answer>{:dn}` is allowed) includes an **`if-at-(immediate-feedback-assessment-technique)-answer`** template that drops in this exact combination of attributes, ready for you to fill in the question and choices.
 </Callout>
 
 ---

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.test.ts
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveCssVariables, valueListLabel } from "./ContextHelpPanel";
+import {
+    completionShortcutLabel,
+    resolveCssVariables,
+    valueListLabel,
+} from "./ContextHelpPanel";
 
 describe("valueListLabel", () => {
     // A translator standing in for a catalog that has none of these keys, so
@@ -128,5 +132,18 @@ describe("resolveCssVariables", () => {
         expect(resolveCssVariables("var(--lightGreen)")).toBe(
             "var(--lightGreen)",
         );
+    });
+});
+
+describe("completionShortcutLabel", () => {
+    it("names Ctrl+Space off a Mac", () => {
+        expect(completionShortcutLabel(false)).toBe("Ctrl+Space");
+    });
+
+    it("names Option+I on a Mac (#1537)", () => {
+        // CodeMirror binds a literal Ctrl-Space everywhere, but macOS eats
+        // Control+Space for input-source switching, so the panel must point
+        // at the mac-only alternate that actually reaches the editor.
+        expect(completionShortcutLabel(true)).toBe("Option+I");
     });
 });

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.test.ts
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.test.ts
@@ -136,7 +136,7 @@ describe("resolveCssVariables", () => {
 });
 
 describe("completionShortcutLabel", () => {
-    it("names Ctrl+Space off a Mac", () => {
+    it("names Ctrl+Space on non-Mac platforms", () => {
         expect(completionShortcutLabel(false)).toBe("Ctrl+Space");
     });
 

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { MathJax } from "better-react-mathjax";
 import { parseInlineMarkdown } from "@doenet/utils/markdown/parseInlineMarkdown";
 import { isMathDefaultValue } from "@doenet/static-assets/schema";
+import { isMacPlatform } from "@doenet/utils";
 import type {
     FunctionNamesBreakdownPayload,
     HelpContent,
@@ -10,6 +11,24 @@ import type { Translator } from "@doenet/i18n";
 import { useT } from "../../utils/i18n";
 import { fillSlots, slot } from "../slots";
 import "./context-help-panel.css";
+
+/**
+ * The key combination that opens the full element-completion menu, named for
+ * the platform the editor is running on.
+ *
+ * CodeMirror's `completionKeymap` binds a literal `Ctrl-Space` on every
+ * platform (it does not use `Mod-`, so this stays Control, not Cmd, on a Mac).
+ * But macOS itself claims Control+Space for "Select the previous input
+ * source", so on a Mac the keystroke is usually swallowed before the browser
+ * ever sees it. Upstream ships mac-only alternates for exactly that reason —
+ * `Alt-i` and ``Alt-` `` — so Mac users are pointed at Option+I, which does
+ * reach the editor.
+ */
+export function completionShortcutLabel(
+    isMac: boolean = isMacPlatform(),
+): string {
+    return isMac ? "Option+I" : "Ctrl+Space";
+}
 
 /**
  * Render schema description text, mapping the shared inline-markdown tokens
@@ -313,7 +332,7 @@ export function ContextHelpPanel({
                                     },
                                     `Press ${slot(0)} to see all ${totalAllowed} components.`,
                                 ),
-                                [<code>Ctrl+Space</code>],
+                                [<code>{completionShortcutLabel()}</code>],
                             )}
                         </p>
                     )}

--- a/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
+++ b/packages/doenetml/src/EditorViewer/contextHelp/context-help-panel.css
@@ -267,8 +267,8 @@
 /*
  * "What can go here?" suggestions surfaced when the cursor sits in an
  * element body or at the top level. The header names the location, the list
- * shows curated starter components as links, and a muted footer points at
- * Ctrl+Space for the full set.
+ * shows curated starter components as links, and a muted footer points at the
+ * platform's completion shortcut for the full set.
  */
 .editor-panel .help-suggestions-header {
     margin: 0;

--- a/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
@@ -253,9 +253,12 @@ describe("Context-sensitive help panel", { tags: ["@group5"] }, function () {
                 "have.length.greaterThan",
                 0,
             );
+            // The footer names the completion shortcut that actually works on
+            // the host platform: macOS swallows Control+Space for input-source
+            // switching, so the panel points Mac users at Option+I instead.
             cy.get(".help-suggestions-footer").should(
                 "contain.text",
-                "Ctrl+Space",
+                Cypress.platform === "darwin" ? "Option+I" : "Ctrl+Space",
             );
         });
     });

--- a/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/contextSensitiveHelp.cy.js
@@ -1,3 +1,5 @@
+import { isMacPlatform } from "@doenet/utils";
+
 // End-to-end smoke tests for the context-sensitive help panel.
 //
 // Unit tests in packages/doenetml/src/EditorViewer/contextHelp/
@@ -254,11 +256,15 @@ describe("Context-sensitive help panel", { tags: ["@group5"] }, function () {
                 0,
             );
             // The footer names the completion shortcut that actually works on
-            // the host platform: macOS swallows Control+Space for input-source
-            // switching, so the panel points Mac users at Option+I instead.
+            // the browser's platform: macOS swallows Control+Space for
+            // input-source switching, so the panel points Mac users at
+            // Option+I instead. Spec code runs in the same browser as the app,
+            // so reusing the app's own detection (rather than, say,
+            // `Cypress.platform`, which reports the OS of the machine running
+            // Cypress) asks exactly the question the panel asked.
             cy.get(".help-suggestions-footer").should(
                 "contain.text",
-                Cypress.platform === "darwin" ? "Option+I" : "Ctrl+Space",
+                isMacPlatform() ? "Option+I" : "Ctrl+Space",
             );
         });
     });


### PR DESCRIPTION
The context-help panel's footer said **"Press Ctrl+Space to see all N components"** on every platform, but that combination cannot work on a Mac.

CodeMirror's `completionKeymap` binds a literal `Ctrl-Space` (it does not use `Mod-`, so it stays Control rather than Cmd on macOS), and macOS itself claims Control+Space for "Select the previous input source" — the keystroke is swallowed before the browser sees it. Upstream ships mac-only alternates for exactly that reason (`Alt-i` and ``Alt-` ``), so the panel now names **Option+I** when running on a Mac. Other platforms are unchanged.

The shortcut is already a message slot (`help-suggestions-footer` takes `$shortcut`), so no catalog changes are needed.

- `completionShortcutLabel()` in `ContextHelpPanel.tsx`, taking `isMacPlatform()` from `@doenet/utils` as a default argument so it can be unit-tested directly.
- Two tests in `ContextHelpPanel.test.ts`.
- The Cypress footer assertion in `contextSensitiveHelp.cy.js` now expects the platform's label, using the app's own `isMacPlatform()` from `@doenet/utils` — spec code runs in the same browser as the app, so this asks exactly the question the panel asked (unlike `Cypress.platform`, which reports the OS of the machine running Cypress). The suite passes when run on a Mac as well as on CI.
- The authoring guides that tell readers to open the autocomplete menu (`guides/mathematical-questions.mdx`, `guides/multiple-choice-questions.mdx`) now name the Mac alternate alongside Ctrl+Space, so the docs and the panel agree.

Closes #1537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
