### PR TITLE
Keep the diagnostics panel scrollbar flush with the editor edge

### DIFF
--- a/.changeset/diagnostics-panel-scrollbar-inset.md
+++ b/.changeset/diagnostics-panel-scrollbar-inset.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: remove the small gap between the diagnostics/help panel's scrollbar and the editor's trailing edge.
+
+The inline padding that insets the panel text was applied to the panel's non-scrolling wrapper, so it pushed the scrolling element — and with it the scrollbar — in from the editor's edge. The padding now lives on the panel content instead, leaving the scrollbar flush against the resizer while the text keeps the same inset.

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -177,10 +177,10 @@
 }
 
 /*
- * The inline padding that insets the panel text from the editor's edges lives
- * here rather than on `.diagnostics-response-tabs-container` so that the
- * scrolling element (`.diagnostics-response-tabs-panels`) spans the full width
- * and its scrollbar sits flush against the resizer.
+ * Each tab panel carries its own inline padding to inset the panel text from
+ * the editor's edges. That keeps the scrolling element
+ * (`.diagnostics-response-tabs-panels`) spanning the full width, so its
+ * scrollbar sits flush against the resizer.
  */
 .editor-panel .diagnostic-panel {
     padding: 0.75rem 0.65rem 1rem;

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -174,11 +174,16 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    padding: 0rem 0.4rem;
 }
 
