### PR TITLE
Give the standalone bundle one instance of @doenet/i18n

### DIFF
--- a/.changeset/single-i18n-instance-in-standalone.md
+++ b/.changeset/single-i18n-instance-in-standalone.md
@@ -14,4 +14,4 @@ The one file held two copies of `@doenet/i18n`: one built from source for `src/i
 
 `@doenet/doenetml` now re-exports `setLocaleLoaders` and `fetchLocaleLoaders`, and `@doenet/standalone` reaches them through the same entry point its viewer comes from, which makes the setter and the reader one instance. A host installing its own catalogs should import them from `@doenet/doenetml` for the same reason.
 
-Two guards, because neither half of this was visible: `npm run check:size -w packages/standalone` now fails the build unless the standalone bundle holds exactly one copy of `@doenet/i18n`, and a component spec renders a document in a language only a served catalog carries and asserts the request goes out.
+Two guards, because neither half of this was visible: `npm run check:i18n-instances` fails the build when any built package holds more than one copy of `@doenet/i18n` in one script, and a component spec renders a document in a language only a served catalog carries and asserts the request goes out.

--- a/.changeset/single-i18n-instance-in-standalone.md
+++ b/.changeset/single-i18n-instance-in-standalone.md
@@ -8,10 +8,10 @@
 
 Fix `@doenet/standalone` rendering every language in English.
 
-The bundle published as 0.7.22 never requested a message catalog. A document declaring `<document lang="ar">` was recognized in every visible way — it laid out right to left, negotiated its locale, labelled itself `lang="ar"` — and then read "Check Work", because the catalog that would have said otherwise was sitting unfetched beside the bundle.
+The bundle published as 0.7.22 never requested a message catalog. A document declaring `<document lang="ar">` was recognized in every visible way — it laid out right to left, negotiated its locale, labelled itself `lang="ar"` — and then read "Check Work", because the catalog that would have said otherwise sat unfetched beside the bundle.
 
-Two copies of `@doenet/i18n` were in the one file: one built from source for `src/index.tsx`, which installs the loaders that fetch the served catalogs, and one already compiled into `@doenet/doenetml`, which is the copy the viewer resolves a language through. The loaders are module-level state and do not cross between instances, so the viewer's copy held none, judged every language unloadable, and fell back to English — which is exactly what it is supposed to do when a catalog cannot be reached, and therefore said nothing about it.
+The one file held two copies of `@doenet/i18n`: one built from source for `src/index.tsx`, which installs the loaders that fetch the served catalogs, and one already compiled into `@doenet/doenetml`, which is the copy the viewer resolves a language through. The loaders are module-level state and do not cross between instances, so the viewer's copy held none, judged every language unloadable, and fell back to English — which is exactly what it is supposed to do when a catalog cannot be reached, and therefore said nothing about it.
 
 `@doenet/doenetml` now re-exports `setLocaleLoaders` and `fetchLocaleLoaders`, and `@doenet/standalone` reaches them through the same entry point its viewer comes from, which makes the setter and the reader one instance. A host installing its own catalogs should import them from `@doenet/doenetml` for the same reason.
 
-Two guards, because neither half of this was visible: `npm run check:size -w packages/standalone` now fails the build when an emitted script holds more than one copy of `@doenet/i18n`, and a component spec renders a document in a language only a served catalog carries and asserts the request goes out.
+Two guards, because neither half of this was visible: `npm run check:size -w packages/standalone` now fails the build unless the standalone bundle holds exactly one copy of `@doenet/i18n`, and a component spec renders a document in a language only a served catalog carries and asserts the request goes out.

--- a/.changeset/single-i18n-instance-in-standalone.md
+++ b/.changeset/single-i18n-instance-in-standalone.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix `@doenet/standalone` rendering every language in English.
+
+The bundle published as 0.7.22 never requested a message catalog. A document declaring `<document lang="ar">` was recognized in every visible way — it laid out right to left, negotiated its locale, labelled itself `lang="ar"` — and then read "Check Work", because the catalog that would have said otherwise was sitting unfetched beside the bundle.
+
+Two copies of `@doenet/i18n` were in the one file: one built from source for `src/index.tsx`, which installs the loaders that fetch the served catalogs, and one already compiled into `@doenet/doenetml`, which is the copy the viewer resolves a language through. The loaders are module-level state and do not cross between instances, so the viewer's copy held none, judged every language unloadable, and fell back to English — which is exactly what it is supposed to do when a catalog cannot be reached, and therefore said nothing about it.
+
+`@doenet/doenetml` now re-exports `setLocaleLoaders` and `fetchLocaleLoaders`, and `@doenet/standalone` reaches them through the same entry point its viewer comes from, which makes the setter and the reader one instance. A host installing its own catalogs should import them from `@doenet/doenetml` for the same reason.
+
+Two guards, because neither half of this was visible: `npm run check:size -w packages/standalone` now fails the build when an emitted script holds more than one copy of `@doenet/i18n`, and a component spec renders a document in a language only a served catalog carries and asserts the request goes out.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
             - name: Check language server bundle
               run: npm run check:size -w packages/lsp
 
+            # A bundle holding two copies of @doenet/i18n installs its locale
+            # loaders on an instance the viewer never reads, so every language
+            # renders in English and nothing says so — which is how 0.7.22
+            # shipped. Every built package is scanned, since any bundle that
+            # combines a prebuilt @doenet/doenetml with a source build of
+            # @doenet/i18n can hit it.
+            - name: Check for duplicate i18n instances
+              run: npm run check:i18n-instances
+
             - name: Debug Build Artifacts
               run: |
                   ls -la ./packages/*/.wireit/ || echo "No .wireit directory found"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "dev": "npm run dev --workspace packages/doenetml",
         "docs": "npm run build --workspace packages/docs-nextra & npm run dev --workspace packages/docs-nextra",
         "lint:i18n": "npm run lint:i18n -w @doenet/i18n",
+        "check:i18n-instances": "npm run check:instances -w @doenet/i18n",
         "prettier:check": "prettier --check .",
         "prettier:format": "prettier --write .",
         "publish": "npm run publish -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07",

--- a/packages/doenetml/src/index.ts
+++ b/packages/doenetml/src/index.ts
@@ -31,3 +31,21 @@ export type {
 } from "@doenet/utils";
 
 export { CodeMirror } from "@doenet/codemirror";
+
+// Where a host installs catalogs the viewer in *this* bundle will read.
+//
+// Re-exported rather than left to `@doenet/i18n` because the loaders are
+// module-level state, and a bundle can hold more than one instance of that
+// module: `@doenet/standalone` builds its own copy of `@doenet/i18n` from
+// source while the viewer it renders carries the copy compiled into this
+// package's `dist/`. Installing loaders on the first leaves the second — the
+// one that actually resolves a document's language — with none, and since a
+// catalog that cannot be reached is a silent fall back to English, the whole
+// arrangement fails without a word. Reaching the setter through the same
+// entry point the viewer comes from is what makes the two the same instance.
+export {
+    setLocaleLoaders,
+    fetchLocaleLoaders,
+    type LocaleLoader,
+    type LocaleLoaders,
+} from "@doenet/i18n";

--- a/packages/doenetml/src/index.ts
+++ b/packages/doenetml/src/index.ts
@@ -34,14 +34,12 @@ export { CodeMirror } from "@doenet/codemirror";
 
 // Where a host installs the message catalogs the viewer in *this* bundle reads.
 //
-// Re-exported rather than left to `@doenet/i18n` because the loaders are
-// module-level state and a bundle can hold more than one instance of that
-// module: `@doenet/standalone` builds its own copy from source while the viewer
-// it renders carries the copy compiled into this package's `dist/`. Installing
-// loaders on the first leaves the second — the one that resolves a document's
-// language — with none, and an unreachable catalog is a silent fall back to
-// English. Reaching the setter through the same entry point the viewer comes
-// from makes the two one instance.
+// The loaders are module-level state, and a bundle can hold more than one
+// instance of `@doenet/i18n` — one built from the host's own source tree, one
+// compiled into this package's `dist/`. Only the latter resolves a document's
+// language, so a host must reach the setter through the entry point its viewer
+// comes from; installing loaders on any other instance leaves the viewer with
+// none, and an unreachable catalog falls back to English in silence.
 export {
     setLocaleLoaders,
     fetchLocaleLoaders,

--- a/packages/doenetml/src/index.ts
+++ b/packages/doenetml/src/index.ts
@@ -32,17 +32,16 @@ export type {
 
 export { CodeMirror } from "@doenet/codemirror";
 
-// Where a host installs catalogs the viewer in *this* bundle will read.
+// Where a host installs the message catalogs the viewer in *this* bundle reads.
 //
 // Re-exported rather than left to `@doenet/i18n` because the loaders are
-// module-level state, and a bundle can hold more than one instance of that
-// module: `@doenet/standalone` builds its own copy of `@doenet/i18n` from
-// source while the viewer it renders carries the copy compiled into this
-// package's `dist/`. Installing loaders on the first leaves the second — the
-// one that actually resolves a document's language — with none, and since a
-// catalog that cannot be reached is a silent fall back to English, the whole
-// arrangement fails without a word. Reaching the setter through the same
-// entry point the viewer comes from is what makes the two the same instance.
+// module-level state and a bundle can hold more than one instance of that
+// module: `@doenet/standalone` builds its own copy from source while the viewer
+// it renders carries the copy compiled into this package's `dist/`. Installing
+// loaders on the first leaves the second — the one that resolves a document's
+// language — with none, and an unreachable catalog is a silent fall back to
+// English. Reaching the setter through the same entry point the viewer comes
+// from makes the two one instance.
 export {
     setLocaleLoaders,
     fetchLocaleLoaders,

--- a/packages/doenetml/test/cypress/component/DoenetViewer.fetchedCatalog.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.fetchedCatalog.cy.tsx
@@ -11,20 +11,16 @@ import {
 // words come back.
 //
 // Both halves are imported from *this package's* entry point rather than from
-// `@doenet/i18n`, and that is the point of the spec rather than an incidental
-// tidiness. The loaders are module-level state. A bundle that holds two copies
-// of `@doenet/i18n` — which `@doenet/standalone` did in 0.7.22, one built from
-// source for the setter and one compiled into `@doenet/doenetml` for the viewer
-// — installs them on an instance the viewer never reads, and then never
-// requests a catalog at all. Nothing said so: an unreachable catalog is a
-// deliberate, silent fall back to English, so every language rendered in
-// English while `lang`/`dir` and locale negotiation went on working perfectly.
+// `@doenet/i18n`, which is the point of the spec. The loaders are module-level
+// state, so a bundle holding two copies of `@doenet/i18n` — as
+// `@doenet/standalone` did in 0.7.22 — installs them on an instance the viewer
+// never reads and then requests no catalog at all, silently falling back to
+// English.
 //
-// A source-built spec cannot reproduce the two instances (there is only ever
-// one here); what it can do is hold the seam that fix rests on — the setter and
-// the viewer reached through one entry point — and assert the request that no
-// other test looks for. `packages/standalone/scripts/check-bundle-size.mjs`
-// counts the copies in the built bundle, which is the half this cannot see.
+// A source-built spec cannot reproduce the two instances; what it can do is
+// hold the seam the fix rests on and assert the request that no other test
+// looks for. `packages/standalone/scripts/check-bundle-size.mjs` counts the
+// copies in the built bundle, which is the half this cannot see.
 
 const VIEWER_TIMEOUT = 15_000;
 

--- a/packages/doenetml/test/cypress/component/DoenetViewer.fetchedCatalog.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.fetchedCatalog.cy.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import {
+    DoenetViewer,
+    fetchLocaleLoaders,
+    setLocaleLoaders,
+} from "../../../src/doenetml-inline-worker";
+
+// The seam `@doenet/standalone` renders through, exercised end to end: install
+// fetch loaders pointed at catalogs served somewhere, render a document in a
+// language only those catalogs carry, and watch the request go out and the
+// words come back.
+//
+// Both halves are imported from *this package's* entry point rather than from
+// `@doenet/i18n`, and that is the point of the spec rather than an incidental
+// tidiness. The loaders are module-level state. A bundle that holds two copies
+// of `@doenet/i18n` — which `@doenet/standalone` did in 0.7.22, one built from
+// source for the setter and one compiled into `@doenet/doenetml` for the viewer
+// — installs them on an instance the viewer never reads, and then never
+// requests a catalog at all. Nothing said so: an unreachable catalog is a
+// deliberate, silent fall back to English, so every language rendered in
+// English while `lang`/`dir` and locale negotiation went on working perfectly.
+//
+// A source-built spec cannot reproduce the two instances (there is only ever
+// one here); what it can do is hold the seam that fix rests on — the setter and
+// the viewer reached through one entry point — and assert the request that no
+// other test looks for. `packages/standalone/scripts/check-bundle-size.mjs`
+// counts the copies in the built bundle, which is the half this cannot see.
+
+const VIEWER_TIMEOUT = 15_000;
+
+/** Where the catalogs are served from, as a host would lay them out. */
+const CATALOG_BASE = "https://catalogs.test/locales/";
+
+/**
+ * `<paginatorControls>`'s words are computed by the core, so a catalog that
+ * reaches them reached the worker rather than only the chrome around it.
+ */
+const CONTROLS = `
+<paginatorControls name="pc" paginator="$pgn" />
+<paginator name="pgn">
+  <section><p>one</p></section>
+  <section><p>two</p></section>
+</paginator>
+`;
+
+/** The language declared in the source, the way an author writes it. */
+const DECLARED_DOENETML = `<document lang="qq">${CONTROLS}</document>`;
+
+/**
+ * Serve `qq`'s content catalog and nothing else, counting what was asked for.
+ *
+ * The other namespaces 404 the way a partially translated locale's would, so
+ * the spec also covers a loader shrugging off the catalogs that are not there.
+ */
+function serveCatalogs(): string[] {
+    const requested: string[] = [];
+    cy.intercept("GET", `${CATALOG_BASE}qq/*.ftl`, (req) => {
+        requested.push(req.url.slice(CATALOG_BASE.length));
+        if (req.url.endsWith("/content.ftl")) {
+            req.reply({
+                statusCode: 200,
+                body: "paginator-previous = Zyxwv\n",
+            });
+        } else {
+            req.reply({ statusCode: 404, body: "" });
+        }
+    });
+    return requested;
+}
+
+describe("catalogs fetched from where a host serves them", () => {
+    beforeEach(() => {
+        // `qq` is not a language this repository ships, so nothing here can
+        // pass on a catalog that happened to be present. It has to be named
+        // explicitly: `fetchLocaleLoaders` offers `SUPPORTED_LOCALES` by
+        // default, and a made-up tag is not one of them.
+        setLocaleLoaders(fetchLocaleLoaders(CATALOG_BASE, ["qq"]));
+    });
+
+    afterEach(() => {
+        // Also empties the request cache, so no spec inherits another's.
+        setLocaleLoaders(null);
+    });
+
+    it("requests the catalog for a language the document declares", () => {
+        const requested = serveCatalogs();
+
+        cy.mount(
+            <DoenetViewer
+                doenetML={DECLARED_DOENETML}
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get("#pc_previous", { timeout: VIEWER_TIMEOUT }).should(
+            "have.text",
+            "Zyxwv",
+        );
+        // The half the served catalog does not translate falls back to English
+        // rather than rendering blank or as its key.
+        cy.get("#pc_next").should("have.text", "Next");
+        // The words could only have come from the request, but assert it
+        // directly: a bundle that installs loaders the viewer cannot see fails
+        // by making no request, and that is the failure worth naming.
+        cy.wrap(null).should(() => {
+            expect(requested).to.include("qq/content.ftl");
+        });
+    });
+
+    it("requests it for a language named by a prop", () => {
+        const requested = serveCatalogs();
+
+        cy.mount(
+            <DoenetViewer
+                doenetML={CONTROLS}
+                documentLocale="qq"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.get("#pc_previous", { timeout: VIEWER_TIMEOUT }).should(
+            "have.text",
+            "Zyxwv",
+        );
+        cy.wrap(null).should(() => {
+            expect(requested).to.include("qq/content.ftl");
+        });
+    });
+
+    it("asks for nothing when the document renders in English", () => {
+        // English ends every fallback chain and is carried in the bundle, so a
+        // document that needs no other language should cost no request at all.
+        const requested = serveCatalogs();
+
+        cy.mount(
+            <DoenetViewer doenetML={CONTROLS} addVirtualKeyboard={false} />,
+        );
+
+        cy.get("#pc_previous", { timeout: VIEWER_TIMEOUT }).should(
+            "have.text",
+            "Previous",
+        );
+        cy.wrap(null).should(() => {
+            expect(requested).to.be.empty;
+        });
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetViewer.loadedLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.loadedLocale.cy.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { setLocaleLoaders } from "@doenet/i18n";
-import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+import {
+    DoenetViewer,
+    setLocaleLoaders,
+} from "../../../src/doenetml-inline-worker";
 
 // A language that is not inlined has to travel further than a bundled one: the
 // main thread loads its catalog while the document is already rendering, and

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -550,8 +550,8 @@ The third way a served catalog goes unread has its own check, `check:instances`
 in this package (`npm run check:i18n-instances` from the root): the loaders are
 module-level state, so a bundle holding two copies of this package installs them
 on an instance the viewer never reads, sees an empty registry, and falls back to
-English in silence. Every built `packages/*/dist/` is scanned, not the bundle
-that has been bitten, because any build combining a prebuilt `@doenet/doenetml`
+English in silence. Every built `packages/*/dist/` is scanned, not only the
+bundle that has been bitten, because any build combining a prebuilt `@doenet/doenetml`
 with a source build of this package can hit it — counted per emitted script,
 since a script is what shares a module registry, and a package that emits both a
 bundle and a worker holds a copy in each quite correctly.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -544,7 +544,10 @@ across. `packages/standalone/scripts/check-bundle-size.mjs` fails the build if
 a served catalog turns up inside an emitted script, and if any locale directory
 did not reach `dist/locales/` — the copy is of the whole directory, English
 included, so the second half stays meaningful whatever the inlining decision
-turns out to be.
+turns out to be. It also fails the build if the bundle holds more than one copy
+of this package, which is the third way a served catalog goes unread: the
+loaders are module-level state, so a viewer compiled against a second instance
+sees an empty registry and falls back to English in silence.
 
 Two lists have to agree for any of this to hold, and `lint:i18n` checks that
 they do: the locales excluded from the glob in `load.ts` are exactly
@@ -558,7 +561,11 @@ call `setLocaleLoaders(fetchLocaleLoaders(url, tags))`. The second replaces the
 loaders for the whole page rather than adding to them — a standalone bundle
 that calls it is no longer reading its own `locales/` — and `tags` is worth
 passing whenever the language is not one DoenetML ships, since the default list
-is `SUPPORTED_LOCALES`.
+is `SUPPORTED_LOCALES`. Import both functions from `@doenet/doenetml`, which
+re-exports them, rather than from `@doenet/i18n` directly: that reaches the same
+instance the viewer resolves a language through, and a host bundle that pulls in
+this package separately would otherwise install the loaders where nothing reads
+them.
 
 ## Keys
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -544,10 +544,17 @@ across. `packages/standalone/scripts/check-bundle-size.mjs` fails the build if
 a served catalog turns up inside an emitted script, and if any locale directory
 did not reach `dist/locales/` — the copy is of the whole directory, English
 included, so the second half stays meaningful whatever the inlining decision
-turns out to be. It also fails the build if the bundle holds more than one copy
-of this package, which is the third way a served catalog goes unread: the
-loaders are module-level state, so a viewer compiled against a second instance
-sees an empty registry and falls back to English in silence.
+turns out to be.
+
+The third way a served catalog goes unread has its own check, `check:instances`
+in this package (`npm run check:i18n-instances` from the root): the loaders are
+module-level state, so a bundle holding two copies of this package installs them
+on an instance the viewer never reads, sees an empty registry, and falls back to
+English in silence. Every built `packages/*/dist/` is scanned, not the bundle
+that has been bitten, because any build combining a prebuilt `@doenet/doenetml`
+with a source build of this package can hit it — counted per emitted script,
+since a script is what shares a module registry, and a package that emits both a
+bundle and a worker holds a copy in each quite correctly.
 
 Two lists have to agree for any of this to hold, and `lint:i18n` checks that
 they do: the locales excluded from the glob in `load.ts` are exactly

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -20,7 +20,8 @@
         "test": "vitest",
         "build": "wireit",
         "codegen": "vite-node ./scripts/generate-message-keys.ts",
-        "lint:i18n": "vite-node ./scripts/lint-catalogs.ts"
+        "lint:i18n": "vite-node ./scripts/lint-catalogs.ts",
+        "check:instances": "vite-node ./scripts/check-bundle-instances.ts"
     },
     "wireit": {
         "build": {

--- a/packages/i18n/scripts/bundleInstances.ts
+++ b/packages/i18n/scripts/bundleInstances.ts
@@ -1,0 +1,161 @@
+/**
+ * Counting instances of this package inside built bundles.
+ *
+ * The pure half of `check-bundle-instances.ts`, kept apart so the tests can
+ * exercise the decisions without a build — the same split `catalogUtils.ts`
+ * has with `lint-catalogs.ts`.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const I18N_ROOT = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+);
+export const PACKAGES_DIR = path.resolve(I18N_ROOT, "..");
+export const LOAD_MODULE_FILE = path.join(I18N_ROOT, "src", "load.ts");
+
+/**
+ * The script that installs the locale loaders and renders the viewer that
+ * reads them, and so must hold exactly one instance rather than at most one.
+ * The one bundle where a second copy is not merely wasteful but breaking.
+ */
+export const SINGLE_INSTANCE_SCRIPT =
+    "packages/standalone/dist/doenet-standalone.js";
+
+/** Emitted JavaScript, in any extension a bundler might choose. */
+const SCRIPT_EXTENSION = /\.[cm]?js$/;
+
+/** The `CATALOG_PATH_PATTERN` declaration in `src/load.ts`. */
+const MARKER_DECLARATION = /^const CATALOG_PATH_PATTERN = (\/.+\/);$/m;
+
+/**
+ * The regex literal `src/load.ts` matches catalog paths with, read out of the
+ * source so the marker cannot drift away from the module it stands for.
+ *
+ * A regex literal is what makes a usable marker: a minifier renames every
+ * binding around it and rewrites the code, but it can only copy the pattern
+ * through verbatim. Counting it counts instances of the module that owns the
+ * loader registry.
+ *
+ * @returns the pattern's source text, or `null` if `load.ts` no longer spells
+ *   it as a literal — which the caller reports rather than skipping, since a
+ *   marker nothing can find would pass every bundle it was shown.
+ */
+export function loaderRegistryMarker(
+    loadModuleFile: string = LOAD_MODULE_FILE,
+): string | null {
+    if (!fs.existsSync(loadModuleFile)) {
+        return null;
+    }
+    const match = MARKER_DECLARATION.exec(
+        fs.readFileSync(loadModuleFile, "utf-8"),
+    );
+    return match ? match[1] : null;
+}
+
+/** Non-overlapping occurrences of a fixed string. */
+export function countInstances(text: string, marker: string): number {
+    return text.split(marker).length - 1;
+}
+
+/** One emitted script and how many copies of this package it holds. */
+export type ScannedScript = { file: string; instances: number };
+
+/**
+ * Every emitted script under `packages/*` /`dist/`, with its instance count,
+ * keyed by a repo-relative path with forward slashes on every platform.
+ *
+ * Only `dist/`, so a dev build (`dist-dev/`) or a test fixture cannot fail the
+ * check for something nobody ships. Source maps are skipped by the extension
+ * test: a map embeds the sources it maps, so it would count the marker again
+ * for a perfectly correct build.
+ */
+export function collectDistScripts(
+    marker: string,
+    packagesDir: string = PACKAGES_DIR,
+): ScannedScript[] {
+    const scanned: ScannedScript[] = [];
+    if (!fs.existsSync(packagesDir)) {
+        return scanned;
+    }
+    for (const pkg of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+        const distDir = path.join(packagesDir, pkg.name, "dist");
+        if (!pkg.isDirectory() || !fs.existsSync(distDir)) {
+            continue;
+        }
+        for (const entry of fs.readdirSync(distDir, {
+            withFileTypes: true,
+            recursive: true,
+        })) {
+            if (!entry.isFile() || !SCRIPT_EXTENSION.test(entry.name)) {
+                continue;
+            }
+            const file = path.join(entry.parentPath, entry.name);
+            scanned.push({
+                file: `packages/${pkg.name}/dist/${path
+                    .relative(distDir, file)
+                    .split(path.sep)
+                    .join("/")}`,
+                instances: countInstances(
+                    fs.readFileSync(file, "utf-8"),
+                    marker,
+                ),
+            });
+        }
+    }
+    return scanned;
+}
+
+/**
+ * Problems with how many copies of `@doenet/i18n` the built bundles hold.
+ *
+ * More than one in a single script is not merely wasteful, it is broken. The
+ * loaders that reach the served catalogs are module-level state, installed
+ * once at startup; a viewer compiled against a *second* instance of that
+ * module reads that instance's registry, which nothing ever fills. Its verdict
+ * is that no catalog is loadable, and since an unreachable catalog is a
+ * deliberate, silent fall back to English, the bundle renders every language in
+ * English while behaving in every other way as though it were translated. That
+ * is what shipped in `@doenet/standalone@0.7.22`: `src/index.tsx` imported the
+ * setter from `@doenet/i18n` while the viewer carried the copy inside
+ * `@doenet/doenetml`. Reaching both through one entry point is the fix, and the
+ * invariant it restores is countable — which is the point of checking it here,
+ * since nothing about the failure is visible in a size budget (a second copy is
+ * a few KB), in a source-built test (where there is only ever one instance), or
+ * on screen.
+ *
+ * Judged per script rather than per package, because a script is the unit that
+ * shares a module registry. A package that emits both a bundle and a worker
+ * holds a copy in each, correctly: the worker is its own realm and resolves its
+ * own catalogs.
+ *
+ * {@link SINGLE_INSTANCE_SCRIPT} is held to exactly one rather than at most
+ * one — zero would mean the loader machinery had been tree-shaken out of the
+ * one bundle whose whole locale story runs through it.
+ *
+ * @param scanned emitted scripts, from {@link collectDistScripts}.
+ */
+export function instanceProblems(scanned: ScannedScript[]): string[] {
+    const problems = scanned
+        .filter(({ instances }) => instances > 1)
+        .map(
+            ({ file, instances }) =>
+                `${file} holds ${instances} copies of @doenet/i18n, so the loaders installed ` +
+                `at startup are not the ones the viewer reads, and every language would ` +
+                `silently render in English. Import setLocaleLoaders from the same ` +
+                `@doenet/doenetml entry point the viewer comes from rather than from ` +
+                `@doenet/i18n.`,
+        );
+    const single = scanned.find(({ file }) => file === SINGLE_INSTANCE_SCRIPT);
+    if (single && single.instances === 0) {
+        problems.push(
+            `${SINGLE_INSTANCE_SCRIPT} holds no copy of @doenet/i18n at all, so either the ` +
+                `loader machinery was tree-shaken out of the one bundle that installs it, or ` +
+                `the marker this is counted with stopped surviving minification. Either way ` +
+                `the count means nothing until it is understood.`,
+        );
+    }
+    return problems;
+}

