### PR TITLE
Purge the core worker, coordinator, and Pyodide runtime on publish

### DIFF
--- a/.github/scripts/purge-jsdelivr-prefigure.sh
+++ b/.github/scripts/purge-jsdelivr-prefigure.sh
@@ -20,5 +20,12 @@ curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}" || exit 1
 
 echo "Purging key prefigure assets for @doenet/prefigure@${TAG}..."
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}/prefigure.js" || exit 1
+# The Pyodide runtime under `assets/` is fetched by URL at run time. Only the
+# fixed-name files need purging: the wheels carry their version in the filename
+# and the bundle's own chunks are content-hashed, so those URLs never change
+# meaning.
+for asset in pyodide.mjs pyodide.asm.js pyodide.asm.wasm pyodide-lock.json python_stdlib.zip; do
+    curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}/assets/${asset}" || exit 1
+done
 
 echo "Successfully purged jsDelivr cache for @doenet/prefigure@${TAG}"

--- a/.github/scripts/purge-jsdelivr-prefigure.sh
+++ b/.github/scripts/purge-jsdelivr-prefigure.sh
@@ -20,10 +20,10 @@ curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}" || exit 1
 
 echo "Purging key prefigure assets for @doenet/prefigure@${TAG}..."
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}/prefigure.js" || exit 1
-# The Pyodide runtime under `assets/` is fetched by URL at run time. Only the
-# fixed-name files need purging: the wheels carry their version in the filename
-# and the bundle's own chunks are content-hashed, so those URLs never change
-# meaning.
+# Pyodide loads its runtime from `assets/` by URL at run time. These are the
+# fixed-name files it fetches; everything else under `assets/` is already
+# immutable per build (wheels carry their version in the filename, the bundle's
+# own chunks are content-hashed), so no other URL can go stale.
 for asset in pyodide.mjs pyodide.asm.js pyodide.asm.wasm pyodide-lock.json python_stdlib.zip; do
     curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${TAG}/assets/${asset}" || exit 1
 done

--- a/.github/scripts/purge-jsdelivr.sh
+++ b/.github/scripts/purge-jsdelivr.sh
@@ -31,9 +31,7 @@ curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/doenetml-work
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/coordinator.js" || exit 1
 
 # The several hundred message catalogs under `locales/` are deliberately left
-# out. A locale added in a release is a URL nothing has cached, so it cannot be
-# stale; only an edit to an existing translation can be, and that costs old
-# wording until the edge TTL expires rather than a broken embed — not worth
-# hundreds of purge requests per release.
+# out: a stale catalog costs old wording until the edge TTL expires, not a
+# broken embed, which is not worth hundreds of purge requests per release.
 
 echo "Successfully purged jsDelivr cache for tag @${TAG}"

--- a/.github/scripts/purge-jsdelivr.sh
+++ b/.github/scripts/purge-jsdelivr.sh
@@ -22,5 +22,16 @@ curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}" || exit 1
 echo "Purging key standalone assets for @${TAG} tag..."
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/doenet-standalone.js" || exit 1
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/style.css" || exit 1
+# The core worker is fetched as its own URL, not carried inside the bundle
+# (#1465), so refreshing the bundle without it leaves an embed on a floating
+# tag driving the previous release's core. Purging one side of a pair that has
+# to agree is worse than purging neither.
+curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/doenetml-worker/index.js" || exit 1
+
+# The message catalogs under `locales/` are not listed. A locale added in a
+# release is a URL nothing has cached, so it cannot be stale; only an edit to
+# an existing translation can be, and it costs old wording for up to the edge
+# TTL rather than a broken embed. There are 528 of them, which is more requests
+# per release than that is worth.
 
 echo "Successfully purged jsDelivr cache for tag @${TAG}"

--- a/.github/scripts/purge-jsdelivr.sh
+++ b/.github/scripts/purge-jsdelivr.sh
@@ -22,16 +22,18 @@ curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}" || exit 1
 echo "Purging key standalone assets for @${TAG} tag..."
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/doenet-standalone.js" || exit 1
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/style.css" || exit 1
-# The core worker is fetched as its own URL, not carried inside the bundle
-# (#1465), so refreshing the bundle without it leaves an embed on a floating
-# tag driving the previous release's core. Purging one side of a pair that has
-# to agree is worse than purging neither.
+# The core worker is fetched as its own URL rather than carried inside the
+# bundle (#1465), so it has to be refreshed alongside the bundle: on a floating
+# tag, a fresh bundle paired with the previous release's core is a broken embed.
 curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/doenetml-worker/index.js" || exit 1