+/*
+ * The inline padding that insets the panel text from the editor's edges lives
+ * here rather than on `.diagnostics-response-tabs-container` so that the
+ * scrolling element (`.diagnostics-response-tabs-panels`) spans the full width
+ * and its scrollbar sits flush against the resizer.
+ */
 .editor-panel .diagnostic-panel {
-    padding: 0.75rem 0.25rem 1rem;
+    padding: 0.75rem 0.65rem 1rem;
 }
 
 .editor-panel .diagnostic-list {

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelInset.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelInset.cy.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+
+const SAMPLE_DOENETML = "<p>hello</p>";
+
+function Harness() {
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <DoenetEditor
+                doenetML={SAMPLE_DOENETML}
+                addVirtualKeyboard={false}
+                initialOpenTab="accessibility"
+            />
+        </div>
+    );
+}
+
+/**
+ * The scrolling element of the diagnostics/help panel must span the full width
+ * of its container so that its scrollbar sits flush against the editor's
+ * trailing edge; the inline inset of the panel text comes from the panels
+ * themselves.
+ */
+describe("Diagnostics panel inset", () => {
+    it("scrolling element spans the container while the panel text is inset", () => {
+        cy.mount(<Harness />);
+
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+
+        cy.get(".diagnostics-response-tabs-container").then(($container) => {
+            const container = $container[0].getBoundingClientRect();
+
+            cy.get(".diagnostics-response-tabs-panels").then(($panels) => {
+                const panels = $panels[0].getBoundingClientRect();
+
+                // No inline padding on the non-scrolling wrapper.
+                expect(panels.left).to.be.closeTo(container.left, 0.5);
+                expect(panels.right).to.be.closeTo(container.right, 0.5);
+            });
+
+            cy.get(".diagnostic-panel:visible").then(($panel) => {
+                const panel = $panel[0];
+                const style = window.getComputedStyle(panel);
+
+                // The panel content still carries the inline inset.
+                expect(parseFloat(style.paddingLeft)).to.be.greaterThan(0);
+                expect(parseFloat(style.paddingRight)).to.be.greaterThan(0);
+            });
+        });
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelInset.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelInset.cy.tsx
@@ -3,52 +3,59 @@ import { DoenetEditor } from "../../../src/doenetml-inline-worker";
 
 const SAMPLE_DOENETML = "<p>hello</p>";
 
-function Harness() {
-    return (
-        <div style={{ height: "500px", width: "900px" }}>
-            <DoenetEditor
-                doenetML={SAMPLE_DOENETML}
-                addVirtualKeyboard={false}
-                initialOpenTab="accessibility"
-            />
-        </div>
-    );
-}
-
 /**
- * The scrolling element of the diagnostics/help panel must span the full width
- * of its container so that its scrollbar sits flush against the editor's
- * trailing edge; the inline inset of the panel text comes from the panels
- * themselves.
+ * The scrolling element of the diagnostics/help panel
+ * (`.diagnostics-response-tabs-panels`) must span the full width of its
+ * container so that its scrollbar sits flush against the editor's trailing
+ * edge. The inline inset of the panel text comes from `.diagnostic-panel`
+ * inside the scrolling element instead of from the container around it.
  */
-describe("Diagnostics panel inset", () => {
-    it("scrolling element spans the container while the panel text is inset", () => {
-        cy.mount(<Harness />);
+describe("DoenetEditor diagnostics panel inset", () => {
+    beforeEach(() => {
+        cy.mount(
+            <div style={{ height: "500px", width: "900px" }}>
+                <DoenetEditor
+                    doenetML={SAMPLE_DOENETML}
+                    initialOpenTab="help"
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
 
         cy.get(".diagnostics-response-tabs-container").should(
             "have.class",
             "is-open",
         );
+    });
 
+    it("scrolling element spans its container edge to edge", () => {
         cy.get(".diagnostics-response-tabs-container").then(($container) => {
             const container = $container[0].getBoundingClientRect();
 
             cy.get(".diagnostics-response-tabs-panels").then(($panels) => {
                 const panels = $panels[0].getBoundingClientRect();
 
-                // No inline padding on the non-scrolling wrapper.
                 expect(panels.left).to.be.closeTo(container.left, 0.5);
                 expect(panels.right).to.be.closeTo(container.right, 0.5);
             });
+        });
+    });
 
-            cy.get(".diagnostic-panel:visible").then(($panel) => {
-                const panel = $panel[0];
-                const style = window.getComputedStyle(panel);
+    it("insets the panel text without insetting the scrolling element", () => {
+        cy.get(".diagnostics-response-tabs-panels").then(($panels) => {
+            const style = window.getComputedStyle($panels[0]);
 
-                // The panel content still carries the inline inset.
-                expect(parseFloat(style.paddingLeft)).to.be.greaterThan(0);
-                expect(parseFloat(style.paddingRight)).to.be.greaterThan(0);
-            });
+            // Inline padding here would push the scrollbar off the edge.
+            expect(parseFloat(style.paddingLeft)).to.equal(0);
+            expect(parseFloat(style.paddingRight)).to.equal(0);
+        });
+
+        cy.get(".diagnostic-panel:visible").then(($panel) => {
+            const style = window.getComputedStyle($panel[0]);
+
+            // The inset the container padding used to provide now lives here.
+            expect(parseFloat(style.paddingLeft)).to.be.greaterThan(0);
+            expect(parseFloat(style.paddingRight)).to.be.greaterThan(0);
         });
     });
 });

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelInset.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelInset.cy.tsx
@@ -42,13 +42,19 @@ describe("DoenetEditor diagnostics panel inset", () => {
     });
 
     it("insets the panel text without insetting the scrolling element", () => {
-        cy.get(".diagnostics-response-tabs-panels").then(($panels) => {
-            const style = window.getComputedStyle($panels[0]);
+        // Inline padding on either the scrolling element or the container
+        // around it would push the scrollbar in from the editor's edge.
+        for (const selector of [
+            ".diagnostics-response-tabs-container",
+            ".diagnostics-response-tabs-panels",
+        ]) {
+            cy.get(selector).then(($el) => {
+                const style = window.getComputedStyle($el[0]);
 
-            // Inline padding here would push the scrollbar off the edge.
-            expect(parseFloat(style.paddingLeft)).to.equal(0);
-            expect(parseFloat(style.paddingRight)).to.equal(0);
-        });
+                expect(parseFloat(style.paddingLeft), selector).to.equal(0);
+                expect(parseFloat(style.paddingRight), selector).to.equal(0);
+            });
+        }
 
         cy.get(".diagnostic-panel:visible").then(($panel) => {
             const style = window.getComputedStyle($panel[0]);


### PR DESCRIPTION
The diagnostics/help panel's scrollbar sat about 0.4rem in from the editor's trailing edge, leaving a visible gap next to the resizer whenever the panel had enough content to scroll.

The cause was where the inline padding lived: `.diagnostics-response-tabs-container` (the non-scrolling flex wrapper) carried `padding: 0rem 0.4rem`, which narrowed its scrolling child `.diagnostics-response-tabs-panels` and therefore inset the scrollbar too.

## Change

- `packages/doenetml/src/EditorViewer/editor-viewer.css`: drop the inline padding from `.diagnostics-response-tabs-container` and fold it into `.diagnostic-panel`'s inline padding (`0.25rem` → `0.65rem`). A comment records why the padding belongs on the panels.

All six tab panels (errors, warnings, info, accessibility, responses, help) carry `.diagnostic-panel`, so the text inset is unchanged at `0.25rem + 0.4rem = 0.65rem` while the scroller — and its scrollbar — now spans the full width.

## Tests

`packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelInset.cy.tsx` mounts the editor with the (static) help tab open and asserts:

- the scrolling element's left/right edges match its container's, edge to edge;
- neither the scrolling element nor the container around it has inline padding, while the visible `.diagnostic-panel` inside does — pinning the inset to the panel rather than the wrapper.

Both assertions fail against the previous CSS and pass against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