--- a/packages/i18n/scripts/check-bundle-instances.ts
+++ b/packages/i18n/scripts/check-bundle-instances.ts
@@ -36,19 +36,23 @@ if (marker === null) {
 const scanned = marker === null ? [] : collectDistScripts(marker);
 const packages = new Set(scanned.map(({ file }) => file.split("/")[1]));
 
-if (marker !== null && scanned.length === 0) {
-    problems.push(
-        `No built scripts found under packages/*/dist/. Build before running this ` +
-            `(npm run build:all-no-docs); a scan of nothing passes trivially.`,
-    );
-}
-if (!scanned.some(({ file }) => file === SINGLE_INSTANCE_SCRIPT)) {
-    // A note rather than a problem: the standalone bundle is the one held to
-    // exactly one copy, but plenty of local builds legitimately do not produce
-    // it, and CI fails on its absence a step earlier at `check:size`.
-    console.log(
-        `note: ${SINGLE_INSTANCE_SCRIPT} was not built, so not checked`,
-    );
+// Only worth saying anything about the scan when there was a marker to scan
+// with; without one nothing was counted, and that is already the problem.
+if (marker !== null) {
+    if (scanned.length === 0) {
+        problems.push(
+            `No built scripts found under packages/*/dist/. Build before running this ` +
+                `(npm run build:all-no-docs); a scan of nothing passes trivially.`,
+        );
+    } else if (!scanned.some(({ file }) => file === SINGLE_INSTANCE_SCRIPT)) {
+        // A note rather than a problem: the standalone bundle is the one held
+        // to exactly one copy, but plenty of local builds legitimately do not
+        // produce it, and CI fails on its absence a step earlier at
+        // `check:size`.
+        console.log(
+            `note: ${SINGLE_INSTANCE_SCRIPT} was not built, so not checked`,
+        );
+    }
 }
 
 problems.push(...instanceProblems(scanned));

--- a/packages/i18n/scripts/check-bundle-instances.ts
+++ b/packages/i18n/scripts/check-bundle-instances.ts
@@ -1,0 +1,70 @@
+/**
+ * CI guard against a bundle holding more than one copy of `@doenet/i18n`. Run
+ * with `npm run check:i18n-instances` from the repo root, after a build.
+ *
+ * Two copies mean the loaders installed at startup are not the ones the viewer
+ * reads, so every language falls back to English without a word — see
+ * {@link instanceProblems} for how that shipped in 0.7.22. Every package's
+ * `dist/` is scanned rather than a listed few: any bundle combining a prebuilt
+ * `@doenet/doenetml` with a source build of this package can hit it, and a new
+ * one should not have to remember to opt in.
+ *
+ * Scans whatever has been built. A package nobody built is not reported as a
+ * problem — but the number of packages scanned is printed, and finding nothing
+ * at all is a failure rather than a pass, so a run against an empty tree cannot
+ * read as a clean bill of health.
+ */
+import {
+    collectDistScripts,
+    instanceProblems,
+    loaderRegistryMarker,
+    SINGLE_INSTANCE_SCRIPT,
+} from "./bundleInstances";
+
+const problems: string[] = [];
+
+const marker = loaderRegistryMarker();
+if (marker === null) {
+    problems.push(
+        `Could not find the CATALOG_PATH_PATTERN regex literal in src/load.ts, which is ` +
+            `what instances of this package are counted with. Restore it as a literal, or ` +
+            `teach loaderRegistryMarker in scripts/bundleInstances.ts to read its new ` +
+            `spelling — an uncountable marker would pass every bundle it was shown.`,
+    );
+}
+
+const scanned = marker === null ? [] : collectDistScripts(marker);
+const packages = new Set(scanned.map(({ file }) => file.split("/")[1]));
+
+if (marker !== null && scanned.length === 0) {
+    problems.push(
+        `No built scripts found under packages/*/dist/. Build before running this ` +
+            `(npm run build:all-no-docs); a scan of nothing passes trivially.`,
+    );
+}
+if (!scanned.some(({ file }) => file === SINGLE_INSTANCE_SCRIPT)) {
+    // A note rather than a problem: the standalone bundle is the one held to
+    // exactly one copy, but plenty of local builds legitimately do not produce
+    // it, and CI fails on its absence a step earlier at `check:size`.
+    console.log(
+        `note: ${SINGLE_INSTANCE_SCRIPT} was not built, so not checked`,
+    );
+}
+
+problems.push(...instanceProblems(scanned));
+
+if (problems.length > 0) {
+    console.error(
+        `\ni18n instance check found ${problems.length} problem(s):\n`,
+    );
+    for (const problem of problems) {
+        console.error(`  - ${problem}\n`);
+    }
+    process.exit(1);
+}
+
+console.log(
+    `i18n instance check passed: ${scanned.length} script(s) across ` +
+        `${packages.size} built package(s), none holding more than one copy of ` +
+        `@doenet/i18n.`,
+);

--- a/packages/i18n/test/bundleInstances.test.ts
+++ b/packages/i18n/test/bundleInstances.test.ts
@@ -1,0 +1,195 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+    SINGLE_INSTANCE_SCRIPT,
+    collectDistScripts,
+    countInstances,
+    instanceProblems,
+    loaderRegistryMarker,
+    type ScannedScript,
+} from "../scripts/bundleInstances";
+
+const MARKER = "/\\/locales\\/([^/]+)\\/([^/]+)\\.ftl$/";
+
+const tempDirs: string[] = [];
+
+/**
+ * A throwaway `packages/` tree: `{ "<pkg>/dist/<file>": contents }`.
+ *
+ * Written to disk rather than mocked because what `collectDistScripts` has to
+ * get right is a directory walk — which files it descends into and which
+ * extensions it counts.
+ */
+function packagesTree(files: Record<string, string>): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "i18n-instances-"));
+    tempDirs.push(root);
+    for (const [relative, contents] of Object.entries(files)) {
+        const file = path.join(root, relative);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, contents);
+    }
+    return root;
+}
+
+/** Scripts in the shape `collectDistScripts` returns. */
+function scanned(counts: Record<string, number>): ScannedScript[] {
+    return Object.entries(counts).map(([file, instances]) => ({
+        file,
+        instances,
+    }));
+}
+
+afterAll(() => {
+    for (const dir of tempDirs) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe("loaderRegistryMarker", () => {
+    it("finds the pattern in the committed load.ts", () => {
+        // The whole check rests on this being findable in the real module: a
+        // marker that stopped matching would leave every script counted as
+        // zero and the check passing on anything.
+        expect(loaderRegistryMarker()).toBe(MARKER);
+    });
+
+    it("reports no marker when load.ts is not where it should be", () => {
+        expect(loaderRegistryMarker("/no/such/load.ts")).toBe(null);
+    });
+
+    it("reports no marker when the declaration is not a literal", () => {
+        const file = path.join(
+            packagesTree({
+                "load.ts": "const CATALOG_PATH_PATTERN = other;\n",
+            }),
+            "load.ts",
+        );
+        expect(loaderRegistryMarker(file)).toBe(null);
+    });
+});
+
+describe("countInstances", () => {
+    it("counts non-overlapping occurrences", () => {
+        expect(countInstances(`a${MARKER}b${MARKER}c`, MARKER)).toBe(2);
+        expect(countInstances("nothing here", MARKER)).toBe(0);
+    });
+});
+
+describe("collectDistScripts", () => {
+    it("counts every emitted script under each package's dist", () => {
+        const root = packagesTree({
+            "standalone/dist/doenet-standalone.js": `x=${MARKER};`,
+            "standalone/dist/doenetml-worker/index.js": `y=${MARKER};`,
+            "doenetml/dist/index.js": "nothing",
+        });
+        expect(collectDistScripts(MARKER, root)).toEqual(
+            expect.arrayContaining([
+                {
+                    file: "packages/standalone/dist/doenet-standalone.js",
+                    instances: 1,
+                },
+                {
+                    file: "packages/standalone/dist/doenetml-worker/index.js",
+                    instances: 1,
+                },
+                { file: "packages/doenetml/dist/index.js", instances: 0 },
+            ]),
+        );
+    });
+
+    it("skips source maps, which embed the sources they map", () => {
+        // A map holds the very module it maps, so counting it would report a
+        // second copy for a perfectly correct build.
+        const root = packagesTree({
+            "standalone/dist/bundle.js": `x=${MARKER};`,
+            "standalone/dist/bundle.js.map": `{"sourcesContent":["${MARKER}"]}`,
+        });
+        expect(collectDistScripts(MARKER, root).map((s) => s.file)).toEqual([
+            "packages/standalone/dist/bundle.js",
+        ]);
+    });
+
+    it("looks at dist only, not a dev or test build beside it", () => {
+        const root = packagesTree({
+            "doenetml-print/dist-dev/index.js": `x=${MARKER}${MARKER};`,
+            "doenetml-prototype/test/utils/dist/run/run.js": `x=${MARKER}${MARKER};`,
+        });
+        expect(collectDistScripts(MARKER, root)).toEqual([]);
+    });
+
+    it("reports nothing when nothing has been built", () => {
+        expect(collectDistScripts(MARKER, packagesTree({}))).toEqual([]);
+        expect(collectDistScripts(MARKER, "/no/such/packages")).toEqual([]);
+    });
+});
+
+describe("instanceProblems", () => {
+    it("accepts one copy per script", () => {
+        expect(
+            instanceProblems(
+                scanned({
+                    [SINGLE_INSTANCE_SCRIPT]: 1,
+                    "packages/doenetml/dist/index.js": 1,
+                }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("accepts a script that carries none at all", () => {
+        // Most emitted scripts have nothing to do with i18n, so holding none
+        // is their normal case.
+        expect(
+            instanceProblems(
+                scanned({
+                    [SINGLE_INSTANCE_SCRIPT]: 1,
+                    "packages/parser/dist/index.js": 0,
+                }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("reports the 0.7.22 failure: two copies in the standalone bundle", () => {
+        const problems = instanceProblems(
+            scanned({ [SINGLE_INSTANCE_SCRIPT]: 2 }),
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain(SINGLE_INSTANCE_SCRIPT);
+        expect(problems[0]).toContain("2 copies");
+    });
+
+    it("reports the same failure in any other package's bundle", () => {
+        // The point of scanning every package rather than the one that has
+        // been bitten: a bundle combining a prebuilt @doenet/doenetml with a
+        // source build of this package can hit it the same way.
+        const problems = instanceProblems(
+            scanned({
+                [SINGLE_INSTANCE_SCRIPT]: 1,
+                "packages/doenetml-prototype/dist/index.js": 2,
+                "packages/doenetml-print/dist/index.js": 3,
+            }),
+        );
+        expect(problems).toHaveLength(2);
+    });
+
+    it("reports a standalone bundle that carries none at all", () => {
+        // Zero in the bundle that installs the loaders means either they were
+        // tree-shaken out or the marker stopped surviving minification, and a
+        // check counting nothing passes anything.
+        const problems = instanceProblems(
+            scanned({ [SINGLE_INSTANCE_SCRIPT]: 0 }),
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("no copy of @doenet/i18n at all");
+    });
+
+    it("says nothing about a standalone bundle nobody built", () => {
+        // Absence is not zero: plenty of builds legitimately do not produce
+        // it, and the runner notes the skip rather than inventing a verdict.
+        expect(
+            instanceProblems(scanned({ "packages/doenetml/dist/index.js": 1 })),
+        ).toEqual([]);
+    });
+});

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -434,8 +434,11 @@ export function duplicateI18nProblems(
  * build, and `dist/style.css` legitimately carries a ~1 MB base64 run of its
  * own (an inlined SVG webfont) that the blob heuristic cannot tell apart from
  * wasm. Only a script can actually execute a duplicated Rust core.
+ *
+ * @param probes `[locale, probe]` pairs, from {@link collectCatalogProbes}.
+ * @param marker from {@link loaderRegistryMarker}, `null` if unreadable.
  */
-function collectEmittedScripts(probes = [], marker = loaderRegistryMarker()) {
+function collectEmittedScripts(probes, marker) {
     const scripts = new Map();
     if (!fs.existsSync(DIST_DIR)) {
         return scripts;

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -11,7 +11,7 @@
  * that puts the blob back into `doenet-standalone.js`, or emits it twice, would
  * be just as quiet.
  *
- * Three checks, doing different jobs:
+ * Four checks, doing different jobs:
  *
  *  - The placement check needs no threshold and never needs adjusting. The
  *    core is meant to sit in {@link WASM_CORE_SCRIPT} and nowhere else, and any
@@ -26,6 +26,11 @@
  *    (see {@link servedCatalogProblems}). Both halves are live: English is the
  *    only inlined locale, so every other catalog this repository ships is one
  *    the first half probes for and the second half insists on finding.
+ *  - The duplicate-instance check (see {@link duplicateI18nProblems}) covers
+ *    the third way the catalogs can fail to arrive, and the quietest: they are
+ *    served, and nothing reads them, because the bundle holds two copies of the
+ *    module that decides what is loadable. It is a placement check too — of a
+ *    module rather than a blob — and needs no threshold for the same reason.
  *  - The size budgets in `bundle-budgets.json` catch the general case the
  *    first two cannot see — a heavy dependency, a duplicated copy of
  *    something that is not wasm. They are expected to be raised as the project
@@ -34,8 +39,9 @@
  * Run via `npm run check:size -w packages/standalone`. Exits non-zero, and
  * prints every problem it found rather than just the first, when a bundle is
  * over budget, when a budgeted file is missing, when `bundle-budgets.json` is
- * unusable, when the core is not inlined exactly once in the right script, or
- * when a served catalog is in the wrong place or missing.
+ * unusable, when the core is not inlined exactly once in the right script, when
+ * a served catalog is in the wrong place or missing, or when a script holds
+ * more than one copy of `@doenet/i18n`.
  *
  * The exported helpers exist so `check-bundle-size.test.mjs` can exercise the
  * decision logic without a build, against synthetic bundles and throwaway
@@ -330,6 +336,77 @@ export function servedCatalogProblems(sourceLocales, emittedLocales) {
 }
 
 /**
+ * The regex literal `@doenet/i18n` matches catalog paths with, read out of
+ * `load.ts` so the marker cannot drift away from the module it stands for.
+ *
+ * A regex literal is what makes a usable marker: a minifier renames every
+ * binding around it and rewrites the code, but it can only copy the pattern
+ * through verbatim. Counting it counts instances of the module that owns the
+ * loader registry.
+ *
+ * @returns the pattern's source text, or `null` if `load.ts` no longer spells
+ *   it as a literal — the caller then skips the check rather than inventing a
+ *   verdict from a marker it could not find.
+ */
+export function loaderRegistryMarker(loadModuleFile = LOAD_MODULE_FILE) {
+    if (!fs.existsSync(loadModuleFile)) {
+        return null;
+    }
+    const source = fs.readFileSync(loadModuleFile, "utf-8");
+    const match = /^const CATALOG_PATH_PATTERN = (\/.+\/);$/m.exec(source);
+    return match ? match[1] : null;
+}
+
+/** Non-overlapping occurrences of a fixed string. */
+function countOccurrences(haystack, needle) {
+    let count = 0;
+    for (
+        let at = haystack.indexOf(needle);
+        at !== -1;
+        at = haystack.indexOf(needle, at + needle.length)
+    ) {
+        count += 1;
+    }
+    return count;
+}
+
+/**
+ * Problems with how many copies of `@doenet/i18n` a script ended up holding.
+ *
+ * More than one is not merely wasteful, it is broken. The loaders that reach
+ * the catalogs served in `dist/locales/` are module-level state, installed once
+ * at startup by `src/index.tsx`; a viewer compiled against a *second* instance
+ * of that module reads that instance's registry, which nothing ever fills. Its
+ * verdict is that no catalog is loadable, and since an unreachable catalog is a
+ * deliberate, silent fall back to English, the bundle renders every language in
+ * English while behaving in every other way as though it were translated. That
+ * is what shipped in 0.7.22: `src/index.tsx` imported the setter from
+ * `@doenet/i18n` while the viewer carried the copy inside `@doenet/doenetml`.
+ *
+ * The fix is to reach both through one entry point, and the invariant it
+ * restores is countable — which is the point of checking it here. Nothing about
+ * the failure is visible in a size budget (the second copy is a few KB), in a
+ * source-built test (where there is only ever one instance), or on screen.
+ *
+ * @param scripts emitted scripts, from {@link collectEmittedScripts}.
+ */
+export function duplicateI18nProblems(scripts) {
+    const problems = [];
+    for (const [relative, { i18nInstances }] of scripts) {
+        if (i18nInstances > 1) {
+            problems.push(
+                `${relative} holds ${i18nInstances} copies of @doenet/i18n, so the message\n` +
+                    `    catalogs installed by src/index.tsx are not the ones the viewer reads,\n` +
+                    `    and every language would silently render in English. Import\n` +
+                    `    setLocaleLoaders from the same @doenet/doenetml entry point the viewer\n` +
+                    `    comes from rather than from @doenet/i18n.`,
+            );
+        }
+    }
+    return problems;
+}
+
+/**
  * Every emitted script under `dist/`, keyed by its path relative to the
  * package root (matching the keys in `bundle-budgets.json`).
  *
@@ -339,7 +416,7 @@ export function servedCatalogProblems(sourceLocales, emittedLocales) {
  * own (an inlined SVG webfont) that the blob heuristic cannot tell apart from
  * wasm. Only a script can actually execute a duplicated Rust core.
  */
-function collectEmittedScripts(probes = []) {
+function collectEmittedScripts(probes = [], marker = loaderRegistryMarker()) {
     const scripts = new Map();
     if (!fs.existsSync(DIST_DIR)) {
         return scripts;
@@ -365,6 +442,11 @@ function collectEmittedScripts(probes = []) {
             wasmUris: contents.match(WASM_URI)?.length ?? 0,
             bigBlobs: countBigBlobs(contents),
             inlinedCatalogs: catalogsInScript(contents, probes),
+            // No marker means `load.ts` stopped spelling its pattern the way
+            // `loaderRegistryMarker` reads it. Reporting 0 keeps the check
+            // quiet rather than failing every build on a marker problem; the
+            // unit tests are what hold the marker itself to being findable.
+            i18nInstances: marker ? countOccurrences(contents, marker) : 0,
         });
     }
     return scripts;
@@ -563,6 +645,7 @@ function main() {
                 collectSourceLocales(),
                 collectEmittedLocales(),
             ),
+            ...duplicateI18nProblems(scripts),
         );
     }
 
@@ -578,8 +661,9 @@ function main() {
     }
 
     console.log(
-        "\nwithin budget, the core is inlined exactly once, and the message catalogs\n" +
-            "are served rather than carried.",
+        "\nwithin budget, the core is inlined exactly once, the message catalogs are\n" +
+            "served rather than carried, and one copy of @doenet/i18n decides what is\n" +
+            "loadable.",
     );
 }
 

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -365,15 +365,7 @@ export function loaderRegistryMarker(loadModuleFile = LOAD_MODULE_FILE) {
 
 /** Non-overlapping occurrences of a fixed string. */
 function countOccurrences(haystack, needle) {
-    let count = 0;
-    for (
-        let at = haystack.indexOf(needle);
-        at !== -1;
-        at = haystack.indexOf(needle, at + needle.length)
-    ) {
-        count += 1;
-    }
-    return count;
+    return haystack.split(needle).length - 1;
 }
 
 /**

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -11,7 +11,7 @@
  * that puts the blob back into `doenet-standalone.js`, or emits it twice, would
  * be just as quiet.
  *
- * Four checks, doing different jobs:
+ * Three checks, doing different jobs:
  *
  *  - The placement check needs no threshold and never needs adjusting. The
  *    core is meant to sit in {@link WASM_CORE_SCRIPT} and nowhere else, and any
@@ -26,11 +26,6 @@
  *    (see {@link servedCatalogProblems}). Both halves are live: English is the
  *    only inlined locale, so every other catalog this repository ships is one
  *    the first half probes for and the second half insists on finding.
- *  - The duplicate-instance check (see {@link duplicateI18nProblems}) covers
- *    the third way the catalogs can fail to arrive, and the quietest: they are
- *    served, and nothing reads them, because the bundle holds two copies of the
- *    module that decides what is loadable. It is a placement check too — of a
- *    module rather than a blob — and needs no threshold for the same reason.
  *  - The size budgets in `bundle-budgets.json` catch the general case the
  *    checks above cannot see — a heavy dependency, a duplicated copy of
  *    something that is not wasm. They are expected to be raised as the project
@@ -39,9 +34,13 @@
  * Run via `npm run check:size -w packages/standalone`. Exits non-zero, and
  * prints every problem it found rather than just the first, when a bundle is
  * over budget, when a budgeted file is missing, when `bundle-budgets.json` is
- * unusable, when the core is not inlined exactly once in the right script, when
- * a served catalog is in the wrong place or missing, or when the standalone
- * bundle does not hold exactly one copy of `@doenet/i18n`.
+ * unusable, when the core is not inlined exactly once in the right script, or
+ * when a served catalog is in the wrong place or missing.
+ *
+ * A third way the catalogs can fail to arrive — served, and nothing reading
+ * them, because a bundle holds two copies of the module that decides what is
+ * loadable — is checked for every package rather than this one, by
+ * `packages/i18n/scripts/check-bundle-instances.ts`.
  *
  * The exported helpers exist so `check-bundle-size.test.mjs` can exercise the
  * decision logic without a build, against synthetic bundles and throwaway
@@ -65,13 +64,6 @@ const DIST_DIR = path.join(PACKAGE_ROOT, "dist");
  * matching one in `bundle-budgets.json` together.
  */
 export const WASM_CORE_SCRIPT = "dist/doenetml-worker/index.js";
-
-/**
- * The emitted script that carries the viewer and installs the locale loaders,
- * and so is the one that must hold exactly one copy of `@doenet/i18n` (see
- * {@link duplicateI18nProblems}).
- */
-export const STANDALONE_SCRIPT = "dist/doenet-standalone.js";
 
 /** `@doenet/i18n`'s catalogs, which this bundle serves rather than carries. */
 const I18N_ROOT = path.resolve(PACKAGE_ROOT, "..", "i18n");
@@ -343,89 +335,6 @@ export function servedCatalogProblems(sourceLocales, emittedLocales) {
 }
 
 /**
- * The regex literal `@doenet/i18n` matches catalog paths with, read out of
- * `load.ts` so the marker cannot drift away from the module it stands for.
- *
- * A regex literal makes a usable marker because a minifier renames the
- * bindings around it but copies the pattern through verbatim, so counting it
- * counts instances of the module that owns the loader registry.
- *
- * @returns the pattern's source text, or `null` if `load.ts` no longer spells
- *   it as a literal, which {@link duplicateI18nProblems} reports rather than
- *   passing on a marker it could not find.
- */
-export function loaderRegistryMarker(loadModuleFile = LOAD_MODULE_FILE) {
-    if (!fs.existsSync(loadModuleFile)) {
-        return null;
-    }
-    const source = fs.readFileSync(loadModuleFile, "utf-8");
-    const match = /^const CATALOG_PATH_PATTERN = (\/.+\/);$/m.exec(source);
-    return match ? match[1] : null;
-}
-
-/** Non-overlapping occurrences of a fixed string. */
-function countOccurrences(haystack, needle) {
-    return haystack.split(needle).length - 1;
-}
-
-/**
- * Problems with how many copies of `@doenet/i18n` a script ended up holding.
- *
- * More than one is not merely wasteful, it is broken. The loaders that reach
- * the catalogs served in `dist/locales/` are module-level state, installed once
- * at startup by `src/index.tsx`; a viewer compiled against a *second* instance
- * of that module reads that instance's registry, which nothing ever fills. It
- * judges no catalog loadable, and an unreachable catalog is a deliberate,
- * silent fall back to English, so the bundle renders every language in English
- * while behaving in every other way as though it were translated. That is what
- * shipped in 0.7.22: `src/index.tsx` imported the setter from `@doenet/i18n`
- * while the viewer carried the copy inside `@doenet/doenetml`. Nothing about
- * the failure shows up in a size budget (the second copy is a few KB), in a
- * source-built test (where there is only ever one instance), or on screen.
- *
- * Zero copies in {@link STANDALONE_SCRIPT}, or no marker to count at all, is
- * reported too: either means the count is measuring nothing, and a check that
- * passes whatever it is shown is the same silent failure one layer up.
- *
- * @param scripts emitted scripts, from {@link collectEmittedScripts}.
- * @param marker from {@link loaderRegistryMarker}, `null` if unreadable.
- */
-export function duplicateI18nProblems(
-    scripts,
-    marker = loaderRegistryMarker(),
-) {
-    const problems = [];
-    if (marker === null) {
-        return [
-            `the @doenet/i18n marker could not be read out of packages/i18n/src/load.ts,\n` +
-                `    so nothing checked how many copies of that module the bundle holds. The\n` +
-                `    marker is the CATALOG_PATH_PATTERN regex literal; if it was renamed or\n` +
-                `    reformatted, update loaderRegistryMarker in this script to match.`,
-        ];
-    }
-    for (const [relative, { i18nInstances }] of scripts) {
-        if (i18nInstances > 1) {
-            problems.push(
-                `${relative} holds ${i18nInstances} copies of @doenet/i18n, so the message\n` +
-                    `    catalogs installed by src/index.tsx are not the ones the viewer reads,\n` +
-                    `    and every language would silently render in English. Import\n` +
-                    `    setLocaleLoaders from the same @doenet/doenetml entry point the viewer\n` +
-                    `    comes from rather than from @doenet/i18n.`,
-            );
-        }
-    }
-    if (scripts.get(STANDALONE_SCRIPT)?.i18nInstances === 0) {
-        problems.push(
-            `${STANDALONE_SCRIPT} holds no copy of @doenet/i18n, which cannot be right:\n` +
-                `    it renders the viewer and installs the locale loaders. Either the marker\n` +
-                `    no longer survives the build — leaving the duplicate-copy check counting\n` +
-                `    nothing — or the bundle really did lose its message catalogs.`,
-        );
-    }
-    return problems;
-}
-
-/**
  * Every emitted script under `dist/`, keyed by its path relative to the
  * package root (matching the keys in `bundle-budgets.json`).
  *
@@ -436,9 +345,8 @@ export function duplicateI18nProblems(
  * wasm. Only a script can actually execute a duplicated Rust core.
  *
  * @param probes `[locale, probe]` pairs, from {@link collectCatalogProbes}.
- * @param marker from {@link loaderRegistryMarker}, `null` if unreadable.
  */
-function collectEmittedScripts(probes, marker) {
+function collectEmittedScripts(probes) {
     const scripts = new Map();
     if (!fs.existsSync(DIST_DIR)) {
         return scripts;
@@ -464,10 +372,6 @@ function collectEmittedScripts(probes, marker) {
             wasmUris: contents.match(WASM_URI)?.length ?? 0,
             bigBlobs: countBigBlobs(contents),
             inlinedCatalogs: catalogsInScript(contents, probes),
-            // 0 when there is no marker to count; `duplicateI18nProblems`
-            // reports the missing marker itself rather than reading anything
-            // into the count.
-            i18nInstances: marker ? countOccurrences(contents, marker) : 0,
         });
     }
     return scripts;
@@ -655,8 +559,7 @@ export function findProblems(budgets, scripts) {
 function main() {
     const budgets = loadBudgets();
     const probes = collectCatalogProbes();
-    const marker = loaderRegistryMarker();
-    const scripts = collectEmittedScripts(probes, marker);
+    const scripts = collectEmittedScripts(probes);
     const { report, problems } = findProblems(budgets, scripts);
 
     // An unbuilt `dist/` has already been reported as such; only ask where the
@@ -667,7 +570,6 @@ function main() {
                 collectSourceLocales(),
                 collectEmittedLocales(),
             ),
-            ...duplicateI18nProblems(scripts, marker),
         );
     }
 
@@ -683,9 +585,8 @@ function main() {
     }
 
     console.log(
-        "\nwithin budget, the core is inlined exactly once, the message catalogs are\n" +
-            "served rather than carried, and one copy of @doenet/i18n decides what is\n" +
-            "loadable.",
+        "\nwithin budget, the core is inlined exactly once, and the message catalogs\n" +
+            "are served rather than carried.",
     );
 }
 

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -32,7 +32,7 @@
  *    module that decides what is loadable. It is a placement check too — of a
  *    module rather than a blob — and needs no threshold for the same reason.
  *  - The size budgets in `bundle-budgets.json` catch the general case the
- *    first two cannot see — a heavy dependency, a duplicated copy of
+ *    checks above cannot see — a heavy dependency, a duplicated copy of
  *    something that is not wasm. They are expected to be raised as the project
  *    grows; the point is that raising one lands in the diff.
  *
@@ -40,8 +40,8 @@
  * prints every problem it found rather than just the first, when a bundle is
  * over budget, when a budgeted file is missing, when `bundle-budgets.json` is
  * unusable, when the core is not inlined exactly once in the right script, when
- * a served catalog is in the wrong place or missing, or when a script holds
- * more than one copy of `@doenet/i18n`.
+ * a served catalog is in the wrong place or missing, or when the standalone
+ * bundle does not hold exactly one copy of `@doenet/i18n`.
  *
  * The exported helpers exist so `check-bundle-size.test.mjs` can exercise the
  * decision logic without a build, against synthetic bundles and throwaway
@@ -65,6 +65,13 @@ const DIST_DIR = path.join(PACKAGE_ROOT, "dist");
  * matching one in `bundle-budgets.json` together.
  */
 export const WASM_CORE_SCRIPT = "dist/doenetml-worker/index.js";
+
+/**
+ * The emitted script that carries the viewer and installs the locale loaders,
+ * and so is the one that must hold exactly one copy of `@doenet/i18n` (see
+ * {@link duplicateI18nProblems}).
+ */
+export const STANDALONE_SCRIPT = "dist/doenet-standalone.js";
 
 /** `@doenet/i18n`'s catalogs, which this bundle serves rather than carries. */
 const I18N_ROOT = path.resolve(PACKAGE_ROOT, "..", "i18n");
@@ -339,14 +346,13 @@ export function servedCatalogProblems(sourceLocales, emittedLocales) {
  * The regex literal `@doenet/i18n` matches catalog paths with, read out of
  * `load.ts` so the marker cannot drift away from the module it stands for.
  *
- * A regex literal is what makes a usable marker: a minifier renames every
- * binding around it and rewrites the code, but it can only copy the pattern
- * through verbatim. Counting it counts instances of the module that owns the
- * loader registry.
+ * A regex literal makes a usable marker because a minifier renames the
+ * bindings around it but copies the pattern through verbatim, so counting it
+ * counts instances of the module that owns the loader registry.
  *
  * @returns the pattern's source text, or `null` if `load.ts` no longer spells
- *   it as a literal — the caller then skips the check rather than inventing a
- *   verdict from a marker it could not find.
+ *   it as a literal, which {@link duplicateI18nProblems} reports rather than
+ *   passing on a marker it could not find.
  */
 export function loaderRegistryMarker(loadModuleFile = LOAD_MODULE_FILE) {
     if (!fs.existsSync(loadModuleFile)) {
@@ -376,22 +382,35 @@ function countOccurrences(haystack, needle) {
  * More than one is not merely wasteful, it is broken. The loaders that reach
  * the catalogs served in `dist/locales/` are module-level state, installed once
  * at startup by `src/index.tsx`; a viewer compiled against a *second* instance
- * of that module reads that instance's registry, which nothing ever fills. Its
- * verdict is that no catalog is loadable, and since an unreachable catalog is a
- * deliberate, silent fall back to English, the bundle renders every language in
- * English while behaving in every other way as though it were translated. That
- * is what shipped in 0.7.22: `src/index.tsx` imported the setter from
- * `@doenet/i18n` while the viewer carried the copy inside `@doenet/doenetml`.
- *
- * The fix is to reach both through one entry point, and the invariant it
- * restores is countable — which is the point of checking it here. Nothing about
- * the failure is visible in a size budget (the second copy is a few KB), in a
+ * of that module reads that instance's registry, which nothing ever fills. It
+ * judges no catalog loadable, and an unreachable catalog is a deliberate,
+ * silent fall back to English, so the bundle renders every language in English
+ * while behaving in every other way as though it were translated. That is what
+ * shipped in 0.7.22: `src/index.tsx` imported the setter from `@doenet/i18n`
+ * while the viewer carried the copy inside `@doenet/doenetml`. Nothing about
+ * the failure shows up in a size budget (the second copy is a few KB), in a
  * source-built test (where there is only ever one instance), or on screen.
  *
+ * Zero copies in {@link STANDALONE_SCRIPT}, or no marker to count at all, is
+ * reported too: either means the count is measuring nothing, and a check that
+ * passes whatever it is shown is the same silent failure one layer up.
+ *
  * @param scripts emitted scripts, from {@link collectEmittedScripts}.
+ * @param marker from {@link loaderRegistryMarker}, `null` if unreadable.
  */
-export function duplicateI18nProblems(scripts) {
+export function duplicateI18nProblems(
+    scripts,
+    marker = loaderRegistryMarker(),
+) {
     const problems = [];
+    if (marker === null) {
+        return [
+            `the @doenet/i18n marker could not be read out of packages/i18n/src/load.ts,\n` +
+                `    so nothing checked how many copies of that module the bundle holds. The\n` +
+                `    marker is the CATALOG_PATH_PATTERN regex literal; if it was renamed or\n` +
+                `    reformatted, update loaderRegistryMarker in this script to match.`,
+        ];
+    }
     for (const [relative, { i18nInstances }] of scripts) {
         if (i18nInstances > 1) {
             problems.push(
@@ -402,6 +421,14 @@ export function duplicateI18nProblems(scripts) {
                     `    comes from rather than from @doenet/i18n.`,
             );
         }
+    }
+    if (scripts.get(STANDALONE_SCRIPT)?.i18nInstances === 0) {
+        problems.push(
+            `${STANDALONE_SCRIPT} holds no copy of @doenet/i18n, which cannot be right:\n` +
+                `    it renders the viewer and installs the locale loaders. Either the marker\n` +
+                `    no longer survives the build — leaving the duplicate-copy check counting\n` +
+                `    nothing — or the bundle really did lose its message catalogs.`,
+        );
     }
     return problems;
 }
@@ -442,10 +469,9 @@ function collectEmittedScripts(probes = [], marker = loaderRegistryMarker()) {
             wasmUris: contents.match(WASM_URI)?.length ?? 0,
             bigBlobs: countBigBlobs(contents),
             inlinedCatalogs: catalogsInScript(contents, probes),
-            // No marker means `load.ts` stopped spelling its pattern the way
-            // `loaderRegistryMarker` reads it. Reporting 0 keeps the check
-            // quiet rather than failing every build on a marker problem; the
-            // unit tests are what hold the marker itself to being findable.
+            // 0 when there is no marker to count; `duplicateI18nProblems`
+            // reports the missing marker itself rather than reading anything
+            // into the count.
             i18nInstances: marker ? countOccurrences(contents, marker) : 0,
         });
     }
@@ -634,7 +660,8 @@ export function findProblems(budgets, scripts) {
 function main() {
     const budgets = loadBudgets();
     const probes = collectCatalogProbes();
-    const scripts = collectEmittedScripts(probes);
+    const marker = loaderRegistryMarker();
+    const scripts = collectEmittedScripts(probes, marker);
     const { report, problems } = findProblems(budgets, scripts);
 
     // An unbuilt `dist/` has already been reported as such; only ask where the
@@ -645,7 +672,7 @@ function main() {
                 collectSourceLocales(),
                 collectEmittedLocales(),
             ),
-            ...duplicateI18nProblems(scripts),
+            ...duplicateI18nProblems(scripts, marker),
         );
     }
 

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
+    STANDALONE_SCRIPT as STANDALONE,
     WASM_CORE_SCRIPT,
     catalogsInScript,
     collectCatalogProbes,
@@ -13,8 +14,6 @@ import {
     loaderRegistryMarker,
     servedCatalogProblems,
 } from "./check-bundle-size.mjs";
-
-const STANDALONE = "dist/doenet-standalone.js";
 
 /** Budgets in the shape `loadBudgets` returns: `[relativePath, budget]` pairs. */
 const BUDGETS = [

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -7,8 +7,10 @@ import {
     catalogsInScript,
     collectCatalogProbes,
     countBigBlobs,
+    duplicateI18nProblems,
     findProblems,
     loadBudgets,
+    loaderRegistryMarker,
     servedCatalogProblems,
 } from "./check-bundle-size.mjs";
 
@@ -422,5 +424,62 @@ describe("servedCatalogProblems", () => {
         const problems = servedCatalogProblems(["en", "es"], null);
         expect(problems).toHaveLength(1);
         expect(problems[0]).toContain("dist/locales/ was not emitted");
+    });
+});
+
+describe("loaderRegistryMarker", () => {
+    it("finds the pattern in the committed load.ts", () => {
+        // The whole duplicate-instance check rests on this being findable in
+        // the real module: a marker that stopped matching would leave every
+        // script counted as zero instances and the check passing on anything.
+        const marker = loaderRegistryMarker();
+        expect(marker).toBeTypeOf("string");
+        expect(marker).toContain("locales");
+        expect(marker).toContain("ftl");
+    });
+
+    it("reports no marker when load.ts is not where it should be", () => {
+        expect(loaderRegistryMarker("/no/such/load.ts")).toBe(null);
+    });
+});
+
+describe("duplicateI18nProblems", () => {
+    /** Emitted scripts holding the given instance counts. */
+    function build(counts) {
+        return new Map(
+            Object.entries(counts).map(([name, i18nInstances]) => [
+                name,
+                { ...script(500), i18nInstances },
+            ]),
+        );
+    }
+
+    it("accepts one copy per script", () => {
+        expect(
+            duplicateI18nProblems(
+                build({ [STANDALONE]: 1, [WASM_CORE_SCRIPT]: 1 }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("accepts a script that carries none at all", () => {
+        // Most emitted scripts have nothing to do with i18n; only holding more
+        // than one copy is a problem, and holding none is the normal case.
+        expect(duplicateI18nProblems(build({ [STANDALONE]: 0 }))).toEqual([]);
+    });
+
+    it("reports the 0.7.22 failure: two copies in the standalone bundle", () => {
+        const problems = duplicateI18nProblems(build({ [STANDALONE]: 2 }));
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain(STANDALONE);
+        expect(problems[0]).toContain("2 copies");
+    });
+
+    it("reports every script that holds more than one", () => {
+        expect(
+            duplicateI18nProblems(
+                build({ [STANDALONE]: 3, [WASM_CORE_SCRIPT]: 2 }),
+            ),
+        ).toHaveLength(2);
     });
 });

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -462,10 +462,31 @@ describe("duplicateI18nProblems", () => {
         ).toEqual([]);
     });
 
-    it("accepts a script that carries none at all", () => {
-        // Most emitted scripts have nothing to do with i18n; only holding more
-        // than one copy is a problem, and holding none is the normal case.
-        expect(duplicateI18nProblems(build({ [STANDALONE]: 0 }))).toEqual([]);
+    it("accepts another script that carries none at all", () => {
+        // Most emitted scripts have nothing to do with i18n, so holding none
+        // is their normal case.
+        expect(
+            duplicateI18nProblems(
+                build({ [STANDALONE]: 1, [WASM_CORE_SCRIPT]: 0 }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("reports a standalone bundle that carries none at all", () => {
+        // Zero in the bundle that renders the viewer means the marker stopped
+        // surviving the build, and a check counting nothing passes anything.
+        const problems = duplicateI18nProblems(build({ [STANDALONE]: 0 }));
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("no copy of @doenet/i18n");
+    });
+
+    it("reports a marker it could not read rather than passing", () => {
+        const problems = duplicateI18nProblems(
+            build({ [STANDALONE]: 0 }),
+            null,
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("could not be read");
     });
 
     it("reports the 0.7.22 failure: two copies in the standalone bundle", () => {

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -3,17 +3,16 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
-    STANDALONE_SCRIPT as STANDALONE,
     WASM_CORE_SCRIPT,
     catalogsInScript,
     collectCatalogProbes,
     countBigBlobs,
-    duplicateI18nProblems,
     findProblems,
     loadBudgets,
-    loaderRegistryMarker,
     servedCatalogProblems,
 } from "./check-bundle-size.mjs";
+
+const STANDALONE = "dist/doenet-standalone.js";
 
 /** Budgets in the shape `loadBudgets` returns: `[relativePath, budget]` pairs. */
 const BUDGETS = [
@@ -423,83 +422,5 @@ describe("servedCatalogProblems", () => {
         const problems = servedCatalogProblems(["en", "es"], null);
         expect(problems).toHaveLength(1);
         expect(problems[0]).toContain("dist/locales/ was not emitted");
-    });
-});
-
-describe("loaderRegistryMarker", () => {
-    it("finds the pattern in the committed load.ts", () => {
-        // The whole duplicate-instance check rests on this being findable in
-        // the real module: a marker that stopped matching would leave every
-        // script counted as zero instances and the check passing on anything.
-        const marker = loaderRegistryMarker();
-        expect(marker).toBeTypeOf("string");
-        expect(marker).toContain("locales");
-        expect(marker).toContain("ftl");
-    });
-
-    it("reports no marker when load.ts is not where it should be", () => {
-        expect(loaderRegistryMarker("/no/such/load.ts")).toBe(null);
-    });
-});
-
-describe("duplicateI18nProblems", () => {
-    /** Emitted scripts holding the given instance counts. */
-    function build(counts) {
-        return new Map(
-            Object.entries(counts).map(([name, i18nInstances]) => [
-                name,
-                { ...script(500), i18nInstances },
-            ]),
-        );
-    }
-
-    it("accepts one copy per script", () => {
-        expect(
-            duplicateI18nProblems(
-                build({ [STANDALONE]: 1, [WASM_CORE_SCRIPT]: 1 }),
-            ),
-        ).toEqual([]);
-    });
-
-    it("accepts another script that carries none at all", () => {
-        // Most emitted scripts have nothing to do with i18n, so holding none
-        // is their normal case.
-        expect(
-            duplicateI18nProblems(
-                build({ [STANDALONE]: 1, [WASM_CORE_SCRIPT]: 0 }),
-            ),
-        ).toEqual([]);
-    });
-
-    it("reports a standalone bundle that carries none at all", () => {
-        // Zero in the bundle that renders the viewer means the marker stopped
-        // surviving the build, and a check counting nothing passes anything.
-        const problems = duplicateI18nProblems(build({ [STANDALONE]: 0 }));
-        expect(problems).toHaveLength(1);
-        expect(problems[0]).toContain("no copy of @doenet/i18n");
-    });
-
-    it("reports a marker it could not read rather than passing", () => {
-        const problems = duplicateI18nProblems(
-            build({ [STANDALONE]: 0 }),
-            null,
-        );
-        expect(problems).toHaveLength(1);
-        expect(problems[0]).toContain("could not be read");
-    });
-
-    it("reports the 0.7.22 failure: two copies in the standalone bundle", () => {
-        const problems = duplicateI18nProblems(build({ [STANDALONE]: 2 }));
-        expect(problems).toHaveLength(1);
-        expect(problems[0]).toContain(STANDALONE);
-        expect(problems[0]).toContain("2 copies");
-    });
-
-    it("reports every script that holds more than one", () => {
-        expect(
-            duplicateI18nProblems(
-                build({ [STANDALONE]: 3, [WASM_CORE_SCRIPT]: 2 }),
-            ),
-        ).toHaveLength(2);
     });
 });

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -17,9 +17,9 @@ import { getStylePalettes, getStylePalette } from "@doenet/utils";
 import type { StylePaletteInfo } from "@doenet/utils";
 // From the same entry point the viewer above comes from, not from
 // `@doenet/i18n` directly: this bundle would otherwise hold two instances of
-// that module — one built here from source, one already compiled into
-// `@doenet/doenetml` — and the loaders installed on the first would not be the
-// ones the second reads. See the re-export in `@doenet/doenetml`'s `index.ts`.
+// that module — one built here from source, one compiled into
+// `@doenet/doenetml` — and the loaders installed on the first are not the ones
+// the second reads. See the re-export in `@doenet/doenetml`'s `index.ts`.
 import {
     fetchLocaleLoaders,
     setLocaleLoaders,

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -15,7 +15,15 @@ import type {
 } from "@doenet/doenetml/doenetml-external-worker.js";
 import { getStylePalettes, getStylePalette } from "@doenet/utils";
 import type { StylePaletteInfo } from "@doenet/utils";
-import { fetchLocaleLoaders, setLocaleLoaders } from "@doenet/i18n";
+// From the same entry point the viewer above comes from, not from
+// `@doenet/i18n` directly: this bundle would otherwise hold two instances of
+// that module — one built here from source, one already compiled into
+// `@doenet/doenetml` — and the loaders installed on the first would not be the
+// ones the second reads. See the re-export in `@doenet/doenetml`'s `index.ts`.
+import {
+    fetchLocaleLoaders,
+    setLocaleLoaders,
+} from "@doenet/doenetml/doenetml-external-worker.js";
 import "@doenet/doenetml/style.css";
 import "./pretext-compat.css";
 import { ResizeWatcher } from "./resize-watcher";


### PR DESCRIPTION
## The bug

`@doenet/standalone@0.7.22` never requested a message catalog, so every language rendered in English.

Reproduced on doenet.org's scratch pad with:

```
<document lang="ar">
  <p>Hello!</p>
  <answer name="ans" forceFullCheckWorkButton>x</answer>
  $ans.submitLabel
</document>
```

The language was recognized in every visible way — the viewer laid out right to left and labelled itself `<div class="doenet-viewer" lang="ar" dir="rtl">` — and the button still read "Check Work". DevTools filtered to jsdelivr showed no request for `locales/ar/*.ftl` at all. The catalogs were published and reachable the whole time: `@0.7.22/locales/ar/content.ftl` served a 200 containing `answer-submit-label = تحقق من الإجابة`.

## Why

The bundle held **two instances of `@doenet/i18n`** — one built from source for `src/index.tsx`, which installs the loaders that fetch the served catalogs, and one already compiled into `@doenet/doenetml`, which is the copy the viewer resolves a language through. Visible in the published file as the `$1` renames Rollup gives a second copy: `inFlight`/`inFlight$1`, `CATALOG_NAMESPACES`/`CATALOG_NAMESPACES$1`, `LAZY_CATALOG_MODULES`/`LAZY_CATALOG_MODULES$1`.

The loaders are module-level state and do not cross between instances. The viewer's copy held none, judged every language unloadable, and fell back to English — which is exactly what it is supposed to do when a catalog cannot be reached, and therefore said nothing about it. Direction kept working because `dir` comes from bundled locale data rather than a catalog, which is why the failure looked like a translation gap rather than a plumbing one.

The minifier then removed both halves as provably dead, which is what the published 0.7.22 contains verbatim:

```js
// copy A — the setter src/index.tsx calls; the assignment is gone
function setLocaleLoaders(D){inFlight.clear()}
// copy B — the reader the viewer uses; the `installedLoaders ??` is gone
function currentLocaleLoaders(){return LAZY_LOCALE_LOADERS}
```

`installedLoaders` appeared zero times in the whole 12 MB file, and copy B's `LAZY_CATALOG_MODULES$1` is `{}` because the single-file build switches code-splitting off.

## The fix

`@doenet/doenetml` re-exports `setLocaleLoaders` and `fetchLocaleLoaders`, and `@doenet/standalone` reaches them through the same entry point its viewer comes from. That makes the setter and the reader one instance. A host installing its own catalogs should import them from `@doenet/doenetml` for the same reason. `packages/i18n/README.md`, which is where a host with its own translation is told to call `setLocaleLoaders(fetchLocaleLoaders(url, tags))`, now says which instance to call them on, and describes the duplicate-instance check that guards it.

## Guards

Neither half of this failure was visible — not in a size budget (the duplicate is a few KB), not in a source-built test (there is only ever one instance there), not on screen. So both halves get a guard:

- **`npm run check:i18n-instances`** (`packages/i18n/scripts/check-bundle-instances.ts`, run in CI after the build) counts copies of `@doenet/i18n` by the `CATALOG_PATH_PATTERN` regex literal read out of `packages/i18n/src/load.ts` — a regex literal is the one thing a minifier copies through verbatim, and reading it from source rather than hardcoding it keeps the marker from drifting away from the module it stands for. It walks **every** built `packages/*/dist/`, not the one bundle that has been bitten: any build combining a prebuilt `@doenet/doenetml` with a source build of `@doenet/i18n` can hit the same trap, and a package that starts shipping a bundle should not have to remember to opt in. Counted per emitted script, since a script is what shares a module registry — a package emitting both a bundle and a worker holds a copy in each, correctly. It also fails when `doenet-standalone.js` holds *none*, when the marker cannot be read, and when nothing was built at all: each means the count is measuring nothing, and a guard that passes whatever it is shown is the same silent failure one layer up.
- **`DoenetViewer.fetchedCatalog.cy.tsx`** installs fetch loaders through *this package's* entry point, renders a document in a language only a served catalog carries, and asserts both the words and the request. Three cases: the language declared in source (`<document lang>`, the reported scenario), one named by `documentLocale`, and an English document that should cost no request at all. `DoenetViewer.loadedLocale.cy.tsx`, which installs loaders the same way, now reaches `setLocaleLoaders` through that entry point too rather than through `@doenet/i18n`, so both specs hold the seam the guidance describes.

## Verification

- Rebuilt bundle: every `$1` duplicate gone, and both eliminated halves are back — `setLocaleLoaders(D){installedLoaders=D,inFlight.clear()}` and `currentLocaleLoaders(){return installedLoaders??LAZY_LOCALE_LOADERS}`. It also shrank 12.0 → 11.65 MiB, which is the duplicate copy going away.
- Serving that `dist/` and rendering the document above now issues all four requests that were absent before: `locales/ar/{chrome,content,diagnostics,editor}.ftl`.
- `npm run check:i18n-instances` passes: 2539 scripts across 23 built packages, none holding more than one copy. `npm run check:size -w packages/standalone` passes too (35 unit tests there, 14 for the new check).
- The duplicate check was confirmed against a real regression rather than only synthetic maps, twice. Reverting `src/index.tsx` to `import ... from "@doenet/i18n"` and rebuilding makes it exit non-zero with *holds 2 copies of @doenet/i18n*, and it passes again once the import is restored. And on first run the widened scan failed on `packages/test-cypress/dist/standalone/doenet-standalone.js` — a stale pre-fix copy of the very bundle this PR fixes, caught in a package the original single-bundle check never looked at. Rebuilding that package clears it.
- `DoenetViewer.fetchedCatalog.cy.tsx`: 3/3 passing.
- `tsc --noEmit` on `@doenet/doenetml`: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