+# Host pages load the activity coordinator directly by URL, so it is stale on a
+# floating tag until purged too.
+curl -fv "https://purge.jsdelivr.net/npm/@doenet/standalone@${TAG}/coordinator.js" || exit 1
 
-# The message catalogs under `locales/` are not listed. A locale added in a
-# release is a URL nothing has cached, so it cannot be stale; only an edit to
-# an existing translation can be, and it costs old wording for up to the edge
-# TTL rather than a broken embed. There are 528 of them, which is more requests
-# per release than that is worth.
+# The several hundred message catalogs under `locales/` are deliberately left
+# out. A locale added in a release is a URL nothing has cached, so it cannot be
+# stale; only an edit to an existing translation can be, and that costs old
+# wording until the edge TTL expires rather than a broken embed — not worth
+# hundreds of purge requests per release.
 
 echo "Successfully purged jsDelivr cache for tag @${TAG}"


### PR DESCRIPTION
`purge-jsdelivr.sh` purges three URLs after every `dev` and `latest` publish: the package-level path, `doenet-standalone.js`, and `style.css`. Those were the standalone package's two assets when it was written. Since then, two more assets are fetched by their own URL at runtime and the script was never told about either.

## The core worker

#1465 moved the core worker out of the bundle and into `doenetml-worker/index.js`. A release refreshes the bundle at the edge and leaves the worker sitting beside it. Both serve the same headers —

```
cache-control: public, max-age=604800, s-maxage=43200
```

— so an embed pinned to a floating tag can hold a *new* bundle driving the *previous* release's core for up to the 12-hour edge TTL, and longer still from a browser that already cached the old worker.

## The activity coordinator

`dist/coordinator.js` is built by `vite.config-coordinator.ts` and is designed to be loaded by host pages directly from the CDN:

```html
<script src="https://cdn.jsdelivr.net/npm/@doenet/standalone@<version>/coordinator.js"></script>
```

It talks a versioned protocol with the child viewers in the bundle, so it has the same stale-pairing exposure and is now purged alongside them.

Both paths verified real on the floating tags (`@latest/doenetml-worker/index.js` and `@latest/coordinator.js` return 200).

## `@doenet/prefigure`

`purge-jsdelivr-prefigure.sh` had the same shape of gap: it purges `prefigure.js`, but the Pyodide runtime under `assets/` is fetched by URL at run time. Pyodide fetches `pyodide.asm.js`, `pyodide.asm.wasm`, `pyodide-lock.json`, and `python_stdlib.zip` from its `indexURL` (confirmed against the built worker chunk), and those names are fixed across releases, so they are now purged — along with `pyodide.mjs`, the directory's ES entry point. Nothing else under `assets/` needs it: the wheels carry their version in the filename and the bundle's own chunks are content-hashed, so those URLs are immutable per build.

## What is deliberately not purged

The several hundred message catalogs under `locales/` (currently 528: 132 locales × 4 namespaces), now noted in a comment so the omission reads as a decision rather than the same oversight a third time. A locale added in a release is a URL nothing has cached, so it cannot be stale; only an edit to an existing translation can be, and that costs old wording until the edge TTL expires rather than a broken embed. Hundreds of purge requests per release is not worth that.

## Worth knowing either way

Whether the existing package-level purge already cascades to files underneath it is not documented — jsDelivr's purge page says only that it purges "a @latest or version aliased URL", with nothing about recursion or scope. If it does cascade, these lines are redundant but harmless; if it does not, they close a real gap. The script's own shape suggests its author assumed no cascade, since it lists the bundle and stylesheet individually.

Separately, purging only clears jsDelivr's edge. The `max-age=604800` browser cache is untouched by any purge, so a client already holding a stale asset keeps it for up to 7 days regardless.

No changeset: this is CI/release tooling only, and no published package's contents change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

