### PR TITLE
Seed catalogs for fifteen Austronesian and Pacific languages

### DIFF
--- a/.changeset/seed-austronesian-languages.md
+++ b/.changeset/seed-austronesian-languages.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Add message catalogs for Ilocano, Waray, Hiligaynon, Kapampangan, Bikol, Balinese, Minangkabau, Acehnese, Madurese, Tetum, Tongan, Fijian, Tahitian, Chamorro and Tok Pisin.
+
+Each covers all four namespaces — the viewer chrome, the editor and language-server surfaces, the prose the core computes into a document, and the warnings and errors. `documentLocale="ilo"` and `<document lang="to">` work with nothing configured, and all fifteen reach `<document lang>`'s autocomplete.
+
+The batch takes the roster across the Philippines, the Indonesian archipelago, Timor-Leste, Polynesia, Micronesia and Papua New Guinea, and it brings the first Bikol macrolanguage fold: `bcl`, `bto`, `cts` and the other members reach the Central Bikol catalog rather than falling to English.
+
+These are **unreviewed machine-generated seeds**, and every file says so in its header. Nothing falls back silently: a key a translation is missing renders in English, which is what makes seeding safe.

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
@@ -404,6 +404,51 @@ describe("style descriptions follow the document locale @group4", () => {
         expect(values.fd).eq("pwen ble");
     });
 
+    it("carries Ilocano's linker through the worker path", async () => {
+        const values = await descriptions(styled, names, "ilo");
+        // The Austronesian batch's prenominal end, and the language whose
+        // ligature is the batch's one unresolved constraint. Ilocano joins an
+        // adjective to what it describes with «a» before a consonant and «nga»
+        // before a vowel — a shape the *following* word decides — so a ligature
+        // in front of a placeable cannot be chosen, and `locales/ilo` writes
+        // «a», which is right for every word its own tables supply but one.
+        expect(values.st).eq("napuskol a naguris-guris a nalabaga");
+        expect(values.stn).eq("napuskol a naguris-guris a nalabaga a linia");
+        expect(values.pt).eq("berde a kuadrado");
+        // That one word is «asul», and this is it: the shape's colour is
+        // vowel-initial, so «napunno a asul» is where the rule the catalog's
+        // header records comes out wrong. It is pinned rather than hidden,
+        // because the fix is a change to how `$part` or a new argument reaches
+        // the ligature rather than a change to this string.
+        expect(values.sh).eq(
+            "napunno a asul a sirkulo nga addaan iti tuldek ken napuskol a naguris-guris a nalabaga nga igid",
+        );
+        // «igid» is vowel-initial too, and there the ligature is «nga» and
+        // fixed, because the catalog writes both words around it.
+        expect(values.bd).eq("napuskol a naguris-guris a nalabaga");
+        expect(values.fd).eq("asul a tuldek");
+    });
+
+    it("puts Tongan's adjectives after the noun", async () => {
+        const values = await descriptions(styled, names, "to");
+        // The other end of the batch's range: the adjectives follow the noun,
+        // nothing agrees with anything, and there is no ligature at all. What
+        // this checks past the word order is that the fakauʻa «ʻ» — U+02BB, a
+        // letter of the Tongan alphabet rather than an apostrophe — survives
+        // `setLocaleData` and the `translator` dependency unchanged.
+        expect(values.st).eq("matolu motumotu kulokula");
+        expect(values.stn).eq("laine matolu motumotu kulokula");
+        expect(values.pt).eq("sikuea lanumata");
+        expect(values.sh).eq(
+            "fuopotopoto fonu lanumoana mo e tongi pea mo e kapa matolu motumotu kulokula",
+        );
+        // «mo e» opens the first clause and «pea mo e» the second, which is the
+        // distinction English draws with "with" against "and" and the only work
+        // `style-border-clause` does in a language with no article.
+        expect(values.bd).eq("matolu motumotu kulokula");
+        expect(values.fd).eq("tongi lanumoana");
+    });
+
     it("falls back to English for a locale with no catalog", async () => {
         // `qaa` is in the ISO 639-3 private-use range, so it can never gain a
         // catalog and this stays a test of the fallback rather than of which

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -71,14 +71,14 @@ English is the source of truth. Every translation — `ace`, `af`, `ak`, `am`,
 `br`, `bs`, `ca`, `ceb`, `ch`, `co`, `cs`, `cy`, `da`, `de`, `ee`, `el`, `es`,
 `et`, `eu`, `fa`, `fi`, `fil`, `fj`, `fo`, `fr`, `fy`, `ga`, `gd`, `gl`, `gn`,
 `gu`, `ha`, `haw`, `he`, `hi`, `hil`, `hnj`, `hr`, `ht`, `hu`, `hy`, `id`, `ig`,
-`ilo`, `is`, `it`, `ja`,
-`jv`, `ka`, `kk`, `km`, `kn`, `ko`, `ky`, `lb`, `lg`, `ln`, `lo`, `lt`, `lv`,
-`mad`, `mg`, `mi`, `min`, `mk`, `ml`, `mn`, `mr`, `ms`, `mt`, `my`, `nah`, `nb`,
-`nds`, `ne`, `nl`, `ny`, `oc`, `oj`, `om`, `or`, `pa`, `pam`, `pl`, `ps`, `pt`,
-`qu`, `quc`, `rm`, `ro`, `ru`, `rw`, `sc`, `scn`, `sd`, `se`, `si`, `sk`, `sl`,
-`sm`, `sn`, `so`, `sq`, `sr`, `st`, `su`, `sv`, `sw`, `ta`, `te`, `tet`, `tg`,
-`th`, `ti`, `tk`, `tn`, `to`, `tpi`, `tr`, `tt`, `ty`, `ug`, `uk`, `ur`, `uz`,
-`vi`, `war`, `wo`, `xh`, `yi`, `yo`, `zh-Hans`, `zh-Hant`, `zu` — is an
+`ilo`, `is`, `it`, `ja`, `jv`, `ka`, `kk`, `km`, `kn`, `ko`, `ky`, `lb`, `lg`,
+`ln`, `lo`, `lt`, `lv`, `mad`, `mg`, `mi`, `min`, `mk`, `ml`, `mn`, `mr`, `ms`,
+`mt`, `my`, `nah`, `nb`, `nds`, `ne`, `nl`, `ny`, `oc`, `oj`, `om`, `or`, `pa`,
+`pam`, `pl`, `ps`, `pt`, `qu`, `quc`, `rm`, `ro`, `ru`, `rw`, `sc`, `scn`, `sd`,
+`se`, `si`, `sk`, `sl`, `sm`, `sn`, `so`, `sq`, `sr`, `st`, `su`, `sv`, `sw`,
+`ta`, `te`, `tet`, `tg`, `th`, `ti`, `tk`, `tn`, `to`, `tpi`, `tr`, `tt`, `ty`,
+`ug`, `uk`, `ur`, `uz`, `vi`, `war`, `wo`, `xh`, `yi`, `yo`, `zh-Hans`,
+`zh-Hant`, `zu` — is an
 **unreviewed machine-generated seed**, which each file's own header says at the
 top, and which is what #1521's translation platform is for. None has been read by
 a speaker. Correcting one needs no permission and no coordination: a wrong string
@@ -94,8 +94,8 @@ Romansh, Occitan, Asturian, Sardinian, Sicilian, Corsican, Northern Sami,
 Yiddish, Haitian Creole, Quechua, Guarani, Aymara, Nahuatl, Kʼicheʼ, Mapudungun,
 Ojibwe, Ilocano, Waray, Hiligaynon, Kapampangan, Bikol, Balinese, Minangkabau,
 Acehnese, Madurese, Tetum, Tongan, Fijian, Tahitian, Chamorro and Tok Pisin
-leave `element-name` and `element-anion-name` out, so those 130 keys
-fall back to English and `lint:i18n` reports the gap.
+leave `element-name` and `element-anion-name` out, so those 130 keys fall back
+to English and `lint:i18n` reports the gap.
 The first nine have no settled chemical nomenclature to seed from, and
 inventing one would be worse than the English a student meets in their own
 textbook. Kannada has two — native coinages reaching a dozen elements and
@@ -190,8 +190,9 @@ and none is the Khmer case of having the names but no convention to reproduce.
 They simply do not have the table, and the catalogs say so in their own headers
 rather than leaving a reader to infer it from a gap.
 
-**All fifteen of the Austronesian batch are partial too, and they split three
-ways along the languages the school systems teach science in.** Ilocano, Waray,
+**All fifteen of the Austronesian batch are partial too, and they split four
+ways.** Three of the four are a fact about a school system rather than about a
+language, which is the split worth keeping straight. Ilocano, Waray,
 Hiligaynon, Kapampangan, Bikol, Chamorro and Tok Pisin are the English-medium
 case — the Philippines from the intermediate grades, Guam and the Northern
 Marianas, Papua New Guinea — which is the `fil` and `ceb` case those two
@@ -206,12 +207,12 @@ chose to carry the table, these choose to leave it. Tetum and Tahitian are the
 colonial-medium case a third and fourth time, Portuguese and French, which is
 `locales/ht`'s exactly.
 
-Tongan and Fijian are the fifteenth and sixteenth languages in this roster whose
-schooling is in a colonial language *and* whose own vocabulary stops well short
-of 118, which is the Samoan and Hawaiian case in `locales/sm` and `locales/haw`
-— Polynesian languages naming the substances known long before the elements were
-and no table over them. That the Pacific catalogs keep landing there is worth
-saying once rather than four times.
+Tongan and Fijian are the fourth case, and the one that is not about a
+ministry: both are schooled in English, but neither has a settled list of all
+118 that stops short of inventing one, which is the Samoan and Hawaiian case in
+`locales/sm` and `locales/haw` — Pacific languages naming the substances known
+long before the elements were and no table over them. That the Pacific catalogs
+keep landing there is worth saying once rather than four times.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -449,9 +450,10 @@ know — see the note on `localeNames` in `catalogUtils.ts` — and nothing here
 hand-writes around it, which is the same rule that leaves `co` reading
 "Corsican" twice. It is a gap in CLDR, and until it closes the label is the tag.
 
-The Austronesian batch adds one macrolanguage, two script asymmetries, three
-naming cases, and a finding about the affix rule that is the batch's real
-contribution.
+The Austronesian batch adds one macrolanguage, two script asymmetries and three
+naming cases. Its finding about the affix rule — the batch's real contribution —
+belongs beside that rule rather than here, and is in
+[A ligature is an affix too](#a-ligature-is-an-affix-too).
 
 `bik` is an ISO 639-3 macrolanguage over the eight Bikol languages of the Bicol
 peninsula, so it joins `MACROLANGUAGE_MEMBERS` for the same published reason
@@ -479,39 +481,6 @@ scale: `to` is the only one of the fifteen whose **endonym** CLDR knows — the
 roster reads "Tongan (lea fakatonga)" — and the other fourteen read their
 English name once. None of the fifteen is right-to-left, so `direction.ts` is
 untouched.
-
-### A ligature is an affix too
-
-The batch's finding, and it belongs beside
-[An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
-rather than under naming. A Philippine language joins an attributive adjective
-to what it describes with a **linker**, and a linker has two forms. Which one is
-right is decided by a neighbouring word — which, in these messages, is often a
-placeable. So the constraint that turned up first as a case ending in Arabic and
-a preposition in Czech turns up here as a ligature, and the five Philippine
-catalogs do not all resolve it the same way:
-
-| | The linker | Decided by | Resolution |
-| --- | --- | --- | --- |
-| `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», which is grammatical in both positions |
-| `ilo` | «a» / «nga» | the word **after** it | no invariant form exists; write «a» and name the exception |
-| `pam` | «a» / `-ng` | the word **before** it | no invariant form exists; write «a» and name the exception |
-| `bik` | «na» / `-ng` | the word **before** it | no invariant form exists; write «na» and name the exception |
-
-Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
-free word in both positions, so writing it out is not a compromise but the form
-that can be written without knowing what stands beside it. That is the same move
-`locales/quc` makes when it writes the free relational «rech» instead of the
-possessive prefix «u-»/«r-», and it is a **fifth way out** to add to the four
-that section lists — *prefer the free allomorph over the bound one*.
-
-The other three cannot, and each header says exactly where its choice comes out
-wrong rather than leaving a reader to find it. Ilocano's is the sharpest and is
-**pinned as a test**: every word in its own tables is consonant-initial but
-«asul», so `styleDescriptionLocale.test.ts` asserts the string «napunno a asul a
-sirkulo» — the one place the rule misfires — rather than hiding it. A fix is a
-change to what the composition messages are handed, not a change to that string,
-and the test is what would notice the day it becomes possible.
 
 A catalog's **comments are in English** whatever it translates into: its
 header, its `##` group headings, and the notes explaining a wording choice.
@@ -954,7 +923,7 @@ meet is one the ending merely sits beside. `locales/tg`'s own header records
 that, because a new entry in its `noun` or `color` table has to be checked
 against it.
 
-There are four ways out, and every catalog here takes one of them:
+There are five ways out, and every catalog here takes one of them:
 
 - **Name what the value is.** «للمكوّن { $component }» — "for the component X"
   — puts the affix on a word the catalog writes.
@@ -966,9 +935,45 @@ There are four ways out, and every catalog here takes one of them:
   have wanted «ve».
 - **Write both forms.** Hungarian's «a(z)» is the standard orthographic answer
   to exactly this problem, and predates software by a long way.
+- **Prefer the free allomorph over the bound one.** Where the affix has a
+  free-standing counterpart that is grammatical in every position, write that:
+  Kʼicheʼ's relational «rech» in place of the possessive prefix «u-»/«r-», and
+  the Bisayan linker «nga» in place of the enclitic `-ng` — see
+  [A ligature is an affix too](#a-ligature-is-an-affix-too).
 
 A select whose variants would land against such an affix carries the affix into
 each variant: Fluent does not care where a select sits inside a pattern.
+
+### A ligature is an affix too
+
+The Austronesian batch's finding. A Philippine language joins an attributive
+adjective to what it describes with a **linker**, and a linker has two forms.
+Which one is right is decided by a neighbouring word — which, in these messages,
+is often a placeable. So the constraint that turned up first as a case ending in
+Arabic and a preposition in Czech turns up here as a ligature, and the five
+Philippine catalogs do not all resolve it the same way:
+
+| | The linker | Decided by | Resolution |
+| --- | --- | --- | --- |
+| `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», which is grammatical in both positions |
+| `ilo` | «a» / «nga» | the word **after** it | no invariant form exists; write «a» and name the exception |
+| `pam` | «a» / `-ng` | the word **before** it | no invariant form exists; write «a» and name the exception |
+| `bik` | «na» / `-ng` | the word **before** it | no invariant form exists; write «na» and name the exception |
+
+Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
+free word in both positions, so writing it out is not a compromise but the form
+that can be written without knowing what stands beside it. That is the same move
+`locales/quc` makes when it writes the free relational «rech» instead of the
+possessive prefix «u-»/«r-», and it is the fifth way out listed above — *prefer
+the free allomorph over the bound one*.
+
+The other three cannot, and each header says exactly where its choice comes out
+wrong rather than leaving a reader to find it. Ilocano's is the sharpest and is
+**pinned as a test**: every word in its own tables is consonant-initial but
+«asul», so `styleDescriptionLocale.test.ts` asserts the string «napunno a asul a
+sirkulo» — the one place the rule misfires — rather than hiding it. A fix is a
+change to what the composition messages are handed, not a change to that string,
+and the test is what would notice the day it becomes possible.
 
 ## Diagnostics
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -66,31 +66,35 @@ locales/<locale>/
   editor.ftl        # editor and LSP surfaces                — uiLocale
 ```
 
-English is the source of truth. Every translation — `af`, `ak`, `am`, `ar`,
-`arn`, `as`, `ast`, `ay`, `az`, `be`, `bg`, `bm`, `bn`, `br`, `bs`, `ca`, `ceb`,
-`co`, `cs`, `cy`, `da`, `de`, `ee`, `el`, `es`, `et`, `eu`, `fa`, `fi`, `fil`,
-`fo`, `fr`, `fy`, `ga`, `gd`, `gl`, `gn`, `gu`, `ha`, `haw`, `he`, `hi`, `hnj`,
-`hr`, `ht`, `hu`, `hy`, `id`, `ig`, `is`, `it`, `ja`, `jv`, `ka`, `kk`, `km`,
-`kn`, `ko`, `ky`, `lb`, `lg`, `ln`, `lo`, `lt`, `lv`, `mg`, `mi`, `mk`, `ml`,
-`mn`, `mr`, `ms`, `mt`, `my`, `nah`, `nb`, `nds`, `ne`, `nl`, `ny`, `oc`, `oj`,
-`om`, `or`, `pa`, `pl`, `ps`, `pt`, `qu`, `quc`, `rm`, `ro`, `ru`, `rw`, `sc`,
-`scn`, `sd`, `se`, `si`, `sk`, `sl`, `sm`, `sn`, `so`, `sq`, `sr`, `st`, `su`,
-`sv`, `sw`, `ta`, `te`, `tg`, `th`, `ti`, `tk`, `tn`, `tr`, `tt`, `ug`, `uk`,
-`ur`, `uz`, `vi`, `wo`, `xh`, `yi`, `yo`, `zh-Hans`, `zh-Hant`, `zu` — is an
+English is the source of truth. Every translation — `ace`, `af`, `ak`, `am`,
+`ar`, `arn`, `as`, `ast`, `ay`, `az`, `ban`, `be`, `bg`, `bik`, `bm`, `bn`,
+`br`, `bs`, `ca`, `ceb`, `ch`, `co`, `cs`, `cy`, `da`, `de`, `ee`, `el`, `es`,
+`et`, `eu`, `fa`, `fi`, `fil`, `fj`, `fo`, `fr`, `fy`, `ga`, `gd`, `gl`, `gn`,
+`gu`, `ha`, `haw`, `he`, `hi`, `hil`, `hnj`, `hr`, `ht`, `hu`, `hy`, `id`, `ig`,
+`ilo`, `is`, `it`, `ja`,
+`jv`, `ka`, `kk`, `km`, `kn`, `ko`, `ky`, `lb`, `lg`, `ln`, `lo`, `lt`, `lv`,
+`mad`, `mg`, `mi`, `min`, `mk`, `ml`, `mn`, `mr`, `ms`, `mt`, `my`, `nah`, `nb`,
+`nds`, `ne`, `nl`, `ny`, `oc`, `oj`, `om`, `or`, `pa`, `pam`, `pl`, `ps`, `pt`,
+`qu`, `quc`, `rm`, `ro`, `ru`, `rw`, `sc`, `scn`, `sd`, `se`, `si`, `sk`, `sl`,
+`sm`, `sn`, `so`, `sq`, `sr`, `st`, `su`, `sv`, `sw`, `ta`, `te`, `tet`, `tg`,
+`th`, `ti`, `tk`, `tn`, `to`, `tpi`, `tr`, `tt`, `ty`, `ug`, `uk`, `ur`, `uz`,
+`vi`, `war`, `wo`, `xh`, `yi`, `yo`, `zh-Hans`, `zh-Hant`, `zu` — is an
 **unreviewed machine-generated seed**, which each file's own header says at the
 top, and which is what #1521's translation platform is for. None has been read by
 a speaker. Correcting one needs no permission and no coordination: a wrong string
 is just wrong, and the English is one key away.
 
-Fifty-eight of them are deliberately partial, all in the same place: Somali,
+Seventy-three of them are deliberately partial, all in the same place: Somali,
 Hmong Njua, Amharic, Assamese, Nepali, Burmese, Pashto, Sindhi, Uyghur,
 Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa, Kinyarwanda, Nyanja,
 Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano, Malagasy, Māori,
 Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona, Southern Sotho,
 Setswana, Tigrinya, Ganda, Luxembourgish, Western Frisian, Low German,
 Romansh, Occitan, Asturian, Sardinian, Sicilian, Corsican, Northern Sami,
-Yiddish, Haitian Creole, Quechua, Guarani, Aymara, Nahuatl, Kʼicheʼ, Mapudungun
-and Ojibwe leave `element-name` and `element-anion-name` out, so those 130 keys
+Yiddish, Haitian Creole, Quechua, Guarani, Aymara, Nahuatl, Kʼicheʼ, Mapudungun,
+Ojibwe, Ilocano, Waray, Hiligaynon, Kapampangan, Bikol, Balinese, Minangkabau,
+Acehnese, Madurese, Tetum, Tongan, Fijian, Tahitian, Chamorro and Tok Pisin
+leave `element-name` and `element-anion-name` out, so those 130 keys
 fall back to English and `lint:i18n` reports the gap.
 The first nine have no settled chemical nomenclature to seed from, and
 inventing one would be worse than the English a student meets in their own
@@ -185,6 +189,29 @@ None of the eight is the Kannada case of having two lists and having to pick,
 and none is the Khmer case of having the names but no convention to reproduce.
 They simply do not have the table, and the catalogs say so in their own headers
 rather than leaving a reader to infer it from a gap.
+
+**All fifteen of the Austronesian batch are partial too, and they split three
+ways along the languages the school systems teach science in.** Ilocano, Waray,
+Hiligaynon, Kapampangan, Bikol, Chamorro and Tok Pisin are the English-medium
+case — the Philippines from the intermediate grades, Guam and the Northern
+Marianas, Papua New Guinea — which is the `fil` and `ceb` case those two
+catalogs already record, and a fact about four education ministries rather than
+about seven languages. Balinese, Minangkabau, Acehnese and Madurese are the
+Indonesian-medium case, and they differ from `jv` and `su` in an instructive
+way: those two *supply* the Indonesian names, because their own vocabulary for
+the substances agrees with Indonesian's often enough that the table reads as
+theirs. These four do not, and copying it whole would be neither language —
+Minangkabau says «ameh» where Indonesian says «emas» — so where `jv` and `su`
+chose to carry the table, these choose to leave it. Tetum and Tahitian are the
+colonial-medium case a third and fourth time, Portuguese and French, which is
+`locales/ht`'s exactly.
+
+Tongan and Fijian are the fifteenth and sixteenth languages in this roster whose
+schooling is in a colonial language *and* whose own vocabulary stops well short
+of 118, which is the Samoan and Hawaiian case in `locales/sm` and `locales/haw`
+— Polynesian languages naming the substances known long before the elements were
+and no table over them. That the Pacific catalogs keep landing there is worth
+saying once rather than four times.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -421,6 +448,70 @@ both the English name and the endonym, so `<document lang>`'s autocomplete offer
 know — see the note on `localeNames` in `catalogUtils.ts` — and nothing here
 hand-writes around it, which is the same rule that leaves `co` reading
 "Corsican" twice. It is a gap in CLDR, and until it closes the label is the tag.
+
+The Austronesian batch adds one macrolanguage, two script asymmetries, three
+naming cases, and a finding about the affix rule that is the batch's real
+contribution.
+
+`bik` is an ISO 639-3 macrolanguage over the eight Bikol languages of the Bicol
+peninsula, so it joins `MACROLANGUAGE_MEMBERS` for the same published reason
+`qu` and `oj` did. The catalog is **Central Bikol** (Naga), which is `bcl` — the
+variety Bikol publishing and the mother-tongue materials use — and `bto`, `cts`,
+`ubl` and the rest reach it. Tagalog is deliberately not in that list and must
+not be added: `fil` is a language of its own with a catalog of its own, and
+folding it would serve a Tagalog reader Bikol. `negotiate.test.ts` holds both
+halves, and holds `pag` (Pangasinan) on English — a Philippine language that
+belongs to no macrolanguage with a catalog, and so falls back rather than being
+guessed at.
+
+`ban` and `ace` add the script asymmetry `pa`, `sr`, `jv` and `su` already have:
+both catalogs are Latin, so a reader arriving under `ban-Bali` (the Balinese
+script) or `ace-Arab` (Jawi) reaches them and gets Latin. As ever the answer is
+a second catalog beside the first rather than a rename of it.
+
+The naming cases are the `ny`-reads-Nyanja rule again, and they are worth
+listing because two of them will look like mistakes: `ilo` appears in
+`<document lang>`'s autocomplete as **Iloko** rather than Ilocano and `pam` as
+**Pampanga** rather than Kapampangan, because that is what `Intl.DisplayNames`
+renders and `supportedLocales.ts` is derived rather than hand-written. Both
+catalogs' headers say which language they are. The third is the `co` case at
+scale: `to` is the only one of the fifteen whose **endonym** CLDR knows — the
+roster reads "Tongan (lea fakatonga)" — and the other fourteen read their
+English name once. None of the fifteen is right-to-left, so `direction.ts` is
+untouched.
+
+### A ligature is an affix too
+
+The batch's finding, and it belongs beside
+[An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
+rather than under naming. A Philippine language joins an attributive adjective
+to what it describes with a **linker**, and a linker has two forms. Which one is
+right is decided by a neighbouring word — which, in these messages, is often a
+placeable. So the constraint that turned up first as a case ending in Arabic and
+a preposition in Czech turns up here as a ligature, and the five Philippine
+catalogs do not all resolve it the same way:
+
+| | The linker | Decided by | Resolution |
+| --- | --- | --- | --- |
+| `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», which is grammatical in both positions |
+| `ilo` | «a» / «nga» | the word **after** it | no invariant form exists; write «a» and name the exception |
+| `pam` | «a» / `-ng` | the word **before** it | no invariant form exists; write «a» and name the exception |
+| `bik` | «na» / `-ng` | the word **before** it | no invariant form exists; write «na» and name the exception |
+
+Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
+free word in both positions, so writing it out is not a compromise but the form
+that can be written without knowing what stands beside it. That is the same move
+`locales/quc` makes when it writes the free relational «rech» instead of the
+possessive prefix «u-»/«r-», and it is a **fifth way out** to add to the four
+that section lists — *prefer the free allomorph over the bound one*.
+
+The other three cannot, and each header says exactly where its choice comes out
+wrong rather than leaving a reader to find it. Ilocano's is the sharpest and is
+**pinned as a test**: every word in its own tables is consonant-initial but
+«asul», so `styleDescriptionLocale.test.ts` asserts the string «napunno a asul a
+sirkulo» — the one place the rule misfires — rather than hiding it. A fix is a
+change to what the composition messages are handed, not a change to that string,
+and the test is what would notice the day it becomes possible.
 
 A catalog's **comments are in English** whatever it translates into: its
 header, its `##` group headings, and the notes explaining a wording choice.
@@ -770,6 +861,18 @@ other half of the same check is reachability: only `describeColor` ever asks
 for `background-clause` or `text-clause`, so a stroke width or a dash pattern
 branching on either is writing a variant nothing can select.
 
+**`standalone` covers two positions, and `locales/tpi` is the first catalog that
+wants them apart.** A Tok Pisin adjective carries «-pela» attributively —
+«retpela lain» — and drops it predicatively: «lain i ret». That is exactly the
+kind of distinction `$role` names, and it is unreachable, because `attachNoun`
+passes `role: "standalone"` for the phrase it is about to put in front of a noun
+and `describeColor` passes the same token for the citation form a state variable
+reports. One token, two positions. So the catalog writes the attributive form
+throughout, which is right wherever a noun follows, and its header records the
+reason rather than the workaround. Splitting `standalone` into a citation
+position and an attributive one is a change to `styleDescriptions.ts` that no
+existing catalog needs and this one would use on the day it lands.
+
 Even the noun is not one string. A regular polygon is "5-sided regular polygon"
 in English but "polígono regular … de 5 lados" in Spanish, wrapped around the
 adjectives rather than sitting beside them, so `noun-regular-polygon` answers
@@ -778,6 +881,16 @@ needs no complement leaves the second half empty. The rule generalizes: **a
 phrase a language cannot keep contiguous has to be split at the source** —
 there is no reaching inside `{ $noun }` from the message that places it, so
 split the phrase, not the message that uses it.
+
+**The split is not the postnominal languages' property**, and the Austronesian
+batch is what shows it. In the Indigenous Americas batch every prenominal
+catalog folded its side count into the head and left `[tail]` empty, because a
+count is a modifier there; here **all fifteen reach `[noun-tail]`, six of them
+with their adjectives in front of the noun**, because in every one of the
+fifteen the count is a relative clause — «nga addaan iti 5 a sikigan», «i gat 5
+sait wankain» — which has to follow the whole phrase whichever side the
+adjectives sit on. What decides the split is the shape of the complement, not
+the order of the adjectives, and `styleDescriptions.test.ts` pins both halves.
 
 Two further Fluent constraints shaped it, and both are easy to rediscover the
 hard way:

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -78,11 +78,10 @@ English is the source of truth. Every translation — `ace`, `af`, `ak`, `am`,
 `se`, `si`, `sk`, `sl`, `sm`, `sn`, `so`, `sq`, `sr`, `st`, `su`, `sv`, `sw`,
 `ta`, `te`, `tet`, `tg`, `th`, `ti`, `tk`, `tn`, `to`, `tpi`, `tr`, `tt`, `ty`,
 `ug`, `uk`, `ur`, `uz`, `vi`, `war`, `wo`, `xh`, `yi`, `yo`, `zh-Hans`,
-`zh-Hant`, `zu` — is an
-**unreviewed machine-generated seed**, which each file's own header says at the
-top, and which is what #1521's translation platform is for. None has been read by
-a speaker. Correcting one needs no permission and no coordination: a wrong string
-is just wrong, and the English is one key away.
+`zh-Hant`, `zu` — is an **unreviewed machine-generated seed**, which each file's
+own header says at the top, and which is what #1521's translation platform is
+for. None has been read by a speaker. Correcting one needs no permission and no
+coordination: a wrong string is just wrong, and the English is one key away.
 
 Seventy-three of them are deliberately partial, all in the same place: Somali,
 Hmong Njua, Amharic, Assamese, Nepali, Burmese, Pashto, Sindhi, Uyghur,
@@ -191,13 +190,11 @@ They simply do not have the table, and the catalogs say so in their own headers
 rather than leaving a reader to infer it from a gap.
 
 **All fifteen of the Austronesian batch are partial too, and they split four
-ways.** Three of the four are a fact about a school system rather than about a
-language, which is the split worth keeping straight. Ilocano, Waray,
+ways**, only one of which is a claim about a language. Ilocano, Waray,
 Hiligaynon, Kapampangan, Bikol, Chamorro and Tok Pisin are the English-medium
 case — the Philippines from the intermediate grades, Guam and the Northern
 Marianas, Papua New Guinea — which is the `fil` and `ceb` case those two
-catalogs already record, and a fact about four education ministries rather than
-about seven languages. Balinese, Minangkabau, Acehnese and Madurese are the
+catalogs already record. Balinese, Minangkabau, Acehnese and Madurese are the
 Indonesian-medium case, and they differ from `jv` and `su` in an instructive
 way: those two *supply* the Indonesian names, because their own vocabulary for
 the substances agrees with Indonesian's often enough that the table reads as
@@ -207,12 +204,14 @@ chose to carry the table, these choose to leave it. Tetum and Tahitian are the
 colonial-medium case a third and fourth time, Portuguese and French, which is
 `locales/ht`'s exactly.
 
-Tongan and Fijian are the fourth case, and the one that is not about a
-ministry: both are schooled in English, but neither has a settled list of all
-118 that stops short of inventing one, which is the Samoan and Hawaiian case in
-`locales/sm` and `locales/haw` — Pacific languages naming the substances known
-long before the elements were and no table over them. That the Pacific catalogs
-keep landing there is worth saying once rather than four times.
+Tongan and Fijian are the fourth case and the one about the languages: both are
+schooled in English, but neither has a settled list of all 118 to seed from
+without inventing one, which is the Samoan and Hawaiian case in `locales/sm`
+and `locales/haw` — Pacific languages naming the substances known long before
+the elements were, with no table over them. Chamorro's header records that
+second reason beside its school system, since Guam's periodic table arrived
+through English rather than through the Spanish the rest of its vocabulary came
+from.
 
 That is a decision per language and not per script: Bangla supplies the names
 its schools use, and Assamese, written in the same letters, does not. The same
@@ -451,8 +450,8 @@ hand-writes around it, which is the same rule that leaves `co` reading
 "Corsican" twice. It is a gap in CLDR, and until it closes the label is the tag.
 
 The Austronesian batch adds one macrolanguage, two script asymmetries and three
-naming cases. Its finding about the affix rule — the batch's real contribution —
-belongs beside that rule rather than here, and is in
+naming cases. What it adds to the affix rule belongs beside that rule rather
+than here, and is in
 [A ligature is an affix too](#a-ligature-is-an-affix-too).
 
 `bik` is an ISO 639-3 macrolanguage over the eight Bikol languages of the Bicol
@@ -938,7 +937,8 @@ There are five ways out, and every catalog here takes one of them:
 - **Prefer the free allomorph over the bound one.** Where the affix has a
   free-standing counterpart that is grammatical in every position, write that:
   Kʼicheʼ's relational «rech» in place of the possessive prefix «u-»/«r-», and
-  the Bisayan linker «nga» in place of the enclitic `-ng` — see
+  the Bisayan linker «nga» in place of the enclitic `-ng`, which is what
+  `locales/ceb` already does — see
   [A ligature is an affix too](#a-ligature-is-an-affix-too).
 
 A select whose variants would land against such an affix carries the affix into
@@ -946,12 +946,18 @@ each variant: Fluent does not care where a select sits inside a pattern.
 
 ### A ligature is an affix too
 
-The Austronesian batch's finding. A Philippine language joins an attributive
-adjective to what it describes with a **linker**, and a linker has two forms.
-Which one is right is decided by a neighbouring word — which, in these messages,
-is often a placeable. So the constraint that turned up first as a case ending in
-Arabic and a preposition in Czech turns up here as a ligature, and the five
-Philippine catalogs do not all resolve it the same way:
+A Philippine language joins an attributive adjective to what it describes with a
+**linker**, and a linker has two forms. Which one is right is decided by a
+neighbouring word — which, in these messages, is often a placeable. So the
+constraint that turned up first as a case ending in Arabic and a preposition in
+Czech turns up here as a ligature.
+
+`locales/ceb` and `locales/fil` reached it first and one at a time: Cebuano's
+header calls writing the uncontracted «nga» everywhere "the one place this seed
+is deliberately stiff", and `fil` escapes the ligature outright by selecting on
+the side count, whose two CLDR plural categories *are* its two linkers. What the
+Austronesian batch adds is the five Philippine catalogs side by side, which is
+what shows that they do not all resolve it the same way:
 
 | | The linker | Decided by | Resolution |
 | --- | --- | --- | --- |
@@ -962,10 +968,11 @@ Philippine catalogs do not all resolve it the same way:
 
 Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
 free word in both positions, so writing it out is not a compromise but the form
-that can be written without knowing what stands beside it. That is the same move
-`locales/quc` makes when it writes the free relational «rech» instead of the
-possessive prefix «u-»/«r-», and it is the fifth way out listed above — *prefer
-the free allomorph over the bound one*.
+that can be written without knowing what stands beside it — the move `locales/ceb`
+already makes, and the same move `locales/quc` makes when it writes the free
+relational «rech» instead of the possessive prefix «u-»/«r-». That is the fifth
+way out listed above — *prefer the free allomorph over the bound one* — and it
+is stated as a rule here because three catalogs now take it.
 
 The other three cannot, and each header says exactly where its choice comes out
 wrong rather than leaving a reader to find it. Ilocano's is the sharpest and is

--- a/packages/i18n/locales/ace/chrome.ftl
+++ b/packages/i18n/locales/ace/chrome.ftl
@@ -10,9 +10,9 @@
 # Written in the **Latin** orthography Acehnese publishing and schooling use,
 # with the diacritics that spell the language's own vowels — «putéh», «titék»,
 # «jaweueb». Acehnese is also written in Jawi, the Arabic script, so a reader
-# arriving under `ace-Arab` reaches this and gets Latin: the asymmetry `ha` and
-# `pa` already have, and the answer to it is a second catalog beside this one
-# rather than a rename of it.
+# arriving under `ace-Arab` reaches this and gets Latin: the asymmetry `pa`,
+# `sr`, `jv` and `su` already have, and the answer to it is a second catalog
+# beside this one rather than a rename of it.
 #
 # Acehnese marks no number on the noun, so a `{ $count -> … }` whose two English
 # branches differ only in the noun renders one string here and the select is

--- a/packages/i18n/locales/ace/chrome.ftl
+++ b/packages/i18n/locales/ace/chrome.ftl
@@ -1,0 +1,144 @@
+# Acehnese viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the **Latin** orthography Acehnese publishing and schooling use,
+# with the diacritics that spell the language's own vowels — «putéh», «titék»,
+# «jaweueb». Acehnese is also written in Jawi, the Arabic script, so a reader
+# arriving under `ace-Arab` reaches this and gets Latin: the asymmetry `ha` and
+# `pa` already have, and the answer to it is a second catalog beside this one
+# rather than a rename of it.
+#
+# Acehnese marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped. A `[0]` branch stays wherever English has one.
+
+
+## Answer submission
+
+answer-checking = Teungoh geupeuréksa…
+answer-submitting = Teungoh geukirém…
+
+answer-checking-status = Teungoh geupeuréksa jaweueb
+answer-submitting-status = Teungoh geukirém jaweueb
+
+answer-correct = Beutôi
+answer-incorrect = Hana beutôi
+
+answer-response-saved = Jaweueb ka geusimpan
+
+answer-percent-credit = { $percent }% kredit
+answer-percent-correct = { $percent }% beutôi
+answer-percent-short = { $percent } %
+
+max-credit-available = Kredit paléng rayeuk nyang jeuet teuhah: { $percent }%
+
+# No select: «cuba» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] hana lé cuba nyang teungoh
+       *[other] na { $count } cuba teungoh
+    }
+
+validation-correct = (Beutôi)
+validation-incorrect = (Hana beutôi)
+validation-partially-correct = (Beutôi siseun bagian)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Peuleumah { $count } jaweueb keu { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentar
+
+collapsible-click-to-open = (klik keu jeuet buka)
+collapsible-click-to-close = (klik keu jeuet tôb)
+
+collapsible-initializing = Teungoh peuphon…
+
+footnote-show = Peuleumah footnote
+footnote-hide = Som footnote
+
+description-more-information = keterangan laén
+
+
+## Controls
+
+slider-previous = Sigohlom
+slider-next = Seulanjut
+
+keyboard-open = Buka papan tuts
+keyboard-close = Tôb papan tuts
+
+choice-input-remove-choice = Peugadôh { $choice }
+
+matrix-remove-row = Peugadôh barih
+matrix-add-row = Tamah barih
+matrix-remove-column = Peugadôh kolom
+matrix-add-column = Tamah kolom
+
+subset-add-remove-points = Tamah/Peugadôh titék
+subset-toggle-points-intervals = Tuka titék ngon interval
+subset-move-points = Peupinah titék
+subset-clear = Peugleh
+
+orbital-add-row = Tamah barih
+orbital-remove-row = Peugadôh barih
+orbital-add-box = Tamah kutak
+orbital-remove-box = Peugadôh kutak
+orbital-add-up-arrow = Tamah panah u ateuh
+orbital-add-down-arrow = Tamah panah u yup
+orbital-remove-arrow = Peugadôh panah
+
+orbital-row-label = Label keu barih { $row }
+
+pretzel-answer = Jaweueb
+
+summary-statistics-caption = Ringkasan statistik { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ungkapan matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ungkapan nyang hana sah:
+
+
+## Document status
+
+viewer-initializing = Teungoh peuphon…
+
+
+## Errors
+
+error-heading = Salah
+
+error-found-at =
+    { $span ->
+        [line] Meuteumeung bak barih { $startLine }.
+       *[lines] Meuteumeung bak barih { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumen nyoe na salah!
+
+diagnostic-heading-error = Salah
+diagnostic-heading-warning = Peuingat
+diagnostic-heading-information = Keterangan
+diagnostic-heading-hint = Peutunyok
+
+accessibility-heading-level-1 = Peulanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Peuingat keuhai aksesibilitas
+
+something-went-wrong = Na nyang hana beutôi.
+
+renderer-load-failed = na renderer nyang hana ék teumuka. Neupeuulang muat laman nyoe.
+
+core-start-failed = Peuleumah dokumen hana ék teupeuphon. Neupeuulang muat laman nyoe.

--- a/packages/i18n/locales/ace/content.ftl
+++ b/packages/i18n/locales/ace/content.ftl
@@ -1,0 +1,252 @@
+# Acehnese content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography; see `chrome.ftl`'s header for the Jawi note.
+#
+# Acehnese has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «garéh mirah», a red line — so every
+# composition message inverts the English order.
+#
+# Acehnese vocabulary diverges from Malay far more than Minangkabau's does, and
+# the colours are where a corrector will see it first: «itam», «putéh»,
+# «mirah», «kuneng» are cognate but not identical, and «abée» for grey is the
+# word for ash rather than a loan. The geometry nouns are the Indonesian ones,
+# because Acehnese schools teach mathematics out of Indonesian-language
+# textbooks — the seam this catalog runs along, and one its header should be
+# read as declaring rather than hiding.
+
+
+## Style vocabulary
+
+color =
+    .black = itam
+    .white = putéh
+    .gray = abée
+    .red = mirah
+    .orange = oranyeu
+    .yellow = kuneng
+    .green = ijo
+    .cyan = sian
+    .blue = biru
+    .purple = unggu
+    .pink = mirah muda
+    .brown = coklat
+
+line-width =
+    .thick = teubai
+    .thin = lipéh
+
+line-style =
+    .dashed = putôh-putôh
+    .dotted = titék-titék
+
+# Noun phrases. Acehnese marks no plural on the noun, so «garéh» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = garéh meulinteueng
+    .vertical = garéh meudong
+    .diagonal = garéh mereng
+    .backdiagonal = garéh mereng meubalék
+    .dots = titék
+    .diamonds = beulah keutupat
+
+noun =
+    .line = garéh
+    .line-segment = ruweueng garéh
+    .ray = sinar
+    .vector = vektor
+    .curve = lengkông
+    .function = fungsi
+    .parabola = parabola
+    .polyline = garéh patah
+    .polygon = poligon
+    .triangle = seugoë lhèë
+    .rectangle = peuseugi panyang
+    .circle = bulat
+    .region = kawasan
+    .point = titék
+    .square = peuseugi
+    .diamond = beulah keutupat
+    .cross = sileuëng
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] nyang na { $numSides } sagoë
+       *[head] poligon beuratura
+    }
+
+# One answer for every noun: Acehnese has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = peunoh
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ngon { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ngon { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } ngon { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Acehnese has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «ngon» against «lom».
+style-border-clause =
+    { $parts ->
+        [with-article] ngon binèh { $border }
+        [and] lom binèh { $border }
+        [and-article] lom binèh { $border }
+       *[with] ngon binèh { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = hana peunoh
+
+style-text =
+    { $parts ->
+        [background] { $color } ngon laté { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = hana
+
+
+## Boolean words
+
+boolean-true = beutôi
+boolean-false = salah
+
+
+## Answer buttons
+
+answer-submit-label = Peuréksa buet
+answer-submit-label-no-correctness = Kirém jaweueb
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Acehnese marks no plural on the noun.
+section-name =
+    .activity = Keugiatan
+    .aside = Catatan binèh
+    .cascade = Kaskade
+    .definition = Bataih
+    .example = Cuntoh
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Jaweueb
+    .note = Catatan
+    .objectives = Tujuan
+    .paragraphs = Paragraf
+    .part = Bagian
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukti
+    .question = Peurtanyaan
+    .section = Bagian
+    .solution = Peunyeulesaian
+    .task = Tugaih
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Peutunyok
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Gamba { $enumeration }
+        [numbered-caption] Gamba { $enumeration }{ ": " }
+        [unnumbered-caption] Gamba{ ": " }
+       *[unnumbered] Gamba
+    }
+
+
+## Paginator controls
+
+paginator-previous = Sigohlom
+paginator-next = Seulanjut
+paginator-page = Laman
+
+paginator-page-status = { $pageLabel } { $currentPage } nibak { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = atawa
+piecewise-condition-if = meunyo
+piecewise-condition-otherwise = meunyo hana
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Acehnese schools teach chemistry out of Indonesian-language
+## textbooks, so the periodic table an Acehnese pupil meets is `locales/id`'s,
+## and Acehnese has no settled table of its own to seed from. The everyday
+## substances it does name itself — «meuh» for gold, «beusoë» for iron — are
+## where a speaker should start rather than at the whole 118.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simbol kimia nyang hana sah
+chemistry-invalid-ionic-compound = Sanyawa ionik nyang hana sah

--- a/packages/i18n/locales/ace/diagnostics.ftl
+++ b/packages/i18n/locales/ace/diagnostics.ftl
@@ -1,0 +1,624 @@
+# Acehnese diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Acehnese marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+
+
+## `<lineSegment>`
+
+# No select: «hana geuhiro» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = hana geuhiro { $attributes } meunyo dua ujông ka geupeuteuntee
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = hana geuhiro { $attributes } meunyo saboh ujông ngon titék teungoh ka geupeuteuntee bandua
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset hana meuguna meunyo hana titék teungoh
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garéh nyang lheuëh bak titék nyang hana teupeuteuntee dimensi jih.
+
+line-points-too-few-dimensions = Garéh harôh lheuëh bak titék nyang na paléng kureueng dua dimensi.
+
+line-points-depend-on-variables = Garéh lheuëh bak titék nyang meugantông bak variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garéh nyang hana sah bak variabel { $variable1 } ngon { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar geupeuteuntee lé through, endpoint ngon direction.  Hana geuhiro through nyang geupeuteuntee.
+
+ray-dimension-mismatch = numDimensions hana meucoco bak sinar.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor geupeuteuntee lé head, tail ngon displacement.  Hana geuhiro head nyang geupeuteuntee.
+
+vector-dimension-mismatch = numDimensions hana meucoco bak vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Hana jeuet teutarék u `<{ $component }>` sabab jih hana variabel keuadaan nearestPoint.
+
+constrain-to-without-nearest-point = Hana jeuet teuikat u `<{ $component }>` sabab jih hana variabel keuadaan nearestPoint.
+
+constrain-to-interior-without-nearest-point = Hana jeuet teuikat u lam `<{ $component }>` sabab jih hana variabel keuadaan nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = hana geuhiro labelPosition bak choiceInput nyang hana inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Hana geuhiro indeks nyang geupeuteuntee keu choiceInput sabab jumlah indeks hana meucoco ngon jumlah aneuk pilihan.
+
+pretzel-indices-count-mismatch = Hana geuhiro indeks nyang geupeuteuntee keu problem sabab jumlah indeks hana meucoco ngon jumlah aneuk problem.
+
+shuffle-indices-count-mismatch = Hana geuhiro indeks nyang geupeuteuntee keu shuffle sabab jumlah indeks hana meucoco ngon jumlah komponen.
+
+indices-ignored-out-of-range = Hana geuhiro indeks nyang geupeuteuntee keu { $component } sabab na indeks nyang leubèh nibak jangkauan.
+
+pretzel-indices-repeated = Hana geuhiro indeks nyang geupeuteuntee keu pretzel sabab na indeks nyang meuulang.
+
+pretzel-circuit-first-index = Hana geuhiro indeks nyang geupeuteuntee keu pretzel bak mode circuit sabab indeks phon harôh 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Mangat `<{ $component }>` jeuet meujalan ngon aneuk string, atribut `type` harôh geupeuteuntee.
+
+invalid-type-defaulting-to-math = type { $type } hana sah keu komponen { $component }. Harôh saboh nibak math, text, number, atawa boolean. Geuguna math.
+
+string-not-valid-component-to-arrange = String "{ $value }" kon komponen nyang sah keu { $component }. Hana geuhiro.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } hana sah, type geupeuduek u number.
+
+invalid-variable-value = Nilai variabel nyang hana sah: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } harôh angka
+
+variant-index-must-be-integer = Indeks varian { $index } harôh bileuëng buleuët
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` gohlom teupeuguna keu ukuran mutlak. Luaih geupeuduek jeuet relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` gohlom teupeuguna keu ukuran mutlak. Margin geupeuduek jeuet relatif.
+
+side-by-side-no-block-child = `<{ $component }>` hana sah: jih harôh na paléng kureueng saboh aneuk block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Hana geuhiro atribut `for` bak `<label>` grafis.
+
+label-for-must-resolve-to-one = Atribut `for` bak `<label>` harôh tunyok teupat u saboh komponen.
+
+label-for-unresolved = Atribut `for` bak `<label>` hana ék jitunyok u saboh komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` bak `<label>` jitunyok u `<answer>` nyang na input nyang geutuléh lé nyang tuléh; tunyok input nyan langsông.
+
+label-for-answer-without-input = Atribut `for` bak `<label>` jitunyok u `<answer>` nyang hana input keu geubri label.
+
+label-for-must-reference-input-or-answer = Atribut `for` bak `<label>` harôh tunyok u saboh input atawa saboh answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Keu aksesibilitas, `<{ $component }>` harôh na keterangan paneuk atawa geupeuteuntee sibagoë hiasan.
+
+accessibility-video-short-description = Keu aksesibilitas, `<video>` harôh na keterangan paneuk.
+
+accessibility-input-short-description-or-label = Keu aksesibilitas, `<{ $component }>` harôh na keterangan paneuk atawa label.
+
+accessibility-answer-input-short-description-or-label = Keu aksesibilitas, `<answer>` nyang peugöt input harôh na keterangan paneuk atawa label.
+
+accessibility-short-description-contains-math = Keterangan paneuk hana jeuet na komponen matematika lagée `<{ $component }>`. Tuléh matematika nyan ngon haba.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kontras { $colorName } kureueng keu teks ulèë bagian (mode seupôt) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; peureulèë paléng kureueng { $threshold }:1).
+       *[other] Kontras { $colorName } kureueng keu teks ulèë bagian ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; peureulèë paléng kureueng { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` nyang lheuëh bak { $count } titék gohlom teupeuguna meunyo titék nyan hana nilai angka.
+
+circle-too-many-through-points = Hana jeuet teukira bulat nyang lheuëh bak leubèh nibak 3 titék.
+
+circle-overprescribed-radius-center-points = Hana jeuet teukira bulat nyang geupeuteuntee jeujarôë, pusat ngon titék nyang jilheuëh.
+
+circle-center-with-multiple-points = Hana jeuet teukira bulat nyang geupeuteuntee pusat jih teuma jilheuëh bak leubèh nibak 1 titék.
+
+circle-radius-too-small = Hana jeuet teukira bulat: sabab jarak dua titék nyan { $distance }, jeujarôë { $radius } nyang geupeuteuntee ubit that.
+
+circle-radius-with-many-points = Hana jeuet teupeugöt bulat nyang lheuëh bak leubèh nibak dua titék ngon jeujarôë nyang geupeuteuntee.
+
+circle-invalid-center-or-through-points = Pusat atawa titék nyang jilheuëh lé bulat hana sah.
+
+circle-radius-center-with-multiple-points = Hana jeuet teukira jeujarôë bulat nyang geupeuteuntee pusat jih teuma jilheuëh bak leubèh nibak 1 titék.
+
+circle-change-radius-non-numerical = Hana jeuet teuubah jeujarôë bulat nyang lheuëh bak titék nyang hana angka
+
+circle-radius-with-points-non-numerical = Hana jeuet teupeugöt bulat nyang lheuëh bak leubèh nibak saboh titék ngon jeujarôë nyang geupeuteuntee meunyo hana nilai angka.
+
+circle-change-center-non-numerical = Peuubah pusat bulat nyang lheuëh bak titék nyang hana nilai angka gohlom teupeuguna.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Acehnese has one, because
+# «interval» and «input» do not change for number. Both selects are dropped and
+# both counts still arrive.
+function-domain-insufficient-dimensions = Dimensi domain keu fungsi kureueng. Domain na { $intervals } interval teuma fungsi na { $inputs } input.
+
+function-domain-invalid-format = Format domain keu fungsi hana sah.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Hana geuhiro nilai paléng rayeuk fungsi nyang hana angka.
+        [minimum] Hana geuhiro nilai paléng ubit fungsi nyang hana angka.
+        [extremum] Hana geuhiro ekstremum fungsi nyang hana angka.
+        [point] Hana geuhiro titék fungsi nyang hana angka.
+        [slope] Hana geuhiro kemiringan fungsi nyang hana angka.
+       *[other] Hana geuhiro { $type } fungsi nyang hana angka.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Hana geuhiro nilai paléng rayeuk fungsi nyang soh.
+        [minimum] Hana geuhiro nilai paléng ubit fungsi nyang soh.
+        [extremum] Hana geuhiro ekstremum fungsi nyang soh.
+        [point] Hana geuhiro titék fungsi nyang soh.
+       *[other] Hana geuhiro { $type } fungsi nyang soh.
+    }
+
+function-points-too-close = Fungsi na dua titék nyang teumpat jih rap that. Fungsi hana ék teubataih.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Iterasi fungsi jeuet mantong meunyo jumlah input saban ngon jumlah output. Fungsi nyoe na { $inputs } input ngon { $outputs } output.
+
+## `<sequence>`
+
+sequence-invalid-length = Panyang sequence hana sah.  Harôh bileuëng buleuët nyang hana negatif.
+
+sequence-invalid-step = step sequence hana sah.  Harôh angka keu sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" sequence angka hana sah.  Harôh angka.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" sequence huruf hana sah.  Harôh kombinasi huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" sequence hana sah.
+
+select-from-sequence-coprime-not-numbers = hana geuhiro coprime sabab nyang geupileh kon angka
+
+select-from-sequence-coprime-with-exclude-combinations = hana geuhiro coprime sabab excludeCombinations geupeuteuntee
+
+## Resolving a `target`
+
+target-not-found = target hana sah keu `<{ $source }>`: target hana meuteumeung.
+
+target-state-variable-not-found = target hana sah keu `<{ $source }>`: variabel keuadaan nyang meunan "{ $property }" hana meuteumeung bak `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel `<odeSystem>` harôh laén nibak variabel beubaih.
+
+ode-system-duplicate-variable-names = Hana jeuet teubataih fungsi RHS ODE nyang nan variabel meugantông jih saban.
+
+ode-system-rhs-function-error = Hana jeuet teubataih fungsi RHS ODE.  Na salah watèe peugöt fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Hana jeuet teubataih sudut lam antara { $count } garéh
+
+angle-invalid-through-point = Titék nyang hana sah bak through `<angle>`
+
+parabola-vertex-too-many-points = Parabola nyang na puncak teuma jilheuëh bak leubèh nibak 1 titék gohlom teupeuguna.
+
+parabola-too-many-points = Parabola nyang lheuëh bak leubèh nibak 3 titék gohlom teupeuguna.
+
+intersection-too-many-items = Peurpotongan keu leubèh nibak dua boh barang gohlom teupeuguna
+
+## Other math components
+
+ionic-compound-not-two-ions = Sanyawa ionik keu nyang laén nibak dua ion gohlom teupeuguna.
+
+ionic-compound-needs-cation-and-anion = Sanyawa ionik teupeuguna mantong keu saboh kation ngon saboh anion.
+
+solve-equations-cannot-evaluate = Hana jeuet teupeuseulesai persamaan sabab persamaan hana ék teunilai: { $equation }
+
+math-operators-operand-number-required = operandNumber harôh geupeuteuntee meunyo neucok operand matematika.
+
+eigen-decomposition-failed = Hana jeuet teukira eigenvalue matriks
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } hana teuka bak pattern, ngon lagée nyan jih sabé meucoco ngon nyang soh.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: hana meupham grid="{ $grid }". Harôh none, medium, dense, atawa dua angka positif nyang meupisah ngon spasi, lagée grid="1 0.5". Hana grid nyang teulukéh.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" hana teudukong bak renderer prefigure; geuguna sifat posisi uneun.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" hana teudukong bak renderer prefigure; geuguna sifat posisi ateuh.
+
+prefigure-invalid-axis-bounds = `<graph>`: bataih sumbu hana sah keu konversi prefigure; geuguna bbox baku (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: luaih hana sah keu konversi prefigure; geuguna luaih diagram baku 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio hana sah keu konversi prefigure; geuguna aspect ratio baku 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jarak grid rap that keu bataih sumbu; grid hana teulukéh bak renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotation hana teulukéh meunyo hana geuguna renderer PreFigure.
+
+multiple-annotations-children = Le aneuk `<annotations>` meuteumeung bak `<graph>`; banmandum hana geuhiro seulaén nyang paléng akhé.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Hana jeuet teupeupanyang atawa teusalén jeuneh komponen nyang hana teuturi: { $type }.
+
+copy-prop-not-found = Prop { $property } hana meuteumeung bak komponen jeuneh { $component }
+
+collect-no-source = Hana meuteumeung source keu collect.
+
+collect-invalid-component-type = Hana jeuet teukumpôi komponen jeuneh `<{ $component }>` sabab jeuneh komponen hana sah.
+
+reference-index-unavailable = Hana jeuet teurujuk indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Hana jeuet teuhôi { $action } bak komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk data hana sah.  Panyang barih hana saban. Meuteumeung bak componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data na nan kolom nyang saban.  Meuteumeung bak componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data kureueng nan kolom.  Meuteumeung bak componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award jaweueb nyoe meudasar bak jaweueb nyang geukirém lé answer tag keudroë, ngon nyan teuka sifat nyang hana geuharap.
+
+answer-max-num-attempts-in-section-wide-check-work = Peuduek `maxNumAttempts` bak `<answer>` lam wadah nyang na `sectionWideCheckWork` hana meuguna, sabab wadah nyan nyang peuatô jumlah cuba. Peuduek `maxNumAttempts` bak wadah nyan.
+
+nested-section-wide-check-work-max-num-attempts = Peuduek `maxNumAttempts` bak wadah nyang na `sectionWideCheckWork` nyang na lam wadah laén nyang na `sectionWideCheckWork` hana meuguna, sabab wadah di luwa nyang peuatô jumlah cuba. Peuduek `maxNumAttempts` bak wadah di luwa.
+
+# No select: «atribut» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Atribut { $attributes } hana meuguna meunyo symbolicEquality hana geupeuduek.
+
+answer-invalid-type = Jeuneh jaweueb nyang hana sah: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sabab komponen `<{ $component }>` hana meunan, jih hana jeuet teuguna keu atribut module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` hana jeuet teuguna sibagoë atribut module sabab jeuneh komponen `<module>` ka na atribut "{ $name }".
+
+conditional-content-condition-ignored = Hana geuhiro atribut `condition` bak komponen `<conditionalContent>` nyang na aneuk case atawa else.
+
+slider-markers-type-mismatch = Jeuneh marker hana meucoco ngon jeuneh slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel hana sah: tiep `<problem>` harôh na saboh `<statement>` ngon saboh `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel hana sah: bak mode="circuit", `<problem>` phon hana jeuet distractor.
+
+## Attribute values
+
+# No select: «nilai» is the same word for one and for many.
+attribute-invalid-values = Nilai { $values } hana sah keu atribut `{ $attribute }`; hana geuhiro.
+
+attribute-must-be-references = Nilai `{ $value }` hana sah keu atribut `{ $attribute }`. Atribut harôh teususôn nibak rujukan nyang phon ngon `$`.
+
+math-input-invalid-function-names = <mathInput>: hana geuhiro nan fungsi nyang hana sah bak { $attribute }: { $names }. Tiep nan harôh na paléng kureueng 2 karakter (huruf atawa tanda sambông); jeuet meuseutôt sufiks `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Jeuneh komponen nyang hana sah: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } hana jeuet teuulang.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" hana sah keu komponen jeuneh `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kontras bataih gaya { $styleNumber } kureueng keu { $context ->
+        [text-on-background] warna teks lawan warna laté
+        [high-contrast] warna kontras manyang lawan kanvas
+        [line] warna garéh lawan kanvas
+        [marker] warna marker lawan kanvas
+       *[text-on-canvas] warna teks lawan kanvas
+    }{ $mode ->
+        [dark] { " (mode seupôt)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; peureulèë paléng kureueng { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Bahle bataih gaya { $styleNumber } na warna nyang geupeuteuntee ngon kontras nyang cukôp keu mode trang, kontras warna teks lawan warna laté kureueng bak warna nyang geucok keu mode seupôt ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; peureulèë paléng kureueng { $threshold }:1). { $suggestion ->
+        [available] Mangat kontras jih cukôp bak mode seupôt, tamah kontras mode trang (miseu, peuduek { $lightAttribute }="{ $lightColor }") atawa gantoë warna mode seupôt (miseu, peuduek { $darkAttribute }="{ $darkColor }").
+       *[none] Mangat kontras jih cukôp bak mode seupôt, tamah kontras mode trang atawa gantoë warna nyang geucok ngon textColorDarkMode dan/atawa backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Bahle bataih gaya { $styleNumber } na warna teks nyang geupeuteuntee ngon kontras nyang cukôp keu mode trang, kontras warna teks nyang geucok keu mode seupôt kureueng lawan kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; peureulèë paléng kureueng { $threshold }:1). { $suggestion ->
+        [available] Mangat kontras jih cukôp bak mode seupôt, tamah kontras mode trang (miseu, peuduek textColor="{ $lightColor }") atawa gantoë warna mode seupôt (miseu, peuduek textColorDarkMode="{ $darkColor }").
+       *[none] Mangat kontras jih cukôp bak mode seupôt, tamah kontras mode trang atawa gantoë warna nyang geucok ngon textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Saboh bagian jeuet jipileh saboh mantong <stylePalette>; geuguna nyang paléng akhé.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = hana jeuet teupeuteuntee varian tunggai { $component } sabab numToSelect kon bileuëng buleuët nyang hana negatif.
+
+variant-num-to-select-not-constant-number = hana jeuet teupeuteuntee varian tunggai { $component } sabab numToSelect kon angka teutap.
+
+variant-with-replacement-not-constant-boolean = hana jeuet teupeuteuntee varian tunggai { $component } sabab withReplacement kon boolean teutap.
+
+variant-select-weight-disables-unique = Varian tunggai keu select geupeumatee meunyo na opsi nyang geupeuteuntee selectWeight atawa selectForVariants
+
+variant-coprime-undetermined = hana jeuet teupeuteuntee varian tunggai { $component } sabab hana jeuet teupeuteuntee coprime sabé false.
+
+variant-attribute-not-constant = hana jeuet teupeuteuntee varian tunggai { $component } sabab { $attribute } hana teutap.
+
+variant-attribute-not-number = hana jeuet teupeuteuntee varian tunggai { $component } sabab { $attribute } kon angka.
+
+variant-attribute-wrong-type-for-sequence =
+    hana jeuet teupeuteuntee varian tunggai { $component } jeuneh { $type } sabab { $attribute } kon { $expected ->
+        [letters-combination] kombinasi huruf
+        [math-expression] ungkapan matematika nyang sah
+        [integer] bileuëng buleuët
+       *[number] angka
+    }.
+
+variant-length-not-integer = hana jeuet teupeuteuntee varian tunggai { $component } sabab length kon bileuëng buleuët.
+
+variant-sort-not-implemented = varian tunggai { $component } nyang na sort gohlom teupeuguna
+
+variant-exclude-combinations-not-implemented = varian tunggai { $component } nyang na excludeCombinations gohlom teupeuguna
+
+variant-math-exclude-not-implemented = varian tunggai { $component } jeuneh math nyang na exclude gohlom teupeuguna
+
+variant-non-constant-exclude-not-implemented = varian tunggai { $component } nyang na exclude hana teutap gohlom teupeuguna
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: hana teudukong bak renderer prefigure graph; keuturunan teulangkah.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometri jih hana teubataih atawa hana leungkap; keuturunan teulangkah.
+
+prefigure-curve-label-omitted = { $subject }: label hana teudukong bak elemen lengkông nyang geukonversi; label hana geuhiro.
+
+prefigure-curve-unsupported-definition-type = { $subject }: jeuneh bataih fungsi lengkông '{ $definitionType }' hana teudukong; keuturunan teulangkah.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions bak regionBetweenCurves hana teudukong; keuturunan teulangkah.
+
+prefigure-region-non-formula-child = { $subject }: aneuk fungsi jeuneh formula mantong nyang teudukong bak regionBetweenCurves; keuturunan teulangkah.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' hana teudukong keu { $labelKind ->
+        [line-family] label keuluarga garéh
+       *[point] label titék
+    }; geuguna perataan baku PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: gaya asoë '{ $fillStyle }' hana teudukong lé PreFigure; woë u asoë nyang padat.
+
+prefigure-line-style-unknown = { $subject }: gaya garéh '{ $lineStyle }' hana teuturi, hana geuhiro bak output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya marker '{ $markerStyle }' geupeuduek u gaya 'diamond' PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: gaya marker '{ $markerStyle }' hana teudukong lé PreFigure; geuguna gaya baku.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` hana sah; target hana ék teutunyok. Annotation hana geuhiro.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` jitunyok u le target; geuguna target phon.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` hana sah; target na di luwa graph nyang na jih. Annotation hana geuhiro.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` hana sah; target kon objek grafis nyang teudukong bak konversi prefigure. Annotation hana geuhiro.
+
+annotation-text-missing = `<annotation>`: `text` kureueng atawa soh; geupeuteubiet teks soh.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Meuteumeung keugantôngan nyang meulingka.
+       *[other] Meuteumeung keugantôngan nyang meulingka nyang meulibat komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Hana meuteumeung nyang geutunyok lé rujukan: `{ $reference }`
+
+reference-multiple-referents = Le nyang geutunyok lé rujukan: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } bak `<{ $componentType }>` hana sah.
+
+children-invalid = Aneuk `<{ $componentType }>` hana sah: meuteumeung aneuk nyang hana sah: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` hana sah keu atribut `{ $attribute }`, geuguna nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } hana meuteumeung.
+       *[other] Versi DoenetML { $version } hana meuteumeung. Woë u versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML hana sah: { $content }
+
+parse-tag-missing-close-tag = DoenetML hana sah: Tag `{ $tag }` hana na tag peunutôb. Geuharap tag nyang jitôb droë atawa tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML hana sah: Na salah bak tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML hana sah: Atribut `{ $attribute }` nyang hana sah lagée kureueng nilai.
+
+parse-attribute-invalid = DoenetML hana sah: Atribut `{ $attribute }` hana sah
+
+parse-attribute-value-invalid = DoenetML hana sah: Nilai atribut `{ $value }` hana sah
+
+parse-attribute-value-quote-mismatch = DoenetML hana sah: Nilai atribut `{ $value }` hana sah. Tanda kutip hana meucoco. Lagée kureueng saboh `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML hana sah: Meuteumeung tag nyang hana meunan, miseu `<`
+
+parse-tag-not-closed = DoenetML hana sah: Tag `{ $tag }` hana teutôb (lagée kureueng `>`).
+
+parse-self-closing-tag-name-missing = DoenetML hana sah: Meuteumeung tag nyang hana meunan `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML hana sah: Tag `{ $tag }` hana teutôb (lagée kureueng `/>`).
+
+parse-tag-invalid-attributes = DoenetML hana sah: Tag `{ $tag }` hana sah. Mungken atribut jih hana beutôi.
+
+parse-close-tag-name-missing = DoenetML hana sah: Meuteumeung tag peunutôb nyang hana meunan, miseu `</`
+
+parse-attribute-value-unquoted = Nilai atribut harôh geupeuduek lam tanda kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML hana sah: Meuteumeung tag peunutôb `{ $tag }`, teuma hana tag peuhah nyang meucoco
+
+parse-close-tag-mismatched = DoenetML hana sah: Tag peunutôb hana meucoco. Geuharap `</{ $expected }>`. Meuteumeung `{ $found }`
+
+parser-node-unconvertible = Node { $node } hana ék teukonversi jeuet node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribut name='{ $name }' hana sah. { $reason ->
+        [characters] Nan jeuet na huruf, angka, garéh yup atawa tanda sambông mantong.
+       *[start] Nan harôh phon ngon huruf.
+    }
+
+component-name-invalid-start = Nan komponen "{ $name }" hana sah. Nan harôh phon ngon huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer nyang type videoWatched harôh na atribut video
+
+answer-video-watched-video-not-reference = Answer nyang type videoWatched harôh na atribut video nyang meurupa rujukan
+
+answer-name-not-single-text = Atribut name bak answer harôh na saboh aneuk text mantong
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Hana jeuet teucok DoenetML di luwa sabab tingkat meuulang jih le that. Na kheueh rujukan nyang meulingka?
+
+external-doenetml-unavailable = Hana jeuet teucok DoenetML nibak { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML nyang geucok nibak { $attribute }="{ $uri }" hana sah: jih hana meucoco ngon jeuneh komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` hana teuguna lé; guna `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` bak `<{ $component }>` hana teuguna lé; guna `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` hana teuguna lé ngon hana geuhiro sabab `{ $to }` pih geupeuteuntee.
+       *[other] [deprecation] Atribut `{ $from }` bak `<{ $component }>` hana teuguna lé ngon hana geuhiro sabab `{ $to }` pih geupeuteuntee.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` bak `<{ $component }>` hana teuguna lé ngon hana geuhiro.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` bak `<{ $component }>` hana teuguna lé; guna aneuk `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` bak atribut `{ $attribute }` bak `<{ $component }>` hana teuguna lé; guna `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` jeuet jipeule bahsa Inggréh mantong, ngon lagée nyan teks jih hana meuubah lam dokumen nyang geutuléh ngon { $locale }. Tuléh langsông bentuk le jih, atawa peuduek ngon atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` kon elemen Doenet nyang teuturi.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` hana teuidin bak ukhuë dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` hana teuidin lam `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` hana na atribut nyang meunan `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` bak elemen `<{ $tag }>` harôh meurupa dapeuta nyang tiep asoë jih saboh nibak: { $allowed }
+       *[other] Atribut `{ $attribute }` bak elemen `<{ $tag }>` harôh saboh nibak: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nan varian hana sah keu select.  Nan varian { $variantName } teuka bak { $numOptions } opsi teuma jumlah nyang keuneuk teupileh { $numToSelect }.
+
+select-variant-name-without-options = Na varian nyang geupeuteuntee keu select teuma hana opsi nyang geupeuteuntee keu nan varian nyang mungken: { $variantName }.
+
+select-variant-name-not-possible = Nan varian { $variantName } nyang geupeuteuntee keu select kon nan varian nyang mungken.
+
+select-too-few-options = Hana jeuet teupileh { $numToSelect } komponen nibak { $numOptions } mantong.
+
+select-from-sequence-too-few-values = Hana jeuet teupileh { $numToSelect } nilai nibak sequence nyang panyang jih { $length }.
+
+select-from-sequence-indices-count-mismatch = Jumlah indeks nyang geupeuteuntee keu select harôh meucoco ngon jumlah nyang keuneuk teupileh
+
+select-from-sequence-indices-not-integers = Banmandum indeks nyang geupeuteuntee keu select harôh bileuëng buleuët
+
+select-from-sequence-index-excluded = Indeks selectfromsequence nyang geupeuteuntee nyan geupeuteubiet
+
+select-from-sequence-indices-excluded-combination = Indeks selectfromsequence nyang geupeuteuntee nyan kombinasi nyang geupeuteubiet
+
+select-from-sequence-coprime-not-positive-integers = Hana jeuet teupileh kombinasi coprime sabab nyang geupileh kon bileuëng buleuët positif.
+
+select-from-sequence-coprime-common-factor = Hana jeuet teupileh angka coprime. Banmandum nilai nyang mungken na faktor nyang saban. (Nilai "from" atawa "to" nyang geupeuteuntee harôh coprime ngon "step".)
+
+select-from-sequence-coprime-single-number = Hana jeuet teupileh kombinasi coprime nibak saboh angka nyang kon 1.
+
+select-from-sequence-excluded-too-many-combinations = Leubèh nibak 70% kombinasi geupeuteubiet bak selectFromSequence
+
+select-from-sequence-coprime-none-found = Hana ék teupileh angka coprime. Banmandum nilai nyang mungken na faktor nyang saban.
+
+select-from-sequence-too-few-unique-values = Hana jeuet teupileh { $numToSelect } nilai tunggai nibak sequence nyang panyang jih { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Hana jeuet teupileh { $numToSelect } nilai nibak dapeuta prima nyang panyang jih { $numValues }
+
+select-prime-numbers-values-count-mismatch = Jumlah nilai nyang geupeuteuntee keu select harôh meucoco ngon jumlah nyang keuneuk teupileh
+
+select-prime-numbers-values-not-prime = Banmandum nilai nyang geupeuteuntee keu select prime number harôh na lam dapeuta prima
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers nyang geupeuteuntee nyan kombinasi nyang geupeuteubiet
+
+select-prime-numbers-excluded-too-many-combinations = Leubèh nibak 70% kombinasi geupeuteubiet bak selectPrimeNumbers
+
+select-random-combination-fluke = Sabab untông nyang jarang that, hana ék teupileh kombinasi nilai acak
+
+select-random-value-fluke = Sabab untông nyang jarang that, hana ék teupileh nilai acak

--- a/packages/i18n/locales/ace/editor.ftl
+++ b/packages/i18n/locales/ace/editor.ftl
@@ -1,0 +1,208 @@
+# Acehnese editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Acehnese marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Peuwoë
+       *[update] Peubaro
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } peuleumah
+       *[other] { $word } peuleumah { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+editor-variant-filter = Saring…
+editor-variant-next = Pileh varian seulanjut
+editor-variant-previous = Pileh varian sigohlom
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Na peulanggaran aksesibilitas WCAG AA nyang meuteumeung. Klik keu jeuet { $action ->
+            [close] tôb
+           *[open] buka
+        } laporan aksesibilitas.
+        [advisories] Klik keu jeuet { $action ->
+            [close] tôb
+           *[open] buka
+        } laporan aksesibilitas. Hana peulanggaran WCAG AA nyang meuteumeung, teuma na saran aksesibilitas laén.
+       *[clean] Klik keu jeuet { $action ->
+            [close] tôb
+           *[open] buka
+        } laporan aksesibilitas. Hana masalah aksesibilitas nyang meuteumeung.
+    }
+
+# No select on `$count` inside the branches: «peulanggaran» and «saran» are the
+# same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Na peulanggaran aksesibilitas WCAG AA nyang meuteumeung. Meuteumeung { $count } peulanggaran WCAG AA. Klik keu jeuet { $action ->
+            [close] tôb
+           *[open] buka
+        } laporan aksesibilitas.
+        [advisories] Hana peulanggaran WCAG AA nyang meuteumeung. Meuteumeung { $count } saran aksesibilitas laén. Klik keu jeuet { $action ->
+            [close] tôb
+           *[open] buka
+        } laporan aksesibilitas.
+       *[clean] Hana peulanggaran WCAG AA nyang meuteumeung. Klik keu jeuet { $action ->
+            [close] tôb
+           *[open] buka
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Versi DoenetML { $version }
+
+editor-tab-help = Bantuan meunurot konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Salah
+editor-tab-warnings = Peuingat
+editor-tab-info = Keterangan
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Jaweueb nyang ka geukirém
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan editor
+editor-format-as-doenetml = Format sibagoë DoenetML
+editor-format-as-xml = Format sibagoë XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Barih #{ $line }
+
+editor-no-errors = Hana salah
+editor-no-warnings = Hana peuingat
+editor-no-info = Hana diagnostik keterangan
+
+editor-show-info-annotations = Peuleumah diagnostik keterangan bak editor
+editor-show-accessibility-annotations = Peuleumah diagnostik aksesibilitas bak editor
+
+editor-accessibility-learn-more = Beulajeue cara Doenet jak peuseumana aksesibilitas
+
+editor-accessibility-violations-heading = Peulanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masalah aksesibilitas laén
+editor-none-found = Hana nyang meuteumeung
+
+
+## Submitted responses
+
+editor-no-responses = Gohlom na jaweueb nyang geukirém
+editor-response-answer-id = Id jaweueb
+editor-response-response = Jaweueb
+editor-response-credit = Kredit
+editor-response-submitted = Geukirém
+
+
+## The context-help panel
+
+help-placeholder = Peuduek kursor bak nan tag, atribut, atawa { $ref } keu dokumentasi.
+
+help-unsupported-ref-chain = Bantuan keu rujukan meubagoë bagian lagée { $example } gohlom teudukong.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Hana meuteumeung nyang geutunyok lé rujukan: { $ref }.
+        [multiple] Le nyang geutunyok lé rujukan: { $ref }.
+       *[indeterminate] Hana ék teupeuteuntee peue nyang geutunyok lé { $ref }.
+    }
+
+help-learn-about-references = Beulajeue keuhai rujukan →
+help-reference-page = Laman rujukan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Lam { $element }
+       *[top] Bak tingkat paléng ateuh
+    }{ $allowed ->
+        [none] { " — hana nyang jeuet teupeuduek disinoe." }
+        [text] { " — tuléh teks disinoe." }
+        [text-and-components] { " — tuléh teks disinoe, atawa cuba:" }
+       *[components] { " — nyang jeuet teucuba:" }
+    }
+
+help-suggestions-footer = Teugon { $shortcut } keu jeuet takalon banmandum { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } na rujukan u { $target }.
+       *[other] { $ref } na rujukan u { $target } (barih { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Geuba lé { $owner } sibagoë { $role }.
+       *[other] Geuba lé { $owner } bak barih { $line } sibagoë { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } na rujukan u sifat { $property } nibak { $element }.
+       *[other] { $ref } na rujukan u sifat { $property } nibak { $element } (barih { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = ceubeuëh kode
+help-kind-array-entry = entri array
+
+help-default = Baku:
+help-active-default = Baku nyang aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai nyang teuidin (saboh keu tiep item):
+       *[other] Nilai nyang teuidin:
+    }
+
+help-suggested-values = Nilai nyang geusaran:
+
+help-inserts = Geuseulop:
+
+# No select: «koordinat» is the same word for one and for many.
+help-coordinates = Koordinat:
+
+help-type = Jeuneh:
+
+help-resolved-style = Gaya nyang ka teupeuteuntee (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nan fungsi nyang ka teupeuteuntee:
+help-reset-list = Dapeuta peuwoë bak input nyoe:
+help-added-on-input = Teutamah bak input nyoe:
+help-removed-on-input = Teupeugadôh bak input nyoe:
+
+help-reset-overrides = { $reset } jipeugantoë { $additional } ngon { $removed }.

--- a/packages/i18n/locales/ban/chrome.ftl
+++ b/packages/i18n/locales/ban/chrome.ftl
@@ -1,0 +1,153 @@
+# Balinese viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the **Latin** orthography Balinese schooling and publishing use, so
+# a reader arriving under `ban-Bali` — the Balinese script — reaches this and
+# gets Latin. That is the asymmetry `pa`, `sr`, `jv` and `su` already have, and
+# the answer to it is a second catalog beside this one rather than a rename of
+# it.
+#
+# **Speech level.** Balinese chooses a register for every sentence, and a file
+# with two registers in it is wrong in both. This catalog is written throughout
+# in **basa andap**, the unmarked everyday level, which is what Balinese writing
+# addressed to a general reader uses and what the alus levels would be derived
+# from. That is the decision `locales/jv` and `locales/su` already record for
+# ngoko and loma. A deployment that wants basa alus supplies its own catalog as
+# `localeResources`; correcting this file sentence by sentence toward it is what
+# would leave the locale in two registers at once.
+#
+# Balinese marks no number on the noun — a count in front of it does that work —
+# so a `{ $count -> … }` whose two English branches differ only in the noun
+# renders one string here and the select is dropped. A `[0]` branch stays
+# wherever English has one.
+
+
+## Answer submission
+
+answer-checking = Ngecek…
+answer-submitting = Ngirim…
+
+answer-checking-status = Ngecek pasaut
+answer-submitting-status = Ngirim pasaut
+
+answer-correct = Beneh
+answer-incorrect = Pelih
+
+answer-response-saved = Pasautne suba kasimpen
+
+answer-percent-credit = { $percent }% kredit
+answer-percent-correct = { $percent }% beneh
+answer-percent-short = { $percent } %
+
+max-credit-available = Kredit paling gede ane bakat: { $percent }%
+
+# No select: «kesempatan» is the same word for one and for many. The `[0]`
+# branch stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] tusing ada kesempatan ane enu
+       *[other] enu { $count } kesempatan
+    }
+
+validation-correct = (Beneh)
+validation-incorrect = (Pelih)
+validation-partially-correct = (Beneh abagian)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Edengang { $count } pasaut anggon { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentar
+
+collapsible-click-to-open = (klik apang mabukak)
+collapsible-click-to-close = (klik apang matutup)
+
+collapsible-initializing = Ngawitin…
+
+footnote-show = Edengang footnote
+footnote-hide = Engkebang footnote
+
+description-more-information = informasi ane lenan
+
+
+## Controls
+
+slider-previous = Sadurunge
+slider-next = Salanturne
+
+keyboard-open = Ampakang papan tuts
+keyboard-close = Tekepang papan tuts
+
+choice-input-remove-choice = Kaadang { $choice }
+
+matrix-remove-row = Kaadang barisne
+matrix-add-row = Imbuhin baris
+matrix-remove-column = Kaadang kolomne
+matrix-add-column = Imbuhin kolom
+
+subset-add-remove-points = Ngimbuhin/Ngaadang titik
+subset-toggle-points-intervals = Nyilurin titik lan interval
+subset-move-points = Genahang titikne
+subset-clear = Kedasin
+
+orbital-add-row = Imbuhin baris
+orbital-remove-row = Kaadang barisne
+orbital-add-box = Imbuhin kotak
+orbital-remove-box = Kaadang kotakne
+orbital-add-up-arrow = Imbuhin panah menek
+orbital-add-down-arrow = Imbuhin panah tuun
+orbital-remove-arrow = Kaadang panahne
+
+orbital-row-label = Label anggon baris { $row }
+
+pretzel-answer = Pasaut
+
+summary-statistics-caption = Ringkesan statistik { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ekspresi matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ekspresi ane tusing sah:
+
+
+## Document status
+
+viewer-initializing = Ngawitin…
+
+
+## Errors
+
+error-heading = Kaiwangan
+
+error-found-at =
+    { $span ->
+        [line] Katemu di baris { $startLine }.
+       *[lines] Katemu di baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumen ene ngelah kaiwangan!
+
+diagnostic-heading-error = Kaiwangan
+diagnostic-heading-warning = Pinget
+diagnostic-heading-information = Informasi
+diagnostic-heading-hint = Tunjuk
+
+accessibility-heading-level-1 = Pelanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Pinget indik aksesibilitas
+
+something-went-wrong = Ada ane pelih.
+
+renderer-load-failed = ada renderer ane tusing nyidang kaload. Ledang muat ulang kacane.
+
+core-start-failed = Panyingakan dokumene tusing nyidang kawitin. Ledang muat ulang kacane.

--- a/packages/i18n/locales/ban/content.ftl
+++ b/packages/i18n/locales/ban/content.ftl
@@ -13,9 +13,10 @@
 #
 # The adjectives **follow** the noun — «garis barak», a red line — so every
 # composition message inverts the English order. That is the first thing this
-# batch does not share: the five Philippine catalogs beside it all put their
-# adjectives in front, and the three Malayic ones and the Polynesian ones put
-# them behind. Sharing a region settles nothing here.
+# batch does not share: the five Philippine catalogs beside it and `locales/tpi`
+# put their adjectives in front, and the eight others — the rest of Indonesia,
+# Tetum and the Pacific — put them behind. Sharing a region settles nothing here,
+# and neither does sharing a family.
 #
 # There is no linker: a Balinese adjective sits directly behind its noun with
 # nothing between them, so none of the constraint `locales/ilo`, `locales/pam`

--- a/packages/i18n/locales/ban/content.ftl
+++ b/packages/i18n/locales/ban/content.ftl
@@ -1,0 +1,259 @@
+# Balinese content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography and throughout in **basa andap**, the
+# unmarked everyday speech level; see `chrome.ftl`'s header for why a catalog
+# must pick one level and stay in it.
+#
+# Balinese has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «garis barak», a red line — so every
+# composition message inverts the English order. That is the first thing this
+# batch does not share: the five Philippine catalogs beside it all put their
+# adjectives in front, and the three Malayic ones and the Polynesian ones put
+# them behind. Sharing a region settles nothing here.
+#
+# There is no linker: a Balinese adjective sits directly behind its noun with
+# nothing between them, so none of the constraint `locales/ilo`, `locales/pam`
+# and `locales/bik` record applies to this file at all.
+#
+# The geometry vocabulary is largely the Indonesian one, because Balinese
+# schools teach mathematics out of Indonesian-language textbooks; the colours,
+# the widths and the everyday words are Balinese.
+
+
+## Style vocabulary
+
+color =
+    .black = selem
+    .white = putih
+    .gray = abu-abu
+    .red = barak
+    .orange = oranye
+    .yellow = kuning
+    .green = gadang
+    .cyan = sian
+    .blue = pelung
+    .purple = ungu
+    .pink = jambon
+    .brown = cokelat
+
+line-width =
+    .thick = tebel
+    .thin = tipis
+
+line-style =
+    .dashed = putus-putus
+    .dotted = titik-titik
+
+# Noun phrases. Balinese marks no plural on the noun, so «garis» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = garis mendatar
+    .vertical = garis majujuk
+    .diagonal = garis miring
+    .backdiagonal = garis miring mabalik
+    .dots = titik
+    .diamonds = belah ketupat
+
+noun =
+    .line = garis
+    .line-segment = ruas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = lengkung
+    .function = fungsi
+    .parabola = parabola
+    .polyline = garis patah
+    .polygon = poligon
+    .triangle = segitiga
+    .rectangle = persegi panjang
+    .circle = bunderan
+    .region = wewidangan
+    .point = titik
+    .square = pesagi
+    .diamond = belah ketupat
+    .cross = pangkah
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe — the `[noun-tail]` branch of `style-with-noun`.
+noun-regular-polygon =
+    { $part ->
+        [tail] ane ngelah { $numSides } sisi
+       *[head] poligon beraturan
+    }
+
+# One answer for every noun: Balinese has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = bek
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } misi { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } misi { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } misi { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Balinese has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «misi» against «tur».
+style-border-clause =
+    { $parts ->
+        [with-article] misi tepi { $border }
+        [and] tur tepi { $border }
+        [and-article] tur tepi { $border }
+       *[with] misi tepi { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = tusing bek
+
+style-text =
+    { $parts ->
+        [background] { $color } misi dasar { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = tusing ada
+
+
+## Boolean words
+
+boolean-true = patut
+boolean-false = iwang
+
+
+## Answer buttons
+
+answer-submit-label = Cek gaene
+answer-submit-label-no-correctness = Kirim pasaut
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Balinese marks no plural on the noun.
+section-name =
+    .activity = Kegiatan
+    .aside = Catetan sisi
+    .cascade = Kaskade
+    .definition = Definisi
+    .example = Conto
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Pasaut
+    .note = Catetan
+    .objectives = Tetujon
+    .paragraphs = Paragraf
+    .part = Bagian
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukti
+    .question = Patakon
+    .section = Bab
+    .solution = Pamragat
+    .task = Tugas
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Tunjuk
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Gambar { $enumeration }
+        [numbered-caption] Gambar { $enumeration }{ ": " }
+        [unnumbered-caption] Gambar{ ": " }
+       *[unnumbered] Gambar
+    }
+
+
+## Paginator controls
+
+paginator-previous = Sadurunge
+paginator-next = Salanturne
+paginator-page = Kaca
+
+paginator-page-status = { $pageLabel } { $currentPage } uli { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = utawi
+piecewise-condition-if = yen
+piecewise-condition-otherwise = yen tusing
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Balinese schools teach chemistry out of Indonesian-language
+## textbooks, so the periodic table a Balinese pupil meets is `locales/id`'s —
+## the case `locales/jv` and `locales/su` are in, with the difference that those
+## two supply the Indonesian names and this one does not, because Balinese has
+## no settled table of its own to seed from and copying Indonesian's whole would
+## report a fact about a textbook rather than about the language. The everyday
+## substances Balinese does name itself are the place a speaker should start.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simbol kimia ane tusing sah
+chemistry-invalid-ionic-compound = Senyawa ionik ane tusing sah

--- a/packages/i18n/locales/ban/diagnostics.ftl
+++ b/packages/i18n/locales/ban/diagnostics.ftl
@@ -1,0 +1,627 @@
+# Balinese diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Written throughout in basa andap, the unmarked everyday speech level; see
+# `chrome.ftl`'s header.
+#
+# Balinese marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+
+
+## `<lineSegment>`
+
+# No select: «kalempasin» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = { $attributes } kalempasin yen dadua tanggune suba katentuang
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } kalempasin yen tanggu lan tengah-tengahne suba katentuang makadadua
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset tusing madaya yen tusing ada tengah-tengah
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis ane liwat titik ane dimensine tusing pasti.
+
+line-points-too-few-dimensions = Garise patut liwat titik ane madimensi paling bedik dadua.
+
+line-points-depend-on-variables = Garise liwat titik ane gumantung ring variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis ane tusing sah ring variabel { $variable1 } lan { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinare katentuang baan through, endpoint lan direction.  through ane katentuang kalempasin.
+
+ray-dimension-mismatch = numDimensions tusing cocok di sinar.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektore katentuang baan head, tail lan displacement.  head ane katentuang kalempasin.
+
+vector-dimension-mismatch = numDimensions tusing cocok di vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Tusing nyidang narik ka `<{ $component }>` krana ia tusing ngelah variabel kahanan nearestPoint.
+
+constrain-to-without-nearest-point = Tusing nyidang ngiket ka `<{ $component }>` krana ia tusing ngelah variabel kahanan nearestPoint.
+
+constrain-to-interior-without-nearest-point = Tusing nyidang ngiket ka tengah `<{ $component }>` krana ia tusing ngelah variabel kahanan nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition kalempasin di choiceInput ane tusing inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indeks ane katentuang anggon choiceInput kalempasin krana liun indekse tusing cocok teken liun pianak pilihane.
+
+pretzel-indices-count-mismatch = Indeks ane katentuang anggon problem kalempasin krana liun indekse tusing cocok teken liun pianak problem.
+
+shuffle-indices-count-mismatch = Indeks ane katentuang anggon shuffle kalempasin krana liun indekse tusing cocok teken liun komponene.
+
+indices-ignored-out-of-range = Indeks ane katentuang anggon { $component } kalempasin krana ada indeks ane liwat jangkauan.
+
+pretzel-indices-repeated = Indeks ane katentuang anggon pretzel kalempasin krana ada indeks ane mabalik.
+
+pretzel-circuit-first-index = Indeks ane katentuang anggon pretzel di mode circuit kalempasin krana indeks ane paling malu patut 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Apang `<{ $component }>` majalan ajak pianak string, atribut `type` patut katentuang.
+
+invalid-type-defaulting-to-math = type { $type } tusing sah anggon komponen { $component }. Patut abesik uli math, text, number, utawi boolean. Nganggon math.
+
+string-not-valid-component-to-arrange = String "{ $value }" tusing dadi komponen ane sah anggon { $component }. Kalempasin.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } tusing sah, typene kasetel dadi number.
+
+invalid-variable-value = Nilai variabel ane tusing sah: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } patut angka
+
+variant-index-must-be-integer = Indeks varian { $index } patut bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` enu tusing kaimplementasi anggon ukuran absolut. Lebarne kasetel dadi relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` enu tusing kaimplementasi anggon ukuran absolut. Margine kasetel dadi relatif.
+
+side-by-side-no-block-child = `<{ $component }>` tusing sah: ia patut ngelah paling bedik abesik pianak block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` di `<label>` grafis kalempasin.
+
+label-for-must-resolve-to-one = Atribut `for` di `<label>` patut nuju pas abesik komponen.
+
+label-for-unresolved = Atribut `for` di `<label>` tusing nyidang nuju komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` di `<label>` nuju `<answer>` ane ngelah input ane katulis baan pangawine; tujuang inputne langsung.
+
+label-for-answer-without-input = Atribut `for` di `<label>` nuju `<answer>` ane tusing ngelah input anggon kalabelin.
+
+label-for-must-reference-input-or-answer = Atribut `for` di `<label>` patut nuju input utawi answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Anggon aksesibilitas, `<{ $component }>` patut ngelah deskripsi bawak utawi katentuang dadi dekoratif.
+
+accessibility-video-short-description = Anggon aksesibilitas, `<video>` patut ngelah deskripsi bawak.
+
+accessibility-input-short-description-or-label = Anggon aksesibilitas, `<{ $component }>` patut ngelah deskripsi bawak utawi label.
+
+accessibility-answer-input-short-description-or-label = Anggon aksesibilitas, `<answer>` ane ngae input patut ngelah deskripsi bawak utawi label.
+
+accessibility-short-description-contains-math = Deskripsi bawak tusing patut misi komponen matematika buka `<{ $component }>`. Tulisang matematikane aji kruna.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kontras { $colorName } kuang anggon teks judul bab (mode peteng) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; merluang paling bedik { $threshold }:1).
+       *[other] Kontras { $colorName } kuang anggon teks judul bab ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; merluang paling bedik { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` ane liwat { $count } titik enu tusing kaimplementasi yen titike tusing ngelah nilai numerik.
+
+circle-too-many-through-points = Tusing nyidang ngitung bunderan ane liwat lebih teken 3 titik.
+
+circle-overprescribed-radius-center-points = Tusing nyidang ngitung bunderan ane katentuang jejeg, tengah lan titik ane kaliwatin.
+
+circle-center-with-multiple-points = Tusing nyidang ngitung bunderan ane katentuang tengahne tur liwat lebih teken 1 titik.
+
+circle-radius-too-small = Tusing nyidang ngitung bunderan: krana jarak titike dadua { $distance }, jejeg { $radius } ane katentuang cenik gati.
+
+circle-radius-with-many-points = Tusing nyidang ngae bunderan ane liwat lebih teken dadua titik ajak jejeg ane katentuang.
+
+circle-invalid-center-or-through-points = Tengah utawi titik ane kaliwatin baan bunderane tusing sah.
+
+circle-radius-center-with-multiple-points = Tusing nyidang ngitung jejeg bunderan ane katentuang tengahne tur liwat lebih teken 1 titik.
+
+circle-change-radius-non-numerical = Tusing nyidang ngubah jejeg bunderan ane liwat titik ane tusing numerik
+
+circle-radius-with-points-non-numerical = Tusing nyidang ngae bunderan ane liwat lebih teken abesik titik ajak jejeg ane katentuang yen tusing ada nilai numerik.
+
+circle-change-center-non-numerical = Ngubah tengah bunderan ane liwat titik ane tusing ngelah nilai numerik enu tusing kaimplementasi.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Balinese has one, because
+# «interval» and «input» do not change for number. Both selects are dropped and
+# both counts still arrive.
+function-domain-insufficient-dimensions = Dimensi domain anggon fungsine kuang. Domaine ngelah { $intervals } interval nanging fungsine ngelah { $inputs } input.
+
+function-domain-invalid-format = Format domain anggon fungsine tusing sah.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Maksimum fungsine ane tusing numerik kalempasin.
+        [minimum] Minimum fungsine ane tusing numerik kalempasin.
+        [extremum] Ekstremum fungsine ane tusing numerik kalempasin.
+        [point] Titik fungsine ane tusing numerik kalempasin.
+        [slope] Kemiringan fungsine ane tusing numerik kalempasin.
+       *[other] { $type } fungsine ane tusing numerik kalempasin.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Maksimum fungsine ane puyung kalempasin.
+        [minimum] Minimum fungsine ane puyung kalempasin.
+        [extremum] Ekstremum fungsine ane puyung kalempasin.
+        [point] Titik fungsine ane puyung kalempasin.
+       *[other] { $type } fungsine ane puyung kalempasin.
+    }
+
+function-points-too-close = Fungsine misi dadua titik ane paek gati genahne. Tusing nyidang ngartiang fungsine.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Iterasi fungsi tuah nyidang yen liun inputne patuh teken liun outputne. Fungsi ene ngelah { $inputs } input lan { $outputs } output.
+
+## `<sequence>`
+
+sequence-invalid-length = Panjang sequence tusing sah.  Patut bilangan bulat ane tusing negatif.
+
+sequence-invalid-step = step sequence tusing sah.  Patut angka anggon sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" sequence angka tusing sah.  Patut angka.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" sequence huruf tusing sah.  Patut kombinasi huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" sequence tusing sah.
+
+select-from-sequence-coprime-not-numbers = coprime kalempasin krana ane kapilih tusing angka
+
+select-from-sequence-coprime-with-exclude-combinations = coprime kalempasin krana excludeCombinations katentuang
+
+## Resolving a `target`
+
+target-not-found = target tusing sah anggon `<{ $source }>`: targete tusing katemu.
+
+target-state-variable-not-found = target tusing sah anggon `<{ $source }>`: variabel kahanan ane maadan "{ $property }" tusing katemu di `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel `<odeSystem>` patut malenan teken variabel bebasne.
+
+ode-system-duplicate-variable-names = Tusing nyidang ngartiang fungsi RHS ODE ane adan variabel gumantungne patuh.
+
+ode-system-rhs-function-error = Tusing nyidang ngartiang fungsi RHS ODE.  Ada kaiwangan ngae fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Tusing nyidang ngartiang sudut di pantaran { $count } garis
+
+angle-invalid-through-point = Titik ane tusing sah di through `<angle>`
+
+parabola-vertex-too-many-points = Parabola ane ngelah puncak tur liwat lebih teken 1 titik enu tusing kaimplementasi.
+
+parabola-too-many-points = Parabola ane liwat lebih teken 3 titik enu tusing kaimplementasi.
+
+intersection-too-many-items = Perpotongan anggon lebih teken dadua barang enu tusing kaimplementasi
+
+## Other math components
+
+ionic-compound-not-two-ions = Senyawa ionik anggon ane lenan teken dadua ion enu tusing kaimplementasi.
+
+ionic-compound-needs-cation-and-anion = Senyawa ionik kaimplementasi tuah anggon abesik kation lan abesik anion.
+
+solve-equations-cannot-evaluate = Tusing nyidang ngamragatang persamaane krana persamaane tusing nyidang kaevaluasi: { $equation }
+
+math-operators-operand-number-required = operandNumber patut katentuang yen nyemak operand matematika.
+
+eigen-decomposition-failed = Tusing nyidang ngitung eigenvalue matriks
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } tusing pesu di pattern, kanti ia setata cocok teken ane puyung.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: tusing ngerti grid="{ $grid }". Patut none, medium, dense, utawi dadua angka positif ane kapisahang aji spasi, buka grid="1 0.5". Tusing ada grid ane kagambar.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" tusing kasokong di renderer prefigure; nganggon kabiasaan posisi tengawan.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" tusing kasokong di renderer prefigure; nganggon kabiasaan posisi duur.
+
+prefigure-invalid-axis-bounds = `<graph>`: batas sumbune tusing sah anggon konversi prefigure; nganggon bbox baku (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lebarne tusing sah anggon konversi prefigure; nganggon lebar diagram baku 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio tusing sah anggon konversi prefigure; nganggon aspect ratio baku 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jarak gride alus gati anggon batas sumbune; gride tusing kagambar di renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotation tusing kagambar yen tusing nganggon renderer PreFigure.
+
+multiple-annotations-children = Ada liu pianak `<annotations>` di `<graph>`; makejang kalempasin sajaba ane paling durine.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Tusing nyidang ngamekelin utawi nyalin jenis komponen ane tusing kakenal: { $type }.
+
+copy-prop-not-found = Prop { $property } tusing katemu di komponen jenis { $component }
+
+collect-no-source = Tusing ada source ane katemu anggon collect.
+
+collect-invalid-component-type = Tusing nyidang munduhang komponen jenis `<{ $component }>` krana jenis komponene tusing sah.
+
+reference-index-unavailable = Tusing nyidang nuju indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Tusing nyidang ngaukin { $action } di komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk datane tusing sah.  Panjang barisne tusing patuh. Katemu di componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Datane ngelah adan kolom ane patuh.  Katemu di componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Datane kuangan adan kolom.  Katemu di componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award pasaut ene madasar teken pasaut ane kakirim baan answer tag padidi, tur ento lakar ngranayang paundukan ane tusing kaaptiang.
+
+answer-max-num-attempts-in-section-wide-check-work = Nyetel `maxNumAttempts` di `<answer>` ane ada di tengah wadah ane ngelah `sectionWideCheckWork` tusing madaya, krana wadahe ane ngatur liun kesempatane. Setel `maxNumAttempts` di wadahe.
+
+nested-section-wide-check-work-max-num-attempts = Nyetel `maxNumAttempts` di wadah ane ngelah `sectionWideCheckWork` tur ada di tengah wadah lenan ane ngelah `sectionWideCheckWork` tusing madaya, krana wadah ane di sisi ane ngatur liun kesempatane. Setel `maxNumAttempts` di wadah ane di sisi.
+
+# No select: «atribut» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Atribut { $attributes } tusing lakar madaya yen symbolicEquality tusing kasetel.
+
+answer-invalid-type = Jenis pasaut ane tusing sah: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Krana komponen `<{ $component }>` tusing ngelah adan, ia tusing nyidang kaanggon dadi atribut module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` tusing nyidang kaanggon dadi atribut module krana jenis komponen `<module>` suba ngelah atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` kalempasin di komponen `<conditionalContent>` ane ngelah pianak case utawi else.
+
+slider-markers-type-mismatch = Jenis markere tusing cocok teken jenis slidere.
+
+pretzel-problem-needs-statement-and-answer = Pretzel tusing sah: asing-asing `<problem>` patut misi abesik `<statement>` lan abesik `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel tusing sah: di mode="circuit", `<problem>` ane paling malu tusing dadi distractor.
+
+## Attribute values
+
+# No select: «nilai» is the same word for one and for many.
+attribute-invalid-values = Nilai { $values } tusing sah anggon atribut `{ $attribute }`; kalempasin.
+
+attribute-must-be-references = Nilai `{ $value }` tusing sah anggon atribut `{ $attribute }`. Atribute patut kasusun aji referensi ane ngawitin aji `$`.
+
+math-input-invalid-function-names = <mathInput>: adan fungsi ane tusing sah di { $attribute } kalempasin: { $names }. Asing-asing adan patut ngelah paling bedik 2 karakter (huruf utawi garis pisah); dadi kasusul baan sufiks `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Jenis komponen ane tusing sah: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } tusing dadi kabalikang.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" tusing sah anggon komponen jenis `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kontras definisi gaya { $styleNumber } kuang anggon { $context ->
+        [text-on-background] warna teks nglawan warna dasar
+        [high-contrast] warna kontras tegeh nglawan kanvas
+        [line] warna garis nglawan kanvas
+        [marker] warna marker nglawan kanvas
+       *[text-on-canvas] warna teks nglawan kanvas
+    }{ $mode ->
+        [dark] { " (mode peteng)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; merluang paling bedik { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Yadiastun definisi gaya { $styleNumber } ngelah warna ane katentuang tur kontrasne cukup anggon mode galang, kontras warna teks nglawan warna dasar kuang di warna ane kaambil anggon mode peteng ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; merluang paling bedik { $threshold }:1). { $suggestion ->
+        [available] Apang kontrasne cukup di mode peteng, imbuhin kontras mode galange (conto, setel { $lightAttribute }="{ $lightColor }") utawi silurin warna mode petenge (conto, setel { $darkAttribute }="{ $darkColor }").
+       *[none] Apang kontrasne cukup di mode peteng, imbuhin kontras mode galange utawi silurin warna ane kaambil aji textColorDarkMode lan/utawi backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Yadiastun definisi gaya { $styleNumber } ngelah warna teks ane katentuang tur kontrasne cukup anggon mode galang, kontras warna teks ane kaambil anggon mode peteng kuang nglawan kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; merluang paling bedik { $threshold }:1). { $suggestion ->
+        [available] Apang kontrasne cukup di mode peteng, imbuhin kontras mode galange (conto, setel textColor="{ $lightColor }") utawi silurin warna mode petenge (conto, setel textColorDarkMode="{ $darkColor }").
+       *[none] Apang kontrasne cukup di mode peteng, imbuhin kontras mode galange utawi silurin warna ane kaambil aji textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Abesik dogen <stylePalette> ane dadi kapilih baan abesik bab; nganggon ane paling durine.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = tusing nyidang mastiang varian tunggal { $component } krana numToSelect tusing bilangan bulat ane tusing negatif.
+
+variant-num-to-select-not-constant-number = tusing nyidang mastiang varian tunggal { $component } krana numToSelect tusing angka konstan.
+
+variant-with-replacement-not-constant-boolean = tusing nyidang mastiang varian tunggal { $component } krana withReplacement tusing boolean konstan.
+
+variant-select-weight-disables-unique = Varian tunggal anggon select kamatiang yen ada opsi ane katentuang selectWeight utawi selectForVariants
+
+variant-coprime-undetermined = tusing nyidang mastiang varian tunggal { $component } krana tusing nyidang mastiang coprime setata false.
+
+variant-attribute-not-constant = tusing nyidang mastiang varian tunggal { $component } krana { $attribute } tusing konstan.
+
+variant-attribute-not-number = tusing nyidang mastiang varian tunggal { $component } krana { $attribute } tusing angka.
+
+variant-attribute-wrong-type-for-sequence =
+    tusing nyidang mastiang varian tunggal { $component } jenis { $type } krana { $attribute } tusing { $expected ->
+        [letters-combination] kombinasi huruf
+        [math-expression] ekspresi matematika ane sah
+        [integer] bilangan bulat
+       *[number] angka
+    }.
+
+variant-length-not-integer = tusing nyidang mastiang varian tunggal { $component } krana length tusing bilangan bulat.
+
+variant-sort-not-implemented = varian tunggal { $component } ane ngelah sort enu tusing kaimplementasi
+
+variant-exclude-combinations-not-implemented = varian tunggal { $component } ane ngelah excludeCombinations enu tusing kaimplementasi
+
+variant-math-exclude-not-implemented = varian tunggal { $component } jenis math ane ngelah exclude enu tusing kaimplementasi
+
+variant-non-constant-exclude-not-implemented = varian tunggal { $component } ane ngelah exclude tusing konstan enu tusing kaimplementasi
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: tusing kasokong di renderer prefigure graph; katurunane kalangkungin.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometrine tusing wates utawi tusing lengkap; katurunane kalangkungin.
+
+prefigure-curve-label-omitted = { $subject }: label tusing kasokong di elemen lengkung ane kakonversi; labele kalempasin.
+
+prefigure-curve-unsupported-definition-type = { $subject }: jenis definisi fungsi lengkung '{ $definitionType }' tusing kasokong; katurunane kalangkungin.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions di regionBetweenCurves tusing kasokong; katurunane kalangkungin.
+
+prefigure-region-non-formula-child = { $subject }: tuah pianak fungsi jenis formula ane kasokong di regionBetweenCurves; katurunane kalangkungin.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' tusing kasokong anggon { $labelKind ->
+        [line-family] label kulawarga garis
+       *[point] label titik
+    }; nganggon perataan baku PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isi '{ $fillStyle }' tusing kasokong baan PreFigure; mabalik ka isi ane pejel.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' tusing kakenal, kalempasin uli output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya marker '{ $markerStyle }' kagenahang ka gaya 'diamond' PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: gaya marker '{ $markerStyle }' tusing kasokong baan PreFigure; nganggon gaya baku.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` tusing sah; targete tusing nyidang katuju. Annotatione kalempasin.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` nuju liu target; nganggon targete ane paling malu.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` tusing sah; targete ada di sisin graph ane misi ia. Annotatione kalempasin.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` tusing sah; targete tusing objek grafis ane kasokong di konversi prefigure. Annotatione kalempasin.
+
+annotation-text-missing = `<annotation>`: `text` kuangan utawi puyung; ngepesuang teks puyung.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Katemu ketergantungan ane mubeng.
+       *[other] Katemu ketergantungan ane mubeng tur nglibatang komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Tusing ada ane katujuang baan referensine: `{ $reference }`
+
+reference-multiple-referents = Liu ane katujuang baan referensine: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } di `<{ $componentType }>` tusing sah.
+
+children-invalid = Pianak `<{ $componentType }>` tusing sah: katemu pianak ane tusing sah: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` tusing sah anggon atribut `{ $attribute }`, nganggon nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } tusing katemu.
+       *[other] Versi DoenetML { $version } tusing katemu. Mabalik ka versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML tusing sah: { $content }
+
+parse-tag-missing-close-tag = DoenetML tusing sah: Tag `{ $tag }` tusing ngelah tag penutup. Kaaptiang tag ane nutup padidi utawi tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML tusing sah: Ada kaiwangan di tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML tusing sah: Atribut `{ $attribute }` ane tusing sah buka kuangan nilai.
+
+parse-attribute-invalid = DoenetML tusing sah: Atribut `{ $attribute }` tusing sah
+
+parse-attribute-value-invalid = DoenetML tusing sah: Nilai atribut `{ $value }` tusing sah
+
+parse-attribute-value-quote-mismatch = DoenetML tusing sah: Nilai atribut `{ $value }` tusing sah. Tanda kutipne tusing cocok. Buka kuangan abesik `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML tusing sah: Katemu tag ane tusing ngelah adan, conto `<`
+
+parse-tag-not-closed = DoenetML tusing sah: Tag `{ $tag }` tusing katutup (buka kuangan `>`).
+
+parse-self-closing-tag-name-missing = DoenetML tusing sah: Katemu tag ane tusing ngelah adan `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML tusing sah: Tag `{ $tag }` tusing katutup (buka kuangan `/>`).
+
+parse-tag-invalid-attributes = DoenetML tusing sah: Tag `{ $tag }` tusing sah. Mirib atributne tusing beneh.
+
+parse-close-tag-name-missing = DoenetML tusing sah: Katemu tag penutup ane tusing ngelah adan, conto `</`
+
+parse-attribute-value-unquoted = Nilai atribut patut kagenahang di tengah tanda kutip: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML tusing sah: Katemu tag penutup `{ $tag }`, nanging tusing ada tag pembuka ane cocok
+
+parse-close-tag-mismatched = DoenetML tusing sah: Tag penutupne tusing cocok. Kaaptiang `</{ $expected }>`. Katemu `{ $found }`
+
+parser-node-unconvertible = Node { $node } tusing nyidang kakonversi dadi node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribut name='{ $name }' tusing sah. { $reason ->
+        [characters] Adan tuah dadi misi huruf, angka, garis bawah utawi garis pisah.
+       *[start] Adan patut ngawitin aji huruf.
+    }
+
+component-name-invalid-start = Adan komponen "{ $name }" tusing sah. Adan patut ngawitin aji huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer ane type videoWatched patut ngelah atribut video
+
+answer-video-watched-video-not-reference = Answer ane type videoWatched patut ngelah atribut video ane dadi referensi
+
+answer-name-not-single-text = Atribut name di answer patut ngelah abesik pianak text dogen
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Tusing nyidang ngambil DoenetML uli sisi krana tingkat pengulangane liu gati. Ada referensi ane mubeng?
+
+external-doenetml-unavailable = Tusing nyidang ngambil DoenetML uli { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ane kaambil uli { $attribute }="{ $uri }" tusing sah: ia tusing cocok teken jenis komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` tusing kaanggon buin; anggon `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` di `<{ $component }>` tusing kaanggon buin; anggon `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` tusing kaanggon buin tur kalempasin krana `{ $to }` masih katentuang.
+       *[other] [deprecation] Atribut `{ $from }` di `<{ $component }>` tusing kaanggon buin tur kalempasin krana `{ $to }` masih katentuang.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` di `<{ $component }>` tusing kaanggon buin tur kalempasin.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` di `<{ $component }>` tusing kaanggon buin; anggon pianak `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` di atribut `{ $attribute }` di `<{ $component }>` tusing kaanggon buin; anggon `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` tuah nyidang ngajamakang basa Inggris, kanti teksne tusing kaubah di dokumen ane katulis aji { $locale }. Tulisang langsung bentuk jamakne, utawi setel aji atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` tusing dadi elemen Doenet ane kakenal.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` tusing kalugra di akah dokumene.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` tusing kalugra di tengah `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` tusing ngelah atribut ane maadan `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` di elemen `<{ $tag }>` patut dadi daftar ane asing-asing isine abesik uli: { $allowed }
+       *[other] Atribut `{ $attribute }` di elemen `<{ $tag }>` patut abesik uli: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Adan varian tusing sah anggon select.  Adan varian { $variantName } pesu di { $numOptions } opsi nanging liun ane lakar kapilih { $numToSelect }.
+
+select-variant-name-without-options = Ada varian ane katentuang anggon select nanging tusing ada opsi ane katentuang anggon adan varian ane dadi: { $variantName }.
+
+select-variant-name-not-possible = Adan varian { $variantName } ane katentuang anggon select tusing dadi adan varian.
+
+select-too-few-options = Tusing nyidang milih { $numToSelect } komponen uli { $numOptions } dogen.
+
+select-from-sequence-too-few-values = Tusing nyidang milih { $numToSelect } nilai uli sequence ane panjangne { $length }.
+
+select-from-sequence-indices-count-mismatch = Liun indeks ane katentuang anggon select patut cocok teken liun ane lakar kapilih
+
+select-from-sequence-indices-not-integers = Makejang indeks ane katentuang anggon select patut bilangan bulat
+
+select-from-sequence-index-excluded = Indeks selectfromsequence ane katentuang ento kaejohang
+
+select-from-sequence-indices-excluded-combination = Indeks selectfromsequence ane katentuang ento kombinasi ane kaejohang
+
+select-from-sequence-coprime-not-positive-integers = Tusing nyidang milih kombinasi coprime krana ane kapilih tusing bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = Tusing nyidang milih angka coprime. Makejang nilai ane dadi ngelah faktor ane patuh. (Nilai "from" utawi "to" ane katentuang patut coprime teken "step".)
+
+select-from-sequence-coprime-single-number = Tusing nyidang milih kombinasi coprime uli abesik angka ane tusing 1.
+
+select-from-sequence-excluded-too-many-combinations = Lebih teken 70% kombinasine kaejohang di selectFromSequence
+
+select-from-sequence-coprime-none-found = Tusing nyidang milih angka coprime. Makejang nilai ane dadi ngelah faktor ane patuh.
+
+select-from-sequence-too-few-unique-values = Tusing nyidang milih { $numToSelect } nilai tunggal uli sequence ane panjangne { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Tusing nyidang milih { $numToSelect } nilai uli daftar prima ane panjangne { $numValues }
+
+select-prime-numbers-values-count-mismatch = Liun nilai ane katentuang anggon select patut cocok teken liun ane lakar kapilih
+
+select-prime-numbers-values-not-prime = Makejang nilai ane katentuang anggon select prime number patut ada di daftar prima
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers ane katentuang ento kombinasi ane kaejohang
+
+select-prime-numbers-excluded-too-many-combinations = Lebih teken 70% kombinasine kaejohang di selectPrimeNumbers
+
+select-random-combination-fluke = Krana nasib ane langah gati, tusing nyidang milih kombinasi nilai acak
+
+select-random-value-fluke = Krana nasib ane langah gati, tusing nyidang milih nilai acak

--- a/packages/i18n/locales/ban/editor.ftl
+++ b/packages/i18n/locales/ban/editor.ftl
@@ -1,0 +1,207 @@
+# Balinese editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Written throughout in basa andap, the unmarked everyday speech level; see
+# `chrome.ftl`'s header.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Balikang
+       *[update] Anyarang
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } panyingakane
+       *[other] { $word } panyingakane { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+editor-variant-filter = Saring…
+editor-variant-next = Pilih varian salanturne
+editor-variant-previous = Pilih varian sadurunge
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Ada pelanggaran aksesibilitas WCAG AA ane katemu. Klik apang { $action ->
+            [close] matutup
+           *[open] mabukak
+        } laporan aksesibilitasne.
+        [advisories] Klik apang { $action ->
+            [close] matutup
+           *[open] mabukak
+        } laporan aksesibilitasne. Tusing ada pelanggaran WCAG AA ane katemu, nanging enu ada saran aksesibilitas ane lenan.
+       *[clean] Klik apang { $action ->
+            [close] matutup
+           *[open] mabukak
+        } laporan aksesibilitasne. Tusing ada masalah aksesibilitas ane katemu.
+    }
+
+# No select on `$count` inside the branches: «pelanggaran» and «saran» are the
+# same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Ada pelanggaran aksesibilitas WCAG AA ane katemu. Katemu { $count } pelanggaran WCAG AA. Klik apang { $action ->
+            [close] matutup
+           *[open] mabukak
+        } laporan aksesibilitasne.
+        [advisories] Tusing ada pelanggaran WCAG AA ane katemu. Katemu { $count } saran aksesibilitas ane lenan. Klik apang { $action ->
+            [close] matutup
+           *[open] mabukak
+        } laporan aksesibilitasne.
+       *[clean] Tusing ada pelanggaran WCAG AA ane katemu. Klik apang { $action ->
+            [close] matutup
+           *[open] mabukak
+        } laporan aksesibilitasne.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Versi DoenetML { $version }
+
+editor-tab-help = Tulung manut konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Kaiwangan
+editor-tab-warnings = Pinget
+editor-tab-info = Informasi
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Pasaut ane suba kakirim
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pilihan editor
+editor-format-as-doenetml = Format dadi DoenetML
+editor-format-as-xml = Format dadi XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Tusing ada kaiwangan
+editor-no-warnings = Tusing ada pinget
+editor-no-info = Tusing ada diagnostik informasi
+
+editor-show-info-annotations = Edengang diagnostik informasi di editor
+editor-show-accessibility-annotations = Edengang diagnostik aksesibilitas di editor
+
+editor-accessibility-learn-more = Plajahin kenken Doenet ngurus aksesibilitas
+
+editor-accessibility-violations-heading = Pelanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masalah aksesibilitas ane lenan
+editor-none-found = Tusing ada ane katemu
+
+
+## Submitted responses
+
+editor-no-responses = Enu tusing ada pasaut ane kakirim
+editor-response-answer-id = Id pasaut
+editor-response-response = Pasaut
+editor-response-credit = Kredit
+editor-response-submitted = Kakirim
+
+
+## The context-help panel
+
+help-placeholder = Genahang kursore di adan tag, atribut, utawi { $ref } anggon dokumentasi.
+
+help-unsupported-ref-chain = Tulung anggon referensi mabagian liu buka { $example } enu tusing kasokong.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Tusing ada ane katujuang baan referensine: { $ref }.
+        [multiple] Liu ane katujuang baan referensine: { $ref }.
+       *[indeterminate] Tusing nyidang kapastiang apa ane katujuang baan { $ref }.
+    }
+
+help-learn-about-references = Plajahin indik referensi →
+help-reference-page = Kaca referensi →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Di tengah { $element }
+       *[top] Di tingkat paling duur
+    }{ $allowed ->
+        [none] { " — tusing ada ane dadi kagenahang dini." }
+        [text] { " — tulisang teks dini." }
+        [text-and-components] { " — tulisang teks dini, utawi cobain:" }
+       *[components] { " — ane dadi cobain:" }
+    }
+
+help-suggestions-footer = Pencet { $shortcut } apang nyingakin makejang { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ento referensi ka { $target }.
+       *[other] { $ref } ento referensi ka { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Kabakta baan { $owner } dadi { $role }.
+       *[other] Kabakta baan { $owner } di baris { $line } dadi { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ento referensi ka properti { $property } uli { $element }.
+       *[other] { $ref } ento referensi ka properti { $property } uli { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = potongan kode
+help-kind-array-entry = entri array
+
+help-default = Baku:
+help-active-default = Baku ane aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai ane dadi (abesik asing-asing):
+       *[other] Nilai ane dadi:
+    }
+
+help-suggested-values = Nilai ane kasaranang:
+
+help-inserts = Nyelipang:
+
+# No select: «koordinat» is the same word for one and for many.
+help-coordinates = Koordinat:
+
+help-type = Jenis:
+
+help-resolved-style = Gaya ane suba kapastiang (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Adan fungsi ane suba kapastiang:
+help-reset-list = Daftar reset di input ene:
+help-added-on-input = Kaimbuhin di input ene:
+help-removed-on-input = Kakaadang di input ene:
+
+help-reset-overrides = { $reset } ngalahang { $additional } lan { $removed }.

--- a/packages/i18n/locales/bik/chrome.ftl
+++ b/packages/i18n/locales/bik/chrome.ftl
@@ -21,8 +21,8 @@
 # dropped; the count still arrives and is still formatted. A `[0]` branch stays
 # wherever English has one.
 #
-# The linker «na»/«-ng» is written as the free «na» throughout; see
-# `content.ftl` for what that gets right and what it does not.
+# The linker «na»/«-ng» is written as the free «na» wherever it lands beside a
+# placeable; see `content.ftl` for what that gets right and what it does not.
 
 
 ## Answer submission

--- a/packages/i18n/locales/bik/chrome.ftl
+++ b/packages/i18n/locales/bik/chrome.ftl
@@ -1,0 +1,150 @@
+# Bikol viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `bik` is an ISO 639-3 **macrolanguage** covering the Bikol languages of the
+# Bicol peninsula, and this catalog is written in **Central Bikol** (Naga), the
+# variety Bikol publishing, broadcasting and the Department of Education's
+# mother-tongue materials use. A reader arriving under one of the other members
+# — `bcl`, `bto`, `cts`, `bln` and the rest — reaches it through
+# `MACROLANGUAGE_MEMBERS` in `negotiate.ts`, which is the same service
+# `locales/qu` and `locales/gn` already get.
+#
+# Bikol marks no number on the noun: plurality is carried by «mga» and a noun
+# after a numeral stays as it is. So a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped; the count still arrives and is still formatted. A `[0]` branch stays
+# wherever English has one.
+#
+# The linker «na»/«-ng» is written as the free «na» throughout; see
+# `content.ftl` for what that gets right and what it does not.
+
+
+## Answer submission
+
+answer-checking = Sinisiyasat…
+answer-submitting = Ipinapadara…
+
+answer-checking-status = Sinisiyasat an simbag
+answer-submitting-status = Ipinapadara an simbag
+
+answer-correct = Tama
+answer-incorrect = Bakong tama
+
+answer-response-saved = Natago an simbag
+
+answer-percent-credit = { $percent }% na kredito
+answer-percent-correct = { $percent }% na tama
+answer-percent-short = { $percent } %
+
+max-credit-available = Pinakahalangkaw na kreditong makukua: { $percent }%
+
+# No select: «purbar» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] mayo nang natadang purbar
+       *[other] { $count } na purbar an natada
+    }
+
+validation-correct = (Tama)
+validation-incorrect = (Bakong tama)
+validation-partially-correct = (Tama sa kabtang)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Ipahiling an { $count } na simbag para sa { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komento
+
+collapsible-click-to-open = (i-klik tanganing mabuksan)
+collapsible-click-to-close = (i-klik tanganing masarahan)
+
+collapsible-initializing = Nagpopoon…
+
+footnote-show = Ipahiling an footnote
+footnote-hide = Itago an footnote
+
+description-more-information = dagdag na impormasyon
+
+
+## Controls
+
+slider-previous = Nakaagi
+slider-next = Sunod
+
+keyboard-open = Buksan an teklado
+keyboard-close = Sarahan an teklado
+
+choice-input-remove-choice = Halion an { $choice }
+
+matrix-remove-row = Halion an linya
+matrix-add-row = Dagdagan nin linya
+matrix-remove-column = Halion an kolum
+matrix-add-column = Dagdagan nin kolum
+
+subset-add-remove-points = Pagdagdag/Paghali nin mga punto
+subset-toggle-points-intervals = Pagsalyo nin mga punto asin interbalo
+subset-move-points = Ibalyo an mga punto
+subset-clear = Linigan
+
+orbital-add-row = Dagdagan nin linya
+orbital-remove-row = Halion an linya
+orbital-add-box = Dagdagan nin kahon
+orbital-remove-box = Halion an kahon
+orbital-add-up-arrow = Dagdagan nin panang pasiring sa itaas
+orbital-add-down-arrow = Dagdagan nin panang pasiring sa ibaba
+orbital-remove-arrow = Halion an pana
+
+orbital-row-label = Etiketa para sa linya { $row }
+
+pretzel-answer = Simbag
+
+summary-statistics-caption = Buod na estadistika kan { $column }
+
+
+## Math input
+
+math-input-preview-region = enot na pagheling sa ekspresyon na matematika
+math-input-preview = Enot na pagheling
+math-input-invalid-expression = Bakong balidong ekspresyon:
+
+
+## Document status
+
+viewer-initializing = Nagpopoon…
+
+
+## Errors
+
+error-heading = Sala
+
+error-found-at =
+    { $span ->
+        [line] Nakua sa linya { $startLine }.
+       *[lines] Nakua sa mga linya { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Igwang sala ining dokumento!
+
+diagnostic-heading-error = Sala
+diagnostic-heading-warning = Patanid
+diagnostic-heading-information = Impormasyon
+diagnostic-heading-hint = Giya
+
+accessibility-heading-level-1 = Paglapas sa aksesibilidad na WCAG AA
+accessibility-heading-level-2 = Patanid manongod sa aksesibilidad
+
+something-went-wrong = Igwang nagkasala.
+
+renderer-load-failed = igwang renderer na dai na-load. Pakiulit i-load an pahina.
+
+core-start-failed = Dai nagpoon an pagheling kan dokumento. Pakiulit i-load an pahina.

--- a/packages/i18n/locales/bik/content.ftl
+++ b/packages/i18n/locales/bik/content.ftl
@@ -15,8 +15,10 @@
 # a consonant-final word and with the enclitic «-ng» welded onto a vowel-final
 # one, and which applies is decided by the word *before* the linker — which at
 # most of the sites below is a placeable. There is no form that is right in both
-# places, so every linker here is written «na»: correct after «itom», wanted as
-# «-ng» after «pula». That is the same constraint `locales/pam` records, and the
+# places, so every linker that lands beside a placeable is written «na»:
+# correct after «itom», wanted as «-ng» after «pula». Where the catalog writes
+# both words around the linker it writes whichever form the preceding one
+# takes, as «balidong simbolong kemikal» does. That is the same constraint `locales/pam` records, and the
 # mirror image of `locales/ilo`'s, whose «a»/«nga» is decided by the word that
 # follows instead. `locales/war` and `locales/hil` escape it, because Bisayan
 # «nga» is grammatical in both positions.

--- a/packages/i18n/locales/bik/content.ftl
+++ b/packages/i18n/locales/bik/content.ftl
@@ -1,0 +1,256 @@
+# Bikol content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in **Central Bikol** (Naga), the variety Bikol publishing and
+# schooling use. `bik` is a macrolanguage; see `chrome.ftl`'s header and
+# `MACROLANGUAGE_MEMBERS` in `negotiate.ts`.
+#
+# Bikol has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# **The linker.** Bikol joins an adjective to what it describes with «na» after
+# a consonant-final word and with the enclitic «-ng» welded onto a vowel-final
+# one, and which applies is decided by the word *before* the linker — which at
+# most of the sites below is a placeable. There is no form that is right in both
+# places, so every linker here is written «na»: correct after «itom», wanted as
+# «-ng» after «pula». That is the same constraint `locales/pam` records, and the
+# mirror image of `locales/ilo`'s, whose «a»/«nga» is decided by the word that
+# follows instead. `locales/war` and `locales/hil` escape it, because Bisayan
+# «nga» is grammatical in both positions.
+#
+# The adjectives **precede** the noun, which is English's order and Bikol's
+# ordinary one.
+#
+# The geometry vocabulary is largely Spanish-derived, as Philippine mathematics
+# teaching carries it; the colours and everyday words are Bikol's own.
+
+
+## Style vocabulary
+
+color =
+    .black = itom
+    .white = puti
+    .gray = abuhon
+    .red = pula
+    .orange = kahel
+    .yellow = dulaw
+    .green = berde
+    .cyan = sian
+    .blue = asul
+    .purple = lila
+    .pink = rosas
+    .brown = kape
+
+line-width =
+    .thick = makapal
+    .thin = manipis
+
+line-style =
+    .dashed = putol-putol
+    .dotted = tuldok-tuldok
+
+# Noun phrases. Bikol marks no plural on the noun, so «linya» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = nakahigda na linya
+    .vertical = nakatindog na linya
+    .diagonal = pahilig na linya
+    .backdiagonal = baliktad na pahilig na linya
+    .dots = tuldok
+    .diamonds = diyamante
+
+noun =
+    .line = linya
+    .line-segment = segmento
+    .ray = sinag
+    .vector = bektor
+    .curve = kurba
+    .function = punsyon
+    .parabola = parabola
+    .polyline = polilinya
+    .polygon = poligono
+    .triangle = triyanggulo
+    .rectangle = rektanggulo
+    .circle = sirkulo
+    .region = rehiyon
+    .point = punto
+    .square = kwadrado
+    .diamond = diyamante
+    .cross = krus
+    .plus = plus
+
+noun-regular-polygon =
+    { $part ->
+        [tail] na may { $numSides } na gilid
+       *[head] regular na poligono
+    }
+
+# One answer for every noun: Bikol has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+# Every linker is written «na» — see the header for the case it gets wrong.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } na { $lineStyle } na { $color }
+        [width-color] { $width } na { $color }
+        [style-color] { $lineStyle } na { $color }
+        [width-style] { $width } na { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } na { $noun } { $nounTail }
+       *[noun] { $description } na { $noun }
+    }
+
+style-filled-word = pano
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } na { $color } na may { $pattern }
+       *[plain] { $filled } na { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } na { $color } na { $noun } na may { $pattern }
+        [plain-tail] { $filled } na { $color } na { $noun } { $nounTail }
+        [pattern-tail] { $filled } na { $color } na { $noun } { $nounTail } na may { $pattern }
+       *[plain] { $filled } na { $color } na { $noun }
+    }
+
+# Bikol has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «na may» against «asin».
+style-border-clause =
+    { $parts ->
+        [with-article] na may { $border } na gilid
+        [and] asin { $border } na gilid
+        [and-article] asin { $border } na gilid
+       *[with] na may { $border } na gilid
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } na { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = bakong pano
+
+style-text =
+    { $parts ->
+        [background] { $color } na may { $background } na background
+       *[plain] { $color }
+    }
+
+style-background-none = mayo
+
+
+## Boolean words
+
+boolean-true = totoo
+boolean-false = bakong totoo
+
+
+## Answer buttons
+
+answer-submit-label = Siyasaton an simbag
+answer-submit-label-no-correctness = Ipadara an simbag
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Bikol marks number on «mga» rather than on the noun, and a heading does
+# not carry it.
+section-name =
+    .activity = Aktibidad
+    .aside = Nota sa gilid
+    .cascade = Kaskada
+    .definition = Depinisyon
+    .example = Halimbawa
+    .exercise = Ehersisyo
+    .exercises = Ehersisyo
+    .given-answer = Simbag
+    .note = Nota
+    .objectives = Katuyuhan
+    .paragraphs = Parapo
+    .part = Kabtang
+    .problem = Problema
+    .problems = Problema
+    .proof = Patunay
+    .question = Hapot
+    .section = Seksyon
+    .solution = Solusyon
+    .task = Gibuhon
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Giya
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Talaan { $enumeration }
+        [numbered-title] Talaan { $enumeration }{ ": " }
+        [unnumbered-title] Talaan{ ": " }
+       *[unnumbered] Talaan
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Pigura { $enumeration }
+        [numbered-caption] Pigura { $enumeration }{ ": " }
+        [unnumbered-caption] Pigura{ ": " }
+       *[unnumbered] Pigura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Nakaagi
+paginator-next = Sunod
+paginator-page = Pahina
+
+paginator-page-status = { $pageLabel } { $currentPage } sa { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = o
+piecewise-condition-if = kun
+piecewise-condition-otherwise = kun bako
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Philippine secondary science is taught in English from the
+## intermediate grades, so the periodic table a Bikol pupil meets is the English
+## one — the same reason `locales/fil` and `locales/ceb` leave these keys out.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Bakong balidong simbolong kemikal
+chemistry-invalid-ionic-compound = Bakong balidong kompuwestong ioniko

--- a/packages/i18n/locales/bik/diagnostics.ftl
+++ b/packages/i18n/locales/bik/diagnostics.ftl
@@ -1,0 +1,628 @@
+# Bikol diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Bikol marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+#
+# A value quoted back from the author's source is reached through «an» or «sa»
+# rather than through a linker, so that no «na»/«-ng» choice depends on a word
+# this catalog has never seen. See `content.ftl`.
+
+
+## `<lineSegment>`
+
+# No select: «dai pinapansin» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = dai pinapansin an { $attributes } kun itinakda an duwang punta
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = dai pinapansin an { $attributes } kun itinakda an sarong punta asin an tanga
+
+line-segment-midpoint-offset-without-midpoint = mayong epekto an midpointOffset kun mayong tanga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linyang minaagi sa mga puntong dai natukdoan an dimensyon.
+
+line-points-too-few-dimensions = Kaipuhan na minaagi an linya sa mga puntong igwang dai kulang sa duwang dimensyon.
+
+line-points-depend-on-variables = An linya minaagi sa mga puntong nakadepende sa mga baryable: { $variables }.
+
+line-equation-invalid-format = Bakong balidong pormat kan ekwasyon kan linya sa mga baryable na { $variable1 } asin { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = An sinag itinakda paagi sa through, endpoint asin direction.  Dai pinapansin an itinakdang through.
+
+ray-dimension-mismatch = dai nagkakauyon an numDimensions sa sinag.
+
+## `<vector>`
+
+vector-overprescribed-head = An bektor itinakda paagi sa head, tail asin displacement.  Dai pinapansin an itinakdang head.
+
+vector-dimension-mismatch = dai nagkakauyon an numDimensions sa bektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Dai puwedeng mag-agyat sa `<{ $component }>` ta mayo iyan nin baryableng estado na nearestPoint.
+
+constrain-to-without-nearest-point = Dai puwedeng magpugol sa `<{ $component }>` ta mayo iyan nin baryableng estado na nearestPoint.
+
+constrain-to-interior-without-nearest-point = Dai puwedeng magpugol sa laog kan `<{ $component }>` ta mayo iyan nin baryableng estado na nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = dai pinapansin an labelPosition para sa choiceInput na bakong inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Dai pinapansin an mga indise na itinakda para sa choiceInput ta dai nagkakauyon an bilang kan mga indise asin an bilang kan mga akeng pipilian.
+
+pretzel-indices-count-mismatch = Dai pinapansin an mga indise na itinakda para sa problem ta dai nagkakauyon an bilang kan mga indise asin an bilang kan mga akeng problem.
+
+shuffle-indices-count-mismatch = Dai pinapansin an mga indise na itinakda para sa shuffle ta dai nagkakauyon an bilang kan mga indise asin an bilang kan mga komponente.
+
+indices-ignored-out-of-range = Dai pinapansin an mga indise na itinakda para sa { $component } ta igwang indise na labi sa sakop.
+
+pretzel-indices-repeated = Dai pinapansin an mga indise na itinakda para sa pretzel ta igwang indise na inulit.
+
+pretzel-circuit-first-index = Dai pinapansin an mga indise na itinakda para sa pretzel sa mode na circuit ta kaipuhan na 1 an enot na indise.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Tanganing maggana an `<{ $component }>` sa mga akeng string, kaipuhan na itakda an atributong `type`.
+
+invalid-type-defaulting-to-math = Bakong balidong type { $type } para sa komponenteng { $component }. Kaipuhan na saro sa math, text, number, o boolean. Ginagamit an math.
+
+string-not-valid-component-to-arrange = An string na "{ $value }" bakong balidong komponente para sa { $component }. Dai pinapansin.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Bakong balidong type { $type }, ibinubutang an type sa number.
+
+invalid-variable-value = Bakong balidong balor kan sarong baryable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Kaipuhan na numero an indise kan baryanteng { $index }
+
+variant-index-must-be-integer = Kaipuhan na integer an indise kan baryanteng { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Dai pa naipapatupad an `<{ $component }>` para sa absolutong sukol. Ibinubutang na relatibo an mga lakbang.
+
+side-by-side-absolute-margins = Dai pa naipapatupad an `<{ $component }>` para sa absolutong sukol. Ibinubutang na relatibo an mga margin.
+
+side-by-side-no-block-child = Bakong balidong `<{ $component }>`: kaipuhan na igwa iyan nin dai kulang sa sarong akeng block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Dai pinapansin an atributong `for` sa grapikal na `<label>`.
+
+label-for-must-resolve-to-one = Kaipuhan na minatukdo an atributong `for` sa `<label>` sa eksaktong sarong komponente.
+
+label-for-unresolved = Dai natukdo an atributong `for` sa `<label>` sa sarong komponente.
+
+label-for-answer-with-authored-inputs = An atributong `for` sa `<label>` minatukdo sa sarong `<answer>` na igwang mga input na sinurat kan autor; tukdoon an input mismo.
+
+label-for-answer-without-input = An atributong `for` sa `<label>` minatukdo sa sarong `<answer>` na mayong input na eetiketahan.
+
+label-for-must-reference-input-or-answer = Kaipuhan na minatukdo an atributong `for` sa `<label>` sa sarong input o sarong answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Para sa aksesibilidad, kaipuhan na igwa an `<{ $component }>` nin halipot na deskripsyon o itinakdang dekoratibo.
+
+accessibility-video-short-description = Para sa aksesibilidad, kaipuhan na igwa an `<video>` nin halipot na deskripsyon.
+
+accessibility-input-short-description-or-label = Para sa aksesibilidad, kaipuhan na igwa an `<{ $component }>` nin halipot na deskripsyon o etiketa.
+
+accessibility-answer-input-short-description-or-label = Para sa aksesibilidad, kaipuhan na igwang halipot na deskripsyon o etiketa an sarong `<answer>` na naggigibo nin input.
+
+accessibility-short-description-contains-math = Dai dapat naglalaog sa mga halipot na deskripsyon an mga komponenteng matematika arog kan `<{ $component }>`. Isurat sa mga tataramon an ano man na matematika.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kulang an kontraste kan { $colorName } para sa teksto kan ulo kan seksyon (madiklom na mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kaipuhan an dai kulang sa { $threshold }:1).
+       *[other] Kulang an kontraste kan { $colorName } para sa teksto kan ulo kan seksyon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kaipuhan an dai kulang sa { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Dai pa naipapatupad an `<circle>` na minaagi sa { $count } na punto kun mayong numerikong balor an mga punto.
+
+circle-too-many-through-points = Dai puwedeng kuwentahon an sirkulong minaagi sa labi sa 3 na punto.
+
+circle-overprescribed-radius-center-points = Dai puwedeng kuwentahon an sirkulong igwang itinakdang radyus, sentro asin mga puntong aagihan.
+
+circle-center-with-multiple-points = Dai puwedeng kuwentahon an sirkulong igwang itinakdang sentro na minaagi sa labi sa 1 na punto.
+
+circle-radius-too-small = Dai puwedeng kuwentahon an sirkulo: huli ta an distansya kan duwang punto iyo an { $distance }, sadit na marhay an itinakdang radyus na { $radius }.
+
+circle-radius-with-many-points = Dai puwedeng maggibo nin sirkulong minaagi sa labi sa duwang punto na igwang itinakdang radyus.
+
+circle-invalid-center-or-through-points = Bakong balido an sentro o an mga puntong aagihan kan sirkulo.
+
+circle-radius-center-with-multiple-points = Dai puwedeng kuwentahon an radyus kan sirkulong igwang itinakdang sentro na minaagi sa labi sa 1 na punto.
+
+circle-change-radius-non-numerical = Dai puwedeng baguhon an radyus kan sirkulong minaagi sa mga puntong bakong numeriko
+
+circle-radius-with-points-non-numerical = Dai puwedeng maggibo nin sirkulong minaagi sa labi sa sarong punto na igwang itinakdang radyus kun mayong numerikong balor.
+
+circle-change-center-non-numerical = Dai pa naipapatupad an pagbago kan sentro kan sirkulong minaagi sa mga puntong mayong numerikong balor.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Bikol has one, because
+# «interbalo» and «input» do not change for number. Both selects are dropped
+# and both counts still arrive.
+function-domain-insufficient-dimensions = Kulang an dimensyon kan domain para sa punsyon. An domain igwang { $intervals } na interbalo alagad an punsyon igwang { $inputs } na input.
+
+function-domain-invalid-format = Bakong balidong pormat kan domain para sa punsyon.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Dai pinapansin an bakong numerikong pinakahalangkaw kan punsyon.
+        [minimum] Dai pinapansin an bakong numerikong pinakahababa kan punsyon.
+        [extremum] Dai pinapansin an bakong numerikong ekstremum kan punsyon.
+        [point] Dai pinapansin an bakong numerikong punto kan punsyon.
+        [slope] Dai pinapansin an bakong numerikong hilig kan punsyon.
+       *[other] Dai pinapansin an bakong numerikong { $type } kan punsyon.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Dai pinapansin an mayong laog na pinakahalangkaw kan punsyon.
+        [minimum] Dai pinapansin an mayong laog na pinakahababa kan punsyon.
+        [extremum] Dai pinapansin an mayong laog na ekstremum kan punsyon.
+        [point] Dai pinapansin an mayong laog na punto kan punsyon.
+       *[other] Dai pinapansin an mayong laog na { $type } kan punsyon.
+    }
+
+function-points-too-close = Igwang duwang punto an punsyon na sobrang rani. Dai madepinaran an punsyon.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Posible sana an mga iterasyon kan punsyon kun pareho an bilang kan mga input asin an bilang kan mga output. Ining punsyon igwang { $inputs } na input asin { $outputs } na output.
+
+## `<sequence>`
+
+sequence-invalid-length = Bakong balido an lawig kan sequence.  Kaipuhan na bakong negatibong integer.
+
+sequence-invalid-step = Bakong balido an step kan sequence.  Kaipuhan na numero para sa sequence na type { $type }.
+
+sequence-invalid-endpoint-number = Bakong balidong "{ $attribute }" kan sequence na numero.  Kaipuhan na numero.
+
+sequence-invalid-endpoint-letters = Bakong balidong "{ $attribute }" kan sequence na letra.  Kaipuhan na kombinasyon kan mga letra.
+
+sequence-invalid-endpoint = Bakong balidong "{ $attribute }" kan sequence.
+
+select-from-sequence-coprime-not-numbers = dai pinapansin an coprime ta bakong numero an pinipili
+
+select-from-sequence-coprime-with-exclude-combinations = dai pinapansin an coprime ta itinakda an excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Bakong balidong target para sa `<{ $source }>`: dai makua an target.
+
+target-state-variable-not-found = Bakong balidong target para sa `<{ $source }>`: dai makua an baryableng estado na inaapod na "{ $property }" sa sarong `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Kaipuhan na iba an mga baryable kan `<odeSystem>` sa independienteng baryable.
+
+ode-system-duplicate-variable-names = Dai madepinaran an mga punsyon na RHS kan ODE na pareho an ngaran kan mga baryableng nakadepende.
+
+ode-system-rhs-function-error = Dai madepinaran an punsyon na RHS kan ODE.  Igwang sala sa paggibo kan punsyon na mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Dai madepinaran an anggulo sa tanga kan { $count } na linya
+
+angle-invalid-through-point = Bakong balidong punto sa through kan `<angle>`
+
+parabola-vertex-too-many-points = Dai pa naipapatupad an parabolang igwang bertise na minaagi sa labi sa 1 na punto.
+
+parabola-too-many-points = Dai pa naipapatupad an parabolang minaagi sa labi sa 3 na punto.
+
+intersection-too-many-items = Dai pa naipapatupad an intersection para sa labi sa duwang bagay
+
+## Other math components
+
+ionic-compound-not-two-ions = Dai pa naipapatupad an kompuwestong ioniko para sa iba apuwera sa duwang ion.
+
+ionic-compound-needs-cation-and-anion = Naipatupad an kompuwestong ioniko para sana sa sarong cation asin sarong anion.
+
+solve-equations-cannot-evaluate = Dai masolusyonan an ekwasyon ta dai natimbang an ekwasyon: { $equation }
+
+math-operators-operand-number-required = Kaipuhan na itakda an operandNumber kun nagkukua nin operand na matematika.
+
+eigen-decomposition-failed = Dai nakuwenta an mga eigenvalue kan matris
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: an parametrong { $parameters } dai nagluluwas sa pattern, kaya danay iyan na natutugma sa blangko.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: dai nasasabotan an grid="{ $grid }". Kaipuhan na none, medium, dense, o duwang positibong numerong pinagsuway nin espasyo, arog kan grid="1 0.5". Mayong grid na iginuguhit.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: mayong suporta an xLabelPosition="left" sa renderer na prefigure; ginagamit an ugali kan tuong posisyon.
+
+prefigure-y-label-position-unsupported = `<graph>`: mayong suporta an yLabelPosition="bottom" sa renderer na prefigure; ginagamit an ugali kan itaas na posisyon.
+
+prefigure-invalid-axis-bounds = `<graph>`: bakong balido an mga sagkodan kan aksis para sa konbersyon na prefigure; ginagamit an nakaugalian na bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: bakong balido an lakbang para sa konbersyon na prefigure; ginagamit an nakaugalian na lakbang kan diagram na 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: bakong balido an aspectRatio para sa konbersyon na prefigure; ginagamit an nakaugalian na aspect ratio na 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: sobrang rani an pagkasuway kan grid para sa mga sagkodan kan aksis; dai ilinalaog an grid sa renderer na prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: dai mare-render an mga annotation kun bakong an renderer na PreFigure an ginagamit.
+
+multiple-annotations-children = Dakol na akeng `<annotations>` an nakua sa `<graph>`: dai pinapansin an gabos apuwera sa huri.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Dai puwedeng i-extend o kopyahon an bakong midbid na klase kan komponente: { $type }.
+
+copy-prop-not-found = Dai nakua an prop na { $property } sa komponenteng klase { $component }
+
+collect-no-source = Mayong nakuang source para sa collect.
+
+collect-invalid-component-type = Dai puwedeng tiponon an mga komponenteng klase `<{ $component }>` ta bakong balidong klase kan komponente.
+
+reference-index-unavailable = Dai matukdo an indise na `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Dai maapod an { $action } sa komponenteng `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bakong balido an porma kan datos.  Dai pareho an lawig kan mga linya. Nakua sa componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Igwang parehong ngaran kan kolum an datos.  Nakua sa componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Mayong ngaran an sarong kolum kan datos.  Nakua sa componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = An award kan simbag na ini nakabase sa mismong ipinadarang simbag kan answer tag, asin madara ini nin bakong linalaom na ugali.
+
+answer-max-num-attempts-in-section-wide-check-work = Mayong epekto an pagbutang nin `maxNumAttempts` sa sarong `<answer>` sa laog kan kontenedor na igwang `sectionWideCheckWork`, ta an kontenedor an nagkokontrol kan bilang kan mga purbar. Ibutang an `maxNumAttempts` sa kontenedor.
+
+nested-section-wide-check-work-max-num-attempts = Mayong epekto an pagbutang nin `maxNumAttempts` sa kontenedor na igwang `sectionWideCheckWork` na nasa laog kan ibang kontenedor na igwang `sectionWideCheckWork`, ta an luwas na kontenedor an nagkokontrol kan bilang kan mga purbar. Ibutang an `maxNumAttempts` sa luwas na kontenedor.
+
+# No select: «atributo» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Mayong epekto an atributong { $attributes } kun dai naibutang an symbolicEquality.
+
+answer-invalid-type = Bakong balidong klase para sa simbag: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Huli ta mayong ngaran an komponenteng `<{ $component }>`, dai iyan magagamit para sa atributo kan module
+
+module-attribute-name-already-defined = Dai magagamit an komponenteng `<{ $component } name="{ $name }">` bilang atributo kan module ta an klase kan komponenteng `<module>` igwa nang atributong "{ $name }".
+
+conditional-content-condition-ignored = Dai pinapansin an atributong `condition` sa komponenteng `<conditionalContent>` na igwang mga akeng case o else.
+
+slider-markers-type-mismatch = Dai nagkakauyon an klase kan mga marker asin an klase kan slider.
+
+pretzel-problem-needs-statement-and-answer = Bakong balidong pretzel: kaipuhan na igwang laog an lambang `<problem>` na sarong `<statement>` asin sarong `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Bakong balidong pretzel: sa mode="circuit", dai puwedeng distractor an enot na `<problem>`.
+
+## Attribute values
+
+# No select: «balor» is the same word for one and for many.
+attribute-invalid-values = Bakong balidong balor na { $values } para sa atributong `{ $attribute }`; dai pinapansin.
+
+attribute-must-be-references = Bakong balidong balor na `{ $value }` para sa atributong `{ $attribute }`. Kaipuhan na binubuo an atributo kan mga reperensiyang nagpopoon sa `$`.
+
+math-input-invalid-function-names = <mathInput>: dai pinansin an mga bakong balidong ngaran kan punsyon sa { $attribute }: { $names }. Kaipuhan na igwa an lambang ngaran nin dai kulang sa 2 na karakter (letra o gitlo); puwedeng magsunod an sarong suffix na `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Bakong balidong klase kan komponente: `<{ $componentType }>`
+
+attribute-repeated = Dai puwedeng uliton an atributong { $attribute }.
+
+attribute-invalid-for-component = Bakong balidong atributong "{ $attribute }" para sa komponenteng klase `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kulang an kontraste kan depinisyon kan estilong { $styleNumber } para sa { $context ->
+        [text-on-background] kolor kan teksto tumang sa kolor kan background
+        [high-contrast] kolor na halangkaw an kontraste tumang sa kanbas
+        [line] kolor kan linya tumang sa kanbas
+        [marker] kolor kan marker tumang sa kanbas
+       *[text-on-canvas] kolor kan teksto tumang sa kanbas
+    }{ $mode ->
+        [dark] { " (madiklom na mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kaipuhan an dai kulang sa { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Minsan ngani igwa an depinisyon kan estilong { $styleNumber } nin itinakdang mga kolor na igo an kontraste para sa maliwanag na mode, kulang an kontraste kan kolor kan teksto tumang sa kolor kan background sa mga kolor na kinua para sa madiklom na mode ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kaipuhan an dai kulang sa { $threshold }:1). { $suggestion ->
+        [available] Tanganing igo an kontraste sa madiklom na mode, dagdagan an kontraste kan maliwanag na mode (halimbawa, ibutang an { $lightAttribute }="{ $lightColor }") o salidahan an kolor kan madiklom na mode (halimbawa, ibutang an { $darkAttribute }="{ $darkColor }").
+       *[none] Tanganing igo an kontraste sa madiklom na mode, dagdagan an kontraste kan maliwanag na mode o salidahan an mga kinuang kolor paagi sa textColorDarkMode asin/o backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Minsan ngani igwa an depinisyon kan estilong { $styleNumber } nin itinakdang kolor kan teksto na igo an kontraste para sa maliwanag na mode, kulang an kontraste kan kolor kan teksto na kinua para sa madiklom na mode tumang sa kanbas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kaipuhan an dai kulang sa { $threshold }:1). { $suggestion ->
+        [available] Tanganing igo an kontraste sa madiklom na mode, dagdagan an kontraste kan maliwanag na mode (halimbawa, ibutang an textColor="{ $lightColor }") o salidahan an kolor kan madiklom na mode (halimbawa, ibutang an textColorDarkMode="{ $darkColor }").
+       *[none] Tanganing igo an kontraste sa madiklom na mode, dagdagan an kontraste kan maliwanag na mode o salidahan an kinuang kolor paagi sa textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Saro sana na <stylePalette> an puwedeng pilion kan sarong seksyon; ginagamit an huri.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = dai matukdoan an mga natatanging baryante kan { $component } ta an numToSelect bakong integer na dai negatibo.
+
+variant-num-to-select-not-constant-number = dai matukdoan an mga natatanging baryante kan { $component } ta an numToSelect bakong konstanteng numero.
+
+variant-with-replacement-not-constant-boolean = dai matukdoan an mga natatanging baryante kan { $component } ta an withReplacement bakong konstanteng boolean.
+
+variant-select-weight-disables-unique = Pinapunduhan an mga natatanging baryante para sa select kun igwang opsyon na itinakdaan nin selectWeight o selectForVariants
+
+variant-coprime-undetermined = dai matukdoan an mga natatanging baryante kan { $component } ta dai matukdoan kun danay na false an coprime.
+
+variant-attribute-not-constant = dai matukdoan an mga natatanging baryante kan { $component } ta bakong konstante an { $attribute }.
+
+variant-attribute-not-number = dai matukdoan an mga natatanging baryante kan { $component } ta bakong numero an { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    dai matukdoan an mga natatanging baryante kan { $component } na klase { $type } ta an { $attribute } bakong { $expected ->
+        [letters-combination] kombinasyon kan mga letra
+        [math-expression] balidong ekspresyon na matematika
+        [integer] integer
+       *[number] numero
+    }.
+
+variant-length-not-integer = dai matukdoan an mga natatanging baryante kan { $component } ta bakong integer an length.
+
+variant-sort-not-implemented = dai pa naipapatupad an mga natatanging baryante kan sarong { $component } na igwang sort
+
+variant-exclude-combinations-not-implemented = dai pa naipapatupad an mga natatanging baryante kan sarong { $component } na igwang excludeCombinations
+
+variant-math-exclude-not-implemented = dai pa naipapatupad an mga natatanging baryante kan sarong { $component } na klase math na igwang exclude
+
+variant-non-constant-exclude-not-implemented = dai pa naipapatupad an mga natatanging baryante kan sarong { $component } na igwang bakong konstanteng exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: mayong suporta sa renderer na prefigure kan graph; linaktawan an kaapo-apohan.
+
+prefigure-descendant-invalid-geometry = { $subject }: bakong sagkodan o bakong kompleto an heometriya; linaktawan an kaapo-apohan.
+
+prefigure-curve-label-omitted = { $subject }: mayong suporta an mga etiketa sa mga na-konberteng kurba; dai pinansin an etiketa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: mayong suportang klase kan depinisyon kan punsyon na kurba na '{ $definitionType }'; linaktawan an kaapo-apohan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: mayong suportang atributong flipFunctions sa regionBetweenCurves; linaktawan an kaapo-apohan.
+
+prefigure-region-non-formula-child = { $subject }: an mga akeng punsyon na klase formula sana an igwang suporta sa regionBetweenCurves; linaktawan an kaapo-apohan.
+
+prefigure-label-position-unsupported =
+    { $subject }: mayong suportang labelPosition '{ $labelPosition }' para sa { $labelKind ->
+        [line-family] etiketa kan pamilya kan linya
+       *[point] etiketa kan punto
+    }; ginagamit an nakaugalian na pagpantay kan PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: mayong suporta an PreFigure sa estilo kan laog na '{ $fillStyle }'; nagbabalik sa solidong laog.
+
+prefigure-line-style-unknown = { $subject }: bakong midbid na estilo kan linya na '{ $lineStyle }', dai inilaog sa output kan PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: isinugpon an estilo kan marker na '{ $markerStyle }' sa estilong 'diamond' kan PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: mayong suporta an PreFigure sa estilo kan marker na '{ $markerStyle }'; ginagamit an nakaugalian na estilo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: bakong balidong `ref`; dai matukdo an target. Dai inilaog an annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: minatukdo an `ref` sa dakol na target; ginagamit an enot na target.
+
+annotation-ref-outside-graph = `<annotation>`: bakong balidong `ref`; nasa luwas an target kan graph na naglalaom kaini. Dai inilaog an annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: bakong balidong `ref`; an target bakong suportadong grapikal na bagay sa konbersyon na prefigure. Dai inilaog an annotation.
+
+annotation-text-missing = `<annotation>`: mayo o blangko an `text`; nagluluwas nin blangkong teksto.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Igwang nakuang sirkular na pagdepende.
+       *[other] Igwang nakuang sirkular na pagdepende na kaiba an komponenteng `<{ $componentType }>`.
+    }
+
+reference-no-referent = Mayong nakuang tinutukdo kan reperensiya: `{ $reference }`
+
+reference-multiple-referents = Dakol an nakuang tinutukdo kan reperensiya: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Bakong balidong pormat kan atributong { $attribute } kan `<{ $componentType }>`.
+
+children-invalid = Bakong balido an mga ake kan `<{ $componentType }>`: nakua an mga bakong balidong ake: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Bakong balidong balor na `{ $value }` para sa atributong `{ $attribute }`, ginagamit an balor na `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Dai nakua an bersyon kan DoenetML na { $version }.
+       *[other] Dai nakua an bersyon kan DoenetML na { $version }. Nagbabalik sa bersyon na { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Bakong balidong DoenetML: { $content }
+
+parse-tag-missing-close-tag = Bakong balidong DoenetML: Mayong pansarang tag an tag na `{ $tag }`. Linalaom an tag na nagsasara sa sadiri o tag na `</{ $tagName }>`.
+
+parse-tag-error = Bakong balidong DoenetML: Igwang sala sa tag na `<{ $tagName }>`
+
+parse-attribute-missing-value = Bakong balidong DoenetML: Garo mayong balor an bakong balidong atributong `{ $attribute }`.
+
+parse-attribute-invalid = Bakong balidong DoenetML: Bakong balidong atributong `{ $attribute }`
+
+parse-attribute-value-invalid = Bakong balidong DoenetML: Bakong balidong balor kan atributong `{ $value }`
+
+parse-attribute-value-quote-mismatch = Bakong balidong DoenetML: Bakong balidong balor kan atributong `{ $value }`. Dai nagkakauyon an mga marka kan sipi. Garo mayong sarong `{ $quote }`
+
+parse-open-tag-name-missing = Bakong balidong DoenetML: Igwang nakuang tag na mayong ngaran, halimbawa `<`
+
+parse-tag-not-closed = Bakong balidong DoenetML: Dai nasara an tag na `{ $tag }` (garo mayong `>`).
+
+parse-self-closing-tag-name-missing = Bakong balidong DoenetML: Igwang nakuang tag na mayong ngaran `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Bakong balidong DoenetML: Dai nasara an tag na `{ $tag }` (garo mayong `/>`).
+
+parse-tag-invalid-attributes = Bakong balidong DoenetML: Bakong balido an tag na `{ $tag }`. Tibaad igwang bakong tamang mga atributo.
+
+parse-close-tag-name-missing = Bakong balidong DoenetML: Igwang nakuang pansarang tag na mayong ngaran, halimbawa `</`
+
+parse-attribute-value-unquoted = Kaipuhan na nasa laog kan mga marka kan sipi an mga balor kan atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Bakong balidong DoenetML: Igwang nakuang pansarang tag na `{ $tag }`, alagad mayong katumbas na pambukas na tag
+
+parse-close-tag-mismatched = Bakong balidong DoenetML: Dai nagkakatugma an pansarang tag. Linalaom an `</{ $expected }>`. Nakua an `{ $found }`
+
+parser-node-unconvertible = Dai na-konberte an node na { $node } sa node na Dast.
+
+## Names
+
+name-attribute-invalid =
+    Bakong balidong atributong name='{ $name }'. { $reason ->
+        [characters] Puwede sanang maglaom an mga ngaran nin mga letra, numero, underscore o gitlo.
+       *[start] Kaipuhan na nagpopoon an mga ngaran sa letra.
+    }
+
+component-name-invalid-start = Bakong balidong ngaran kan komponenteng "{ $name }". Kaipuhan na nagpopoon an mga ngaran sa letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Kaipuhan na igwang atributong video an answer na type videoWatched
+
+answer-video-watched-video-not-reference = Kaipuhan na reperensiya an atributong video kan answer na type videoWatched
+
+answer-name-not-single-text = Kaipuhan na igwang sarong akeng text sana an atributong name kan answer
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Dai nakua an luwas na DoenetML huli sa sobrang dakol na lebel kan pag-uulit. Igwa daw na sirkular na reperensiya?
+
+external-doenetml-unavailable = Dai nakua an DoenetML hali sa { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Bakong balidong DoenetML an nakua hali sa { $attribute }="{ $uri }": dai iyan nagtutugma sa klase kan komponenteng "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Dai na ginagamit an atributong `{ $from }`; gamiton an `{ $to }`.
+       *[other] [deprecation] Dai na ginagamit an atributong `{ $from }` sa `<{ $component }>`; gamiton an `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Dai na ginagamit an atributong `{ $from }` asin dai pinapansin ta itinakda man an `{ $to }`.
+       *[other] [deprecation] Dai na ginagamit an atributong `{ $from }` sa `<{ $component }>` asin dai pinapansin ta itinakda man an `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Dai na ginagamit an atributong `{ $attribute }` sa `<{ $component }>` asin dai pinapansin.
+
+deprecated-attribute-to-child = [deprecation] Dai na ginagamit an atributong `{ $attribute }` sa `<{ $component }>`; gamiton an akeng `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Dai na ginagamit an balor na `{ $value }` kan atributong `{ $attribute }` sa `<{ $component }>`; gamiton an `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = An `<pluralize>` makakapadakol sana nin Ingles, kaya dai nababago an teksto kaini sa dokumentong sinurat sa { $locale }. Isurat mismo an pormang dakol, o ibutang ini paagi sa atributong `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = An elementong `<{ $tag }>` bakong midbid na elemento kan Doenet.
+
+schema-element-not-allowed-at-root = Dai tinutugotan an elementong `<{ $tag }>` sa gamot kan dokumento.
+
+schema-element-not-allowed-inside = Dai tinutugotan an elementong `<{ $tag }>` sa laog kan `<{ $parent }>`.
+
+schema-attribute-unrecognized = Mayong atributong inaapod na `{ $attribute }` an elementong `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Kaipuhan na lista an atributong `{ $attribute }` kan elementong `<{ $tag }>` na an lambang bagay saro sa: { $allowed }
+       *[other] Kaipuhan na saro sa mga ini an atributong `{ $attribute }` kan elementong `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Bakong balidong ngaran kan baryante para sa select.  An ngaran kan baryanteng { $variantName } nagluluwas sa { $numOptions } na opsyon alagad { $numToSelect } an bilang na pipilion.
+
+select-variant-name-without-options = Igwang itinakdang mga baryante para sa select alagad mayong itinakdang opsyon para sa posibleng ngaran kan baryante: { $variantName }.
+
+select-variant-name-not-possible = An ngaran kan baryanteng { $variantName } na itinakda para sa select bakong posibleng ngaran kan baryante.
+
+select-too-few-options = Dai puwedeng mamili nin { $numToSelect } na komponente hali sa { $numOptions } sana.
+
+select-from-sequence-too-few-values = Dai puwedeng mamili nin { $numToSelect } na balor hali sa sequence na { $length } an lawig.
+
+select-from-sequence-indices-count-mismatch = Kaipuhan na magtugma an bilang kan mga indise na itinakda para sa select asin an bilang na pipilion
+
+select-from-sequence-indices-not-integers = Kaipuhan na integer an gabos na indise na itinakda para sa select
+
+select-from-sequence-index-excluded = Itinakda an indise kan selectfromsequence na dai inilaog
+
+select-from-sequence-indices-excluded-combination = Itinakda an mga indise kan selectfromsequence na sarong dai inilaog na kombinasyon
+
+select-from-sequence-coprime-not-positive-integers = Dai puwedeng mamili nin mga kombinasyon na coprime ta bakong positibong integer an pinipili.
+
+select-from-sequence-coprime-common-factor = Dai puwedeng mamili nin mga numerong coprime. Igwang sarong paktor na pareho an gabos na posibleng balor. (Kaipuhan na coprime an itinakdang balor kan "from" o "to" sa "step".)
+
+select-from-sequence-coprime-single-number = Dai puwedeng mamili nin mga kombinasyon na coprime hali sa sarong numero sana na bakong 1.
+
+select-from-sequence-excluded-too-many-combinations = Dai inilaog an labi sa 70% kan mga kombinasyon sa selectFromSequence
+
+select-from-sequence-coprime-none-found = Dai nakapamili nin mga numerong coprime. Igwang sarong paktor na pareho an gabos na posibleng balor.
+
+select-from-sequence-too-few-unique-values = Dai puwedeng mamili nin { $numToSelect } na natatanging balor hali sa sequence na { $numPossibleValues } an lawig
+
+select-prime-numbers-too-few-values = Dai puwedeng mamili nin { $numToSelect } na balor hali sa listang prime na { $numValues } an lawig
+
+select-prime-numbers-values-count-mismatch = Kaipuhan na magtugma an bilang kan mga balor na itinakda para sa select asin an bilang na pipilion
+
+select-prime-numbers-values-not-prime = Kaipuhan na nasa listang prime an gabos na balor na itinakda para sa select prime number
+
+select-prime-numbers-values-excluded-combination = An itinakdang mga balor kan selectPrimeNumbers sarong dai inilaog na kombinasyon
+
+select-prime-numbers-excluded-too-many-combinations = Dai inilaog an labi sa 70% kan mga kombinasyon sa selectPrimeNumbers
+
+select-random-combination-fluke = Huli sa bihirang marhay na kapaladan, dai nakapamili nin kombinasyon kan mga random na balor
+
+select-random-value-fluke = Huli sa bihirang marhay na kapaladan, dai nakapamili nin random na balor

--- a/packages/i18n/locales/bik/editor.ftl
+++ b/packages/i18n/locales/bik/editor.ftl
@@ -1,0 +1,208 @@
+# Bikol editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Bikol marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ibalik
+       *[update] Baguhon
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } an pagheling
+       *[other] { $word } an pagheling { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Baryante
+editor-variant-filter = Salaon…
+editor-variant-next = Pilion an sunod na baryante
+editor-variant-previous = Pilion an nakaaging baryante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Igwang nakuang paglapas sa aksesibilidad na WCAG AA. I-klik tanganing { $action ->
+            [close] masarahan
+           *[open] mabuksan
+        } an report kan aksesibilidad.
+        [advisories] I-klik tanganing { $action ->
+            [close] masarahan
+           *[open] mabuksan
+        } an report kan aksesibilidad. Mayong nakuang paglapas sa WCAG AA, alagad igwa pang dagdag na rekomendasyon sa aksesibilidad.
+       *[clean] I-klik tanganing { $action ->
+            [close] masarahan
+           *[open] mabuksan
+        } an report kan aksesibilidad. Mayong nakuang problema sa aksesibilidad.
+    }
+
+# No select on `$count` inside the branches: «paglapas» and «rekomendasyon» are
+# the same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Igwang nakuang paglapas sa aksesibilidad na WCAG AA. { $count } na paglapas sa WCAG AA an nakua. I-klik tanganing { $action ->
+            [close] masarahan
+           *[open] mabuksan
+        } an report kan aksesibilidad.
+        [advisories] Mayong nakuang paglapas sa WCAG AA. { $count } na dagdag na rekomendasyon sa aksesibilidad an nakua. I-klik tanganing { $action ->
+            [close] masarahan
+           *[open] mabuksan
+        } an report kan aksesibilidad.
+       *[clean] Mayong nakuang paglapas sa WCAG AA. I-klik tanganing { $action ->
+            [close] masarahan
+           *[open] mabuksan
+        } an report kan aksesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersyon kan DoenetML { $version }
+
+editor-tab-help = Tabang na sunod sa konteksto
+editor-tab-help-short = Konteksto
+editor-tab-errors = Sala
+editor-tab-warnings = Patanid
+editor-tab-info = Impormasyon
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Ipinadarang mga simbag
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Mga opsyon kan editor
+editor-format-as-doenetml = I-pormat bilang DoenetML
+editor-format-as-xml = I-pormat bilang XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linya #{ $line }
+
+editor-no-errors = Mayong sala
+editor-no-warnings = Mayong patanid
+editor-no-info = Mayong diagnostikong impormasyon
+
+editor-show-info-annotations = Ipahiling an mga diagnostikong impormasyon sa editor
+editor-show-accessibility-annotations = Ipahiling an mga diagnostiko kan aksesibilidad sa editor
+
+editor-accessibility-learn-more = Aramon kun paano inaatubang kan Doenet an aksesibilidad
+
+editor-accessibility-violations-heading = Mga paglapas sa aksesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Ibang problema sa aksesibilidad
+editor-none-found = Mayong nakua
+
+
+## Submitted responses
+
+editor-no-responses = Mayo pang ipinadarang simbag
+editor-response-answer-id = Id kan simbag
+editor-response-response = Simbag
+editor-response-credit = Kredito
+editor-response-submitted = Ipinadara
+
+
+## The context-help panel
+
+help-placeholder = Ibutang an kursor sa ngaran kan tag, atributo, o { $ref } para sa dokumentasyon.
+
+help-unsupported-ref-chain = Mayo pang suporta an tabang para sa mga reperensiyang dakol an kabtang arog kan { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Mayong nakuang tinutukdo kan reperensiya: { $ref }.
+        [multiple] Dakol an nakuang tinutukdo kan reperensiya: { $ref }.
+       *[indeterminate] Dai natukdoan an tinutukdo kan { $ref }.
+    }
+
+help-learn-about-references = Aramon an manongod sa mga reperensiya →
+help-reference-page = Pahina kan reperensiya →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Sa laog kan { $element }
+       *[top] Sa pinakahalangkaw na lebel
+    }{ $allowed ->
+        [none] { " — mayong puwedeng ibutang digdi." }
+        [text] { " — magsurat nin teksto digdi." }
+        [text-and-components] { " — magsurat nin teksto digdi, o purbaran:" }
+       *[components] { " — mga puwedeng purbaran:" }
+    }
+
+help-suggestions-footer = Pindoton an { $shortcut } tanganing mahiling an gabos na { $total } na komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] An { $ref } sarong reperensiya sa { $target }.
+       *[other] An { $ref } sarong reperensiya sa { $target } (linya { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Dinara kan { $owner } bilang { $role }.
+       *[other] Dinara kan { $owner } sa linya { $line } bilang { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] An { $ref } sarong reperensiya sa propyedad na { $property } kan { $element }.
+       *[other] An { $ref } sarong reperensiya sa propyedad na { $property } kan { $element } (linya { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = sadit na kodigo
+help-kind-array-entry = entrada sa array
+
+help-default = Nakaugalian:
+help-active-default = Aktibong nakaugalian:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Mga tinutugotan na balor (saro kada bagay):
+       *[other] Mga tinutugotan na balor:
+    }
+
+help-suggested-values = Mga isinusuherenciang balor:
+
+help-inserts = Naglalaog:
+
+# No select: «koordinado» is the same word for one and for many.
+help-coordinates = Koordinado:
+
+help-type = Klase:
+
+help-resolved-style = Natukdoan na estilo (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Natukdoan na mga ngaran kan punsyon:
+help-reset-list = Lista kan pagbalik sa input na ini:
+help-added-on-input = Idinagdag sa input na ini:
+help-removed-on-input = Hinali sa input na ini:
+
+help-reset-overrides = An { $reset } sinasalidahan an { $additional } asin { $removed }.

--- a/packages/i18n/locales/ch/chrome.ftl
+++ b/packages/i18n/locales/ch/chrome.ftl
@@ -1,0 +1,144 @@
+# Chamorro viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Guam orthography (Kumisión i Fino' CHamoru), which writes the
+# glottal stop as «'» and the low vowel as «å». The Northern Marianas spell some
+# of the same words differently, and a deployment that wants the CNMI standard
+# supplies its own catalog as `localeResources`; correcting this file word by
+# word toward it is what would leave the locale in two orthographies at once.
+#
+# Chamorro marks no number on the noun — «siha» after it is the plural, and a
+# numeral does not take it — so a `{ $count -> … }` whose two English branches
+# differ only in the noun renders one string here and the select is dropped. A
+# `[0]` branch stays wherever English has one.
+
+
+## Answer submission
+
+answer-checking = Machecheki…
+answer-submitting = Manmanenå'i…
+
+answer-checking-status = Machecheki i ineppe'
+answer-submitting-status = Manmanenå'i i ineppe'
+
+answer-correct = Korekto
+answer-incorrect = Ti korekto
+
+answer-response-saved = Masåtba i ineppe'
+
+answer-percent-credit = { $percent }% na kredito
+answer-percent-correct = { $percent }% korekto
+answer-percent-short = { $percent } %
+
+max-credit-available = I mås takhilo' na kredito ni siña masodda': { $percent }%
+
+# No select: «chinagi» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] taya' mås chinagi ni sesetbe
+       *[other] { $count } na chinagi sesetbe ha'
+    }
+
+validation-correct = (Korekto)
+validation-incorrect = (Ti korekto)
+validation-partially-correct = (Korekto gi patte)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Na'annok { $count } na ineppe' para i { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Kumentåyu
+
+collapsible-click-to-open = (klek para u mababa)
+collapsible-click-to-close = (klek para u mahuchom)
+
+collapsible-initializing = Matutuhon…
+
+footnote-show = Na'annok i footnote
+footnote-hide = Na'atok i footnote
+
+description-more-information = mås infotmasion
+
+
+## Controls
+
+slider-previous = Antes
+slider-next = Sigiente
+
+keyboard-open = Baba i tekladu
+keyboard-close = Huchom i tekladu
+
+choice-input-remove-choice = Na'suha i { $choice }
+
+matrix-remove-row = Na'suha i liña
+matrix-add-row = Na'saga un liña
+matrix-remove-column = Na'suha i kolumna
+matrix-add-column = Na'saga un kolumna
+
+subset-add-remove-points = Na'saga/Na'suha puntos
+subset-toggle-points-intervals = Tulaika puntos yan intetbalu
+subset-move-points = Na'mudda i puntos
+subset-clear = Na'gasgas
+
+orbital-add-row = Na'saga un liña
+orbital-remove-row = Na'suha i liña
+orbital-add-box = Na'saga un kahon
+orbital-remove-box = Na'suha i kahon
+orbital-add-up-arrow = Na'saga un flecha hulo'
+orbital-add-down-arrow = Na'saga un flecha papa'
+orbital-remove-arrow = Na'suha i flecha
+
+orbital-row-label = Etiketa para i liña { $row }
+
+pretzel-answer = Ineppe'
+
+summary-statistics-caption = Kabåles na estadistika i { $column }
+
+
+## Math input
+
+math-input-preview-region = fine'nana na atan i ekspresion matemåtika
+math-input-preview = Fine'nana na atan
+math-input-invalid-expression = Ti maolek na ekspresion:
+
+
+## Document status
+
+viewer-initializing = Matutuhon…
+
+
+## Errors
+
+error-heading = Linachi
+
+error-found-at =
+    { $span ->
+        [line] Masodda' gi liña { $startLine }.
+       *[lines] Masodda' gi liña { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Guaha linachi este na dokumento!
+
+diagnostic-heading-error = Linachi
+diagnostic-heading-warning = Adbertensia
+diagnostic-heading-information = Infotmasion
+diagnostic-heading-hint = Hinasso
+
+accessibility-heading-level-1 = Kinentra i akseso WCAG AA
+accessibility-heading-level-2 = Adbertensia put i akseso
+
+something-went-wrong = Guaha ti maolek.
+
+renderer-load-failed = guaha renderer ni ti masetbe. Pot fabot na'nuebu i påhina.
+
+core-start-failed = Ti siña matutuhon i atan i dokumento. Pot fabot na'nuebu i påhina.

--- a/packages/i18n/locales/ch/content.ftl
+++ b/packages/i18n/locales/ch/content.ftl
@@ -1,0 +1,255 @@
+# Chamorro content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Guam orthography; see `chrome.ftl`'s header.
+#
+# Chamorro has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «liña agaga'», a red line — so every
+# composition message inverts the English order.
+#
+# **This is the batch's most heavily Spanish catalog, and the loans are the
+# language rather than a shortcut in it.** Three centuries of contact left
+# Chamorro with Spanish colour words («betde», «asut», «amariyu»), Spanish
+# numerals in most counting, and Spanish geometry vocabulary — and they are
+# fully Chamorro words now, taking Chamorro affixes and Chamorro spelling. So
+# the seam this file runs along is not Chamorro-against-Spanish; it is where the
+# native word survives beside the loan, as «attelong» does beside no loan at
+# all and «å'paka'» does beside «blanko». Those choices are the ones a speaker
+# should check.
+
+
+## Style vocabulary
+
+color =
+    .black = attelong
+    .white = å'paka'
+    .gray = kulot senisa
+    .red = agaga'
+    .orange = kulot nåranha
+    .yellow = amariyu
+    .green = betde
+    .cyan = siyan
+    .blue = asut
+    .purple = lila
+    .pink = rosåda
+    .brown = kulot chukulåti
+
+line-width =
+    .thick = damo'
+    .thin = dilikåo
+
+line-style =
+    .dashed = ma'ipe'-ipe'
+    .dotted = tuntos-tuntos
+
+# Noun phrases. Chamorro marks no plural on the noun, so «liña» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = liña orisontåt
+    .vertical = liña bettikåt
+    .diagonal = liña diagonåt
+    .backdiagonal = liña diagonåt ma'atrasa
+    .dots = tuntos
+    .diamonds = diamånti
+
+noun =
+    .line = liña
+    .line-segment = pidåson liña
+    .ray = raya
+    .vector = bektot
+    .curve = kotba
+    .function = funsion
+    .parabola = paråbola
+    .polyline = liña ma'ipe'
+    .polygon = poligono
+    .triangle = triånggulo
+    .rectangle = rektånggulo
+    .circle = sirkulo
+    .region = rehion
+    .point = punto
+    .square = kuadrao
+    .diamond = diamånti
+    .cross = kilu'us
+    .plus = mås
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] ni guaha { $numSides } na kanton
+       *[head] poligono regulåt
+    }
+
+# One answer for every noun: Chamorro has no grammatical gender, and its Spanish
+# loans do not carry Spanish agreement either.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = bula
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } yan { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } yan { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } yan { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Chamorro's «i» is the definite article and is not what English's "a" is doing
+# here, so all four branches read alike but for the connective: «yan» opens the
+# first clause and «yan lokkue'» a further one.
+style-border-clause =
+    { $parts ->
+        [with-article] yan kanton { $border }
+        [and] yan lokkue' kanton { $border }
+        [and-article] yan lokkue' kanton { $border }
+       *[with] yan kanton { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ti bula
+
+style-text =
+    { $parts ->
+        [background] { $color } yan i tatte { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = taya'
+
+
+## Boolean words
+
+boolean-true = magåhet
+boolean-false = dinagi
+
+
+## Answer buttons
+
+answer-submit-label = Cheki i che'cho'
+answer-submit-label-no-correctness = Na'hålom i ineppe'
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Chamorro's plural is «siha», and a heading does not carry it.
+section-name =
+    .activity = Aktibidåt
+    .aside = Nota gi kanton
+    .cascade = Kaskåda
+    .definition = Definasion
+    .example = Ehemplo
+    .exercise = Ehetsisiu
+    .exercises = Ehetsisiu
+    .given-answer = Ineppe'
+    .note = Nota
+    .objectives = Ineppok
+    .paragraphs = Parafo
+    .part = Patte
+    .problem = Problema
+    .problems = Problema
+    .proof = Prueba
+    .question = Faisen
+    .section = Seksion
+    .solution = Solusion
+    .task = Cho'cho'
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Hinasso
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Låmasa { $enumeration }
+        [numbered-title] Låmasa { $enumeration }{ ": " }
+        [unnumbered-title] Låmasa{ ": " }
+       *[unnumbered] Låmasa
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Litråtu { $enumeration }
+        [numbered-caption] Litråtu { $enumeration }{ ": " }
+        [unnumbered-caption] Litråtu{ ": " }
+       *[unnumbered] Litråtu
+    }
+
+
+## Paginator controls
+
+paginator-previous = Antes
+paginator-next = Sigiente
+paginator-page = Påhina
+
+paginator-page-status = { $pageLabel } { $currentPage } gi { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = pat
+piecewise-condition-if = yanggen
+piecewise-condition-otherwise = yanggen ti
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Guam and the Northern Marianas teach secondary science in English,
+## and Chamorro has no settled list of all 118 to seed from. The Spanish loans
+## this catalog carries elsewhere are no help here: the periodic table arrived
+## through the English-medium school system rather than through Spanish, so
+## there is neither a Chamorro table nor a Spanish one behind it.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Ti maolek na simbolon kimika
+chemistry-invalid-ionic-compound = Ti maolek na kompuesto ioniko

--- a/packages/i18n/locales/ch/diagnostics.ftl
+++ b/packages/i18n/locales/ch/diagnostics.ftl
@@ -1,0 +1,624 @@
+# Chamorro diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Written in the Guam orthography; see `chrome.ftl`. Chamorro marks no number on
+# the noun, so a counted message whose only English difference is the noun's
+# number renders one string here and the select is dropped.
+
+
+## `<lineSegment>`
+
+# No select: «ma'ignora» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = ma'ignora i { $attributes } yanggen madetetmina i dos na kanton
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ma'ignora i { $attributes } yanggen madetetmina i un kanton yan i talo'
+
+line-segment-midpoint-offset-without-midpoint = taya' efekto i midpointOffset yanggen taya' talo'
+
+## `<line>`
+
+line-points-undetermined-dimensions = Liña ni malolofan gi puntos ni ti matungo' i dimension-ñiha.
+
+line-points-too-few-dimensions = Debi di u malofan i liña gi puntos ni guaha dos pat mås na dimension.
+
+line-points-depend-on-variables = Malolofan i liña gi puntos ni dependeyon i bariåble: { $variables }.
+
+line-equation-invalid-format = Ti maolek na fotmåtu i ekuasion i liña gi bariåble { $variable1 } yan { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Madetetmina i raya ginen i through, endpoint yan direction.  Ma'ignora i through ni madetetmina.
+
+ray-dimension-mismatch = ti parehu i numDimensions gi raya.
+
+## `<vector>`
+
+vector-overprescribed-head = Madetetmina i bektot ginen i head, tail yan displacement.  Ma'ignora i head ni madetetmina.
+
+vector-dimension-mismatch = ti parehu i numDimensions gi bektot.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ti siña ma'atrai para i `<{ $component }>` sa' taya' bariåblen estao nearestPoint-ña.
+
+constrain-to-without-nearest-point = Ti siña ma'oppe para i `<{ $component }>` sa' taya' bariåblen estao nearestPoint-ña.
+
+constrain-to-interior-without-nearest-point = Ti siña ma'oppe gi halom i `<{ $component }>` sa' taya' bariåblen estao nearestPoint-ña.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ma'ignora i labelPosition gi choiceInput ni ti inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ma'ignora i indise ni madetetmina para i choiceInput sa' ti parehu i kuenton indise yan i kuenton famagu'on ayek.
+
+pretzel-indices-count-mismatch = Ma'ignora i indise ni madetetmina para i problem sa' ti parehu i kuenton indise yan i kuenton famagu'on problem.
+
+shuffle-indices-count-mismatch = Ma'ignora i indise ni madetetmina para i shuffle sa' ti parehu i kuenton indise yan i kuenton komponente.
+
+indices-ignored-out-of-range = Ma'ignora i indise ni madetetmina para i { $component } sa' guaha indise ni humuyong gi rånggo.
+
+pretzel-indices-repeated = Ma'ignora i indise ni madetetmina para i pretzel sa' guaha indise ni marepiti.
+
+pretzel-circuit-first-index = Ma'ignora i indise ni madetetmina para i pretzel gi mode circuit sa' debi di u 1 i fine'nana na indise.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Para u fañetbe i `<{ $component }>` yan i famagu'on string, debi di u madetetmina i atributo `type`.
+
+invalid-type-defaulting-to-math = Ti maolek na type { $type } para i komponente { $component }. Debi di unu gi math, text, number, pat boolean. Masetbe i math.
+
+string-not-valid-component-to-arrange = I string "{ $value }" ti maolek na komponente para i { $component }. Ma'ignora.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Ti maolek na type { $type }, mapo'lo i type gi number.
+
+invalid-variable-value = Ti maolek na balot un bariåble: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Debi di u numero i indisen bariånte { $index }
+
+variant-index-must-be-integer = Debi di u kabåles na numero i indisen bariånte { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Trabiha ti mafa'tinas i `<{ $component }>` para i medida absoluto. Mapo'lo i ankon-ñiha relatibo.
+
+side-by-side-absolute-margins = Trabiha ti mafa'tinas i `<{ $component }>` para i medida absoluto. Mapo'lo i mahen-ñiha relatibo.
+
+side-by-side-no-block-child = Ti maolek na `<{ $component }>`: debi di guaha unu na famagu'on block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ma'ignora i atributo `for` gi `<label>` grafiko.
+
+label-for-must-resolve-to-one = Debi di u apunta i atributo `for` gi `<label>` para unu ha' na komponente.
+
+label-for-unresolved = Ti siña ma'apunta i atributo `for` gi `<label>` para un komponente.
+
+label-for-answer-with-authored-inputs = I atributo `for` gi `<label>` ha apunta un `<answer>` ni guaha input tinige' i autót; apunta i input mismo.
+
+label-for-answer-without-input = I atributo `for` gi `<label>` ha apunta un `<answer>` ni taya' input para u ma'etiketa.
+
+label-for-must-reference-input-or-answer = Debi di u apunta i atributo `for` gi `<label>` para un input pat un answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Para i akseso, debi di guaha dikike' na deskripsion i `<{ $component }>` pat madetetmina komo dekoratibu.
+
+accessibility-video-short-description = Para i akseso, debi di guaha dikike' na deskripsion i `<video>`.
+
+accessibility-input-short-description-or-label = Para i akseso, debi di guaha dikike' na deskripsion pat etiketa i `<{ $component }>`.
+
+accessibility-answer-input-short-description-or-label = Para i akseso, debi di guaha dikike' na deskripsion pat etiketa un `<answer>` ni ha fa'tinas un input.
+
+accessibility-short-description-contains-math = Ti debi di guaha komponenten matemåtika kalan i `<{ $component }>` gi dikike' na deskripsion. Tuge' i matemåtika ni palåbra.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Ti nahong i kontrasten { $colorName } para i tekston i tetulon i seksion (mode homhom) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nesesita { $threshold }:1 pat mås).
+       *[other] Ti nahong i kontrasten { $colorName } para i tekston i tetulon i seksion ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nesesita { $threshold }:1 pat mås).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Trabiha ti mafa'tinas i `<circle>` ni malolofan gi { $count } na punto yanggen taya' balot numeriko i puntos.
+
+circle-too-many-through-points = Ti siña makuenta un sirkulo ni malolofan gi mås ki 3 na punto.
+
+circle-overprescribed-radius-center-points = Ti siña makuenta un sirkulo ni madetetmina i rådion-ña, i sentro-ña yan i puntos ni malolofan.
+
+circle-center-with-multiple-points = Ti siña makuenta un sirkulo ni madetetmina i sentro-ña ya malolofan gi mås ki 1 na punto.
+
+circle-radius-too-small = Ti siña makuenta i sirkulo: sa' i disgåsian i dos na punto { $distance }, dikike' megai i rådio { $radius } ni madetetmina.
+
+circle-radius-with-many-points = Ti siña mafa'tinas un sirkulo ni malolofan gi mås ki dos na punto yan un rådio ni madetetmina.
+
+circle-invalid-center-or-through-points = Ti maolek i sentro pat i puntos ni malolofan i sirkulo.
+
+circle-radius-center-with-multiple-points = Ti siña makuenta i rådion un sirkulo ni madetetmina i sentro-ña ya malolofan gi mås ki 1 na punto.
+
+circle-change-radius-non-numerical = Ti siña matulaika i rådion un sirkulo ni malolofan gi puntos ni ti numeriko
+
+circle-radius-with-points-non-numerical = Ti siña mafa'tinas un sirkulo ni malolofan gi mås ki unu na punto yan un rådio ni madetetmina yanggen taya' balot numeriko.
+
+circle-change-center-non-numerical = Trabiha ti mafa'tinas i tinilaika i sentron un sirkulo ni malolofan gi puntos ni taya' balot numeriko.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Chamorro has one, because
+# «intetbalu» and «input» do not change for number. Both selects are dropped and
+# both counts still arrive.
+function-domain-insufficient-dimensions = Ti nahong i dimension i domain para i funsion. Guaha { $intervals } na intetbalu i domain lao guaha { $inputs } na input i funsion.
+
+function-domain-invalid-format = Ti maolek na fotmåtu i domain para i funsion.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ma'ignora i mås takhilo' i funsion ni ti numeriko.
+        [minimum] Ma'ignora i mås takpapa' i funsion ni ti numeriko.
+        [extremum] Ma'ignora i ekstremum i funsion ni ti numeriko.
+        [point] Ma'ignora i punton i funsion ni ti numeriko.
+        [slope] Ma'ignora i inklinasion i funsion ni ti numeriko.
+       *[other] Ma'ignora i { $type } i funsion ni ti numeriko.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ma'ignora i mås takhilo' i funsion ni taya' sanhalom-ña.
+        [minimum] Ma'ignora i mås takpapa' i funsion ni taya' sanhalom-ña.
+        [extremum] Ma'ignora i ekstremum i funsion ni taya' sanhalom-ña.
+        [point] Ma'ignora i punton i funsion ni taya' sanhalom-ña.
+       *[other] Ma'ignora i { $type } i funsion ni taya' sanhalom-ña.
+    }
+
+function-points-too-close = Guaha dos na punto i funsion ni hihot megai. Ti siña madefina i funsion.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Siña ha' i iterasion i funsion yanggen parehu i kuenton input yan i kuenton output. Este na funsion guaha { $inputs } na input yan { $outputs } na output.
+
+## `<sequence>`
+
+sequence-invalid-length = Ti maolek i anåkkon i sequence.  Debi di u kabåles na numero ni ti negatibu.
+
+sequence-invalid-step = Ti maolek i step i sequence.  Debi di u numero para i sequence type { $type }.
+
+sequence-invalid-endpoint-number = Ti maolek na "{ $attribute }" i sequence numero.  Debi di u numero.
+
+sequence-invalid-endpoint-letters = Ti maolek na "{ $attribute }" i sequence letra.  Debi di u kombinasion letra.
+
+sequence-invalid-endpoint = Ti maolek na "{ $attribute }" i sequence.
+
+select-from-sequence-coprime-not-numbers = ma'ignora i coprime sa' ti numero i ma'ayek
+
+select-from-sequence-coprime-with-exclude-combinations = ma'ignora i coprime sa' madetetmina i excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Ti maolek na target para i `<{ $source }>`: ti masodda' i target.
+
+target-state-variable-not-found = Ti maolek na target para i `<{ $source }>`: ti masodda' un bariåblen estao ni na'ån-ña "{ $property }" gi un `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Debi di u diferentes i bariåblen i `<odeSystem>` ginen i bariåble indipendiente.
+
+ode-system-duplicate-variable-names = Ti siña madefina i funsion RHS i ODE ni parehu i na'ån bariåble dependiente.
+
+ode-system-rhs-function-error = Ti siña madefina i funsion RHS i ODE.  Guaha linachi gi fina'tinas i funsion mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ti siña madefina un ånggulo gi entalo' { $count } na liña
+
+angle-invalid-through-point = Ti maolek na punto gi through i `<angle>`
+
+parabola-vertex-too-many-points = Trabiha ti mafa'tinas i paråbola ni guaha bettise-ña ya malolofan gi mås ki 1 na punto.
+
+parabola-too-many-points = Trabiha ti mafa'tinas i paråbola ni malolofan gi mås ki 3 na punto.
+
+intersection-too-many-items = Trabiha ti mafa'tinas i inetnon para mås ki dos na guinaha
+
+## Other math components
+
+ionic-compound-not-two-ions = Trabiha ti mafa'tinas i kompuesto ioniko para otro ki dos na ion.
+
+ionic-compound-needs-cation-and-anion = Mafa'tinas i kompuesto ioniko para unu ha' na kation yan unu ha' na anion.
+
+solve-equations-cannot-evaluate = Ti siña masotta i ekuasion sa' ti siña ma'ebalúa: { $equation }
+
+math-operators-operand-number-required = Debi di u madetetmina i operandNumber yanggen machule' un operand matemåtika.
+
+eigen-decomposition-failed = Ti siña makuenta i eigenvalue i matris
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: i parametro { $parameters } ti humuyong gi pattern, pues siempre ha nå'i i taya'.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ti matungo' i grid="{ $grid }". Debi di none, medium, dense, pat dos na numero positibu ni madibide ni espasio, kalan i grid="1 0.5". Taya' grid madibuha.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: ti masetbe i xLabelPosition="left" gi renderer prefigure; masetbe i kostumbren i banda agapa'.
+
+prefigure-y-label-position-unsupported = `<graph>`: ti masetbe i yLabelPosition="bottom" gi renderer prefigure; masetbe i kostumbren i banda hulo'.
+
+prefigure-invalid-axis-bounds = `<graph>`: ti maolek i limiten i åksis para i konbetsion prefigure; masetbe i kostumbren bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: ti maolek i anko' para i konbetsion prefigure; masetbe i kostumbren anko' diagrama 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: ti maolek i aspectRatio para i konbetsion prefigure; masetbe i kostumbren aspect ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: hihot megai i espasion i grid para i limiten i åksis; ti madibuha i grid gi renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: ti madibuha i annotation yanggen ti masetbe i renderer PreFigure.
+
+multiple-annotations-children = Meggai famagu'on `<annotations>` masodda' gi `<graph>`; ma'ignora todu na ti i uttimo.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ti siña ma'estende pat makopia un klåsen komponente ni ti matungo': { $type }.
+
+copy-prop-not-found = Ti masodda' i prop { $property } gi komponente klåsi { $component }
+
+collect-no-source = Taya' source masodda' para i collect.
+
+collect-invalid-component-type = Ti siña marekohe i komponente klåsi `<{ $component }>` sa' ti maolek i klåsen komponente.
+
+reference-index-unavailable = Ti siña marefirensia i indise `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ti siña ma'ågang i { $action } gi komponente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Ti maolek i fotman i data.  Ti parehu i anåkkon i liña. Masodda' gi componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Guaha na'ån kolumna ni parehu gi data.  Masodda' gi componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Taya' na'ån un kolumna gi data.  Masodda' gi componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = I award este na ineppe' basåo gi ineppe' ni manenå'i i answer tag mismo, ya u fa'na'guaha ti manangga na cho'cho'.
+
+answer-max-num-attempts-in-section-wide-check-work = Taya' efekto i mapo'lo i `maxNumAttempts` gi un `<answer>` gi halom un kahon ni guaha `sectionWideCheckWork`, sa' i kahon ha kontrola i kuenton chinagi. Po'lo i `maxNumAttempts` gi kahon.
+
+nested-section-wide-check-work-max-num-attempts = Taya' efekto i mapo'lo i `maxNumAttempts` gi un kahon ni guaha `sectionWideCheckWork` ni gaige gi halom otro kahon ni guaha `sectionWideCheckWork`, sa' i kahon gi sanhiyong ha kontrola i kuenton chinagi. Po'lo i `maxNumAttempts` gi kahon gi sanhiyong.
+
+# No select: «atributo» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Taya' efekton i atributo { $attributes } yanggen ti mapo'lo i symbolicEquality.
+
+answer-invalid-type = Ti maolek na klåsi para i ineppe': { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sa' taya' na'ån i komponente `<{ $component }>`, ti siña masetbe komo atributon i module
+
+module-attribute-name-already-defined = Ti siña masetbe i komponente `<{ $component } name="{ $name }">` komo atributon i module sa' guaha esta atributo "{ $name }" i klåsen komponente `<module>`.
+
+conditional-content-condition-ignored = Ma'ignora i atributo `condition` gi komponente `<conditionalContent>` ni guaha famagu'on case pat else.
+
+slider-markers-type-mismatch = Ti parehu i klåsen marker yan i klåsen slider.
+
+pretzel-problem-needs-statement-and-answer = Ti maolek na pretzel: debi di guaha unu na `<statement>` yan unu na `<answer>` kada `<problem>`.
+
+pretzel-circuit-first-problem-distractor = Ti maolek na pretzel: gi mode="circuit", ti siña distractor i fine'nana na `<problem>`.
+
+## Attribute values
+
+# No select: «balot» is the same word for one and for many.
+attribute-invalid-values = Ti maolek na balot { $values } para i atributo `{ $attribute }`; ma'ignora.
+
+attribute-must-be-references = Ti maolek na balot `{ $value }` para i atributo `{ $attribute }`. Debi di u mafa'tinas i atributo ginen refirensia ni matutuhon ni `$`.
+
+math-input-invalid-function-names = <mathInput>: ma'ignora i na'ån funsion ni ti maolek gi { $attribute }: { $names }. Debi di guaha dos pat mås na letra kada na'ån (letra pat gion); siña ha dalalak un suffix `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Ti maolek na klåsen komponente: `<{ $componentType }>`
+
+attribute-repeated = Ti siña marepiti i atributo { $attribute }.
+
+attribute-invalid-for-component = Ti maolek na atributo "{ $attribute }" para i komponente klåsi `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Ti nahong i kontrasten i definasion estilo { $styleNumber } para i { $context ->
+        [text-on-background] kulot i teksto kontra i kulot i tatte
+        [high-contrast] kulot takhilo' na kontraste kontra i kanbas
+        [line] kulot i liña kontra i kanbas
+        [marker] kulot i marker kontra i kanbas
+       *[text-on-canvas] kulot i teksto kontra i kanbas
+    }{ $mode ->
+        [dark] { " (mode homhom)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nesesita { $threshold }:1 pat mås).
+
+style-definition-dark-mode-text-background-contrast =
+    Achok' ha' guaha kulot ni madetetmina i definasion estilo { $styleNumber } ya nahong i kontrasten-ñiha para i mode mananana, ti nahong i kontrasten i kulot i teksto kontra i kulot i tatte gi kulot ni machule' para i mode homhom ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nesesita { $threshold }:1 pat mås). { $suggestion ->
+        [available] Para u nahong i kontraste gi mode homhom, na'dångkulo i kontrasten i mode mananana (ehemplo, po'lo i { $lightAttribute }="{ $lightColor }") pat tulaika i kulot i mode homhom (ehemplo, po'lo i { $darkAttribute }="{ $darkColor }").
+       *[none] Para u nahong i kontraste gi mode homhom, na'dångkulo i kontrasten i mode mananana pat tulaika i kulot ni machule' ni textColorDarkMode yan/pat backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Achok' ha' guaha kulot teksto ni madetetmina i definasion estilo { $styleNumber } ya nahong i kontraste-ña para i mode mananana, ti nahong i kontrasten i kulot teksto ni machule' para i mode homhom kontra i kanbas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; nesesita { $threshold }:1 pat mås). { $suggestion ->
+        [available] Para u nahong i kontraste gi mode homhom, na'dångkulo i kontrasten i mode mananana (ehemplo, po'lo i textColor="{ $lightColor }") pat tulaika i kulot i mode homhom (ehemplo, po'lo i textColorDarkMode="{ $darkColor }").
+       *[none] Para u nahong i kontraste gi mode homhom, na'dångkulo i kontrasten i mode mananana pat tulaika i kulot ni machule' ni textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Unu ha' na <stylePalette> siña ma'ayek un seksion; masetbe i uttimo.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ti siña madetetmina i bariånte unibetsåt i { $component } sa' ti kabåles na numero ni ti negatibu i numToSelect.
+
+variant-num-to-select-not-constant-number = ti siña madetetmina i bariånte unibetsåt i { $component } sa' ti konstante na numero i numToSelect.
+
+variant-with-replacement-not-constant-boolean = ti siña madetetmina i bariånte unibetsåt i { $component } sa' ti konstante na boolean i withReplacement.
+
+variant-select-weight-disables-unique = Mapuno' i bariånte unibetsåt para i select yanggen guaha opsion ni madetetmina i selectWeight pat i selectForVariants
+
+variant-coprime-undetermined = ti siña madetetmina i bariånte unibetsåt i { $component } sa' ti siña madetetmina na siempre false i coprime.
+
+variant-attribute-not-constant = ti siña madetetmina i bariånte unibetsåt i { $component } sa' ti konstante i { $attribute }.
+
+variant-attribute-not-number = ti siña madetetmina i bariånte unibetsåt i { $component } sa' ti numero i { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    ti siña madetetmina i bariånte unibetsåt i { $component } klåsi { $type } sa' ti { $expected ->
+        [letters-combination] kombinasion letra
+        [math-expression] maolek na ekspresion matemåtika
+        [integer] kabåles na numero
+       *[number] numero
+    } i { $attribute }.
+
+variant-length-not-integer = ti siña madetetmina i bariånte unibetsåt i { $component } sa' ti kabåles na numero i length.
+
+variant-sort-not-implemented = trabiha ti mafa'tinas i bariånte unibetsåt un { $component } ni guaha sort
+
+variant-exclude-combinations-not-implemented = trabiha ti mafa'tinas i bariånte unibetsåt un { $component } ni guaha excludeCombinations
+
+variant-math-exclude-not-implemented = trabiha ti mafa'tinas i bariånte unibetsåt un { $component } klåsi math ni guaha exclude
+
+variant-non-constant-exclude-not-implemented = trabiha ti mafa'tinas i bariånte unibetsåt un { $component } ni guaha exclude ni ti konstante
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ti masetbe gi renderer prefigure i graph; malaktos i linahyan.
+
+prefigure-descendant-invalid-geometry = { $subject }: ti kabåles pat ti finite i heometria; malaktos i linahyan.
+
+prefigure-curve-label-omitted = { $subject }: ti masetbe i etiketa gi kotba ni makonbietti; ma'ignora i etiketa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ti masetbe i klåsen definasion funsion kotba '{ $definitionType }'; malaktos i linahyan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: ti masetbe i atributo flipFunctions gi regionBetweenCurves; malaktos i linahyan.
+
+prefigure-region-non-formula-child = { $subject }: i famagu'on funsion klåsi formula ha' masetbe gi regionBetweenCurves; malaktos i linahyan.
+
+prefigure-label-position-unsupported =
+    { $subject }: ti masetbe i labelPosition '{ $labelPosition }' para i { $labelKind ->
+        [line-family] etiketan i familian liña
+       *[point] etiketan i punto
+    }; masetbe i kostumbren alineasion PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: ti masetbe ni PreFigure i estilon i sanhalom '{ $fillStyle }'; matalo' guatu gi bula na sanhalom.
+
+prefigure-line-style-unknown = { $subject }: ti matungo' i estilon liña '{ $lineStyle }', ma'ignora gi output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: mapega i estilon marker '{ $markerStyle }' gi estilo 'diamond' PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: ti masetbe ni PreFigure i estilon marker '{ $markerStyle }'; masetbe i kostumbren estilo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: ti maolek na `ref`; ti siña ma'apunta i target. Ma'ignora i annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: ha apunta i `ref` meggai na target; masetbe i fine'nana na target.
+
+annotation-ref-outside-graph = `<annotation>`: ti maolek na `ref`; gaige i target gi sanhiyong i graph ni gaige gui'. Ma'ignora i annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: ti maolek na `ref`; ti grafiko na guinaha ni masetbe i target gi konbetsion prefigure. Ma'ignora i annotation.
+
+annotation-text-missing = `<annotation>`: taya' pat baså i `text`; ha na'huyong baså na teksto.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Masodda' un dependensia sirkulåt.
+       *[other] Masodda' un dependensia sirkulåt ni ha inkluye i komponente `<{ $componentType }>`.
+    }
+
+reference-no-referent = Taya' masodda' ni ma'apunta i refirensia: `{ $reference }`
+
+reference-multiple-referents = Meggai masodda' ni ma'apunta i refirensia: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Ti maolek na fotmåtu i atributo { $attribute } i `<{ $componentType }>`.
+
+children-invalid = Ti maolek i famagu'on i `<{ $componentType }>`: masodda' famagu'on ni ti maolek: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ti maolek na balot `{ $value }` para i atributo `{ $attribute }`, masetbe i balot `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ti masodda' i betsion DoenetML { $version }.
+       *[other] Ti masodda' i betsion DoenetML { $version }. Matalo' guatu gi betsion { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Ti maolek na DoenetML: { $content }
+
+parse-tag-missing-close-tag = Ti maolek na DoenetML: Taya' tag pangkhuchom i tag `{ $tag }`. Manangga un tag ni ha huchom maisa pat un tag `</{ $tagName }>`.
+
+parse-tag-error = Ti maolek na DoenetML: Guaha linachi gi tag `<{ $tagName }>`
+
+parse-attribute-missing-value = Ti maolek na DoenetML: Kalan taya' balot i atributo ni ti maolek `{ $attribute }`.
+
+parse-attribute-invalid = Ti maolek na DoenetML: Ti maolek na atributo `{ $attribute }`
+
+parse-attribute-value-invalid = Ti maolek na DoenetML: Ti maolek na balot atributo `{ $value }`
+
+parse-attribute-value-quote-mismatch = Ti maolek na DoenetML: Ti maolek na balot atributo `{ $value }`. Ti parehu i marka sita. Kalan taya' unu na `{ $quote }`
+
+parse-open-tag-name-missing = Ti maolek na DoenetML: Masodda' un tag ni taya' na'ån-ña, ehemplo `<`
+
+parse-tag-not-closed = Ti maolek na DoenetML: Ti mahuchom i tag `{ $tag }` (kalan taya' `>`).
+
+parse-self-closing-tag-name-missing = Ti maolek na DoenetML: Masodda' un tag ni taya' na'ån-ña `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Ti maolek na DoenetML: Ti mahuchom i tag `{ $tag }` (kalan taya' `/>`).
+
+parse-tag-invalid-attributes = Ti maolek na DoenetML: Ti maolek i tag `{ $tag }`. Siña ti maolek i atributo-ña.
+
+parse-close-tag-name-missing = Ti maolek na DoenetML: Masodda' un tag pangkhuchom ni taya' na'ån-ña, ehemplo `</`
+
+parse-attribute-value-unquoted = Debi di u mapo'lo gi halom marka sita i balot atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Ti maolek na DoenetML: Masodda' un tag pangkhuchom `{ $tag }`, lao taya' tag pangbaba ni parehu
+
+parse-close-tag-mismatched = Ti maolek na DoenetML: Ti parehu i tag pangkhuchom. Manangga i `</{ $expected }>`. Masodda' i `{ $found }`
+
+parser-node-unconvertible = Ti siña makonbietti i node { $node } para un node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Ti maolek na atributo name='{ $name }'. { $reason ->
+        [characters] Siña ha' guaha letra, numero, guion papa' pat guion gi na'ån.
+       *[start] Debi di u tutuhon i na'ån ni un letra.
+    }
+
+component-name-invalid-start = Ti maolek na na'ån komponente "{ $name }". Debi di u tutuhon i na'ån ni un letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Debi di guaha atributo video i answer ni type videoWatched
+
+answer-video-watched-video-not-reference = Debi di refirensia i atributo video i answer ni type videoWatched
+
+answer-name-not-single-text = Debi di guaha unu ha' na famagu'on text i atributo name i answer
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ti siña machule' i DoenetML gi sanhiyong sa' megai megai i nibet i marepiti. Guaha refirensia sirkulåt?
+
+external-doenetml-unavailable = Ti siña machule' i DoenetML ginen i { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Ti maolek na DoenetML machule' ginen i { $attribute }="{ $uri }": ti parehu yan i klåsen komponente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Ti masetbe mås i atributo `{ $from }`; setbe i `{ $to }`.
+       *[other] [deprecation] Ti masetbe mås i atributo `{ $from }` gi `<{ $component }>`; setbe i `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Ti masetbe mås i atributo `{ $from }` ya ma'ignora sa' madetetmina lokkue' i `{ $to }`.
+       *[other] [deprecation] Ti masetbe mås i atributo `{ $from }` gi `<{ $component }>` ya ma'ignora sa' madetetmina lokkue' i `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Ti masetbe mås i atributo `{ $attribute }` gi `<{ $component }>` ya ma'ignora.
+
+deprecated-attribute-to-child = [deprecation] Ti masetbe mås i atributo `{ $attribute }` gi `<{ $component }>`; setbe un famagu'on `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Ti masetbe mås i balot `{ $value }` i atributo `{ $attribute }` gi `<{ $component }>`; setbe i `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = Siña ha' ha na'meggai i `<pluralize>` i fino' Engles, pues ti matulaika i teksto-ña gi dokumento ni matuge' ni { $locale }. Tuge' mismo i fotman meggai, pat po'lo ni atributo `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = I elemento `<{ $tag }>` ti elementon Doenet ni matungo'.
+
+schema-element-not-allowed-at-root = Ti mapetmiti i elemento `<{ $tag }>` gi hale' i dokumento.
+
+schema-element-not-allowed-inside = Ti mapetmiti i elemento `<{ $tag }>` gi halom i `<{ $parent }>`.
+
+schema-attribute-unrecognized = Taya' atributo na'ån-ña `{ $attribute }` i elemento `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Debi di u lista i atributo `{ $attribute }` i elemento `<{ $tag }>` ni kada guinaha-ña unu gi: { $allowed }
+       *[other] Debi di unu gi este siha i atributo `{ $attribute }` i elemento `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Ti maolek na na'ån bariånte para i select.  Humuyong i na'ån bariånte { $variantName } gi { $numOptions } na opsion lao { $numToSelect } i kuenton ma'ayek.
+
+select-variant-name-without-options = Guaha bariånte madetetmina para i select lao taya' opsion madetetmina para i posiblen na'ån bariånte: { $variantName }.
+
+select-variant-name-not-possible = I na'ån bariånte { $variantName } ni madetetmina para i select ti posiblen na'ån bariånte.
+
+select-too-few-options = Ti siña ma'ayek { $numToSelect } na komponente ginen { $numOptions } ha'.
+
+select-from-sequence-too-few-values = Ti siña ma'ayek { $numToSelect } na balot ginen un sequence ni { $length } i anåkkon-ña.
+
+select-from-sequence-indices-count-mismatch = Debi di u parehu i kuenton indise ni madetetmina para i select yan i kuenton ma'ayek
+
+select-from-sequence-indices-not-integers = Debi di kabåles na numero todu i indise ni madetetmina para i select
+
+select-from-sequence-index-excluded = I indisen selectfromsequence ni madetetmina ma'ekskluye
+
+select-from-sequence-indices-excluded-combination = I indisen selectfromsequence ni madetetmina un kombinasion ni ma'ekskluye
+
+select-from-sequence-coprime-not-positive-integers = Ti siña ma'ayek kombinasion coprime sa' ti kabåles na numero positibu i ma'ayek.
+
+select-from-sequence-coprime-common-factor = Ti siña ma'ayek numero coprime. Guaha faktot parehu todu i posiblen balot. (Debi di u coprime i balot "from" pat "to" yan i "step".)
+
+select-from-sequence-coprime-single-number = Ti siña ma'ayek kombinasion coprime ginen unu ha' na numero ni ti 1.
+
+select-from-sequence-excluded-too-many-combinations = Ma'ekskluye mås ki 70% i kombinasion gi selectFromSequence
+
+select-from-sequence-coprime-none-found = Ti siña ma'ayek numero coprime. Guaha faktot parehu todu i posiblen balot.
+
+select-from-sequence-too-few-unique-values = Ti siña ma'ayek { $numToSelect } na balot unibetsåt ginen un sequence ni { $numPossibleValues } i anåkkon-ña
+
+select-prime-numbers-too-few-values = Ti siña ma'ayek { $numToSelect } na balot ginen un listan prima ni { $numValues } i anåkkon-ña
+
+select-prime-numbers-values-count-mismatch = Debi di u parehu i kuenton balot ni madetetmina para i select yan i kuenton ma'ayek
+
+select-prime-numbers-values-not-prime = Debi di gaige gi listan prima todu i balot ni madetetmina para i select prime number
+
+select-prime-numbers-values-excluded-combination = I balotan selectPrimeNumbers ni madetetmina un kombinasion ni ma'ekskluye
+
+select-prime-numbers-excluded-too-many-combinations = Ma'ekskluye mås ki 70% i kombinasion gi selectPrimeNumbers
+
+select-random-combination-fluke = Sa' un suette ni ti guaguan, ti siña ma'ayek un kombinasion balot råndom
+
+select-random-value-fluke = Sa' un suette ni ti guaguan, ti siña ma'ayek un balot råndom

--- a/packages/i18n/locales/ch/editor.ftl
+++ b/packages/i18n/locales/ch/editor.ftl
@@ -1,0 +1,208 @@
+# Chamorro editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Written in the Guam orthography; see `chrome.ftl`. Chamorro marks no number on
+# the noun, so a `{ $count -> … }` whose two English branches differ only in the
+# noun renders one string here and the select is dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Na'tålo'
+       *[update] Na'nuebu
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } i atan
+       *[other] { $word } i atan { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Bariånte
+editor-variant-filter = Sedåsu…
+editor-variant-next = Ayek i sigiente na bariånte
+editor-variant-previous = Ayek i antes na bariånte
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Masodda' un kinentra i akseso WCAG AA. Klek para u { $action ->
+            [close] mahuchom
+           *[open] mababa
+        } i ripot i akseso.
+        [advisories] Klek para u { $action ->
+            [close] mahuchom
+           *[open] mababa
+        } i ripot i akseso. Taya' kinentra WCAG AA masodda', lao guaha mås na rekomendasion put i akseso.
+       *[clean] Klek para u { $action ->
+            [close] mahuchom
+           *[open] mababa
+        } i ripot i akseso. Taya' problema put i akseso masodda'.
+    }
+
+# No select on `$count` inside the branches: «kinentra» and «rekomendasion» are
+# the same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Masodda' un kinentra i akseso WCAG AA. Masodda' { $count } na kinentra WCAG AA. Klek para u { $action ->
+            [close] mahuchom
+           *[open] mababa
+        } i ripot i akseso.
+        [advisories] Taya' kinentra WCAG AA masodda'. Masodda' { $count } na mås rekomendasion put i akseso. Klek para u { $action ->
+            [close] mahuchom
+           *[open] mababa
+        } i ripot i akseso.
+       *[clean] Taya' kinentra WCAG AA masodda'. Klek para u { $action ->
+            [close] mahuchom
+           *[open] mababa
+        } i ripot i akseso.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Betsion DoenetML { $version }
+
+editor-tab-help = Ayudu ni tåtte i kontekto
+editor-tab-help-short = Kontekto
+editor-tab-errors = Linachi
+editor-tab-warnings = Adbertensia
+editor-tab-info = Infotmasion
+editor-tab-accessibility = Akseso
+editor-tab-responses = Ineppe' ni manmanenå'i
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opsion i editót
+editor-format-as-doenetml = Fotmåtu komo DoenetML
+editor-format-as-xml = Fotmåtu komo XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Liña #{ $line }
+
+editor-no-errors = Taya' linachi
+editor-no-warnings = Taya' adbertensia
+editor-no-info = Taya' diagnostiko infotmasion
+
+editor-show-info-annotations = Na'annok i diagnostiko infotmasion gi editót
+editor-show-accessibility-annotations = Na'annok i diagnostiko i akseso gi editót
+
+editor-accessibility-learn-more = Eyak håfa kumekeilek-ña i akseso para Doenet
+
+editor-accessibility-violations-heading = Kinentra i akseso ({ $standard })
+
+editor-accessibility-other-heading = Otro na problema put i akseso
+editor-none-found = Taya' masodda'
+
+
+## Submitted responses
+
+editor-no-responses = Trabiha taya' ineppe' manmanenå'i
+editor-response-answer-id = Id i ineppe'
+editor-response-response = Ineppe'
+editor-response-credit = Kredito
+editor-response-submitted = Manmanenå'i
+
+
+## The context-help panel
+
+help-placeholder = Po'lo i kutsot gi na'ån tag, atributo, pat gi { $ref } para i dokumentasion.
+
+help-unsupported-ref-chain = Trabiha ti masetbe i ayudu para i refirensia ni meggai na patte kalan i { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Taya' masodda' ni ma'apunta i refirensia: { $ref }.
+        [multiple] Meggai masodda' ni ma'apunta i refirensia: { $ref }.
+       *[indeterminate] Ti siña matungo' håfa ma'apunta i { $ref }.
+    }
+
+help-learn-about-references = Eyak put i refirensia →
+help-reference-page = Påhinan refirensia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Gi halom { $element }
+       *[top] Gi mås takhilo' na nibet
+    }{ $allowed ->
+        [none] { " — taya' siña mapo'lo guini." }
+        [text] { " — tuge' teksto guini." }
+        [text-and-components] { " — tuge' teksto guini, pat chagi:" }
+       *[components] { " — siña machagi:" }
+    }
+
+help-suggestions-footer = Pucha i { $shortcut } para un li'e' todu i { $total } na komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] I { $ref } refirensia para i { $target }.
+       *[other] I { $ref } refirensia para i { $target } (liña { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Machule' ginen i { $owner } komo { $role }.
+       *[other] Machule' ginen i { $owner } gi liña { $line } komo { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] I { $ref } refirensia para i propiedåt { $property } i { $element }.
+       *[other] I { $ref } refirensia para i propiedåt { $property } i { $element } (liña { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = dikike' na kodigo
+help-kind-array-entry = entråda gi array
+
+help-default = Kostumbre:
+help-active-default = Kostumbre ni aktibo:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Balot ni matulaika (unu kada bånda):
+       *[other] Balot ni matulaika:
+    }
+
+help-suggested-values = Balot ni marekomienda:
+
+help-inserts = Muna'hålom:
+
+# No select: «koordinåda» is the same word for one and for many.
+help-coordinates = Koordinåda:
+
+help-type = Klåsi:
+
+help-resolved-style = Estilo ni matungo' (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Na'ån funsion ni matungo':
+help-reset-list = Listan na'tålo' gi este na input:
+help-added-on-input = Mana'saga gi este na input:
+help-removed-on-input = Mana'suha gi este na input:
+
+help-reset-overrides = I { $reset } ha tulaika i { $additional } yan i { $removed }.

--- a/packages/i18n/locales/fj/chrome.ftl
+++ b/packages/i18n/locales/fj/chrome.ftl
@@ -1,0 +1,144 @@
+# Fijian viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Standard Fijian (Bauan), the variety Fijian publishing, radio and
+# the school readers use. The orthography is the one the Bible translation
+# settled and the Ministry of Education follows: «b», «d», «q» and «g» are the
+# prenasalized and velar consonants, not the English ones, so «drokadroka» and
+# «karakarawa» are spelled as they stand rather than respelled.
+#
+# Fijian marks no number on the noun — «e dua na laini» and «e vica na laini»
+# differ in the numeral, not in the noun — so a `{ $count -> … }` whose two
+# English branches differ only in the noun renders one string here and the
+# select is dropped. A `[0]` branch stays wherever English has one.
+
+
+## Answer submission
+
+answer-checking = Sa vakadikevi tiko…
+answer-submitting = Sa vakau tiko…
+
+answer-checking-status = Sa vakadikevi tiko na isau
+answer-submitting-status = Sa vakau tiko na isau
+
+answer-correct = Dodonu
+answer-incorrect = Sega ni dodonu
+
+answer-response-saved = Sa maroroi na isau
+
+answer-percent-credit = { $percent }% na ivotavota
+answer-percent-correct = { $percent }% dodonu
+answer-percent-short = { $percent } %
+
+max-credit-available = Ivotavota levu duadua e rawati: { $percent }%
+
+# No select: «itovo ni saga» is the same phrase for one and for many. The `[0]`
+# branch stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] sa sega na isaga e vo
+       *[other] e vo tiko e { $count } na isaga
+    }
+
+validation-correct = (Dodonu)
+validation-incorrect = (Sega ni dodonu)
+validation-partially-correct = (Dodonu ena dua na tikina)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Vakaraitaka e { $count } na isau me baleta na { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Ivakamacala
+
+collapsible-click-to-open = (kilika me dolavi)
+collapsible-click-to-close = (kilika me sogoti)
+
+collapsible-initializing = Sa tekivu tiko…
+
+footnote-show = Vakaraitaka na footnote
+footnote-hide = Vunitaka na footnote
+
+description-more-information = itukutuku tale
+
+
+## Controls
+
+slider-previous = Liu
+slider-next = Tarava
+
+keyboard-open = Dolava na kipodi
+keyboard-close = Sogota na kipodi
+
+choice-input-remove-choice = Kau tani na { $choice }
+
+matrix-remove-row = Kau tani na rowa
+matrix-add-row = Kuria e dua na rowa
+matrix-remove-column = Kau tani na duru
+matrix-add-column = Kuria e dua na duru
+
+subset-add-remove-points = Kuria/Kau tani na poini
+subset-toggle-points-intervals = Veisautaka na poini kei na kalawa
+subset-move-points = Toso na poini
+subset-clear = Vakasavasavataka
+
+orbital-add-row = Kuria e dua na rowa
+orbital-remove-row = Kau tani na rowa
+orbital-add-box = Kuria e dua na kato
+orbital-remove-box = Kau tani na kato
+orbital-add-up-arrow = Kuria e dua na iviri cake
+orbital-add-down-arrow = Kuria e dua na iviri sobu
+orbital-remove-arrow = Kau tani na iviri
+
+orbital-row-label = Iyacana ni rowa { $row }
+
+pretzel-answer = Isau
+
+summary-statistics-caption = Ilairai vakaiwiliwili ni { $column }
+
+
+## Math input
+
+math-input-preview-region = irairai taumada ni ivakamacala vakaiwiliwili
+math-input-preview = Irairai taumada
+math-input-invalid-expression = Ivakamacala e sega ni dodonu:
+
+
+## Document status
+
+viewer-initializing = Sa tekivu tiko…
+
+
+## Errors
+
+error-heading = Cala
+
+error-found-at =
+    { $span ->
+        [line] E kune ena laini { $startLine }.
+       *[lines] E kune ena laini { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = E tiko e so na cala ena ivola oqo!
+
+diagnostic-heading-error = Cala
+diagnostic-heading-warning = Ivakasalasala
+diagnostic-heading-information = Itukutuku
+diagnostic-heading-hint = Idusidusi
+
+accessibility-heading-level-1 = Beitaki ni ivakatagedegede ni rawarawa WCAG AA
+accessibility-heading-level-2 = Ivakasalasala me baleta na rawarawa
+
+something-went-wrong = E dua na ka e cala.
+
+renderer-load-failed = e dua na renderer e sega ni laveti rawa. Yalovinaka lomani tale na tabana.
+
+core-start-failed = Sa sega ni tekivu rawa na irairai ni ivola. Yalovinaka lomani tale na tabana.

--- a/packages/i18n/locales/fj/content.ftl
+++ b/packages/i18n/locales/fj/content.ftl
@@ -1,0 +1,257 @@
+# Fijian content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Standard Fijian (Bauan); see `chrome.ftl`'s header.
+#
+# Fijian has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «laini damudamu», a red line — so every
+# composition message inverts the English order.
+#
+# **The colour words are reduplicated stems**, which is the shape Fijian gives a
+# property word: «loaloa», «vulavula», «damudamu», «drokadroka». That is not
+# emphasis and not a plural; the reduplicated form *is* the colour word, and a
+# corrector who shortens one to its bare stem is writing a different word.
+# «karakarawa» is the entry to look at first: it names the blue of deep water
+# and reaches into the greens, so the line between it and «drokadroka» does not
+# fall where English puts the line between blue and green, and `.cyan` sits
+# inside it with nothing of its own — the transliteration written there is a
+# placeholder rather than a word.
+#
+# The geometry vocabulary is largely English-derived, because Fiji teaches
+# mathematics in English from the primary grades: «laini», «sekele»,
+# «rekitageli». Where Fijian has its own word it is written. That seam is a fact
+# about the school system and is the first thing a speaker should judge.
+
+
+## Style vocabulary
+
+color =
+    .black = loaloa
+    .white = vulavula
+    .gray = kuvukuvu
+    .red = damudamu
+    .orange = oreni
+    .yellow = dromodromo
+    .green = drokadroka
+    .cyan = saiani
+    .blue = karakarawa
+    .purple = vaiolete
+    .pink = pingi
+    .brown = buraunu
+
+line-width =
+    .thick = levu
+    .thin = lailai
+
+line-style =
+    .dashed = musumusu
+    .dotted = tokitoki
+
+# Noun phrases. Fijian marks no plural on the noun, so «laini» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = laini davo
+    .vertical = laini duri
+    .diagonal = laini sivia
+    .backdiagonal = laini sivia vakasosomi
+    .dots = toki
+    .diamonds = daimani
+
+noun =
+    .line = laini
+    .line-segment = iwase ni laini
+    .ray = serau
+    .vector = vekita
+    .curve = kavu
+    .function = fanisini
+    .parabola = parabola
+    .polyline = laini vakabekabe
+    .polygon = poligani
+    .triangle = taraiageli
+    .rectangle = rekitageli
+    .circle = sekele
+    .region = yasana
+    .point = poini
+    .square = sikuea
+    .diamond = daimani
+    .cross = kurusi
+    .plus = purasi
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] e { $numSides } na yasana
+       *[head] poligani veitautauvata
+    }
+
+# One answer for every noun: Fijian has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = sinai
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } kei na { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } kei na { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } kei na { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Fijian's «na» is the common article and is not what English's "a" is doing
+# here, so all four branches read alike but for the connective: «kei na» opens
+# the first clause and «kei na tale ga» a further one.
+style-border-clause =
+    { $parts ->
+        [with-article] kei na bati { $border }
+        [and] kei na tale ga na bati { $border }
+        [and-article] kei na tale ga na bati { $border }
+       *[with] kei na bati { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = sega ni sinai
+
+style-text =
+    { $parts ->
+        [background] { $color } kei na tuvaki { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = sega
+
+
+## Boolean words
+
+boolean-true = dina
+boolean-false = lasu
+
+
+## Answer buttons
+
+answer-submit-label = Vakadikeva na cakacaka
+answer-submit-label-no-correctness = Vakauta na isau
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Fijian marks no plural on the noun.
+section-name =
+    .activity = Cakacaka
+    .aside = Ivola ni yasana
+    .cascade = Kasiketi
+    .definition = Ibalebale
+    .example = Ivakaraitaki
+    .exercise = Ivakatovotovo
+    .exercises = Ivakatovotovo
+    .given-answer = Isau
+    .note = Ivola
+    .objectives = Inaki
+    .paragraphs = Parakaravu
+    .part = Tikina
+    .problem = Ituvatuva ni leqa
+    .problems = Ituvatuva ni leqa
+    .proof = Ivakadinadina
+    .question = Taro
+    .section = Wase
+    .solution = Isolisoli ni leqa
+    .task = Itavi
+    .theorem = Tioreme
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Idusidusi
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Teveli { $enumeration }
+        [numbered-title] Teveli { $enumeration }{ ": " }
+        [unnumbered-title] Teveli{ ": " }
+       *[unnumbered] Teveli
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Iyaloyalo { $enumeration }
+        [numbered-caption] Iyaloyalo { $enumeration }{ ": " }
+        [unnumbered-caption] Iyaloyalo{ ": " }
+       *[unnumbered] Iyaloyalo
+    }
+
+
+## Paginator controls
+
+paginator-previous = Liu
+paginator-next = Tarava
+paginator-page = Tabana
+
+paginator-page-status = { $pageLabel } { $currentPage } mai na { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = se
+piecewise-condition-if = kevaka
+piecewise-condition-otherwise = kevaka e sega
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Fiji teaches secondary science in English, and Fijian has no settled
+## list of all 118 to seed from — the Samoan, Hawaiian and Tongan case, and for
+## the same reason.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Ivakatakilakila ni kemikali e sega ni dodonu
+chemistry-invalid-ionic-compound = Iwiliwili ni aioni e sega ni dodonu

--- a/packages/i18n/locales/fj/diagnostics.ftl
+++ b/packages/i18n/locales/fj/diagnostics.ftl
@@ -1,0 +1,624 @@
+# Fijian diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Fijian marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+
+
+## `<lineSegment>`
+
+# No select: «sa beci» does not agree with what is ignored, and the list carries
+# no number of its own.
+line-segment-attributes-ignored-with-endpoints = sa beci na { $attributes } ni sa vakatakilai na rua na iyalayala
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = sa beci na { $attributes } ni sa vakatakilai na dua na iyalayala kei na loma
+
+line-segment-midpoint-offset-without-midpoint = e sega ni yaga na midpointOffset ke sega na loma
+
+## `<line>`
+
+line-points-undetermined-dimensions = Laini e lako yani ena poini e sega ni kilai na kena rabalevu.
+
+line-points-too-few-dimensions = E dodonu me lako na laini ena poini e rua se sivia na kena rabalevu.
+
+line-points-depend-on-variables = Na laini e lako yani ena poini e vakararavi ena veisau: { $variables }.
+
+line-equation-invalid-format = Ivakarau ni ikuwe ni laini e sega ni dodonu ena veisau { $variable1 } kei na { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Na serau e vakatakilai ena through, endpoint kei na direction.  Sa beci na through e vakatakilai.
+
+ray-dimension-mismatch = e sega ni veiganiti na numDimensions ena serau.
+
+## `<vector>`
+
+vector-overprescribed-head = Na vekita e vakatakilai ena head, tail kei na displacement.  Sa beci na head e vakatakilai.
+
+vector-dimension-mismatch = e sega ni veiganiti na numDimensions ena vekita.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = E sega ni rawa ni dreti ki na `<{ $component }>` ni sega ni tiko vua na veisau ni ituvaki nearestPoint.
+
+constrain-to-without-nearest-point = E sega ni rawa ni vakaiyalayalataki ki na `<{ $component }>` ni sega ni tiko vua na veisau ni ituvaki nearestPoint.
+
+constrain-to-interior-without-nearest-point = E sega ni rawa ni vakaiyalayalataki ki na loma ni `<{ $component }>` ni sega ni tiko vua na veisau ni ituvaki nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = sa beci na labelPosition ena choiceInput e sega ni inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Sa beci na indeki e vakatakilai me baleta na choiceInput ni sega ni veiganiti na iwiliwili ni indeki kei na iwiliwili ni digidigi.
+
+pretzel-indices-count-mismatch = Sa beci na indeki e vakatakilai me baleta na problem ni sega ni veiganiti na iwiliwili ni indeki kei na iwiliwili ni problem.
+
+shuffle-indices-count-mismatch = Sa beci na indeki e vakatakilai me baleta na shuffle ni sega ni veiganiti na iwiliwili ni indeki kei na iwiliwili ni iwasewase.
+
+indices-ignored-out-of-range = Sa beci na indeki e vakatakilai me baleta na { $component } ni tiko e dua na indeki e sivia na iyalayala.
+
+pretzel-indices-repeated = Sa beci na indeki e vakatakilai me baleta na pretzel ni tiko e dua na indeki e vakaruataki.
+
+pretzel-circuit-first-index = Sa beci na indeki e vakatakilai me baleta na pretzel ena mode circuit ni dodonu me 1 na indeki imatai.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Me cakacaka na `<{ $component }>` kei na luvena string, e dodonu me vakatakilai na atirabiuti `type`.
+
+invalid-type-defaulting-to-math = Na type { $type } e sega ni dodonu me baleta na iwasewase { $component }. E dodonu me dua vei math, text, number, se boolean. Sa vakayagataki na math.
+
+string-not-valid-component-to-arrange = Na string "{ $value }" e sega ni iwasewase dodonu me baleta na { $component }. Sa beci.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Na type { $type } e sega ni dodonu, sa biu na type ki na number.
+
+invalid-variable-value = Ivalu ni veisau e sega ni dodonu: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = E dodonu me namba na indeki ni ivakaduidui { $index }
+
+variant-index-must-be-integer = E dodonu me namba taucoko na indeki ni ivakaduidui { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Se bera ni caka rawa na `<{ $component }>` me baleta na ivakarau dei. Sa biu me veisau na kena rabalevu.
+
+side-by-side-absolute-margins = Se bera ni caka rawa na `<{ $component }>` me baleta na ivakarau dei. Sa biu me veisau na kena bati.
+
+side-by-side-no-block-child = `<{ $component }>` e sega ni dodonu: e dodonu me tiko vua e dua na luvena block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Sa beci na atirabiuti `for` ena `<label>` vakairairai.
+
+label-for-must-resolve-to-one = E dodonu me dusia na atirabiuti `for` ena `<label>` e dua ga na iwasewase.
+
+label-for-unresolved = E sega ni dusia rawa na atirabiuti `for` ena `<label>` e dua na iwasewase.
+
+label-for-answer-with-authored-inputs = Na atirabiuti `for` ena `<label>` e dusia e dua na `<answer>` e tiko kina na icurucuru e volai vua na dauvola; dusia sara ga na icurucuru.
+
+label-for-answer-without-input = Na atirabiuti `for` ena `<label>` e dusia e dua na `<answer>` e sega ni tiko kina e dua na icurucuru me vakayacani.
+
+label-for-must-reference-input-or-answer = E dodonu me dusia na atirabiuti `for` ena `<label>` e dua na icurucuru se e dua na answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Me baleta na rawarawa, e dodonu me tiko vua na `<{ $component }>` e dua na ivakamacala lekaleka se me vakatakilai me iukuuku.
+
+accessibility-video-short-description = Me baleta na rawarawa, e dodonu me tiko vua na `<video>` e dua na ivakamacala lekaleka.
+
+accessibility-input-short-description-or-label = Me baleta na rawarawa, e dodonu me tiko vua na `<{ $component }>` e dua na ivakamacala lekaleka se e dua na iyaca.
+
+accessibility-answer-input-short-description-or-label = Me baleta na rawarawa, e dodonu me tiko vua e dua na `<answer>` e buli icurucuru e dua na ivakamacala lekaleka se e dua na iyaca.
+
+accessibility-short-description-contains-math = E sega ni dodonu me tiko ena ivakamacala lekaleka na iwasewase vakaiwiliwili me vaka na `<{ $component }>`. Vola ena vosa na veika vakaiwiliwili.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] E sega ni rauta na duidui ni { $colorName } me baleta na itukutuku ni ulutaga ni wase (mode butobuto) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e gadrevi me { $threshold }:1 se sivia).
+       *[other] E sega ni rauta na duidui ni { $colorName } me baleta na itukutuku ni ulutaga ni wase ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e gadrevi me { $threshold }:1 se sivia).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Se bera ni caka rawa na `<circle>` e lako ena { $count } na poini ke sega ni tiko na kedra ivalu vakanamba.
+
+circle-too-many-through-points = E sega ni rawa ni wilika e dua na sekele e lako ena poini e sivia na 3.
+
+circle-overprescribed-radius-center-points = E sega ni rawa ni wilika e dua na sekele e vakatakilai na kena reidiasi, na kena loma kei na poini e lako kina.
+
+circle-center-with-multiple-points = E sega ni rawa ni wilika e dua na sekele e vakatakilai na kena loma ka lako ena poini e sivia na 1.
+
+circle-radius-too-small = E sega ni rawa ni wilika na sekele: ni na yawa ni rua na poini e { $distance }, sa lailai vakalevu na reidiasi { $radius } e vakatakilai.
+
+circle-radius-with-many-points = E sega ni rawa ni buli e dua na sekele e lako ena poini e sivia na rua kei na reidiasi e vakatakilai.
+
+circle-invalid-center-or-through-points = E sega ni dodonu na loma se na poini e lako kina na sekele.
+
+circle-radius-center-with-multiple-points = E sega ni rawa ni wilika na reidiasi ni sekele e vakatakilai na kena loma ka lako ena poini e sivia na 1.
+
+circle-change-radius-non-numerical = E sega ni rawa ni veisautaki na reidiasi ni sekele e lako ena poini e sega ni vakanamba
+
+circle-radius-with-points-non-numerical = E sega ni rawa ni buli e dua na sekele e lako ena poini e sivia na dua kei na reidiasi e vakatakilai ke sega na ivalu vakanamba.
+
+circle-change-center-non-numerical = Se bera ni caka rawa na veisau ni loma ni sekele e lako ena poini e sega ni tiko na kedra ivalu vakanamba.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Fijian has one, because
+# «kalawa» and «icurucuru» do not change for number. Both selects are dropped
+# and both counts still arrive.
+function-domain-insufficient-dimensions = E sega ni rauta na rabalevu ni domain me baleta na fanisini. E tiko ena domain e { $intervals } na kalawa ia e tiko ena fanisini e { $inputs } na icurucuru.
+
+function-domain-invalid-format = Ivakarau ni domain me baleta na fanisini e sega ni dodonu.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Sa beci na kena levu duadua ni fanisini e sega ni vakanamba.
+        [minimum] Sa beci na kena lailai duadua ni fanisini e sega ni vakanamba.
+        [extremum] Sa beci na kena iyalayala ni fanisini e sega ni vakanamba.
+        [point] Sa beci na poini ni fanisini e sega ni vakanamba.
+        [slope] Sa beci na kena tacini ni fanisini e sega ni vakanamba.
+       *[other] Sa beci na { $type } ni fanisini e sega ni vakanamba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Sa beci na kena levu duadua ni fanisini e lala.
+        [minimum] Sa beci na kena lailai duadua ni fanisini e lala.
+        [extremum] Sa beci na kena iyalayala ni fanisini e lala.
+        [point] Sa beci na poini ni fanisini e lala.
+       *[other] Sa beci na { $type } ni fanisini e lala.
+    }
+
+function-points-too-close = E tiko ena fanisini e rua na poini e veivolekati vakalevu. E sega ni rawa ni vakamacalataki na fanisini.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = E rawa ga na veivakaruataki ni fanisini ke tautauvata na iwiliwili ni icurucuru kei na iwiliwili ni ilavo. Na fanisini oqo e tiko kina e { $inputs } na icurucuru kei na { $outputs } na ilavo.
+
+## `<sequence>`
+
+sequence-invalid-length = Kena balavu ni sequence e sega ni dodonu.  E dodonu me namba taucoko e sega ni lolovira.
+
+sequence-invalid-step = Na step ni sequence e sega ni dodonu.  E dodonu me namba me baleta na sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ni sequence vakanamba e sega ni dodonu.  E dodonu me namba.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ni sequence vakamatanivola e sega ni dodonu.  E dodonu me iwiliwili ni matanivola.
+
+sequence-invalid-endpoint = "{ $attribute }" ni sequence e sega ni dodonu.
+
+select-from-sequence-coprime-not-numbers = sa beci na coprime ni sega ni namba e digitaki
+
+select-from-sequence-coprime-with-exclude-combinations = sa beci na coprime ni sa vakatakilai na excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = target e sega ni dodonu me baleta na `<{ $source }>`: e sega ni kune na target.
+
+target-state-variable-not-found = target e sega ni dodonu me baleta na `<{ $source }>`: e sega ni kune e dua na veisau ni ituvaki e yacana "{ $property }" ena dua na `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = E dodonu me duidui na veisau ni `<odeSystem>` mai na veisau galala.
+
+ode-system-duplicate-variable-names = E sega ni rawa ni vakamacalataki na fanisini RHS ni ODE ke tautauvata na yaca ni veisau vakararavi.
+
+ode-system-rhs-function-error = E sega ni rawa ni vakamacalataki na fanisini RHS ni ODE.  E dua na cala ena buli ni fanisini mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = E sega ni rawa ni vakamacalataki e dua na kona ena kedra maliwa e { $count } na laini
+
+angle-invalid-through-point = Poini e sega ni dodonu ena through ni `<angle>`
+
+parabola-vertex-too-many-points = Se bera ni caka rawa na parabola e tiko kina na kena dela ka lako ena poini e sivia na 1.
+
+parabola-too-many-points = Se bera ni caka rawa na parabola e lako ena poini e sivia na 3.
+
+intersection-too-many-items = Se bera ni caka rawa na veitaravi me sivia na rua na ka
+
+## Other math components
+
+ionic-compound-not-two-ions = Se bera ni caka rawa na iwiliwili ni aioni me baleta e dua tale na ka ka sega ni rua na aioni.
+
+ionic-compound-needs-cation-and-anion = E caka ga na iwiliwili ni aioni me baleta e dua na kationi kei na dua na anioni.
+
+solve-equations-cannot-evaluate = E sega ni rawa ni wali na ikuwe ni sega ni rawa ni vakadikevi: { $equation }
+
+math-operators-operand-number-required = E dodonu me vakatakilai na operandNumber ni sa taura e dua na operand vakaiwiliwili.
+
+eigen-decomposition-failed = E sega ni rawa ni wilika na eigenvalue ni matiriki
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: na parameter { $parameters } e sega ni basika ena pattern, o koya e na veiganiti wale ga kei na ka lala.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: e sega ni matata na grid="{ $grid }". E dodonu me none, medium, dense, se rua na namba vinaka e wasei ena kalawa, me vaka na grid="1 0.5". E sega ni droini e dua na grid.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: e sega ni tokoni na xLabelPosition="left" ena renderer prefigure; sa vakayagataki na itovo ni vanua imatau.
+
+prefigure-y-label-position-unsupported = `<graph>`: e sega ni tokoni na yLabelPosition="bottom" ena renderer prefigure; sa vakayagataki na itovo ni vanua cake.
+
+prefigure-invalid-axis-bounds = `<graph>`: e sega ni dodonu na iyalayala ni akesisi me baleta na veisau prefigure; sa vakayagataki na bbox dau vakayagataki (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: e sega ni dodonu na rabalevu me baleta na veisau prefigure; sa vakayagataki na rabalevu ni draki 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: e sega ni dodonu na aspectRatio me baleta na veisau prefigure; sa vakayagataki na aspect ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: sa lailai vakalevu na kalawa ni grid me baleta na iyalayala ni akesisi; e sega ni droini na grid ena renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: e sega ni droini na annotation ke sega ni vakayagataki na renderer PreFigure.
+
+multiple-annotations-children = E kune e levu na luvena `<annotations>` ena `<graph>`; sa beci kece vakavo na kena iotioti.
+
+## Referring to other components
+
+copy-unrecognized-component-type = E sega ni rawa ni vakabalavutaki se vakatetei e dua na mataqali iwasewase e sega ni kilai: { $type }.
+
+copy-prop-not-found = E sega ni kune na prop { $property } ena iwasewase mataqali { $component }
+
+collect-no-source = E sega ni kune e dua na source me baleta na collect.
+
+collect-invalid-component-type = E sega ni rawa ni kumuni na iwasewase mataqali `<{ $component }>` ni sega ni dodonu na mataqali iwasewase.
+
+reference-index-unavailable = E sega ni rawa ni dusi na indeki `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = E sega ni rawa ni kacivi na { $action } ena iwasewase `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = E sega ni dodonu na ivakarau ni idatabesi.  E sega ni tautauvata na kedra balavu na rowa. E kune ena componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = E tiko ena idatabesi e dua na yaca ni duru e vakaruataki.  E kune ena componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = E sega ni tiko na yaca ni dua na duru ena idatabesi.  E kune ena componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Na award ni isau oqo e yavutaki ena isau e vakau mai na answer tag ga, ka na vakavuna e dua na itovo e sega ni namaki.
+
+answer-max-num-attempts-in-section-wide-check-work = E sega ni yaga na biu ni `maxNumAttempts` ena dua na `<answer>` e tiko ena loma ni kato e tiko kina na `sectionWideCheckWork`, ni na kato e lewa na iwiliwili ni isaga. Biuta na `maxNumAttempts` ena kato.
+
+nested-section-wide-check-work-max-num-attempts = E sega ni yaga na biu ni `maxNumAttempts` ena kato e tiko kina na `sectionWideCheckWork` ka tiko ena loma ni dua tale na kato e tiko kina na `sectionWideCheckWork`, ni na kato e tu i tuba e lewa na iwiliwili ni isaga. Biuta na `maxNumAttempts` ena kato e tu i tuba.
+
+# No select: «atirabiuti» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = E na sega ni yaga na atirabiuti { $attributes } ke sega ni biu na symbolicEquality.
+
+answer-invalid-type = Mataqali e sega ni dodonu me baleta na isau: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ni sega ni tiko vua na iwasewase `<{ $component }>` e dua na yaca, e sega ni rawa ni vakayagataki me atirabiuti ni module
+
+module-attribute-name-already-defined = E sega ni rawa ni vakayagataki na iwasewase `<{ $component } name="{ $name }">` me atirabiuti ni module ni sa tiko rawa vua na mataqali iwasewase `<module>` na atirabiuti "{ $name }".
+
+conditional-content-condition-ignored = Sa beci na atirabiuti `condition` ena iwasewase `<conditionalContent>` e tiko kina na luvena case se else.
+
+slider-markers-type-mismatch = E sega ni veiganiti na mataqali ni marker kei na mataqali ni slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel e sega ni dodonu: e dodonu me tiko ena `<problem>` yadua e dua na `<statement>` kei na dua na `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel e sega ni dodonu: ena mode="circuit", e sega ni rawa me distractor na `<problem>` imatai.
+
+## Attribute values
+
+# No select: «ivalu» is the same word for one and for many.
+attribute-invalid-values = Ivalu { $values } e sega ni dodonu me baleta na atirabiuti `{ $attribute }`; sa beci.
+
+attribute-must-be-references = Ivalu `{ $value }` e sega ni dodonu me baleta na atirabiuti `{ $attribute }`. E dodonu me buli na atirabiuti mai na ivakadewa e tekivu ena `$`.
+
+math-input-invalid-function-names = <mathInput>: sa beci na yaca ni fanisini e sega ni dodonu ena { $attribute }: { $names }. E dodonu me tiko ena yaca yadua e rua se sivia na matanivola (matanivola se laini); e rawa ni muri e dua na suffix `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Mataqali iwasewase e sega ni dodonu: `<{ $componentType }>`
+
+attribute-repeated = E sega ni rawa ni vakaruataki na atirabiuti { $attribute }.
+
+attribute-invalid-for-component = Atirabiuti "{ $attribute }" e sega ni dodonu me baleta na iwasewase mataqali `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    E sega ni rauta na duidui ni ivakamacala ni isitaili { $styleNumber } me baleta na { $context ->
+        [text-on-background] roka ni itukutuku vaka ki na roka ni tuvaki
+        [high-contrast] roka duidui cecere vaka ki na kanavasi
+        [line] roka ni laini vaka ki na kanavasi
+        [marker] roka ni marker vaka ki na kanavasi
+       *[text-on-canvas] roka ni itukutuku vaka ki na kanavasi
+    }{ $mode ->
+        [dark] { " (mode butobuto)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e gadrevi me { $threshold }:1 se sivia).
+
+style-definition-dark-mode-text-background-contrast =
+    Dina ga ni tiko ena ivakamacala ni isitaili { $styleNumber } na roka e vakatakilai ka rauta na kena duidui ena mode rarama, e sega ni rauta na duidui ni roka ni itukutuku vaka ki na roka ni tuvaki ena roka e taurivaki me baleta na mode butobuto ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e gadrevi me { $threshold }:1 se sivia). { $suggestion ->
+        [available] Me rauta na duidui ena mode butobuto, vakalevutaka na duidui ni mode rarama (kena ivakaraitaki, biuta na { $lightAttribute }="{ $lightColor }") se sosomitaka na roka ni mode butobuto (kena ivakaraitaki, biuta na { $darkAttribute }="{ $darkColor }").
+       *[none] Me rauta na duidui ena mode butobuto, vakalevutaka na duidui ni mode rarama se sosomitaka na roka e taurivaki ena textColorDarkMode kei/se na backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Dina ga ni tiko ena ivakamacala ni isitaili { $styleNumber } na roka ni itukutuku e vakatakilai ka rauta na kena duidui ena mode rarama, e sega ni rauta na duidui ni roka ni itukutuku e taurivaki me baleta na mode butobuto vaka ki na kanavasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e gadrevi me { $threshold }:1 se sivia). { $suggestion ->
+        [available] Me rauta na duidui ena mode butobuto, vakalevutaka na duidui ni mode rarama (kena ivakaraitaki, biuta na textColor="{ $lightColor }") se sosomitaka na roka ni mode butobuto (kena ivakaraitaki, biuta na textColorDarkMode="{ $darkColor }").
+       *[none] Me rauta na duidui ena mode butobuto, vakalevutaka na duidui ni mode rarama se sosomitaka na roka e taurivaki ena textColorDarkMode.
+    }
+
+section-multiple-style-palettes = E dua ga na <stylePalette> e rawa ni digitaka e dua na wase; sa vakayagataki na kena iotioti.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } ni sega ni namba taucoko e sega ni lolovira na numToSelect.
+
+variant-num-to-select-not-constant-number = e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } ni sega ni namba dei na numToSelect.
+
+variant-with-replacement-not-constant-boolean = e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } ni sega ni boolean dei na withReplacement.
+
+variant-select-weight-disables-unique = Sa vakamatei na ivakaduidui duatani me baleta na select ke tiko e dua na digidigi e vakatakilai kina na selectWeight se selectForVariants
+
+variant-coprime-undetermined = e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } ni sega ni rawa ni vakadeitaki ni false tiko ga na coprime.
+
+variant-attribute-not-constant = e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } ni sega ni dei na { $attribute }.
+
+variant-attribute-not-number = e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } ni sega ni namba na { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } mataqali { $type } ni sega ni { $expected ->
+        [letters-combination] iwiliwili ni matanivola
+        [math-expression] ivakamacala vakaiwiliwili dodonu
+        [integer] namba taucoko
+       *[number] namba
+    } na { $attribute }.
+
+variant-length-not-integer = e sega ni rawa ni vakadeitaki na ivakaduidui duatani ni { $component } ni sega ni namba taucoko na length.
+
+variant-sort-not-implemented = se bera ni caka rawa na ivakaduidui duatani ni dua na { $component } e tiko kina na sort
+
+variant-exclude-combinations-not-implemented = se bera ni caka rawa na ivakaduidui duatani ni dua na { $component } e tiko kina na excludeCombinations
+
+variant-math-exclude-not-implemented = se bera ni caka rawa na ivakaduidui duatani ni dua na { $component } mataqali math e tiko kina na exclude
+
+variant-non-constant-exclude-not-implemented = se bera ni caka rawa na ivakaduidui duatani ni dua na { $component } e tiko kina na exclude e sega ni dei
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: e sega ni tokoni ena renderer prefigure ni graph; sa lauti na kawa.
+
+prefigure-descendant-invalid-geometry = { $subject }: e sega ni yalani se sega ni taucoko na kena ivakarau; sa lauti na kawa.
+
+prefigure-curve-label-omitted = { $subject }: e sega ni tokoni na iyaca ena kavu e vakasosomitaki; sa beci na iyaca.
+
+prefigure-curve-unsupported-definition-type = { $subject }: mataqali ivakamacala ni fanisini kavu '{ $definitionType }' e sega ni tokoni; sa lauti na kawa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: e sega ni tokoni na atirabiuti flipFunctions ena regionBetweenCurves; sa lauti na kawa.
+
+prefigure-region-non-formula-child = { $subject }: na luvena fanisini mataqali formula ga e tokoni ena regionBetweenCurves; sa lauti na kawa.
+
+prefigure-label-position-unsupported =
+    { $subject }: e sega ni tokoni na labelPosition '{ $labelPosition }' me baleta na { $labelKind ->
+        [line-family] iyaca ni matavuvale ni laini
+       *[point] iyaca ni poini
+    }; sa vakayagataki na ivakadodonu ni PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: e sega ni tokoni e PreFigure na isitaili ni loma '{ $fillStyle }'; sa lesu ki na loma sinai.
+
+prefigure-line-style-unknown = { $subject }: isitaili ni laini '{ $lineStyle }' e sega ni kilai, sa beci mai na output ni PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: sa vauci na isitaili ni marker '{ $markerStyle }' ki na isitaili 'diamond' ni PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: e sega ni tokoni e PreFigure na isitaili ni marker '{ $markerStyle }'; sa vakayagataki na isitaili dau vakayagataki.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` e sega ni dodonu; e sega ni rawa ni dusi na target. Sa beci na annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: e dusia na `ref` e levu na target; sa vakayagataki na target imatai.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` e sega ni dodonu; e tu i tuba na target mai na graph e tiko kina. Sa beci na annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` e sega ni dodonu; na target e sega ni ka vakairairai e tokoni ena veisau prefigure. Sa beci na annotation.
+
+annotation-text-missing = `<annotation>`: e sega se lala na `text`; sa biu e dua na itukutuku lala.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] E kune e dua na veivakararavi vakavolivoli.
+       *[other] E kune e dua na veivakararavi vakavolivoli e okati kina na iwasewase `<{ $componentType }>`.
+    }
+
+reference-no-referent = E sega ni kune e dua na ka e dusia na ivakadewa: `{ $reference }`
+
+reference-multiple-referents = E levu na ka e kune e dusia na ivakadewa: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Ivakarau ni atirabiuti { $attribute } ni `<{ $componentType }>` e sega ni dodonu.
+
+children-invalid = E sega ni dodonu na luvena `<{ $componentType }>`: e kune na luvena e sega ni dodonu: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ivalu `{ $value }` e sega ni dodonu me baleta na atirabiuti `{ $attribute }`, sa vakayagataki na ivalu `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] E sega ni kune na kena ivakarau DoenetML { $version }.
+       *[other] E sega ni kune na kena ivakarau DoenetML { $version }. Sa lesu ki na kena ivakarau { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML e sega ni dodonu: { $content }
+
+parse-tag-missing-close-tag = DoenetML e sega ni dodonu: E sega ni tiko vua na tag `{ $tag }` e dua na tag ni sogo. E namaki e dua na tag e sogota koya se e dua na tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML e sega ni dodonu: E dua na cala ena tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML e sega ni dodonu: E vaka me sega ni tiko vua na atirabiuti `{ $attribute }` e dua na ivalu.
+
+parse-attribute-invalid = DoenetML e sega ni dodonu: Atirabiuti `{ $attribute }` e sega ni dodonu
+
+parse-attribute-value-invalid = DoenetML e sega ni dodonu: Ivalu ni atirabiuti `{ $value }` e sega ni dodonu
+
+parse-attribute-value-quote-mismatch = DoenetML e sega ni dodonu: Ivalu ni atirabiuti `{ $value }` e sega ni dodonu. E sega ni veiganiti na ivakatakilakila ni vosa. E vaka me sega e dua na `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML e sega ni dodonu: E kune e dua na tag e sega ni yacani, me vaka na `<`
+
+parse-tag-not-closed = DoenetML e sega ni dodonu: E sega ni sogoti na tag `{ $tag }` (e vaka me sega e dua na `>`).
+
+parse-self-closing-tag-name-missing = DoenetML e sega ni dodonu: E kune e dua na tag e sega ni yacani `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML e sega ni dodonu: E sega ni sogoti na tag `{ $tag }` (e vaka me sega e dua na `/>`).
+
+parse-tag-invalid-attributes = DoenetML e sega ni dodonu: E sega ni dodonu na tag `{ $tag }`. De dua e sega ni dodonu na kena atirabiuti.
+
+parse-close-tag-name-missing = DoenetML e sega ni dodonu: E kune e dua na tag ni sogo e sega ni yacani, me vaka na `</`
+
+parse-attribute-value-unquoted = E dodonu me biu na ivalu ni atirabiuti ena loma ni ivakatakilakila ni vosa: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML e sega ni dodonu: E kune e dua na tag ni sogo `{ $tag }`, ia e sega ni tiko na tag ni dola e veiganiti
+
+parse-close-tag-mismatched = DoenetML e sega ni dodonu: E sega ni veiganiti na tag ni sogo. E namaki na `</{ $expected }>`. E kune na `{ $found }`
+
+parser-node-unconvertible = E sega ni rawa ni vakasosomitaki na node { $node } ki na node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atirabiuti name='{ $name }' e sega ni dodonu. { $reason ->
+        [characters] E rawa ga ni tiko ena yaca na matanivola, namba, laini e ra se laini ni veiwasei.
+       *[start] E dodonu me tekivu na yaca ena dua na matanivola.
+    }
+
+component-name-invalid-start = Yaca ni iwasewase "{ $name }" e sega ni dodonu. E dodonu me tekivu na yaca ena dua na matanivola.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = E dodonu me tiko vua na answer e type videoWatched e dua na atirabiuti video
+
+answer-video-watched-video-not-reference = E dodonu me ivakadewa na atirabiuti video ni answer e type videoWatched
+
+answer-name-not-single-text = E dodonu me tiko vua na atirabiuti name ni answer e dua ga na luvena text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = E sega ni rawa ni taurivaki na DoenetML mai tuba ena vuku ni levu ni kena tabana ni veivakaruataki. E tiko beka e dua na ivakadewa vakavolivoli?
+
+external-doenetml-unavailable = E sega ni rawa ni taurivaki na DoenetML mai na { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML e sega ni dodonu e taurivaki mai na { $attribute }="{ $uri }": e sega ni veiganiti kei na mataqali iwasewase "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Sa sega ni vakayagataki na atirabiuti `{ $from }`; vakayagataka na `{ $to }`.
+       *[other] [deprecation] Sa sega ni vakayagataki na atirabiuti `{ $from }` ena `<{ $component }>`; vakayagataka na `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Sa sega ni vakayagataki na atirabiuti `{ $from }` ka sa beci ni sa vakatakilai talega na `{ $to }`.
+       *[other] [deprecation] Sa sega ni vakayagataki na atirabiuti `{ $from }` ena `<{ $component }>` ka sa beci ni sa vakatakilai talega na `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Sa sega ni vakayagataki na atirabiuti `{ $attribute }` ena `<{ $component }>` ka sa beci.
+
+deprecated-attribute-to-child = [deprecation] Sa sega ni vakayagataki na atirabiuti `{ $attribute }` ena `<{ $component }>`; vakayagataka e dua na luvena `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Sa sega ni vakayagataki na ivalu `{ $value }` ni atirabiuti `{ $attribute }` ena `<{ $component }>`; vakayagataka na `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = Na `<pluralize>` e rawa ga ni vakalevutaka na vosa vakavalagi, o koya e sega kina ni veisau na kena itukutuku ena ivola e volai ena { $locale }. Vola sara ga na kena ivakarau levu, se biuta ena atirabiuti `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Na elemede `<{ $tag }>` e sega ni elemede ni Doenet e kilai.
+
+schema-element-not-allowed-at-root = E sega ni vakadonui na elemede `<{ $tag }>` ena wakana ni ivola.
+
+schema-element-not-allowed-inside = E sega ni vakadonui na elemede `<{ $tag }>` ena loma ni `<{ $parent }>`.
+
+schema-attribute-unrecognized = E sega ni tiko vua na elemede `<{ $tag }>` e dua na atirabiuti e yacana `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] E dodonu me ilisi na atirabiuti `{ $attribute }` ni elemede `<{ $tag }>` ka dua ena kena ka yadua mai na: { $allowed }
+       *[other] E dodonu me dua mai na oqo na atirabiuti `{ $attribute }` ni elemede `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Yaca ni ivakaduidui e sega ni dodonu me baleta na select.  Na yaca ni ivakaduidui { $variantName } e basika ena { $numOptions } na digidigi ia na iwiliwili me digitaki e { $numToSelect }.
+
+select-variant-name-without-options = E vakatakilai e so na ivakaduidui me baleta na select ia e sega ni vakatakilai e dua na digidigi me baleta na yaca ni ivakaduidui: { $variantName }.
+
+select-variant-name-not-possible = Na yaca ni ivakaduidui { $variantName } e vakatakilai me baleta na select e sega ni yaca ni ivakaduidui e rawa.
+
+select-too-few-options = E sega ni rawa ni digitaki e { $numToSelect } na iwasewase mai na { $numOptions } ga.
+
+select-from-sequence-too-few-values = E sega ni rawa ni digitaki e { $numToSelect } na ivalu mai na sequence e { $length } na kena balavu.
+
+select-from-sequence-indices-count-mismatch = E dodonu me veiganiti na iwiliwili ni indeki e vakatakilai me baleta na select kei na iwiliwili me digitaki
+
+select-from-sequence-indices-not-integers = E dodonu me namba taucoko na indeki kece e vakatakilai me baleta na select
+
+select-from-sequence-index-excluded = Na indeki ni selectfromsequence e vakatakilai e a tabu
+
+select-from-sequence-indices-excluded-combination = Na indeki ni selectfromsequence e vakatakilai e dua na iwiliwili e a tabu
+
+select-from-sequence-coprime-not-positive-integers = E sega ni rawa ni digitaki na iwiliwili coprime ni sega ni namba taucoko vinaka e digitaki.
+
+select-from-sequence-coprime-common-factor = E sega ni rawa ni digitaki na namba coprime. E tiko ena ivalu kece e dua na faketa vata. (E dodonu me coprime na ivalu "from" se "to" kei na "step".)
+
+select-from-sequence-coprime-single-number = E sega ni rawa ni digitaki na iwiliwili coprime mai na dua ga na namba e sega ni 1.
+
+select-from-sequence-excluded-too-many-combinations = E sivia na 70% ni iwiliwili e tabu ena selectFromSequence
+
+select-from-sequence-coprime-none-found = E sega ni rawa ni digitaki na namba coprime. E tiko ena ivalu kece e dua na faketa vata.
+
+select-from-sequence-too-few-unique-values = E sega ni rawa ni digitaki e { $numToSelect } na ivalu duatani mai na sequence e { $numPossibleValues } na kena balavu
+
+select-prime-numbers-too-few-values = E sega ni rawa ni digitaki e { $numToSelect } na ivalu mai na ilisi ni namba prime e { $numValues } na kena balavu
+
+select-prime-numbers-values-count-mismatch = E dodonu me veiganiti na iwiliwili ni ivalu e vakatakilai me baleta na select kei na iwiliwili me digitaki
+
+select-prime-numbers-values-not-prime = E dodonu me tiko ena ilisi ni namba prime na ivalu kece e vakatakilai me baleta na select prime number
+
+select-prime-numbers-values-excluded-combination = Na ivalu ni selectPrimeNumbers e vakatakilai e dua na iwiliwili e a tabu
+
+select-prime-numbers-excluded-too-many-combinations = E sivia na 70% ni iwiliwili e tabu ena selectPrimeNumbers
+
+select-random-combination-fluke = Ena vuku ni dua na ka e dredre sara ni yaco, e sega ni rawa ni digitaki e dua na iwiliwili ni ivalu veiveisau
+
+select-random-value-fluke = Ena vuku ni dua na ka e dredre sara ni yaco, e sega ni rawa ni digitaki e dua na ivalu veiveisau

--- a/packages/i18n/locales/fj/editor.ftl
+++ b/packages/i18n/locales/fj/editor.ftl
@@ -1,0 +1,208 @@
+# Fijian editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Fijian marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Vakasukaya
+       *[update] Vakavoui
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } na irairai
+       *[other] { $word } na irairai { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Ivakaduidui
+editor-variant-filter = Vakawiliwili…
+editor-variant-next = Digitaka na ivakaduidui tarava
+editor-variant-previous = Digitaka na ivakaduidui liu
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] E kune e dua na beitaki ni rawarawa WCAG AA. Kilika me { $action ->
+            [close] sogoti
+           *[open] dolavi
+        } na ripote ni rawarawa.
+        [advisories] Kilika me { $action ->
+            [close] sogoti
+           *[open] dolavi
+        } na ripote ni rawarawa. E sega ni kune e dua na beitaki WCAG AA, ia e tiko e so tale na ivakasala ni rawarawa.
+       *[clean] Kilika me { $action ->
+            [close] sogoti
+           *[open] dolavi
+        } na ripote ni rawarawa. E sega ni kune e dua na leqa ni rawarawa.
+    }
+
+# No select on `$count` inside the branches: «beitaki» and «ivakasala» are the
+# same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] E kune e dua na beitaki ni rawarawa WCAG AA. E kune e { $count } na beitaki WCAG AA. Kilika me { $action ->
+            [close] sogoti
+           *[open] dolavi
+        } na ripote ni rawarawa.
+        [advisories] E sega ni kune e dua na beitaki WCAG AA. E kune e { $count } tale na ivakasala ni rawarawa. Kilika me { $action ->
+            [close] sogoti
+           *[open] dolavi
+        } na ripote ni rawarawa.
+       *[clean] E sega ni kune e dua na beitaki WCAG AA. Kilika me { $action ->
+            [close] sogoti
+           *[open] dolavi
+        } na ripote ni rawarawa.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Kena ivakarau DoenetML { $version }
+
+editor-tab-help = Veivuke me salavata kei na ituvaki
+editor-tab-help-short = Ituvaki
+editor-tab-errors = Cala
+editor-tab-warnings = Ivakasalasala
+editor-tab-info = Itukutuku
+editor-tab-accessibility = Rawarawa
+editor-tab-responses = Isau sa vakau
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Digidigi ni idraudrau ni volavola
+editor-format-as-doenetml = Vakarautaka me DoenetML
+editor-format-as-xml = Vakarautaka me XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Laini #{ $line }
+
+editor-no-errors = Sega ni dua na cala
+editor-no-warnings = Sega ni dua na ivakasalasala
+editor-no-info = Sega ni dua na itukutuku ni vakadidike
+
+editor-show-info-annotations = Vakaraitaka na itukutuku ni vakadidike ena idraudrau ni volavola
+editor-show-accessibility-annotations = Vakaraitaka na vakadidike ni rawarawa ena idraudrau ni volavola
+
+editor-accessibility-learn-more = Vulica na sala e qarava kina o Doenet na rawarawa
+
+editor-accessibility-violations-heading = Beitaki ni rawarawa ({ $standard })
+
+editor-accessibility-other-heading = Leqa tale ni rawarawa
+editor-none-found = Sega ni dua e kune
+
+
+## Submitted responses
+
+editor-no-responses = Se bera ni dua na isau e vakau
+editor-response-answer-id = Id ni isau
+editor-response-response = Isau
+editor-response-credit = Ivotavota
+editor-response-submitted = Sa vakau
+
+
+## The context-help panel
+
+help-placeholder = Biuta na kasolo ena yaca ni tag, ena atirabiuti, se ena { $ref } me baleta na ivola ni veivuke.
+
+help-unsupported-ref-chain = Se bera ni tokoni na veivuke me baleta na ivakadewa levu na tikina me vaka na { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] E sega ni kune e dua na ka e dusia na ivakadewa: { $ref }.
+        [multiple] E levu na ka e kune e dusia na ivakadewa: { $ref }.
+       *[indeterminate] E sega ni rawa ni vakadeitaki na ka e dusia na { $ref }.
+    }
+
+help-learn-about-references = Vulica na veika me baleta na ivakadewa →
+help-reference-page = Tabana ni ivakadewa →
+
+help-suggestions-header =
+    { $location ->
+        [inside] E loma ni { $element }
+       *[top] Ena vanua cecere duadua
+    }{ $allowed ->
+        [none] { " — e sega ni dua na ka e biu eke." }
+        [text] { " — vola e dua na itukutuku eke." }
+        [text-and-components] { " — vola e dua na itukutuku eke, se tovolea:" }
+       *[components] { " — na ka me tovoleti:" }
+    }
+
+help-suggestions-footer = Butuka na { $shortcut } mo raica kece na { $total } na iwasewase.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] Na { $ref } e ivakadewa ki na { $target }.
+       *[other] Na { $ref } e ivakadewa ki na { $target } (laini { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] E kau mai vei { $owner } me { $role }.
+       *[other] E kau mai vei { $owner } ena laini { $line } me { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] Na { $ref } e ivakadewa ki na itovo { $property } ni { $element }.
+       *[other] Na { $ref } e ivakadewa ki na itovo { $property } ni { $element } (laini { $line }).
+    }
+
+help-kind-attribute = atirabiuti
+help-kind-snippet = tikitiki ni kodi
+help-kind-array-entry = icurucuru ni array
+
+help-default = Ka e dau vakayagataki:
+help-active-default = Ka e dau vakayagataki tiko:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ivalu e vakadonui (e dua ena ka yadua):
+       *[other] Ivalu e vakadonui:
+    }
+
+help-suggested-values = Ivalu e vakatututaki:
+
+help-inserts = E biu curu:
+
+# No select: «kodineti» is the same word for one and for many.
+help-coordinates = Kodineti:
+
+help-type = Mataqali:
+
+help-resolved-style = Isitaili sa vakadeitaki (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Yaca ni fanisini sa vakadeitaki:
+help-reset-list = Ilisi ni veivakasukai ena icurucuru oqo:
+help-added-on-input = E kuria ena icurucuru oqo:
+help-removed-on-input = E kau tani ena icurucuru oqo:
+
+help-reset-overrides = Na { $reset } e sosomitaka na { $additional } kei na { $removed }.

--- a/packages/i18n/locales/hil/chrome.ftl
+++ b/packages/i18n/locales/hil/chrome.ftl
@@ -1,0 +1,147 @@
+# Hiligaynon viewer chrome. Translated from `locales/en/chrome.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography of Hiligaynon publishing and of the
+# Department of Education's mother-tongue materials for Western Visayas. The
+# language is also called Ilonggo; `hil` is the code and CLDR names it
+# Hiligaynon, which is what the roster shows.
+#
+# Hiligaynon marks no number on the noun: plurality is carried by «ang mga» and
+# a noun after a numeral stays as it is. So a `{ $count -> … }` whose two
+# English branches differ only in the noun renders one string here and the
+# select is dropped; the count still arrives and is still formatted. A `[0]`
+# branch stays wherever English has one.
+#
+# The linker «nga» is written in full at every site, for the reason given in
+# `content.ftl`.
+
+
+## Answer submission
+
+answer-checking = Ginausisa…
+answer-submitting = Ginapadala…
+
+answer-checking-status = Ginausisa ang sabat
+answer-submitting-status = Ginapadala ang sabat
+
+answer-correct = Husto
+answer-incorrect = Indi husto
+
+answer-response-saved = Natipigan ang sabat
+
+answer-percent-credit = { $percent }% nga kredito
+answer-percent-correct = { $percent }% nga husto
+answer-percent-short = { $percent } %
+
+max-credit-available = Pinakamataas nga kredito nga mabaton: { $percent }%
+
+# No select: «tilaw» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] wala na sing nabilin nga tilaw
+       *[other] { $count } nga tilaw ang nabilin
+    }
+
+validation-correct = (Husto)
+validation-incorrect = (Indi husto)
+validation-partially-correct = (Husto sa bahin)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Ipakita ang { $count } nga sabat para sa { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komento
+
+collapsible-click-to-open = (i-klik agod mabuksan)
+collapsible-click-to-close = (i-klik agod matakpan)
+
+collapsible-initializing = Ginasugdan…
+
+footnote-show = Ipakita ang footnote
+footnote-hide = Itago ang footnote
+
+description-more-information = dugang nga impormasyon
+
+
+## Controls
+
+slider-previous = Nagligad
+slider-next = Sunod
+
+keyboard-open = Buksi ang teklado
+keyboard-close = Takpi ang teklado
+
+choice-input-remove-choice = Kuhaa ang { $choice }
+
+matrix-remove-row = Kuhaa ang lakan
+matrix-add-row = Dugangi sing lakan
+matrix-remove-column = Kuhaa ang kolum
+matrix-add-column = Dugangi sing kolum
+
+subset-add-remove-points = Pagdugang/Pagkuha sing mga punto
+subset-toggle-points-intervals = Pagbaylo sing mga punto kag interbalo
+subset-move-points = Ibalhin ang mga punto
+subset-clear = Limpyuhi
+
+orbital-add-row = Dugangi sing lakan
+orbital-remove-row = Kuhaa ang lakan
+orbital-add-box = Dugangi sing kahon
+orbital-remove-box = Kuhaa ang kahon
+orbital-add-up-arrow = Dugangi sing pana nga pasaka
+orbital-add-down-arrow = Dugangi sing pana nga padulhog
+orbital-remove-arrow = Kuhaa ang pana
+
+orbital-row-label = Etiketa para sa lakan { $row }
+
+pretzel-answer = Sabat
+
+summary-statistics-caption = Sumaryo nga estadistika sang { $column }
+
+
+## Math input
+
+math-input-preview-region = pahiuna nga pagtan-aw sang ekspresyon nga matematika
+math-input-preview = Pahiuna nga pagtan-aw
+math-input-invalid-expression = Indi balido nga ekspresyon:
+
+
+## Document status
+
+viewer-initializing = Ginasugdan…
+
+
+## Errors
+
+error-heading = Sayop
+
+error-found-at =
+    { $span ->
+        [line] Nakita sa linya { $startLine }.
+       *[lines] Nakita sa mga linya { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = May sayop ini nga dokumento!
+
+diagnostic-heading-error = Sayop
+diagnostic-heading-warning = Paandam
+diagnostic-heading-information = Impormasyon
+diagnostic-heading-hint = Giya
+
+accessibility-heading-level-1 = Paglapas sa aksesibilidad nga WCAG AA
+accessibility-heading-level-2 = Paandam parte sa aksesibilidad
+
+something-went-wrong = May nagsayop.
+
+renderer-load-failed = may renderer nga wala na-load. Palihog i-reload ang pahina.
+
+core-start-failed = Wala nagsugod ang pagtan-aw sang dokumento. Palihog i-reload ang pahina.

--- a/packages/i18n/locales/hil/content.ftl
+++ b/packages/i18n/locales/hil/content.ftl
@@ -1,0 +1,252 @@
+# Hiligaynon content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Hiligaynon has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The **linker** «nga» is written in full at every site. Hiligaynon also has the
+# enclitic `-ng` on a vowel-final word, but which of the two is available is
+# decided by the word *before* the linker, and in these messages that word is
+# often a placeable. The free form is grammatical wherever the enclitic is, so
+# writing it out is what makes these messages safe rather than a compromise —
+# the same move `locales/war` makes, and the thing `locales/ilo`, `locales/pam`
+# and `locales/bik` cannot do, because their linkers have no invariant form.
+#
+# The adjectives **precede** the noun, which is English's order and
+# Hiligaynon's ordinary one: «pula nga linya».
+#
+# The geometry vocabulary is largely Spanish-derived, as Philippine mathematics
+# teaching carries it; the colours and everyday words are Hiligaynon's own.
+# «kolor» words a corrector may want to revisit: `.gray` is written «abuhon»
+# rather than the loan «gris», and `.brown` «kape» rather than «tsokolate».
+
+
+## Style vocabulary
+
+color =
+    .black = itom
+    .white = puti
+    .gray = abuhon
+    .red = pula
+    .orange = kahel
+    .yellow = dalag
+    .green = berde
+    .cyan = sian
+    .blue = asul
+    .purple = lila
+    .pink = rosas
+    .brown = kape
+
+line-width =
+    .thick = madamol
+    .thin = manipis
+
+line-style =
+    .dashed = putol-putol
+    .dotted = tuldok-tuldok
+
+# Noun phrases. Hiligaynon marks no plural on the noun, so «linya» is the word
+# for one line and for many alike.
+fill-style =
+    .horizontal = hapa nga linya
+    .vertical = tindog nga linya
+    .diagonal = halihad nga linya
+    .backdiagonal = balikwaot nga halihad nga linya
+    .dots = tuldok
+    .diamonds = diyamante
+
+noun =
+    .line = linya
+    .line-segment = segmento
+    .ray = silak
+    .vector = bektor
+    .curve = kurba
+    .function = punsyon
+    .parabola = parabola
+    .polyline = polilinya
+    .polygon = poligono
+    .triangle = triyanggulo
+    .rectangle = rektanggulo
+    .circle = sirkulo
+    .region = rehiyon
+    .point = punto
+    .square = kwadrado
+    .diamond = diyamante
+    .cross = krus
+    .plus = plus
+
+noun-regular-polygon =
+    { $part ->
+        [tail] nga may { $numSides } nga kilid
+       *[head] regular nga poligono
+    }
+
+# One answer for every noun: Hiligaynon has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } nga { $lineStyle } nga { $color }
+        [width-color] { $width } nga { $color }
+        [style-color] { $lineStyle } nga { $color }
+        [width-style] { $width } nga { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } nga { $noun } { $nounTail }
+       *[noun] { $description } nga { $noun }
+    }
+
+style-filled-word = puno
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } nga { $color } nga may { $pattern }
+       *[plain] { $filled } nga { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } nga { $color } nga { $noun } nga may { $pattern }
+        [plain-tail] { $filled } nga { $color } nga { $noun } { $nounTail }
+        [pattern-tail] { $filled } nga { $color } nga { $noun } { $nounTail } nga may { $pattern }
+       *[plain] { $filled } nga { $color } nga { $noun }
+    }
+
+# Hiligaynon has no article, so the two `-article` branches say what the other
+# two say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «nga may» against «kag».
+style-border-clause =
+    { $parts ->
+        [with-article] nga may { $border } nga ligid
+        [and] kag { $border } nga ligid
+        [and-article] kag { $border } nga ligid
+       *[with] nga may { $border } nga ligid
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } nga { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = indi puno
+
+style-text =
+    { $parts ->
+        [background] { $color } nga may { $background } nga background
+       *[plain] { $color }
+    }
+
+style-background-none = wala
+
+
+## Boolean words
+
+boolean-true = matuod
+boolean-false = butig
+
+
+## Answer buttons
+
+answer-submit-label = Usisaa ang sabat
+answer-submit-label-no-correctness = Ipadala ang sabat
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Hiligaynon marks number on the article rather than on the noun, and a
+# heading carries no article.
+section-name =
+    .activity = Aktibidad
+    .aside = Nota sa kilid
+    .cascade = Kaskada
+    .definition = Kahulugan
+    .example = Halimbawa
+    .exercise = Ehersisyo
+    .exercises = Ehersisyo
+    .given-answer = Sabat
+    .note = Nota
+    .objectives = Tulumuron
+    .paragraphs = Parapo
+    .part = Bahin
+    .problem = Problema
+    .problems = Problema
+    .proof = Pamatuod
+    .question = Pamangkot
+    .section = Seksyon
+    .solution = Solusyon
+    .task = Buluhaton
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Giya
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Talaan { $enumeration }
+        [numbered-title] Talaan { $enumeration }{ ": " }
+        [unnumbered-title] Talaan{ ": " }
+       *[unnumbered] Talaan
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Pigura { $enumeration }
+        [numbered-caption] Pigura { $enumeration }{ ": " }
+        [unnumbered-caption] Pigura{ ": " }
+       *[unnumbered] Pigura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Nagligad
+paginator-next = Sunod
+paginator-page = Pahina
+
+paginator-page-status = { $pageLabel } { $currentPage } sa { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ukon
+piecewise-condition-if = kon
+piecewise-condition-otherwise = kon indi
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Philippine secondary science is taught in English from the
+## intermediate grades, so the periodic table a Hiligaynon pupil meets is the
+## English one — the same reason `locales/fil` and `locales/ceb` leave these
+## keys out.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Indi balido nga simbolo nga kemikal
+chemistry-invalid-ionic-compound = Indi balido nga kompuwesto nga ioniko

--- a/packages/i18n/locales/hil/diagnostics.ftl
+++ b/packages/i18n/locales/hil/diagnostics.ftl
@@ -1,0 +1,626 @@
+# Hiligaynon diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Hiligaynon marks no number on the noun, so a counted message whose only
+# English difference is the noun's number renders one string here and the
+# select is dropped. The count still arrives and is still formatted.
+#
+# The linker is written as the free «nga» throughout; see `content.ftl`.
+
+
+## `<lineSegment>`
+
+# No select: «ginabaliwala» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = ginabaliwala ang { $attributes } kon gintakda ang duha ka punta
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ginabaliwala ang { $attributes } kon gintakda ang isa ka punta kag ang tunga
+
+line-segment-midpoint-offset-without-midpoint = wala sing epekto ang midpointOffset kon wala sing tunga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linya nga nagaagi sa mga punto nga wala matukoy ang dimensyon.
+
+line-points-too-few-dimensions = Kinahanglan nagaagi ang linya sa mga punto nga may indi kubos sa duha ka dimensyon.
+
+line-points-depend-on-variables = Ang linya nagaagi sa mga punto nga nagasandig sa mga baryable: { $variables }.
+
+line-equation-invalid-format = Indi balido nga pormat sang ekwasyon sang linya sa mga baryable nga { $variable1 } kag { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ang silak gintakda paagi sa through, endpoint kag direction.  Ginabaliwala ang gintakda nga through.
+
+ray-dimension-mismatch = indi nagakadungan ang numDimensions sa silak.
+
+## `<vector>`
+
+vector-overprescribed-head = Ang bektor gintakda paagi sa head, tail kag displacement.  Ginabaliwala ang gintakda nga head.
+
+vector-dimension-mismatch = indi nagakadungan ang numDimensions sa bektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Indi mahimo mag-agda pakadto sa `<{ $component }>` kay wala ini sing baryable nga estado nga nearestPoint.
+
+constrain-to-without-nearest-point = Indi mahimo magpugong pakadto sa `<{ $component }>` kay wala ini sing baryable nga estado nga nearestPoint.
+
+constrain-to-interior-without-nearest-point = Indi mahimo magpugong sa sulod sang `<{ $component }>` kay wala ini sing baryable nga estado nga nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ginabaliwala ang labelPosition para sa choiceInput nga indi inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ginabaliwala ang mga indise nga gintakda para sa choiceInput kay indi nagakadungan ang kadamuon sang mga indise kag ang kadamuon sang mga bata nga pilianan.
+
+pretzel-indices-count-mismatch = Ginabaliwala ang mga indise nga gintakda para sa problem kay indi nagakadungan ang kadamuon sang mga indise kag ang kadamuon sang mga bata nga problem.
+
+shuffle-indices-count-mismatch = Ginabaliwala ang mga indise nga gintakda para sa shuffle kay indi nagakadungan ang kadamuon sang mga indise kag ang kadamuon sang mga komponente.
+
+indices-ignored-out-of-range = Ginabaliwala ang mga indise nga gintakda para sa { $component } kay may indise nga labaw sa sakop.
+
+pretzel-indices-repeated = Ginabaliwala ang mga indise nga gintakda para sa pretzel kay may indise nga ginsulit.
+
+pretzel-circuit-first-index = Ginabaliwala ang mga indise nga gintakda para sa pretzel sa mode nga circuit kay kinahanglan 1 ang una nga indise.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Agod mag-obra ang `<{ $component }>` sa mga bata nga string, kinahanglan itakda ang atributo nga `type`.
+
+invalid-type-defaulting-to-math = Indi balido nga type { $type } para sa komponente nga { $component }. Kinahanglan isa sa math, text, number, ukon boolean. Ginagamit ang math.
+
+string-not-valid-component-to-arrange = Ang string nga "{ $value }" indi balido nga komponente para sa { $component }. Ginabaliwala.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Indi balido nga type { $type }, ginabutang ang type sa number.
+
+invalid-variable-value = Indi balido nga balor sang isa ka baryable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Kinahanglan numero ang indise sang baryante nga { $index }
+
+variant-index-must-be-integer = Kinahanglan integer ang indise sang baryante nga { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Wala pa maipatuman ang `<{ $component }>` para sa absoluto nga sukat. Ginabutang nga relatibo ang mga kasangkaron.
+
+side-by-side-absolute-margins = Wala pa maipatuman ang `<{ $component }>` para sa absoluto nga sukat. Ginabutang nga relatibo ang mga margin.
+
+side-by-side-no-block-child = Indi balido nga `<{ $component }>`: kinahanglan may isa man lang ini ka bata nga block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ginabaliwala ang atributo nga `for` sa grapikal nga `<label>`.
+
+label-for-must-resolve-to-one = Kinahanglan magtudlo ang atributo nga `for` sa `<label>` sa eksakto nga isa ka komponente.
+
+label-for-unresolved = Wala nakatudlo ang atributo nga `for` sa `<label>` sa isa ka komponente.
+
+label-for-answer-with-authored-inputs = Ang atributo nga `for` sa `<label>` nagatudlo sa isa ka `<answer>` nga may mga input nga ginsulat sang awtor; tudlua ang input mismo.
+
+label-for-answer-without-input = Ang atributo nga `for` sa `<label>` nagatudlo sa isa ka `<answer>` nga wala sing input nga etiketahan.
+
+label-for-must-reference-input-or-answer = Kinahanglan nagatudlo ang atributo nga `for` sa `<label>` sa isa ka input ukon isa ka answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Para sa aksesibilidad, kinahanglan may malip-ot nga deskripsyon ang `<{ $component }>` ukon gintakda nga dekoratibo.
+
+accessibility-video-short-description = Para sa aksesibilidad, kinahanglan may malip-ot nga deskripsyon ang `<video>`.
+
+accessibility-input-short-description-or-label = Para sa aksesibilidad, kinahanglan may malip-ot nga deskripsyon ukon etiketa ang `<{ $component }>`.
+
+accessibility-answer-input-short-description-or-label = Para sa aksesibilidad, kinahanglan may malip-ot nga deskripsyon ukon etiketa ang isa ka `<answer>` nga nagahimo sing input.
+
+accessibility-short-description-contains-math = Indi dapat magsulod ang mga malip-ot nga deskripsyon sing mga komponente nga matematika subong sang `<{ $component }>`. Isulat sa mga tinaga ang bisan ano nga matematika.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kulang ang kontraste sang { $colorName } para sa teksto sang ulohan sang seksyon (madulom nga mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginakinahanglan ang indi kubos sa { $threshold }:1).
+       *[other] Kulang ang kontraste sang { $colorName } para sa teksto sang ulohan sang seksyon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginakinahanglan ang indi kubos sa { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wala pa maipatuman ang `<circle>` nga nagaagi sa { $count } ka punto kon wala sing numeriko nga balor ang mga punto.
+
+circle-too-many-through-points = Indi mahimo kwentahon ang sirkulo nga nagaagi sa sobra sa 3 ka punto.
+
+circle-overprescribed-radius-center-points = Indi mahimo kwentahon ang sirkulo nga may gintakda nga radyus, sentro kag mga punto nga agyan.
+
+circle-center-with-multiple-points = Indi mahimo kwentahon ang sirkulo nga may gintakda nga sentro nga nagaagi sa sobra sa 1 ka punto.
+
+circle-radius-too-small = Indi mahimo kwentahon ang sirkulo: tungod nga ang distansya sang duha ka punto amo ang { $distance }, gamay gid ang gintakda nga radyus nga { $radius }.
+
+circle-radius-with-many-points = Indi mahimo maghimo sing sirkulo nga nagaagi sa sobra sa duha ka punto nga may gintakda nga radyus.
+
+circle-invalid-center-or-through-points = Indi balido ang sentro ukon ang mga punto nga agyan sang sirkulo.
+
+circle-radius-center-with-multiple-points = Indi mahimo kwentahon ang radyus sang sirkulo nga may gintakda nga sentro nga nagaagi sa sobra sa 1 ka punto.
+
+circle-change-radius-non-numerical = Indi mahimo baylohan ang radyus sang sirkulo nga nagaagi sa mga punto nga indi numeriko
+
+circle-radius-with-points-non-numerical = Indi mahimo maghimo sing sirkulo nga nagaagi sa sobra sa isa ka punto nga may gintakda nga radyus kon wala sing numeriko nga balor.
+
+circle-change-center-non-numerical = Wala pa maipatuman ang pagbag-o sang sentro sang sirkulo nga nagaagi sa mga punto nga wala sing numeriko nga balor.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Hiligaynon has one,
+# because «interbalo» and «input» do not change for number. Both selects are
+# dropped and both counts still arrive.
+function-domain-insufficient-dimensions = Kulang ang dimensyon sang domain para sa punsyon. Ang domain may { $intervals } nga interbalo pero ang punsyon may { $inputs } nga input.
+
+function-domain-invalid-format = Indi balido nga pormat sang domain para sa punsyon.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ginabaliwala ang indi numeriko nga pinakamataas sang punsyon.
+        [minimum] Ginabaliwala ang indi numeriko nga pinakamanubo sang punsyon.
+        [extremum] Ginabaliwala ang indi numeriko nga ekstremum sang punsyon.
+        [point] Ginabaliwala ang indi numeriko nga punto sang punsyon.
+        [slope] Ginabaliwala ang indi numeriko nga halihad sang punsyon.
+       *[other] Ginabaliwala ang indi numeriko nga { $type } sang punsyon.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ginabaliwala ang wala sing unod nga pinakamataas sang punsyon.
+        [minimum] Ginabaliwala ang wala sing unod nga pinakamanubo sang punsyon.
+        [extremum] Ginabaliwala ang wala sing unod nga ekstremum sang punsyon.
+        [point] Ginabaliwala ang wala sing unod nga punto sang punsyon.
+       *[other] Ginabaliwala ang wala sing unod nga { $type } sang punsyon.
+    }
+
+function-points-too-close = May duha ka punto ang punsyon nga tama kalapit. Indi mahimo depinaron ang punsyon.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Posible lamang ang mga iterasyon sang punsyon kon palareho ang kadamuon sang mga input kag ang kadamuon sang mga output. Ini nga punsyon may { $inputs } nga input kag { $outputs } nga output.
+
+## `<sequence>`
+
+sequence-invalid-length = Indi balido ang kalabaon sang sequence.  Kinahanglan indi negatibo nga integer.
+
+sequence-invalid-step = Indi balido ang step sang sequence.  Kinahanglan numero para sa sequence nga type { $type }.
+
+sequence-invalid-endpoint-number = Indi balido nga "{ $attribute }" sang sequence nga numero.  Kinahanglan numero.
+
+sequence-invalid-endpoint-letters = Indi balido nga "{ $attribute }" sang sequence nga letra.  Kinahanglan kombinasyon sang mga letra.
+
+sequence-invalid-endpoint = Indi balido nga "{ $attribute }" sang sequence.
+
+select-from-sequence-coprime-not-numbers = ginabaliwala ang coprime kay indi numero ang ginapili
+
+select-from-sequence-coprime-with-exclude-combinations = ginabaliwala ang coprime kay gintakda ang excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Indi balido nga target para sa `<{ $source }>`: indi makita ang target.
+
+target-state-variable-not-found = Indi balido nga target para sa `<{ $source }>`: indi makita ang baryable nga estado nga ginhingalanan nga "{ $property }" sa isa ka `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Kinahanglan tuhay ang mga baryable sang `<odeSystem>` sa independente nga baryable.
+
+ode-system-duplicate-variable-names = Indi mahimo depinaron ang mga punsyon nga RHS sang ODE nga palareho ang ngalan sang mga baryable nga nagasandig.
+
+ode-system-rhs-function-error = Indi mahimo depinaron ang punsyon nga RHS sang ODE.  May sayop sa paghimo sang punsyon nga mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Indi mahimo depinaron ang anggulo sa tunga sang { $count } ka linya
+
+angle-invalid-through-point = Indi balido nga punto sa through sang `<angle>`
+
+parabola-vertex-too-many-points = Wala pa maipatuman ang parabola nga may bertise nga nagaagi sa sobra sa 1 ka punto.
+
+parabola-too-many-points = Wala pa maipatuman ang parabola nga nagaagi sa sobra sa 3 ka punto.
+
+intersection-too-many-items = Wala pa maipatuman ang intersection para sa sobra sa duha ka butang
+
+## Other math components
+
+ionic-compound-not-two-ions = Wala pa maipatuman ang kompuwesto nga ioniko para sa iban luwas sa duha ka ion.
+
+ionic-compound-needs-cation-and-anion = Ginpatuman ang kompuwesto nga ioniko para lamang sa isa ka cation kag isa ka anion.
+
+solve-equations-cannot-evaluate = Indi masulbad ang ekwasyon kay indi matimbang ang ekwasyon: { $equation }
+
+math-operators-operand-number-required = Kinahanglan itakda ang operandNumber kon nagakuha sing operand nga matematika.
+
+eigen-decomposition-failed = Wala makwenta ang mga eigenvalue sang matris
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: ang parametro nga { $parameters } wala nagaagi sa pattern, gani permi ini magatugbang sa blangko.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: indi mahangpan ang grid="{ $grid }". Kinahanglan none, medium, dense, ukon duha ka positibo nga numero nga ginbulag sing espasyo, subong sang grid="1 0.5". Wala sing grid nga ginadrowing.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: wala sing suporta ang xLabelPosition="left" sa renderer nga prefigure; ginagamit ang paggawi sang tuo nga posisyon.
+
+prefigure-y-label-position-unsupported = `<graph>`: wala sing suporta ang yLabelPosition="bottom" sa renderer nga prefigure; ginagamit ang paggawi sang ibabaw nga posisyon.
+
+prefigure-invalid-axis-bounds = `<graph>`: indi balido ang mga dulunan sang aksis para sa konbersyon nga prefigure; ginagamit ang naandan nga bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: indi balido ang kasangkaron para sa konbersyon nga prefigure; ginagamit ang naandan nga kasangkaron sang diagram nga 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: indi balido ang aspectRatio para sa konbersyon nga prefigure; ginagamit ang naandan nga aspect ratio nga 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: tama kagamay ang tunga sang grid para sa mga dulunan sang aksis; ginabaliwala ang grid sa renderer nga prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: indi ma-render ang mga annotation kon indi ang renderer nga PreFigure ang ginagamit.
+
+multiple-annotations-children = Madamo nga bata nga `<annotations>` ang nakita sa `<graph>`; ginabaliwala ang tanan luwas sa ulihi.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Indi mahimo i-extend ukon kopyahon ang indi kilala nga klase sang komponente: { $type }.
+
+copy-prop-not-found = Wala makita ang prop nga { $property } sa komponente nga klase { $component }
+
+collect-no-source = Wala sing nakita nga source para sa collect.
+
+collect-invalid-component-type = Indi mahimo tipunon ang mga komponente nga klase `<{ $component }>` kay indi balido nga klase sang komponente.
+
+reference-index-unavailable = Indi matudlo ang indise nga `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Indi matawag ang { $action } sa komponente nga `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Indi balido ang porma sang datos.  Indi palareho ang kalabaon sang mga lakan. Nakita sa componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = May palareho nga ngalan sang kolum ang datos.  Nakita sa componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wala sing ngalan ang isa ka kolum sang datos.  Nakita sa componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ang award sini nga sabat nabase sa mismo nga ginpadala nga sabat sang answer tag, kag magadala ini sing indi ginapaabot nga paggawi.
+
+answer-max-num-attempts-in-section-wide-check-work = Wala sing epekto ang pagbutang sing `maxNumAttempts` sa isa ka `<answer>` sa sulod sang kontenedor nga may `sectionWideCheckWork`, kay ang kontenedor ang nagakontrol sang kadamuon sang mga tilaw. Ibutang ang `maxNumAttempts` sa kontenedor.
+
+nested-section-wide-check-work-max-num-attempts = Wala sing epekto ang pagbutang sing `maxNumAttempts` sa kontenedor nga may `sectionWideCheckWork` nga yara sa sulod sang isa pa ka kontenedor nga may `sectionWideCheckWork`, kay ang gwa nga kontenedor ang nagakontrol sang kadamuon sang mga tilaw. Ibutang ang `maxNumAttempts` sa gwa nga kontenedor.
+
+# No select: «atributo» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Wala sing epekto ang atributo nga { $attributes } kon wala mabutang ang symbolicEquality.
+
+answer-invalid-type = Indi balido nga klase para sa sabat: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Tungod nga wala sing ngalan ang komponente nga `<{ $component }>`, indi ini magamit para sa atributo sang module
+
+module-attribute-name-already-defined = Indi magamit ang komponente nga `<{ $component } name="{ $name }">` subong atributo sang module kay ang klase sang komponente nga `<module>` may atributo na nga "{ $name }".
+
+conditional-content-condition-ignored = Ginabaliwala ang atributo nga `condition` sa komponente nga `<conditionalContent>` nga may mga bata nga case ukon else.
+
+slider-markers-type-mismatch = Indi nagakadungan ang klase sang mga marker kag ang klase sang slider.
+
+pretzel-problem-needs-statement-and-answer = Indi balido nga pretzel: kinahanglan may unod ang kada `<problem>` nga isa ka `<statement>` kag isa ka `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Indi balido nga pretzel: sa mode="circuit", indi mahimo distractor ang una nga `<problem>`.
+
+## Attribute values
+
+# No select: «balor» is the same word for one and for many.
+attribute-invalid-values = Indi balido nga balor nga { $values } para sa atributo nga `{ $attribute }`; ginabaliwala.
+
+attribute-must-be-references = Indi balido nga balor nga `{ $value }` para sa atributo nga `{ $attribute }`. Kinahanglan ginabuo ang atributo sang mga reperensya nga nagasugod sa `$`.
+
+math-input-invalid-function-names = <mathInput>: ginbaliwala ang mga indi balido nga ngalan sang punsyon sa { $attribute }: { $names }. Kinahanglan may indi kubos sa 2 ka karakter ang kada ngalan (letra ukon gitlo); mahimo magsunod ang isa ka suffix nga `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Indi balido nga klase sang komponente: `<{ $componentType }>`
+
+attribute-repeated = Indi mahimo suliton ang atributo nga { $attribute }.
+
+attribute-invalid-for-component = Indi balido nga atributo nga "{ $attribute }" para sa komponente nga klase `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kulang ang kontraste sang depinisyon sang estilo nga { $styleNumber } para sa { $context ->
+        [text-on-background] kolor sang teksto kontra sa kolor sang background
+        [high-contrast] kolor nga mataas ang kontraste kontra sa kanbas
+        [line] kolor sang linya kontra sa kanbas
+        [marker] kolor sang marker kontra sa kanbas
+       *[text-on-canvas] kolor sang teksto kontra sa kanbas
+    }{ $mode ->
+        [dark] { " (madulom nga mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginakinahanglan ang indi kubos sa { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Bisan kon ang depinisyon sang estilo nga { $styleNumber } may gintakda nga mga kolor nga bastante ang kontraste para sa masanag nga mode, kulang ang kontraste sang kolor sang teksto kontra sa kolor sang background sa mga kolor nga ginkuha para sa madulom nga mode ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginakinahanglan ang indi kubos sa { $threshold }:1). { $suggestion ->
+        [available] Agod bastante ang kontraste sa madulom nga mode, dugangi ang kontraste sang masanag nga mode (halimbawa, ibutang ang { $lightAttribute }="{ $lightColor }") ukon ilisan ang kolor sang madulom nga mode (halimbawa, ibutang ang { $darkAttribute }="{ $darkColor }").
+       *[none] Agod bastante ang kontraste sa madulom nga mode, dugangi ang kontraste sang masanag nga mode ukon ilisan ang mga ginkuha nga kolor paagi sa textColorDarkMode kag/ukon backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Bisan kon ang depinisyon sang estilo nga { $styleNumber } may gintakda nga kolor sang teksto nga bastante ang kontraste para sa masanag nga mode, kulang ang kontraste sang kolor sang teksto nga ginkuha para sa madulom nga mode kontra sa kanbas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginakinahanglan ang indi kubos sa { $threshold }:1). { $suggestion ->
+        [available] Agod bastante ang kontraste sa madulom nga mode, dugangi ang kontraste sang masanag nga mode (halimbawa, ibutang ang textColor="{ $lightColor }") ukon ilisan ang kolor sang madulom nga mode (halimbawa, ibutang ang textColorDarkMode="{ $darkColor }").
+       *[none] Agod bastante ang kontraste sa madulom nga mode, dugangi ang kontraste sang masanag nga mode ukon ilisan ang ginkuha nga kolor paagi sa textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Isa lang ka <stylePalette> ang mahimo pilion sang isa ka seksyon; ginagamit ang ulihi.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = indi matukoy ang mga talagsahon nga baryante sang { $component } kay ang numToSelect indi integer nga indi negatibo.
+
+variant-num-to-select-not-constant-number = indi matukoy ang mga talagsahon nga baryante sang { $component } kay ang numToSelect indi konstante nga numero.
+
+variant-with-replacement-not-constant-boolean = indi matukoy ang mga talagsahon nga baryante sang { $component } kay ang withReplacement indi konstante nga boolean.
+
+variant-select-weight-disables-unique = Ginapatay ang mga talagsahon nga baryante para sa select kon may opsyon nga gintakdaan sing selectWeight ukon selectForVariants
+
+variant-coprime-undetermined = indi matukoy ang mga talagsahon nga baryante sang { $component } kay indi matukoy kon permi false ang coprime.
+
+variant-attribute-not-constant = indi matukoy ang mga talagsahon nga baryante sang { $component } kay indi konstante ang { $attribute }.
+
+variant-attribute-not-number = indi matukoy ang mga talagsahon nga baryante sang { $component } kay indi numero ang { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    indi matukoy ang mga talagsahon nga baryante sang { $component } nga klase { $type } kay ang { $attribute } indi { $expected ->
+        [letters-combination] kombinasyon sang mga letra
+        [math-expression] balido nga ekspresyon nga matematika
+        [integer] integer
+       *[number] numero
+    }.
+
+variant-length-not-integer = indi matukoy ang mga talagsahon nga baryante sang { $component } kay indi integer ang length.
+
+variant-sort-not-implemented = wala pa maipatuman ang mga talagsahon nga baryante sang isa ka { $component } nga may sort
+
+variant-exclude-combinations-not-implemented = wala pa maipatuman ang mga talagsahon nga baryante sang isa ka { $component } nga may excludeCombinations
+
+variant-math-exclude-not-implemented = wala pa maipatuman ang mga talagsahon nga baryante sang isa ka { $component } nga klase math nga may exclude
+
+variant-non-constant-exclude-not-implemented = wala pa maipatuman ang mga talagsahon nga baryante sang isa ka { $component } nga may indi konstante nga exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: wala sing suporta sa renderer nga prefigure sang graph; ginlaktawan ang kaliwat.
+
+prefigure-descendant-invalid-geometry = { $subject }: indi limitado ukon indi kompleto ang heometriya; ginlaktawan ang kaliwat.
+
+prefigure-curve-label-omitted = { $subject }: wala sing suporta ang mga etiketa sa mga nakonberte nga kurba; ginbaliwala ang etiketa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: wala sing suporta nga klase sang depinisyon sang punsyon nga kurba nga '{ $definitionType }'; ginlaktawan ang kaliwat.
+
+prefigure-region-flip-functions-unsupported = { $subject }: wala sing suporta nga atributo nga flipFunctions sa regionBetweenCurves; ginlaktawan ang kaliwat.
+
+prefigure-region-non-formula-child = { $subject }: ang mga bata nga punsyon nga klase formula lang ang may suporta sa regionBetweenCurves; ginlaktawan ang kaliwat.
+
+prefigure-label-position-unsupported =
+    { $subject }: wala sing suporta nga labelPosition '{ $labelPosition }' para sa { $labelKind ->
+        [line-family] etiketa sang pamilya sang linya
+       *[point] etiketa sang punto
+    }; ginagamit ang naandan nga pagpahiuyon sang PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: wala sing suporta ang PreFigure sa estilo sang unod nga '{ $fillStyle }'; nagabalik sa solido nga unod.
+
+prefigure-line-style-unknown = { $subject }: indi kilala nga estilo sang linya nga '{ $lineStyle }', ginbaliwala sa output sang PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gin-angot ang estilo sang marker nga '{ $markerStyle }' sa estilo nga 'diamond' sang PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: wala sing suporta ang PreFigure sa estilo sang marker nga '{ $markerStyle }'; ginagamit ang naandan nga estilo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: indi balido nga `ref`; indi matudlo ang target. Ginbaliwala ang annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: nagatudlo ang `ref` sa madamo nga target; ginagamit ang una nga target.
+
+annotation-ref-outside-graph = `<annotation>`: indi balido nga `ref`; yara ang target sa gwa sang graph nga nagaunod sini. Ginbaliwala ang annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: indi balido nga `ref`; ang target indi suportado nga grapikal nga butang sa konbersyon nga prefigure. Ginbaliwala ang annotation.
+
+annotation-text-missing = `<annotation>`: wala ukon blangko ang `text`; nagapagwa sing blangko nga teksto.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] May nakita nga sirkular nga pagsandig.
+       *[other] May nakita nga sirkular nga pagsandig nga nagalakip sang komponente nga `<{ $componentType }>`.
+    }
+
+reference-no-referent = Wala sing nakita nga ginatudlo sang reperensya: `{ $reference }`
+
+reference-multiple-referents = Madamo ang nakita nga ginatudlo sang reperensya: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Indi balido nga pormat sang atributo nga { $attribute } sang `<{ $componentType }>`.
+
+children-invalid = Indi balido ang mga bata sang `<{ $componentType }>`: nakita ang mga indi balido nga bata: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Indi balido nga balor nga `{ $value }` para sa atributo nga `{ $attribute }`, ginagamit ang balor nga `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Wala makita ang bersyon sang DoenetML nga { $version }.
+       *[other] Wala makita ang bersyon sang DoenetML nga { $version }. Nagabalik sa bersyon nga { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Indi balido nga DoenetML: { $content }
+
+parse-tag-missing-close-tag = Indi balido nga DoenetML: Wala sing pangsira nga tag ang tag nga `{ $tag }`. Ginapaabot ang tag nga nagasira sa kaugalingon ukon tag nga `</{ $tagName }>`.
+
+parse-tag-error = Indi balido nga DoenetML: May sayop sa tag nga `<{ $tagName }>`
+
+parse-attribute-missing-value = Indi balido nga DoenetML: Daw wala sing balor ang indi balido nga atributo nga `{ $attribute }`.
+
+parse-attribute-invalid = Indi balido nga DoenetML: Indi balido nga atributo nga `{ $attribute }`
+
+parse-attribute-value-invalid = Indi balido nga DoenetML: Indi balido nga balor sang atributo nga `{ $value }`
+
+parse-attribute-value-quote-mismatch = Indi balido nga DoenetML: Indi balido nga balor sang atributo nga `{ $value }`. Indi nagakadungan ang mga marka sang sipi. Daw wala sing isa ka `{ $quote }`
+
+parse-open-tag-name-missing = Indi balido nga DoenetML: May nakita nga tag nga wala sing ngalan, halimbawa `<`
+
+parse-tag-not-closed = Indi balido nga DoenetML: Wala nasira ang tag nga `{ $tag }` (daw wala sing `>`).
+
+parse-self-closing-tag-name-missing = Indi balido nga DoenetML: May nakita nga tag nga wala sing ngalan `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Indi balido nga DoenetML: Wala nasira ang tag nga `{ $tag }` (daw wala sing `/>`).
+
+parse-tag-invalid-attributes = Indi balido nga DoenetML: Indi balido ang tag nga `{ $tag }`. Basi may indi husto nga mga atributo.
+
+parse-close-tag-name-missing = Indi balido nga DoenetML: May nakita nga pangsira nga tag nga wala sing ngalan, halimbawa `</`
+
+parse-attribute-value-unquoted = Kinahanglan nakabutang sa sulod sang mga marka sang sipi ang mga balor sang atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Indi balido nga DoenetML: May nakita nga pangsira nga tag nga `{ $tag }`, pero wala sing katugbang nga pangbukas nga tag
+
+parse-close-tag-mismatched = Indi balido nga DoenetML: Indi magkatugbang ang pangsira nga tag. Ginapaabot ang `</{ $expected }>`. Nakita ang `{ $found }`
+
+parser-node-unconvertible = Wala nakonberte ang node nga { $node } pakadto sa node nga Dast.
+
+## Names
+
+name-attribute-invalid =
+    Indi balido nga atributo nga name='{ $name }'. { $reason ->
+        [characters] Mahimo lang magsulod ang mga ngalan sing mga letra, numero, underscore ukon gitlo.
+       *[start] Kinahanglan nagasugod ang mga ngalan sa letra.
+    }
+
+component-name-invalid-start = Indi balido nga ngalan sang komponente nga "{ $name }". Kinahanglan nagasugod ang mga ngalan sa letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Kinahanglan may atributo nga video ang answer nga type videoWatched
+
+answer-video-watched-video-not-reference = Kinahanglan reperensya ang atributo nga video sang answer nga type videoWatched
+
+answer-name-not-single-text = Kinahanglan may isa lang ka bata nga text ang atributo nga name sang answer
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Wala makuha ang gwa nga DoenetML tungod sa sobra kadamo nga lebel sang pagsulit-sulit. May sirkular bala nga reperensya?
+
+external-doenetml-unavailable = Wala makuha ang DoenetML halin sa { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Indi balido nga DoenetML ang nakuha halin sa { $attribute }="{ $uri }": wala ini nagatugbang sa klase sang komponente nga "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Indi na ginagamit ang atributo nga `{ $from }`; gamita ang `{ $to }`.
+       *[other] [deprecation] Indi na ginagamit ang atributo nga `{ $from }` sa `<{ $component }>`; gamita ang `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Indi na ginagamit ang atributo nga `{ $from }` kag ginabaliwala kay gintakda man ang `{ $to }`.
+       *[other] [deprecation] Indi na ginagamit ang atributo nga `{ $from }` sa `<{ $component }>` kag ginabaliwala kay gintakda man ang `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Indi na ginagamit ang atributo nga `{ $attribute }` sa `<{ $component }>` kag ginabaliwala.
+
+deprecated-attribute-to-child = [deprecation] Indi na ginagamit ang atributo nga `{ $attribute }` sa `<{ $component }>`; gamita ang bata nga `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Indi na ginagamit ang balor nga `{ $value }` sang atributo nga `{ $attribute }` sa `<{ $component }>`; gamita ang `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = Ang `<pluralize>` makahimo lang magpadamo sing Ingles, gani wala nabag-o ang teksto sini sa dokumento nga ginsulat sa { $locale }. Isulat mismo ang porma nga damo, ukon ibutang ini paagi sa atributo nga `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ang elemento nga `<{ $tag }>` indi kilala nga elemento sang Doenet.
+
+schema-element-not-allowed-at-root = Indi ginatugutan ang elemento nga `<{ $tag }>` sa gamot sang dokumento.
+
+schema-element-not-allowed-inside = Indi ginatugutan ang elemento nga `<{ $tag }>` sa sulod sang `<{ $parent }>`.
+
+schema-attribute-unrecognized = Wala sing atributo nga ginhingalanan nga `{ $attribute }` ang elemento nga `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Kinahanglan lista ang atributo nga `{ $attribute }` sang elemento nga `<{ $tag }>` nga ang kada butang isa sa: { $allowed }
+       *[other] Kinahanglan isa sa mga ini ang atributo nga `{ $attribute }` sang elemento nga `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Indi balido nga ngalan sang baryante para sa select.  Ang ngalan sang baryante nga { $variantName } nagaagi sa { $numOptions } nga opsyon pero { $numToSelect } ang kadamuon nga pilion.
+
+select-variant-name-without-options = May gintakda nga mga baryante para sa select pero wala sing gintakda nga opsyon para sa posible nga ngalan sang baryante: { $variantName }.
+
+select-variant-name-not-possible = Ang ngalan sang baryante nga { $variantName } nga gintakda para sa select indi posible nga ngalan sang baryante.
+
+select-too-few-options = Indi mahimo magpili sing { $numToSelect } nga komponente halin sa { $numOptions } lang.
+
+select-from-sequence-too-few-values = Indi mahimo magpili sing { $numToSelect } nga balor halin sa sequence nga { $length } ang kalabaon.
+
+select-from-sequence-indices-count-mismatch = Kinahanglan magkatugbang ang kadamuon sang mga indise nga gintakda para sa select kag ang kadamuon nga pilion
+
+select-from-sequence-indices-not-integers = Kinahanglan integer ang tanan nga indise nga gintakda para sa select
+
+select-from-sequence-index-excluded = Gintakda ang indise sang selectfromsequence nga ginbaliwala
+
+select-from-sequence-indices-excluded-combination = Gintakda ang mga indise sang selectfromsequence nga isa ka ginbaliwala nga kombinasyon
+
+select-from-sequence-coprime-not-positive-integers = Indi mahimo magpili sing mga kombinasyon nga coprime kay indi positibo nga integer ang ginapili.
+
+select-from-sequence-coprime-common-factor = Indi mahimo magpili sing mga numero nga coprime. May isa ka paktor nga palareho ang tanan nga posible nga balor. (Kinahanglan coprime ang gintakda nga balor sang "from" ukon "to" sa "step".)
+
+select-from-sequence-coprime-single-number = Indi mahimo magpili sing mga kombinasyon nga coprime halin sa isa lang ka numero nga indi 1.
+
+select-from-sequence-excluded-too-many-combinations = Ginbaliwala ang sobra sa 70% sang mga kombinasyon sa selectFromSequence
+
+select-from-sequence-coprime-none-found = Wala makapili sing mga numero nga coprime. May isa ka paktor nga palareho ang tanan nga posible nga balor.
+
+select-from-sequence-too-few-unique-values = Indi mahimo magpili sing { $numToSelect } nga talagsahon nga balor halin sa sequence nga { $numPossibleValues } ang kalabaon
+
+select-prime-numbers-too-few-values = Indi mahimo magpili sing { $numToSelect } nga balor halin sa lista sang mga prime nga { $numValues } ang kalabaon
+
+select-prime-numbers-values-count-mismatch = Kinahanglan magkatugbang ang kadamuon sang mga balor nga gintakda para sa select kag ang kadamuon nga pilion
+
+select-prime-numbers-values-not-prime = Kinahanglan yara sa lista sang mga prime ang tanan nga balor nga gintakda para sa select prime number
+
+select-prime-numbers-values-excluded-combination = Ang gintakda nga mga balor sang selectPrimeNumbers isa ka ginbaliwala nga kombinasyon
+
+select-prime-numbers-excluded-too-many-combinations = Ginbaliwala ang sobra sa 70% sang mga kombinasyon sa selectPrimeNumbers
+
+select-random-combination-fluke = Tungod sa talagsahon gid nga swerte, wala makapili sing kombinasyon sang mga random nga balor
+
+select-random-value-fluke = Tungod sa talagsahon gid nga swerte, wala makapili sing random nga balor

--- a/packages/i18n/locales/hil/editor.ftl
+++ b/packages/i18n/locales/hil/editor.ftl
@@ -1,0 +1,208 @@
+# Hiligaynon editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Hiligaynon marks no number on the noun, so a `{ $count -> … }` whose two
+# English branches differ only in the noun renders one string here and the
+# select is dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ibalik
+       *[update] Update
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } ang pagtan-aw
+       *[other] { $word } ang pagtan-aw { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Baryante
+editor-variant-filter = Sagion…
+editor-variant-next = Pilia ang sunod nga baryante
+editor-variant-previous = Pilia ang nagligad nga baryante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] May nakita nga paglapas sa aksesibilidad nga WCAG AA. I-klik agod { $action ->
+            [close] matakpan
+           *[open] mabuksan
+        } ang report sang aksesibilidad.
+        [advisories] I-klik agod { $action ->
+            [close] matakpan
+           *[open] mabuksan
+        } ang report sang aksesibilidad. Wala sing nakita nga paglapas sa WCAG AA, pero may dugang pa nga rekomendasyon sa aksesibilidad.
+       *[clean] I-klik agod { $action ->
+            [close] matakpan
+           *[open] mabuksan
+        } ang report sang aksesibilidad. Wala sing nakita nga problema sa aksesibilidad.
+    }
+
+# No select on `$count` inside the branches: «paglapas» and «rekomendasyon» are
+# the same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] May nakita nga paglapas sa aksesibilidad nga WCAG AA. { $count } nga paglapas sa WCAG AA ang nakita. I-klik agod { $action ->
+            [close] matakpan
+           *[open] mabuksan
+        } ang report sang aksesibilidad.
+        [advisories] Wala sing nakita nga paglapas sa WCAG AA. { $count } nga dugang nga rekomendasyon sa aksesibilidad ang nakita. I-klik agod { $action ->
+            [close] matakpan
+           *[open] mabuksan
+        } ang report sang aksesibilidad.
+       *[clean] Wala sing nakita nga paglapas sa WCAG AA. I-klik agod { $action ->
+            [close] matakpan
+           *[open] mabuksan
+        } ang report sang aksesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersyon sang DoenetML { $version }
+
+editor-tab-help = Bulig nga suno sa konteksto
+editor-tab-help-short = Konteksto
+editor-tab-errors = Sayop
+editor-tab-warnings = Paandam
+editor-tab-info = Impormasyon
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Ginpadala nga mga sabat
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Mga opsyon sang editor
+editor-format-as-doenetml = I-pormat subong DoenetML
+editor-format-as-xml = I-pormat subong XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linya #{ $line }
+
+editor-no-errors = Wala sing sayop
+editor-no-warnings = Wala sing paandam
+editor-no-info = Wala sing diagnostiko nga impormasyon
+
+editor-show-info-annotations = Ipakita ang mga diagnostiko nga impormasyon sa editor
+editor-show-accessibility-annotations = Ipakita ang mga diagnostiko sang aksesibilidad sa editor
+
+editor-accessibility-learn-more = Tun-i kon paano ginaatubang sang Doenet ang aksesibilidad
+
+editor-accessibility-violations-heading = Mga paglapas sa aksesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Iban pa nga problema sa aksesibilidad
+editor-none-found = Wala sing nakita
+
+
+## Submitted responses
+
+editor-no-responses = Wala pa sing ginpadala nga sabat
+editor-response-answer-id = Id sang sabat
+editor-response-response = Sabat
+editor-response-credit = Kredito
+editor-response-submitted = Ginpadala
+
+
+## The context-help panel
+
+help-placeholder = Ibutang ang kursor sa ngalan sang tag, atributo, ukon { $ref } para sa dokumentasyon.
+
+help-unsupported-ref-chain = Wala pa sing suporta ang bulig para sa mga reperensya nga madamo ang bahin subong sang { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Wala sing nakita nga ginatudlo sang reperensya: { $ref }.
+        [multiple] Madamo ang nakita nga ginatudlo sang reperensya: { $ref }.
+       *[indeterminate] Wala matukoy ang ginatudlo sang { $ref }.
+    }
+
+help-learn-about-references = Tun-i ang parte sa mga reperensya →
+help-reference-page = Pahina sang reperensya →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Sa sulod sang { $element }
+       *[top] Sa pinakamataas nga lebel
+    }{ $allowed ->
+        [none] { " — wala sing mabutang diri." }
+        [text] { " — magsulat sing teksto diri." }
+        [text-and-components] { " — magsulat sing teksto diri, ukon tilawi:" }
+       *[components] { " — mga matilawan:" }
+    }
+
+help-suggestions-footer = Pisla ang { $shortcut } agod makita ang tanan nga { $total } nga komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] Ang { $ref } isa ka reperensya sa { $target }.
+       *[other] Ang { $ref } isa ka reperensya sa { $target } (linya { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Gindala sang { $owner } subong { $role }.
+       *[other] Gindala sang { $owner } sa linya { $line } subong { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] Ang { $ref } isa ka reperensya sa propyedad nga { $property } sang { $element }.
+       *[other] Ang { $ref } isa ka reperensya sa propyedad nga { $property } sang { $element } (linya { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = gamay nga kodigo
+help-kind-array-entry = entrada sa array
+
+help-default = Naandan:
+help-active-default = Aktibo nga naandan:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Mga tugot nga balor (isa kada butang):
+       *[other] Mga tugot nga balor:
+    }
+
+help-suggested-values = Mga ginasuhestyon nga balor:
+
+help-inserts = Nagasulod:
+
+# No select: «koordinado» is the same word for one and for many.
+help-coordinates = Koordinado:
+
+help-type = Klase:
+
+help-resolved-style = Natukoy nga estilo (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Natukoy nga mga ngalan sang punsyon:
+help-reset-list = Lista sang pagbalik sa sini nga input:
+help-added-on-input = Gindugang sa sini nga input:
+help-removed-on-input = Ginkuha sa sini nga input:
+
+help-reset-overrides = Ang { $reset } nagailis sang { $additional } kag { $removed }.

--- a/packages/i18n/locales/ilo/chrome.ftl
+++ b/packages/i18n/locales/ilo/chrome.ftl
@@ -1,0 +1,157 @@
+# Ilocano viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the modern Latin orthography Ilocano publishing and the Department
+# of Education's mother-tongue materials use.
+#
+# Ilocano does not mark number on the noun. Plurality is carried by the article
+# — «ti» against «dagiti» — and a noun after a numeral stays singular, so a
+# `{ $count -> … }` whose only English difference is the noun's number renders
+# one string here and the select is dropped. The count still arrives and is
+# still formatted. A `[0]` branch stays wherever English has one: "none left" is
+# its own sentence rather than a form of the sentence beside it.
+#
+# The **linker** is this catalog's one recurring decision. An attributive
+# adjective is joined to its noun by «nga» after a vowel and «a» after a
+# consonant, and which one is right is decided by the word *before* it. Where
+# that word is one this catalog writes, the linker is written out; where it
+# would land against a placeable — an author's own answer name, a choice's
+# text — the sentence is built so that no linker is needed at all. See the
+# header of `content.ftl`, where the same constraint decides the shape of every
+# composition message.
+
+
+## Answer submission
+
+answer-checking = Sursukimaten…
+answer-submitting = Ipatpatulod…
+
+answer-checking-status = Sursukimaten ti sungbat
+answer-submitting-status = Ipatpatulod ti sungbat
+
+answer-correct = Husto
+answer-incorrect = Saan a husto
+
+answer-response-saved = Naidulin ti sungbat
+
+answer-percent-credit = { $percent }% a kredito
+answer-percent-correct = { $percent }% a husto
+answer-percent-short = { $percent } %
+
+max-credit-available = Kangatuan a kredito a magun-od: { $percent }%
+
+# No select: «padas» is the same word for one and for many — the number in front
+# of it does the work — so both English categories render one string here. The
+# `[0]` branch stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] awanen ti nabati a padas
+       *[other] { $count } ti nabati a padas
+    }
+
+validation-correct = (Husto)
+validation-incorrect = (Saan a husto)
+validation-partially-correct = (Husto iti paset)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated, so the sentence reaches it through «iti»
+# rather than through a linker whose shape that name would decide.
+answer-show-responses = Ipakita ti { $count } a sungbat iti { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komento
+
+collapsible-click-to-open = (pinduten tapno maluktan)
+collapsible-click-to-close = (pinduten tapno mairikep)
+
+collapsible-initializing = Mangrugrugi…
+
+footnote-show = Ipakita ti footnote
+footnote-hide = Ilemmeng ti footnote
+
+description-more-information = ad-adu pay nga impormasion
+
+
+## Controls
+
+slider-previous = Napalabas
+slider-next = Sumaruno
+
+keyboard-open = Luktan ti teklado
+keyboard-close = Irikep ti teklado
+
+# `$choice` is the choice's own text and is never translated. It follows «ti»,
+# so no linker has to agree with a word this catalog has not seen.
+choice-input-remove-choice = Ikkaten ti { $choice }
+
+matrix-remove-row = Ikkaten ti intar
+matrix-add-row = Mangnayon iti intar
+matrix-remove-column = Ikkaten ti adigi
+matrix-add-column = Mangnayon iti adigi
+
+subset-add-remove-points = Mangnayon/Mangikkat kadagiti punto
+subset-toggle-points-intervals = Agbaliw kadagiti punto ken interbalo
+subset-move-points = Iyalis dagiti punto
+subset-clear = Dalusan
+
+orbital-add-row = Mangnayon iti intar
+orbital-remove-row = Ikkaten ti intar
+orbital-add-box = Mangnayon iti kahon
+orbital-remove-box = Ikkaten ti kahon
+orbital-add-up-arrow = Mangnayon iti pana nga agpangato
+orbital-add-down-arrow = Mangnayon iti pana nga agpababa
+orbital-remove-arrow = Ikkaten ti pana
+
+orbital-row-label = Etiketa para iti intar { $row }
+
+pretzel-answer = Sungbat
+
+summary-statistics-caption = Pakabuklan a estadistika ti { $column }
+
+
+## Math input
+
+math-input-preview-region = pagsakbayan ti ekspresion a matematika
+math-input-preview = Pagsakbayan
+math-input-invalid-expression = Imbalido nga ekspresion:
+
+
+## Document status
+
+viewer-initializing = Mangrugrugi…
+
+
+## Errors
+
+error-heading = Biddut
+
+# `$startLine` and `$endLine` are line numbers and arrive as text.
+error-found-at =
+    { $span ->
+        [line] Nasarakan iti linia { $startLine }.
+       *[lines] Nasarakan kadagiti linia { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Adda biddut daytoy a dokumento!
+
+diagnostic-heading-error = Biddut
+diagnostic-heading-warning = Ballaag
+diagnostic-heading-information = Impormasion
+diagnostic-heading-hint = Palagip
+
+accessibility-heading-level-1 = Panaglabsing iti aksesibilidad a WCAG AA
+accessibility-heading-level-2 = Ballaag maipapan iti aksesibilidad
+
+something-went-wrong = Adda saan a nasayaat a napasamak.
+
+renderer-load-failed = adda renderer a saan a naikarga. Pangngaasi ta i-reload ti panid.
+
+core-start-failed = Saan a nairugi ti pagbuyaan ti dokumento. Pangngaasi ta i-reload ti panid.

--- a/packages/i18n/locales/ilo/chrome.ftl
+++ b/packages/i18n/locales/ilo/chrome.ftl
@@ -18,10 +18,10 @@
 # its own sentence rather than a form of the sentence beside it.
 #
 # The **linker** is this catalog's one recurring decision. An attributive
-# adjective is joined to its noun by «nga» after a vowel and «a» after a
-# consonant, and which one is right is decided by the word *before* it. Where
+# adjective is joined to its noun by «nga» before a vowel and «a» before a
+# consonant, and which one is right is decided by the word *after* it. Where
 # that word is one this catalog writes, the linker is written out; where it
-# would land against a placeable — an author's own answer name, a choice's
+# would land in front of a placeable — an author's own answer name, a choice's
 # text — the sentence is built so that no linker is needed at all. See the
 # header of `content.ftl`, where the same constraint decides the shape of every
 # composition message.

--- a/packages/i18n/locales/ilo/content.ftl
+++ b/packages/i18n/locales/ilo/content.ftl
@@ -141,7 +141,8 @@ style-filled-with-noun =
 # Ilocano has no article, so the two `-article` branches say what the other two
 # say. They are kept apart because English's distinction is between a first
 # clause and a further one, which this file does mark: «nga addaan iti» against
-# «ken».
+# «ken». The ligature in front of «igid» is «nga» and is fixed, because «igid»
+# is vowel-initial and this catalog writes it.
 style-border-clause =
     { $parts ->
         [with-article] nga addaan iti { $border } nga igid
@@ -150,7 +151,6 @@ style-border-clause =
        *[with] nga addaan iti { $border } nga igid
     }
 
-# «igid» is vowel-initial, so its ligature is «nga» and is fixed.
 style-fill =
     { $parts ->
         [pattern] { $color } a { $pattern }
@@ -262,8 +262,8 @@ piecewise-condition-otherwise = no saan
 ## English. Philippine secondary science is taught in English from the
 ## intermediate grades, so the periodic table an Ilocano pupil meets is the
 ## English one — the same reason `locales/fil` and `locales/ceb` leave these
-## keys out, and a fact about one school system rather than about three
-## languages.
+## keys out, and a fact about one school system rather than about the seven
+## Philippine languages the roster now carries.
 
 ion-name-oxidation-state = { $name } ({ $numeral })
 

--- a/packages/i18n/locales/ilo/content.ftl
+++ b/packages/i18n/locales/ilo/content.ftl
@@ -1,0 +1,271 @@
+# Ilocano content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the modern Latin orthography of Ilocano publishing.
+#
+# Ilocano has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+# What the composition messages do is order and link — nothing more.
+#
+# **The linker decides the shape of this file.** An attributive adjective is
+# joined to what it describes by a ligature, and Ilocano's has two forms whose
+# choice is made by the **first sound of the word that follows it**: «nga»
+# before a vowel, «a» before a consonant. That is the Kʼicheʼ «u-»/«r-» case of
+# `locales/quc` seen in a Philippine language — an affix whose shape an unknown
+# following word decides — and unlike the Bisayan and Bikol linkers it has no
+# form that is right in both places, so it cannot simply be written out in full.
+#
+# Every entry in this catalog's own tables is consonant-initial but one: «asul».
+# So every ligature that lands in front of a placeable is written «a», which is
+# right for every word this file supplies except that one, and right for an
+# author's own `lineColorWord` unless they wrote a vowel-initial word. A
+# corrector adding a vowel-initial colour or noun has to check the ligature
+# beside it; that is the one thing in this file a table edit can break.
+#
+# The adjectives **precede** the noun, which is English's order and Ilocano's
+# ordinary one for a descriptive phrase.
+#
+# The geometry vocabulary is largely Spanish-derived — «linia», «sirkulo»,
+# «poligono» — because that is the vocabulary Philippine mathematics teaching
+# carries, in Ilocano as in Tagalog. The colours and the everyday words are
+# Ilocano's own.
+
+
+## Style vocabulary
+
+color =
+    .black = nangisit
+    .white = puraw
+    .gray = dapo
+    .red = nalabaga
+    .orange = kahel
+    .yellow = duyaw
+    .green = berde
+    .cyan = sian
+    .blue = asul
+    .purple = lila
+    .pink = rosas
+    .brown = kapé
+
+line-width =
+    .thick = napuskol
+    .thin = nanipis
+
+line-style =
+    .dashed = naguris-guris
+    .dotted = natuldek-tuldek
+
+# Noun phrases. Ilocano marks no plural on the noun, so «guris» is the word for
+# one line and for many alike; these are not plurals of anything.
+fill-style =
+    .horizontal = pakleb a guris
+    .vertical = takder a guris
+    .diagonal = kilo a guris
+    .backdiagonal = supadi a kilo a guris
+    .dots = tuldek
+    .diamonds = diamante
+
+noun =
+    .line = linia
+    .line-segment = segmento
+    .ray = sinag
+    .vector = bektor
+    .curve = kurba
+    .function = punsion
+    .parabola = parabola
+    .polyline = polilinia
+    .polygon = poligono
+    .triangle = triangulo
+    .rectangle = rektanggulo
+    .circle = sirkulo
+    .region = rehion
+    .point = punto
+    .square = kuadrado
+    .diamond = diamante
+    .cross = krus
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe. «nga» here is correct and fixed: «addaan» is
+# vowel-initial and is this catalog's own word.
+noun-regular-polygon =
+    { $part ->
+        [tail] nga addaan iti { $numSides } a sikigan
+       *[head] regular a poligono
+    }
+
+# One answer for every noun: Ilocano has no grammatical gender, so nothing
+# downstream has anything to agree with.
+noun-gender = neuter
+
+
+## Style composition
+
+# Each ligature is written «a», the form before a consonant — see the header.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } a { $lineStyle } a { $color }
+        [width-color] { $width } a { $color }
+        [style-color] { $lineStyle } a { $color }
+        [width-style] { $width } a { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } a { $noun } { $nounTail }
+       *[noun] { $description } a { $noun }
+    }
+
+style-filled-word = napunno
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } a { $color } nga addaan iti { $pattern }
+       *[plain] { $filled } a { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } a { $color } a { $noun } nga addaan iti { $pattern }
+        [plain-tail] { $filled } a { $color } a { $noun } { $nounTail }
+        [pattern-tail] { $filled } a { $color } a { $noun } { $nounTail } nga addaan iti { $pattern }
+       *[plain] { $filled } a { $color } a { $noun }
+    }
+
+# Ilocano has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «nga addaan iti» against
+# «ken».
+style-border-clause =
+    { $parts ->
+        [with-article] nga addaan iti { $border } nga igid
+        [and] ken { $border } nga igid
+        [and-article] ken { $border } nga igid
+       *[with] nga addaan iti { $border } nga igid
+    }
+
+# «igid» is vowel-initial, so its ligature is «nga» and is fixed.
+style-fill =
+    { $parts ->
+        [pattern] { $color } a { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = saan a napunno
+
+style-text =
+    { $parts ->
+        [background] { $color } nga addaan iti { $background } a likudan
+       *[plain] { $color }
+    }
+
+style-background-none = awan
+
+
+## Boolean words
+
+boolean-true = pudno
+boolean-false = saan a pudno
+
+
+## Answer buttons
+
+answer-submit-label = Sukimaten ti sungbat
+answer-submit-label-no-correctness = Ipatulod ti sungbat
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Ilocano marks number on the article rather than on the noun, and a
+# heading carries no article. Two ids with one translation is what that looks
+# like here, not a copy-paste.
+section-name =
+    .activity = Aktibidad
+    .aside = Nota iti sikigan
+    .cascade = Kaskada
+    .definition = Depinision
+    .example = Ehemplo
+    .exercise = Ehersisio
+    .exercises = Ehersisio
+    .given-answer = Sungbat
+    .note = Nota
+    .objectives = Panggep
+    .paragraphs = Parapo
+    .part = Paset
+    .problem = Problema
+    .problems = Problema
+    .proof = Pammaneknek
+    .question = Saludsod
+    .section = Seksion
+    .solution = Solusion
+    .task = Trabaho
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Palagip
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabla { $enumeration }
+        [numbered-title] Tabla { $enumeration }{ ": " }
+        [unnumbered-title] Tabla{ ": " }
+       *[unnumbered] Tabla
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Pigura { $enumeration }
+        [numbered-caption] Pigura { $enumeration }{ ": " }
+        [unnumbered-caption] Pigura{ ": " }
+       *[unnumbered] Pigura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Napalabas
+paginator-next = Sumaruno
+paginator-page = Panid
+
+paginator-page-status = { $pageLabel } { $currentPage } iti { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = wenno
+piecewise-condition-if = no
+piecewise-condition-otherwise = no saan
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Philippine secondary science is taught in English from the
+## intermediate grades, so the periodic table an Ilocano pupil meets is the
+## English one — the same reason `locales/fil` and `locales/ceb` leave these
+## keys out, and a fact about one school system rather than about three
+## languages.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Imbalido a simbolo a kemikal
+chemistry-invalid-ionic-compound = Imbalido a kompuesto nga ioniko

--- a/packages/i18n/locales/ilo/diagnostics.ftl
+++ b/packages/i18n/locales/ilo/diagnostics.ftl
@@ -1,0 +1,629 @@
+# Ilocano diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Ilocano marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+#
+# A value quoted back from the author's source is reached through «ti» or
+# «iti» rather than through a ligature, so that no «a»/«nga» choice depends on
+# a word this catalog has never seen. See `content.ftl`'s header for the rule
+# and for the one place it could not be avoided.
+
+
+## `<lineSegment>`
+
+# No select: «mailaksid» does not agree with what is ignored, and the list
+# carries no number of its own. One string covers both English categories.
+line-segment-attributes-ignored-with-endpoints = mailaksid ti { $attributes } no naespesipika ti dua a bout
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = mailaksid ti { $attributes } no naespesipika ti maysa a bout ken ti tengnga
+
+line-segment-midpoint-offset-without-midpoint = awan ti epekto ti midpointOffset no awan ti tengnga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linia a lumasat kadagiti punto a saan a nadeterminaran ti dimension da.
+
+line-points-too-few-dimensions = Masapul a lumasat ti linia kadagiti punto nga addaan iti saan a nababbaba ngem dua a dimension.
+
+line-points-depend-on-variables = Lumasat ti linia kadagiti punto nga agpannuray kadagiti baribariabol: { $variables }.
+
+line-equation-invalid-format = Imbalido a pormat ti ekuasion ti linia kadagiti baribariabol a { $variable1 } ken { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Naiprisibi ti sinag babaen ti through, endpoint ken direction.  Mailaksid ti naespesipika a through.
+
+ray-dimension-mismatch = saan nga agtutunos ti numDimensions iti sinag.
+
+## `<vector>`
+
+vector-overprescribed-head = Naiprisibi ti bektor babaen ti head, tail ken displacement.  Mailaksid ti naespesipika a head.
+
+vector-dimension-mismatch = saan nga agtutunos ti numDimensions iti bektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Saan a mabalin nga agguyod iti `<{ $component }>` ta awan ti baribariabol nga estado a nearestPoint na.
+
+constrain-to-without-nearest-point = Saan a mabalin a mangpatingga iti `<{ $component }>` ta awan ti baribariabol nga estado a nearestPoint na.
+
+constrain-to-interior-without-nearest-point = Saan a mabalin a mangpatingga iti uneg ti `<{ $component }>` ta awan ti baribariabol nga estado a nearestPoint na.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = mailaksid ti labelPosition iti choiceInput a saan nga inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Mailaksid dagiti indeks a naespesipika para iti choiceInput ta saan nga agtutunos ti bilang dagiti indeks ken ti bilang dagiti anak a pagpilian.
+
+pretzel-indices-count-mismatch = Mailaksid dagiti indeks a naespesipika para iti problem ta saan nga agtutunos ti bilang dagiti indeks ken ti bilang dagiti anak a problem.
+
+shuffle-indices-count-mismatch = Mailaksid dagiti indeks a naespesipika para iti shuffle ta saan nga agtutunos ti bilang dagiti indeks ken ti bilang dagiti komponente.
+
+indices-ignored-out-of-range = Mailaksid dagiti indeks a naespesipika para iti { $component } ta adda indeks a rimmuar iti benneg.
+
+pretzel-indices-repeated = Mailaksid dagiti indeks a naespesipika para iti pretzel ta adda indeks a naulit.
+
+pretzel-circuit-first-index = Mailaksid dagiti indeks a naespesipika para iti pretzel iti mode a circuit ta masapul a 1 ti umuna nga indeks.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Tapno agandar ti `<{ $component }>` kadagiti anak a string, masapul a maespesipika ti atributo a `type`.
+
+invalid-type-defaulting-to-math = Imbalido a type { $type } para iti komponente a { $component }. Masapul a maysa kadagiti math, text, number, wenno boolean. Agus-usar iti math.
+
+string-not-valid-component-to-arrange = Ti string a "{ $value }" ket saan a balido a komponente para iti { $component }. Mailaksid.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Imbalido a type { $type }, maisaad ti type iti number.
+
+invalid-variable-value = Imbalido a pateg ti maysa a baribariabol: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Masapul a numero ti indeks ti baryante a { $index }
+
+variant-index-must-be-integer = Masapul nga integer ti indeks ti baryante a { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Saan a naipatungpal ti `<{ $component }>` para kadagiti absoluto a rukod. Maisaad dagiti kaakaba a relatibo.
+
+side-by-side-absolute-margins = Saan a naipatungpal ti `<{ $component }>` para kadagiti absoluto a rukod. Maisaad dagiti margin a relatibo.
+
+side-by-side-no-block-child = Imbalido a `<{ $component }>`: masapul nga addaan iti saan a nababbaba ngem maysa nga anak a block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Mailaksid ti atributo a `for` iti grapikal a `<label>`.
+
+label-for-must-resolve-to-one = Masapul a maiturong ti atributo a `for` iti `<label>` iti eksakto a maysa a komponente.
+
+label-for-unresolved = Saan a naiturong ti atributo a `for` iti `<label>` iti maysa a komponente.
+
+label-for-answer-with-authored-inputs = Tuktukoyen ti atributo a `for` iti `<label>` ti maysa nga `<answer>` nga addaan kadagiti input a sinurat ti autor; tukoyen ti input a mismo.
+
+label-for-answer-without-input = Tuktukoyen ti atributo a `for` iti `<label>` ti maysa nga `<answer>` nga awan ti input a maetiketaan.
+
+label-for-must-reference-input-or-answer = Masapul a tukoyen ti atributo a `for` iti `<label>` ti maysa nga input wenno maysa nga answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Para iti aksesibilidad, masapul nga addaan ti `<{ $component }>` iti ababa a deskripsion wenno maespesipika a dekoratibo.
+
+accessibility-video-short-description = Para iti aksesibilidad, masapul nga addaan ti `<video>` iti ababa a deskripsion.
+
+accessibility-input-short-description-or-label = Para iti aksesibilidad, masapul nga addaan ti `<{ $component }>` iti ababa a deskripsion wenno etiketa.
+
+accessibility-answer-input-short-description-or-label = Para iti aksesibilidad, masapul nga addaan iti ababa a deskripsion wenno etiketa ti maysa nga `<answer>` a mangpartuat iti input.
+
+accessibility-short-description-contains-math = Saan koma nga aglaon dagiti ababa a deskripsion kadagiti komponente a matematika a kas ti `<{ $component }>`. Isurat iti sasao ti aniaman a matematika.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kurang ti kontraste ti { $colorName } para iti teksto ti ulo ti seksion (nasipnget a mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; masapul ti saan a nababbaba ngem { $threshold }:1).
+       *[other] Kurang ti kontraste ti { $colorName } para iti teksto ti ulo ti seksion ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; masapul ti saan a nababbaba ngem { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Saan pay a naipatungpal ti `<circle>` a lumasat iti { $count } a punto no awan ti numeriko a pateg dagiti punto.
+
+circle-too-many-through-points = Saan a mabalin a kalkulaen ti sirkulo a lumasat iti nasursurok ngem 3 a punto.
+
+circle-overprescribed-radius-center-points = Saan a mabalin a kalkulaen ti sirkulo nga addaan iti naespesipika a radio, sentro ken punto a lasatenna.
+
+circle-center-with-multiple-points = Saan a mabalin a kalkulaen ti sirkulo nga addaan iti naespesipika a sentro a lumasat iti nasursurok ngem 1 a punto.
+
+circle-radius-too-small = Saan a mabalin a kalkulaen ti sirkulo: gapu ta ti distansia ti dua a punto ket { $distance }, bassit unay ti naespesipika a radio a { $radius }.
+
+circle-radius-with-many-points = Saan a mabalin a mangpartuat iti sirkulo a lumasat iti nasursurok ngem dua a punto nga addaan iti naespesipika a radio.
+
+circle-invalid-center-or-through-points = Imbalido ti sentro wenno dagiti punto a lasaten ti sirkulo.
+
+circle-radius-center-with-multiple-points = Saan a mabalin a kalkulaen ti radio ti sirkulo nga addaan iti naespesipika a sentro a lumasat iti nasursurok ngem 1 a punto.
+
+circle-change-radius-non-numerical = Saan a mabalin a sukatan ti radio ti sirkulo a lumasat kadagiti punto a saan a numeriko
+
+circle-radius-with-points-non-numerical = Saan a mabalin a mangpartuat iti sirkulo a lumasat iti nasursurok ngem maysa a punto nga addaan iti naespesipika a radio no awan dagiti numeriko a pateg.
+
+circle-change-center-non-numerical = Saan pay a naipatungpal ti panangsukat iti sentro ti sirkulo a lumasat kadagiti punto nga awan ti numeriko a pateg da.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Ilocano has one, because
+# «interbalo» and «input» do not change for number. Both selects are dropped
+# and both counts still arrive.
+function-domain-insufficient-dimensions = Kurang ti dimension ti domain para iti punsion. Ti domain ket addaan iti { $intervals } nga interbalo ngem ti punsion ket addaan iti { $inputs } nga input.
+
+function-domain-invalid-format = Imbalido a pormat ti domain para iti punsion.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Mailaksid ti saan a numeriko a kangatuan ti punsion.
+        [minimum] Mailaksid ti saan a numeriko a kababaan ti punsion.
+        [extremum] Mailaksid ti saan a numeriko nga ekstremum ti punsion.
+        [point] Mailaksid ti saan a numeriko a punto ti punsion.
+        [slope] Mailaksid ti saan a numeriko a kilo ti punsion.
+       *[other] Mailaksid ti saan a numeriko a { $type } ti punsion.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Mailaksid ti awan naglaonna a kangatuan ti punsion.
+        [minimum] Mailaksid ti awan naglaonna a kababaan ti punsion.
+        [extremum] Mailaksid ti awan naglaonna nga ekstremum ti punsion.
+        [point] Mailaksid ti awan naglaonna a punto ti punsion.
+       *[other] Mailaksid ti awan naglaonna a { $type } ti punsion.
+    }
+
+function-points-too-close = Aglaon ti punsion iti dua a punto nga asideg unay ti ayan da. Saan a maidepinar ti punsion.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Mabalin laeng dagiti iterasion ti punsion no agpada ti bilang dagiti input ken ti bilang dagiti output. Daytoy a punsion ket addaan iti { $inputs } nga input ken { $outputs } nga output.
+
+## `<sequence>`
+
+sequence-invalid-length = Imbalido ti kaatiddog ti sequence.  Masapul a saan a negatibo nga integer.
+
+sequence-invalid-step = Imbalido ti step ti sequence.  Masapul a numero para iti sequence a type { $type }.
+
+sequence-invalid-endpoint-number = Imbalido a "{ $attribute }" ti sequence a numero.  Masapul a numero.
+
+sequence-invalid-endpoint-letters = Imbalido a "{ $attribute }" ti sequence a letra.  Masapul a kombinasion dagiti letra.
+
+sequence-invalid-endpoint = Imbalido a "{ $attribute }" ti sequence.
+
+select-from-sequence-coprime-not-numbers = mailaksid ti coprime ta saan a numero ti mapilpili
+
+select-from-sequence-coprime-with-exclude-combinations = mailaksid ti coprime ta naespesipika ti excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Imbalido a target para iti `<{ $source }>`: saan a masarakan ti target.
+
+target-state-variable-not-found = Imbalido a target para iti `<{ $source }>`: saan a masarakan ti baribariabol nga estado a managan iti "{ $property }" iti maysa a `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Masapul a naiduma dagiti baribariabol ti `<odeSystem>` iti nawaya a baribariabol.
+
+ode-system-duplicate-variable-names = Saan a maidepinar dagiti punsion nga RHS ti ODE nga addaan iti agpada a nagan ti baribariabol nga agpannuray.
+
+ode-system-rhs-function-error = Saan a maidepinar ti punsion nga RHS ti ODE.  Adda biddut iti panangpartuat iti punsion a mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Saan a maidepinar ti anggulo iti nagbaetan ti { $count } a linia
+
+angle-invalid-through-point = Imbalido a punto iti through ti `<angle>`
+
+parabola-vertex-too-many-points = Saan pay a naipatungpal ti parabola nga addaan iti bertise a lumasat iti nasursurok ngem 1 a punto.
+
+parabola-too-many-points = Saan pay a naipatungpal ti parabola a lumasat iti nasursurok ngem 3 a punto.
+
+intersection-too-many-items = Saan pay a naipatungpal ti panagsabet iti nasursurok ngem dua a banag
+
+## Other math components
+
+ionic-compound-not-two-ions = Saan pay a naipatungpal ti kompuesto nga ioniko malaksid iti dua nga ion.
+
+ionic-compound-needs-cation-and-anion = Naipatungpal ti kompuesto nga ioniko para laeng iti maysa a cation ken maysa nga anion.
+
+solve-equations-cannot-evaluate = Saan a marisut ti ekuasion ta saan a nabalatong ti ekuasion: { $equation }
+
+math-operators-operand-number-required = Masapul a maespesipika ti operandNumber no mangalaen ti maysa nga operand a matematika.
+
+eigen-decomposition-failed = Saan a nakalkula dagiti eigenvalue ti matris
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: ti parametro a { $parameters } ket saan nga agparang iti pattern, isu nga agtutunosto latta iti blangko.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: saan a maawatan ti grid="{ $grid }". Masapul a none, medium, dense, wenno dua a positibo a numero a nagsina iti espasio, a kas ti grid="1 0.5". Awan ti grid a maidrowing.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: saan a suportado ti xLabelPosition="left" iti renderer a prefigure; usaren ti kababalin ti kanawan a posision.
+
+prefigure-y-label-position-unsupported = `<graph>`: saan a suportado ti yLabelPosition="bottom" iti renderer a prefigure; usaren ti kababalin ti akin-ngato a posision.
+
+prefigure-invalid-axis-bounds = `<graph>`: imbalido dagiti benneg ti aksis para iti konbersion a prefigure; usaren ti kasisigud a bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: imbalido ti kaakaba para iti konbersion a prefigure; usaren ti kasisigud a kaakaba ti diagram a 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: imbalido ti aspectRatio para iti konbersion a prefigure; usaren ti kasisigud nga aspect ratio a 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: nakaringgat unay ti nagbaetan ti grid para kadagiti patingga ti aksis; mailaksid ti grid iti renderer a prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: saan a mairender dagiti annotation no saan a ti renderer a PreFigure ti maus-usar.
+
+multiple-annotations-children = Adu nga anak nga `<annotations>` ti nasarakan iti `<graph>`; mailaksid amin malaksid iti maudi.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Saan a mabalin nga i-extend wenno kopiaen ti saan a mabigbig a kita ti komponente: { $type }.
+
+copy-prop-not-found = Saan a nasarakan ti prop a { $property } iti komponente a kita { $component }
+
+collect-no-source = Awan ti nasarakan a source para iti collect.
+
+collect-invalid-component-type = Saan a mabalin nga urnongen dagiti komponente a kita `<{ $component }>` ta imbalido a kita ti komponente.
+
+reference-index-unavailable = Saan a matukoy ti indeks a `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Saan a maawagan ti { $action } iti komponente a `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Imbalido ti langa ti datos.  Saan nga agpapada ti kaatiddog dagiti intar. Nasarakan iti componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Adda agpada a nagan ti adigi ti datos.  Nasarakan iti componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Awan ti nagan ti maysa nga adigi ti datos.  Nasarakan iti componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ti award daytoy a sungbat ket naibatay iti mismo a naipatulod a sungbat ti answer tag, ket agbanagto daytoy iti saan a namnamaen a kababalin.
+
+answer-max-num-attempts-in-section-wide-check-work = Awan ti epekto ti panangisaad iti `maxNumAttempts` iti maysa nga `<answer>` iti uneg ti kontenedor nga addaan iti `sectionWideCheckWork`, ta ti kontenedor ti mangtengngel iti bilang dagiti padas. Isaad ti `maxNumAttempts` iti kontenedor.
+
+nested-section-wide-check-work-max-num-attempts = Awan ti epekto ti panangisaad iti `maxNumAttempts` iti kontenedor nga addaan iti `sectionWideCheckWork` nga adda iti uneg ti sabali a kontenedor nga addaan iti `sectionWideCheckWork`, ta ti akinruar a kontenedor ti mangtengngel iti bilang dagiti padas. Isaad ti `maxNumAttempts` iti akinruar a kontenedor.
+
+# No select: «atributo» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Awanto ti epekto ti atributo a { $attributes } no saan a naisaad ti symbolicEquality.
+
+answer-invalid-type = Imbalido a kita para iti sungbat: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Gapu ta awan ti nagan ti komponente a `<{ $component }>`, saan a mabalin nga usaren para iti atributo ti module
+
+module-attribute-name-already-defined = Saan a mabalin nga usaren ti komponente a `<{ $component } name="{ $name }">` a kas atributo ti module gapu ta addaan ti kita a komponente nga `<module>` iti atributo a "{ $name }".
+
+conditional-content-condition-ignored = Mailaksid ti atributo a `condition` iti komponente a `<conditionalContent>` nga addaan kadagiti anak a case wenno else.
+
+slider-markers-type-mismatch = Saan nga agtutunos ti kita dagiti marker iti kita ti slider.
+
+pretzel-problem-needs-statement-and-answer = Imbalido a pretzel: masapul nga aglaon ti tunggal `<problem>` iti maysa a `<statement>` ken maysa nga `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Imbalido a pretzel: iti mode="circuit", saan a mabalin a distractor ti umuna a `<problem>`.
+
+## Attribute values
+
+# No select: «pateg» is the same word for one and for many.
+attribute-invalid-values = Imbalido a pateg a { $values } para iti atributo a `{ $attribute }`; mailaksid.
+
+attribute-must-be-references = Imbalido a pateg a `{ $value }` para iti atributo a `{ $attribute }`. Masapul a nabuo ti atributo kadagiti reperensia a mangrugi iti `$`.
+
+math-input-invalid-function-names = <mathInput>: mailaksid dagiti imbalido a nagan ti punsion iti { $attribute }: { $names }. Masapul nga addaan ti tunggal nagan iti saan a nababbaba ngem 2 a karakter (letra wenno gitlo); mabalin a sumaruno ti maysa a suffix a `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Imbalido a kita ti komponente: `<{ $componentType }>`
+
+attribute-repeated = Saan a mabalin nga uliten ti atributo a { $attribute }.
+
+attribute-invalid-for-component = Imbalido nga atributo a "{ $attribute }" para iti komponente a kita `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kurang ti kontraste ti depinision ti estilo a { $styleNumber } para iti { $context ->
+        [text-on-background] kolor ti teksto maibusor iti kolor ti likudan
+        [high-contrast] kolor a nangato ti kontraste maibusor iti kanbas
+        [line] kolor ti linia maibusor iti kanbas
+        [marker] kolor ti marker maibusor iti kanbas
+       *[text-on-canvas] kolor ti teksto maibusor iti kanbas
+    }{ $mode ->
+        [dark] { " (nasipnget a mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; masapul ti saan a nababbaba ngem { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Uray no ti depinision ti estilo a { $styleNumber } ket addaan kadagiti naespesipika a kolor nga umanay ti kontraste da para iti nalawag a mode, kurang ti kontraste ti kolor ti teksto maibusor iti kolor ti likudan kadagiti kolor a naala para iti nasipnget a mode ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; masapul ti saan a nababbaba ngem { $threshold }:1). { $suggestion ->
+        [available] Tapno umanay ti kontraste iti nasipnget a mode, nayonan ti kontraste ti nalawag a mode (kas pagarigan, isaad ti { $lightAttribute }="{ $lightColor }") wenno sukatan ti kolor ti nasipnget a mode (kas pagarigan, isaad ti { $darkAttribute }="{ $darkColor }").
+       *[none] Tapno umanay ti kontraste iti nasipnget a mode, nayonan ti kontraste ti nalawag a mode wenno sukatan dagiti naala a kolor babaen ti textColorDarkMode ken/wenno backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Uray no ti depinision ti estilo a { $styleNumber } ket addaan iti naespesipika a kolor ti teksto nga umanay ti kontraste na para iti nalawag a mode, kurang ti kontraste ti kolor ti teksto a naala para iti nasipnget a mode maibusor iti kanbas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; masapul ti saan a nababbaba ngem { $threshold }:1). { $suggestion ->
+        [available] Tapno umanay ti kontraste iti nasipnget a mode, nayonan ti kontraste ti nalawag a mode (kas pagarigan, isaad ti textColor="{ $lightColor }") wenno sukatan ti kolor ti nasipnget a mode (kas pagarigan, isaad ti textColorDarkMode="{ $darkColor }").
+       *[none] Tapno umanay ti kontraste iti nasipnget a mode, nayonan ti kontraste ti nalawag a mode wenno sukatan ti naala a kolor babaen ti textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Maysa laeng a <stylePalette> ti mabalin a pilien ti maysa a seksion; usaren ti maudi.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } ta saan a saan a negatibo nga integer ti numToSelect.
+
+variant-num-to-select-not-constant-number = saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } ta saan a konstante a numero ti numToSelect.
+
+variant-with-replacement-not-constant-boolean = saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } ta saan a konstante a boolean ti withReplacement.
+
+variant-select-weight-disables-unique = Maiddep dagiti naisangsangayan a baryante para iti select no adda opsion nga addaan iti selectWeight wenno selectForVariants a naespesipika
+
+variant-coprime-undetermined = saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } ta saan a madeterminaran no kanayon a false ti coprime.
+
+variant-attribute-not-constant = saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } ta saan a konstante ti { $attribute }.
+
+variant-attribute-not-number = saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } ta saan a numero ti { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } a kita { $type } ta ti { $attribute } ket saan a { $expected ->
+        [letters-combination] kombinasion dagiti letra
+        [math-expression] balido nga ekspresion a matematika
+        [integer] integer
+       *[number] numero
+    }.
+
+variant-length-not-integer = saan a madeterminaran dagiti naisangsangayan a baryante ti { $component } ta saan nga integer ti length.
+
+variant-sort-not-implemented = saan pay a naipatungpal dagiti naisangsangayan a baryante ti maysa a { $component } nga addaan iti sort
+
+variant-exclude-combinations-not-implemented = saan pay a naipatungpal dagiti naisangsangayan a baryante ti maysa a { $component } nga addaan iti excludeCombinations
+
+variant-math-exclude-not-implemented = saan pay a naipatungpal dagiti naisangsangayan a baryante ti maysa a { $component } a kita math nga addaan iti exclude
+
+variant-non-constant-exclude-not-implemented = saan pay a naipatungpal dagiti naisangsangayan a baryante ti maysa a { $component } nga addaan iti saan a konstante nga exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: saan a suportado iti renderer a prefigure ti graph; nailaksid ti kaputotan.
+
+prefigure-descendant-invalid-geometry = { $subject }: saan a limitado wenno saan a kompleto ti heometria; nailaksid ti kaputotan.
+
+prefigure-curve-label-omitted = { $subject }: saan a suportado dagiti etiketa kadagiti nakombierte a kurba; nailaksid ti etiketa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: saan a suportado a kita ti depinision ti punsion a kurba a '{ $definitionType }'; nailaksid ti kaputotan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: saan a suportado nga atributo a flipFunctions iti regionBetweenCurves; nailaksid ti kaputotan.
+
+prefigure-region-non-formula-child = { $subject }: dagiti anak a punsion a kita formula laeng ti suportado iti regionBetweenCurves; nailaksid ti kaputotan.
+
+prefigure-label-position-unsupported =
+    { $subject }: saan a suportado a labelPosition '{ $labelPosition }' para iti { $labelKind ->
+        [line-family] etiketa ti pamilia ti linia
+       *[point] etiketa ti punto
+    }; usaren ti kasisigud a panagpartuat ti PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: saan a suportado ti PreFigure iti estilo ti punno a '{ $fillStyle }'; agsubli iti napunno a kolor.
+
+prefigure-line-style-unknown = { $subject }: saan a mabigbig nga estilo ti linia a '{ $lineStyle }', nailaksid iti output ti PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: naisilpo ti estilo ti marker a '{ $markerStyle }' iti estilo a 'diamond' ti PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: saan a suportado ti PreFigure iti estilo ti marker a '{ $markerStyle }'; usaren ti kasisigud nga estilo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: imbalido a `ref`; saan a matukoy ti target. Nailaksid ti annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: naiturong ti `ref` iti adu a target; usaren ti umuna a target.
+
+annotation-ref-outside-graph = `<annotation>`: imbalido a `ref`; adda ti target iti ruar ti graph a naglaon kenkuana. Nailaksid ti annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: imbalido a `ref`; saan a suportado a grapikal a banag ti target iti konbersion a prefigure. Nailaksid ti annotation.
+
+annotation-text-missing = `<annotation>`: awan wenno blangko ti `text`; agpataud iti blangko a teksto.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Adda nasarakan a nagsikkarud a panagpannuray.
+       *[other] Adda nasarakan a nagsikkarud a panagpannuray a mairaman ti komponente a `<{ $componentType }>`.
+    }
+
+reference-no-referent = Awan ti nasarakan a tuktukoyen ti reperensia: `{ $reference }`
+
+reference-multiple-referents = Adu ti nasarakan a tuktukoyen ti reperensia: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Imbalido a pormat ti atributo a { $attribute } ti `<{ $componentType }>`.
+
+children-invalid = Imbalido dagiti anak ti `<{ $componentType }>`: nasarakan dagiti imbalido nga anak: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Imbalido a pateg a `{ $value }` para iti atributo a `{ $attribute }`, usaren ti pateg a `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Saan a nasarakan ti bersion ti DoenetML a { $version }.
+       *[other] Saan a nasarakan ti bersion ti DoenetML a { $version }. Agsubli iti bersion a { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Imbalido a DoenetML: { $content }
+
+parse-tag-missing-close-tag = Imbalido a DoenetML: Awan ti pangserra a tag ti tag a `{ $tag }`. Namnamaen ti tag a mangserra iti bagina wenno tag a `</{ $tagName }>`.
+
+parse-tag-error = Imbalido a DoenetML: Adda biddut iti tag a `<{ $tagName }>`
+
+parse-attribute-missing-value = Imbalido a DoenetML: Kasla awan ti pateg ti imbalido nga atributo a `{ $attribute }`.
+
+parse-attribute-invalid = Imbalido a DoenetML: Imbalido nga atributo a `{ $attribute }`
+
+parse-attribute-value-invalid = Imbalido a DoenetML: Imbalido a pateg ti atributo a `{ $value }`
+
+parse-attribute-value-quote-mismatch = Imbalido a DoenetML: Imbalido a pateg ti atributo a `{ $value }`. Saan nga agtutunos dagiti marka ti sipi. Kasla awan ti maysa a `{ $quote }`
+
+parse-open-tag-name-missing = Imbalido a DoenetML: Adda nasarakan a tag nga awan ti nagan na, kas pagarigan `<`
+
+parse-tag-not-closed = Imbalido a DoenetML: Saan a naserraan ti tag a `{ $tag }` (kasla awan ti `>`).
+
+parse-self-closing-tag-name-missing = Imbalido a DoenetML: Adda nasarakan a tag nga awan ti nagan na `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Imbalido a DoenetML: Saan a naserraan ti tag a `{ $tag }` (kasla awan ti `/>`).
+
+parse-tag-invalid-attributes = Imbalido a DoenetML: Saan a balido ti tag a `{ $tag }`. Mabalin nga adda saan a husto nga atributo na.
+
+parse-close-tag-name-missing = Imbalido a DoenetML: Adda nasarakan a pangserra a tag nga awan ti nagan na, kas pagarigan `</`
+
+parse-attribute-value-unquoted = Masapul nga adda iti uneg dagiti marka ti sipi ti pateg ti atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Imbalido a DoenetML: Adda nasarakan a pangserra a tag a `{ $tag }`, ngem awan ti kapada na a pangluktan a tag
+
+parse-close-tag-mismatched = Imbalido a DoenetML: Saan nga agtutunos ti pangserra a tag. Namnamaen ti `</{ $expected }>`. Nasarakan ti `{ $found }`
+
+parser-node-unconvertible = Saan a nakombierte ti node a { $node } iti node a Dast.
+
+## Names
+
+name-attribute-invalid =
+    Imbalido nga atributo a name='{ $name }'. { $reason ->
+        [characters] Mabalin nga aglaon dagiti nagan kadagiti letra, numero, underscore wenno gitlo laeng.
+       *[start] Masapul nga agrugi dagiti nagan iti letra.
+    }
+
+component-name-invalid-start = Imbalido a nagan ti komponente a "{ $name }". Masapul nga agrugi dagiti nagan iti letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Masapul nga addaan ti answer a type videoWatched iti atributo a video
+
+answer-video-watched-video-not-reference = Masapul nga addaan ti answer a type videoWatched iti atributo a video a maysa a reperensia
+
+answer-name-not-single-text = Masapul nga addaan ti atributo a name ti answer iti maymaysa nga anak a text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Saan a naala ti akinruar a DoenetML gapu iti nakaad-adu a tukad ti panagulit-ulit. Adda kadi nagsikkarud a reperensia?
+
+external-doenetml-unavailable = Saan a naala ti DoenetML manipud iti { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Imbalido a DoenetML ti naala manipud iti { $attribute }="{ $uri }": saan nga agtutunos iti kita ti komponente a "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Saanen a maus-usar ti atributo a `{ $from }`; usaren ti `{ $to }`.
+       *[other] [deprecation] Saanen a maus-usar ti atributo a `{ $from }` iti `<{ $component }>`; usaren ti `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Saanen a maus-usar ti atributo a `{ $from }` ket mailaksid gapu ta naespesipika met ti `{ $to }`.
+       *[other] [deprecation] Saanen a maus-usar ti atributo a `{ $from }` iti `<{ $component }>` ket mailaksid gapu ta naespesipika met ti `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Saanen a maus-usar ti atributo a `{ $attribute }` iti `<{ $component }>` ket mailaksid.
+
+deprecated-attribute-to-child = [deprecation] Saanen a maus-usar ti atributo a `{ $attribute }` iti `<{ $component }>`; usaren ti anak a `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Saanen a maus-usar ti pateg a `{ $value }` ti atributo a `{ $attribute }` iti `<{ $component }>`; usaren ti `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = Ti `<pluralize>` ket mabalin na laeng a pagpaadduen ti Ingles, isu a saan a masukatan ti teksto na iti dokumento a naisurat iti { $locale }. Isurat a mismo ti porma a paadu, wenno isaad daytoy babaen ti atributo a `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ti elemento a `<{ $tag }>` ket saan a mabigbig nga elemento ti Doenet.
+
+schema-element-not-allowed-at-root = Saan a mapalubosan ti elemento a `<{ $tag }>` iti ramut ti dokumento.
+
+schema-element-not-allowed-inside = Saan a mapalubosan ti elemento a `<{ $tag }>` iti uneg ti `<{ $parent }>`.
+
+schema-attribute-unrecognized = Awan ti atributo a managan iti `{ $attribute }` ti elemento a `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Masapul a listaan ti atributo a `{ $attribute }` ti elemento a `<{ $tag }>` a ti tunggal banag na ket maysa kadagiti: { $allowed }
+       *[other] Masapul a maysa kadagiti sumaganad ti atributo a `{ $attribute }` ti elemento a `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Imbalido a nagan ti baryante para iti select.  Agparang ti nagan ti baryante a { $variantName } iti { $numOptions } nga opsion ngem ti bilang a pilien ket { $numToSelect }.
+
+select-variant-name-without-options = Adda naespesipika a baryante para iti select ngem awan ti naespesipika nga opsion para iti mabalin a nagan ti baryante: { $variantName }.
+
+select-variant-name-not-possible = Ti nagan ti baryante a { $variantName } a naespesipika para iti select ket saan a mabalin a nagan ti baryante.
+
+select-too-few-options = Saan a mabalin a mangpili iti { $numToSelect } a komponente manipud iti { $numOptions } laeng.
+
+select-from-sequence-too-few-values = Saan a mabalin a mangpili iti { $numToSelect } a pateg manipud iti sequence a kaatiddog na ket { $length }.
+
+select-from-sequence-indices-count-mismatch = Masapul nga agtutunos ti bilang dagiti indeks a naespesipika para iti select ken ti bilang a pilien
+
+select-from-sequence-indices-not-integers = Masapul nga integer amin dagiti indeks a naespesipika para iti select
+
+select-from-sequence-index-excluded = Naespesipika ti indeks ti selectfromsequence a nailaksid
+
+select-from-sequence-indices-excluded-combination = Naespesipika dagiti indeks ti selectfromsequence a maysa a nailaksid a kombinasion
+
+select-from-sequence-coprime-not-positive-integers = Saan a mabalin a mangpili kadagiti kombinasion a coprime ta saan a positibo nga integer ti mapilpili.
+
+select-from-sequence-coprime-common-factor = Saan a mabalin a mangpili kadagiti numero a coprime. Aggiddan dagiti amin a posible a pateg iti maysa a paktor. (Masapul a coprime ti naespesipika a pateg ti "from" wenno "to" iti "step".)
+
+select-from-sequence-coprime-single-number = Saan a mabalin a mangpili kadagiti kombinasion a coprime manipud iti maymaysa a numero a saan a 1.
+
+select-from-sequence-excluded-too-many-combinations = Nailaksid ti nasursurok ngem 70% dagiti kombinasion iti selectFromSequence
+
+select-from-sequence-coprime-none-found = Saan a nakapili kadagiti numero a coprime. Aggiddan dagiti amin a posible a pateg iti maysa a paktor.
+
+select-from-sequence-too-few-unique-values = Saan a mabalin a mangpili iti { $numToSelect } a naisangsangayan a pateg manipud iti sequence a kaatiddog na ket { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Saan a mabalin a mangpili iti { $numToSelect } a pateg manipud iti listaan dagiti prime a kaatiddog na ket { $numValues }
+
+select-prime-numbers-values-count-mismatch = Masapul nga agtutunos ti bilang dagiti pateg a naespesipika para iti select ken ti bilang a pilien
+
+select-prime-numbers-values-not-prime = Masapul nga adda iti listaan dagiti prime ti amin a pateg a naespesipika para iti select prime number
+
+select-prime-numbers-values-excluded-combination = Ti naespesipika a pateg ti selectPrimeNumbers ket maysa a nailaksid a kombinasion
+
+select-prime-numbers-excluded-too-many-combinations = Nailaksid ti nasursurok ngem 70% dagiti kombinasion iti selectPrimeNumbers
+
+select-random-combination-fluke = Gapu iti nakaskasdaaw a gasat, saan a nakapili iti kombinasion dagiti nagraman a pateg
+
+select-random-value-fluke = Gapu iti nakaskasdaaw a gasat, saan a nakapili iti nagraman a pateg

--- a/packages/i18n/locales/ilo/editor.ftl
+++ b/packages/i18n/locales/ilo/editor.ftl
@@ -1,0 +1,210 @@
+# Ilocano editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Ilocano marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped. Where the surrounding sentence differs, the select stays.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Isubli
+       *[update] Pabaruen
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } ti pagbuyaan
+       *[other] { $word } ti pagbuyaan { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Baryante
+editor-variant-filter = Sagaten…
+editor-variant-next = Pilien ti sumaruno a baryante
+editor-variant-previous = Pilien ti napalabas a baryante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Adda nasarakan a panaglabsing iti aksesibilidad a WCAG AA. Pinduten tapno { $action ->
+            [close] mairikep
+           *[open] maluktan
+        } ti report ti aksesibilidad.
+        [advisories] Pinduten tapno { $action ->
+            [close] mairikep
+           *[open] maluktan
+        } ti report ti aksesibilidad. Awan ti nasarakan a panaglabsing iti WCAG AA, ngem adda pay dadduma a rekomendasion iti aksesibilidad.
+       *[clean] Pinduten tapno { $action ->
+            [close] mairikep
+           *[open] maluktan
+        } ti report ti aksesibilidad. Awan ti nasarakan a parikut iti aksesibilidad.
+    }
+
+# No select on `$count` inside the branches: «panaglabsing» and
+# «rekomendasion» are the same words for one and for many, so both categories
+# would render the same string. The count still arrives and is still formatted.
+editor-accessibility-label =
+    { $status ->
+        [violations] Adda nasarakan a panaglabsing iti aksesibilidad a WCAG AA. { $count } a panaglabsing iti WCAG AA ti nasarakan. Pinduten tapno { $action ->
+            [close] mairikep
+           *[open] maluktan
+        } ti report ti aksesibilidad.
+        [advisories] Awan ti nasarakan a panaglabsing iti WCAG AA. { $count } a dadduma pay a rekomendasion iti aksesibilidad ti nasarakan. Pinduten tapno { $action ->
+            [close] mairikep
+           *[open] maluktan
+        } ti report ti aksesibilidad.
+       *[clean] Awan ti nasarakan a panaglabsing iti WCAG AA. Pinduten tapno { $action ->
+            [close] mairikep
+           *[open] maluktan
+        } ti report ti aksesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersion ti DoenetML { $version }
+
+editor-tab-help = Tulong a maibatay iti konteksto
+editor-tab-help-short = Konteksto
+editor-tab-errors = Biddut
+editor-tab-warnings = Ballaag
+editor-tab-info = Impormasion
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Naipatulod a sungbat
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opsion ti editor
+editor-format-as-doenetml = Iporma a kas DoenetML
+editor-format-as-xml = Iporma a kas XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linia #{ $line }
+
+editor-no-errors = Awan ti biddut
+editor-no-warnings = Awan ti ballaag
+editor-no-info = Awan ti diagnostiko nga impormasion
+
+editor-show-info-annotations = Ipakita dagiti diagnostiko nga impormasion iti editor
+editor-show-accessibility-annotations = Ipakita dagiti diagnostiko ti aksesibilidad iti editor
+
+editor-accessibility-learn-more = Ammuen no kasano ti panangtaming ti Doenet iti aksesibilidad
+
+editor-accessibility-violations-heading = Panaglabsing iti aksesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Dadduma pay a parikut iti aksesibilidad
+editor-none-found = Awan ti nasarakan
+
+
+## Submitted responses
+
+editor-no-responses = Awan pay ti naipatulod a sungbat
+editor-response-answer-id = Id ti sungbat
+editor-response-response = Sungbat
+editor-response-credit = Kredito
+editor-response-submitted = Naipatulod
+
+
+## The context-help panel
+
+help-placeholder = Ikabil ti kursor iti nagan ti tag, atributo, wenno { $ref } para iti dokumentasion.
+
+help-unsupported-ref-chain = Saan pay a suportado ti tulong para kadagiti nadumaduma a paset a reperensia a kas ti { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Awan ti nasarakan a tuktukoyen ti reperensia: { $ref }.
+        [multiple] Adu ti nasarakan a tuktukoyen ti reperensia: { $ref }.
+       *[indeterminate] Saan a nadeterminaran ti tuktukoyen ti { $ref }.
+    }
+
+help-learn-about-references = Ammuen ti maipapan kadagiti reperensia →
+help-reference-page = Panid a reperensia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Iti uneg ti { $element }
+       *[top] Iti kangatuan a tukad
+    }{ $allowed ->
+        [none] { " — awan ti mabalin nga ikabil ditoy." }
+        [text] { " — agsurat iti teksto ditoy." }
+        [text-and-components] { " — agsurat iti teksto ditoy, wenno padasen:" }
+       *[components] { " — mabalin a padasen:" }
+    }
+
+help-suggestions-footer = Pinduten ti { $shortcut } tapno makita ti amin a { $total } a komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] Ti { $ref } ket reperensia iti { $target }.
+       *[other] Ti { $ref } ket reperensia iti { $target } (linia { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Inyeg ti { $owner } a kas { $role }.
+       *[other] Inyeg ti { $owner } iti linia { $line } a kas { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] Ti { $ref } ket reperensia iti pagilasinan a { $property } ti { $element }.
+       *[other] Ti { $ref } ket reperensia iti pagilasinan a { $property } ti { $element } (linia { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = bassit a kodigo
+help-kind-array-entry = pagserkan iti array
+
+help-default = Kasisigud:
+help-active-default = Aktibo a kasisigud:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Mapalubosan a pateg (maysa iti tunggal banag):
+       *[other] Mapalubosan a pateg:
+    }
+
+help-suggested-values = Naisingasing a pateg:
+
+help-inserts = Mangiserrek iti:
+
+# No select: «koordinado» is the same word for one and for many, so both
+# categories would render the same string.
+help-coordinates = Koordinado:
+
+help-type = Kita:
+
+help-resolved-style = Narisut nga estilo (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Narisut a nagan ti punsion:
+help-reset-list = Listaan ti pannakaisubli iti daytoy nga input:
+help-added-on-input = Nainayon iti daytoy nga input:
+help-removed-on-input = Naikkat iti daytoy nga input:
+
+help-reset-overrides = Ti { $reset } ti mangsukat iti { $additional } ken { $removed }.

--- a/packages/i18n/locales/mad/chrome.ftl
+++ b/packages/i18n/locales/mad/chrome.ftl
@@ -1,0 +1,150 @@
+# Madurese viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography of Madurese publishing, with the vowel marks
+# the language spells — «konèng», «jhâwâban», «bendher».
+#
+# **Speech level.** Madurese chooses a register for every sentence, and a file
+# with two registers in it is wrong in both. This catalog is written throughout
+# in **enjâ'-iyâ**, the plain everyday level, which is what Madurese writing
+# addressed to a general reader uses; èngghi-enten and èngghi-bunten are derived
+# from it rather than the other way round. That is the decision `locales/jv`,
+# `locales/su` and `locales/ban` already record. A deployment that wants a
+# higher level supplies its own catalog as `localeResources`; correcting this
+# file sentence by sentence toward one is what would leave the locale in two
+# registers at once.
+#
+# Madurese marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped. A `[0]` branch stays wherever English has one.
+
+
+## Answer submission
+
+answer-checking = Mareksa…
+answer-submitting = Ngèrèm…
+
+answer-checking-status = Mareksa jhâwâban
+answer-submitting-status = Ngèrèm jhâwâban
+
+answer-correct = Bendher
+answer-incorrect = Ta' bendher
+
+answer-response-saved = Jhâwâbanna la èsimpen
+
+answer-percent-credit = { $percent }% kredit
+answer-percent-correct = { $percent }% bendher
+answer-percent-short = { $percent } %
+
+max-credit-available = Kredit se paleng bânnya' se ekaollè: { $percent }%
+
+# No select: «coba» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] tadâ' pole coba se karè
+       *[other] karè { $count } coba
+    }
+
+validation-correct = (Bendher)
+validation-incorrect = (Ta' bendher)
+validation-partially-correct = (Bendher sabâgiyân)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Toduwagi { $count } jhâwâban kaangguy { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentar
+
+collapsible-click-to-open = (klik sopaja abukka')
+collapsible-click-to-close = (klik sopaja atotop)
+
+collapsible-initializing = Molaè…
+
+footnote-show = Toduwagi footnote
+footnote-hide = Nyèmponnè footnote
+
+description-more-information = katerrangan laèn
+
+
+## Controls
+
+slider-previous = Sabellunna
+slider-next = Salanjudde
+
+keyboard-open = Bukka' papan tuts
+keyboard-close = Totop papan tuts
+
+choice-input-remove-choice = Buwang { $choice }
+
+matrix-remove-row = Buwang barisa
+matrix-add-row = Tambâ baris
+matrix-remove-column = Buwang kolomma
+matrix-add-column = Tambâ kolom
+
+subset-add-remove-points = Nambâ/Mowang titik
+subset-toggle-points-intervals = Ngoba titik ban interval
+subset-move-points = Pindâ titikka
+subset-clear = Berseagi
+
+orbital-add-row = Tambâ baris
+orbital-remove-row = Buwang barisa
+orbital-add-box = Tambâ kotak
+orbital-remove-box = Buwang kotakka
+orbital-add-up-arrow = Tambâ panah ka attas
+orbital-add-down-arrow = Tambâ panah ka bâbâ
+orbital-remove-arrow = Buwang panahha
+
+orbital-row-label = Label kaangguy baris { $row }
+
+pretzel-answer = Jhâwâban
+
+summary-statistics-caption = Ringkesan statistik { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ungkapan matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ungkapan se ta' sah:
+
+
+## Document status
+
+viewer-initializing = Molaè…
+
+
+## Errors
+
+error-heading = Kasalaan
+
+error-found-at =
+    { $span ->
+        [line] Etemmo e baris { $startLine }.
+       *[lines] Etemmo e baris { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumen rèya badâ kasalaanna!
+
+diagnostic-heading-error = Kasalaan
+diagnostic-heading-warning = Parèngèdan
+diagnostic-heading-information = Katerrangan
+diagnostic-heading-hint = Petodu
+
+accessibility-heading-level-1 = Palanggharân aksesibilitas WCAG AA
+accessibility-heading-level-2 = Parèngèdan parkara aksesibilitas
+
+something-went-wrong = Badâ se sala.
+
+renderer-load-failed = badâ renderer se ta' bisa emowat. Nyo'on mowat pole kacana.
+
+core-start-failed = Panèngalan dokumen ta' bisa emolaè. Nyo'on mowat pole kacana.

--- a/packages/i18n/locales/mad/content.ftl
+++ b/packages/i18n/locales/mad/content.ftl
@@ -1,0 +1,247 @@
+# Madurese content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written throughout in **enjâ'-iyâ**, the plain everyday speech level; see
+# `chrome.ftl`'s header for why a catalog must pick one level and stay in it.
+#
+# Madurese has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «garis mera», a red line — so every
+# composition message inverts the English order.
+#
+# The geometry vocabulary is largely the Indonesian one, because Madurese
+# schools teach mathematics out of Indonesian-language textbooks; the colours,
+# the widths and the everyday words are Madurese.
+
+
+## Style vocabulary
+
+color =
+    .black = celleng
+    .white = pote
+    .gray = abu-abu
+    .red = mera
+    .orange = oranyè
+    .yellow = konèng
+    .green = ijo
+    .cyan = sian
+    .blue = biru
+    .purple = ungu
+    .pink = mera ngodhâ
+    .brown = coklat
+
+line-width =
+    .thick = kandel
+    .thin = tipis
+
+line-style =
+    .dashed = pote'-pote'
+    .dotted = titik-titik
+
+# Noun phrases. Madurese marks no plural on the noun, so «garis» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = garis malèntang
+    .vertical = garis majhâjhâr
+    .diagonal = garis mèrèng
+    .backdiagonal = garis mèrèng tabâli'
+    .dots = titik
+    .diamonds = bellâ ketupat
+
+noun =
+    .line = garis
+    .line-segment = roas garis
+    .ray = sinar
+    .vector = vektor
+    .curve = lengkong
+    .function = fungsi
+    .parabola = parabola
+    .polyline = garis potong
+    .polygon = poligon
+    .triangle = segitiga
+    .rectangle = pasagi lanjhâng
+    .circle = bunderan
+    .region = dhâerâ
+    .point = titik
+    .square = pasagi
+    .diamond = bellâ ketupat
+    .cross = sèlang
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] se badâ { $numSides } essèna
+       *[head] poligon beraturan
+    }
+
+# One answer for every noun: Madurese has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = possa'
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } bân { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } bân { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } bân { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Madurese has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «bân» against «sarta».
+style-border-clause =
+    { $parts ->
+        [with-article] bân penggir { $border }
+        [and] sarta penggir { $border }
+        [and-article] sarta penggir { $border }
+       *[with] bân penggir { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ta' possa'
+
+style-text =
+    { $parts ->
+        [background] { $color } bân latar { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = tadâ'
+
+
+## Boolean words
+
+boolean-true = bendher
+boolean-false = sala
+
+
+## Answer buttons
+
+answer-submit-label = Pareksa lalakon
+answer-submit-label-no-correctness = Kèrèm jhâwâban
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Madurese marks no plural on the noun.
+section-name =
+    .activity = Kagiyâtan
+    .aside = Catetan penggir
+    .cascade = Kaskade
+    .definition = Bâtessa
+    .example = Conto
+    .exercise = Latèyan
+    .exercises = Latèyan
+    .given-answer = Jhâwâban
+    .note = Catetan
+    .objectives = Tojjhuwân
+    .paragraphs = Paragraf
+    .part = Bâgiyân
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukte
+    .question = Pertanyaan
+    .section = Bâgiyân
+    .solution = Panyalesaan
+    .task = Tugas
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Petodu
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Gâmbhâr { $enumeration }
+        [numbered-caption] Gâmbhâr { $enumeration }{ ": " }
+        [unnumbered-caption] Gâmbhâr{ ": " }
+       *[unnumbered] Gâmbhâr
+    }
+
+
+## Paginator controls
+
+paginator-previous = Sabellunna
+paginator-next = Salanjudde
+paginator-page = Kaca
+
+paginator-page-status = { $pageLabel } { $currentPage } dâri { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = otabâ
+piecewise-condition-if = mon
+piecewise-condition-otherwise = mon bunten
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Madurese schools teach chemistry out of Indonesian-language
+## textbooks, so the periodic table a Madurese pupil meets is `locales/id`'s,
+## and Madurese has no settled table of its own to seed from.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simbol kimia se ta' sah
+chemistry-invalid-ionic-compound = Sanyawa ionik se ta' sah

--- a/packages/i18n/locales/mad/diagnostics.ftl
+++ b/packages/i18n/locales/mad/diagnostics.ftl
@@ -1,0 +1,627 @@
+# Madurese diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Written throughout in enjâ'-iyâ, the plain everyday speech level; see
+# `chrome.ftl`'s header.
+#
+# Madurese marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+
+
+## `<lineSegment>`
+
+# No select: «ta' èanggep» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = { $attributes } ta' èanggep mon dhuwâ' konco'na la èpastèagi
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } ta' èanggep mon settong konco' ban tengngana la èpastèagi kadhuwâ
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset tadâ' gunana mon tadâ' tengngana
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garis se lèbât e titik se dimensina ta' tanto.
+
+line-points-too-few-dimensions = Garis kodu lèbât e titik se badâ dhuwâ' dimensina.
+
+line-points-depend-on-variables = Garis lèbât e titik se agântong ka variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garis se ta' sah e variabel { $variable1 } ban { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar èpastèagi bi' through, endpoint ban direction.  through se èpastèagi ta' èanggep.
+
+ray-dimension-mismatch = numDimensions ta' cocok e sinar.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor èpastèagi bi' head, tail ban displacement.  head se èpastèagi ta' èanggep.
+
+vector-dimension-mismatch = numDimensions ta' cocok e vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ta' bisa narè' ka `<{ $component }>` sabab tadâ' variabel kaadaan nearestPoint-na.
+
+constrain-to-without-nearest-point = Ta' bisa ngèket ka `<{ $component }>` sabab tadâ' variabel kaadaan nearestPoint-na.
+
+constrain-to-interior-without-nearest-point = Ta' bisa ngèket ka dâlem `<{ $component }>` sabab tadâ' variabel kaadaan nearestPoint-na.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition ta' èanggep e choiceInput se ta' inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indeks se èpastèagi kaangguy choiceInput ta' èanggep sabab bânnya'na indeks ta' cocok bân bânnya'na ana' pelean.
+
+pretzel-indices-count-mismatch = Indeks se èpastèagi kaangguy problem ta' èanggep sabab bânnya'na indeks ta' cocok bân bânnya'na ana' problem.
+
+shuffle-indices-count-mismatch = Indeks se èpastèagi kaangguy shuffle ta' èanggep sabab bânnya'na indeks ta' cocok bân bânnya'na komponen.
+
+indices-ignored-out-of-range = Indeks se èpastèagi kaangguy { $component } ta' èanggep sabab badâ indeks se lebbi dâri jangkauan.
+
+pretzel-indices-repeated = Indeks se èpastèagi kaangguy pretzel ta' èanggep sabab badâ indeks se èolang.
+
+pretzel-circuit-first-index = Indeks se èpastèagi kaangguy pretzel e mode circuit ta' èanggep sabab indeks se dâ'-adâ' kodu 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Sopaja `<{ $component }>` bisa ajhâlân bân ana' string, atribut `type` kodu èpastèagi.
+
+invalid-type-defaulting-to-math = type { $type } ta' sah kaangguy komponen { $component }. Kodu sala settong dâri math, text, number, otabâ boolean. Ngangguy math.
+
+string-not-valid-component-to-arrange = String "{ $value }" banne komponen se sah kaangguy { $component }. Ta' èanggep.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } ta' sah, type èsabâ' ka number.
+
+invalid-variable-value = Nilai variabel se ta' sah: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } kodu angka
+
+variant-index-must-be-integer = Indeks varian { $index } kodu bilangan bulat
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` gi' ta' èterapaghi kaangguy okoran mutlak. Lèbârra èsabâ' relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` gi' ta' èterapaghi kaangguy okoran mutlak. Marginna èsabâ' relatif.
+
+side-by-side-no-block-child = `<{ $component }>` ta' sah: kodu badâ settong ana' block-na.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` e `<label>` grafis ta' èanggep.
+
+label-for-must-resolve-to-one = Atribut `for` e `<label>` kodu noduwagi pas ka settong komponen.
+
+label-for-unresolved = Atribut `for` e `<label>` ta' bisa noduwagi ka komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` e `<label>` noduwagi ka `<answer>` se badâ input se ètolès bi' se ngarang; toduwagi input rowa langsong.
+
+label-for-answer-without-input = Atribut `for` e `<label>` noduwagi ka `<answer>` se tadâ' inputta se èlabelè.
+
+label-for-must-reference-input-or-answer = Atribut `for` e `<label>` kodu noduwagi ka settong input otabâ settong answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Kaangguy aksesibilitas, `<{ $component }>` kodu badâ katerrangan pandhâ' otabâ èpastèagi menangka hiasan.
+
+accessibility-video-short-description = Kaangguy aksesibilitas, `<video>` kodu badâ katerrangan pandhâ'.
+
+accessibility-input-short-description-or-label = Kaangguy aksesibilitas, `<{ $component }>` kodu badâ katerrangan pandhâ' otabâ label.
+
+accessibility-answer-input-short-description-or-label = Kaangguy aksesibilitas, `<answer>` se agabây input kodu badâ katerrangan pandhâ' otabâ label.
+
+accessibility-short-description-contains-math = Katerrangan pandhâ' ta' olle badâ komponen matematika akadi `<{ $component }>`. Tolès matematikana ngangguy oca'.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kontras { $colorName } korang kaangguy teks judul bâgiyân (mode petteng) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; parlo sakone'na { $threshold }:1).
+       *[other] Kontras { $colorName } korang kaangguy teks judul bâgiyân ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; parlo sakone'na { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` se lèbât e { $count } titik gi' ta' èterapaghi mon titikka tadâ' nilai angkana.
+
+circle-too-many-through-points = Ta' bisa ngètong bunderan se lèbât e lebbi dâri 3 titik.
+
+circle-overprescribed-radius-center-points = Ta' bisa ngètong bunderan se èpastèagi jhâri-jhârina, tengngana ban titik se èlèbâdi.
+
+circle-center-with-multiple-points = Ta' bisa ngètong bunderan se èpastèagi tengngana tapè lèbât e lebbi dâri 1 titik.
+
+circle-radius-too-small = Ta' bisa ngètong bunderan: sabab jârâ'na dhuwâ' titik rowa { $distance }, jhâri-jhâri { $radius } se èpastèagi ce' kene'na.
+
+circle-radius-with-many-points = Ta' bisa agabây bunderan se lèbât e lebbi dâri dhuwâ' titik bân jhâri-jhâri se èpastèagi.
+
+circle-invalid-center-or-through-points = Tengngana otabâ titik se èlèbâdi bunderan ta' sah.
+
+circle-radius-center-with-multiple-points = Ta' bisa ngètong jhâri-jhâri bunderan se èpastèagi tengngana tapè lèbât e lebbi dâri 1 titik.
+
+circle-change-radius-non-numerical = Ta' bisa ngoba jhâri-jhâri bunderan se lèbât e titik se ta' aangka
+
+circle-radius-with-points-non-numerical = Ta' bisa agabây bunderan se lèbât e lebbi dâri settong titik bân jhâri-jhâri se èpastèagi mon tadâ' nilai angkana.
+
+circle-change-center-non-numerical = Ngoba tengngana bunderan se lèbât e titik se tadâ' nilai angkana gi' ta' èterapaghi.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Madurese has one, because
+# «interval» and «input» do not change for number. Both selects are dropped and
+# both counts still arrive.
+function-domain-insufficient-dimensions = Dimensi domain kaangguy fungsi korang. Domainna badâ { $intervals } interval tapè fungsina badâ { $inputs } input.
+
+function-domain-invalid-format = Format domain kaangguy fungsi ta' sah.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Nilai se paleng tenggi dâri fungsi se ta' aangka ta' èanggep.
+        [minimum] Nilai se paleng bâbâ dâri fungsi se ta' aangka ta' èanggep.
+        [extremum] Ekstremum fungsi se ta' aangka ta' èanggep.
+        [point] Titik fungsi se ta' aangka ta' èanggep.
+        [slope] Kamèrèngan fungsi se ta' aangka ta' èanggep.
+       *[other] { $type } fungsi se ta' aangka ta' èanggep.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Nilai se paleng tenggi dâri fungsi se kosong ta' èanggep.
+        [minimum] Nilai se paleng bâbâ dâri fungsi se kosong ta' èanggep.
+        [extremum] Ekstremum fungsi se kosong ta' èanggep.
+        [point] Titik fungsi se kosong ta' èanggep.
+       *[other] { $type } fungsi se kosong ta' èanggep.
+    }
+
+function-points-too-close = Fungsina badâ dhuwâ' titik se ce' semma'na. Fungsina ta' bisa èbâtessè.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Iterasi fungsi pera' bisa mon bânnya'na input padâ bân bânnya'na output. Fungsi rèya badâ { $inputs } input ban { $outputs } output.
+
+## `<sequence>`
+
+sequence-invalid-length = Lanjhângnga sequence ta' sah.  Kodu bilangan bulat se ta' negatif.
+
+sequence-invalid-step = step sequence ta' sah.  Kodu angka kaangguy sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" sequence angka ta' sah.  Kodu angka.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" sequence huruf ta' sah.  Kodu kombinasi huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" sequence ta' sah.
+
+select-from-sequence-coprime-not-numbers = coprime ta' èanggep sabab se èpele banne angka
+
+select-from-sequence-coprime-with-exclude-combinations = coprime ta' èanggep sabab excludeCombinations èpastèagi
+
+## Resolving a `target`
+
+target-not-found = target ta' sah kaangguy `<{ $source }>`: targetta ta' etemmo.
+
+target-state-variable-not-found = target ta' sah kaangguy `<{ $source }>`: variabel kaadaan se anyama "{ $property }" ta' etemmo e `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel `<odeSystem>` kodu bidâ dâri variabel bebas.
+
+ode-system-duplicate-variable-names = Ta' bisa mâbâtes fungsi RHS ODE se nyamana variabel agântongnga padâ.
+
+ode-system-rhs-function-error = Ta' bisa mâbâtes fungsi RHS ODE.  Badâ kasalaan e bakto agabây fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ta' bisa mâbâtes sudut e antarana { $count } garis
+
+angle-invalid-through-point = Titik se ta' sah e through `<angle>`
+
+parabola-vertex-too-many-points = Parabola se badâ pucca'na tapè lèbât e lebbi dâri 1 titik gi' ta' èterapaghi.
+
+parabola-too-many-points = Parabola se lèbât e lebbi dâri 3 titik gi' ta' èterapaghi.
+
+intersection-too-many-items = Papotongan kaangguy lebbi dâri dhuwâ' bârâng gi' ta' èterapaghi
+
+## Other math components
+
+ionic-compound-not-two-ions = Sanyawa ionik kaangguy se laèn dâri dhuwâ' ion gi' ta' èterapaghi.
+
+ionic-compound-needs-cation-and-anion = Sanyawa ionik èterapaghi pera' kaangguy settong kation ban settong anion.
+
+solve-equations-cannot-evaluate = Ta' bisa maberes persamaan sabab persamaanna ta' bisa ènilai: { $equation }
+
+math-operators-operand-number-required = operandNumber kodu èpastèagi mon ngala' operand matematika.
+
+eigen-decomposition-failed = Ta' bisa ngètong eigenvalue matriks
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } ta' kalowar e pattern, daddi salanjângnga cocok bân se kosong.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ta' ngarté grid="{ $grid }". Kodu none, medium, dense, otabâ dhuwâ' angka positif se èpèsa spasi, akadi grid="1 0.5". Tadâ' grid se èghâmbhâr.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ta' èdukung e renderer prefigure; ngangguy tengka posisi kanan.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ta' èdukung e renderer prefigure; ngangguy tengka posisi attas.
+
+prefigure-invalid-axis-bounds = `<graph>`: bâtessa sumbu ta' sah kaangguy konversi prefigure; ngangguy bbox baku (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: lèbârra ta' sah kaangguy konversi prefigure; ngangguy lèbâr diagram baku 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio ta' sah kaangguy konversi prefigure; ngangguy aspect ratio baku 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jârâ'na grid ce' semma'na kaangguy bâtessa sumbu; grid ta' èghâmbhâr e renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotation ta' èghâmbhâr mon ta' ngangguy renderer PreFigure.
+
+multiple-annotations-children = Bânnya' ana' `<annotations>` etemmo e `<graph>`; sakabbinna ta' èanggep kajhâbâ se dhi'-budhi'na.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ta' bisa manjhâng otabâ nyalèn jhinis komponen se ta' ètao: { $type }.
+
+copy-prop-not-found = Prop { $property } ta' etemmo e komponen jhinis { $component }
+
+collect-no-source = Tadâ' source se etemmo kaangguy collect.
+
+collect-invalid-component-type = Ta' bisa ngompol komponen jhinis `<{ $component }>` sabab jhinis komponenna ta' sah.
+
+reference-index-unavailable = Ta' bisa nyebbut indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ta' bisa nyellok { $action } e komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bentuk datana ta' sah.  Lanjhângnga baris ta' padâ. Etemmo e componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Datana badâ nyama kolom se padâ.  Etemmo e componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Datana korang nyama kolom.  Etemmo e componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award jhâwâban rèya adâsar ka jhâwâban se èkèrèm bi' answer tag dibi', ban rèya bâkal magibâ tengka se ta' èarep.
+
+answer-max-num-attempts-in-section-wide-check-work = Nyabâ' `maxNumAttempts` e `<answer>` e dâlem wadâ se badâ `sectionWideCheckWork` tadâ' gunana, sabab wadâna se ngator bânnya'na coba. Sabâ' `maxNumAttempts` e wadâna.
+
+nested-section-wide-check-work-max-num-attempts = Nyabâ' `maxNumAttempts` e wadâ se badâ `sectionWideCheckWork` se badâ e dâlem wadâ laèn se badâ `sectionWideCheckWork` tadâ' gunana, sabab wadâ se e lowar se ngator bânnya'na coba. Sabâ' `maxNumAttempts` e wadâ se e lowar.
+
+# No select: «atribut» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Atribut { $attributes } tadâ' gunana mon symbolicEquality ta' èsabâ'.
+
+answer-invalid-type = Jhinis jhâwâban se ta' sah: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sabab komponen `<{ $component }>` tadâ' nyamana, rowa ta' bisa èangguy kaangguy atribut module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` ta' bisa èangguy menangka atribut module sabab jhinis komponen `<module>` la badâ atribut "{ $name }"-na.
+
+conditional-content-condition-ignored = Atribut `condition` ta' èanggep e komponen `<conditionalContent>` se badâ ana' case otabâ else.
+
+slider-markers-type-mismatch = Jhinis marker ta' cocok bân jhinis slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel ta' sah: sabbân `<problem>` kodu badâ settong `<statement>` ban settong `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel ta' sah: e mode="circuit", `<problem>` se dâ'-adâ' ta' olle distractor.
+
+## Attribute values
+
+# No select: «nilai» is the same word for one and for many.
+attribute-invalid-values = Nilai { $values } ta' sah kaangguy atribut `{ $attribute }`; ta' èanggep.
+
+attribute-must-be-references = Nilai `{ $value }` ta' sah kaangguy atribut `{ $attribute }`. Atribut kodu èsoson dâri rujuan se molaè bân `$`.
+
+math-input-invalid-function-names = <mathInput>: nyamana fungsi se ta' sah e { $attribute } ta' èanggep: { $names }. Sabbân nyama kodu badâ 2 karakterra (huruf otabâ tanda sambung); olle èterrossagi sufiks `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Jhinis komponen se ta' sah: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } ta' olle èolang.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" ta' sah kaangguy komponen jhinis `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kontras bâtessa gaya { $styleNumber } korang kaangguy { $context ->
+        [text-on-background] wârnana teks nyabâ' wârnana latar
+        [high-contrast] wârna kontras tenggi nyabâ' kanvas
+        [line] wârnana garis nyabâ' kanvas
+        [marker] wârnana marker nyabâ' kanvas
+       *[text-on-canvas] wârnana teks nyabâ' kanvas
+    }{ $mode ->
+        [dark] { " (mode petteng)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; parlo sakone'na { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Maskè bâtessa gaya { $styleNumber } badâ wârna se èpastèagi bân kontras se cokop kaangguy mode terrang, kontras wârnana teks nyabâ' wârnana latar korang e wârna se èkala' kaangguy mode petteng ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; parlo sakone'na { $threshold }:1). { $suggestion ->
+        [available] Sopaja kontrassa cokop e mode petteng, tambâ kontras mode terrang (contona, sabâ' { $lightAttribute }="{ $lightColor }") otabâ genté wârna mode petteng (contona, sabâ' { $darkAttribute }="{ $darkColor }").
+       *[none] Sopaja kontrassa cokop e mode petteng, tambâ kontras mode terrang otabâ genté wârna se èkala' bân textColorDarkMode ban/otabâ backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Maskè bâtessa gaya { $styleNumber } badâ wârnana teks se èpastèagi bân kontras se cokop kaangguy mode terrang, kontras wârnana teks se èkala' kaangguy mode petteng korang nyabâ' kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; parlo sakone'na { $threshold }:1). { $suggestion ->
+        [available] Sopaja kontrassa cokop e mode petteng, tambâ kontras mode terrang (contona, sabâ' textColor="{ $lightColor }") otabâ genté wârna mode petteng (contona, sabâ' textColorDarkMode="{ $darkColor }").
+       *[none] Sopaja kontrassa cokop e mode petteng, tambâ kontras mode terrang otabâ genté wârna se èkala' bân textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Settong bâgiyân pera' olle mele settong <stylePalette>; ngangguy se dhi'-budhi'na.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ta' bisa mastèagi varian tunggâl { $component } sabab numToSelect banne bilangan bulat se ta' negatif.
+
+variant-num-to-select-not-constant-number = ta' bisa mastèagi varian tunggâl { $component } sabab numToSelect banne angka tetep.
+
+variant-with-replacement-not-constant-boolean = ta' bisa mastèagi varian tunggâl { $component } sabab withReplacement banne boolean tetep.
+
+variant-select-weight-disables-unique = Varian tunggâl kaangguy select èmatèagi mon badâ opsi se èpastèagi selectWeight otabâ selectForVariants
+
+variant-coprime-undetermined = ta' bisa mastèagi varian tunggâl { $component } sabab ta' bisa èpastèagi coprime salanjângnga false.
+
+variant-attribute-not-constant = ta' bisa mastèagi varian tunggâl { $component } sabab { $attribute } ta' tetep.
+
+variant-attribute-not-number = ta' bisa mastèagi varian tunggâl { $component } sabab { $attribute } banne angka.
+
+variant-attribute-wrong-type-for-sequence =
+    ta' bisa mastèagi varian tunggâl { $component } jhinis { $type } sabab { $attribute } banne { $expected ->
+        [letters-combination] kombinasi huruf
+        [math-expression] ungkapan matematika se sah
+        [integer] bilangan bulat
+       *[number] angka
+    }.
+
+variant-length-not-integer = ta' bisa mastèagi varian tunggâl { $component } sabab length banne bilangan bulat.
+
+variant-sort-not-implemented = varian tunggâl { $component } se badâ sort-na gi' ta' èterapaghi
+
+variant-exclude-combinations-not-implemented = varian tunggâl { $component } se badâ excludeCombinations-sa gi' ta' èterapaghi
+
+variant-math-exclude-not-implemented = varian tunggâl { $component } jhinis math se badâ exclude-na gi' ta' èterapaghi
+
+variant-non-constant-exclude-not-implemented = varian tunggâl { $component } se badâ exclude ta' tetep gi' ta' èterapaghi
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ta' èdukung e renderer prefigure graph; katoronanna èlangkae.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometrina ta' abâtes otabâ ta' ganna'; katoronanna èlangkae.
+
+prefigure-curve-label-omitted = { $subject }: label ta' èdukung e elemen lengkong se èkonversi; labella ta' èanggep.
+
+prefigure-curve-unsupported-definition-type = { $subject }: jhinis bâtessa fungsi lengkong '{ $definitionType }' ta' èdukung; katoronanna èlangkae.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions e regionBetweenCurves ta' èdukung; katoronanna èlangkae.
+
+prefigure-region-non-formula-child = { $subject }: pera' ana' fungsi jhinis formula se èdukung e regionBetweenCurves; katoronanna èlangkae.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ta' èdukung kaangguy { $labelKind ->
+        [line-family] label kaluarga garis
+       *[point] label titik
+    }; ngangguy perataan baku PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: gaya essè '{ $fillStyle }' ta' èdukung bi' PreFigure; abâli ka essè se padet.
+
+prefigure-line-style-unknown = { $subject }: gaya garis '{ $lineStyle }' ta' ètao, ta' èanggep e output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya marker '{ $markerStyle }' èpetakaghi ka gaya 'diamond' PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: gaya marker '{ $markerStyle }' ta' èdukung bi' PreFigure; ngangguy gaya baku.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ta' sah; targetta ta' bisa èduduwagi. Annotationna ta' èanggep.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` noduwagi ka bânnya' target; ngangguy target se dâ'-adâ'.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ta' sah; targetta badâ e lowarra graph se badâ jârowa. Annotationna ta' èanggep.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ta' sah; targetta banne objek grafis se èdukung e konversi prefigure. Annotationna ta' èanggep.
+
+annotation-text-missing = `<annotation>`: `text` korang otabâ kosong; makalowar teks kosong.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Etemmo kagântongan se abunder.
+       *[other] Etemmo kagântongan se abunder se agâbung bân komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Tadâ' se etemmo se èdduduwagi rujuanna: `{ $reference }`
+
+reference-multiple-referents = Bânnya' se etemmo se èdduduwagi rujuanna: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } e `<{ $componentType }>` ta' sah.
+
+children-invalid = Ana' `<{ $componentType }>` ta' sah: etemmo ana' se ta' sah: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` ta' sah kaangguy atribut `{ $attribute }`, ngangguy nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } ta' etemmo.
+       *[other] Versi DoenetML { $version } ta' etemmo. Abâli ka versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ta' sah: { $content }
+
+parse-tag-missing-close-tag = DoenetML ta' sah: Tag `{ $tag }` tadâ' tag panotobba. Èarep tag se notop dibi' otabâ tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ta' sah: Badâ kasalaan e tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ta' sah: Atribut `{ $attribute }` se ta' sah akadi korang nilaina.
+
+parse-attribute-invalid = DoenetML ta' sah: Atribut `{ $attribute }` ta' sah
+
+parse-attribute-value-invalid = DoenetML ta' sah: Nilai atribut `{ $value }` ta' sah
+
+parse-attribute-value-quote-mismatch = DoenetML ta' sah: Nilai atribut `{ $value }` ta' sah. Tanda kutebba ta' cocok. Akadi korang settong `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML ta' sah: Etemmo tag se tadâ' nyamana, contona `<`
+
+parse-tag-not-closed = DoenetML ta' sah: Tag `{ $tag }` ta' ètotop (akadi korang `>`).
+
+parse-self-closing-tag-name-missing = DoenetML ta' sah: Etemmo tag se tadâ' nyamana `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ta' sah: Tag `{ $tag }` ta' ètotop (akadi korang `/>`).
+
+parse-tag-invalid-attributes = DoenetML ta' sah: Tag `{ $tag }` ta' sah. Bisa jhâ' atributta ta' bendher.
+
+parse-close-tag-name-missing = DoenetML ta' sah: Etemmo tag panotob se tadâ' nyamana, contona `</`
+
+parse-attribute-value-unquoted = Nilai atribut kodu èsabâ' e dâlem tanda kuteb: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ta' sah: Etemmo tag panotob `{ $tag }`, tapè tadâ' tag pambukka' se cocok
+
+parse-close-tag-mismatched = DoenetML ta' sah: Tag panotobba ta' cocok. Èarep `</{ $expected }>`. Etemmo `{ $found }`
+
+parser-node-unconvertible = Node { $node } ta' bisa èkonversi daddi node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribut name='{ $name }' ta' sah. { $reason ->
+        [characters] Nyama pera' olle badâ huruf, angka, garis bâbâ otabâ tanda sambung.
+       *[start] Nyama kodu molaè bân huruf.
+    }
+
+component-name-invalid-start = Nyamana komponen "{ $name }" ta' sah. Nyama kodu molaè bân huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer se type videoWatched kodu badâ atribut video-na
+
+answer-video-watched-video-not-reference = Answer se type videoWatched kodu badâ atribut video se aropa rujuan
+
+answer-name-not-single-text = Atribut name e answer kodu badâ settong ana' text malolo
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ta' bisa ngala' DoenetML dâri lowar sabab tingkat ngolangnga ce' bânnya'na. Badâ rujuan se abunder?
+
+external-doenetml-unavailable = Ta' bisa ngala' DoenetML dâri { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML se èkala' dâri { $attribute }="{ $uri }" ta' sah: rowa ta' cocok bân jhinis komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` ta' èangguy pole; angguy `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` e `<{ $component }>` ta' èangguy pole; angguy `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` ta' èangguy pole ban ta' èanggep sabab `{ $to }` èpastèagi keya.
+       *[other] [deprecation] Atribut `{ $from }` e `<{ $component }>` ta' èangguy pole ban ta' èanggep sabab `{ $to }` èpastèagi keya.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` e `<{ $component }>` ta' èangguy pole ban ta' èanggep.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` e `<{ $component }>` ta' èangguy pole; angguy ana' `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` e atribut `{ $attribute }` e `<{ $component }>` ta' èangguy pole; angguy `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` pera' bisa mabânnya' bâsa Inggris, daddi teksa ta' aoba e dokumen se ètolès bân { $locale }. Tolès langsong bentuk bânnya'na, otabâ sabâ' bân atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` banne elemen Doenet se ètao.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` ta' èolèagi e ramona dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` ta' èolèagi e dâlem `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` tadâ' atribut se anyama `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` e elemen `<{ $tag }>` kodu aropa daftar se sabbân essèna sala settong dâri: { $allowed }
+       *[other] Atribut `{ $attribute }` e elemen `<{ $tag }>` kodu sala settong dâri: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nyamana varian ta' sah kaangguy select.  Nyamana varian { $variantName } kalowar e { $numOptions } opsi tapè bânnya'na se èpelea { $numToSelect }.
+
+select-variant-name-without-options = Badâ varian se èpastèagi kaangguy select tapè tadâ' opsi se èpastèagi kaangguy nyamana varian se bisa: { $variantName }.
+
+select-variant-name-not-possible = Nyamana varian { $variantName } se èpastèagi kaangguy select banne nyamana varian se bisa.
+
+select-too-few-options = Ta' bisa mele { $numToSelect } komponen dâri { $numOptions } malolo.
+
+select-from-sequence-too-few-values = Ta' bisa mele { $numToSelect } nilai dâri sequence se lanjhângnga { $length }.
+
+select-from-sequence-indices-count-mismatch = Bânnya'na indeks se èpastèagi kaangguy select kodu cocok bân bânnya'na se èpelea
+
+select-from-sequence-indices-not-integers = Sakabbinna indeks se èpastèagi kaangguy select kodu bilangan bulat
+
+select-from-sequence-index-excluded = Indeks selectfromsequence se èpastèagi rowa èkalowarraghi
+
+select-from-sequence-indices-excluded-combination = Indeks selectfromsequence se èpastèagi rowa kombinasi se èkalowarraghi
+
+select-from-sequence-coprime-not-positive-integers = Ta' bisa mele kombinasi coprime sabab se èpele banne bilangan bulat positif.
+
+select-from-sequence-coprime-common-factor = Ta' bisa mele angka coprime. Sakabbinna nilai se bisa badâ faktor se padâ. (Nilai "from" otabâ "to" se èpastèagi kodu coprime bân "step".)
+
+select-from-sequence-coprime-single-number = Ta' bisa mele kombinasi coprime dâri settong angka se banne 1.
+
+select-from-sequence-excluded-too-many-combinations = Lebbi dâri 70% kombinasina èkalowarraghi e selectFromSequence
+
+select-from-sequence-coprime-none-found = Ta' bisa mele angka coprime. Sakabbinna nilai se bisa badâ faktor se padâ.
+
+select-from-sequence-too-few-unique-values = Ta' bisa mele { $numToSelect } nilai tunggâl dâri sequence se lanjhângnga { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Ta' bisa mele { $numToSelect } nilai dâri daftar prima se lanjhângnga { $numValues }
+
+select-prime-numbers-values-count-mismatch = Bânnya'na nilai se èpastèagi kaangguy select kodu cocok bân bânnya'na se èpelea
+
+select-prime-numbers-values-not-prime = Sakabbinna nilai se èpastèagi kaangguy select prime number kodu badâ e daftar prima
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers se èpastèagi rowa kombinasi se èkalowarraghi
+
+select-prime-numbers-excluded-too-many-combinations = Lebbi dâri 70% kombinasina èkalowarraghi e selectPrimeNumbers
+
+select-random-combination-fluke = Sabab ontong se ce' jhârângnga, ta' bisa mele kombinasi nilai acak
+
+select-random-value-fluke = Sabab ontong se ce' jhârângnga, ta' bisa mele nilai acak

--- a/packages/i18n/locales/mad/editor.ftl
+++ b/packages/i18n/locales/mad/editor.ftl
@@ -1,0 +1,207 @@
+# Madurese editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Written throughout in enjâ'-iyâ, the plain everyday speech level; see
+# `chrome.ftl`'s header.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Bâlik
+       *[update] Anyarraghi
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } panèngalanna
+       *[other] { $word } panèngalanna { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+editor-variant-filter = Saring…
+editor-variant-next = Pele varian salanjudde
+editor-variant-previous = Pele varian sabellunna
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Badâ palanggharân aksesibilitas WCAG AA se etemmo. Klik sopaja { $action ->
+            [close] atotop
+           *[open] abukka'
+        } laporan aksesibilitassa.
+        [advisories] Klik sopaja { $action ->
+            [close] atotop
+           *[open] abukka'
+        } laporan aksesibilitassa. Tadâ' palanggharân WCAG AA se etemmo, tapè badâ saran aksesibilitas laèn.
+       *[clean] Klik sopaja { $action ->
+            [close] atotop
+           *[open] abukka'
+        } laporan aksesibilitassa. Tadâ' masala aksesibilitas se etemmo.
+    }
+
+# No select on `$count` inside the branches: «palanggharân» and «saran» are the
+# same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Badâ palanggharân aksesibilitas WCAG AA se etemmo. Etemmo { $count } palanggharân WCAG AA. Klik sopaja { $action ->
+            [close] atotop
+           *[open] abukka'
+        } laporan aksesibilitassa.
+        [advisories] Tadâ' palanggharân WCAG AA se etemmo. Etemmo { $count } saran aksesibilitas laèn. Klik sopaja { $action ->
+            [close] atotop
+           *[open] abukka'
+        } laporan aksesibilitassa.
+       *[clean] Tadâ' palanggharân WCAG AA se etemmo. Klik sopaja { $action ->
+            [close] atotop
+           *[open] abukka'
+        } laporan aksesibilitassa.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Versi DoenetML { $version }
+
+editor-tab-help = Bantowan noro' konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Kasalaan
+editor-tab-warnings = Parèngèdan
+editor-tab-info = Katerrangan
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Jhâwâban se la èkèrèm
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Pelean editor
+editor-format-as-doenetml = Format menangka DoenetML
+editor-format-as-xml = Format menangka XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Baris #{ $line }
+
+editor-no-errors = Tadâ' kasalaan
+editor-no-warnings = Tadâ' parèngèdan
+editor-no-info = Tadâ' diagnostik katerrangan
+
+editor-show-info-annotations = Toduwagi diagnostik katerrangan e editor
+editor-show-accessibility-annotations = Toduwagi diagnostik aksesibilitas e editor
+
+editor-accessibility-learn-more = Ajhâr kadi ponapa Doenet nangani aksesibilitas
+
+editor-accessibility-violations-heading = Palanggharân aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masala aksesibilitas laèn
+editor-none-found = Tadâ' se etemmo
+
+
+## Submitted responses
+
+editor-no-responses = Gi' tadâ' jhâwâban se èkèrèm
+editor-response-answer-id = Id jhâwâban
+editor-response-response = Jhâwâban
+editor-response-credit = Kredit
+editor-response-submitted = Èkèrèm
+
+
+## The context-help panel
+
+help-placeholder = Sabâ' kursor e nyamana tag, atribut, otabâ { $ref } kaangguy dokumentasi.
+
+help-unsupported-ref-chain = Bantowan kaangguy rujuan bânnya' bâgiyân akadi { $example } gi' ta' èdukung.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Tadâ' se etemmo se èdduduwagi rujuanna: { $ref }.
+        [multiple] Bânnya' se etemmo se èdduduwagi rujuanna: { $ref }.
+       *[indeterminate] Ta' bisa èpastèagi apa se èdduduwagi { $ref }.
+    }
+
+help-learn-about-references = Ajhâr parkara rujuan →
+help-reference-page = Kaca rujuan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] E dâlem { $element }
+       *[top] E tingkat se paleng attas
+    }{ $allowed ->
+        [none] { " — tadâ' se bisa èsabâ' e ka'dinto." }
+        [text] { " — tolès teks e ka'dinto." }
+        [text-and-components] { " — tolès teks e ka'dinto, otabâ coba:" }
+       *[components] { " — se bisa ècoba:" }
+    }
+
+help-suggestions-footer = Penet { $shortcut } sopaja nèngale sakabbinna { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } rowa rujuan ka { $target }.
+       *[other] { $ref } rowa rujuan ka { $target } (baris { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Èghibâ bi' { $owner } menangka { $role }.
+       *[other] Èghibâ bi' { $owner } e baris { $line } menangka { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } rowa rujuan ka sipat { $property } dâri { $element }.
+       *[other] { $ref } rowa rujuan ka sipat { $property } dâri { $element } (baris { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = potongan kode
+help-kind-array-entry = entri array
+
+help-default = Baku:
+help-active-default = Baku se aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai se èolèagi (settong sabbân bârâng):
+       *[other] Nilai se èolèagi:
+    }
+
+help-suggested-values = Nilai se èsaranagi:
+
+help-inserts = Nyoccok:
+
+# No select: «koordinat» is the same word for one and for many.
+help-coordinates = Koordinat:
+
+help-type = Jhinis:
+
+help-resolved-style = Gaya se la èpastèagi (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nyamana fungsi se la èpastèagi:
+help-reset-list = Daftar reset e input rèya:
+help-added-on-input = Ètambâ e input rèya:
+help-removed-on-input = Èbuwang e input rèya:
+
+help-reset-overrides = { $reset } ngalang { $additional } ban { $removed }.

--- a/packages/i18n/locales/min/chrome.ftl
+++ b/packages/i18n/locales/min/chrome.ftl
@@ -1,0 +1,146 @@
+# Minangkabau viewer chrome. Translated from `locales/en/chrome.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography of Minangkabau publishing, which spells the
+# language's own vowels rather than Indonesian's: «garih» and not «garis»,
+# «itam» and not «hitam», «taba» and not «tebal». Minangkabau is Malayic and a
+# great deal of its vocabulary is shared with `locales/id` and `locales/ms`; a
+# corrector's most useful check is where this file agrees with them and should
+# not.
+#
+# Minangkabau marks no number on the noun — reduplication is available but
+# optional, and a count in front of the noun does the work — so a
+# `{ $count -> … }` whose two English branches differ only in the noun renders
+# one string here and the select is dropped. A `[0]` branch stays wherever
+# English has one.
+
+
+## Answer submission
+
+answer-checking = Mamareso…
+answer-submitting = Mangirim…
+
+answer-checking-status = Mamareso jawaban
+answer-submitting-status = Mangirim jawaban
+
+answer-correct = Batua
+answer-incorrect = Indak batua
+
+answer-response-saved = Jawaban alah disimpan
+
+answer-percent-credit = { $percent }% kredit
+answer-percent-correct = { $percent }% batua
+answer-percent-short = { $percent } %
+
+max-credit-available = Kredit paliang gadang nan bisa didapek: { $percent }%
+
+# No select: «cubo» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] indak ado cubo nan tingga lai
+       *[other] tingga { $count } cubo
+    }
+
+validation-correct = (Batua)
+validation-incorrect = (Indak batua)
+validation-partially-correct = (Batua sabagian)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Tampilkan { $count } jawaban untuak { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentar
+
+collapsible-click-to-open = (klik untuak mambukak)
+collapsible-click-to-close = (klik untuak manutuik)
+
+collapsible-initializing = Mamulai…
+
+footnote-show = Tampilkan footnote
+footnote-hide = Sambunyian footnote
+
+description-more-information = katarangan tambahan
+
+
+## Controls
+
+slider-previous = Sabalunnyo
+slider-next = Salanjuiknyo
+
+keyboard-open = Bukak papan tuts
+keyboard-close = Tutuik papan tuts
+
+choice-input-remove-choice = Hapuih { $choice }
+
+matrix-remove-row = Hapuih barih
+matrix-add-row = Tambah barih
+matrix-remove-column = Hapuih kolom
+matrix-add-column = Tambah kolom
+
+subset-add-remove-points = Tambah/Hapuih titiak
+subset-toggle-points-intervals = Tuka titiak jo interval
+subset-move-points = Pindahkan titiak
+subset-clear = Basiahkan
+
+orbital-add-row = Tambah barih
+orbital-remove-row = Hapuih barih
+orbital-add-box = Tambah kotak
+orbital-remove-box = Hapuih kotak
+orbital-add-up-arrow = Tambah panah ka ateh
+orbital-add-down-arrow = Tambah panah ka bawah
+orbital-remove-arrow = Hapuih panah
+
+orbital-row-label = Label untuak barih { $row }
+
+pretzel-answer = Jawaban
+
+summary-statistics-caption = Ringkasan statistik { $column }
+
+
+## Math input
+
+math-input-preview-region = pratinjau ungkapan matematika
+math-input-preview = Pratinjau
+math-input-invalid-expression = Ungkapan nan indak sah:
+
+
+## Document status
+
+viewer-initializing = Mamulai…
+
+
+## Errors
+
+error-heading = Kasalahan
+
+error-found-at =
+    { $span ->
+        [line] Basuo di barih { $startLine }.
+       *[lines] Basuo di barih { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumen ko ado kasalahan!
+
+diagnostic-heading-error = Kasalahan
+diagnostic-heading-warning = Peringatan
+diagnostic-heading-information = Katarangan
+diagnostic-heading-hint = Pituah
+
+accessibility-heading-level-1 = Palanggaran aksesibilitas WCAG AA
+accessibility-heading-level-2 = Peringatan tantang aksesibilitas
+
+something-went-wrong = Ado nan salah.
+
+renderer-load-failed = ado renderer nan indak tamuek. Tolong muek ulang laman ko.
+
+core-start-failed = Panampil dokumen indak bisa dimulai. Tolong muek ulang laman ko.

--- a/packages/i18n/locales/min/content.ftl
+++ b/packages/i18n/locales/min/content.ftl
@@ -1,0 +1,257 @@
+# Minangkabau content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Minangkabau has no grammatical gender and no case, so `noun-gender` answers
+# one token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «garih sirah», a red line — so every
+# composition message inverts the English order, as `locales/ban`,
+# `locales/ace` and `locales/mad` do and as none of the five Philippine
+# catalogs in this batch does.
+#
+# There is no linker between a noun and its adjective, so nothing here meets the
+# constraint `locales/ilo`, `locales/pam` and `locales/bik` record. What
+# Minangkabau does have is the relativizer «nan», and it is used here only where
+# the catalog supplies both words around it.
+#
+# The geometry vocabulary is largely the Indonesian one, because Minangkabau
+# schools teach mathematics out of Indonesian-language textbooks. Where
+# Minangkabau has its own everyday form it is written — «garih», «bulatan»,
+# «titiak» — and that is where this file differs from `locales/id` rather than
+# copying it.
+
+
+## Style vocabulary
+
+color =
+    .black = itam
+    .white = putiah
+    .gray = kalabu
+    .red = sirah
+    .orange = jingga
+    .yellow = kuniang
+    .green = ijau
+    .cyan = sian
+    .blue = biru
+    .purple = unggu
+    .pink = sirah jambu
+    .brown = coklaik
+
+line-width =
+    .thick = taba
+    .thin = tipih
+
+line-style =
+    .dashed = putuih-putuih
+    .dotted = titiak-titiak
+
+# Noun phrases. Minangkabau marks no plural on the noun, so «garih» is the word
+# for one line and for many alike.
+fill-style =
+    .horizontal = garih mandata
+    .vertical = garih tagak
+    .diagonal = garih serong
+    .backdiagonal = garih serong tabaliak
+    .dots = titiak
+    .diamonds = balah katupek
+
+noun =
+    .line = garih
+    .line-segment = ruweh garih
+    .ray = sinar
+    .vector = vektor
+    .curve = lengkuang
+    .function = fungsi
+    .parabola = parabola
+    .polyline = garih patah
+    .polygon = poligon
+    .triangle = sagitigo
+    .rectangle = pasagi panjang
+    .circle = bulatan
+    .region = kawasan
+    .point = titiak
+    .square = pasagi
+    .diamond = balah katupek
+    .cross = silang
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] nan basisi { $numSides }
+       *[head] poligon baraturan
+    }
+
+# One answer for every noun: Minangkabau has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = taisi
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } jo { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } jo { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } jo { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Minangkabau has no article, so the two `-article` branches say what the other
+# two say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «jo» against «sarato».
+style-border-clause =
+    { $parts ->
+        [with-article] jo tapi { $border }
+        [and] sarato tapi { $border }
+        [and-article] sarato tapi { $border }
+       *[with] jo tapi { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = indak taisi
+
+style-text =
+    { $parts ->
+        [background] { $color } jo latar { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = indak ado
+
+
+## Boolean words
+
+boolean-true = bana
+boolean-false = indak bana
+
+
+## Answer buttons
+
+answer-submit-label = Pareso karajo
+answer-submit-label-no-correctness = Kirim jawaban
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Minangkabau marks no plural on the noun.
+section-name =
+    .activity = Kagiatan
+    .aside = Catatan sisi
+    .cascade = Kaskade
+    .definition = Batasan
+    .example = Contoh
+    .exercise = Latihan
+    .exercises = Latihan
+    .given-answer = Jawaban
+    .note = Catatan
+    .objectives = Tujuan
+    .paragraphs = Paragraf
+    .part = Bagian
+    .problem = Soal
+    .problems = Soal
+    .proof = Bukti
+    .question = Patanyaan
+    .section = Bagian
+    .solution = Panyalasaian
+    .task = Tugeh
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Pituah
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabel { $enumeration }
+        [numbered-title] Tabel { $enumeration }{ ": " }
+        [unnumbered-title] Tabel{ ": " }
+       *[unnumbered] Tabel
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Gambar { $enumeration }
+        [numbered-caption] Gambar { $enumeration }{ ": " }
+        [unnumbered-caption] Gambar{ ": " }
+       *[unnumbered] Gambar
+    }
+
+
+## Paginator controls
+
+paginator-previous = Sabalunnyo
+paginator-next = Salanjuiknyo
+paginator-page = Laman
+
+paginator-page-status = { $pageLabel } { $currentPage } dari { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = atau
+piecewise-condition-if = jiko
+piecewise-condition-otherwise = jiko indak
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Minangkabau schools teach chemistry out of Indonesian-language
+## textbooks, so the periodic table a Minangkabau pupil meets is `locales/id`'s.
+## `locales/jv` and `locales/su` supply the Indonesian names for that reason;
+## this catalog does not, because Minangkabau's own forms differ from
+## Indonesian's often enough — «ameh» for gold, «basi» for iron — that copying
+## the Indonesian table whole would be neither language, and no settled
+## Minangkabau table of all 118 exists to seed from.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simbol kimia nan indak sah
+chemistry-invalid-ionic-compound = Sanyawa ionik nan indak sah

--- a/packages/i18n/locales/min/diagnostics.ftl
+++ b/packages/i18n/locales/min/diagnostics.ftl
@@ -1,0 +1,624 @@
+# Minangkabau diagnostics. Translated from `locales/en/diagnostics.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Minangkabau marks no number on the noun, so a counted message whose only
+# English difference is the noun's number renders one string here and the
+# select is dropped. The count still arrives and is still formatted.
+
+
+## `<lineSegment>`
+
+# No select: «diabaikan» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = { $attributes } diabaikan bilo duo ujuang alah ditantukan
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = { $attributes } diabaikan bilo ciek ujuang jo titiak tangah alah ditantukan kaduonyo
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset indak baguno tanpa titiak tangah
+
+## `<line>`
+
+line-points-undetermined-dimensions = Garih nan malalui titiak nan dimensinyo indak tantu.
+
+line-points-too-few-dimensions = Garih harus malalui titiak nan padoso duo dimensi.
+
+line-points-depend-on-variables = Garih malalui titiak nan bagantuang ka variabel: { $variables }.
+
+line-equation-invalid-format = Format persamaan garih nan indak sah pado variabel { $variable1 } jo { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Sinar ditantukan dek through, endpoint jo direction.  through nan ditantukan diabaikan.
+
+ray-dimension-mismatch = numDimensions indak cocok di sinar.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektor ditantukan dek head, tail jo displacement.  head nan ditantukan diabaikan.
+
+vector-dimension-mismatch = numDimensions indak cocok di vektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Indak dapek manarik ka `<{ $component }>` karano inyo indak padoso variabel keadaan nearestPoint.
+
+constrain-to-without-nearest-point = Indak dapek maikek ka `<{ $component }>` karano inyo indak padoso variabel keadaan nearestPoint.
+
+constrain-to-interior-without-nearest-point = Indak dapek maikek ka dalam `<{ $component }>` karano inyo indak padoso variabel keadaan nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition diabaikan pado choiceInput nan indak inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indeks nan ditantukan untuak choiceInput diabaikan karano jumlah indeks indak cocok jo jumlah anak piliahan.
+
+pretzel-indices-count-mismatch = Indeks nan ditantukan untuak problem diabaikan karano jumlah indeks indak cocok jo jumlah anak problem.
+
+shuffle-indices-count-mismatch = Indeks nan ditantukan untuak shuffle diabaikan karano jumlah indeks indak cocok jo jumlah komponen.
+
+indices-ignored-out-of-range = Indeks nan ditantukan untuak { $component } diabaikan karano ado indeks nan lua jangkauan.
+
+pretzel-indices-repeated = Indeks nan ditantukan untuak pretzel diabaikan karano ado indeks nan baulang.
+
+pretzel-circuit-first-index = Indeks nan ditantukan untuak pretzel di mode circuit diabaikan karano indeks partamo harus 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Supayo `<{ $component }>` bajalan jo anak string, atribut `type` harus ditantukan.
+
+invalid-type-defaulting-to-math = type { $type } indak sah untuak komponen { $component }. Harus salah ciek dari math, text, number, atau boolean. Mamakai math.
+
+string-not-valid-component-to-arrange = String "{ $value }" bukan komponen nan sah untuak { $component }. Diabaikan.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } indak sah, type diatur ka number.
+
+invalid-variable-value = Nilai variabel nan indak sah: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks varian { $index } harus angko
+
+variant-index-must-be-integer = Indeks varian { $index } harus bilangan bulek
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` alun diterapkan untuak ukuran mutlak. Leba diatur jadi relatif.
+
+side-by-side-absolute-margins = `<{ $component }>` alun diterapkan untuak ukuran mutlak. Margin diatur jadi relatif.
+
+side-by-side-no-block-child = `<{ $component }>` indak sah: inyo harus padoso ciek anak block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Atribut `for` pado `<label>` grafis diabaikan.
+
+label-for-must-resolve-to-one = Atribut `for` pado `<label>` harus manunjuak tapek ka ciek komponen.
+
+label-for-unresolved = Atribut `for` pado `<label>` indak dapek manunjuak ka komponen.
+
+label-for-answer-with-authored-inputs = Atribut `for` pado `<label>` manunjuak ka `<answer>` nan padoso input nan ditulis dek panulis; tunjuak input tu langsuang.
+
+label-for-answer-without-input = Atribut `for` pado `<label>` manunjuak ka `<answer>` nan indak padoso input untuak dilabeli.
+
+label-for-must-reference-input-or-answer = Atribut `for` pado `<label>` harus manunjuak ka input atau ka answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Untuak aksesibilitas, `<{ $component }>` harus padoso katarangan singkek atau ditantukan sabagai hiasan.
+
+accessibility-video-short-description = Untuak aksesibilitas, `<video>` harus padoso katarangan singkek.
+
+accessibility-input-short-description-or-label = Untuak aksesibilitas, `<{ $component }>` harus padoso katarangan singkek atau label.
+
+accessibility-answer-input-short-description-or-label = Untuak aksesibilitas, `<answer>` nan mambuek input harus padoso katarangan singkek atau label.
+
+accessibility-short-description-contains-math = Katarangan singkek indak buliah maisi komponen matematika saroman `<{ $component }>`. Tuliskan matematikanyo jo kato.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kontras { $colorName } kurang untuak teks judul bagian (mode kalam) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mambutuahkan padoso { $threshold }:1).
+       *[other] Kontras { $colorName } kurang untuak teks judul bagian ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mambutuahkan padoso { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` nan malalui { $count } titiak alun diterapkan bilo titiaknyo indak padoso nilai angko.
+
+circle-too-many-through-points = Indak dapek maituang bulatan nan malalui labiah dari 3 titiak.
+
+circle-overprescribed-radius-center-points = Indak dapek maituang bulatan nan ditantukan jari-jari, pusek jo titiak nan dilalui.
+
+circle-center-with-multiple-points = Indak dapek maituang bulatan nan ditantukan puseknyo tapi malalui labiah dari 1 titiak.
+
+circle-radius-too-small = Indak dapek maituang bulatan: karano jarak antaro duo titiak tu { $distance }, jari-jari { $radius } nan ditantukan talalu ketek.
+
+circle-radius-with-many-points = Indak dapek mambuek bulatan nan malalui labiah dari duo titiak jo jari-jari nan ditantukan.
+
+circle-invalid-center-or-through-points = Pusek atau titiak nan dilalui bulatan indak sah.
+
+circle-radius-center-with-multiple-points = Indak dapek maituang jari-jari bulatan nan ditantukan puseknyo tapi malalui labiah dari 1 titiak.
+
+circle-change-radius-non-numerical = Indak dapek maubah jari-jari bulatan nan malalui titiak nan indak baangko
+
+circle-radius-with-points-non-numerical = Indak dapek mambuek bulatan nan malalui labiah dari ciek titiak jo jari-jari nan ditantukan bilo indak ado nilai angko.
+
+circle-change-center-non-numerical = Maubah pusek bulatan nan malalui titiak nan indak padoso nilai angko alun diterapkan.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Minangkabau has one,
+# because «interval» and «input» do not change for number. Both selects are
+# dropped and both counts still arrive.
+function-domain-insufficient-dimensions = Dimensi domain untuak fungsi kurang. Domain padoso { $intervals } interval tapi fungsi padoso { $inputs } input.
+
+function-domain-invalid-format = Format domain untuak fungsi indak sah.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Nilai paliang gadang fungsi nan indak baangko diabaikan.
+        [minimum] Nilai paliang ketek fungsi nan indak baangko diabaikan.
+        [extremum] Ekstremum fungsi nan indak baangko diabaikan.
+        [point] Titiak fungsi nan indak baangko diabaikan.
+        [slope] Kamiriangan fungsi nan indak baangko diabaikan.
+       *[other] { $type } fungsi nan indak baangko diabaikan.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Nilai paliang gadang fungsi nan kosong diabaikan.
+        [minimum] Nilai paliang ketek fungsi nan kosong diabaikan.
+        [extremum] Ekstremum fungsi nan kosong diabaikan.
+        [point] Titiak fungsi nan kosong diabaikan.
+       *[other] { $type } fungsi nan kosong diabaikan.
+    }
+
+function-points-too-close = Fungsi maisi duo titiak nan tampeknyo talalu dakek. Fungsi indak dapek dibateh.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Iterasi fungsi hanyo mungkin bilo jumlah input samo jo jumlah output. Fungsi ko padoso { $inputs } input jo { $outputs } output.
+
+## `<sequence>`
+
+sequence-invalid-length = Panjang sequence indak sah.  Harus bilangan bulek nan indak negatif.
+
+sequence-invalid-step = step sequence indak sah.  Harus angko untuak sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" sequence angko indak sah.  Harus angko.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" sequence huruf indak sah.  Harus kombinasi huruf.
+
+sequence-invalid-endpoint = "{ $attribute }" sequence indak sah.
+
+select-from-sequence-coprime-not-numbers = coprime diabaikan karano nan dipiliah bukan angko
+
+select-from-sequence-coprime-with-exclude-combinations = coprime diabaikan karano excludeCombinations ditantukan
+
+## Resolving a `target`
+
+target-not-found = target indak sah untuak `<{ $source }>`: target indak basuo.
+
+target-state-variable-not-found = target indak sah untuak `<{ $source }>`: variabel keadaan nan banamo "{ $property }" indak basuo pado `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variabel `<odeSystem>` harus balain jo variabel bebas.
+
+ode-system-duplicate-variable-names = Indak dapek mambateh fungsi RHS ODE nan namo variabel bagantuangnyo samo.
+
+ode-system-rhs-function-error = Indak dapek mambateh fungsi RHS ODE.  Ado kasalahan mambuek fungsi mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Indak dapek mambateh sudut antaro { $count } garih
+
+angle-invalid-through-point = Titiak nan indak sah di through `<angle>`
+
+parabola-vertex-too-many-points = Parabola nan padoso puncak tapi malalui labiah dari 1 titiak alun diterapkan.
+
+parabola-too-many-points = Parabola nan malalui labiah dari 3 titiak alun diterapkan.
+
+intersection-too-many-items = Parpotongan untuak labiah dari duo bandanyo alun diterapkan
+
+## Other math components
+
+ionic-compound-not-two-ions = Sanyawa ionik untuak salain duo ion alun diterapkan.
+
+ionic-compound-needs-cation-and-anion = Sanyawa ionik hanyo diterapkan untuak ciek kation jo ciek anion.
+
+solve-equations-cannot-evaluate = Indak dapek manyalasaikan persamaan karano persamaan indak dapek dinilai: { $equation }
+
+math-operators-operand-number-required = operandNumber harus ditantukan bilo maambiak operand matematika.
+
+eigen-decomposition-failed = Indak dapek maituang eigenvalue matriks
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameter { $parameters } indak muncua di pattern, jadi inyo salalu cocok jo nan kosong.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: indak mangarati grid="{ $grid }". Harus none, medium, dense, atau duo angko positif nan dipisah spasi, saroman grid="1 0.5". Indak ado grid nan digambar.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" indak didukuang di renderer prefigure; mamakai parilaku posisi suok.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" indak didukuang di renderer prefigure; mamakai parilaku posisi ateh.
+
+prefigure-invalid-axis-bounds = `<graph>`: bateh sumbu indak sah untuak konversi prefigure; mamakai bbox baku (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: leba indak sah untuak konversi prefigure; mamakai leba diagram baku 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio indak sah untuak konversi prefigure; mamakai aspect ratio baku 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: jarak grid talalu rapek untuak bateh sumbu; grid indak digambar di renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotation indak digambar bilo indak mamakai renderer PreFigure.
+
+multiple-annotations-children = Banyak anak `<annotations>` basuo di `<graph>`; sadonyo diabaikan salain nan tarakhia.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Indak dapek maambiak atau manyalin jinih komponen nan indak dikana: { $type }.
+
+copy-prop-not-found = Prop { $property } indak basuo pado komponen jinih { $component }
+
+collect-no-source = Indak ado source nan basuo untuak collect.
+
+collect-invalid-component-type = Indak dapek mangumpuan komponen jinih `<{ $component }>` karano jinih komponen indak sah.
+
+reference-index-unavailable = Indak dapek marujuak indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Indak dapek mamanggia { $action } pado komponen `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bantuak data indak sah.  Panjang barih indak samo. Basuo di componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data padoso namo kolom nan samo.  Basuo di componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Data kurang namo kolom.  Basuo di componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award jawaban ko badasarkan jawaban nan dikirim dek answer tag surang, dan ko ka mambaok parilaku nan indak diharokkan.
+
+answer-max-num-attempts-in-section-wide-check-work = Maatur `maxNumAttempts` pado `<answer>` di dalam wadah nan padoso `sectionWideCheckWork` indak baguno, karano wadah tu nan mangatua jumlah cubo. Atur `maxNumAttempts` pado wadahnyo.
+
+nested-section-wide-check-work-max-num-attempts = Maatur `maxNumAttempts` pado wadah nan padoso `sectionWideCheckWork` nan barado di dalam wadah lain nan padoso `sectionWideCheckWork` indak baguno, karano wadah nan di lua nan mangatua jumlah cubo. Atur `maxNumAttempts` pado wadah nan di lua.
+
+# No select: «atribut» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Atribut { $attributes } indak ka baguno tanpa symbolicEquality diatur.
+
+answer-invalid-type = Jinih jawaban nan indak sah: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Karano komponen `<{ $component }>` indak banamo, inyo indak dapek dipakai untuak atribut module
+
+module-attribute-name-already-defined = Komponen `<{ $component } name="{ $name }">` indak dapek dipakai sabagai atribut module karano jinih komponen `<module>` alah padoso atribut "{ $name }".
+
+conditional-content-condition-ignored = Atribut `condition` diabaikan pado komponen `<conditionalContent>` nan padoso anak case atau else.
+
+slider-markers-type-mismatch = Jinih marker indak cocok jo jinih slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel indak sah: satiok `<problem>` harus maisi ciek `<statement>` jo ciek `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel indak sah: di mode="circuit", `<problem>` partamo indak buliah distractor.
+
+## Attribute values
+
+# No select: «nilai» is the same word for one and for many.
+attribute-invalid-values = Nilai { $values } indak sah untuak atribut `{ $attribute }`; diabaikan.
+
+attribute-must-be-references = Nilai `{ $value }` indak sah untuak atribut `{ $attribute }`. Atribut harus disusun dari rujuakan nan mulai jo `$`.
+
+math-input-invalid-function-names = <mathInput>: namo fungsi nan indak sah di { $attribute } diabaikan: { $names }. Satiok namo harus padoso 2 karakter (huruf atau tando sambuang); buliah diikuti sufiks `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Jinih komponen nan indak sah: `<{ $componentType }>`
+
+attribute-repeated = Atribut { $attribute } indak buliah diulang.
+
+attribute-invalid-for-component = Atribut "{ $attribute }" indak sah untuak komponen jinih `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kontras batasan gaya { $styleNumber } kurang untuak { $context ->
+        [text-on-background] warno teks malawan warno latar
+        [high-contrast] warno kontras tinggi malawan kanvas
+        [line] warno garih malawan kanvas
+        [marker] warno marker malawan kanvas
+       *[text-on-canvas] warno teks malawan kanvas
+    }{ $mode ->
+        [dark] { " (mode kalam)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mambutuahkan padoso { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Walaupun batasan gaya { $styleNumber } padoso warno nan ditantukan jo kontras nan cukuik untuak mode tarang, kontras warno teks malawan warno latar kurang pado warno nan diambiak untuak mode kalam ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mambutuahkan padoso { $threshold }:1). { $suggestion ->
+        [available] Supayo kontrasnyo cukuik di mode kalam, tambah kontras mode tarang (contoh, atur { $lightAttribute }="{ $lightColor }") atau ganti warno mode kalam (contoh, atur { $darkAttribute }="{ $darkColor }").
+       *[none] Supayo kontrasnyo cukuik di mode kalam, tambah kontras mode tarang atau ganti warno nan diambiak jo textColorDarkMode dan/atau backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Walaupun batasan gaya { $styleNumber } padoso warno teks nan ditantukan jo kontras nan cukuik untuak mode tarang, kontras warno teks nan diambiak untuak mode kalam kurang malawan kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; mambutuahkan padoso { $threshold }:1). { $suggestion ->
+        [available] Supayo kontrasnyo cukuik di mode kalam, tambah kontras mode tarang (contoh, atur textColor="{ $lightColor }") atau ganti warno mode kalam (contoh, atur textColorDarkMode="{ $darkColor }").
+       *[none] Supayo kontrasnyo cukuik di mode kalam, tambah kontras mode tarang atau ganti warno nan diambiak jo textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Ciek bagian hanyo buliah mamiliah ciek <stylePalette>; mamakai nan tarakhia.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = indak dapek manantukan varian tunggal { $component } karano numToSelect bukan bilangan bulek nan indak negatif.
+
+variant-num-to-select-not-constant-number = indak dapek manantukan varian tunggal { $component } karano numToSelect bukan angko tetap.
+
+variant-with-replacement-not-constant-boolean = indak dapek manantukan varian tunggal { $component } karano withReplacement bukan boolean tetap.
+
+variant-select-weight-disables-unique = Varian tunggal untuak select dimatikan bilo ado opsi nan ditantukan selectWeight atau selectForVariants
+
+variant-coprime-undetermined = indak dapek manantukan varian tunggal { $component } karano indak dapek manantukan coprime salalu false.
+
+variant-attribute-not-constant = indak dapek manantukan varian tunggal { $component } karano { $attribute } indak tetap.
+
+variant-attribute-not-number = indak dapek manantukan varian tunggal { $component } karano { $attribute } bukan angko.
+
+variant-attribute-wrong-type-for-sequence =
+    indak dapek manantukan varian tunggal { $component } jinih { $type } karano { $attribute } bukan { $expected ->
+        [letters-combination] kombinasi huruf
+        [math-expression] ungkapan matematika nan sah
+        [integer] bilangan bulek
+       *[number] angko
+    }.
+
+variant-length-not-integer = indak dapek manantukan varian tunggal { $component } karano length bukan bilangan bulek.
+
+variant-sort-not-implemented = varian tunggal { $component } nan padoso sort alun diterapkan
+
+variant-exclude-combinations-not-implemented = varian tunggal { $component } nan padoso excludeCombinations alun diterapkan
+
+variant-math-exclude-not-implemented = varian tunggal { $component } jinih math nan padoso exclude alun diterapkan
+
+variant-non-constant-exclude-not-implemented = varian tunggal { $component } nan padoso exclude indak tetap alun diterapkan
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: indak didukuang di renderer prefigure graph; katurunan dilewati.
+
+prefigure-descendant-invalid-geometry = { $subject }: geometrinyo indak tabateh atau indak lengkap; katurunan dilewati.
+
+prefigure-curve-label-omitted = { $subject }: label indak didukuang pado elemen lengkuang nan dikonversi; label diabaikan.
+
+prefigure-curve-unsupported-definition-type = { $subject }: jinih batasan fungsi lengkuang '{ $definitionType }' indak didukuang; katurunan dilewati.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribut flipFunctions pado regionBetweenCurves indak didukuang; katurunan dilewati.
+
+prefigure-region-non-formula-child = { $subject }: hanyo anak fungsi jinih formula nan didukuang pado regionBetweenCurves; katurunan dilewati.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' indak didukuang untuak { $labelKind ->
+        [line-family] label kaluargo garih
+       *[point] label titiak
+    }; mamakai perataan baku PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: gaya isi '{ $fillStyle }' indak didukuang dek PreFigure; baliak ka isi padek.
+
+prefigure-line-style-unknown = { $subject }: gaya garih '{ $lineStyle }' indak dikana, diabaikan dari output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: gaya marker '{ $markerStyle }' dipetakan ka gaya 'diamond' PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: gaya marker '{ $markerStyle }' indak didukuang dek PreFigure; mamakai gaya baku.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` indak sah; target indak dapek ditunjuak. Annotation diabaikan.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` manunjuak ka banyak target; mamakai target partamo.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` indak sah; target barado di lua graph nan maisinyo. Annotation diabaikan.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` indak sah; target bukan objek grafis nan didukuang di konversi prefigure. Annotation diabaikan.
+
+annotation-text-missing = `<annotation>`: `text` kurang atau kosong; mangaluakan teks kosong.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Basuo katagantuangan nan bakuliliang.
+       *[other] Basuo katagantuangan nan bakuliliang nan malibatkan komponen `<{ $componentType }>`.
+    }
+
+reference-no-referent = Indak basuo nan ditunjuak dek rujuakan: `{ $reference }`
+
+reference-multiple-referents = Banyak nan ditunjuak dek rujuakan: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Format atribut { $attribute } pado `<{ $componentType }>` indak sah.
+
+children-invalid = Anak `<{ $componentType }>` indak sah: basuo anak nan indak sah: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nilai `{ $value }` indak sah untuak atribut `{ $attribute }`, mamakai nilai `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Versi DoenetML { $version } indak basuo.
+       *[other] Versi DoenetML { $version } indak basuo. Baliak ka versi { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML indak sah: { $content }
+
+parse-tag-missing-close-tag = DoenetML indak sah: Tag `{ $tag }` indak padoso tag panutuik. Diharokkan tag nan manutuik surang atau tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML indak sah: Ado kasalahan di tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML indak sah: Atribut `{ $attribute }` nan indak sah nampak kurang nilai.
+
+parse-attribute-invalid = DoenetML indak sah: Atribut `{ $attribute }` indak sah
+
+parse-attribute-value-invalid = DoenetML indak sah: Nilai atribut `{ $value }` indak sah
+
+parse-attribute-value-quote-mismatch = DoenetML indak sah: Nilai atribut `{ $value }` indak sah. Tando kutiknyo indak cocok. Nampak kurang ciek `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML indak sah: Basuo tag nan indak banamo, contoh `<`
+
+parse-tag-not-closed = DoenetML indak sah: Tag `{ $tag }` indak ditutuik (nampak kurang `>`).
+
+parse-self-closing-tag-name-missing = DoenetML indak sah: Basuo tag nan indak banamo `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML indak sah: Tag `{ $tag }` indak ditutuik (nampak kurang `/>`).
+
+parse-tag-invalid-attributes = DoenetML indak sah: Tag `{ $tag }` indak sah. Mungkin atributnyo indak batua.
+
+parse-close-tag-name-missing = DoenetML indak sah: Basuo tag panutuik nan indak banamo, contoh `</`
+
+parse-attribute-value-unquoted = Nilai atribut harus dilatakkan di dalam tando kutik: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML indak sah: Basuo tag panutuik `{ $tag }`, tapi indak ado tag pambukak nan cocok
+
+parse-close-tag-mismatched = DoenetML indak sah: Tag panutuik indak cocok. Diharokkan `</{ $expected }>`. Basuo `{ $found }`
+
+parser-node-unconvertible = Node { $node } indak dapek dikonversi jadi node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribut name='{ $name }' indak sah. { $reason ->
+        [characters] Namo hanyo buliah maisi huruf, angko, garih bawah atau tando sambuang.
+       *[start] Namo harus mulai jo huruf.
+    }
+
+component-name-invalid-start = Namo komponen "{ $name }" indak sah. Namo harus mulai jo huruf.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer nan type videoWatched harus padoso atribut video
+
+answer-video-watched-video-not-reference = Answer nan type videoWatched harus padoso atribut video nan barupo rujuakan
+
+answer-name-not-single-text = Atribut name pado answer harus padoso ciek anak text sajo
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Indak dapek maambiak DoenetML dari lua karano tingkek pangulangannyo talalu banyak. Adokah rujuakan nan bakuliliang?
+
+external-doenetml-unavailable = Indak dapek maambiak DoenetML dari { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML nan diambiak dari { $attribute }="{ $uri }" indak sah: inyo indak cocok jo jinih komponen "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` indak dipakai lai; pakai `{ $to }`.
+       *[other] [deprecation] Atribut `{ $from }` pado `<{ $component }>` indak dipakai lai; pakai `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribut `{ $from }` indak dipakai lai jo diabaikan karano `{ $to }` juo ditantukan.
+       *[other] [deprecation] Atribut `{ $from }` pado `<{ $component }>` indak dipakai lai jo diabaikan karano `{ $to }` juo ditantukan.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribut `{ $attribute }` pado `<{ $component }>` indak dipakai lai jo diabaikan.
+
+deprecated-attribute-to-child = [deprecation] Atribut `{ $attribute }` pado `<{ $component }>` indak dipakai lai; pakai anak `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Nilai `{ $value }` pado atribut `{ $attribute }` di `<{ $component }>` indak dipakai lai; pakai `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` hanyo dapek mambuek jamak bahaso Inggirih, jadi teksnyo indak barubah di dokumen nan ditulis jo { $locale }. Tuliskan langsuang bantuak jamaknyo, atau atur jo atribut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` bukan elemen Doenet nan dikana.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` indak dibuliahkan di akar dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` indak dibuliahkan di dalam `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` indak padoso atribut nan banamo `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribut `{ $attribute }` pado elemen `<{ $tag }>` harus barupo daftar nan satiok isinyo salah ciek dari: { $allowed }
+       *[other] Atribut `{ $attribute }` pado elemen `<{ $tag }>` harus salah ciek dari: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Namo varian indak sah untuak select.  Namo varian { $variantName } muncua di { $numOptions } opsi tapi jumlah nan ka dipiliah { $numToSelect }.
+
+select-variant-name-without-options = Ado varian nan ditantukan untuak select tapi indak ado opsi nan ditantukan untuak namo varian nan mungkin: { $variantName }.
+
+select-variant-name-not-possible = Namo varian { $variantName } nan ditantukan untuak select bukan namo varian nan mungkin.
+
+select-too-few-options = Indak dapek mamiliah { $numToSelect } komponen dari { $numOptions } sajo.
+
+select-from-sequence-too-few-values = Indak dapek mamiliah { $numToSelect } nilai dari sequence nan panjangnyo { $length }.
+
+select-from-sequence-indices-count-mismatch = Jumlah indeks nan ditantukan untuak select harus cocok jo jumlah nan ka dipiliah
+
+select-from-sequence-indices-not-integers = Sadonyo indeks nan ditantukan untuak select harus bilangan bulek
+
+select-from-sequence-index-excluded = Indeks selectfromsequence nan ditantukan tu dikaluakan
+
+select-from-sequence-indices-excluded-combination = Indeks selectfromsequence nan ditantukan tu kombinasi nan dikaluakan
+
+select-from-sequence-coprime-not-positive-integers = Indak dapek mamiliah kombinasi coprime karano nan dipiliah bukan bilangan bulek positif.
+
+select-from-sequence-coprime-common-factor = Indak dapek mamiliah angko coprime. Sadonyo nilai nan mungkin padoso faktor nan samo. (Nilai "from" atau "to" nan ditantukan harus coprime jo "step".)
+
+select-from-sequence-coprime-single-number = Indak dapek mamiliah kombinasi coprime dari ciek angko nan bukan 1.
+
+select-from-sequence-excluded-too-many-combinations = Labiah dari 70% kombinasi dikaluakan di selectFromSequence
+
+select-from-sequence-coprime-none-found = Indak dapek mamiliah angko coprime. Sadonyo nilai nan mungkin padoso faktor nan samo.
+
+select-from-sequence-too-few-unique-values = Indak dapek mamiliah { $numToSelect } nilai tunggal dari sequence nan panjangnyo { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Indak dapek mamiliah { $numToSelect } nilai dari daftar prima nan panjangnyo { $numValues }
+
+select-prime-numbers-values-count-mismatch = Jumlah nilai nan ditantukan untuak select harus cocok jo jumlah nan ka dipiliah
+
+select-prime-numbers-values-not-prime = Sadonyo nilai nan ditantukan untuak select prime number harus ado di daftar prima
+
+select-prime-numbers-values-excluded-combination = Nilai selectPrimeNumbers nan ditantukan tu kombinasi nan dikaluakan
+
+select-prime-numbers-excluded-too-many-combinations = Labiah dari 70% kombinasi dikaluakan di selectPrimeNumbers
+
+select-random-combination-fluke = Karano untuang nan sangaik jarang, indak dapek mamiliah kombinasi nilai acak
+
+select-random-value-fluke = Karano untuang nan sangaik jarang, indak dapek mamiliah nilai acak

--- a/packages/i18n/locales/min/editor.ftl
+++ b/packages/i18n/locales/min/editor.ftl
@@ -1,0 +1,208 @@
+# Minangkabau editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Minangkabau marks no number on the noun, so a `{ $count -> … }` whose two
+# English branches differ only in the noun renders one string here and the
+# select is dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Kambalikan
+       *[update] Pabarui
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } panampil
+       *[other] { $word } panampil { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Varian
+editor-variant-filter = Sariang…
+editor-variant-next = Piliah varian salanjuiknyo
+editor-variant-previous = Piliah varian sabalunnyo
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Ado palanggaran aksesibilitas WCAG AA nan basuo. Klik untuak { $action ->
+            [close] manutuik
+           *[open] mambukak
+        } laporan aksesibilitas.
+        [advisories] Klik untuak { $action ->
+            [close] manutuik
+           *[open] mambukak
+        } laporan aksesibilitas. Indak ado palanggaran WCAG AA nan basuo, tapi ado saran aksesibilitas nan lain.
+       *[clean] Klik untuak { $action ->
+            [close] manutuik
+           *[open] mambukak
+        } laporan aksesibilitas. Indak ado masalah aksesibilitas nan basuo.
+    }
+
+# No select on `$count` inside the branches: «palanggaran» and «saran» are the
+# same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Ado palanggaran aksesibilitas WCAG AA nan basuo. Basuo { $count } palanggaran WCAG AA. Klik untuak { $action ->
+            [close] manutuik
+           *[open] mambukak
+        } laporan aksesibilitas.
+        [advisories] Indak ado palanggaran WCAG AA nan basuo. Basuo { $count } saran aksesibilitas nan lain. Klik untuak { $action ->
+            [close] manutuik
+           *[open] mambukak
+        } laporan aksesibilitas.
+       *[clean] Indak ado palanggaran WCAG AA nan basuo. Klik untuak { $action ->
+            [close] manutuik
+           *[open] mambukak
+        } laporan aksesibilitas.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Versi DoenetML { $version }
+
+editor-tab-help = Bantuan manuruik konteks
+editor-tab-help-short = Konteks
+editor-tab-errors = Kasalahan
+editor-tab-warnings = Peringatan
+editor-tab-info = Katarangan
+editor-tab-accessibility = Aksesibilitas
+editor-tab-responses = Jawaban nan alah dikirim
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Piliahan editor
+editor-format-as-doenetml = Format sabagai DoenetML
+editor-format-as-xml = Format sabagai XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Barih #{ $line }
+
+editor-no-errors = Indak ado kasalahan
+editor-no-warnings = Indak ado peringatan
+editor-no-info = Indak ado diagnostik katarangan
+
+editor-show-info-annotations = Tampilkan diagnostik katarangan di editor
+editor-show-accessibility-annotations = Tampilkan diagnostik aksesibilitas di editor
+
+editor-accessibility-learn-more = Palajari caro Doenet manangani aksesibilitas
+
+editor-accessibility-violations-heading = Palanggaran aksesibilitas ({ $standard })
+
+editor-accessibility-other-heading = Masalah aksesibilitas nan lain
+editor-none-found = Indak ado nan basuo
+
+
+## Submitted responses
+
+editor-no-responses = Alun ado jawaban nan dikirim
+editor-response-answer-id = Id jawaban
+editor-response-response = Jawaban
+editor-response-credit = Kredit
+editor-response-submitted = Dikirim
+
+
+## The context-help panel
+
+help-placeholder = Latakkan kursor di namo tag, atribut, atau { $ref } untuak dokumentasi.
+
+help-unsupported-ref-chain = Bantuan untuak rujuakan babagai bagian saroman { $example } alun didukuang lai.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Indak basuo nan ditunjuak dek rujuakan: { $ref }.
+        [multiple] Banyak nan ditunjuak dek rujuakan: { $ref }.
+       *[indeterminate] Indak bisa ditantukan apo nan ditunjuak dek { $ref }.
+    }
+
+help-learn-about-references = Palajari tantang rujuakan →
+help-reference-page = Laman rujuakan →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Di dalam { $element }
+       *[top] Di tingkek paliang ateh
+    }{ $allowed ->
+        [none] { " — indak ado nan buliah dilatakkan di siko." }
+        [text] { " — tuliskan teks di siko." }
+        [text-and-components] { " — tuliskan teks di siko, atau cubo:" }
+       *[components] { " — nan bisa dicubo:" }
+    }
+
+help-suggestions-footer = Takan { $shortcut } untuak maliek sadonyo { $total } komponen.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } adolah rujuakan ka { $target }.
+       *[other] { $ref } adolah rujuakan ka { $target } (barih { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Dibaok dek { $owner } sabagai { $role }.
+       *[other] Dibaok dek { $owner } di barih { $line } sabagai { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } adolah rujuakan ka sifat { $property } dari { $element }.
+       *[other] { $ref } adolah rujuakan ka sifat { $property } dari { $element } (barih { $line }).
+    }
+
+help-kind-attribute = atribut
+help-kind-snippet = potongan kode
+help-kind-array-entry = entri array
+
+help-default = Baku:
+help-active-default = Baku nan aktif:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nilai nan dibuliahkan (ciek satiok item):
+       *[other] Nilai nan dibuliahkan:
+    }
+
+help-suggested-values = Nilai nan disarankan:
+
+help-inserts = Manyisipkan:
+
+# No select: «koordinat» is the same word for one and for many.
+help-coordinates = Koordinat:
+
+help-type = Jinih:
+
+help-resolved-style = Gaya nan alah ditantukan (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Namo fungsi nan alah ditantukan:
+help-reset-list = Daftar reset di input ko:
+help-added-on-input = Ditambah di input ko:
+help-removed-on-input = Dihapuih di input ko:
+
+help-reset-overrides = { $reset } mangatasi { $additional } jo { $removed }.

--- a/packages/i18n/locales/pam/chrome.ftl
+++ b/packages/i18n/locales/pam/chrome.ftl
@@ -1,0 +1,150 @@
+# Kapampangan viewer chrome. Translated from `locales/en/chrome.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography of Kapampangan publishing.
+#
+# Kapampangan marks no number on the noun: plurality is carried by «deng» and a
+# noun after a numeral stays as it is. So a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped; the count still arrives and is still formatted. A `[0]` branch stays
+# wherever English has one.
+#
+# The **linker** is this catalog's one unresolved problem, and it is the
+# Ilocano one seen from the other end. Kapampangan joins an adjective to what it
+# describes with «a» after a consonant and the enclitic «-ng» welded onto a
+# vowel-final word — and which is right is decided by the word *before* it. So
+# where the preceding word is a placeable, this catalog writes the free «a»,
+# which is right after a consonant and which a vowel-final word would want as
+# «-ng». `content.ftl`'s header says where that bites and why it cannot be
+# written any other way.
+
+
+## Answer submission
+
+answer-checking = Sisiyasat…
+answer-submitting = Ipapadala…
+
+answer-checking-status = Sisiyasat ya ing pakibat
+answer-submitting-status = Ipapadala ne ing pakibat
+
+answer-correct = Tama
+answer-incorrect = Ali tama
+
+answer-response-saved = Meimbak ne ing pakibat
+
+answer-percent-credit = { $percent }% a kredito
+answer-percent-correct = { $percent }% a tama
+answer-percent-short = { $percent } %
+
+max-credit-available = Kamaragulan a kreditong makakuha: { $percent }%
+
+# No select: «subuk» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] alang natad a subuk
+       *[other] { $count } a subuk ing natad
+    }
+
+validation-correct = (Tama)
+validation-incorrect = (Ali tama)
+validation-partially-correct = (Tama king dake)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Ipakit ing { $count } a pakibat para king { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komento
+
+collapsible-click-to-open = (i-klik ban mabuklat)
+collapsible-click-to-close = (i-klik ban masara)
+
+collapsible-initializing = Migsisimula…
+
+footnote-show = Ipakit ing footnote
+footnote-hide = Isalikut ing footnote
+
+description-more-information = dagdag a impormasyon
+
+
+## Controls
+
+slider-previous = Milabas
+slider-next = Tutuki
+
+keyboard-open = Buklat ing teklado
+keyboard-close = Isara ing teklado
+
+choice-input-remove-choice = Alilan ing { $choice }
+
+matrix-remove-row = Alilan ing gulis
+matrix-add-row = Dagdagan pang gulis
+matrix-remove-column = Alilan ing haligi
+matrix-add-column = Dagdagan pang haligi
+
+subset-add-remove-points = Pagdagdag/Pag-alis da reng punto
+subset-toggle-points-intervals = Pamalit da reng punto at interbalo
+subset-move-points = Igalo la reng punto
+subset-clear = Linisan
+
+orbital-add-row = Dagdagan pang gulis
+orbital-remove-row = Alilan ing gulis
+orbital-add-box = Dagdagan pang kaha
+orbital-remove-box = Alilan ing kaha
+orbital-add-up-arrow = Dagdagan pang panang paitas
+orbital-add-down-arrow = Dagdagan pang panang palalam
+orbital-remove-arrow = Alilan ing pana
+
+orbital-row-label = Etiketa para king gulis { $row }
+
+pretzel-answer = Pakibat
+
+summary-statistics-caption = Buung estadistika ning { $column }
+
+
+## Math input
+
+math-input-preview-region = mumunang pamanakit king ekspresyon a matematika
+math-input-preview = Mumunang pamanakit
+math-input-invalid-expression = Ali balido a ekspresyon:
+
+
+## Document status
+
+viewer-initializing = Migsisimula…
+
+
+## Errors
+
+error-heading = Kamalian
+
+error-found-at =
+    { $span ->
+        [line] Mekit king gulis { $startLine }.
+       *[lines] Mekit karing gulis { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Atin kamalian ining dokumento!
+
+diagnostic-heading-error = Kamalian
+diagnostic-heading-warning = Babala
+diagnostic-heading-information = Impormasyon
+diagnostic-heading-hint = Giya
+
+accessibility-heading-level-1 = Pamanlabag king aksesibilidad a WCAG AA
+accessibility-heading-level-2 = Babala tungkul king aksesibilidad
+
+something-went-wrong = Atin bageng mekamali.
+
+renderer-load-failed = atin renderer a ali me-load. Pakisuyung i-reload ing bulung.
+
+core-start-failed = Ali me-umpisan ing pamanakit king dokumento. Pakisuyung i-reload ing bulung.

--- a/packages/i18n/locales/pam/content.ftl
+++ b/packages/i18n/locales/pam/content.ftl
@@ -1,0 +1,257 @@
+# Kapampangan content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Kapampangan has no grammatical gender and no case, so `noun-gender` answers
+# one token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# **The linker is the one thing this catalog cannot get right in every case.**
+# Kapampangan links an adjective to what it describes with «a» after a
+# consonant-final word and with the enclitic «-ng» welded onto a vowel-final
+# one. Which applies is decided by the word *before* the linker, and that word
+# is a placeable at most of the sites below — a colour this file supplies, or an
+# author's own `lineColorWord`, which passes through untranslated and which the
+# catalog has never seen. There is no form that is right in both places, so
+# every linker here is written «a»: correct after «matuling» and «maputi»,
+# wanted as «-ng» after «malutu» and «madilo». That is the affix rule of the
+# README biting on a *ligature* rather than on a case ending, and it is the
+# mirror image of `locales/ilo`'s, whose «a»/«nga» is decided by the word that
+# follows, and it is `locales/bik`'s exactly. `locales/war` and `locales/hil`
+# escape it, because their «nga» is grammatical in both positions.
+#
+# The adjectives **precede** the noun, which is English's order and
+# Kapampangan's ordinary one.
+#
+# The geometry vocabulary is largely Spanish-derived, as Philippine mathematics
+# teaching carries it; the colours and everyday words are Kapampangan's own.
+
+
+## Style vocabulary
+
+color =
+    .black = matuling
+    .white = maputi
+    .gray = abwan
+    .red = malutu
+    .orange = kahel
+    .yellow = madilo
+    .green = berde
+    .cyan = sian
+    .blue = asul
+    .purple = lila
+    .pink = rosas
+    .brown = kape
+
+line-width =
+    .thick = makapal
+    .thin = manipis
+
+line-style =
+    .dashed = putul-putul
+    .dotted = tuldik-tuldik
+
+# Noun phrases. Kapampangan marks no plural on the noun, so «gulis» is the word
+# for one line and for many alike.
+fill-style =
+    .horizontal = mihiga a gulis
+    .vertical = mitalakad a gulis
+    .diagonal = mihilis a gulis
+    .backdiagonal = kabaligtaran a mihilis a gulis
+    .dots = tuldik
+    .diamonds = diyamante
+
+noun =
+    .line = linya
+    .line-segment = segmento
+    .ray = sinag
+    .vector = bektor
+    .curve = kurba
+    .function = punsyon
+    .parabola = parabola
+    .polyline = polilinya
+    .polygon = poligono
+    .triangle = triyanggulo
+    .rectangle = rektanggulo
+    .circle = sirkulo
+    .region = rehiyon
+    .point = punto
+    .square = kwadrado
+    .diamond = diyamante
+    .cross = krus
+    .plus = plus
+
+noun-regular-polygon =
+    { $part ->
+        [tail] a atin { $numSides } a gilid
+       *[head] regular a poligono
+    }
+
+# One answer for every noun: Kapampangan has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+# Every linker is written «a» — see the header for the case it gets wrong.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } a { $lineStyle } a { $color }
+        [width-color] { $width } a { $color }
+        [style-color] { $lineStyle } a { $color }
+        [width-style] { $width } a { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } a { $noun } { $nounTail }
+       *[noun] { $description } a { $noun }
+    }
+
+style-filled-word = mitmo
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } a { $color } a atin { $pattern }
+       *[plain] { $filled } a { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } a { $color } a { $noun } a atin { $pattern }
+        [plain-tail] { $filled } a { $color } a { $noun } { $nounTail }
+        [pattern-tail] { $filled } a { $color } a { $noun } { $nounTail } a atin { $pattern }
+       *[plain] { $filled } a { $color } a { $noun }
+    }
+
+# Kapampangan has no article, so the two `-article` branches say what the other
+# two say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «a atin» against «at».
+style-border-clause =
+    { $parts ->
+        [with-article] a atin { $border } a gilid
+        [and] at { $border } a gilid
+        [and-article] at { $border } a gilid
+       *[with] a atin { $border } a gilid
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } a { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = ali mitmo
+
+style-text =
+    { $parts ->
+        [background] { $color } a atin { $background } a background
+       *[plain] { $color }
+    }
+
+style-background-none = ala
+
+
+## Boolean words
+
+boolean-true = tutu
+boolean-false = ali tutu
+
+
+## Answer buttons
+
+answer-submit-label = Siyasatan ing pakibat
+answer-submit-label-no-correctness = Ipadala ing pakibat
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Kapampangan marks number on the article rather than on the noun, and a
+# heading carries no article.
+section-name =
+    .activity = Aktibidad
+    .aside = Notang gilid
+    .cascade = Kaskada
+    .definition = Kahulugan
+    .example = Alimbawa
+    .exercise = Ehersisyo
+    .exercises = Ehersisyo
+    .given-answer = Pakibat
+    .note = Nota
+    .objectives = Layon
+    .paragraphs = Parapo
+    .part = Dake
+    .problem = Problema
+    .problems = Problema
+    .proof = Patune
+    .question = Kutang
+    .section = Seksyon
+    .solution = Solusyon
+    .task = Dapat
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Giya
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Talaan { $enumeration }
+        [numbered-title] Talaan { $enumeration }{ ": " }
+        [unnumbered-title] Talaan{ ": " }
+       *[unnumbered] Talaan
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Pigura { $enumeration }
+        [numbered-caption] Pigura { $enumeration }{ ": " }
+        [unnumbered-caption] Pigura{ ": " }
+       *[unnumbered] Pigura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Milabas
+paginator-next = Tutuki
+paginator-page = Bulung
+
+paginator-page-status = { $pageLabel } { $currentPage } king { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = o
+piecewise-condition-if = nung
+piecewise-condition-otherwise = nung ali
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Philippine secondary science is taught in English from the
+## intermediate grades, so the periodic table a Kapampangan pupil meets is the
+## English one — the same reason `locales/fil` and `locales/ceb` leave these
+## keys out.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Ali balido a simbolong kemikal
+chemistry-invalid-ionic-compound = Ali balido a kompuwestong ioniko

--- a/packages/i18n/locales/pam/content.ftl
+++ b/packages/i18n/locales/pam/content.ftl
@@ -14,8 +14,10 @@
 # is a placeable at most of the sites below — a colour this file supplies, or an
 # author's own `lineColorWord`, which passes through untranslated and which the
 # catalog has never seen. There is no form that is right in both places, so
-# every linker here is written «a»: correct after «matuling» and «maputi»,
-# wanted as «-ng» after «malutu» and «madilo». That is the affix rule of the
+# every linker that lands beside a placeable is written «a»: correct after
+# «matuling» and «abwan», wanted as «-ng» after «maputi», «malutu» and
+# «madilo». Where the catalog writes both words around the linker it writes
+# whichever form the preceding one takes, as «simbolong kemikal» does. That is the affix rule of the
 # README biting on a *ligature* rather than on a case ending, and it is the
 # mirror image of `locales/ilo`'s, whose «a»/«nga» is decided by the word that
 # follows, and it is `locales/bik`'s exactly. `locales/war` and `locales/hil`

--- a/packages/i18n/locales/pam/diagnostics.ftl
+++ b/packages/i18n/locales/pam/diagnostics.ftl
@@ -1,0 +1,629 @@
+# Kapampangan diagnostics. Translated from `locales/en/diagnostics.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Kapampangan marks no number on the noun, so a counted message whose only
+# English difference is the noun's number renders one string here and the
+# select is dropped. The count still arrives and is still formatted.
+#
+# A value quoted back from the author's source is reached through «ing» or
+# «king» rather than through a linker, so that no «a»/«-ng» choice depends on a
+# word this catalog has never seen. See `content.ftl`'s header for where that
+# could not be avoided.
+
+
+## `<lineSegment>`
+
+# No select: «ali papansinan» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = ali papansinan ing { $attributes } nung mitakda la reng adwang sepu
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ali papansinan ing { $attributes } nung mitakda ing metung a sepu at ing kalibutad
+
+line-segment-midpoint-offset-without-midpoint = alang epektu ing midpointOffset nung alang kalibutad
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linyang dumalan karing puntong ali me-alaman ing dimensyon da.
+
+line-points-too-few-dimensions = Dapat dumalan ing linya karing puntong atin ali kulang king adwang dimensyon.
+
+line-points-depend-on-variables = Ing linya dumalan ya karing puntong manalig karing baryable: { $variables }.
+
+line-equation-invalid-format = Ali balido a pormat ning ekwasyon ning linya karing baryable a { $variable1 } at { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ing sinag metakda ya king through, endpoint at direction.  Ali papansinan ing metakdang through.
+
+ray-dimension-mismatch = ali mitutugma ing numDimensions king sinag.
+
+## `<vector>`
+
+vector-overprescribed-head = Ing bektor metakda ya king head, tail at displacement.  Ali papansinan ing metakdang head.
+
+vector-dimension-mismatch = ali mitutugma ing numDimensions king bektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ali malyaring makanyaya king `<{ $component }>` uling alang baryable a estadu a nearestPoint.
+
+constrain-to-without-nearest-point = Ali malyaring pigilan king `<{ $component }>` uling alang baryable a estadu a nearestPoint.
+
+constrain-to-interior-without-nearest-point = Ali malyaring pigilan kilub ning `<{ $component }>` uling alang baryable a estadu a nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ali papansinan ing labelPosition para king choiceInput a ali inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ali papansinan la reng indise a metakda para king choiceInput uling ali mitutugma ing bilang da reng indise at ing bilang da reng anak a pipamilian.
+
+pretzel-indices-count-mismatch = Ali papansinan la reng indise a metakda para king problem uling ali mitutugma ing bilang da reng indise at ing bilang da reng anak a problem.
+
+shuffle-indices-count-mismatch = Ali papansinan la reng indise a metakda para king shuffle uling ali mitutugma ing bilang da reng indise at ing bilang da reng komponente.
+
+indices-ignored-out-of-range = Ali papansinan la reng indise a metakda para king { $component } uling atin indise a labis king sakup.
+
+pretzel-indices-repeated = Ali papansinan la reng indise a metakda para king pretzel uling atin indise a meulit.
+
+pretzel-circuit-first-index = Ali papansinan la reng indise a metakda para king pretzel king mode a circuit uling dapat 1 ing mumunang indise.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ban gumana ing `<{ $component }>` karing anak a string, dapat matakda ing atributo a `type`.
+
+invalid-type-defaulting-to-math = Ali balido a type { $type } para king komponente a { $component }. Dapat metung king math, text, number, o boolean. Gagamitan ing math.
+
+string-not-valid-component-to-arrange = Ing string a "{ $value }" ali ya balidung komponente para king { $component }. Ali papansinan.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Ali balido a type { $type }, ilalage ing type king number.
+
+invalid-variable-value = Ali balido a alaga ning metung a baryable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Dapat numero ing indise ning baryante a { $index }
+
+variant-index-must-be-integer = Dapat integer ing indise ning baryante a { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Ala pang mapatupad ing `<{ $component }>` para karing absolutong sukat. Ilalage lang relatibo reng lapad.
+
+side-by-side-absolute-margins = Ala pang mapatupad ing `<{ $component }>` para karing absolutong sukat. Ilalage lang relatibo reng margin.
+
+side-by-side-no-block-child = Ali balido a `<{ $component }>`: dapat atin yang ali kulang king metung a anak a block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ali papansinan ing atributo a `for` king grapikal a `<label>`.
+
+label-for-must-resolve-to-one = Dapat manuru ing atributo a `for` king `<label>` king eksaktung metung a komponente.
+
+label-for-unresolved = Ali me-turu ing atributo a `for` king `<label>` king metung a komponente.
+
+label-for-answer-with-authored-inputs = Ing atributo a `for` king `<label>` manuru ya king metung a `<answer>` a atin input a sinulat ning autor; ituru ing input a mismu.
+
+label-for-answer-without-input = Ing atributo a `for` king `<label>` manuru ya king metung a `<answer>` a alang input a etiketan.
+
+label-for-must-reference-input-or-answer = Dapat manuru ing atributo a `for` king `<label>` king metung a input o metung a answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Para king aksesibilidad, dapat atin ing `<{ $component }>` makuyad a deskripsyon o metakdang dekoratibo.
+
+accessibility-video-short-description = Para king aksesibilidad, dapat atin ing `<video>` makuyad a deskripsyon.
+
+accessibility-input-short-description-or-label = Para king aksesibilidad, dapat atin ing `<{ $component }>` makuyad a deskripsyon o etiketa.
+
+accessibility-answer-input-short-description-or-label = Para king aksesibilidad, dapat atin makuyad a deskripsyon o etiketa ing metung a `<answer>` a gagawang input.
+
+accessibility-short-description-contains-math = Ali dapat maglaman deng makuyad a deskripsyon karing komponenteng matematika anti ing `<{ $component }>`. Isulat king amanu ing nanumang matematika.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kulang ing kontraste ning { $colorName } para king teksto ning pamagat ning seksyon (madalumdum a mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kailangan ing ali kulang king { $threshold }:1).
+       *[other] Kulang ing kontraste ning { $colorName } para king teksto ning pamagat ning seksyon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kailangan ing ali kulang king { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Ala pang mapatupad ing `<circle>` a dumalan karing { $count } a punto nung alang numerikung alaga reng punto.
+
+circle-too-many-through-points = Ali malyaring kwentan ing sirkulong dumalan karing labis king 3 a punto.
+
+circle-overprescribed-radius-center-points = Ali malyaring kwentan ing sirkulong atin metakdang radyus, sentro at puntong daralanan.
+
+circle-center-with-multiple-points = Ali malyaring kwentan ing sirkulong atin metakdang sentro a dumalan king labis king 1 a punto.
+
+circle-radius-too-small = Ali malyaring kwentan ing sirkulo: uling ing distansya da reng adwang punto { $distance } ya, malati ya masyadu ing metakdang radyus a { $radius }.
+
+circle-radius-with-many-points = Ali malyaring gumawa sirkulong dumalan king labis king adwang punto a atin metakdang radyus.
+
+circle-invalid-center-or-through-points = Ali balido ing sentro o deng puntong daralanan ning sirkulo.
+
+circle-radius-center-with-multiple-points = Ali malyaring kwentan ing radyus ning sirkulong atin metakdang sentro a dumalan king labis king 1 a punto.
+
+circle-change-radius-non-numerical = Ali malyaring baltan ing radyus ning sirkulong dumalan karing puntong ali numeriku
+
+circle-radius-with-points-non-numerical = Ali malyaring gumawa sirkulong dumalan king labis king metung a punto a atin metakdang radyus nung alang numerikung alaga.
+
+circle-change-center-non-numerical = Ala pang mapatupad ing pamagbayu king sentro ning sirkulong dumalan karing puntong alang numerikung alaga.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Kapampangan has one,
+# because «interbalo» and «input» do not change for number. Both selects are
+# dropped and both counts still arrive.
+function-domain-insufficient-dimensions = Kulang ing dimensyon ning domain para king punsyon. Ing domain atin yang { $intervals } a interbalo oneng ing punsyon atin yang { $inputs } a input.
+
+function-domain-invalid-format = Ali balido a pormat ning domain para king punsyon.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ali papansinan ing ali numerikung kamaragulan ning punsyon.
+        [minimum] Ali papansinan ing ali numerikung kaditakan ning punsyon.
+        [extremum] Ali papansinan ing ali numerikung ekstremum ning punsyon.
+        [point] Ali papansinan ing ali numerikung punto ning punsyon.
+        [slope] Ali papansinan ing ali numerikung hilis ning punsyon.
+       *[other] Ali papansinan ing ali numerikung { $type } ning punsyon.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ali papansinan ing alang lamang kamaragulan ning punsyon.
+        [minimum] Ali papansinan ing alang lamang kaditakan ning punsyon.
+        [extremum] Ali papansinan ing alang lamang ekstremum ning punsyon.
+        [point] Ali papansinan ing alang lamang punto ning punsyon.
+       *[other] Ali papansinan ing alang lamang { $type } ning punsyon.
+    }
+
+function-points-too-close = Atin adwang punto ing punsyon a masyadung malapit. Ali malyaring depinisyunan ing punsyon.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Malyari mu reng iterasyon ning punsyon nung pareu ing bilang da reng input at ing bilang da reng output. Ining punsyon atin yang { $inputs } a input at { $outputs } a output.
+
+## `<sequence>`
+
+sequence-invalid-length = Ali balido ing kaba ning sequence.  Dapat ali negatibong integer.
+
+sequence-invalid-step = Ali balido ing step ning sequence.  Dapat numero para king sequence a type { $type }.
+
+sequence-invalid-endpoint-number = Ali balido a "{ $attribute }" ning sequence a numero.  Dapat numero.
+
+sequence-invalid-endpoint-letters = Ali balido a "{ $attribute }" ning sequence a letra.  Dapat kombinasyon da reng letra.
+
+sequence-invalid-endpoint = Ali balido a "{ $attribute }" ning sequence.
+
+select-from-sequence-coprime-not-numbers = ali papansinan ing coprime uling ali numero ing pipilinan
+
+select-from-sequence-coprime-with-exclude-combinations = ali papansinan ing coprime uling metakda ing excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Ali balido a target para king `<{ $source }>`: ali akit ing target.
+
+target-state-variable-not-found = Ali balido a target para king `<{ $source }>`: ali akit ing baryable a estadu a milagyuang "{ $property }" king metung a `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Dapat aliwa la reng baryable ning `<odeSystem>` king independienteng baryable.
+
+ode-system-duplicate-variable-names = Ali malyaring depinisyunan deng punsyon a RHS ning ODE a pareu ing lagyu da reng baryable a manalig.
+
+ode-system-rhs-function-error = Ali malyaring depinisyunan ing punsyon a RHS ning ODE.  Atin kamalian king pamagawa king punsyon a mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ali malyaring depinisyunan ing anggulo king libutad da reng { $count } a linya
+
+angle-invalid-through-point = Ali balido a punto king through ning `<angle>`
+
+parabola-vertex-too-many-points = Ala pang mapatupad ing parabolang atin bertise a dumalan king labis king 1 a punto.
+
+parabola-too-many-points = Ala pang mapatupad ing parabolang dumalan king labis king 3 a punto.
+
+intersection-too-many-items = Ala pang mapatupad ing intersection para king labis king adwang bage
+
+## Other math components
+
+ionic-compound-not-two-ions = Ala pang mapatupad ing kompuwestong ioniko para king aliwa liban king adwang ion.
+
+ionic-compound-needs-cation-and-anion = Mepatupad ing kompuwestong ioniko para mu king metung a cation at metung a anion.
+
+solve-equations-cannot-evaluate = Ali malutas ing ekwasyon uling ali me-timbang ing ekwasyon: { $equation }
+
+math-operators-operand-number-required = Dapat matakda ing operandNumber nung kukwa kang operand a matematika.
+
+eigen-decomposition-failed = Ali mekwenta reng eigenvalue ning matris
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: ing parametro a { $parameters } ali ya lalto king pattern, inya lagi yang mitutugma king blangko.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ali maintindian ing grid="{ $grid }". Dapat none, medium, dense, o adwang positibong numerung mibulag king espasyo, anti ing grid="1 0.5". Alang grid a igugulis.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: alang suporta ing xLabelPosition="left" king renderer a prefigure; gagamitan ing ugali ning wanan a posisyon.
+
+prefigure-y-label-position-unsupported = `<graph>`: alang suporta ing yLabelPosition="bottom" king renderer a prefigure; gagamitan ing ugali ning babo a posisyon.
+
+prefigure-invalid-axis-bounds = `<graph>`: ali balido reng angganan ning aksis para king konbersyon a prefigure; gagamitan ing karaniwan a bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: ali balido ing lapad para king konbersyon a prefigure; gagamitan ing karaniwan a lapad ning diagram a 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: ali balido ing aspectRatio para king konbersyon a prefigure; gagamitan ing karaniwan a aspect ratio a 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: masyadung malapit ing libutad ning grid para karing angganan ning aksis; ali ilalage ing grid king renderer a prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: ali ma-render deng annotation nung ali ing renderer a PreFigure ing gagamitan.
+
+multiple-annotations-children = Dakal a anak a `<annotations>` ing mekit king `<graph>`; ali papansinan la ngan liban king tauli.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ali malyaring i-extend o kopyan ing ali kilalang klase ning komponente: { $type }.
+
+copy-prop-not-found = Ali akit ing prop a { $property } king komponenteng klase { $component }
+
+collect-no-source = Alang mekit a source para king collect.
+
+collect-invalid-component-type = Ali malyaring tipunan deng komponenteng klase `<{ $component }>` uling ali balidung klase ning komponente.
+
+reference-index-unavailable = Ali maturu ing indise a `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ali matawag ing { $action } king komponente a `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Ali balido ing porma ning datos.  Ali pareu ing kaba da reng gulis. Mekit king componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Atin pareung lagyu ning haligi ing datos.  Mekit king componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Alang lagyu ing metung a haligi ning datos.  Mekit king componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ing award ning pakibat a ini mibase ya king mismung mipadalang pakibat ning answer tag, at magdala ya ining ali inaasahan a ugali.
+
+answer-max-num-attempts-in-section-wide-check-work = Alang epektu ing pamaglage `maxNumAttempts` king metung a `<answer>` kilub ning kontenedor a atin `sectionWideCheckWork`, uling ing kontenedor ing manibala king bilang da reng subuk. Ilage ing `maxNumAttempts` king kontenedor.
+
+nested-section-wide-check-work-max-num-attempts = Alang epektu ing pamaglage `maxNumAttempts` king kontenedor a atin `sectionWideCheckWork` a atiu kilub ning aliwang kontenedor a atin `sectionWideCheckWork`, uling ing kilwal a kontenedor ing manibala king bilang da reng subuk. Ilage ing `maxNumAttempts` king kilwal a kontenedor.
+
+# No select: «atributo» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Alang epektu ing atributo a { $attributes } nung ali melage ing symbolicEquality.
+
+answer-invalid-type = Ali balido a klase para king pakibat: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Uling alang lagyu ing komponente a `<{ $component }>`, ali ya magamit para king atributo ning module
+
+module-attribute-name-already-defined = Ali magamit ing komponente a `<{ $component } name="{ $name }">` antimong atributo ning module uling ing klase ning komponente a `<module>` atin neng atributo a "{ $name }".
+
+conditional-content-condition-ignored = Ali papansinan ing atributo a `condition` king komponente a `<conditionalContent>` a atin anak a case o else.
+
+slider-markers-type-mismatch = Ali mitutugma ing klase da reng marker at ing klase ning slider.
+
+pretzel-problem-needs-statement-and-answer = Ali balido a pretzel: dapat atin lamang metung a `<statement>` at metung a `<answer>` ing balang `<problem>`.
+
+pretzel-circuit-first-problem-distractor = Ali balido a pretzel: king mode="circuit", ali malyaring distractor ing mumunang `<problem>`.
+
+## Attribute values
+
+# No select: «alaga» is the same word for one and for many.
+attribute-invalid-values = Ali balido a alaga a { $values } para king atributo a `{ $attribute }`; ali papansinan.
+
+attribute-must-be-references = Ali balido a alaga a `{ $value }` para king atributo a `{ $attribute }`. Dapat mibuu ing atributo karing referensiang mangumpisa king `$`.
+
+math-input-invalid-function-names = <mathInput>: ali pepansinan deng ali balidung lagyu ning punsyon king { $attribute }: { $names }. Dapat atin ing balang lagyu ali kulang king 2 a karakter (letra o gitlo); malyaring tuki ing metung a suffix a `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Ali balido a klase ning komponente: `<{ $componentType }>`
+
+attribute-repeated = Ali malyaring uliten ing atributo a { $attribute }.
+
+attribute-invalid-for-component = Ali balido a atributo a "{ $attribute }" para king komponenteng klase `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kulang ing kontraste ning depinisyon ning estilo a { $styleNumber } para king { $context ->
+        [text-on-background] kule ning teksto laban king kule ning background
+        [high-contrast] kuleng matas ing kontraste laban king kanbas
+        [line] kule ning linya laban king kanbas
+        [marker] kule ning marker laban king kanbas
+       *[text-on-canvas] kule ning teksto laban king kanbas
+    }{ $mode ->
+        [dark] { " (madalumdum a mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kailangan ing ali kulang king { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Agyang atin ing depinisyon ning estilo a { $styleNumber } metakdang kule a sapat ing kontraste para king malino a mode, kulang ing kontraste ning kule ning teksto laban king kule ning background karing kuleng mekuha para king madalumdum a mode ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kailangan ing ali kulang king { $threshold }:1). { $suggestion ->
+        [available] Ban sapat ing kontraste king madalumdum a mode, dagdagan ing kontraste ning malino a mode (alimbawa, ilage ing { $lightAttribute }="{ $lightColor }") o salinan ing kule ning madalumdum a mode (alimbawa, ilage ing { $darkAttribute }="{ $darkColor }").
+       *[none] Ban sapat ing kontraste king madalumdum a mode, dagdagan ing kontraste ning malino a mode o salinan deng mekuhang kule king textColorDarkMode at/o backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Agyang atin ing depinisyon ning estilo a { $styleNumber } metakdang kule ning teksto a sapat ing kontraste para king malino a mode, kulang ing kontraste ning kule ning teksto a mekuha para king madalumdum a mode laban king kanbas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kailangan ing ali kulang king { $threshold }:1). { $suggestion ->
+        [available] Ban sapat ing kontraste king madalumdum a mode, dagdagan ing kontraste ning malino a mode (alimbawa, ilage ing textColor="{ $lightColor }") o salinan ing kule ning madalumdum a mode (alimbawa, ilage ing textColorDarkMode="{ $darkColor }").
+       *[none] Ban sapat ing kontraste king madalumdum a mode, dagdagan ing kontraste ning malino a mode o salinan ing mekuhang kule king textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Metung mu a <stylePalette> ing malyaring piliin ning metung a seksyon; gagamitan ing tauli.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ali me-alaman deng bukod tanging baryante ning { $component } uling ing numToSelect ali yang integer a ali negatibo.
+
+variant-num-to-select-not-constant-number = ali me-alaman deng bukod tanging baryante ning { $component } uling ing numToSelect ali yang konstanteng numero.
+
+variant-with-replacement-not-constant-boolean = ali me-alaman deng bukod tanging baryante ning { $component } uling ing withReplacement ali yang konstanteng boolean.
+
+variant-select-weight-disables-unique = Mipapatda reng bukod tanging baryante para king select nung atin opsyon a metakdaan king selectWeight o selectForVariants
+
+variant-coprime-undetermined = ali me-alaman deng bukod tanging baryante ning { $component } uling ali me-alaman nung lagi yang false ing coprime.
+
+variant-attribute-not-constant = ali me-alaman deng bukod tanging baryante ning { $component } uling ali konstante ing { $attribute }.
+
+variant-attribute-not-number = ali me-alaman deng bukod tanging baryante ning { $component } uling ali numero ing { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    ali me-alaman deng bukod tanging baryante ning { $component } a klase { $type } uling ing { $attribute } ali ya { $expected ->
+        [letters-combination] kombinasyon da reng letra
+        [math-expression] balidung ekspresyon a matematika
+        [integer] integer
+       *[number] numero
+    }.
+
+variant-length-not-integer = ali me-alaman deng bukod tanging baryante ning { $component } uling ali integer ing length.
+
+variant-sort-not-implemented = ala pang mapatupad deng bukod tanging baryante ning metung a { $component } a atin sort
+
+variant-exclude-combinations-not-implemented = ala pang mapatupad deng bukod tanging baryante ning metung a { $component } a atin excludeCombinations
+
+variant-math-exclude-not-implemented = ala pang mapatupad deng bukod tanging baryante ning metung a { $component } a klase math a atin exclude
+
+variant-non-constant-exclude-not-implemented = ala pang mapatupad deng bukod tanging baryante ning metung a { $component } a atin ali konstanteng exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: alang suporta king renderer a prefigure ning graph; melaktawan ing kaladwan.
+
+prefigure-descendant-invalid-geometry = { $subject }: ali angganan o ali kumpletu ing heometriya; melaktawan ing kaladwan.
+
+prefigure-curve-label-omitted = { $subject }: alang suporta deng etiketa karing mekonberteng kurba; ali pepansinan ing etiketa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: alang suporta a klase ning depinisyon ning punsyon a kurba a '{ $definitionType }'; melaktawan ing kaladwan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: alang suporta a atributo a flipFunctions king regionBetweenCurves; melaktawan ing kaladwan.
+
+prefigure-region-non-formula-child = { $subject }: deng anak a punsyon a klase formula mu ing atin suporta king regionBetweenCurves; melaktawan ing kaladwan.
+
+prefigure-label-position-unsupported =
+    { $subject }: alang suporta a labelPosition '{ $labelPosition }' para king { $labelKind ->
+        [line-family] etiketa ning pamilya ning linya
+       *[point] etiketa ning punto
+    }; gagamitan ing karaniwan a pamagpantay ning PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: alang suporta ing PreFigure king estilo ning laman a '{ $fillStyle }'; mibalik king solidung laman.
+
+prefigure-line-style-unknown = { $subject }: ali kilalang estilo ning linya a '{ $lineStyle }', ali melage king output ning PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: mesugpung ing estilo ning marker a '{ $markerStyle }' king estilo a 'diamond' ning PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: alang suporta ing PreFigure king estilo ning marker a '{ $markerStyle }'; gagamitan ing karaniwan a estilo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: ali balido a `ref`; ali maturu ing target. Ali melage ing annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: minuru ya ing `ref` karing dakal a target; gagamitan ing mumunang target.
+
+annotation-ref-outside-graph = `<annotation>`: ali balido a `ref`; atiu ing target kilwal ning graph a maglaman kaniti. Ali melage ing annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: ali balido a `ref`; ing target ali yang suportadung grapikal a bage king konbersyon a prefigure. Ali melage ing annotation.
+
+annotation-text-missing = `<annotation>`: ala o blangko ing `text`; maglalabas blangkung teksto.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Atin mekit a sirkular a pamanalig.
+       *[other] Atin mekit a sirkular a pamanalig a kayabe ne ing komponente a `<{ $componentType }>`.
+    }
+
+reference-no-referent = Alang mekit a tinuturu ning referensia: `{ $reference }`
+
+reference-multiple-referents = Dakal a mekit a tinuturu ning referensia: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Ali balido a pormat ning atributo a { $attribute } ning `<{ $componentType }>`.
+
+children-invalid = Ali balido la reng anak ning `<{ $componentType }>`: mekit la reng ali balidung anak: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ali balido a alaga a `{ $value }` para king atributo a `{ $attribute }`, gagamitan ing alaga a `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ali akit ing bersyon ning DoenetML a { $version }.
+       *[other] Ali akit ing bersyon ning DoenetML a { $version }. Mibalik king bersyon a { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Ali balido a DoenetML: { $content }
+
+parse-tag-missing-close-tag = Ali balido a DoenetML: Alang pamanyarang tag ing tag a `{ $tag }`. Aasahan ing tag a sasara king sarili o tag a `</{ $tagName }>`.
+
+parse-tag-error = Ali balido a DoenetML: Atin kamalian king tag a `<{ $tagName }>`
+
+parse-attribute-missing-value = Ali balido a DoenetML: Anti mo alang alaga ing ali balidung atributo a `{ $attribute }`.
+
+parse-attribute-invalid = Ali balido a DoenetML: Ali balido a atributo a `{ $attribute }`
+
+parse-attribute-value-invalid = Ali balido a DoenetML: Ali balido a alaga ning atributo a `{ $value }`
+
+parse-attribute-value-quote-mismatch = Ali balido a DoenetML: Ali balido a alaga ning atributo a `{ $value }`. Ali mitutugma reng marka ning sipi. Anti mo alang metung a `{ $quote }`
+
+parse-open-tag-name-missing = Ali balido a DoenetML: Atin mekit a tag a alang lagyu, alimbawa `<`
+
+parse-tag-not-closed = Ali balido a DoenetML: Ali mesara ing tag a `{ $tag }` (anti mo alang `>`).
+
+parse-self-closing-tag-name-missing = Ali balido a DoenetML: Atin mekit a tag a alang lagyu `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Ali balido a DoenetML: Ali mesara ing tag a `{ $tag }` (anti mo alang `/>`).
+
+parse-tag-invalid-attributes = Ali balido a DoenetML: Ali balido ing tag a `{ $tag }`. Baka atin ali tamang atributo.
+
+parse-close-tag-name-missing = Ali balido a DoenetML: Atin mekit a pamanyarang tag a alang lagyu, alimbawa `</`
+
+parse-attribute-value-unquoted = Dapat atiu kilub da reng marka ning sipi deng alaga ning atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Ali balido a DoenetML: Atin mekit a pamanyarang tag a `{ $tag }`, oneng alang katumbas a pamagbuklat a tag
+
+parse-close-tag-mismatched = Ali balido a DoenetML: Ali mitutugma ing pamanyarang tag. Aasahan ing `</{ $expected }>`. Mekit ing `{ $found }`
+
+parser-node-unconvertible = Ali mekonberte ing node a { $node } king node a Dast.
+
+## Names
+
+name-attribute-invalid =
+    Ali balido a atributo a name='{ $name }'. { $reason ->
+        [characters] Malyari mung maglaman deng lagyu karing letra, numero, underscore o gitlo.
+       *[start] Dapat mangumpisa reng lagyu king letra.
+    }
+
+component-name-invalid-start = Ali balido a lagyu ning komponente a "{ $name }". Dapat mangumpisa reng lagyu king letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Dapat atin atributo a video ing answer a type videoWatched
+
+answer-video-watched-video-not-reference = Dapat referensia ing atributo a video ning answer a type videoWatched
+
+answer-name-not-single-text = Dapat atin metung mu a anak a text ing atributo a name ning answer
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ali mekua ing kilwal a DoenetML uling masyadung dakal a lebel ning pamanulit. Atin wari sirkular a referensia?
+
+external-doenetml-unavailable = Ali mekua ing DoenetML manibat king { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Ali balido a DoenetML ing mekua manibat king { $attribute }="{ $uri }": ali ya mitugma king klase ning komponente a "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Ali na gagamitan ing atributo a `{ $from }`; gamitan ing `{ $to }`.
+       *[other] [deprecation] Ali na gagamitan ing atributo a `{ $from }` king `<{ $component }>`; gamitan ing `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Ali na gagamitan ing atributo a `{ $from }` at ali papansinan uling metakda mu naman ing `{ $to }`.
+       *[other] [deprecation] Ali na gagamitan ing atributo a `{ $from }` king `<{ $component }>` at ali papansinan uling metakda mu naman ing `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Ali na gagamitan ing atributo a `{ $attribute }` king `<{ $component }>` at ali papansinan.
+
+deprecated-attribute-to-child = [deprecation] Ali na gagamitan ing atributo a `{ $attribute }` king `<{ $component }>`; gamitan ing anak a `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Ali na gagamitan ing alaga a `{ $value }` ning atributo a `{ $attribute }` king `<{ $component }>`; gamitan ing `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = Ing `<pluralize>` malyari na mung padakalan ing Ingles, inya ali mibayu ing teksto na king dokumentung mesulat king { $locale }. Isulat a mismu ing pormang dakal, o ilage ya king atributo a `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ing elemento a `<{ $tag }>` ali yang kilalang elemento ning Doenet.
+
+schema-element-not-allowed-at-root = Ali mipapayntulut ing elemento a `<{ $tag }>` king ugat ning dokumento.
+
+schema-element-not-allowed-inside = Ali mipapayntulut ing elemento a `<{ $tag }>` kilub ning `<{ $parent }>`.
+
+schema-attribute-unrecognized = Alang atributo a milagyuang `{ $attribute }` ing elemento a `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Dapat lista ing atributo a `{ $attribute }` ning elemento a `<{ $tag }>` a ing balang bage na metung karing: { $allowed }
+       *[other] Dapat metung karing reti ing atributo a `{ $attribute }` ning elemento a `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Ali balido a lagyu ning baryante para king select.  Ing lagyu ning baryante a { $variantName } lalto ya king { $numOptions } a opsyon oneng { $numToSelect } ing bilang a pipilinan.
+
+select-variant-name-without-options = Atin metakdang baryante para king select oneng alang metakdang opsyon para king malyaring lagyu ning baryante: { $variantName }.
+
+select-variant-name-not-possible = Ing lagyu ning baryante a { $variantName } a metakda para king select ali yang malyaring lagyu ning baryante.
+
+select-too-few-options = Ali malyaring mamili { $numToSelect } a komponente manibat king { $numOptions } mu.
+
+select-from-sequence-too-few-values = Ali malyaring mamili { $numToSelect } a alaga manibat king sequence a { $length } ing kaba.
+
+select-from-sequence-indices-count-mismatch = Dapat mitugma ing bilang da reng indise a metakda para king select at ing bilang a pipilinan
+
+select-from-sequence-indices-not-integers = Dapat integer la ngan deng indise a metakda para king select
+
+select-from-sequence-index-excluded = Metakda ing indise ning selectfromsequence a ali melage
+
+select-from-sequence-indices-excluded-combination = Metakda reng indise ning selectfromsequence a metung a ali melageng kombinasyon
+
+select-from-sequence-coprime-not-positive-integers = Ali malyaring mamili kombinasyon a coprime uling ali positibong integer ing pipilinan.
+
+select-from-sequence-coprime-common-factor = Ali malyaring mamili numerong coprime. Atin metung a paktor a pareu la ngan deng malyaring alaga. (Dapat coprime ing metakdang alaga ning "from" o "to" king "step".)
+
+select-from-sequence-coprime-single-number = Ali malyaring mamili kombinasyon a coprime manibat king metung mung numerung ali 1.
+
+select-from-sequence-excluded-too-many-combinations = Ali melage ing labis king 70% da reng kombinasyon king selectFromSequence
+
+select-from-sequence-coprime-none-found = Ali mekapamili numerong coprime. Atin metung a paktor a pareu la ngan deng malyaring alaga.
+
+select-from-sequence-too-few-unique-values = Ali malyaring mamili { $numToSelect } a bukod tanging alaga manibat king sequence a { $numPossibleValues } ing kaba
+
+select-prime-numbers-too-few-values = Ali malyaring mamili { $numToSelect } a alaga manibat king listang prime a { $numValues } ing kaba
+
+select-prime-numbers-values-count-mismatch = Dapat mitugma ing bilang da reng alaga a metakda para king select at ing bilang a pipilinan
+
+select-prime-numbers-values-not-prime = Dapat atiu king listang prime la ngan deng alaga a metakda para king select prime number
+
+select-prime-numbers-values-excluded-combination = Deng metakdang alaga ning selectPrimeNumbers metung lang ali melageng kombinasyon
+
+select-prime-numbers-excluded-too-many-combinations = Ali melage ing labis king 70% da reng kombinasyon king selectPrimeNumbers
+
+select-random-combination-fluke = Uling king pambihirang swerte, ali mekapamili kombinasyon da reng random a alaga
+
+select-random-value-fluke = Uling king pambihirang swerte, ali mekapamili random a alaga

--- a/packages/i18n/locales/pam/editor.ftl
+++ b/packages/i18n/locales/pam/editor.ftl
@@ -1,0 +1,208 @@
+# Kapampangan editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Kapampangan marks no number on the noun, so a `{ $count -> … }` whose two
+# English branches differ only in the noun renders one string here and the
+# select is dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ibalik
+       *[update] Bayuan
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } ing pamanakit
+       *[other] { $word } ing pamanakit { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Baryante
+editor-variant-filter = Salain…
+editor-variant-next = Piliin ing tutuking baryante
+editor-variant-previous = Piliin ing milabas a baryante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Atin mekit a pamanlabag king aksesibilidad a WCAG AA. I-klik ban { $action ->
+            [close] masara
+           *[open] mabuklat
+        } ing report ning aksesibilidad.
+        [advisories] I-klik ban { $action ->
+            [close] masara
+           *[open] mabuklat
+        } ing report ning aksesibilidad. Alang mekit a pamanlabag king WCAG AA, oneng atin pang dagdag a rekomendasyon king aksesibilidad.
+       *[clean] I-klik ban { $action ->
+            [close] masara
+           *[open] mabuklat
+        } ing report ning aksesibilidad. Alang mekit a problema king aksesibilidad.
+    }
+
+# No select on `$count` inside the branches: «pamanlabag» and «rekomendasyon»
+# are the same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Atin mekit a pamanlabag king aksesibilidad a WCAG AA. { $count } a pamanlabag king WCAG AA ing mekit. I-klik ban { $action ->
+            [close] masara
+           *[open] mabuklat
+        } ing report ning aksesibilidad.
+        [advisories] Alang mekit a pamanlabag king WCAG AA. { $count } a dagdag a rekomendasyon king aksesibilidad ing mekit. I-klik ban { $action ->
+            [close] masara
+           *[open] mabuklat
+        } ing report ning aksesibilidad.
+       *[clean] Alang mekit a pamanlabag king WCAG AA. I-klik ban { $action ->
+            [close] masara
+           *[open] mabuklat
+        } ing report ning aksesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersyon ning DoenetML { $version }
+
+editor-tab-help = Saup a agpang king konteksto
+editor-tab-help-short = Konteksto
+editor-tab-errors = Kamalian
+editor-tab-warnings = Babala
+editor-tab-info = Impormasyon
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Mipadalang pakibat
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Deng opsyon ning editor
+editor-format-as-doenetml = I-pormat antimong DoenetML
+editor-format-as-xml = I-pormat antimong XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Gulis #{ $line }
+
+editor-no-errors = Alang kamalian
+editor-no-warnings = Alang babala
+editor-no-info = Alang diagnostikong impormasyon
+
+editor-show-info-annotations = Ipakit la reng diagnostikong impormasyon king editor
+editor-show-accessibility-annotations = Ipakit la reng diagnostiko ning aksesibilidad king editor
+
+editor-accessibility-learn-more = Pag-aralan nung makananu tinuki ing Doenet king aksesibilidad
+
+editor-accessibility-violations-heading = Pamanlabag king aksesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Aliwa pang problema king aksesibilidad
+editor-none-found = Alang mekit
+
+
+## Submitted responses
+
+editor-no-responses = Ala pang mipadalang pakibat
+editor-response-answer-id = Id ning pakibat
+editor-response-response = Pakibat
+editor-response-credit = Kredito
+editor-response-submitted = Mipadala
+
+
+## The context-help panel
+
+help-placeholder = Ilage ing kursor king lagyu ning tag, atributo, o { $ref } para king dokumentasyon.
+
+help-unsupported-ref-chain = Ala pang suporta ing saup para karing referensiang dakal a dake anti ing { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Alang mekit a tinuturu ning referensia: { $ref }.
+        [multiple] Dakal a mekit a tinuturu ning referensia: { $ref }.
+       *[indeterminate] Ali me-alaman ing tinuturu ning { $ref }.
+    }
+
+help-learn-about-references = Pag-aralan la reng referensia →
+help-reference-page = Bulung ning referensia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Kilub ning { $element }
+       *[top] King kamaragulan a lebel
+    }{ $allowed ->
+        [none] { " — alang maylage keni." }
+        [text] { " — manulat kang teksto keni." }
+        [text-and-components] { " — manulat kang teksto keni, o subukan mu:" }
+       *[components] { " — deng masubukan:" }
+    }
+
+help-suggestions-footer = Pindutan me ing { $shortcut } ban akit la reng eganagana a { $total } a komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] Ing { $ref } metung yang referensia king { $target }.
+       *[other] Ing { $ref } metung yang referensia king { $target } (gulis { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Dinala ne ning { $owner } antimong { $role }.
+       *[other] Dinala ne ning { $owner } king gulis { $line } antimong { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] Ing { $ref } metung yang referensia king propyedad a { $property } ning { $element }.
+       *[other] Ing { $ref } metung yang referensia king propyedad a { $property } ning { $element } (gulis { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = malating kodigo
+help-kind-array-entry = entrada king array
+
+help-default = Karaniwan:
+help-active-default = Aktibong karaniwan:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Deng makatuldung alaga (metung kada bage):
+       *[other] Deng makatuldung alaga:
+    }
+
+help-suggested-values = Deng misusuherinang alaga:
+
+help-inserts = Maglalage:
+
+# No select: «koordinado» is the same word for one and for many.
+help-coordinates = Koordinado:
+
+help-type = Klase:
+
+help-resolved-style = Me-alaman a estilo (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Me-alaman a lagyu ning punsyon:
+help-reset-list = Lista ning pamanibalik king input a ini:
+help-added-on-input = Medagdag king input a ini:
+help-removed-on-input = Me-alis king input a ini:
+
+help-reset-overrides = Ing { $reset } salinan na ing { $additional } at { $removed }.

--- a/packages/i18n/locales/tet/chrome.ftl
+++ b/packages/i18n/locales/tet/chrome.ftl
@@ -1,0 +1,145 @@
+# Tetum viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in **Tetun Dili** (Tetun Prasa), the variety that is co-official in
+# Timor-Leste and the one the Instituto Nacional de Linguística's orthography
+# standardizes — not Tetun Terik. That choice shows most in the vocabulary: this
+# catalog uses the Portuguese loans the standard uses («verifika», «pájina»,
+# «grosu») rather than coining, which is what Tetun Dili itself does, and the
+# seam between the two is where a speaker's judgement is most wanted.
+#
+# Tetum marks no number on the noun — the plural is the postposed «sira» and a
+# noun after a numeral does not take it — so a `{ $count -> … }` whose two
+# English branches differ only in the noun renders one string here and the
+# select is dropped. A `[0]` branch stays wherever English has one.
+
+
+## Answer submission
+
+answer-checking = Sei verifika…
+answer-submitting = Sei haruka…
+
+answer-checking-status = Sei verifika resposta
+answer-submitting-status = Sei haruka resposta
+
+answer-correct = Loos
+answer-incorrect = La loos
+
+answer-response-saved = Resposta rai ona
+
+answer-percent-credit = { $percent }% kréditu
+answer-percent-correct = { $percent }% loos
+answer-percent-short = { $percent } %
+
+max-credit-available = Kréditu máximu ne'ebé bele hetan: { $percent }%
+
+# No select: «koko» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] la iha koko ida sei hela
+       *[other] sei hela koko { $count }
+    }
+
+validation-correct = (Loos)
+validation-incorrect = (La loos)
+validation-partially-correct = (Loos parsialmente)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Hatudu resposta { $count } ba { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komentáriu
+
+collapsible-click-to-open = (klik atu loke)
+collapsible-click-to-close = (klik atu taka)
+
+collapsible-initializing = Hahú hela…
+
+footnote-show = Hatudu footnote
+footnote-hide = Subar footnote
+
+description-more-information = informasaun tan
+
+
+## Controls
+
+slider-previous = Uluk
+slider-next = Tuirmai
+
+keyboard-open = Loke tekladu
+keyboard-close = Taka tekladu
+
+choice-input-remove-choice = Hasai { $choice }
+
+matrix-remove-row = Hasai liña
+matrix-add-row = Tau tan liña
+matrix-remove-column = Hasai koluna
+matrix-add-column = Tau tan koluna
+
+subset-add-remove-points = Tau/Hasai pontu
+subset-toggle-points-intervals = Troka pontu ho intervalu
+subset-move-points = Book pontu sira
+subset-clear = Hamoos
+
+orbital-add-row = Tau tan liña
+orbital-remove-row = Hasai liña
+orbital-add-box = Tau tan kaixa
+orbital-remove-box = Hasai kaixa
+orbital-add-up-arrow = Tau tan fleixa ba leten
+orbital-add-down-arrow = Tau tan fleixa ba kraik
+orbital-remove-arrow = Hasai fleixa
+
+orbital-row-label = Etiketa ba liña { $row }
+
+pretzel-answer = Resposta
+
+summary-statistics-caption = Rezumu estatístika husi { $column }
+
+
+## Math input
+
+math-input-preview-region = pré-vizualizasaun ba espresaun matemátika
+math-input-preview = Pré-vizualizasaun
+math-input-invalid-expression = Espresaun la válidu:
+
+
+## Document status
+
+viewer-initializing = Hahú hela…
+
+
+## Errors
+
+error-heading = Sala
+
+error-found-at =
+    { $span ->
+        [line] Hetan iha liña { $startLine }.
+       *[lines] Hetan iha liña { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dokumentu ne'e iha sala!
+
+diagnostic-heading-error = Sala
+diagnostic-heading-warning = Avizu
+diagnostic-heading-information = Informasaun
+diagnostic-heading-hint = Matadalan
+
+accessibility-heading-level-1 = Violasaun asesibilidade WCAG AA
+accessibility-heading-level-2 = Avizu kona-ba asesibilidade
+
+something-went-wrong = Iha buat ida la loos.
+
+renderer-load-failed = iha renderer ida la bele karega. Favor karega fali pájina ne'e.
+
+core-start-failed = Vizualizadór dokumentu la bele hahú. Favor karega fali pájina ne'e.

--- a/packages/i18n/locales/tet/content.ftl
+++ b/packages/i18n/locales/tet/content.ftl
@@ -18,9 +18,10 @@
 # composition message inverts the English order.
 #
 # The geometry vocabulary is Portuguese-derived, which is what Timorese
-# schooling carries; the colours and the everyday words are Tetum's own, and
-# `.blue` is the one colour in the table that is a loan, because Tetum's own
-# «matak» covers blue and green together. This catalog assigns «matak» to green
+# schooling carries. Several colours are Portuguese loans as Tetun Dili writes
+# them — «sinza», «laranja», «roxu», «rosa», «kastañu» — but `.blue` is the one
+# whose loan stands in for a word Tetum has, because Tetum's own «matak» covers
+# blue and green together. This catalog assigns «matak» to green
 # and the loan «azúl» to blue, which is what Timorese school materials do, and
 # it is a partition of the spectrum rather than a translation of two English
 # words — the same shape `locales/gn` and `locales/oj` record for their own

--- a/packages/i18n/locales/tet/content.ftl
+++ b/packages/i18n/locales/tet/content.ftl
@@ -1,0 +1,260 @@
+# Tetum content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Tetun Dili, the co-official variety; see `chrome.ftl`'s header.
+#
+# Tetum has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`. Note
+# that the **Portuguese loans keep their Portuguese shape but not its
+# agreement**: «azúl» and «matak» do not change for the noun beside them, so a
+# borrowed adjective is as invariant here as a native one. That is worth saying
+# because a corrector who reads «regulár» and reaches for «regulares» would be
+# translating Portuguese rather than Tetum.
+#
+# The adjectives **follow** the noun — «liña mean», a red line — so every
+# composition message inverts the English order.
+#
+# The geometry vocabulary is Portuguese-derived, which is what Timorese
+# schooling carries; the colours and the everyday words are Tetum's own, and
+# `.blue` is the one colour in the table that is a loan, because Tetum's own
+# «matak» covers blue and green together. This catalog assigns «matak» to green
+# and the loan «azúl» to blue, which is what Timorese school materials do, and
+# it is a partition of the spectrum rather than a translation of two English
+# words — the same shape `locales/gn` and `locales/oj` record for their own
+# colour tables.
+
+
+## Style vocabulary
+
+color =
+    .black = metan
+    .white = mutin
+    .gray = sinza
+    .red = mean
+    .orange = laranja
+    .yellow = kinur
+    .green = matak
+    .cyan = sian
+    .blue = azúl
+    .purple = roxu
+    .pink = rosa
+    .brown = kastañu
+
+line-width =
+    .thick = grosu
+    .thin = finu
+
+line-style =
+    .dashed = traku-traku
+    .dotted = pontu-pontu
+
+# Noun phrases. Tetum marks no plural on the noun, so «liña» is the word for one
+# line and for many alike.
+fill-style =
+    .horizontal = liña orizontál
+    .vertical = liña vertikál
+    .diagonal = liña diagonál
+    .backdiagonal = liña diagonál kotuk
+    .dots = pontu
+    .diamonds = losangu
+
+noun =
+    .line = liña
+    .line-segment = segmentu liña
+    .ray = raiu
+    .vector = vetór
+    .curve = kurva
+    .function = funsaun
+    .parabola = parábola
+    .polyline = liña keta-ketak
+    .polygon = polígonu
+    .triangle = triángulu
+    .rectangle = retángulu
+    .circle = sírkulu
+    .region = rejiaun
+    .point = pontu
+    .square = kuadradu
+    .diamond = losangu
+    .cross = kruz
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] ho sorin { $numSides }
+       *[head] polígonu regulár
+    }
+
+# One answer for every noun: Tetum has no grammatical gender, and its borrowed
+# adjectives do not agree either.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = nakonu
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ho { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ho { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } ho { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Tetum has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «ho» against «no».
+style-border-clause =
+    { $parts ->
+        [with-article] ho sorin-lalais { $border }
+        [and] no sorin-lalais { $border }
+        [and-article] no sorin-lalais { $border }
+       *[with] ho sorin-lalais { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = la nakonu
+
+style-text =
+    { $parts ->
+        [background] { $color } ho fundu { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = laiha
+
+
+## Boolean words
+
+boolean-true = loos
+boolean-false = sala
+
+
+## Answer buttons
+
+answer-submit-label = Verifika serbisu
+answer-submit-label-no-correctness = Haruka resposta
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Tetum's plural is the postposed «sira», and a heading does not carry it.
+section-name =
+    .activity = Atividade
+    .aside = Nota sorin
+    .cascade = Kaskata
+    .definition = Definisaun
+    .example = Ezemplu
+    .exercise = Ezersísiu
+    .exercises = Ezersísiu
+    .given-answer = Resposta
+    .note = Nota
+    .objectives = Objetivu
+    .paragraphs = Parágrafu
+    .part = Parte
+    .problem = Problema
+    .problems = Problema
+    .proof = Prova
+    .question = Pergunta
+    .section = Seksaun
+    .solution = Solusaun
+    .task = Tarefa
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Matadalan
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabela { $enumeration }
+        [numbered-title] Tabela { $enumeration }{ ": " }
+        [unnumbered-title] Tabela{ ": " }
+       *[unnumbered] Tabela
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figura { $enumeration }
+        [numbered-caption] Figura { $enumeration }{ ": " }
+        [unnumbered-caption] Figura{ ": " }
+       *[unnumbered] Figura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Uluk
+paginator-next = Tuirmai
+paginator-page = Pájina
+
+paginator-page-status = { $pageLabel } { $currentPage } husi { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ka
+piecewise-condition-if = se
+piecewise-condition-otherwise = se lae
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Timorese secondary science is taught in Portuguese, out of
+## Portuguese textbooks, so the chemical vocabulary a pupil meets is
+## `locales/pt`'s. Tetum is the language of the early grades and of the
+## classroom talk around the lesson; there is no settled Tetum table for a seed
+## to reproduce. That is the `locales/ht` case exactly, one colonial language
+## over.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Símbolu kímiku la válidu
+chemistry-invalid-ionic-compound = Kompostu ióniku la válidu

--- a/packages/i18n/locales/tet/diagnostics.ftl
+++ b/packages/i18n/locales/tet/diagnostics.ftl
@@ -1,0 +1,624 @@
+# Tetum diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Written in Tetun Dili; see `chrome.ftl`'s header. Tetum marks no number on the
+# noun, so a counted message whose only English difference is the noun's number
+# renders one string here and the select is dropped.
+
+
+## `<lineSegment>`
+
+# No select: «la konsidera» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = la konsidera { $attributes } bainhira rohan rua determina ona
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = la konsidera { $attributes } bainhira rohan ida ho pontu klaran determina hotu ona
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset laiha efeitu se laiha pontu klaran
+
+## `<line>`
+
+line-points-undetermined-dimensions = Liña ne'ebé liu pontu sira ne'ebé dimensaun la determinadu.
+
+line-points-too-few-dimensions = Liña tenke liu pontu sira ne'ebé iha dimensaun rua ka liu.
+
+line-points-depend-on-variables = Liña liu pontu sira ne'ebé depende ba variavel: { $variables }.
+
+line-equation-invalid-format = Formatu ekuasaun liña la válidu iha variavel { $variable1 } no { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Raiu determina husi through, endpoint no direction.  La konsidera through ne'ebé determina ona.
+
+ray-dimension-mismatch = numDimensions la hanesan iha raiu.
+
+## `<vector>`
+
+vector-overprescribed-head = Vetór determina husi head, tail no displacement.  La konsidera head ne'ebé determina ona.
+
+vector-dimension-mismatch = numDimensions la hanesan iha vetór.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = La bele dada ba `<{ $component }>` tanba nia laiha variavel estadu nearestPoint.
+
+constrain-to-without-nearest-point = La bele limita ba `<{ $component }>` tanba nia laiha variavel estadu nearestPoint.
+
+constrain-to-interior-without-nearest-point = La bele limita ba laran husi `<{ $component }>` tanba nia laiha variavel estadu nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = la konsidera labelPosition ba choiceInput ne'ebé la inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = La konsidera índise sira ne'ebé determina ba choiceInput tanba númeru índise la hanesan ho númeru oan hili nian.
+
+pretzel-indices-count-mismatch = La konsidera índise sira ne'ebé determina ba problem tanba númeru índise la hanesan ho númeru oan problem nian.
+
+shuffle-indices-count-mismatch = La konsidera índise sira ne'ebé determina ba shuffle tanba númeru índise la hanesan ho númeru komponente.
+
+indices-ignored-out-of-range = La konsidera índise sira ne'ebé determina ba { $component } tanba iha índise ida sai husi limite.
+
+pretzel-indices-repeated = La konsidera índise sira ne'ebé determina ba pretzel tanba iha índise ida repete.
+
+pretzel-circuit-first-index = La konsidera índise sira ne'ebé determina ba pretzel iha mode circuit tanba índise dahuluk tenke 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Atu `<{ $component }>` bele serbisu ho oan string, atributu `type` tenke determina.
+
+invalid-type-defaulting-to-math = type { $type } la válidu ba komponente { $component }. Tenke ida husi math, text, number, ka boolean. Uza math.
+
+string-not-valid-component-to-arrange = String "{ $value }" la'ós komponente válidu ba { $component }. La konsidera.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } la válidu, tau type ba number.
+
+invalid-variable-value = Valór variavel la válidu: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Índise variante { $index } tenke númeru
+
+variant-index-must-be-integer = Índise variante { $index } tenke númeru inteiru
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` seidauk implementa ba medida absolutu. Tau luan sira ba relativu.
+
+side-by-side-absolute-margins = `<{ $component }>` seidauk implementa ba medida absolutu. Tau marjen sira ba relativu.
+
+side-by-side-no-block-child = `<{ $component }>` la válidu: nia tenke iha oan block ida.
+
+## `<label>`
+
+label-for-ignored-on-graphical = La konsidera atributu `for` iha `<label>` gráfiku.
+
+label-for-must-resolve-to-one = Atributu `for` iha `<label>` tenke hatudu ba komponente ida de'it.
+
+label-for-unresolved = Atributu `for` iha `<label>` la bele hatudu ba komponente ida.
+
+label-for-answer-with-authored-inputs = Atributu `for` iha `<label>` hatudu ba `<answer>` ne'ebé iha input ne'ebé autór hakerek; hatudu input rasik.
+
+label-for-answer-without-input = Atributu `for` iha `<label>` hatudu ba `<answer>` ne'ebé laiha input atu fó etiketa.
+
+label-for-must-reference-input-or-answer = Atributu `for` iha `<label>` tenke hatudu ba input ida ka answer ida.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ba asesibilidade, `<{ $component }>` tenke iha deskrisaun badak ka determina nu'udar dekorativu.
+
+accessibility-video-short-description = Ba asesibilidade, `<video>` tenke iha deskrisaun badak.
+
+accessibility-input-short-description-or-label = Ba asesibilidade, `<{ $component }>` tenke iha deskrisaun badak ka etiketa.
+
+accessibility-answer-input-short-description-or-label = Ba asesibilidade, `<answer>` ne'ebé kria input tenke iha deskrisaun badak ka etiketa.
+
+accessibility-short-description-contains-math = Deskrisaun badak la bele iha komponente matemátika hanesan `<{ $component }>`. Hakerek matemátika ho liafuan.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kontraste husi { $colorName } la to'o ba testu títulu seksaun (mode nakukun) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; presiza uitoan liu { $threshold }:1).
+       *[other] Kontraste husi { $colorName } la to'o ba testu títulu seksaun ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; presiza uitoan liu { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` ne'ebé liu pontu { $count } seidauk implementa se pontu sira laiha valór numériku.
+
+circle-too-many-through-points = La bele kalkula sírkulu ne'ebé liu pontu liu 3.
+
+circle-overprescribed-radius-center-points = La bele kalkula sírkulu ho raiu, sentru no pontu sira ne'ebé determina ona.
+
+circle-center-with-multiple-points = La bele kalkula sírkulu ho sentru determinadu ne'ebé liu pontu liu 1.
+
+circle-radius-too-small = La bele kalkula sírkulu: tanba distánsia entre pontu rua mak { $distance }, raiu { $radius } ne'ebé determina ki'ik liu.
+
+circle-radius-with-many-points = La bele kria sírkulu ne'ebé liu pontu liu rua ho raiu ne'ebé determina.
+
+circle-invalid-center-or-through-points = Sentru ka pontu sira ne'ebé sírkulu liu la válidu.
+
+circle-radius-center-with-multiple-points = La bele kalkula raiu sírkulu ho sentru determinadu ne'ebé liu pontu liu 1.
+
+circle-change-radius-non-numerical = La bele troka raiu sírkulu ne'ebé liu pontu sira ne'ebé la numériku
+
+circle-radius-with-points-non-numerical = La bele kria sírkulu ne'ebé liu pontu liu ida ho raiu ne'ebé determina se laiha valór numériku.
+
+circle-change-center-non-numerical = Troka sentru sírkulu ne'ebé liu pontu sira ne'ebé laiha valór numériku seidauk implementa.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Tetum has one, because
+# «intervalu» and «input» do not change for number. Both selects are dropped
+# and both counts still arrive.
+function-domain-insufficient-dimensions = Dimensaun domíniu ba funsaun la to'o. Domíniu iha intervalu { $intervals } maibé funsaun iha input { $inputs }.
+
+function-domain-invalid-format = Formatu domíniu ba funsaun la válidu.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] La konsidera máximu funsaun nian ne'ebé la numériku.
+        [minimum] La konsidera mínimu funsaun nian ne'ebé la numériku.
+        [extremum] La konsidera estremu funsaun nian ne'ebé la numériku.
+        [point] La konsidera pontu funsaun nian ne'ebé la numériku.
+        [slope] La konsidera inklinasaun funsaun nian ne'ebé la numériku.
+       *[other] La konsidera { $type } funsaun nian ne'ebé la numériku.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] La konsidera máximu funsaun nian ne'ebé mamuk.
+        [minimum] La konsidera mínimu funsaun nian ne'ebé mamuk.
+        [extremum] La konsidera estremu funsaun nian ne'ebé mamuk.
+        [point] La konsidera pontu funsaun nian ne'ebé mamuk.
+       *[other] La konsidera { $type } funsaun nian ne'ebé mamuk.
+    }
+
+function-points-too-close = Funsaun iha pontu rua ne'ebé fatin besik liu. La bele define funsaun.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Iterasaun funsaun bele de'it se númeru input hanesan ho númeru output. Funsaun ne'e iha input { $inputs } no output { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Naruk sequence la válidu.  Tenke númeru inteiru ne'ebé la negativu.
+
+sequence-invalid-step = step sequence la válidu.  Tenke númeru ba sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" sequence númeru la válidu.  Tenke númeru.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" sequence letra la válidu.  Tenke kombinasaun letra.
+
+sequence-invalid-endpoint = "{ $attribute }" sequence la válidu.
+
+select-from-sequence-coprime-not-numbers = la konsidera coprime tanba buat ne'ebé hili la'ós númeru
+
+select-from-sequence-coprime-with-exclude-combinations = la konsidera coprime tanba excludeCombinations determina ona
+
+## Resolving a `target`
+
+target-not-found = target la válidu ba `<{ $source }>`: la hetan target.
+
+target-state-variable-not-found = target la válidu ba `<{ $source }>`: la hetan variavel estadu ho naran "{ $property }" iha `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Variavel `<odeSystem>` tenke la hanesan ho variavel independente.
+
+ode-system-duplicate-variable-names = La bele define funsaun RHS ODE ho naran variavel dependente hanesan.
+
+ode-system-rhs-function-error = La bele define funsaun RHS ODE.  Iha sala kuandu kria funsaun mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = La bele define ángulu entre liña { $count }
+
+angle-invalid-through-point = Pontu la válidu iha through husi `<angle>`
+
+parabola-vertex-too-many-points = Parábola ho vértise ne'ebé liu pontu liu 1 seidauk implementa.
+
+parabola-too-many-points = Parábola ne'ebé liu pontu liu 3 seidauk implementa.
+
+intersection-too-many-items = Interseksaun ba buat liu rua seidauk implementa
+
+## Other math components
+
+ionic-compound-not-two-ions = Kompostu ióniku ba buat seluk fó-liu ion rua seidauk implementa.
+
+ionic-compound-needs-cation-and-anion = Kompostu ióniku implementa ba katiaun ida no aniaun ida de'it.
+
+solve-equations-cannot-evaluate = La bele rezolve ekuasaun tanba la bele avalia ekuasaun: { $equation }
+
+math-operators-operand-number-required = operandNumber tenke determina bainhira foti operandu matemátiku.
+
+eigen-decomposition-failed = La bele kalkula eigenvalue matriz nian
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parametru { $parameters } la mosu iha pattern, entaun nia sempre kombina ho mamuk.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: la komprende grid="{ $grid }". Tenke none, medium, dense, ka númeru pozitivu rua ne'ebé espasu ida fahe, hanesan grid="1 0.5". Laiha grid ne'ebé dezeña.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" la suporta iha renderer prefigure; uza hahalok pozisaun loos.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" la suporta iha renderer prefigure; uza hahalok pozisaun leten.
+
+prefigure-invalid-axis-bounds = `<graph>`: limite eixu la válidu ba konversaun prefigure; uza bbox padraun (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: luan la válidu ba konversaun prefigure; uza luan diagrama padraun 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio la válidu ba konversaun prefigure; uza aspect ratio padraun 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: espasu grid ki'ik liu ba limite eixu; la dezeña grid iha renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: la dezeña annotation se la uza renderer PreFigure.
+
+multiple-annotations-children = Hetan oan `<annotations>` barak iha `<graph>`; la konsidera hotu-hotu la'ós ikus liu.
+
+## Referring to other components
+
+copy-unrecognized-component-type = La bele estende ka kopia tipu komponente ne'ebé la rekoñese: { $type }.
+
+copy-prop-not-found = La hetan prop { $property } iha komponente tipu { $component }
+
+collect-no-source = La hetan source ba collect.
+
+collect-invalid-component-type = La bele halibur komponente tipu `<{ $component }>` tanba tipu komponente la válidu.
+
+reference-index-unavailable = La bele refere índise `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = La bele bolu { $action } iha komponente `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Forma dadus la válidu.  Naruk liña la hanesan. Hetan iha componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Dadus iha naran koluna hanesan.  Hetan iha componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Dadus la iha naran koluna ida.  Hetan iha componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award resposta ne'e bazeia ba resposta ne'ebé answer tag rasik haruka, no ne'e sei lori hahalok ne'ebé la hein.
+
+answer-max-num-attempts-in-section-wide-check-work = Tau `maxNumAttempts` iha `<answer>` ida iha laran husi kontenedór ho `sectionWideCheckWork` laiha efeitu, tanba kontenedór mak kontrola númeru koko. Tau `maxNumAttempts` iha kontenedór.
+
+nested-section-wide-check-work-max-num-attempts = Tau `maxNumAttempts` iha kontenedór ho `sectionWideCheckWork` ne'ebé iha laran husi kontenedór seluk ho `sectionWideCheckWork` laiha efeitu, tanba kontenedór liur mak kontrola númeru koko. Tau `maxNumAttempts` iha kontenedór liur.
+
+# No select: «atributu» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Atributu { $attributes } sei laiha efeitu se symbolicEquality la tau.
+
+answer-invalid-type = Tipu la válidu ba resposta: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Tanba komponente `<{ $component }>` laiha naran, nia la bele uza ba atributu module
+
+module-attribute-name-already-defined = Komponente `<{ $component } name="{ $name }">` la bele uza nu'udar atributu module tanba tipu komponente `<module>` iha ona atributu "{ $name }".
+
+conditional-content-condition-ignored = La konsidera atributu `condition` iha komponente `<conditionalContent>` ho oan case ka else.
+
+slider-markers-type-mismatch = Tipu marker la hanesan ho tipu slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel la válidu: kada `<problem>` tenke iha `<statement>` ida no `<answer>` ida.
+
+pretzel-circuit-first-problem-distractor = Pretzel la válidu: iha mode="circuit", `<problem>` dahuluk la bele distractor.
+
+## Attribute values
+
+# No select: «valór» is the same word for one and for many.
+attribute-invalid-values = Valór { $values } la válidu ba atributu `{ $attribute }`; la konsidera.
+
+attribute-must-be-references = Valór `{ $value }` la válidu ba atributu `{ $attribute }`. Atributu tenke kompostu husi referénsia sira ne'ebé hahú ho `$`.
+
+math-input-invalid-function-names = <mathInput>: la konsidera naran funsaun la válidu iha { $attribute }: { $names }. Kada naran tenke iha karakter rua ka liu (letra ka traku); bele tuir sufiksu `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Tipu komponente la válidu: `<{ $componentType }>`
+
+attribute-repeated = La bele repete atributu { $attribute }.
+
+attribute-invalid-for-component = Atributu "{ $attribute }" la válidu ba komponente tipu `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kontraste husi definisaun estilu { $styleNumber } la to'o ba { $context ->
+        [text-on-background] kór testu hasoru kór fundu
+        [high-contrast] kór kontraste aas hasoru kanvas
+        [line] kór liña hasoru kanvas
+        [marker] kór marker hasoru kanvas
+       *[text-on-canvas] kór testu hasoru kanvas
+    }{ $mode ->
+        [dark] { " (mode nakukun)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; presiza uitoan liu { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Maski definisaun estilu { $styleNumber } iha kór sira ne'ebé determina ho kontraste to'o ba mode naroman, kontraste kór testu hasoru kór fundu la to'o iha kór sira ne'ebé foti ba mode nakukun ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; presiza uitoan liu { $threshold }:1). { $suggestion ->
+        [available] Atu kontraste to'o iha mode nakukun, aumenta kontraste mode naroman (ezemplu, tau { $lightAttribute }="{ $lightColor }") ka troka kór mode nakukun (ezemplu, tau { $darkAttribute }="{ $darkColor }").
+       *[none] Atu kontraste to'o iha mode nakukun, aumenta kontraste mode naroman ka troka kór sira ne'ebé foti ho textColorDarkMode no/ka backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Maski definisaun estilu { $styleNumber } iha kór testu ne'ebé determina ho kontraste to'o ba mode naroman, kontraste kór testu ne'ebé foti ba mode nakukun la to'o hasoru kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; presiza uitoan liu { $threshold }:1). { $suggestion ->
+        [available] Atu kontraste to'o iha mode nakukun, aumenta kontraste mode naroman (ezemplu, tau textColor="{ $lightColor }") ka troka kór mode nakukun (ezemplu, tau textColorDarkMode="{ $darkColor }").
+       *[none] Atu kontraste to'o iha mode nakukun, aumenta kontraste mode naroman ka troka kór ne'ebé foti ho textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Seksaun ida bele hili <stylePalette> ida de'it; uza ida ikus.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = la bele determina variante úniku husi { $component } tanba numToSelect la'ós númeru inteiru ne'ebé la negativu.
+
+variant-num-to-select-not-constant-number = la bele determina variante úniku husi { $component } tanba numToSelect la'ós númeru konstante.
+
+variant-with-replacement-not-constant-boolean = la bele determina variante úniku husi { $component } tanba withReplacement la'ós boolean konstante.
+
+variant-select-weight-disables-unique = Variante úniku ba select desativa se iha opsaun ho selectWeight ka selectForVariants determinadu
+
+variant-coprime-undetermined = la bele determina variante úniku husi { $component } tanba la bele determina katak coprime sempre false.
+
+variant-attribute-not-constant = la bele determina variante úniku husi { $component } tanba { $attribute } la konstante.
+
+variant-attribute-not-number = la bele determina variante úniku husi { $component } tanba { $attribute } la'ós númeru.
+
+variant-attribute-wrong-type-for-sequence =
+    la bele determina variante úniku husi { $component } tipu { $type } tanba { $attribute } la'ós { $expected ->
+        [letters-combination] kombinasaun letra
+        [math-expression] espresaun matemátika válidu
+        [integer] númeru inteiru
+       *[number] númeru
+    }.
+
+variant-length-not-integer = la bele determina variante úniku husi { $component } tanba length la'ós númeru inteiru.
+
+variant-sort-not-implemented = variante úniku husi { $component } ho sort seidauk implementa
+
+variant-exclude-combinations-not-implemented = variante úniku husi { $component } ho excludeCombinations seidauk implementa
+
+variant-math-exclude-not-implemented = variante úniku husi { $component } tipu math ho exclude seidauk implementa
+
+variant-non-constant-exclude-not-implemented = variante úniku husi { $component } ho exclude la konstante seidauk implementa
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: la suporta iha renderer prefigure husi graph; soe tiha desendente.
+
+prefigure-descendant-invalid-geometry = { $subject }: jeometria la finitu ka la kompletu; soe tiha desendente.
+
+prefigure-curve-label-omitted = { $subject }: la suporta etiketa iha elementu kurva ne'ebé konverte; la konsidera etiketa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: tipu definisaun funsaun kurva '{ $definitionType }' la suporta; soe tiha desendente.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atributu flipFunctions iha regionBetweenCurves la suporta; soe tiha desendente.
+
+prefigure-region-non-formula-child = { $subject }: oan funsaun tipu formula de'it mak suporta iha regionBetweenCurves; soe tiha desendente.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' la suporta ba { $labelKind ->
+        [line-family] etiketa família liña
+       *[point] etiketa pontu
+    }; uza aliñamentu padraun PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: estilu prenxe '{ $fillStyle }' la suporta husi PreFigure; fila ba prenxe sólidu.
+
+prefigure-line-style-unknown = { $subject }: estilu liña '{ $lineStyle }' la rekoñese, la konsidera iha output PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: estilu marker '{ $markerStyle }' mapea ba estilu 'diamond' husi PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: estilu marker '{ $markerStyle }' la suporta husi PreFigure; uza estilu padraun.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` la válidu; la bele hatudu target. La konsidera annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` hatudu ba target barak; uza target dahuluk.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` la válidu; target iha liur husi graph ne'ebé kaer nia. La konsidera annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` la válidu; target la'ós objetu gráfiku ne'ebé suporta iha konversaun prefigure. La konsidera annotation.
+
+annotation-text-missing = `<annotation>`: `text` la iha ka mamuk; sai testu mamuk.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Hetan dependénsia sirkulár.
+       *[other] Hetan dependénsia sirkulár ne'ebé envolve komponente `<{ $componentType }>`.
+    }
+
+reference-no-referent = La hetan buat ne'ebé referénsia hatudu: `{ $reference }`
+
+reference-multiple-referents = Hetan buat barak ne'ebé referénsia hatudu: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Formatu atributu { $attribute } husi `<{ $componentType }>` la válidu.
+
+children-invalid = Oan husi `<{ $componentType }>` la válidu: hetan oan la válidu: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Valór `{ $value }` la válidu ba atributu `{ $attribute }`, uza valór `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] La hetan versaun DoenetML { $version }.
+       *[other] La hetan versaun DoenetML { $version }. Fila ba versaun { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML la válidu: { $content }
+
+parse-tag-missing-close-tag = DoenetML la válidu: Tag `{ $tag }` laiha tag taka. Hein tag ne'ebé taka an rasik ka tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML la válidu: Iha sala iha tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML la válidu: Atributu `{ $attribute }` la válidu hanesan laiha valór.
+
+parse-attribute-invalid = DoenetML la válidu: Atributu `{ $attribute }` la válidu
+
+parse-attribute-value-invalid = DoenetML la válidu: Valór atributu `{ $value }` la válidu
+
+parse-attribute-value-quote-mismatch = DoenetML la válidu: Valór atributu `{ $value }` la válidu. Marka aspas la hanesan. Hanesan laiha `{ $quote }` ida
+
+parse-open-tag-name-missing = DoenetML la válidu: Hetan tag ida laiha naran, ezemplu `<`
+
+parse-tag-not-closed = DoenetML la válidu: Tag `{ $tag }` la taka (hanesan laiha `>`).
+
+parse-self-closing-tag-name-missing = DoenetML la válidu: Hetan tag ida laiha naran `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML la válidu: Tag `{ $tag }` la taka (hanesan laiha `/>`).
+
+parse-tag-invalid-attributes = DoenetML la válidu: Tag `{ $tag }` la válidu. Karik atributu sira la loos.
+
+parse-close-tag-name-missing = DoenetML la válidu: Hetan tag taka ida laiha naran, ezemplu `</`
+
+parse-attribute-value-unquoted = Valór atributu tenke tau iha aspas laran: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML la válidu: Hetan tag taka `{ $tag }`, maibé laiha tag loke ne'ebé hanesan
+
+parse-close-tag-mismatched = DoenetML la válidu: Tag taka la hanesan. Hein `</{ $expected }>`. Hetan `{ $found }`
+
+parser-node-unconvertible = La bele konverte node { $node } ba node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atributu name='{ $name }' la válidu. { $reason ->
+        [characters] Naran bele iha letra, númeru, traku okos ka traku de'it.
+       *[start] Naran tenke hahú ho letra.
+    }
+
+component-name-invalid-start = Naran komponente "{ $name }" la válidu. Naran tenke hahú ho letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer ho type videoWatched tenke iha atributu video
+
+answer-video-watched-video-not-reference = Answer ho type videoWatched tenke iha atributu video ne'ebé referénsia
+
+answer-name-not-single-text = Atributu name husi answer tenke iha oan text ida de'it
+
+## Referencing another document
+
+external-doenetml-recursion-limit = La bele foti DoenetML husi liur tanba nivel repetisaun barak liu. Iha referénsia sirkulár ka lae?
+
+external-doenetml-unavailable = La bele foti DoenetML husi { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ne'ebé foti husi { $attribute }="{ $uri }" la válidu: nia la hanesan ho tipu komponente "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atributu `{ $from }` la uza ona; uza `{ $to }`.
+       *[other] [deprecation] Atributu `{ $from }` iha `<{ $component }>` la uza ona; uza `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atributu `{ $from }` la uza ona no la konsidera tanba `{ $to }` mós determina ona.
+       *[other] [deprecation] Atributu `{ $from }` iha `<{ $component }>` la uza ona no la konsidera tanba `{ $to }` mós determina ona.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atributu `{ $attribute }` iha `<{ $component }>` la uza ona no la konsidera.
+
+deprecated-attribute-to-child = [deprecation] Atributu `{ $attribute }` iha `<{ $component }>` la uza ona; uza oan `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Valór `{ $value }` husi atributu `{ $attribute }` iha `<{ $component }>` la uza ona; uza `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` bele halo plurál ba lian Inglés de'it, entaun nia testu la muda iha dokumentu ne'ebé hakerek ho { $locale }. Hakerek rasik forma plurál, ka tau ho atributu `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elementu `<{ $tag }>` la'ós elementu Doenet ne'ebé rekoñese.
+
+schema-element-not-allowed-at-root = Elementu `<{ $tag }>` la permite iha abut dokumentu nian.
+
+schema-element-not-allowed-inside = Elementu `<{ $tag }>` la permite iha laran husi `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elementu `<{ $tag }>` laiha atributu ho naran `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atributu `{ $attribute }` husi elementu `<{ $tag }>` tenke lista ida ne'ebé kada item mak ida husi: { $allowed }
+       *[other] Atributu `{ $attribute }` husi elementu `<{ $tag }>` tenke ida husi: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Naran variante la válidu ba select.  Naran variante { $variantName } mosu iha opsaun { $numOptions } maibé númeru atu hili mak { $numToSelect }.
+
+select-variant-name-without-options = Iha variante determinadu ba select maibé laiha opsaun determinadu ba naran variante posivel: { $variantName }.
+
+select-variant-name-not-possible = Naran variante { $variantName } ne'ebé determina ba select la'ós naran variante posivel.
+
+select-too-few-options = La bele hili komponente { $numToSelect } husi { $numOptions } de'it.
+
+select-from-sequence-too-few-values = La bele hili valór { $numToSelect } husi sequence ho naruk { $length }.
+
+select-from-sequence-indices-count-mismatch = Númeru índise ne'ebé determina ba select tenke hanesan ho númeru atu hili
+
+select-from-sequence-indices-not-integers = Índise hotu ne'ebé determina ba select tenke númeru inteiru
+
+select-from-sequence-index-excluded = Índise selectfromsequence ne'ebé determina ne'e hasai ona
+
+select-from-sequence-indices-excluded-combination = Índise selectfromsequence ne'ebé determina ne'e kombinasaun ne'ebé hasai ona
+
+select-from-sequence-coprime-not-positive-integers = La bele hili kombinasaun coprime tanba buat ne'ebé hili la'ós númeru inteiru pozitivu.
+
+select-from-sequence-coprime-common-factor = La bele hili númeru coprime. Valór posivel hotu iha fatór hanesan. (Valór "from" ka "to" ne'ebé determina tenke coprime ho "step".)
+
+select-from-sequence-coprime-single-number = La bele hili kombinasaun coprime husi númeru ida de'it ne'ebé la'ós 1.
+
+select-from-sequence-excluded-too-many-combinations = Hasai liu 70% husi kombinasaun sira iha selectFromSequence
+
+select-from-sequence-coprime-none-found = La bele hili númeru coprime. Valór posivel hotu iha fatór hanesan.
+
+select-from-sequence-too-few-unique-values = La bele hili valór úniku { $numToSelect } husi sequence ho naruk { $numPossibleValues }
+
+select-prime-numbers-too-few-values = La bele hili valór { $numToSelect } husi lista prima ho naruk { $numValues }
+
+select-prime-numbers-values-count-mismatch = Númeru valór ne'ebé determina ba select tenke hanesan ho númeru atu hili
+
+select-prime-numbers-values-not-prime = Valór hotu ne'ebé determina ba select prime number tenke iha lista prima
+
+select-prime-numbers-values-excluded-combination = Valór selectPrimeNumbers ne'ebé determina ne'e kombinasaun ne'ebé hasai ona
+
+select-prime-numbers-excluded-too-many-combinations = Hasai liu 70% husi kombinasaun sira iha selectPrimeNumbers
+
+select-random-combination-fluke = Tanba sorte raru tebes, la bele hili kombinasaun valór randómiku
+
+select-random-value-fluke = Tanba sorte raru tebes, la bele hili valór randómiku

--- a/packages/i18n/locales/tet/editor.ftl
+++ b/packages/i18n/locales/tet/editor.ftl
@@ -1,0 +1,208 @@
+# Tetum editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Written in Tetun Dili; see `chrome.ftl`'s header. Tetum marks no number on the
+# noun, so a `{ $count -> … }` whose two English branches differ only in the
+# noun renders one string here and the select is dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Fila fali
+       *[update] Atualiza
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } vizualizadór
+       *[other] { $word } vizualizadór { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Variante
+editor-variant-filter = Filtra…
+editor-variant-next = Hili variante tuirmai
+editor-variant-previous = Hili variante uluk
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Hetan violasaun asesibilidade WCAG AA. Klik atu { $action ->
+            [close] taka
+           *[open] loke
+        } relatóriu asesibilidade.
+        [advisories] Klik atu { $action ->
+            [close] taka
+           *[open] loke
+        } relatóriu asesibilidade. La hetan violasaun WCAG AA ida, maibé iha rekomendasaun asesibilidade seluk.
+       *[clean] Klik atu { $action ->
+            [close] taka
+           *[open] loke
+        } relatóriu asesibilidade. La hetan problema asesibilidade ida.
+    }
+
+# No select on `$count` inside the branches: «violasaun» and «rekomendasaun»
+# are the same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Hetan violasaun asesibilidade WCAG AA. Hetan violasaun WCAG AA { $count }. Klik atu { $action ->
+            [close] taka
+           *[open] loke
+        } relatóriu asesibilidade.
+        [advisories] La hetan violasaun WCAG AA ida. Hetan rekomendasaun asesibilidade seluk { $count }. Klik atu { $action ->
+            [close] taka
+           *[open] loke
+        } relatóriu asesibilidade.
+       *[clean] La hetan violasaun WCAG AA ida. Klik atu { $action ->
+            [close] taka
+           *[open] loke
+        } relatóriu asesibilidade.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Versaun DoenetML { $version }
+
+editor-tab-help = Ajuda tuir kontestu
+editor-tab-help-short = Kontestu
+editor-tab-errors = Sala
+editor-tab-warnings = Avizu
+editor-tab-info = Informasaun
+editor-tab-accessibility = Asesibilidade
+editor-tab-responses = Resposta ne'ebé haruka ona
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Opsaun editór
+editor-format-as-doenetml = Formata nu'udar DoenetML
+editor-format-as-xml = Formata nu'udar XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Liña #{ $line }
+
+editor-no-errors = Laiha sala
+editor-no-warnings = Laiha avizu
+editor-no-info = Laiha diagnóstiku informasaun
+
+editor-show-info-annotations = Hatudu diagnóstiku informasaun iha editór
+editor-show-accessibility-annotations = Hatudu diagnóstiku asesibilidade iha editór
+
+editor-accessibility-learn-more = Aprende oinsá Doenet hala'o asesibilidade
+
+editor-accessibility-violations-heading = Violasaun asesibilidade ({ $standard })
+
+editor-accessibility-other-heading = Problema asesibilidade seluk
+editor-none-found = La hetan ida
+
+
+## Submitted responses
+
+editor-no-responses = Seidauk iha resposta ne'ebé haruka
+editor-response-answer-id = Id resposta
+editor-response-response = Resposta
+editor-response-credit = Kréditu
+editor-response-submitted = Haruka ona
+
+
+## The context-help panel
+
+help-placeholder = Tau kursór iha naran tag, atributu, ka { $ref } ba dokumentasaun.
+
+help-unsupported-ref-chain = Ajuda ba referénsia ho parte barak hanesan { $example } seidauk suporta.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] La hetan buat ne'ebé referénsia hatudu: { $ref }.
+        [multiple] Hetan buat barak ne'ebé referénsia hatudu: { $ref }.
+       *[indeterminate] La bele determina buat ne'ebé { $ref } hatudu.
+    }
+
+help-learn-about-references = Aprende kona-ba referénsia →
+help-reference-page = Pájina referénsia →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Iha laran { $element }
+       *[top] Iha nivel aas liu
+    }{ $allowed ->
+        [none] { " — laiha buat ida bele tau iha ne'e." }
+        [text] { " — hakerek testu iha ne'e." }
+        [text-and-components] { " — hakerek testu iha ne'e, ka koko:" }
+       *[components] { " — buat sira ne'ebé bele koko:" }
+    }
+
+help-suggestions-footer = Hanehan { $shortcut } atu haree komponente { $total } hotu.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } mak referénsia ba { $target }.
+       *[other] { $ref } mak referénsia ba { $target } (liña { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Lori husi { $owner } nu'udar { $role }.
+       *[other] Lori husi { $owner } iha liña { $line } nu'udar { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } mak referénsia ba propriedade { $property } husi { $element }.
+       *[other] { $ref } mak referénsia ba propriedade { $property } husi { $element } (liña { $line }).
+    }
+
+help-kind-attribute = atributu
+help-kind-snippet = kódigu badak
+help-kind-array-entry = entrada array
+
+help-default = Padraun:
+help-active-default = Padraun ativu:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valór ne'ebé permite (ida ba kada item):
+       *[other] Valór ne'ebé permite:
+    }
+
+help-suggested-values = Valór ne'ebé sujere:
+
+help-inserts = Tau tama:
+
+# No select: «koordenada» is the same word for one and for many.
+help-coordinates = Koordenada:
+
+help-type = Tipu:
+
+help-resolved-style = Estilu ne'ebé determina ona (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Naran funsaun ne'ebé determina ona:
+help-reset-list = Lista reset iha input ne'e:
+help-added-on-input = Tau tan iha input ne'e:
+help-removed-on-input = Hasai iha input ne'e:
+
+help-reset-overrides = { $reset } troka { $additional } no { $removed }.

--- a/packages/i18n/locales/to/chrome.ftl
+++ b/packages/i18n/locales/to/chrome.ftl
@@ -1,0 +1,146 @@
+# Tongan viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# **Two marks carry meaning and both are written here.** The glottal stop is the
+# *fakauʻa* «ʻ» — U+02BB MODIFIER LETTER TURNED COMMA, a letter of the alphabet,
+# never U+0027 or a typographic quote — and vowel length is the *toloi*, the
+# macron, «ā ē ī ō ū». Both distinguish words, so a corrector who replaces a
+# fakauʻa with an apostrophe is changing the spelling of the word: the two
+# render alike and compare unequal, which is the trap `locales/yi` records for
+# its own digraphs.
+#
+# Tongan marks no number on the noun — plurality is «ʻu» or «ngaahi» before it,
+# and a numeral does not take them — so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped. A `[0]` branch stays wherever English has one.
+
+
+## Answer submission
+
+answer-checking = ʻOku sivi…
+answer-submitting = ʻOku ʻave…
+
+answer-checking-status = ʻOku sivi ʻa e tali
+answer-submitting-status = ʻOku ʻave ʻa e tali
+
+answer-correct = Totonu
+answer-incorrect = Hala
+
+answer-response-saved = Kuo tauhi ʻa e tali
+
+answer-percent-credit = { $percent }% ʻo e mataʻitohi
+answer-percent-correct = { $percent }% totonu
+answer-percent-short = { $percent } %
+
+max-credit-available = Mataʻitohi lahi taha ʻe lava ʻo maʻu: { $percent }%
+
+# No select: «feinga» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] ʻoku ʻikai toe ʻi ai ha feinga
+       *[other] ʻoku toe ʻi ai ʻa e feinga ʻe { $count }
+    }
+
+validation-correct = (Totonu)
+validation-incorrect = (Hala)
+validation-partially-correct = (Totonu fakakonga)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Fakahā ʻa e tali ʻe { $count } ki he { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Fakamatala
+
+collapsible-click-to-open = (lomiʻi ke fakaava)
+collapsible-click-to-close = (lomiʻi ke tāpuni)
+
+collapsible-initializing = ʻOku kamata…
+
+footnote-show = Fakahā ʻa e footnote
+footnote-hide = Fufū ʻa e footnote
+
+description-more-information = fakamatala lahi ange
+
+
+## Controls
+
+slider-previous = Kimuʻa
+slider-next = Hoko
+
+keyboard-open = Fakaava ʻa e kīpoti
+keyboard-close = Tāpuni ʻa e kīpoti
+
+choice-input-remove-choice = Toʻo ʻa e { $choice }
+
+matrix-remove-row = Toʻo ʻa e laine
+matrix-add-row = Tānaki ha laine
+matrix-remove-column = Toʻo ʻa e kolomu
+matrix-add-column = Tānaki ha kolomu
+
+subset-add-remove-points = Tānaki/Toʻo ʻa e ngaahi poini
+subset-toggle-points-intervals = Liliu ʻa e ngaahi poini mo e vahaʻa
+subset-move-points = Hiki ʻa e ngaahi poini
+subset-clear = Fakamaʻa
+
+orbital-add-row = Tānaki ha laine
+orbital-remove-row = Toʻo ʻa e laine
+orbital-add-box = Tānaki ha puha
+orbital-remove-box = Toʻo ʻa e puha
+orbital-add-up-arrow = Tānaki ha ngahau ki ʻolunga
+orbital-add-down-arrow = Tānaki ha ngahau ki lalo
+orbital-remove-arrow = Toʻo ʻa e ngahau
+
+orbital-row-label = Fakaʻilonga ki he laine { $row }
+
+pretzel-answer = Tali
+
+summary-statistics-caption = Fakanounou fakafuainoa ʻo e { $column }
+
+
+## Math input
+
+math-input-preview-region = fakahā muʻa ʻo e fakamatala fika
+math-input-preview = Fakahā muʻa
+math-input-invalid-expression = Fakamatala fika taʻetotonu:
+
+
+## Document status
+
+viewer-initializing = ʻOku kamata…
+
+
+## Errors
+
+error-heading = Hala
+
+error-found-at =
+    { $span ->
+        [line] Naʻe maʻu ʻi he laine { $startLine }.
+       *[lines] Naʻe maʻu ʻi he ngaahi laine { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = ʻOku ʻi ai ha hala ʻi he pepa ni!
+
+diagnostic-heading-error = Hala
+diagnostic-heading-warning = Fakatokanga
+diagnostic-heading-information = Fakamatala
+diagnostic-heading-hint = Fakahinohino
+
+accessibility-heading-level-1 = Maumauʻi ʻo e aʻusia WCAG AA
+accessibility-heading-level-2 = Fakatokanga fekauʻaki mo e aʻusia
+
+something-went-wrong = Naʻe ʻi ai ha meʻa naʻe hala.
+
+renderer-load-failed = naʻe ʻikai lava ʻo hū mai ha renderer. Kātaki ʻo toe fakaake ʻa e peesi.
+
+core-start-failed = Naʻe ʻikai lava ʻo kamata ʻa e mata sio ki he pepa. Kātaki ʻo toe fakaake ʻa e peesi.

--- a/packages/i18n/locales/to/content.ftl
+++ b/packages/i18n/locales/to/content.ftl
@@ -1,0 +1,261 @@
+# Tongan content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# The fakauʻa «ʻ» is U+02BB and the toloi is the macron; see `chrome.ftl`.
+#
+# Tongan has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «laine kulokula», a red line — so every
+# composition message inverts the English order, as the other two Polynesian
+# catalogs in this batch do.
+#
+# **The colour table is where Tongan does not fit English's twelve keys**, and
+# it fails to fit in the way a great many Pacific languages do: «lanu» plus a
+# thing of that colour is the productive pattern, so blue is «lanumoana», the
+# colour of the deep sea, and green is «lanumata», the colour of raw or unripe
+# growth. Those two are not translations of "blue" and "green" — they are the
+# sea and the leaf, and the boundary between them falls where the sea meets the
+# land rather than where English puts it. `.cyan` is the key with no answer at
+# all: it lands inside «lanumoana» with nothing to distinguish it, and the
+# transliteration written here is a placeholder a speaker should replace or
+# delete. `.purple` and `.pink` are loans, which is what Tongan writing uses.
+#
+# The geometry vocabulary is a mixture: the shapes Tongan names itself
+# («fuopotopoto», «tapatolu») are its own, and the terms schooling introduced
+# are transliterations, because secondary mathematics in Tonga is taught in
+# English.
+
+
+## Style vocabulary
+
+color =
+    .black = ʻuliʻuli
+    .white = hinehina
+    .gray = efuefu
+    .red = kulokula
+    .orange = moli
+    .yellow = engeenga
+    .green = lanumata
+    .cyan = saiane
+    .blue = lanumoana
+    .purple = vaioleti
+    .pink = pingi
+    .brown = melo
+
+line-width =
+    .thick = matolu
+    .thin = manifinifi
+
+line-style =
+    .dashed = motumotu
+    .dotted = tuʻitongi
+
+# Noun phrases. Tongan marks no plural on the noun, so «laine» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = laine fakatokalalo
+    .vertical = laine fakatuʻu
+    .diagonal = laine fakahekeheke
+    .backdiagonal = laine fakahekeheke fakafoki
+    .dots = tongi
+    .diamonds = taimane
+
+noun =
+    .line = laine
+    .line-segment = konga laine
+    .ray = huelo
+    .vector = veketā
+    .curve = pikopiko
+    .function = ngāue fika
+    .parabola = palapola
+    .polyline = laine tuʻo lahi
+    .polygon = polikoni
+    .triangle = tapatolu
+    .rectangle = tapafā loloa
+    .circle = fuopotopoto
+    .region = feituʻu
+    .point = poini
+    .square = sikuea
+    .diamond = taimane
+    .cross = kolosi
+    .plus = tānaki
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] ʻoku tapa { $numSides }
+       *[head] polikoni tatau
+    }
+
+# One answer for every noun: Tongan has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = fonu
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } mo e { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } mo e { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } mo e { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Tongan's article is «ha» for an indefinite and «e» for a definite, and neither
+# is what English's "a" is doing here, so all four branches read alike but for
+# the connective: «mo e» opens the first clause and «pea mo e» a further one.
+style-border-clause =
+    { $parts ->
+        [with-article] mo e kapa { $border }
+        [and] pea mo e kapa { $border }
+        [and-article] pea mo e kapa { $border }
+       *[with] mo e kapa { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = taʻefonu
+
+style-text =
+    { $parts ->
+        [background] { $color } mo e tuʻunga { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ʻikai ha taha
+
+
+## Boolean words
+
+boolean-true = moʻoni
+boolean-false = loi
+
+
+## Answer buttons
+
+answer-submit-label = Sivi ʻa e ngāue
+answer-submit-label-no-correctness = ʻAve ʻa e tali
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Tongan marks no plural on the noun.
+section-name =
+    .activity = Ngāue
+    .aside = Fakamatala tafaʻaki
+    .cascade = Kasikeiti
+    .definition = Fakamatala
+    .example = Fakatātā
+    .exercise = Ngāue fakaako
+    .exercises = Ngāue fakaako
+    .given-answer = Tali
+    .note = Nouti
+    .objectives = Taumuʻa
+    .paragraphs = Palakalafa
+    .part = Konga
+    .problem = Palopalema
+    .problems = Palopalema
+    .proof = Fakamoʻoni
+    .question = Fehuʻi
+    .section = Vahe
+    .solution = Fakalelei
+    .task = Ngāue
+    .theorem = Tioleme
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Fakahinohino
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tēpile { $enumeration }
+        [numbered-title] Tēpile { $enumeration }{ ": " }
+        [unnumbered-title] Tēpile{ ": " }
+       *[unnumbered] Tēpile
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Fakatātā { $enumeration }
+        [numbered-caption] Fakatātā { $enumeration }{ ": " }
+        [unnumbered-caption] Fakatātā{ ": " }
+       *[unnumbered] Fakatātā
+    }
+
+
+## Paginator controls
+
+paginator-previous = Kimuʻa
+paginator-next = Hoko
+paginator-page = Peesi
+
+paginator-page-status = { $pageLabel } { $currentPage } ʻo e { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = pe
+piecewise-condition-if = kapau
+piecewise-condition-otherwise = kapau ʻoku ʻikai
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Tonga teaches secondary science in English, and Tongan has no
+## settled list of all 118 to seed from — the Samoan and Hawaiian case in
+## `locales/sm` and `locales/haw`, and for the same reason: what exists is
+## everyday vocabulary for the substances known long before the elements were,
+## not a table.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Fakaʻilonga kemikale taʻetotonu
+chemistry-invalid-ionic-compound = Fefiofi ʻaioniki taʻetotonu

--- a/packages/i18n/locales/to/content.ftl
+++ b/packages/i18n/locales/to/content.ftl
@@ -10,8 +10,8 @@
 # token for every noun and nothing here selects on `$gender` or on `$role`.
 #
 # The adjectives **follow** the noun — «laine kulokula», a red line — so every
-# composition message inverts the English order, as the other two Polynesian
-# catalogs in this batch do.
+# composition message inverts the English order, as `locales/ty` and
+# `locales/fj` do.
 #
 # **The colour table is where Tongan does not fit English's twelve keys**, and
 # it fails to fit in the way a great many Pacific languages do: «lanu» plus a

--- a/packages/i18n/locales/to/diagnostics.ftl
+++ b/packages/i18n/locales/to/diagnostics.ftl
@@ -1,0 +1,625 @@
+# Tongan diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The fakauʻa «ʻ» is U+02BB and the toloi is the macron; see `chrome.ftl`.
+# Tongan marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped.
+
+
+## `<lineSegment>`
+
+# No select: «taʻetokangaʻi» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = ʻoku taʻetokangaʻi ʻa e { $attributes } ʻi he taimi kuo pau ai ʻa e ngataʻanga ʻe ua
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ʻoku taʻetokangaʻi ʻa e { $attributes } ʻi he taimi kuo pau ai ʻa e ngataʻanga ʻe taha mo e lotolotonga
+
+line-segment-midpoint-offset-without-midpoint = ʻoku ʻikai ha ola ʻo e midpointOffset ʻo kapau ʻoku ʻikai ha lotolotonga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Laine ʻoku ʻalu ʻi ha ngaahi poini ʻoku ʻikai ʻiloa honau ngaahi fua.
+
+line-points-too-few-dimensions = Kuo pau ke ʻalu ʻa e laine ʻi ha ngaahi poini ʻoku fua ʻe ua pe lahi ange.
+
+line-points-depend-on-variables = ʻOku ʻalu ʻa e laine ʻi ha ngaahi poini ʻoku fakatuʻunga ki he ngaahi fetongi: { $variables }.
+
+line-equation-invalid-format = Fakafuofua taʻetotonu ki he laine ʻi he fetongi { $variable1 } mo e { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = ʻOku fakapapauʻi ʻa e huelo ʻe he through, endpoint mo e direction.  ʻOku taʻetokangaʻi ʻa e through kuo fakapapauʻi.
+
+ray-dimension-mismatch = ʻoku ʻikai fetaulaki ʻa e numDimensions ʻi he huelo.
+
+## `<vector>`
+
+vector-overprescribed-head = ʻOku fakapapauʻi ʻa e veketā ʻe he head, tail mo e displacement.  ʻOku taʻetokangaʻi ʻa e head kuo fakapapauʻi.
+
+vector-dimension-mismatch = ʻoku ʻikai fetaulaki ʻa e numDimensions ʻi he veketā.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = ʻE ʻikai lava ke toho ki ha `<{ $component }>` he ʻoku ʻikai haʻane fetongi tuʻunga nearestPoint.
+
+constrain-to-without-nearest-point = ʻE ʻikai lava ke fakangatangata ki ha `<{ $component }>` he ʻoku ʻikai haʻane fetongi tuʻunga nearestPoint.
+
+constrain-to-interior-without-nearest-point = ʻE ʻikai lava ke fakangatangata ki loto ʻi ha `<{ $component }>` he ʻoku ʻikai haʻane fetongi tuʻunga nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ʻoku taʻetokangaʻi ʻa e labelPosition ki ha choiceInput ʻoku ʻikai inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = ʻOku taʻetokangaʻi ʻa e ngaahi index ki he choiceInput he ʻoku ʻikai fetaulaki ʻa e lau ʻo e index mo e lau ʻo e ngaahi fili.
+
+pretzel-indices-count-mismatch = ʻOku taʻetokangaʻi ʻa e ngaahi index ki he problem he ʻoku ʻikai fetaulaki ʻa e lau ʻo e index mo e lau ʻo e ngaahi problem.
+
+shuffle-indices-count-mismatch = ʻOku taʻetokangaʻi ʻa e ngaahi index ki he shuffle he ʻoku ʻikai fetaulaki ʻa e lau ʻo e index mo e lau ʻo e ngaahi konga.
+
+indices-ignored-out-of-range = ʻOku taʻetokangaʻi ʻa e ngaahi index ki he { $component } he ʻoku ʻi ai ha index ʻoku ʻalu ʻi tuʻa.
+
+pretzel-indices-repeated = ʻOku taʻetokangaʻi ʻa e ngaahi index ki he pretzel he ʻoku ʻi ai ha index kuo toe fai.
+
+pretzel-circuit-first-index = ʻOku taʻetokangaʻi ʻa e ngaahi index ki he pretzel ʻi he mode circuit he kuo pau ke 1 ʻa e index ʻuluaki.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ke ngāue ʻa e `<{ $component }>` mo e ngaahi fānau string, kuo pau ke fakapapauʻi ʻa e ʻatilipiuti `type`.
+
+invalid-type-defaulting-to-math = Ko e type { $type } ʻoku taʻetotonu ki he konga { $component }. Kuo pau ke taha ʻi he math, text, number, pe boolean. ʻOku ngāueʻaki ʻa e math.
+
+string-not-valid-component-to-arrange = Ko e string "{ $value }" ʻoku ʻikai ko ha konga totonu ki he { $component }. ʻOku taʻetokangaʻi.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Ko e type { $type } ʻoku taʻetotonu, ʻoku fokotuʻu ʻa e type ki he number.
+
+invalid-variable-value = Mahuʻinga taʻetotonu ʻo ha fetongi: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Kuo pau ke fika ʻa e index ʻo e kehekehe { $index }
+
+variant-index-must-be-integer = Kuo pau ke fika kakato ʻa e index ʻo e kehekehe { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = ʻOku teʻeki fakahoko ʻa e `<{ $component }>` ki he fua fakapapau. ʻOku fokotuʻu ʻa e maokupu ki he fakatatau.
+
+side-by-side-absolute-margins = ʻOku teʻeki fakahoko ʻa e `<{ $component }>` ki he fua fakapapau. ʻOku fokotuʻu ʻa e kapa ki he fakatatau.
+
+side-by-side-no-block-child = Ko e `<{ $component }>` taʻetotonu: kuo pau ke ʻi ai haʻane fānau block ʻe taha.
+
+## `<label>`
+
+label-for-ignored-on-graphical = ʻOku taʻetokangaʻi ʻa e ʻatilipiuti `for` ʻi ha `<label>` fakatātā.
+
+label-for-must-resolve-to-one = Kuo pau ke tuhu ʻa e ʻatilipiuti `for` ʻi he `<label>` ki ha konga pē ʻe taha.
+
+label-for-unresolved = Naʻe ʻikai lava ʻa e ʻatilipiuti `for` ʻi he `<label>` ke tuhu ki ha konga.
+
+label-for-answer-with-authored-inputs = ʻOku tuhu ʻa e ʻatilipiuti `for` ʻi he `<label>` ki ha `<answer>` ʻoku ʻi ai ha input naʻe tohi ʻe he tokotaha fatu; tuhu terus ki he input.
+
+label-for-answer-without-input = ʻOku tuhu ʻa e ʻatilipiuti `for` ʻi he `<label>` ki ha `<answer>` ʻoku ʻikai haʻane input ke fakaʻilongaʻi.
+
+label-for-must-reference-input-or-answer = Kuo pau ke tuhu ʻa e ʻatilipiuti `for` ʻi he `<label>` ki ha input pe ki ha answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ki he aʻusia, kuo pau ke ʻi ai ha fakamatala nounou ʻa e `<{ $component }>` pe ke fakapapauʻi ko e teuteu.
+
+accessibility-video-short-description = Ki he aʻusia, kuo pau ke ʻi ai ha fakamatala nounou ʻa e `<video>`.
+
+accessibility-input-short-description-or-label = Ki he aʻusia, kuo pau ke ʻi ai ha fakamatala nounou pe fakaʻilonga ʻa e `<{ $component }>`.
+
+accessibility-answer-input-short-description-or-label = Ki he aʻusia, kuo pau ke ʻi ai ha fakamatala nounou pe fakaʻilonga ʻa ha `<answer>` ʻoku ne fakatupu ha input.
+
+accessibility-short-description-contains-math = ʻOku ʻikai totonu ke ʻi ai ha konga fika hangē ko e `<{ $component }>` ʻi ha fakamatala nounou. Tohi ʻa e fika ʻaki ʻa e ngaahi lea.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] ʻOku ʻikai feʻunga ʻa e faikehekehe ʻo e { $colorName } ki he tohi ʻo e kaveinga vahe (mode fakapoʻuli) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ʻoku fiemaʻu ʻa e { $threshold }:1 pe lahi ange).
+       *[other] ʻOku ʻikai feʻunga ʻa e faikehekehe ʻo e { $colorName } ki he tohi ʻo e kaveinga vahe ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ʻoku fiemaʻu ʻa e { $threshold }:1 pe lahi ange).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = ʻOku teʻeki fakahoko ʻa e `<circle>` ʻoku ʻalu ʻi he poini ʻe { $count } ʻo kapau ʻoku ʻikai ha mahuʻinga fika ʻa e ngaahi poini.
+
+circle-too-many-through-points = ʻE ʻikai lava ke fika ha fuopotopoto ʻoku ʻalu ʻi ha poini lahi hake ʻi he 3.
+
+circle-overprescribed-radius-center-points = ʻE ʻikai lava ke fika ha fuopotopoto ʻoku fakapapauʻi hono lahi, hono loto mo e ngaahi poini ʻoku ʻalu ai.
+
+circle-center-with-multiple-points = ʻE ʻikai lava ke fika ha fuopotopoto ʻoku fakapapauʻi hono loto ka ʻoku ʻalu ʻi ha poini lahi hake ʻi he 1.
+
+circle-radius-too-small = ʻE ʻikai lava ke fika ʻa e fuopotopoto: koeʻuhi ko e mamaʻo ʻo e poini ʻe ua ko e { $distance }, ʻoku siʻi fau ʻa e lahi { $radius } kuo fakapapauʻi.
+
+circle-radius-with-many-points = ʻE ʻikai lava ke fakatupu ha fuopotopoto ʻoku ʻalu ʻi ha poini lahi hake ʻi he ua mo ha lahi kuo fakapapauʻi.
+
+circle-invalid-center-or-through-points = ʻOku taʻetotonu ʻa e loto pe ko e ngaahi poini ʻoku ʻalu ai ʻa e fuopotopoto.
+
+circle-radius-center-with-multiple-points = ʻE ʻikai lava ke fika ʻa e lahi ʻo ha fuopotopoto ʻoku fakapapauʻi hono loto ka ʻoku ʻalu ʻi ha poini lahi hake ʻi he 1.
+
+circle-change-radius-non-numerical = ʻE ʻikai lava ke liliu ʻa e lahi ʻo ha fuopotopoto ʻoku ʻalu ʻi ha ngaahi poini taʻefika
+
+circle-radius-with-points-non-numerical = ʻE ʻikai lava ke fakatupu ha fuopotopoto ʻoku ʻalu ʻi ha poini lahi hake ʻi he taha mo ha lahi kuo fakapapauʻi ʻo kapau ʻoku ʻikai ha mahuʻinga fika.
+
+circle-change-center-non-numerical = ʻOku teʻeki fakahoko ʻa e liliu ʻo e loto ʻo ha fuopotopoto ʻoku ʻalu ʻi ha ngaahi poini ʻoku ʻikai haʻanau mahuʻinga fika.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Tongan has one, because
+# «vahaʻa» and «input» do not change for number. Both selects are dropped and
+# both counts still arrive.
+function-domain-insufficient-dimensions = ʻOku ʻikai feʻunga ʻa e fua ʻo e domain ki he ngāue fika. ʻOku ʻi he domain ʻa e vahaʻa ʻe { $intervals } ka ʻoku ʻi he ngāue fika ʻa e input ʻe { $inputs }.
+
+function-domain-invalid-format = Fakafuofua taʻetotonu ʻo e domain ki he ngāue fika.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] ʻOku taʻetokangaʻi ʻa e lahi taha taʻefika ʻo e ngāue fika.
+        [minimum] ʻOku taʻetokangaʻi ʻa e siʻi taha taʻefika ʻo e ngāue fika.
+        [extremum] ʻOku taʻetokangaʻi ʻa e ngataʻanga taʻefika ʻo e ngāue fika.
+        [point] ʻOku taʻetokangaʻi ʻa e poini taʻefika ʻo e ngāue fika.
+        [slope] ʻOku taʻetokangaʻi ʻa e hekeheke taʻefika ʻo e ngāue fika.
+       *[other] ʻOku taʻetokangaʻi ʻa e { $type } taʻefika ʻo e ngāue fika.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] ʻOku taʻetokangaʻi ʻa e lahi taha maha ʻo e ngāue fika.
+        [minimum] ʻOku taʻetokangaʻi ʻa e siʻi taha maha ʻo e ngāue fika.
+        [extremum] ʻOku taʻetokangaʻi ʻa e ngataʻanga maha ʻo e ngāue fika.
+        [point] ʻOku taʻetokangaʻi ʻa e poini maha ʻo e ngāue fika.
+       *[other] ʻOku taʻetokangaʻi ʻa e { $type } maha ʻo e ngāue fika.
+    }
+
+function-points-too-close = ʻOku ʻi he ngāue fika ha poini ʻe ua ʻoku ofi fau. ʻE ʻikai lava ke fakamatalaʻi ʻa e ngāue fika.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = ʻE lava pē ʻa e toe fai ʻo e ngāue fika ʻo kapau ʻoku tatau ʻa e lau ʻo e input mo e lau ʻo e output. ʻOku ʻi he ngāue fika ko ʻeni ʻa e input ʻe { $inputs } mo e output ʻe { $outputs }.
+
+## `<sequence>`
+
+sequence-invalid-length = Loloa taʻetotonu ʻo e sequence.  Kuo pau ke fika kakato taʻefakafuofua siʻi hifo ʻi he noa.
+
+sequence-invalid-step = step taʻetotonu ʻo e sequence.  Kuo pau ke fika ki ha sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" taʻetotonu ʻo ha sequence fika.  Kuo pau ke fika.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" taʻetotonu ʻo ha sequence mataʻitohi.  Kuo pau ke ko ha fakataha mataʻitohi.
+
+sequence-invalid-endpoint = "{ $attribute }" taʻetotonu ʻo e sequence.
+
+select-from-sequence-coprime-not-numbers = ʻoku taʻetokangaʻi ʻa e coprime he ʻoku ʻikai ko ha fika ʻoku fili
+
+select-from-sequence-coprime-with-exclude-combinations = ʻoku taʻetokangaʻi ʻa e coprime he kuo fakapapauʻi ʻa e excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = target taʻetotonu ki he `<{ $source }>`: ʻoku ʻikai maʻu ʻa e target.
+
+target-state-variable-not-found = target taʻetotonu ki he `<{ $source }>`: ʻoku ʻikai maʻu ha fetongi tuʻunga ko hono hingoa "{ $property }" ʻi ha `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Kuo pau ke kehe ʻa e ngaahi fetongi ʻo e `<odeSystem>` mei he fetongi tauʻatāina.
+
+ode-system-duplicate-variable-names = ʻE ʻikai lava ke fakamatalaʻi ʻa e ngaahi ngāue RHS ʻo e ODE ʻoku tatau honau hingoa fetongi.
+
+ode-system-rhs-function-error = ʻE ʻikai lava ke fakamatalaʻi ʻa e ngāue RHS ʻo e ODE.  Naʻe hala ʻa e fakatupu ʻo e ngāue mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = ʻE ʻikai lava ke fakamatalaʻi ha tuliki ʻi he vahaʻa ʻo e laine ʻe { $count }
+
+angle-invalid-through-point = Poini taʻetotonu ʻi he through ʻo e `<angle>`
+
+parabola-vertex-too-many-points = ʻOku teʻeki fakahoko ʻa e palapola ʻoku ʻi ai hono tumutumu ka ʻoku ʻalu ʻi ha poini lahi hake ʻi he 1.
+
+parabola-too-many-points = ʻOku teʻeki fakahoko ʻa e palapola ʻoku ʻalu ʻi ha poini lahi hake ʻi he 3.
+
+intersection-too-many-items = ʻOku teʻeki fakahoko ʻa e fetaulakiʻanga ki ha meʻa lahi hake ʻi he ua
+
+## Other math components
+
+ionic-compound-not-two-ions = ʻOku teʻeki fakahoko ʻa e fefiofi ʻaioniki ki ha meʻa kehe mei he ʻaione ʻe ua.
+
+ionic-compound-needs-cation-and-anion = Naʻe fakahoko pē ʻa e fefiofi ʻaioniki ki ha katione ʻe taha mo ha ʻanione ʻe taha.
+
+solve-equations-cannot-evaluate = ʻE ʻikai lava ke solova ʻa e fakafuofua he naʻe ʻikai lava ke sivi: { $equation }
+
+math-operators-operand-number-required = Kuo pau ke fakapapauʻi ʻa e operandNumber ʻi he taimi ʻoku toʻo ai ha operand fika.
+
+eigen-decomposition-failed = Naʻe ʻikai lava ke fika ʻa e eigenvalue ʻo e matiliki
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: ʻoku ʻikai hā ʻa e parameter { $parameters } ʻi he pattern, ko ia ʻe fetaulaki maʻu pē ia mo ha maha.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ʻoku ʻikai mahino ʻa e grid="{ $grid }". Kuo pau ke none, medium, dense, pe ko ha fika lelei ʻe ua kuo vaheʻi ʻaki ha vā, hangē ko e grid="1 0.5". ʻOku ʻikai ha grid ʻoku tā.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: ʻoku ʻikai poupouʻi ʻa e xLabelPosition="left" ʻi he renderer prefigure; ʻoku ngāueʻaki ʻa e tuʻunga ʻo e potu toʻomataʻu.
+
+prefigure-y-label-position-unsupported = `<graph>`: ʻoku ʻikai poupouʻi ʻa e yLabelPosition="bottom" ʻi he renderer prefigure; ʻoku ngāueʻaki ʻa e tuʻunga ʻo e potu ʻi ʻolunga.
+
+prefigure-invalid-axis-bounds = `<graph>`: ngataʻanga taʻetotonu ʻo e ʻakisi ki he liliu prefigure; ʻoku ngāueʻaki ʻa e bbox angamaheni (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: maokupu taʻetotonu ki he liliu prefigure; ʻoku ngāueʻaki ʻa e maokupu angamaheni 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio taʻetotonu ki he liliu prefigure; ʻoku ngāueʻaki ʻa e aspect ratio angamaheni 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: ʻoku ofi fau ʻa e vā ʻo e grid ki he ngataʻanga ʻo e ʻakisi; ʻoku ʻikai tā ʻa e grid ʻi he renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: ʻe ʻikai tā ʻa e annotation ʻo kapau ʻoku ʻikai ngāueʻaki ʻa e renderer PreFigure.
+
+multiple-annotations-children = Naʻe maʻu ha fānau `<annotations>` lahi ʻi he `<graph>`; ʻoku taʻetokangaʻi kotoa tuku kehe ʻa e ki mui taha.
+
+## Referring to other components
+
+copy-unrecognized-component-type = ʻE ʻikai lava ke fakalahi pe hiki ha faʻahinga konga ʻoku ʻikai ʻiloa: { $type }.
+
+copy-prop-not-found = Naʻe ʻikai maʻu ʻa e prop { $property } ʻi ha konga faʻahinga { $component }
+
+collect-no-source = Naʻe ʻikai maʻu ha source ki he collect.
+
+collect-invalid-component-type = ʻE ʻikai lava ke tānaki ʻa e ngaahi konga faʻahinga `<{ $component }>` he ʻoku taʻetotonu ʻa e faʻahinga konga.
+
+reference-index-unavailable = ʻE ʻikai lava ke fakasino ki he index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = ʻE ʻikai lava ke ui ʻa e { $action } ʻi he konga `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = ʻOku taʻetotonu ʻa e anga ʻo e ngaahi fakamatala.  ʻOku ʻikai tatau ʻa e loloa ʻo e ngaahi laine. Naʻe maʻu ʻi he componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = ʻOku ʻi he fakamatala ha hingoa kolomu tatau.  Naʻe maʻu ʻi he componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = ʻOku ʻikai ha hingoa ʻo ha kolomu ʻi he fakamatala.  Naʻe maʻu ʻi he componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ʻOku fakatuʻunga ʻa e award ʻo e tali ni ki he tali ʻa e answer tag tonu, pea ʻe iku ia ki ha ʻulungaanga taʻeʻamanekina.
+
+answer-max-num-attempts-in-section-wide-check-work = ʻOku ʻikai ha ola ʻo hono fokotuʻu ʻo e `maxNumAttempts` ʻi ha `<answer>` ʻoku ʻi loto ʻi ha kato ʻoku ʻi ai ʻa e `sectionWideCheckWork`, he ko e kato ia ʻoku ne puleʻi ʻa e lau ʻo e feinga. Fokotuʻu ʻa e `maxNumAttempts` ʻi he kato.
+
+nested-section-wide-check-work-max-num-attempts = ʻOku ʻikai ha ola ʻo hono fokotuʻu ʻo e `maxNumAttempts` ʻi ha kato ʻoku ʻi ai ʻa e `sectionWideCheckWork` pea ʻoku ʻi loto ia ʻi ha kato kehe ʻoku ʻi ai ʻa e `sectionWideCheckWork`, he ko e kato ʻi tuʻa ia ʻoku ne puleʻi ʻa e lau ʻo e feinga. Fokotuʻu ʻa e `maxNumAttempts` ʻi he kato ʻi tuʻa.
+
+# No select: «ʻatilipiuti» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = ʻE ʻikai ha ola ʻo e ʻatilipiuti { $attributes } ʻo kapau ʻoku ʻikai fokotuʻu ʻa e symbolicEquality.
+
+answer-invalid-type = Faʻahinga taʻetotonu ki he tali: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Koeʻuhi ʻoku ʻikai ha hingoa ʻo e konga `<{ $component }>`, ʻe ʻikai lava ke ngāueʻaki ia ki ha ʻatilipiuti ʻo e module
+
+module-attribute-name-already-defined = ʻE ʻikai lava ke ngāueʻaki ʻa e konga `<{ $component } name="{ $name }">` ko ha ʻatilipiuti ʻo e module he ʻoku ʻi he faʻahinga konga `<module>` ʻa e ʻatilipiuti "{ $name }" ʻi ai.
+
+conditional-content-condition-ignored = ʻOku taʻetokangaʻi ʻa e ʻatilipiuti `condition` ʻi ha konga `<conditionalContent>` ʻoku ʻi ai ha fānau case pe else.
+
+slider-markers-type-mismatch = ʻOku ʻikai fetaulaki ʻa e faʻahinga ʻo e marker mo e faʻahinga ʻo e slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel taʻetotonu: kuo pau ke ʻi he `<problem>` taki taha ha `<statement>` ʻe taha mo ha `<answer>` ʻe taha.
+
+pretzel-circuit-first-problem-distractor = Pretzel taʻetotonu: ʻi he mode="circuit", ʻe ʻikai lava ke distractor ʻa e `<problem>` ʻuluaki.
+
+## Attribute values
+
+# No select: «mahuʻinga» is the same word for one and for many.
+attribute-invalid-values = Mahuʻinga taʻetotonu { $values } ki he ʻatilipiuti `{ $attribute }`; ʻoku taʻetokangaʻi.
+
+attribute-must-be-references = Mahuʻinga taʻetotonu `{ $value }` ki he ʻatilipiuti `{ $attribute }`. Kuo pau ke fakatupu ʻa e ʻatilipiuti mei ha ngaahi fakasino ʻoku kamata ʻaki ha `$`.
+
+math-input-invalid-function-names = <mathInput>: naʻe taʻetokangaʻi ʻa e hingoa ngāue fika taʻetotonu ʻi he { $attribute }: { $names }. Kuo pau ke ʻi ai ha mataʻitohi ʻe 2 pe lahi ange ʻi he hingoa taki taha (mataʻitohi pe kohi); ʻe lava ke muimui ha suffix `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Faʻahinga konga taʻetotonu: `<{ $componentType }>`
+
+attribute-repeated = ʻE ʻikai lava ke toe fai ʻa e ʻatilipiuti { $attribute }.
+
+attribute-invalid-for-component = ʻAtilipiuti taʻetotonu "{ $attribute }" ki ha konga faʻahinga `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    ʻOku ʻikai feʻunga ʻa e faikehekehe ʻo e sitaila { $styleNumber } ki he { $context ->
+        [text-on-background] lanu ʻo e tohi ki he lanu ʻo e tuʻunga
+        [high-contrast] lanu faikehekehe māʻolunga ki he kanivasi
+        [line] lanu ʻo e laine ki he kanivasi
+        [marker] lanu ʻo e marker ki he kanivasi
+       *[text-on-canvas] lanu ʻo e tohi ki he kanivasi
+    }{ $mode ->
+        [dark] { " (mode fakapoʻuli)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ʻoku fiemaʻu ʻa e { $threshold }:1 pe lahi ange).
+
+style-definition-dark-mode-text-background-contrast =
+    Neongo ʻoku ʻi he sitaila { $styleNumber } ha ngaahi lanu kuo fakapapauʻi mo feʻunga honau faikehekehe ki he mode maama, ʻoku ʻikai feʻunga ʻa e faikehekehe ʻo e lanu ʻo e tohi ki he lanu ʻo e tuʻunga ʻi he ngaahi lanu naʻe toʻo ki he mode fakapoʻuli ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ʻoku fiemaʻu ʻa e { $threshold }:1 pe lahi ange). { $suggestion ->
+        [available] Ke feʻunga ʻa e faikehekehe ʻi he mode fakapoʻuli, fakalahi ʻa e faikehekehe ʻo e mode maama (hangē, fokotuʻu ʻa e { $lightAttribute }="{ $lightColor }") pe fetongi ʻa e lanu ʻo e mode fakapoʻuli (hangē, fokotuʻu ʻa e { $darkAttribute }="{ $darkColor }").
+       *[none] Ke feʻunga ʻa e faikehekehe ʻi he mode fakapoʻuli, fakalahi ʻa e faikehekehe ʻo e mode maama pe fetongi ʻa e ngaahi lanu naʻe toʻo ʻaki ʻa e textColorDarkMode mo/pe ko e backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Neongo ʻoku ʻi he sitaila { $styleNumber } ha lanu tohi kuo fakapapauʻi mo feʻunga hono faikehekehe ki he mode maama, ʻoku ʻikai feʻunga ʻa e faikehekehe ʻo e lanu tohi naʻe toʻo ki he mode fakapoʻuli ki he kanivasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ʻoku fiemaʻu ʻa e { $threshold }:1 pe lahi ange). { $suggestion ->
+        [available] Ke feʻunga ʻa e faikehekehe ʻi he mode fakapoʻuli, fakalahi ʻa e faikehekehe ʻo e mode maama (hangē, fokotuʻu ʻa e textColor="{ $lightColor }") pe fetongi ʻa e lanu ʻo e mode fakapoʻuli (hangē, fokotuʻu ʻa e textColorDarkMode="{ $darkColor }").
+       *[none] Ke feʻunga ʻa e faikehekehe ʻi he mode fakapoʻuli, fakalahi ʻa e faikehekehe ʻo e mode maama pe fetongi ʻa e lanu naʻe toʻo ʻaki ʻa e textColorDarkMode.
+    }
+
+section-multiple-style-palettes = ʻE lava pē ke fili ʻe ha vahe ha <stylePalette> ʻe taha; ʻoku ngāueʻaki ʻa e ki mui taha.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } he ʻoku ʻikai ko ha fika kakato taʻesiʻi hifo ʻi he noa ʻa e numToSelect.
+
+variant-num-to-select-not-constant-number = ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } he ʻoku ʻikai ko ha fika tuʻumaʻu ʻa e numToSelect.
+
+variant-with-replacement-not-constant-boolean = ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } he ʻoku ʻikai ko ha boolean tuʻumaʻu ʻa e withReplacement.
+
+variant-select-weight-disables-unique = ʻOku taʻofi ʻa e ngaahi kehekehe taha pē ki he select ʻo kapau ʻoku ʻi ai ha fili kuo fakapapauʻi ʻa e selectWeight pe selectForVariants
+
+variant-coprime-undetermined = ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } he ʻoku ʻikai lava ke fakapapauʻi ʻoku false maʻu pē ʻa e coprime.
+
+variant-attribute-not-constant = ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } he ʻoku ʻikai tuʻumaʻu ʻa e { $attribute }.
+
+variant-attribute-not-number = ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } he ʻoku ʻikai ko ha fika ʻa e { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } faʻahinga { $type } he ʻoku ʻikai ko ha { $expected ->
+        [letters-combination] fakataha mataʻitohi
+        [math-expression] fakamatala fika totonu
+        [integer] fika kakato
+       *[number] fika
+    } ʻa e { $attribute }.
+
+variant-length-not-integer = ʻe ʻikai lava ke fakapapauʻi ʻa e ngaahi kehekehe taha pē ʻo e { $component } he ʻoku ʻikai ko ha fika kakato ʻa e length.
+
+variant-sort-not-implemented = ʻoku teʻeki fakahoko ʻa e ngaahi kehekehe taha pē ʻo ha { $component } ʻoku ʻi ai ha sort
+
+variant-exclude-combinations-not-implemented = ʻoku teʻeki fakahoko ʻa e ngaahi kehekehe taha pē ʻo ha { $component } ʻoku ʻi ai ha excludeCombinations
+
+variant-math-exclude-not-implemented = ʻoku teʻeki fakahoko ʻa e ngaahi kehekehe taha pē ʻo ha { $component } faʻahinga math ʻoku ʻi ai ha exclude
+
+variant-non-constant-exclude-not-implemented = ʻoku teʻeki fakahoko ʻa e ngaahi kehekehe taha pē ʻo ha { $component } ʻoku ʻi ai ha exclude taʻetuʻumaʻu
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ʻoku ʻikai poupouʻi ʻi he renderer prefigure ʻo e graph; naʻe fakalaka ʻa e hako.
+
+prefigure-descendant-invalid-geometry = { $subject }: ʻoku taʻengata pe taʻekakato ʻa e sino fua; naʻe fakalaka ʻa e hako.
+
+prefigure-curve-label-omitted = { $subject }: ʻoku ʻikai poupouʻi ʻa e fakaʻilonga ʻi he ngaahi pikopiko kuo liliu; naʻe taʻetokangaʻi ʻa e fakaʻilonga.
+
+prefigure-curve-unsupported-definition-type = { $subject }: faʻahinga fakamatala pikopiko '{ $definitionType }' ʻoku ʻikai poupouʻi; naʻe fakalaka ʻa e hako.
+
+prefigure-region-flip-functions-unsupported = { $subject }: ʻoku ʻikai poupouʻi ʻa e ʻatilipiuti flipFunctions ʻi he regionBetweenCurves; naʻe fakalaka ʻa e hako.
+
+prefigure-region-non-formula-child = { $subject }: ko e fānau ngāue fika faʻahinga formula pē ʻoku poupouʻi ʻi he regionBetweenCurves; naʻe fakalaka ʻa e hako.
+
+prefigure-label-position-unsupported =
+    { $subject }: ʻoku ʻikai poupouʻi ʻa e labelPosition '{ $labelPosition }' ki he { $labelKind ->
+        [line-family] fakaʻilonga ʻo e fāmili laine
+       *[point] fakaʻilonga ʻo e poini
+    }; ʻoku ngāueʻaki ʻa e fakahangatonu angamaheni ʻa PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: ʻoku ʻikai poupouʻi ʻe PreFigure ʻa e sitaila fonu '{ $fillStyle }'; ʻoku foki ki he fonu kakato.
+
+prefigure-line-style-unknown = { $subject }: sitaila laine '{ $lineStyle }' ʻoku ʻikai ʻiloa, naʻe taʻetokangaʻi mei he output ʻa PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: naʻe fakafehokotaki ʻa e sitaila marker '{ $markerStyle }' ki he sitaila 'diamond' ʻa PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: ʻoku ʻikai poupouʻi ʻe PreFigure ʻa e sitaila marker '{ $markerStyle }'; ʻoku ngāueʻaki ʻa e sitaila angamaheni.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` taʻetotonu; ʻe ʻikai lava ke tuhu ki he target. Naʻe taʻetokangaʻi ʻa e annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: naʻe tuhu ʻa e `ref` ki ha target lahi; ʻoku ngāueʻaki ʻa e target ʻuluaki.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` taʻetotonu; ʻoku ʻi tuʻa ʻa e target mei he graph ʻoku ne maʻu ia. Naʻe taʻetokangaʻi ʻa e annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` taʻetotonu; ʻoku ʻikai ko ha meʻa fakatātā ʻoku poupouʻi ʻa e target ʻi he liliu prefigure. Naʻe taʻetokangaʻi ʻa e annotation.
+
+annotation-text-missing = `<annotation>`: ʻoku ʻikai pe maha ʻa e `text`; ʻoku ʻoatu ha tohi maha.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Naʻe maʻu ha fakatuʻunga takatakai.
+       *[other] Naʻe maʻu ha fakatuʻunga takatakai ʻoku kau ki ai ʻa e konga `<{ $componentType }>`.
+    }
+
+reference-no-referent = Naʻe ʻikai maʻu ha meʻa ʻoku tuhu ki ai ʻa e fakasino: `{ $reference }`
+
+reference-multiple-referents = Naʻe maʻu ha meʻa lahi ʻoku tuhu ki ai ʻa e fakasino: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Fakafuofua taʻetotonu ʻo e ʻatilipiuti { $attribute } ʻo e `<{ $componentType }>`.
+
+children-invalid = Fānau taʻetotonu ʻo e `<{ $componentType }>`: naʻe maʻu ha fānau taʻetotonu: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Mahuʻinga taʻetotonu `{ $value }` ki he ʻatilipiuti `{ $attribute }`, ʻoku ngāueʻaki ʻa e mahuʻinga `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Naʻe ʻikai maʻu ʻa e fatu DoenetML { $version }.
+       *[other] Naʻe ʻikai maʻu ʻa e fatu DoenetML { $version }. ʻOku foki ki he fatu { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML taʻetotonu: { $content }
+
+parse-tag-missing-close-tag = DoenetML taʻetotonu: ʻOku ʻikai ha tag tāpuni ʻo e tag `{ $tag }`. Naʻe ʻamanekina ha tag ʻoku ne tāpuni ia pe ko ha tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML taʻetotonu: Naʻe ʻi ai ha hala ʻi he tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML taʻetotonu: ʻOku hangē ʻoku ʻikai ha mahuʻinga ʻo e ʻatilipiuti taʻetotonu `{ $attribute }`.
+
+parse-attribute-invalid = DoenetML taʻetotonu: ʻAtilipiuti taʻetotonu `{ $attribute }`
+
+parse-attribute-value-invalid = DoenetML taʻetotonu: Mahuʻinga ʻatilipiuti taʻetotonu `{ $value }`
+
+parse-attribute-value-quote-mismatch = DoenetML taʻetotonu: Mahuʻinga ʻatilipiuti taʻetotonu `{ $value }`. ʻOku ʻikai fetaulaki ʻa e fakaʻilonga lea. ʻOku hangē ʻoku ʻikai ha `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML taʻetotonu: Naʻe maʻu ha tag ʻoku ʻikai hano hingoa, hangē ko e `<`
+
+parse-tag-not-closed = DoenetML taʻetotonu: Naʻe ʻikai tāpuni ʻa e tag `{ $tag }` (ʻoku hangē ʻoku ʻikai ha `>`).
+
+parse-self-closing-tag-name-missing = DoenetML taʻetotonu: Naʻe maʻu ha tag ʻoku ʻikai hano hingoa `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML taʻetotonu: Naʻe ʻikai tāpuni ʻa e tag `{ $tag }` (ʻoku hangē ʻoku ʻikai ha `/>`).
+
+parse-tag-invalid-attributes = DoenetML taʻetotonu: ʻOku taʻetotonu ʻa e tag `{ $tag }`. Mahalo ʻoku hala hono ngaahi ʻatilipiuti.
+
+parse-close-tag-name-missing = DoenetML taʻetotonu: Naʻe maʻu ha tag tāpuni ʻoku ʻikai hano hingoa, hangē ko e `</`
+
+parse-attribute-value-unquoted = Kuo pau ke tuku ʻa e mahuʻinga ʻo e ʻatilipiuti ʻi loto ʻi he fakaʻilonga lea: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML taʻetotonu: Naʻe maʻu ha tag tāpuni `{ $tag }`, ka ʻoku ʻikai hano tag fakaava fetaulaki
+
+parse-close-tag-mismatched = DoenetML taʻetotonu: ʻOku ʻikai fetaulaki ʻa e tag tāpuni. Naʻe ʻamanekina ʻa e `</{ $expected }>`. Naʻe maʻu ʻa e `{ $found }`
+
+parser-node-unconvertible = Naʻe ʻikai lava ke liliu ʻa e node { $node } ki ha node Dast.
+
+## Names
+
+name-attribute-invalid =
+    ʻAtilipiuti taʻetotonu name='{ $name }'. { $reason ->
+        [characters] ʻE lava pē ke ʻi he hingoa ha mataʻitohi, fika, kohi ʻi lalo pe kohi.
+       *[start] Kuo pau ke kamata ʻa e hingoa ʻaki ha mataʻitohi.
+    }
+
+component-name-invalid-start = Hingoa konga taʻetotonu "{ $name }". Kuo pau ke kamata ʻa e hingoa ʻaki ha mataʻitohi.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Kuo pau ke ʻi ai ha ʻatilipiuti video ʻa e answer ʻoku type videoWatched
+
+answer-video-watched-video-not-reference = Kuo pau ke ko ha fakasino ʻa e ʻatilipiuti video ʻo e answer ʻoku type videoWatched
+
+answer-name-not-single-text = Kuo pau ke ʻi ai ha fānau text pē ʻe taha ʻa e ʻatilipiuti name ʻo e answer
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Naʻe ʻikai lava ke toʻo ʻa e DoenetML mei tuʻa koeʻuhi ko e lahi fau ʻo e ngaahi tuʻunga toe fai. ʻOku ʻi ai ha fakasino takatakai?
+
+external-doenetml-unavailable = Naʻe ʻikai lava ke toʻo ʻa e DoenetML mei he { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML taʻetotonu naʻe toʻo mei he { $attribute }="{ $uri }": naʻe ʻikai fetaulaki mo e faʻahinga konga "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] ʻOku ʻikai toe ngāueʻaki ʻa e ʻatilipiuti `{ $from }`; ngāueʻaki ʻa e `{ $to }`.
+       *[other] [deprecation] ʻOku ʻikai toe ngāueʻaki ʻa e ʻatilipiuti `{ $from }` ʻi he `<{ $component }>`; ngāueʻaki ʻa e `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] ʻOku ʻikai toe ngāueʻaki ʻa e ʻatilipiuti `{ $from }` pea ʻoku taʻetokangaʻi he kuo fakapapauʻi foki mo e `{ $to }`.
+       *[other] [deprecation] ʻOku ʻikai toe ngāueʻaki ʻa e ʻatilipiuti `{ $from }` ʻi he `<{ $component }>` pea ʻoku taʻetokangaʻi he kuo fakapapauʻi foki mo e `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] ʻOku ʻikai toe ngāueʻaki ʻa e ʻatilipiuti `{ $attribute }` ʻi he `<{ $component }>` pea ʻoku taʻetokangaʻi.
+
+deprecated-attribute-to-child = [deprecation] ʻOku ʻikai toe ngāueʻaki ʻa e ʻatilipiuti `{ $attribute }` ʻi he `<{ $component }>`; ngāueʻaki ha fānau `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] ʻOku ʻikai toe ngāueʻaki ʻa e mahuʻinga `{ $value }` ʻo e ʻatilipiuti `{ $attribute }` ʻi he `<{ $component }>`; ngāueʻaki ʻa e `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = ʻOku lava pē ʻe he `<pluralize>` ke fakalahi ʻa e lea faka-Pilitānia, ko ia ʻoku ʻikai liliu hono tohi ʻi ha pepa kuo tohi ʻi he { $locale }. Tohi tonu ʻa e foʻi lea lahi, pe fokotuʻu ia ʻaki ʻa e ʻatilipiuti `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = ʻOku ʻikai ko ha elemēniti Doenet ʻoku ʻiloa ʻa e `<{ $tag }>`.
+
+schema-element-not-allowed-at-root = ʻOku ʻikai fakangofua ʻa e elemēniti `<{ $tag }>` ʻi he tefito ʻo e pepa.
+
+schema-element-not-allowed-inside = ʻOku ʻikai fakangofua ʻa e elemēniti `<{ $tag }>` ʻi loto ʻi he `<{ $parent }>`.
+
+schema-attribute-unrecognized = ʻOku ʻikai ha ʻatilipiuti ko hono hingoa `{ $attribute }` ʻa e elemēniti `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Kuo pau ke ko ha lisi ʻa e ʻatilipiuti `{ $attribute }` ʻo e elemēniti `<{ $tag }>` ʻa ia ko hono meʻa taki taha ko e taha ʻi he: { $allowed }
+       *[other] Kuo pau ke taha ʻi he ngaahi meʻa ni ʻa e ʻatilipiuti `{ $attribute }` ʻo e elemēniti `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Hingoa kehekehe taʻetotonu ki he select.  ʻOku hā ʻa e hingoa kehekehe { $variantName } ʻi he fili ʻe { $numOptions } ka ko e lau ke fili ko e { $numToSelect }.
+
+select-variant-name-without-options = Kuo fakapapauʻi ha kehekehe ki he select ka ʻoku ʻikai ha fili kuo fakapapauʻi ki he hingoa kehekehe: { $variantName }.
+
+select-variant-name-not-possible = Ko e hingoa kehekehe { $variantName } kuo fakapapauʻi ki he select ʻoku ʻikai ko ha hingoa kehekehe ʻe lava.
+
+select-too-few-options = ʻE ʻikai lava ke fili ha konga ʻe { $numToSelect } mei he { $numOptions } pē.
+
+select-from-sequence-too-few-values = ʻE ʻikai lava ke fili ha mahuʻinga ʻe { $numToSelect } mei ha sequence ko hono loloa ko e { $length }.
+
+select-from-sequence-indices-count-mismatch = Kuo pau ke fetaulaki ʻa e lau ʻo e index kuo fakapapauʻi ki he select mo e lau ke fili
+
+select-from-sequence-indices-not-integers = Kuo pau ke fika kakato ʻa e index kotoa kuo fakapapauʻi ki he select
+
+select-from-sequence-index-excluded = Ko e index ʻo e selectfromsequence kuo fakapapauʻi naʻe fakataʻeʻaongaʻi
+
+select-from-sequence-indices-excluded-combination = Ko e ngaahi index ʻo e selectfromsequence kuo fakapapauʻi ko ha fakataha kuo fakataʻeʻaongaʻi
+
+select-from-sequence-coprime-not-positive-integers = ʻE ʻikai lava ke fili ha fakataha coprime he ʻoku ʻikai ko ha fika kakato lelei ʻoku fili.
+
+select-from-sequence-coprime-common-factor = ʻE ʻikai lava ke fili ha fika coprime. ʻOku ʻi he mahuʻinga kotoa ha faktoa tatau. (Kuo pau ke coprime ʻa e mahuʻinga "from" pe "to" mo e "step".)
+
+select-from-sequence-coprime-single-number = ʻE ʻikai lava ke fili ha fakataha coprime mei ha fika pē ʻe taha ʻoku ʻikai ko e 1.
+
+select-from-sequence-excluded-too-many-combinations = Naʻe fakataʻeʻaongaʻi ʻa e laka hake ʻi he 70% ʻo e ngaahi fakataha ʻi he selectFromSequence
+
+select-from-sequence-coprime-none-found = Naʻe ʻikai lava ke fili ha fika coprime. ʻOku ʻi he mahuʻinga kotoa ha faktoa tatau.
+
+select-from-sequence-too-few-unique-values = ʻE ʻikai lava ke fili ha mahuʻinga makehe ʻe { $numToSelect } mei ha sequence ko hono loloa ko e { $numPossibleValues }
+
+select-prime-numbers-too-few-values = ʻE ʻikai lava ke fili ha mahuʻinga ʻe { $numToSelect } mei ha lisi fika totonu ko hono loloa ko e { $numValues }
+
+select-prime-numbers-values-count-mismatch = Kuo pau ke fetaulaki ʻa e lau ʻo e mahuʻinga kuo fakapapauʻi ki he select mo e lau ke fili
+
+select-prime-numbers-values-not-prime = Kuo pau ke ʻi he lisi fika totonu ʻa e mahuʻinga kotoa kuo fakapapauʻi ki he select prime number
+
+select-prime-numbers-values-excluded-combination = Ko e mahuʻinga ʻo e selectPrimeNumbers kuo fakapapauʻi ko ha fakataha kuo fakataʻeʻaongaʻi
+
+select-prime-numbers-excluded-too-many-combinations = Naʻe fakataʻeʻaongaʻi ʻa e laka hake ʻi he 70% ʻo e ngaahi fakataha ʻi he selectPrimeNumbers
+
+select-random-combination-fluke = Koeʻuhi ko ha monūʻia taʻeʻamanekina ʻaupito, naʻe ʻikai lava ke fili ha fakataha ʻo e mahuʻinga taʻefokotuʻu
+
+select-random-value-fluke = Koeʻuhi ko ha monūʻia taʻeʻamanekina ʻaupito, naʻe ʻikai lava ke fili ha mahuʻinga taʻefokotuʻu

--- a/packages/i18n/locales/to/editor.ftl
+++ b/packages/i18n/locales/to/editor.ftl
@@ -1,0 +1,209 @@
+# Tongan editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# The fakauʻa «ʻ» is U+02BB and the toloi is the macron; see `chrome.ftl`.
+# Tongan marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Fakafoki
+       *[update] Fakafoʻou
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } ʻa e mata sio
+       *[other] { $word } ʻa e mata sio { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Kehekehe
+editor-variant-filter = Fakamama…
+editor-variant-next = Fili ʻa e kehekehe hoko
+editor-variant-previous = Fili ʻa e kehekehe kimuʻa
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Naʻe maʻu ha maumauʻi ʻo e aʻusia WCAG AA. Lomiʻi ke { $action ->
+            [close] tāpuni
+           *[open] fakaava
+        } ʻa e lipooti aʻusia.
+        [advisories] Lomiʻi ke { $action ->
+            [close] tāpuni
+           *[open] fakaava
+        } ʻa e lipooti aʻusia. Naʻe ʻikai maʻu ha maumauʻi WCAG AA, ka ʻoku ʻi ai ha fokotuʻu aʻusia kehe.
+       *[clean] Lomiʻi ke { $action ->
+            [close] tāpuni
+           *[open] fakaava
+        } ʻa e lipooti aʻusia. Naʻe ʻikai maʻu ha palopalema aʻusia.
+    }
+
+# No select on `$count` inside the branches: «maumauʻi» and «fokotuʻu» are the
+# same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Naʻe maʻu ha maumauʻi ʻo e aʻusia WCAG AA. Naʻe maʻu ʻa e maumauʻi WCAG AA ʻe { $count }. Lomiʻi ke { $action ->
+            [close] tāpuni
+           *[open] fakaava
+        } ʻa e lipooti aʻusia.
+        [advisories] Naʻe ʻikai maʻu ha maumauʻi WCAG AA. Naʻe maʻu ʻa e fokotuʻu aʻusia kehe ʻe { $count }. Lomiʻi ke { $action ->
+            [close] tāpuni
+           *[open] fakaava
+        } ʻa e lipooti aʻusia.
+       *[clean] Naʻe ʻikai maʻu ha maumauʻi WCAG AA. Lomiʻi ke { $action ->
+            [close] tāpuni
+           *[open] fakaava
+        } ʻa e lipooti aʻusia.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Fatu DoenetML { $version }
+
+editor-tab-help = Tokoni fakatatau ki he tuʻunga
+editor-tab-help-short = Tuʻunga
+editor-tab-errors = Hala
+editor-tab-warnings = Fakatokanga
+editor-tab-info = Fakamatala
+editor-tab-accessibility = Aʻusia
+editor-tab-responses = Ngaahi tali kuo ʻave
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Ngaahi fili ʻo e tohitaʻu
+editor-format-as-doenetml = Fokotuʻutuʻu ko e DoenetML
+editor-format-as-xml = Fokotuʻutuʻu ko e XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Laine #{ $line }
+
+editor-no-errors = ʻIkai ha hala
+editor-no-warnings = ʻIkai ha fakatokanga
+editor-no-info = ʻIkai ha fakamatala fakasivi
+
+editor-show-info-annotations = Fakahā ʻa e fakamatala fakasivi ʻi he tohitaʻu
+editor-show-accessibility-annotations = Fakahā ʻa e fakasivi aʻusia ʻi he tohitaʻu
+
+editor-accessibility-learn-more = Ako pe ʻoku fakahoko fēfē ʻe Doenet ʻa e aʻusia
+
+editor-accessibility-violations-heading = Maumauʻi ʻo e aʻusia ({ $standard })
+
+editor-accessibility-other-heading = Palopalema aʻusia kehe
+editor-none-found = ʻIkai maʻu ha taha
+
+
+## Submitted responses
+
+editor-no-responses = ʻOku teʻeki ke ʻi ai ha tali kuo ʻave
+editor-response-answer-id = Id ʻo e tali
+editor-response-response = Tali
+editor-response-credit = Mataʻitohi
+editor-response-submitted = Kuo ʻave
+
+
+## The context-help panel
+
+help-placeholder = Tuku ʻa e kāsolo ki ha hingoa tag, ha ʻatilipiuti, pe ko e { $ref } ki he fakamatala.
+
+help-unsupported-ref-chain = ʻOku teʻeki poupouʻi ʻa e tokoni ki he ngaahi fakasino konga lahi hangē ko e { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Naʻe ʻikai maʻu ha meʻa ʻoku tuhu ki ai ʻa e fakasino: { $ref }.
+        [multiple] Naʻe maʻu ha meʻa lahi ʻoku tuhu ki ai ʻa e fakasino: { $ref }.
+       *[indeterminate] Naʻe ʻikai lava ke fakapapauʻi pe ko e hā ʻoku tuhu ki ai ʻa e { $ref }.
+    }
+
+help-learn-about-references = Ako fekauʻaki mo e ngaahi fakasino →
+help-reference-page = Peesi fakasino →
+
+help-suggestions-header =
+    { $location ->
+        [inside] ʻI loto ʻi he { $element }
+       *[top] ʻI he tuʻunga ʻi ʻolunga
+    }{ $allowed ->
+        [none] { " — ʻoku ʻikai ha meʻa ʻe lava ke tuku heni." }
+        [text] { " — tohi ha tohi heni." }
+        [text-and-components] { " — tohi ha tohi heni, pe ʻahiʻahiʻi:" }
+       *[components] { " — ngaahi meʻa ke ʻahiʻahiʻi:" }
+    }
+
+help-suggestions-footer = Lomiʻi ʻa e { $shortcut } ke sio ki he konga kotoa ʻe { $total }.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] Ko e { $ref } ko e fakasino ia ki he { $target }.
+       *[other] Ko e { $ref } ko e fakasino ia ki he { $target } (laine { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Naʻe ʻomi ʻe he { $owner } ko e { $role }.
+       *[other] Naʻe ʻomi ʻe he { $owner } ʻi he laine { $line } ko e { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] Ko e { $ref } ko e fakasino ia ki he tuʻunga { $property } ʻo e { $element }.
+       *[other] Ko e { $ref } ko e fakasino ia ki he tuʻunga { $property } ʻo e { $element } (laine { $line }).
+    }
+
+help-kind-attribute = ʻatilipiuti
+help-kind-snippet = konga koti
+help-kind-array-entry = hū ki he array
+
+help-default = Angamaheni:
+help-active-default = Angamaheni ngāue:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Mahuʻinga ngofua (taha ki he meʻa taki taha):
+       *[other] Mahuʻinga ngofua:
+    }
+
+help-suggested-values = Mahuʻinga fokotuʻu:
+
+help-inserts = ʻOku fakahū:
+
+# No select: «kōtinaite» is the same word for one and for many.
+help-coordinates = Kōtinaite:
+
+help-type = Faʻahinga:
+
+help-resolved-style = Sitaila kuo fakapapauʻi (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Hingoa ngāue fika kuo fakapapauʻi:
+help-reset-list = Lisi fakafoki ʻi he input ko ʻeni:
+help-added-on-input = Naʻe tānaki ʻi he input ko ʻeni:
+help-removed-on-input = Naʻe toʻo ʻi he input ko ʻeni:
+
+help-reset-overrides = ʻOku fetongi ʻe he { $reset } ʻa e { $additional } mo e { $removed }.

--- a/packages/i18n/locales/tpi/chrome.ftl
+++ b/packages/i18n/locales/tpi/chrome.ftl
@@ -1,0 +1,148 @@
+# Tok Pisin viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Tok Pisin is the one locale in this batch that is **not Austronesian**: it is
+# an English-lexified creole and the lingua franca of Papua New Guinea, with a
+# grammar of its own that its English vocabulary does not predict. The trap for
+# a corrector is exactly that: a word here looks like an English word and is not
+# one, so «gutpela» is not "good fellow" and «long» is not "long".
+#
+# Written in the standard orthography of PNG publishing (Wantok, Buk Baibel),
+# which spells the language phonemically — «bilong», «tasol», «painim» — rather
+# than after the English words behind them.
+#
+# Tok Pisin marks no number on the noun: the plural is «ol» before it, and a
+# noun after a numeral stays as it is. So a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped. A `[0]` branch stays wherever English has one.
+
+
+## Answer submission
+
+answer-checking = Skelim i stap…
+answer-submitting = Salim i stap…
+
+answer-checking-status = Skelim bekim
+answer-submitting-status = Salim bekim
+
+answer-correct = Stret
+answer-incorrect = I no stret
+
+answer-response-saved = Bekim i stap sef
+
+answer-percent-credit = { $percent }% mak
+answer-percent-correct = { $percent }% stret
+answer-percent-short = { $percent } %
+
+max-credit-available = Bikpela mak yu inap kisim: { $percent }%
+
+# No select: «traim» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] i no gat traim i stap yet
+       *[other] { $count } traim i stap yet
+    }
+
+validation-correct = (Stret)
+validation-incorrect = (I no stret)
+validation-partially-correct = (Stret liklik)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Soim { $count } bekim bilong { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Toktok bek
+
+collapsible-click-to-open = (klikim bilong opim)
+collapsible-click-to-close = (klikim bilong pasim)
+
+collapsible-initializing = Kirapim i stap…
+
+footnote-show = Soim footnote
+footnote-hide = Haitim footnote
+
+description-more-information = moa tok save
+
+
+## Controls
+
+slider-previous = Bipo
+slider-next = Neks
+
+keyboard-open = Opim kibot
+keyboard-close = Pasim kibot
+
+choice-input-remove-choice = Rausim { $choice }
+
+matrix-remove-row = Rausim lain
+matrix-add-row = Putim wanpela lain
+matrix-remove-column = Rausim kolam
+matrix-add-column = Putim wanpela kolam
+
+subset-add-remove-points = Putim/Rausim ol poin
+subset-toggle-points-intervals = Senisim ol poin na ol namel
+subset-move-points = Muvim ol poin
+subset-clear = Klinim
+
+orbital-add-row = Putim wanpela lain
+orbital-remove-row = Rausim lain
+orbital-add-box = Putim wanpela bokis
+orbital-remove-box = Rausim bokis
+orbital-add-up-arrow = Putim wanpela spia i go antap
+orbital-add-down-arrow = Putim wanpela spia i go daun
+orbital-remove-arrow = Rausim spia
+
+orbital-row-label = Nem bilong lain { $row }
+
+pretzel-answer = Bekim
+
+summary-statistics-caption = Sotpela ripot namba bilong { $column }
+
+
+## Math input
+
+math-input-preview-region = lukluk pastaim long tok matematik
+math-input-preview = Lukluk pastaim
+math-input-invalid-expression = Tok i no stret:
+
+
+## Document status
+
+viewer-initializing = Kirapim i stap…
+
+
+## Errors
+
+error-heading = Asua
+
+error-found-at =
+    { $span ->
+        [line] Painim long lain { $startLine }.
+       *[lines] Painim long ol lain { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dispela dokumen i gat asua!
+
+diagnostic-heading-error = Asua
+diagnostic-heading-warning = Tok lukaut
+diagnostic-heading-information = Tok save
+diagnostic-heading-hint = Tok helpim
+
+accessibility-heading-level-1 = Brukim lo bilong akses WCAG AA
+accessibility-heading-level-2 = Tok lukaut long akses
+
+something-went-wrong = Wanpela samting i no orait.
+
+renderer-load-failed = wanpela renderer i no lodim. Plis lodim gen dispela pes.
+
+core-start-failed = Luk bilong dokumen i no inap kirap. Plis lodim gen dispela pes.

--- a/packages/i18n/locales/tpi/content.ftl
+++ b/packages/i18n/locales/tpi/content.ftl
@@ -1,0 +1,270 @@
+# Tok Pisin content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Tok Pisin has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun.
+#
+# **`-pela` is this catalog's whole story, and it is a `$role` fork that cannot
+# be written.** An attributive adjective in Tok Pisin carries the suffix
+# «-pela» and stands **before** the noun — «retpela lain», a red line — while a
+# predicative one drops it: «lain i ret». Those are two forms of one word, and
+# which is wanted depends on the position the phrase is going into, which is
+# exactly what `$role` names.
+#
+# It cannot be used here. `standalone` covers **both** the citation form a state
+# variable reports and the attributive use inside `style-with-noun` — see
+# `attachNoun` in `@doenet/utils/style/styleDescriptions.ts`, which passes
+# `role: "standalone"` for the phrase that is about to be put in front of a
+# noun. So one token arrives for two positions, and this catalog writes the
+# `-pela` form throughout, which is right wherever a noun follows and reads as
+# the attributive form where `backgroundColor` reports a colour on its own. The
+# three clause roles get `-pela` too, since a noun follows in each.
+#
+# That is worth recording as a limitation of the argument rather than of the
+# language: `$gender`'s token set and `$role`'s are the catalog's own business,
+# but a distinction the *code* does not draw is one no catalog can recover. A
+# later split of `standalone` into a citation position and an attributive one is
+# what this file would want, and `locales/tpi` is the first catalog that would
+# use it.
+#
+# The adjectives therefore **precede** the noun, as in English and as in the
+# five Philippine catalogs of this batch, and unlike the eight others.
+#
+# The geometry vocabulary is largely English-derived, because PNG teaches
+# mathematics in English; where Tok Pisin has its own word it is written.
+
+
+## Style vocabulary
+
+color =
+    .black = blakpela
+    .white = waitpela
+    .gray = gripela
+    .red = retpela
+    .orange = orenspela
+    .yellow = yelopela
+    .green = grinpela
+    .cyan = sianpela
+    .blue = blupela
+    .purple = purpelpela
+    .pink = pingpela
+    .brown = braunpela
+
+line-width =
+    .thick = patpela
+    .thin = tinpela
+
+line-style =
+    .dashed = brukbruk
+    .dotted = tikitiki
+
+# Noun phrases. Tok Pisin marks no plural on the noun, so «lain» is the word for
+# one line and for many alike; «ol» before it is the plural and a description
+# does not carry it.
+fill-style =
+    .horizontal = ol lain i slip
+    .vertical = ol lain i sanap
+    .diagonal = ol lain i go krungut
+    .backdiagonal = ol lain i go krungut long narapela sait
+    .dots = ol tiki
+    .diamonds = ol daimon
+
+noun =
+    .line = lain
+    .line-segment = hap lain
+    .ray = ret
+    .vector = vekta
+    .curve = kurup
+    .function = pankisen
+    .parabola = parabola
+    .polyline = planti hap lain
+    .polygon = poligon
+    .triangle = trianggel
+    .rectangle = rektanggel
+    .circle = raunpela
+    .region = hap
+    .point = poin
+    .square = skwea
+    .diamond = daimon
+    .cross = kruse
+    .plus = plas
+
+# The side count follows the noun as a complement, because «-pela» adjectives
+# must sit directly in front of it and a counted phrase in front of them would
+# read as a comment on the sides.
+noun-regular-polygon =
+    { $part ->
+        [tail] i gat { $numSides } sait wankain
+       *[head] poligon
+    }
+
+# One answer for every noun: Tok Pisin has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = pulapela
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } wantaim { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } wantaim { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wantaim { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+# Tok Pisin has no article, so the two `-article` branches say what the other
+# two say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «wantaim» against «na».
+style-border-clause =
+    { $parts ->
+        [with-article] wantaim { $border } arere
+        [and] na { $border } arere
+        [and-article] na { $border } arere
+       *[with] wantaim { $border } arere
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = i no pulap
+
+style-text =
+    { $parts ->
+        [background] { $color } wantaim { $background } baksait
+       *[plain] { $color }
+    }
+
+style-background-none = i no gat
+
+
+## Boolean words
+
+boolean-true = tru
+boolean-false = giaman
+
+
+## Answer buttons
+
+answer-submit-label = Skelim wok
+answer-submit-label-no-correctness = Salim bekim
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Tok Pisin marks number with «ol» rather than on the noun, and a heading
+# does not carry it.
+section-name =
+    .activity = Wok
+    .aside = Tok long arere
+    .cascade = Kaskad
+    .definition = Mining
+    .example = Piksa tok
+    .exercise = Traim wok
+    .exercises = Traim wok
+    .given-answer = Bekim
+    .note = Tok
+    .objectives = Ol as tingting
+    .paragraphs = Ol paragraf
+    .part = Hap
+    .problem = Askim hatwok
+    .problems = Askim hatwok
+    .proof = Pruv
+    .question = Askim
+    .section = Seksen
+    .solution = Rot bilong bekim
+    .task = Wok
+    .theorem = Tiorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Tok helpim
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tebol { $enumeration }
+        [numbered-title] Tebol { $enumeration }{ ": " }
+        [unnumbered-title] Tebol{ ": " }
+       *[unnumbered] Tebol
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Piksa { $enumeration }
+        [numbered-caption] Piksa { $enumeration }{ ": " }
+        [unnumbered-caption] Piksa{ ": " }
+       *[unnumbered] Piksa
+    }
+
+
+## Paginator controls
+
+paginator-previous = Bipo
+paginator-next = Neks
+paginator-page = Pes
+
+paginator-page-status = { $pageLabel } { $currentPage } bilong { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = o
+piecewise-condition-if = sapos
+piecewise-condition-otherwise = sapos nogat
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Papua New Guinea teaches secondary science in English, so the
+## periodic table a pupil meets is the English one, and Tok Pisin has no settled
+## table of its own to seed from. Tok Pisin does name the substances known long
+## before the elements were — «ain» for iron, «gol» for gold — and those, rather
+## than the whole 118, are where a speaker should start.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simbol kemikol i no stret
+chemistry-invalid-ionic-compound = Kompaun aionik i no stret

--- a/packages/i18n/locales/tpi/content.ftl
+++ b/packages/i18n/locales/tpi/content.ftl
@@ -31,7 +31,7 @@
 # use it.
 #
 # The adjectives therefore **precede** the noun, as in English and as in the
-# five Philippine catalogs of this batch, and unlike the eight others.
+# five Philippine catalogs of this batch, and unlike the nine others.
 #
 # The geometry vocabulary is largely English-derived, because PNG teaches
 # mathematics in English; where Tok Pisin has its own word it is written.

--- a/packages/i18n/locales/tpi/diagnostics.ftl
+++ b/packages/i18n/locales/tpi/diagnostics.ftl
@@ -1,0 +1,626 @@
+# Tok Pisin diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source. That line matters more here than in any other catalog in this
+# batch, because Tok Pisin's own words look like English ones: «lain» is a
+# translated word and `line` in a tag name is not.
+#
+# Tok Pisin marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+
+
+## `<lineSegment>`
+
+# No select: «i no bihainim» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = i no bihainim { $attributes } taim tupela arere i makim pinis
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = i no bihainim { $attributes } taim wanpela arere na namel i makim pinis
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset i no gat wok sapos i no gat namel
+
+## `<line>`
+
+line-points-undetermined-dimensions = Lain i go long ol poin we ol i no save long ol dimensen bilong en.
+
+line-points-too-few-dimensions = Lain i mas go long ol poin i gat tupela o moa dimensen.
+
+line-points-depend-on-variables = Lain i go long ol poin i sanap long ol veriebol: { $variables }.
+
+line-equation-invalid-format = Fomat bilong ikuesen bilong lain i no stret long ol veriebol { $variable1 } na { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ret i kam long through, endpoint na direction.  I no bihainim through ol i makim.
+
+ray-dimension-mismatch = numDimensions i no wankain insait long ret.
+
+## `<vector>`
+
+vector-overprescribed-head = Vekta i kam long head, tail na displacement.  I no bihainim head ol i makim.
+
+vector-dimension-mismatch = numDimensions i no wankain insait long vekta.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = I no inap pulim i go long `<{ $component }>`, long wanem em i no gat veriebol nearestPoint.
+
+constrain-to-without-nearest-point = I no inap pasim i go long `<{ $component }>`, long wanem em i no gat veriebol nearestPoint.
+
+constrain-to-interior-without-nearest-point = I no inap pasim i go insait long `<{ $component }>`, long wanem em i no gat veriebol nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = i no bihainim labelPosition long choiceInput i no inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = I no bihainim ol indeks ol i makim long choiceInput, long wanem namba bilong ol indeks i no wankain wantaim namba bilong ol pikinini bilong makim.
+
+pretzel-indices-count-mismatch = I no bihainim ol indeks ol i makim long problem, long wanem namba bilong ol indeks i no wankain wantaim namba bilong ol pikinini problem.
+
+shuffle-indices-count-mismatch = I no bihainim ol indeks ol i makim long shuffle, long wanem namba bilong ol indeks i no wankain wantaim namba bilong ol hap.
+
+indices-ignored-out-of-range = I no bihainim ol indeks ol i makim long { $component }, long wanem sampela indeks i go ausait long mak.
+
+pretzel-indices-repeated = I no bihainim ol indeks ol i makim long pretzel, long wanem sampela indeks i kamap tupela taim.
+
+pretzel-circuit-first-index = I no bihainim ol indeks ol i makim long pretzel long mode circuit, long wanem namba wan indeks i mas 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Bilong `<{ $component }>` i ken wok wantaim ol pikinini string, ol i mas makim atribiut `type`.
+
+invalid-type-defaulting-to-math = type { $type } i no stret long hap { $component }. Em i mas wanpela bilong math, text, number, o boolean. Yusim math.
+
+string-not-valid-component-to-arrange = String "{ $value }" i no stretpela hap long { $component }. I no bihainim.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = type { $type } i no stret, ol i putim type long number.
+
+invalid-variable-value = Valiu bilong wanpela veriebol i no stret: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Indeks bilong kain { $index } i mas stap namba
+
+variant-index-must-be-integer = Indeks bilong kain { $index } i mas stap namba i no gat hap
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` i no wok yet long ol mak i stap strong. Ol brait i kamap relatiu.
+
+side-by-side-absolute-margins = `<{ $component }>` i no wok yet long ol mak i stap strong. Ol majin i kamap relatiu.
+
+side-by-side-no-block-child = `<{ $component }>` i no stret: em i mas gat wanpela pikinini block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = I no bihainim atribiut `for` long `<label>` bilong piksa.
+
+label-for-must-resolve-to-one = Atribiut `for` long `<label>` i mas makim wanpela hap tasol.
+
+label-for-unresolved = Atribiut `for` long `<label>` i no inap makim wanpela hap.
+
+label-for-answer-with-authored-inputs = Atribiut `for` long `<label>` i makim wanpela `<answer>` i gat ol input man i raitim; makim input stret.
+
+label-for-answer-without-input = Atribiut `for` long `<label>` i makim wanpela `<answer>` i no gat input bilong putim nem.
+
+label-for-must-reference-input-or-answer = Atribiut `for` long `<label>` i mas makim wanpela input o wanpela answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Bilong akses, `<{ $component }>` i mas gat sotpela tok save o ol i makim olsem bilas tasol.
+
+accessibility-video-short-description = Bilong akses, `<video>` i mas gat sotpela tok save.
+
+accessibility-input-short-description-or-label = Bilong akses, `<{ $component }>` i mas gat sotpela tok save o nem.
+
+accessibility-answer-input-short-description-or-label = Bilong akses, wanpela `<answer>` i wokim input i mas gat sotpela tok save o nem.
+
+accessibility-short-description-contains-math = Ol sotpela tok save i no ken gat ol hap matematik olsem `<{ $component }>`. Raitim matematik long ol tok.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kontras bilong { $colorName } i sot long tok bilong het bilong seksen (mode tudak) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nidim { $threshold }:1 o moa).
+       *[other] Kontras bilong { $colorName } i sot long tok bilong het bilong seksen ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nidim { $threshold }:1 o moa).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` i go long { $count } poin i no wok yet sapos ol poin i no gat valiu namba.
+
+circle-too-many-through-points = I no inap kaunim raunpela i go long moa long 3 poin.
+
+circle-overprescribed-radius-center-points = I no inap kaunim raunpela we ol i makim redias, namel na ol poin em i go long en.
+
+circle-center-with-multiple-points = I no inap kaunim raunpela we ol i makim namel bilong en na em i go long moa long 1 poin.
+
+circle-radius-too-small = I no inap kaunim raunpela: long wanem spes namel long tupela poin em { $distance }, na redias { $radius } ol i makim em i liklik tumas.
+
+circle-radius-with-many-points = I no inap wokim raunpela i go long moa long tupela poin wantaim redias ol i makim.
+
+circle-invalid-center-or-through-points = Namel o ol poin raunpela i go long en i no stret.
+
+circle-radius-center-with-multiple-points = I no inap kaunim redias bilong raunpela we ol i makim namel bilong en na em i go long moa long 1 poin.
+
+circle-change-radius-non-numerical = I no inap senisim redias bilong raunpela i go long ol poin i no gat namba
+
+circle-radius-with-points-non-numerical = I no inap wokim raunpela i go long moa long wanpela poin wantaim redias ol i makim sapos i no gat valiu namba.
+
+circle-change-center-non-numerical = Senisim namel bilong raunpela i go long ol poin i no gat valiu namba i no wok yet.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Tok Pisin has one,
+# because «namel» and «input» do not change for number. Both selects are dropped
+# and both counts still arrive.
+function-domain-insufficient-dimensions = Ol dimensen bilong domain i sot long pankisen. Domain i gat { $intervals } namel tasol pankisen i gat { $inputs } input.
+
+function-domain-invalid-format = Fomat bilong domain long pankisen i no stret.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] I no bihainim bikpela mak bilong pankisen we i no namba.
+        [minimum] I no bihainim liklik mak bilong pankisen we i no namba.
+        [extremum] I no bihainim las mak bilong pankisen we i no namba.
+        [point] I no bihainim poin bilong pankisen we i no namba.
+        [slope] I no bihainim slop bilong pankisen we i no namba.
+       *[other] I no bihainim { $type } bilong pankisen we i no namba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] I no bihainim bikpela mak bilong pankisen we i emti.
+        [minimum] I no bihainim liklik mak bilong pankisen we i emti.
+        [extremum] I no bihainim las mak bilong pankisen we i emti.
+        [point] I no bihainim poin bilong pankisen we i emti.
+       *[other] I no bihainim { $type } bilong pankisen we i emti.
+    }
+
+function-points-too-close = Pankisen i gat tupela poin i stap klostu tumas. I no inap makim pankisen.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Ol iteret bilong pankisen inap kamap tasol sapos namba bilong ol input i wankain wantaim namba bilong ol autput. Dispela pankisen i gat { $inputs } input na { $outputs } autput.
+
+## `<sequence>`
+
+sequence-invalid-length = Longpela bilong sequence i no stret.  Em i mas namba i no gat hap na i no daunbilo long zero.
+
+sequence-invalid-step = step bilong sequence i no stret.  Em i mas namba long sequence type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" bilong sequence namba i no stret.  Em i mas namba.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" bilong sequence leta i no stret.  Em i mas bung bilong ol leta.
+
+sequence-invalid-endpoint = "{ $attribute }" bilong sequence i no stret.
+
+select-from-sequence-coprime-not-numbers = i no bihainim coprime long wanem samting ol i makim i no namba
+
+select-from-sequence-coprime-with-exclude-combinations = i no bihainim coprime long wanem ol i makim excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = target i no stret long `<{ $source }>`: i no painim target.
+
+target-state-variable-not-found = target i no stret long `<{ $source }>`: i no painim veriebol i gat nem "{ $property }" long wanpela `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Ol veriebol bilong `<odeSystem>` i mas narapela long veriebol i stap fri.
+
+ode-system-duplicate-variable-names = I no inap makim ol pankisen RHS bilong ODE we ol nem veriebol i wankain.
+
+ode-system-rhs-function-error = I no inap makim pankisen RHS bilong ODE.  I gat asua long wokim pankisen mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = I no inap makim wanpela kona namel long { $count } lain
+
+angle-invalid-through-point = Poin i no stret long through bilong `<angle>`
+
+parabola-vertex-too-many-points = Parabola i gat het na i go long moa long 1 poin i no wok yet.
+
+parabola-too-many-points = Parabola i go long moa long 3 poin i no wok yet.
+
+intersection-too-many-items = Bung bilong moa long tupela samting i no wok yet
+
+## Other math components
+
+ionic-compound-not-two-ions = Kompaun aionik long narapela samting i no tupela aion i no wok yet.
+
+ionic-compound-needs-cation-and-anion = Kompaun aionik i wok tasol long wanpela katiaon na wanpela aniaon.
+
+solve-equations-cannot-evaluate = I no inap stretim ikuesen long wanem i no inap skelim ikuesen: { $equation }
+
+math-operators-operand-number-required = Ol i mas makim operandNumber taim ol i kisim wanpela operand matematik.
+
+eigen-decomposition-failed = I no inap kaunim ol eigenvalue bilong matriks
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: parameta { $parameters } i no kamap insait long pattern, olsem na em bai wankain wantaim emti samting oltaim.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: i no save long grid="{ $grid }". Em i mas none, medium, dense, o tupela gutpela namba i gat spes namel, olsem grid="1 0.5". I no gat grid ol i draim.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" i no wok long renderer prefigure; yusim pasin bilong ples long raitsait.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" i no wok long renderer prefigure; yusim pasin bilong ples long antap.
+
+prefigure-invalid-axis-bounds = `<graph>`: ol arere bilong akses i no stret long senis prefigure; yusim nomol bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: brait i no stret long senis prefigure; yusim nomol brait bilong daiagram 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio i no stret long senis prefigure; yusim nomol aspect ratio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: spes bilong grid i liklik tumas long ol arere bilong akses; i no draim grid long renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: i no draim ol annotation sapos i no yusim renderer PreFigure.
+
+multiple-annotations-children = Painim planti pikinini `<annotations>` insait long `<graph>`; i no bihainim olgeta, las wan tasol.
+
+## Referring to other components
+
+copy-unrecognized-component-type = I no inap kopim o skruim kain hap ol i no save long en: { $type }.
+
+copy-prop-not-found = I no painim prop { $property } long hap kain { $component }
+
+collect-no-source = I no painim source long collect.
+
+collect-invalid-component-type = I no inap bungim ol hap kain `<{ $component }>` long wanem kain hap i no stret.
+
+reference-index-unavailable = I no inap makim indeks `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = I no inap singautim { $action } long hap `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Sep bilong deta i no stret.  Longpela bilong ol lain i no wankain. Painim long componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Deta i gat ol nem kolam i wankain.  Painim long componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Deta i no gat nem bilong wanpela kolam.  Painim long componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award bilong dispela bekim i sanap long bekim answer tag yet i salim, na dispela bai kamapim pasin yumi no wetim.
+
+answer-max-num-attempts-in-section-wide-check-work = Putim `maxNumAttempts` long wanpela `<answer>` insait long wanpela bokis i gat `sectionWideCheckWork` i no gat wok, long wanem bokis i bosim namba bilong ol traim. Putim `maxNumAttempts` long bokis.
+
+nested-section-wide-check-work-max-num-attempts = Putim `maxNumAttempts` long wanpela bokis i gat `sectionWideCheckWork` we em i stap insait long narapela bokis i gat `sectionWideCheckWork` i no gat wok, long wanem bokis ausait i bosim namba bilong ol traim. Putim `maxNumAttempts` long bokis ausait.
+
+# No select: «atribiut» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Atribiut { $attributes } bai i no gat wok sapos symbolicEquality i no stap.
+
+answer-invalid-type = Kain i no stret long bekim: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Long wanem hap `<{ $component }>` i no gat nem, em i no inap wok olsem atribiut bilong module
+
+module-attribute-name-already-defined = Hap `<{ $component } name="{ $name }">` i no inap wok olsem atribiut bilong module long wanem kain hap `<module>` i gat atribiut "{ $name }" pinis.
+
+conditional-content-condition-ignored = I no bihainim atribiut `condition` long hap `<conditionalContent>` i gat ol pikinini case o else.
+
+slider-markers-type-mismatch = Kain bilong ol marker i no wankain wantaim kain bilong slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel i no stret: olgeta `<problem>` i mas gat wanpela `<statement>` na wanpela `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel i no stret: long mode="circuit", namba wan `<problem>` i no ken stap distractor.
+
+## Attribute values
+
+# No select: «valiu» is the same word for one and for many.
+attribute-invalid-values = Valiu { $values } i no stret long atribiut `{ $attribute }`; i no bihainim.
+
+attribute-must-be-references = Valiu `{ $value }` i no stret long atribiut `{ $attribute }`. Atribiut i mas kamap long ol refrens i kirap wantaim `$`.
+
+math-input-invalid-function-names = <mathInput>: i no bihainim ol nem pankisen i no stret long { $attribute }: { $names }. Olgeta nem i mas gat 2 o moa leta (leta o haipen); wanpela sufiks `|<mathspeak alternative>` inap bihainim.
+
+## Building components from the source
+
+component-type-invalid = Kain hap i no stret: `<{ $componentType }>`
+
+attribute-repeated = I no inap raitim atribiut { $attribute } tupela taim.
+
+attribute-invalid-for-component = Atribiut "{ $attribute }" i no stret long hap kain `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kontras bilong stail { $styleNumber } i sot long { $context ->
+        [text-on-background] kala bilong tok i birua long kala bilong baksait
+        [high-contrast] kala i gat bikpela kontras i birua long kanvas
+        [line] kala bilong lain i birua long kanvas
+        [marker] kala bilong marker i birua long kanvas
+       *[text-on-canvas] kala bilong tok i birua long kanvas
+    }{ $mode ->
+        [dark] { " (mode tudak)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nidim { $threshold }:1 o moa).
+
+style-definition-dark-mode-text-background-contrast =
+    Maski stail { $styleNumber } i gat ol kala ol i makim na kontras bilong ol i inap long mode lait, kontras bilong kala bilong tok i birua long kala bilong baksait i sot insait long ol kala ol i kisim long mode tudak ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nidim { $threshold }:1 o moa). { $suggestion ->
+        [available] Bilong kontras i inap long mode tudak, apim kontras bilong mode lait (olsem, putim { $lightAttribute }="{ $lightColor }") o senisim kala bilong mode tudak (olsem, putim { $darkAttribute }="{ $darkColor }").
+       *[none] Bilong kontras i inap long mode tudak, apim kontras bilong mode lait o senisim ol kala ol i kisim wantaim textColorDarkMode na/o backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Maski stail { $styleNumber } i gat kala bilong tok ol i makim na kontras bilong en i inap long mode lait, kontras bilong kala bilong tok ol i kisim long mode tudak i sot i birua long kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nidim { $threshold }:1 o moa). { $suggestion ->
+        [available] Bilong kontras i inap long mode tudak, apim kontras bilong mode lait (olsem, putim textColor="{ $lightColor }") o senisim kala bilong mode tudak (olsem, putim textColorDarkMode="{ $darkColor }").
+       *[none] Bilong kontras i inap long mode tudak, apim kontras bilong mode lait o senisim kala ol i kisim wantaim textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wanpela seksen inap makim wanpela <stylePalette> tasol; yusim las wan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = i no inap save long ol kain i narapela bilong { $component } long wanem numToSelect i no namba i no gat hap na i no daunbilo long zero.
+
+variant-num-to-select-not-constant-number = i no inap save long ol kain i narapela bilong { $component } long wanem numToSelect i no namba i stap strong.
+
+variant-with-replacement-not-constant-boolean = i no inap save long ol kain i narapela bilong { $component } long wanem withReplacement i no boolean i stap strong.
+
+variant-select-weight-disables-unique = Ol kain i narapela bilong select i dai sapos i gat wanpela opsen i gat selectWeight o selectForVariants
+
+variant-coprime-undetermined = i no inap save long ol kain i narapela bilong { $component } long wanem i no inap save olsem coprime i false oltaim.
+
+variant-attribute-not-constant = i no inap save long ol kain i narapela bilong { $component } long wanem { $attribute } i no stap strong.
+
+variant-attribute-not-number = i no inap save long ol kain i narapela bilong { $component } long wanem { $attribute } i no namba.
+
+variant-attribute-wrong-type-for-sequence =
+    i no inap save long ol kain i narapela bilong { $component } kain { $type } long wanem { $attribute } i no { $expected ->
+        [letters-combination] bung bilong ol leta
+        [math-expression] stretpela tok matematik
+        [integer] namba i no gat hap
+       *[number] namba
+    }.
+
+variant-length-not-integer = i no inap save long ol kain i narapela bilong { $component } long wanem length i no namba i no gat hap.
+
+variant-sort-not-implemented = ol kain i narapela bilong wanpela { $component } i gat sort i no wok yet
+
+variant-exclude-combinations-not-implemented = ol kain i narapela bilong wanpela { $component } i gat excludeCombinations i no wok yet
+
+variant-math-exclude-not-implemented = ol kain i narapela bilong wanpela { $component } kain math i gat exclude i no wok yet
+
+variant-non-constant-exclude-not-implemented = ol kain i narapela bilong wanpela { $component } i gat exclude i no stap strong i no wok yet
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: i no wok long renderer prefigure bilong graph; kalapim dispela pikinini.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiometri i no pinis o i no gat arere; kalapim dispela pikinini.
+
+prefigure-curve-label-omitted = { $subject }: ol nem i no wok long ol kurup ol i senisim; i no bihainim nem.
+
+prefigure-curve-unsupported-definition-type = { $subject }: kain mining bilong pankisen kurup '{ $definitionType }' i no wok; kalapim dispela pikinini.
+
+prefigure-region-flip-functions-unsupported = { $subject }: atribiut flipFunctions long regionBetweenCurves i no wok; kalapim dispela pikinini.
+
+prefigure-region-non-formula-child = { $subject }: ol pikinini pankisen kain formula tasol i wok long regionBetweenCurves; kalapim dispela pikinini.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' i no wok long { $labelKind ->
+        [line-family] nem bilong famili bilong lain
+       *[point] nem bilong poin
+    }; yusim nomol pasin bilong stretim bilong PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: stail bilong pulapim '{ $fillStyle }' i no wok long PreFigure; go bek long pulap i strong.
+
+prefigure-line-style-unknown = { $subject }: stail bilong lain '{ $lineStyle }' ol i no save long en, i no bihainim long autput bilong PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: stail bilong marker '{ $markerStyle }' i go long stail 'diamond' bilong PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: stail bilong marker '{ $markerStyle }' i no wok long PreFigure; yusim nomol stail.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` i no stret; i no inap makim target. I no bihainim annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` i makim planti target; yusim namba wan target.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` i no stret; target i stap ausait long graph i holim em. I no bihainim annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` i no stret; target i no wanpela samting bilong piksa i wok long senis prefigure. I no bihainim annotation.
+
+annotation-text-missing = `<annotation>`: `text` i no stap o i emti; i givim emti tok.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Painim wanpela raunwara sanap.
+       *[other] Painim wanpela raunwara sanap i kisim hap `<{ $componentType }>` insait.
+    }
+
+reference-no-referent = I no gat samting ol i painim we refrens i makim: `{ $reference }`
+
+reference-multiple-referents = Planti samting ol i painim we refrens i makim: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Fomat bilong atribiut { $attribute } bilong `<{ $componentType }>` i no stret.
+
+children-invalid = Ol pikinini bilong `<{ $componentType }>` i no stret: painim ol pikinini i no stret: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Valiu `{ $value }` i no stret long atribiut `{ $attribute }`, yusim valiu `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] I no painim vesen DoenetML { $version }.
+       *[other] I no painim vesen DoenetML { $version }. Go bek long vesen { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML i no stret: { $content }
+
+parse-tag-missing-close-tag = DoenetML i no stret: Tag `{ $tag }` i no gat tag bilong pasim. Yumi wet long tag i pasim em yet o tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML i no stret: I gat asua long tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML i no stret: I luk olsem atribiut `{ $attribute }` i no gat valiu.
+
+parse-attribute-invalid = DoenetML i no stret: Atribiut `{ $attribute }` i no stret
+
+parse-attribute-value-invalid = DoenetML i no stret: Valiu bilong atribiut `{ $value }` i no stret
+
+parse-attribute-value-quote-mismatch = DoenetML i no stret: Valiu bilong atribiut `{ $value }` i no stret. Ol mak bilong kot i no wankain. I luk olsem i sot wanpela `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML i no stret: Painim wanpela tag i no gat nem, olsem `<`
+
+parse-tag-not-closed = DoenetML i no stret: Tag `{ $tag }` i no pas (i luk olsem i sot `>`).
+
+parse-self-closing-tag-name-missing = DoenetML i no stret: Painim wanpela tag i no gat nem `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML i no stret: Tag `{ $tag }` i no pas (i luk olsem i sot `/>`).
+
+parse-tag-invalid-attributes = DoenetML i no stret: Tag `{ $tag }` i no stret. Ating ol atribiut bilong en i no stret.
+
+parse-close-tag-name-missing = DoenetML i no stret: Painim wanpela tag bilong pasim i no gat nem, olsem `</`
+
+parse-attribute-value-unquoted = Ol valiu bilong atribiut i mas stap insait long ol mak bilong kot: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML i no stret: Painim tag bilong pasim `{ $tag }`, tasol i no gat tag bilong opim i wankain
+
+parse-close-tag-mismatched = DoenetML i no stret: Tag bilong pasim i no wankain. Yumi wet long `</{ $expected }>`. Painim `{ $found }`
+
+parser-node-unconvertible = I no inap senisim node { $node } i go long node Dast.
+
+## Names
+
+name-attribute-invalid =
+    Atribiut name='{ $name }' i no stret. { $reason ->
+        [characters] Ol nem inap gat ol leta, ol namba, andaskoa o haipen tasol.
+       *[start] Ol nem i mas kirap long wanpela leta.
+    }
+
+component-name-invalid-start = Nem bilong hap "{ $name }" i no stret. Ol nem i mas kirap long wanpela leta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer i gat type videoWatched i mas gat atribiut video
+
+answer-video-watched-video-not-reference = Atribiut video bilong answer i gat type videoWatched i mas stap wanpela refrens
+
+answer-name-not-single-text = Atribiut name bilong answer i mas gat wanpela pikinini text tasol
+
+## Referencing another document
+
+external-doenetml-recursion-limit = I no inap kisim DoenetML long ausait, long wanem i gat planti tumas lain bilong ripit. Ating i gat wanpela refrens i raunim em yet?
+
+external-doenetml-unavailable = I no inap kisim DoenetML long { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ol i kisim long { $attribute }="{ $uri }" i no stret: em i no wankain wantaim kain hap "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Atribiut `{ $from }` i no wok moa; yusim `{ $to }`.
+       *[other] [deprecation] Atribiut `{ $from }` long `<{ $component }>` i no wok moa; yusim `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Atribiut `{ $from }` i no wok moa na i no bihainim long wanem ol i makim `{ $to }` tu.
+       *[other] [deprecation] Atribiut `{ $from }` long `<{ $component }>` i no wok moa na i no bihainim long wanem ol i makim `{ $to }` tu.
+    }
+
+deprecated-attribute-ignored = [deprecation] Atribiut `{ $attribute }` long `<{ $component }>` i no wok moa na i no bihainim.
+
+deprecated-attribute-to-child = [deprecation] Atribiut `{ $attribute }` long `<{ $component }>` i no wok moa; yusim wanpela pikinini `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Valiu `{ $value }` bilong atribiut `{ $attribute }` long `<{ $component }>` i no wok moa; yusim `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` inap mekim planti long tok Inglis tasol, olsem na tok bilong en i no senis insait long dokumen ol i raitim long { $locale }. Raitim stret fom bilong planti, o putim wantaim atribiut `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Elemen `<{ $tag }>` i no wanpela elemen bilong Doenet ol i save long en.
+
+schema-element-not-allowed-at-root = Elemen `<{ $tag }>` i no ken stap long as bilong dokumen.
+
+schema-element-not-allowed-inside = Elemen `<{ $tag }>` i no ken stap insait long `<{ $parent }>`.
+
+schema-attribute-unrecognized = Elemen `<{ $tag }>` i no gat atribiut i gat nem `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Atribiut `{ $attribute }` bilong elemen `<{ $tag }>` i mas stap wanpela lista we olgeta samting insait em wanpela bilong: { $allowed }
+       *[other] Atribiut `{ $attribute }` bilong elemen `<{ $tag }>` i mas stap wanpela bilong: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nem bilong kain i no stret long select.  Nem bilong kain { $variantName } i kamap long { $numOptions } opsen tasol namba bilong makim em { $numToSelect }.
+
+select-variant-name-without-options = Ol i makim sampela kain long select tasol i no gat opsen ol i makim long nem bilong kain: { $variantName }.
+
+select-variant-name-not-possible = Nem bilong kain { $variantName } ol i makim long select i no wanpela nem bilong kain i ken kamap.
+
+select-too-few-options = I no inap makim { $numToSelect } hap long { $numOptions } tasol.
+
+select-from-sequence-too-few-values = I no inap makim { $numToSelect } valiu long wanpela sequence i gat longpela { $length }.
+
+select-from-sequence-indices-count-mismatch = Namba bilong ol indeks ol i makim long select i mas wankain wantaim namba bilong makim
+
+select-from-sequence-indices-not-integers = Olgeta indeks ol i makim long select i mas namba i no gat hap
+
+select-from-sequence-index-excluded = Indeks bilong selectfromsequence ol i makim em ol i rausim
+
+select-from-sequence-indices-excluded-combination = Ol indeks bilong selectfromsequence ol i makim em wanpela bung ol i rausim
+
+select-from-sequence-coprime-not-positive-integers = I no inap makim ol bung coprime long wanem samting ol i makim i no namba i no gat hap na i antap long zero.
+
+select-from-sequence-coprime-common-factor = I no inap makim ol namba coprime. Olgeta valiu i gat wankain faktor. (Valiu bilong "from" o "to" ol i makim i mas coprime wantaim "step".)
+
+select-from-sequence-coprime-single-number = I no inap makim ol bung coprime long wanpela namba tasol i no 1.
+
+select-from-sequence-excluded-too-many-combinations = Ol i rausim moa long 70% bilong ol bung long selectFromSequence
+
+select-from-sequence-coprime-none-found = I no inap makim ol namba coprime. Olgeta valiu i gat wankain faktor.
+
+select-from-sequence-too-few-unique-values = I no inap makim { $numToSelect } valiu i narapela long wanpela sequence i gat longpela { $numPossibleValues }
+
+select-prime-numbers-too-few-values = I no inap makim { $numToSelect } valiu long wanpela lista prima i gat longpela { $numValues }
+
+select-prime-numbers-values-count-mismatch = Namba bilong ol valiu ol i makim long select i mas wankain wantaim namba bilong makim
+
+select-prime-numbers-values-not-prime = Olgeta valiu ol i makim long select prime number i mas stap long lista prima
+
+select-prime-numbers-values-excluded-combination = Ol valiu bilong selectPrimeNumbers ol i makim em wanpela bung ol i rausim
+
+select-prime-numbers-excluded-too-many-combinations = Ol i rausim moa long 70% bilong ol bung long selectPrimeNumbers
+
+select-random-combination-fluke = Long wanpela samting i no save kamap, i no inap makim wanpela bung bilong ol namba i kamap nating
+
+select-random-value-fluke = Long wanpela samting i no save kamap, i no inap makim wanpela namba i kamap nating

--- a/packages/i18n/locales/tpi/editor.ftl
+++ b/packages/i18n/locales/tpi/editor.ftl
@@ -1,0 +1,208 @@
+# Tok Pisin editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Tok Pisin marks no number on the noun, so a `{ $count -> … }` whose two
+# English branches differ only in the noun renders one string here and the
+# select is dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Setim gen
+       *[update] Apdetim
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } luk
+       *[other] { $word } luk { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Kain
+editor-variant-filter = Rausim sampela…
+editor-variant-next = Makim neks kain
+editor-variant-previous = Makim kain bipo
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Ol i painim wanpela brukim lo bilong akses WCAG AA. Klikim bilong { $action ->
+            [close] pasim
+           *[open] opim
+        } ripot bilong akses.
+        [advisories] Klikim bilong { $action ->
+            [close] pasim
+           *[open] opim
+        } ripot bilong akses. I no gat brukim lo WCAG AA ol i painim, tasol i gat sampela moa tok helpim long akses.
+       *[clean] Klikim bilong { $action ->
+            [close] pasim
+           *[open] opim
+        } ripot bilong akses. I no gat hevi bilong akses ol i painim.
+    }
+
+# No select on `$count` inside the branches: «brukim lo» and «tok helpim» are
+# the same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Ol i painim wanpela brukim lo bilong akses WCAG AA. Ol i painim { $count } brukim lo WCAG AA. Klikim bilong { $action ->
+            [close] pasim
+           *[open] opim
+        } ripot bilong akses.
+        [advisories] I no gat brukim lo WCAG AA ol i painim. Ol i painim { $count } moa tok helpim long akses. Klikim bilong { $action ->
+            [close] pasim
+           *[open] opim
+        } ripot bilong akses.
+       *[clean] I no gat brukim lo WCAG AA ol i painim. Klikim bilong { $action ->
+            [close] pasim
+           *[open] opim
+        } ripot bilong akses.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Vesen DoenetML { $version }
+
+editor-tab-help = Helpim i bihainim ples bilong kursa
+editor-tab-help-short = Ples
+editor-tab-errors = Asua
+editor-tab-warnings = Tok lukaut
+editor-tab-info = Tok save
+editor-tab-accessibility = Akses
+editor-tab-responses = Ol bekim ol i salim
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Ol samting bilong editor
+editor-format-as-doenetml = Fomatim olsem DoenetML
+editor-format-as-xml = Fomatim olsem XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Lain #{ $line }
+
+editor-no-errors = I no gat asua
+editor-no-warnings = I no gat tok lukaut
+editor-no-info = I no gat tok save bilong skelim
+
+editor-show-info-annotations = Soim ol tok save bilong skelim insait long editor
+editor-show-accessibility-annotations = Soim ol skelim bilong akses insait long editor
+
+editor-accessibility-learn-more = Lainim rot Doenet i bihainim long akses
+
+editor-accessibility-violations-heading = Ol brukim lo bilong akses ({ $standard })
+
+editor-accessibility-other-heading = Ol arapela hevi bilong akses
+editor-none-found = I no gat wanpela ol i painim
+
+
+## Submitted responses
+
+editor-no-responses = I no gat bekim ol i salim yet
+editor-response-answer-id = Id bilong bekim
+editor-response-response = Bekim
+editor-response-credit = Mak
+editor-response-submitted = Ol i salim
+
+
+## The context-help panel
+
+help-placeholder = Putim kursa long nem bilong tag, long atribiut, o long { $ref } bilong kisim tok save.
+
+help-unsupported-ref-chain = Helpim bilong ol refrens i gat planti hap olsem { $example } i no wok yet.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] I no gat samting ol i painim we refrens i makim: { $ref }.
+        [multiple] Planti samting ol i painim we refrens i makim: { $ref }.
+       *[indeterminate] Ol i no inap save wanem samting { $ref } i makim.
+    }
+
+help-learn-about-references = Lainim long ol refrens →
+help-reference-page = Pes bilong refrens →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Insait long { $element }
+       *[top] Long antap tru
+    }{ $allowed ->
+        [none] { " — i no gat samting yu ken putim hia." }
+        [text] { " — raitim tok hia." }
+        [text-and-components] { " — raitim tok hia, o traim:" }
+       *[components] { " — ol samting bilong traim:" }
+    }
+
+help-suggestions-footer = Paitim { $shortcut } bilong lukim olgeta { $total } hap.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } em wanpela refrens i go long { $target }.
+       *[other] { $ref } em wanpela refrens i go long { $target } (lain { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } i bringim olsem { $role }.
+       *[other] { $owner } i bringim long lain { $line } olsem { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } em wanpela refrens i go long propati { $property } bilong { $element }.
+       *[other] { $ref } em wanpela refrens i go long propati { $property } bilong { $element } (lain { $line }).
+    }
+
+help-kind-attribute = atribiut
+help-kind-snippet = liklik kod
+help-kind-array-entry = entri bilong array
+
+help-default = Nomol:
+help-active-default = Nomol i wok nau:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ol valiu i orait (wanpela long wanwan samting):
+       *[other] Ol valiu i orait:
+    }
+
+help-suggested-values = Ol valiu ol i tok yu ken traim:
+
+help-inserts = I putim insait:
+
+# No select: «koodinet» is the same word for one and for many.
+help-coordinates = Koodinet:
+
+help-type = Kain:
+
+help-resolved-style = Stail ol i painim pinis (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Ol nem pankisen ol i painim pinis:
+help-reset-list = Lista bilong setim gen long dispela input:
+help-added-on-input = Ol i putim long dispela input:
+help-removed-on-input = Ol i rausim long dispela input:
+
+help-reset-overrides = { $reset } i winim { $additional } na { $removed }.

--- a/packages/i18n/locales/ty/chrome.ftl
+++ b/packages/i18n/locales/ty/chrome.ftl
@@ -1,0 +1,146 @@
+# Tahitian viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the orthography of the Académie tahitienne (Fare Vānaʻa), which
+# writes both marks that distinguish words: the glottal stop as the *ʻeta* «ʻ» —
+# U+02BB, a letter and not an apostrophe — and vowel length as the *tārava*, the
+# macron. That is the same trap `locales/to` records: the two render alike and
+# compare unequal, so replacing a ʻeta with U+0027 changes the spelling of the
+# word. The older missionary orthography writes neither mark; this catalog is
+# not in it.
+#
+# Tahitian marks no number on the noun — plurality is «te mau» before it — so a
+# `{ $count -> … }` whose two English branches differ only in the noun renders
+# one string here and the select is dropped. A `[0]` branch stays wherever
+# English has one.
+
+
+## Answer submission
+
+answer-checking = Te hiʻopoʻa nei…
+answer-submitting = Te hōpoi nei…
+
+answer-checking-status = Te hiʻopoʻa nei i te pāhonoraʻa
+answer-submitting-status = Te hōpoi nei i te pāhonoraʻa
+
+answer-correct = Tano
+answer-incorrect = Tano ʻore
+
+answer-response-saved = Ua tāpeʻahia te pāhonoraʻa
+
+answer-percent-credit = { $percent }% o te tāpuraʻa
+answer-percent-correct = { $percent }% tano
+answer-percent-short = { $percent } %
+
+max-credit-available = Tāpuraʻa rahi roa e nehenehe e noaʻa: { $percent }%
+
+# No select: «tāmataraʻa» is the same word for one and for many. The `[0]`
+# branch stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] ʻaita ʻe tāmataraʻa i toe
+       *[other] e { $count } tāmataraʻa i toe
+    }
+
+validation-correct = (Tano)
+validation-incorrect = (Tano ʻore)
+validation-partially-correct = (Tano i te tahi tuhaʻa)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Faʻaʻite i te { $count } pāhonoraʻa nō te { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Manaʻo faʻahou
+
+collapsible-click-to-open = (pāto no te ʻiriti)
+collapsible-click-to-close = (pāto no te ʻōpani)
+
+collapsible-initializing = Te haʻamata nei…
+
+footnote-show = Faʻaʻite i te footnote
+footnote-hide = Hunā i te footnote
+
+description-more-information = haʻamāramaramaraʻa hau
+
+
+## Controls
+
+slider-previous = I mua
+slider-next = I muri
+
+keyboard-open = ʻIriti i te papa taio
+keyboard-close = ʻŌpani i te papa taio
+
+choice-input-remove-choice = Iriti ê i te { $choice }
+
+matrix-remove-row = Iriti ê i te ʻāfata roa
+matrix-add-row = Tuʻu i te tahi ʻāfata roa
+matrix-remove-column = Iriti ê i te tīʻā
+matrix-add-column = Tuʻu i te tahi tīʻā
+
+subset-add-remove-points = Tuʻu/Iriti ê i te mau poini
+subset-toggle-points-intervals = Taui i te mau poini ʻe te mau ārearea
+subset-move-points = Faʻanehenehe i te mau poini
+subset-clear = Tāmā
+
+orbital-add-row = Tuʻu i te tahi ʻāfata roa
+orbital-remove-row = Iriti ê i te ʻāfata roa
+orbital-add-box = Tuʻu i te tahi ʻāfata
+orbital-remove-box = Iriti ê i te ʻāfata
+orbital-add-up-arrow = Tuʻu i te tahi ʻōfaʻi i niʻa
+orbital-add-down-arrow = Tuʻu i te tahi ʻōfaʻi i raro
+orbital-remove-arrow = Iriti ê i te ʻōfaʻi
+
+orbital-row-label = Tāpaʻo nō te ʻāfata roa { $row }
+
+pretzel-answer = Pāhonoraʻa
+
+summary-statistics-caption = Haʻapotoraʻa numera o te { $column }
+
+
+## Math input
+
+math-input-preview-region = hiʻoraʻa nā mua o te parau numera
+math-input-preview = Hiʻoraʻa nā mua
+math-input-invalid-expression = Parau numera tano ʻore:
+
+
+## Document status
+
+viewer-initializing = Te haʻamata nei…
+
+
+## Errors
+
+error-heading = Hape
+
+error-found-at =
+    { $span ->
+        [line] Ua ʻitehia i te reni { $startLine }.
+       *[lines] Ua ʻitehia i te mau reni { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Tē vai nei te hape i roto i teie papaʻiraʻa!
+
+diagnostic-heading-error = Hape
+diagnostic-heading-warning = Faʻaararaʻa
+diagnostic-heading-information = Haʻamāramaramaraʻa
+diagnostic-heading-hint = Aratairaʻa
+
+accessibility-heading-level-1 = Ofatiraʻa i te ture ʻāravehi WCAG AA
+accessibility-heading-level-2 = Faʻaararaʻa nō te ʻāravehi
+
+something-went-wrong = Ua tupu te tahi hape.
+
+renderer-load-failed = ʻaita te tahi renderer i hōhoʻahia. A tāmata faʻahou i te ʻāpī.
+
+core-start-failed = ʻAita te hiʻoraʻa o te papaʻiraʻa i haʻamatahia. A tāmata faʻahou i te ʻāpī.

--- a/packages/i18n/locales/ty/content.ftl
+++ b/packages/i18n/locales/ty/content.ftl
@@ -1,0 +1,258 @@
+# Tahitian content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Fare Vānaʻa orthography, with the ʻeta and the tārava; see
+# `chrome.ftl`'s header.
+#
+# Tahitian has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The adjectives **follow** the noun — «reni ʻuteʻute», a red line — so every
+# composition message inverts the English order, as `locales/to` and
+# `locales/fj` do.
+#
+# **The colour words are reduplicated stems** as they are in Tongan and Fijian:
+# «ʻereʻere», «teatea», «ʻuteʻute». «ninamu» is the blue of the lagoon and
+# «matie» the green of growth, and the line between them is not English's line
+# between blue and green; `.cyan` sits inside «ninamu» with nothing of its own,
+# and what is written there is a placeholder. `.purple` and `.pink` are French
+# loans, which is what Tahitian writing uses.
+#
+# The geometry vocabulary is largely French-derived, because schooling in French
+# Polynesia is in French from the earliest grades and mathematics is taught in
+# it throughout. That seam is the first thing a speaker should judge.
+
+
+## Style vocabulary
+
+color =
+    .black = ʻereʻere
+    .white = teatea
+    .gray = rehu
+    .red = ʻuteʻute
+    .orange = ʻanani
+    .yellow = reʻareʻa
+    .green = matie
+    .cyan = tianu
+    .blue = ninamu
+    .purple = vaiorete
+    .pink = roze
+    .brown = parauri
+
+line-width =
+    .thick = mātotoru
+    .thin = rairai
+
+line-style =
+    .dashed = motumotu
+    .dotted = tāpaʻo iti
+
+# Noun phrases. Tahitian marks no plural on the noun, so «reni» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = reni tāʻōtiʻa
+    .vertical = reni tiʻa
+    .diagonal = reni pīʻao
+    .backdiagonal = reni pīʻao huri
+    .dots = tāpaʻo iti
+    .diamonds = tiamane
+
+noun =
+    .line = reni
+    .line-segment = tuhaʻa reni
+    .ray = hihi
+    .vector = vetetera
+    .curve = pīʻao
+    .function = fonotio
+    .parabola = parabole
+    .polyline = reni ʻāfaʻifaʻi
+    .polygon = poligone
+    .triangle = tapatoru
+    .rectangle = tapafā roa
+    .circle = ʻāpōpōti
+    .region = tuhaʻa fenua
+    .point = poini
+    .square = tapafā ʻaifaito
+    .diamond = tiamane
+    .cross = ʻafaʻifaʻi
+    .plus = tāpiʻi
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] e { $numSides } hiti tōna
+       *[head] poligone ʻaifaito
+    }
+
+# One answer for every noun: Tahitian has no grammatical gender.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun first and the adjectives behind it, which is the opposite of English.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = ʻī
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } e { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } e { $pattern }
+        [plain-tail] { $noun } { $filled } { $color } { $nounTail }
+        [pattern-tail] { $noun } { $filled } { $color } { $nounTail } e { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# Tahitian's «te» is the article and is not what English's "a" is doing here, so
+# all four branches read alike but for the connective: «e» opens the first
+# clause and «ʻe» a further one.
+style-border-clause =
+    { $parts ->
+        [with-article] e hiti { $border }
+        [and] ʻe hiti { $border }
+        [and-article] ʻe hiti { $border }
+       *[with] e hiti { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ʻī ʻore
+
+style-text =
+    { $parts ->
+        [background] { $color } e niʻa { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ʻaita
+
+
+## Boolean words
+
+boolean-true = mau
+boolean-false = hape
+
+
+## Answer buttons
+
+answer-submit-label = Hiʻopoʻa i te ʻohipa
+answer-submit-label-no-correctness = Hōpoi i te pāhonoraʻa
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Tahitian marks no plural on the noun.
+section-name =
+    .activity = ʻOhipa
+    .aside = Nota hiti
+    .cascade = Kasakade
+    .definition = Faʻataʻaraʻa
+    .example = Hiʻoraʻa
+    .exercise = Tāmataraʻa
+    .exercises = Tāmataraʻa
+    .given-answer = Pāhonoraʻa
+    .note = Nota
+    .objectives = Fā
+    .paragraphs = Paratarafe
+    .part = Tuhaʻa
+    .problem = Fifi
+    .problems = Fifi
+    .proof = Haʻapāpūraʻa
+    .question = Uiraʻa
+    .section = Tuhaʻa
+    .solution = Ravaʻi
+    .task = ʻOhipa rave
+    .theorem = Teoreme
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Aratairaʻa
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tāpura { $enumeration }
+        [numbered-title] Tāpura { $enumeration }{ ": " }
+        [unnumbered-title] Tāpura{ ": " }
+       *[unnumbered] Tāpura
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Hōhoʻa { $enumeration }
+        [numbered-caption] Hōhoʻa { $enumeration }{ ": " }
+        [unnumbered-caption] Hōhoʻa{ ": " }
+       *[unnumbered] Hōhoʻa
+    }
+
+
+## Paginator controls
+
+paginator-previous = I mua
+paginator-next = I muri
+paginator-page = ʻĀpī
+
+paginator-page-status = { $pageLabel } { $currentPage } nō roto i te { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = aore rā
+piecewise-condition-if = mai te mea
+piecewise-condition-otherwise = mai te mea ʻaita
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Secondary science in French Polynesia is taught in French, out of
+## French textbooks, so the chemical vocabulary a pupil meets is `locales/fr`'s.
+## Tahitian is the language of the early grades and of the classroom talk around
+## the lesson; there is no settled Tahitian table for a seed to reproduce. That
+## is the `locales/ht` case with a different colonial language on the other side
+## of it.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Tāpaʻo tāʻiʻaʻi tano ʻore
+chemistry-invalid-ionic-compound = Faʻaʻamuraʻa ionika tano ʻore

--- a/packages/i18n/locales/ty/diagnostics.ftl
+++ b/packages/i18n/locales/ty/diagnostics.ftl
@@ -1,0 +1,624 @@
+# Tahitian diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Written with the ʻeta and the tārava; see `chrome.ftl`. Tahitian marks no
+# number on the noun, so a counted message whose only English difference is the
+# noun's number renders one string here and the select is dropped.
+
+
+## `<lineSegment>`
+
+# No select: «ʻaita e faʻaohipahia» does not agree with what is ignored, and the
+# list carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = ʻaita te { $attributes } e faʻaohipahia ia haʻapāpūhia nā hopeʻa e piti
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ʻaita te { $attributes } e faʻaohipahia ia haʻapāpūhia te hopeʻa ʻe te ropū
+
+line-segment-midpoint-offset-without-midpoint = ʻaita te midpointOffset e ʻohipa mai te mea ʻaita e ropū
+
+## `<line>`
+
+line-points-undetermined-dimensions = Reni e nā roto i te mau poini ʻaita i haʻapāpūhia tō rātou faito.
+
+line-points-too-few-dimensions = E tiʻa i te reni ia haere nā roto i te mau poini e piti aore rā hau atu tō rātou faito.
+
+line-points-depend-on-variables = Tē haere nei te reni nā roto i te mau poini e tiʻaturi nei i te mau taui: { $variables }.
+
+line-equation-invalid-format = Huru tano ʻore nō te faʻataʻaraʻa o te reni i roto i te mau taui { $variable1 } ʻe { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ua haʻapāpūhia te hihi e te through, te endpoint ʻe te direction.  ʻAita te through i haʻapāpūhia e faʻaohipahia.
+
+ray-dimension-mismatch = ʻaita te numDimensions e tuʻati i roto i te hihi.
+
+## `<vector>`
+
+vector-overprescribed-head = Ua haʻapāpūhia te vetetera e te head, te tail ʻe te displacement.  ʻAita te head i haʻapāpūhia e faʻaohipahia.
+
+vector-dimension-mismatch = ʻaita te numDimensions e tuʻati i roto i te vetetera.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = ʻEita e nehenehe e huti i te `<{ $component }>` nō te mea ʻaita tōna taui huru nearestPoint.
+
+constrain-to-without-nearest-point = ʻEita e nehenehe e tāpeʻa i te `<{ $component }>` nō te mea ʻaita tōna taui huru nearestPoint.
+
+constrain-to-interior-without-nearest-point = ʻEita e nehenehe e tāpeʻa i roto i te `<{ $component }>` nō te mea ʻaita tōna taui huru nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ʻaita te labelPosition e faʻaohipahia i roto i te choiceInput ʻaita e inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = ʻAita te mau indeki i haʻapāpūhia nō te choiceInput e faʻaohipahia nō te mea ʻaita te rahiraʻa indeki e tuʻati i te rahiraʻa māʻitiraʻa.
+
+pretzel-indices-count-mismatch = ʻAita te mau indeki i haʻapāpūhia nō te problem e faʻaohipahia nō te mea ʻaita te rahiraʻa indeki e tuʻati i te rahiraʻa problem.
+
+shuffle-indices-count-mismatch = ʻAita te mau indeki i haʻapāpūhia nō te shuffle e faʻaohipahia nō te mea ʻaita te rahiraʻa indeki e tuʻati i te rahiraʻa tuhaʻa.
+
+indices-ignored-out-of-range = ʻAita te mau indeki i haʻapāpūhia nō te { $component } e faʻaohipahia nō te mea tē vai nei te indeki i ʻō atu i te ʻōtiʻa.
+
+pretzel-indices-repeated = ʻAita te mau indeki i haʻapāpūhia nō te pretzel e faʻaohipahia nō te mea ua faʻahiti-piti-hia te tahi indeki.
+
+pretzel-circuit-first-index = ʻAita te mau indeki i haʻapāpūhia nō te pretzel i te mode circuit e faʻaohipahia nō te mea e tiʻa i te indeki mātāmua ia riro ei 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Ia ʻohipa te `<{ $component }>` e te mau tamariʻi string, e tiʻa ia haʻapāpūhia te ʻatirivite `type`.
+
+invalid-type-defaulting-to-math = Tano ʻore te type { $type } nō te tuhaʻa { $component }. E tiʻa ia riro ei hōʻē o te math, text, number, aore rā boolean. Tē faʻaohipahia nei te math.
+
+string-not-valid-component-to-arrange = ʻAita te string "{ $value }" e tuhaʻa tano nō te { $component }. ʻAita e faʻaohipahia.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Tano ʻore te type { $type }, ua tuʻuhia te type i te number.
+
+invalid-variable-value = Faito tano ʻore o te tahi taui: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = E tiʻa i te indeki o te huru taʻa ê { $index } ia riro ei numera
+
+variant-index-must-be-integer = E tiʻa i te indeki o te huru taʻa ê { $index } ia riro ei numera taʻato ʻa
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = ʻAitaʻe te `<{ $component }>` i faʻatupuhia nō te faito pāpū. Ua tuʻuhia te ʻāteatea ei faito tāʻiʻiti.
+
+side-by-side-absolute-margins = ʻAitaʻe te `<{ $component }>` i faʻatupuhia nō te faito pāpū. Ua tuʻuhia te hiti ei faito tāʻiʻiti.
+
+side-by-side-no-block-child = `<{ $component }>` tano ʻore: e tiʻa ia vai te hōʻē tamariʻi block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = ʻAita te ʻatirivite `for` i roto i te `<label>` hōhoʻa e faʻaohipahia.
+
+label-for-must-resolve-to-one = E tiʻa i te ʻatirivite `for` i roto i te `<label>` ia faʻataʻa i te hōʻē noa tuhaʻa.
+
+label-for-unresolved = ʻAita te ʻatirivite `for` i roto i te `<label>` i nehenehe e faʻataʻa i te tahi tuhaʻa.
+
+label-for-answer-with-authored-inputs = Tē faʻataʻa nei te ʻatirivite `for` i roto i te `<label>` i te hōʻē `<answer>` e vai ra te mau tuʻuraʻa i papaʻihia e te taata papaʻi; a faʻataʻa tōtiʻa i te tuʻuraʻa.
+
+label-for-answer-without-input = Tē faʻataʻa nei te ʻatirivite `for` i roto i te `<label>` i te hōʻē `<answer>` ʻaita tōna tuʻuraʻa e tāpaʻohia.
+
+label-for-must-reference-input-or-answer = E tiʻa i te ʻatirivite `for` i roto i te `<label>` ia faʻataʻa i te hōʻē input aore rā i te hōʻē answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Nō te ʻāravehi, e tiʻa i te `<{ $component }>` ia vai te faʻataʻaraʻa poto aore rā ia haʻapāpūhia ei faʻanehenehe.
+
+accessibility-video-short-description = Nō te ʻāravehi, e tiʻa i te `<video>` ia vai te faʻataʻaraʻa poto.
+
+accessibility-input-short-description-or-label = Nō te ʻāravehi, e tiʻa i te `<{ $component }>` ia vai te faʻataʻaraʻa poto aore rā te tāpaʻo.
+
+accessibility-answer-input-short-description-or-label = Nō te ʻāravehi, e tiʻa i te hōʻē `<answer>` e faʻatupu nei i te tuʻuraʻa ia vai te faʻataʻaraʻa poto aore rā te tāpaʻo.
+
+accessibility-short-description-contains-math = ʻEita e tiʻa i te mau faʻataʻaraʻa poto ia vai te mau tuhaʻa numera mai te `<{ $component }>`. A papaʻi i te numera na roto i te parau.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] ʻAita te taʻa ê o te { $colorName } e navai nō te parau upoʻo o te tuhaʻa (huru pōuri) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e titauhia te { $threshold }:1 aore rā hau atu).
+       *[other] ʻAita te taʻa ê o te { $colorName } e navai nō te parau upoʻo o te tuhaʻa ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e titauhia te { $threshold }:1 aore rā hau atu).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = ʻAitaʻe te `<circle>` e haere nā roto i te { $count } poini i faʻatupuhia mai te mea ʻaita te mau poini e faito numera.
+
+circle-too-many-through-points = ʻEita e nehenehe e tāpura i te ʻāpōpōti e haere nā roto i te hau atu i te 3 poini.
+
+circle-overprescribed-radius-center-points = ʻEita e nehenehe e tāpura i te ʻāpōpōti e haʻapāpūhia tōna ʻātea, tōna ropū ʻe te mau poini e haere nā roto.
+
+circle-center-with-multiple-points = ʻEita e nehenehe e tāpura i te ʻāpōpōti e haʻapāpūhia tōna ropū e haere rā nā roto i te hau atu i te 1 poini.
+
+circle-radius-too-small = ʻEita e nehenehe e tāpura i te ʻāpōpōti: nō te mea e { $distance } te ʻātea o nā poini e piti, mea iti roa te ʻātea { $radius } i haʻapāpūhia.
+
+circle-radius-with-many-points = ʻEita e nehenehe e faʻatupu i te ʻāpōpōti e haere nā roto i te hau atu i te piti poini e te ʻātea i haʻapāpūhia.
+
+circle-invalid-center-or-through-points = Tano ʻore te ropū aore rā te mau poini e haere nā roto te ʻāpōpōti.
+
+circle-radius-center-with-multiple-points = ʻEita e nehenehe e tāpura i te ʻātea o te ʻāpōpōti e haʻapāpūhia tōna ropū e haere rā nā roto i te hau atu i te 1 poini.
+
+circle-change-radius-non-numerical = ʻEita e nehenehe e taui i te ʻātea o te ʻāpōpōti e haere nā roto i te mau poini ʻaore e numera
+
+circle-radius-with-points-non-numerical = ʻEita e nehenehe e faʻatupu i te ʻāpōpōti e haere nā roto i te hau atu i te hōʻē poini e te ʻātea i haʻapāpūhia mai te mea ʻaita e faito numera.
+
+circle-change-center-non-numerical = ʻAitaʻe te tauiraʻa o te ropū o te ʻāpōpōti e haere nā roto i te mau poini ʻaore e faito numera i faʻatupuhia.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Tahitian has one, because
+# «ārearea» and «tuʻuraʻa» do not change for number. Both selects are dropped
+# and both counts still arrive.
+function-domain-insufficient-dimensions = ʻAita te faito o te domain e navai nō te fonotio. E { $intervals } ārearea tō te domain, e { $inputs } tuʻuraʻa rā tō te fonotio.
+
+function-domain-invalid-format = Huru tano ʻore o te domain nō te fonotio.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] ʻAita te faito teitei roa o te fonotio ʻaore e numera e faʻaohipahia.
+        [minimum] ʻAita te faito haʻehaʻa roa o te fonotio ʻaore e numera e faʻaohipahia.
+        [extremum] ʻAita te ʻōtiʻa o te fonotio ʻaore e numera e faʻaohipahia.
+        [point] ʻAita te poini o te fonotio ʻaore e numera e faʻaohipahia.
+        [slope] ʻAita te pīʻao o te fonotio ʻaore e numera e faʻaohipahia.
+       *[other] ʻAita te { $type } o te fonotio ʻaore e numera e faʻaohipahia.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] ʻAita te faito teitei roa o te fonotio ʻaore e mea e faʻaohipahia.
+        [minimum] ʻAita te faito haʻehaʻa roa o te fonotio ʻaore e mea e faʻaohipahia.
+        [extremum] ʻAita te ʻōtiʻa o te fonotio ʻaore e mea e faʻaohipahia.
+        [point] ʻAita te poini o te fonotio ʻaore e mea e faʻaohipahia.
+       *[other] ʻAita te { $type } o te fonotio ʻaore e mea e faʻaohipahia.
+    }
+
+function-points-too-close = E piti poini tō te fonotio mea piri roa. ʻEita e nehenehe e faʻataʻa i te fonotio.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = E nehenehe noa te faʻahitiraʻa o te fonotio mai te mea e ʻaifaito te rahiraʻa tuʻuraʻa e te rahiraʻa faʻahopeʻaraʻa. E { $inputs } tuʻuraʻa e { $outputs } faʻahopeʻaraʻa tō teie fonotio.
+
+## `<sequence>`
+
+sequence-invalid-length = Tano ʻore te roa o te sequence.  E tiʻa ia riro ei numera taʻato ʻa ʻaore e haʻehaʻa i te ʻōre.
+
+sequence-invalid-step = Tano ʻore te step o te sequence.  E tiʻa ia riro ei numera nō te sequence type { $type }.
+
+sequence-invalid-endpoint-number = Tano ʻore te "{ $attribute }" o te sequence numera.  E tiʻa ia riro ei numera.
+
+sequence-invalid-endpoint-letters = Tano ʻore te "{ $attribute }" o te sequence reta.  E tiʻa ia riro ei tuʻatiraʻa reta.
+
+sequence-invalid-endpoint = Tano ʻore te "{ $attribute }" o te sequence.
+
+select-from-sequence-coprime-not-numbers = ʻaita te coprime e faʻaohipahia nō te mea ʻaita e numera tē māʻitihia
+
+select-from-sequence-coprime-with-exclude-combinations = ʻaita te coprime e faʻaohipahia nō te mea ua haʻapāpūhia te excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = target tano ʻore nō te `<{ $source }>`: ʻaita i ʻitehia te target.
+
+target-state-variable-not-found = target tano ʻore nō te `<{ $source }>`: ʻaita i ʻitehia te taui huru tōna iʻoa "{ $property }" i roto i te `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = E tiʻa i te mau taui o te `<odeSystem>` ia taʻa ê i te taui tiʻamā.
+
+ode-system-duplicate-variable-names = ʻEita e nehenehe e faʻataʻa i te mau fonotio RHS o te ODE mai te mea e hoʻē â te iʻoa o te mau taui tiʻaturi.
+
+ode-system-rhs-function-error = ʻEita e nehenehe e faʻataʻa i te fonotio RHS o te ODE.  Ua hape te faʻatupuraʻa o te fonotio mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = ʻEita e nehenehe e faʻataʻa i te tahi ʻōtiʻa i rotopū i te { $count } reni
+
+angle-invalid-through-point = Poini tano ʻore i roto i te through o te `<angle>`
+
+parabola-vertex-too-many-points = ʻAitaʻe te parabole e vai ra tōna upoʻo e haere rā nā roto i te hau atu i te 1 poini i faʻatupuhia.
+
+parabola-too-many-points = ʻAitaʻe te parabole e haere nā roto i te hau atu i te 3 poini i faʻatupuhia.
+
+intersection-too-many-items = ʻAitaʻe te fāraʻiraʻa nō te hau atu i te piti mea i faʻatupuhia
+
+## Other math components
+
+ionic-compound-not-two-ions = ʻAitaʻe te faʻaʻamuraʻa ionika nō te tahi atu mea ʻaore ra e piti ion i faʻatupuhia.
+
+ionic-compound-needs-cation-and-anion = Ua faʻatupuhia te faʻaʻamuraʻa ionika nō te hōʻē noa cation e te hōʻē noa anion.
+
+solve-equations-cannot-evaluate = ʻEita e nehenehe e faʻaʻoti i te faʻataʻaraʻa nō te mea ʻaita i nehenehe i hiʻopoʻa: { $equation }
+
+math-operators-operand-number-required = E tiʻa ia haʻapāpūhia te operandNumber ia rave i te tahi operand numera.
+
+eigen-decomposition-failed = ʻAita i nehenehe i tāpura i te eigenvalue o te matiri
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: ʻaita te parameter { $parameters } e ʻitehia i roto i te pattern, nō reira e tuʻati noa ʻoia i te mea ʻaore.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ʻaita i taʻa te grid="{ $grid }". E tiʻa ia riro ei none, medium, dense, aore rā e piti numera maitaʻi i faʻataʻahia e te hōʻē vāhi ʻaore, mai te grid="1 0.5". ʻAita e grid e hōhoʻahia.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: ʻaita te xLabelPosition="left" e tauturuhia i roto i te renderer prefigure; tē faʻaohipa nei i te huru o te vāhi ʻatau.
+
+prefigure-y-label-position-unsupported = `<graph>`: ʻaita te yLabelPosition="bottom" e tauturuhia i roto i te renderer prefigure; tē faʻaohipa nei i te huru o te vāhi i niʻa.
+
+prefigure-invalid-axis-bounds = `<graph>`: tano ʻore te mau ʻōtiʻa o te ʻāfata nō te tauiraʻa prefigure; tē faʻaohipa nei i te bbox mātauhia (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: tano ʻore te ʻāteatea nō te tauiraʻa prefigure; tē faʻaohipa nei i te ʻāteatea mātauhia o te hōhoʻa 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: tano ʻore te aspectRatio nō te tauiraʻa prefigure; tē faʻaohipa nei i te aspect ratio mātauhia 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: mea piri roa te ʻāteatea o te grid nō te mau ʻōtiʻa o te ʻāfata; ʻaita te grid e hōhoʻahia i roto i te renderer prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: ʻaita te mau annotation e hōhoʻahia mai te mea ʻaita te renderer PreFigure e faʻaohipahia.
+
+multiple-annotations-children = E rave rahi tamariʻi `<annotations>` i ʻitehia i roto i te `<graph>`; ʻaita te tāʻato ʻaraʻa e faʻaohipahia maori râ te hopeʻa.
+
+## Referring to other components
+
+copy-unrecognized-component-type = ʻEita e nehenehe e faʻaroa aore rā e huri i te huru tuhaʻa ʻaita i ʻitehia: { $type }.
+
+copy-prop-not-found = ʻAita i ʻitehia te prop { $property } i roto i te tuhaʻa huru { $component }
+
+collect-no-source = ʻAita i ʻitehia te source nō te collect.
+
+collect-invalid-component-type = ʻEita e nehenehe e haʻaputu i te mau tuhaʻa huru `<{ $component }>` nō te mea tano ʻore te huru tuhaʻa.
+
+reference-index-unavailable = ʻEita e nehenehe e faʻahiti i te indeki `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = ʻEita e nehenehe e piʻi i te { $action } i roto i te tuhaʻa `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Tano ʻore te huru o te mau numera.  ʻAita te roa o te mau ʻāfata roa e ʻaifaito. Ua ʻitehia i te componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = E vai ra te iʻoa tīʻā hōʻē â i roto i te mau numera.  Ua ʻitehia i te componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = ʻAita te iʻoa o te tahi tīʻā i roto i te mau numera.  Ua ʻitehia i te componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Tē tiʻaturi nei te award o teie pāhonoraʻa i te pāhonoraʻa tā te answer tag iho i hōpoi, ʻe e faʻatupu te reira i te huru ʻaita i tiʻaturihia.
+
+answer-max-num-attempts-in-section-wide-check-work = ʻAita te tuʻuraʻa i te `maxNumAttempts` i roto i te hōʻē `<answer>` i roto i te ʻāfata e vai ra te `sectionWideCheckWork` e ʻohipa, nō te mea nā te ʻāfata e faʻanaho i te rahiraʻa tāmataraʻa. A tuʻu i te `maxNumAttempts` i niʻa i te ʻāfata.
+
+nested-section-wide-check-work-max-num-attempts = ʻAita te tuʻuraʻa i te `maxNumAttempts` i niʻa i te ʻāfata e vai ra te `sectionWideCheckWork` e vai ra i roto i te tahi atu ʻāfata e vai ra te `sectionWideCheckWork` e ʻohipa, nō te mea nā te ʻāfata i rāpae e faʻanaho i te rahiraʻa tāmataraʻa. A tuʻu i te `maxNumAttempts` i niʻa i te ʻāfata i rāpae.
+
+# No select: «ʻatirivite» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = ʻEita te ʻatirivite { $attributes } e ʻohipa mai te mea ʻaita te symbolicEquality i tuʻuhia.
+
+answer-invalid-type = Huru tano ʻore nō te pāhonoraʻa: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Nō te mea ʻaita te iʻoa o te tuhaʻa `<{ $component }>`, ʻeita e nehenehe e faʻaohipa i te reira ei ʻatirivite nō te module
+
+module-attribute-name-already-defined = ʻEita e nehenehe e faʻaohipa i te tuhaʻa `<{ $component } name="{ $name }">` ei ʻatirivite nō te module nō te mea tē vai nei tā te huru tuhaʻa `<module>` te ʻatirivite "{ $name }".
+
+conditional-content-condition-ignored = ʻAita te ʻatirivite `condition` e faʻaohipahia i roto i te tuhaʻa `<conditionalContent>` e vai ra te mau tamariʻi case aore rā else.
+
+slider-markers-type-mismatch = ʻAita te huru o te marker e tuʻati i te huru o te slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel tano ʻore: e tiʻa i te `<problem>` tāʻitahi ia vai te hōʻē `<statement>` ʻe te hōʻē `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Pretzel tano ʻore: i te mode="circuit", ʻeita e nehenehe te `<problem>` mātāmua ia riro ei distractor.
+
+## Attribute values
+
+# No select: «faito» is the same word for one and for many.
+attribute-invalid-values = Faito tano ʻore { $values } nō te ʻatirivite `{ $attribute }`; ʻaita e faʻaohipahia.
+
+attribute-must-be-references = Faito tano ʻore `{ $value }` nō te ʻatirivite `{ $attribute }`. E tiʻa i te ʻatirivite ia hāmanihia i te mau faʻahitiraʻa e haʻamata i te `$`.
+
+math-input-invalid-function-names = <mathInput>: ʻaita te mau iʻoa fonotio tano ʻore i roto i te { $attribute } e faʻaohipahia: { $names }. E tiʻa i te iʻoa tāʻitahi ia vai e piti aore rā hau atu reta (reta aore rā tuʻatiraʻa); e nehenehe te suffix `|<mathspeak alternative>` e pee.
+
+## Building components from the source
+
+component-type-invalid = Huru tuhaʻa tano ʻore: `<{ $componentType }>`
+
+attribute-repeated = ʻEita e nehenehe e faʻahiti piti i te ʻatirivite { $attribute }.
+
+attribute-invalid-for-component = ʻAtirivite tano ʻore "{ $attribute }" nō te tuhaʻa huru `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    ʻAita te taʻa ê o te faʻataʻaraʻa huru { $styleNumber } e navai nō te { $context ->
+        [text-on-background] ʻiriʻiri o te parau i mua i te ʻiriʻiri o niʻa
+        [high-contrast] ʻiriʻiri taʻa ê teitei i mua i te ʻāfata
+        [line] ʻiriʻiri o te reni i mua i te ʻāfata
+        [marker] ʻiriʻiri o te marker i mua i te ʻāfata
+       *[text-on-canvas] ʻiriʻiri o te parau i mua i te ʻāfata
+    }{ $mode ->
+        [dark] { " (huru pōuri)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e titauhia te { $threshold }:1 aore rā hau atu).
+
+style-definition-dark-mode-text-background-contrast =
+    Noa atu â e vai ra i roto i te faʻataʻaraʻa huru { $styleNumber } te mau ʻiriʻiri i haʻapāpūhia e navai tō rātou taʻa ê nō te huru māramarama, ʻaita te taʻa ê o te ʻiriʻiri o te parau i mua i te ʻiriʻiri o niʻa e navai i roto i te mau ʻiriʻiri i ravehia nō te huru pōuri ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e titauhia te { $threshold }:1 aore rā hau atu). { $suggestion ->
+        [available] Ia navai te taʻa ê i te huru pōuri, a faʻarahi i te taʻa ê o te huru māramarama (ei hiʻoraʻa, a tuʻu i te { $lightAttribute }="{ $lightColor }") aore rā a mono i te ʻiriʻiri o te huru pōuri (ei hiʻoraʻa, a tuʻu i te { $darkAttribute }="{ $darkColor }").
+       *[none] Ia navai te taʻa ê i te huru pōuri, a faʻarahi i te taʻa ê o te huru māramarama aore rā a mono i te mau ʻiriʻiri i ravehia na roto i te textColorDarkMode ʻe/aore rā te backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Noa atu â e vai ra i roto i te faʻataʻaraʻa huru { $styleNumber } te ʻiriʻiri parau i haʻapāpūhia e navai tōna taʻa ê nō te huru māramarama, ʻaita te taʻa ê o te ʻiriʻiri parau i ravehia nō te huru pōuri e navai i mua i te ʻāfata ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e titauhia te { $threshold }:1 aore rā hau atu). { $suggestion ->
+        [available] Ia navai te taʻa ê i te huru pōuri, a faʻarahi i te taʻa ê o te huru māramarama (ei hiʻoraʻa, a tuʻu i te textColor="{ $lightColor }") aore rā a mono i te ʻiriʻiri o te huru pōuri (ei hiʻoraʻa, a tuʻu i te textColorDarkMode="{ $darkColor }").
+       *[none] Ia navai te taʻa ê i te huru pōuri, a faʻarahi i te taʻa ê o te huru māramarama aore rā a mono i te ʻiriʻiri i ravehia na roto i te textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Hōʻē noa <stylePalette> e nehenehe e māʻitihia e te hōʻē tuhaʻa; tē faʻaohipa nei i te hopeʻa.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } nō te mea ʻaita te numToSelect e numera taʻato ʻa ʻaore e haʻehaʻa i te ʻōre.
+
+variant-num-to-select-not-constant-number = ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } nō te mea ʻaita te numToSelect e numera pāpū.
+
+variant-with-replacement-not-constant-boolean = ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } nō te mea ʻaita te withReplacement e boolean pāpū.
+
+variant-select-weight-disables-unique = Ua tāpeʻahia te mau huru taʻa ê otahi nō te select mai te mea e vai ra te māʻitiraʻa e haʻapāpūhia te selectWeight aore rā te selectForVariants
+
+variant-coprime-undetermined = ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } nō te mea ʻeita e nehenehe e haʻapāpū e false noa te coprime.
+
+variant-attribute-not-constant = ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } nō te mea ʻaita te { $attribute } e pāpū.
+
+variant-attribute-not-number = ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } nō te mea ʻaita te { $attribute } e numera.
+
+variant-attribute-wrong-type-for-sequence =
+    ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } huru { $type } nō te mea ʻaita te { $attribute } e { $expected ->
+        [letters-combination] tuʻatiraʻa reta
+        [math-expression] parau numera tano
+        [integer] numera taʻato ʻa
+       *[number] numera
+    }.
+
+variant-length-not-integer = ʻeita e nehenehe e haʻapāpū i te mau huru taʻa ê otahi o te { $component } nō te mea ʻaita te length e numera taʻato ʻa.
+
+variant-sort-not-implemented = ʻaitaʻe te mau huru taʻa ê otahi o te hōʻē { $component } e vai ra te sort i faʻatupuhia
+
+variant-exclude-combinations-not-implemented = ʻaitaʻe te mau huru taʻa ê otahi o te hōʻē { $component } e vai ra te excludeCombinations i faʻatupuhia
+
+variant-math-exclude-not-implemented = ʻaitaʻe te mau huru taʻa ê otahi o te hōʻē { $component } huru math e vai ra te exclude i faʻatupuhia
+
+variant-non-constant-exclude-not-implemented = ʻaitaʻe te mau huru taʻa ê otahi o te hōʻē { $component } e vai ra te exclude ʻaore e pāpū i faʻatupuhia
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ʻaita e tauturuhia i roto i te renderer prefigure o te graph; ua faʻarue i te huaʻai.
+
+prefigure-descendant-invalid-geometry = { $subject }: ʻaore e ʻōtiʻa aore rā ʻaita i ʻoti te huru; ua faʻarue i te huaʻai.
+
+prefigure-curve-label-omitted = { $subject }: ʻaita te mau tāpaʻo e tauturuhia i niʻa i te mau pīʻao i hurihia; ua faʻaruehia te tāpaʻo.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ʻaita te huru faʻataʻaraʻa pīʻao '{ $definitionType }' e tauturuhia; ua faʻarue i te huaʻai.
+
+prefigure-region-flip-functions-unsupported = { $subject }: ʻaita te ʻatirivite flipFunctions i niʻa i te regionBetweenCurves e tauturuhia; ua faʻarue i te huaʻai.
+
+prefigure-region-non-formula-child = { $subject }: te mau tamariʻi fonotio huru formula ana ʻe tē tauturuhia i roto i te regionBetweenCurves; ua faʻarue i te huaʻai.
+
+prefigure-label-position-unsupported =
+    { $subject }: ʻaita te labelPosition '{ $labelPosition }' e tauturuhia nō te { $labelKind ->
+        [line-family] tāpaʻo o te ʻutuāfare reni
+       *[point] tāpaʻo o te poini
+    }; tē faʻaohipa nei i te faʻaʻaifaitoraʻa mātauhia a PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: ʻaita te huru ʻīraʻa '{ $fillStyle }' e tauturuhia e PreFigure; tē hoʻi nei i te ʻīraʻa pāpū.
+
+prefigure-line-style-unknown = { $subject }: ʻaita te huru reni '{ $lineStyle }' i ʻitehia, ua faʻaruehia i roto i te output a PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: ua tuʻatihia te huru marker '{ $markerStyle }' i te huru 'diamond' a PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: ʻaita te huru marker '{ $markerStyle }' e tauturuhia e PreFigure; tē faʻaohipa nei i te huru mātauhia.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` tano ʻore; ʻeita e nehenehe e faʻataʻa i te target. Ua faʻaruehia te annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: ua faʻataʻa te `ref` i te rave rahi target; tē faʻaohipa nei i te target mātāmua.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` tano ʻore; tē vai nei te target i rāpae i te graph e vai ra i roto. Ua faʻaruehia te annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` tano ʻore; ʻaita te target e mea hōhoʻa e tauturuhia i roto i te tauiraʻa prefigure. Ua faʻaruehia te annotation.
+
+annotation-text-missing = `<annotation>`: ʻaita aore rā ʻaore e mea i roto i te `text`; tē faʻaʻite nei i te parau ʻaore.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Ua ʻitehia te tiʻaturiraʻa ʻāti.
+       *[other] Ua ʻitehia te tiʻaturiraʻa ʻāti e ʻo mai ra te tuhaʻa `<{ $componentType }>`.
+    }
+
+reference-no-referent = ʻAita i ʻitehia te mea tā te faʻahitiraʻa e faʻataʻa nei: `{ $reference }`
+
+reference-multiple-referents = E rave rahi mea i ʻitehia tā te faʻahitiraʻa e faʻataʻa nei: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Huru tano ʻore o te ʻatirivite { $attribute } o te `<{ $componentType }>`.
+
+children-invalid = Tano ʻore te mau tamariʻi o te `<{ $componentType }>`: ua ʻitehia te mau tamariʻi tano ʻore: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Faito tano ʻore `{ $value }` nō te ʻatirivite `{ $attribute }`, tē faʻaohipa nei i te faito `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] ʻAita i ʻitehia te huru DoenetML { $version }.
+       *[other] ʻAita i ʻitehia te huru DoenetML { $version }. Tē hoʻi nei i te huru { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML tano ʻore: { $content }
+
+parse-tag-missing-close-tag = DoenetML tano ʻore: ʻAita te tag ʻōpani o te tag `{ $tag }`. E tiʻaturihia te tag e ʻōpani ia ʻoia iho aore rā te tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML tano ʻore: E hape tō roto i te tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML tano ʻore: Mai te mea ʻaita te faito o te ʻatirivite tano ʻore `{ $attribute }`.
+
+parse-attribute-invalid = DoenetML tano ʻore: ʻAtirivite tano ʻore `{ $attribute }`
+
+parse-attribute-value-invalid = DoenetML tano ʻore: Faito ʻatirivite tano ʻore `{ $value }`
+
+parse-attribute-value-quote-mismatch = DoenetML tano ʻore: Faito ʻatirivite tano ʻore `{ $value }`. ʻAita te mau tāpaʻo parau e tuʻati. Mai te mea ʻaita te hōʻē `{ $quote }`
+
+parse-open-tag-name-missing = DoenetML tano ʻore: Ua ʻitehia te tag ʻaore tōna iʻoa, mai te `<`
+
+parse-tag-not-closed = DoenetML tano ʻore: ʻAita te tag `{ $tag }` i ʻōpanihia (mai te mea ʻaita te `>`).
+
+parse-self-closing-tag-name-missing = DoenetML tano ʻore: Ua ʻitehia te tag ʻaore tōna iʻoa `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML tano ʻore: ʻAita te tag `{ $tag }` i ʻōpanihia (mai te mea ʻaita te `/>`).
+
+parse-tag-invalid-attributes = DoenetML tano ʻore: Tano ʻore te tag `{ $tag }`. Peneiaʻe tano ʻore tōna mau ʻatirivite.
+
+parse-close-tag-name-missing = DoenetML tano ʻore: Ua ʻitehia te tag ʻōpani ʻaore tōna iʻoa, mai te `</`
+
+parse-attribute-value-unquoted = E tiʻa i te mau faito ʻatirivite ia tuʻuhia i roto i te mau tāpaʻo parau: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML tano ʻore: Ua ʻitehia te tag ʻōpani `{ $tag }`, ʻaita rā te tag ʻiriti e tuʻati
+
+parse-close-tag-mismatched = DoenetML tano ʻore: ʻAita te tag ʻōpani e tuʻati. E tiʻaturihia te `</{ $expected }>`. Ua ʻitehia te `{ $found }`
+
+parser-node-unconvertible = ʻAita i nehenehe i huri i te node { $node } ei node Dast.
+
+## Names
+
+name-attribute-invalid =
+    ʻAtirivite tano ʻore name='{ $name }'. { $reason ->
+        [characters] E nehenehe noa te mau iʻoa ia vai te reta, te numera, te reni i raro aore rā te reni faʻataʻa.
+       *[start] E tiʻa i te mau iʻoa ia haʻamata i te hōʻē reta.
+    }
+
+component-name-invalid-start = Iʻoa tuhaʻa tano ʻore "{ $name }". E tiʻa i te mau iʻoa ia haʻamata i te hōʻē reta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = E tiʻa i te answer e type videoWatched ia vai te ʻatirivite video
+
+answer-video-watched-video-not-reference = E tiʻa i te ʻatirivite video o te answer e type videoWatched ia riro ei faʻahitiraʻa
+
+answer-name-not-single-text = E tiʻa i te ʻatirivite name o te answer ia vai te hōʻē noa tamariʻi text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = ʻEita e nehenehe e rave i te DoenetML nō rāpae nō te rahi roa o te mau faito faʻahitiraʻa. Tē vai nei anei te faʻahitiraʻa ʻāti?
+
+external-doenetml-unavailable = ʻEita e nehenehe e rave i te DoenetML nō roto mai i te { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML tano ʻore i ravehia mai roto mai i te { $attribute }="{ $uri }": ʻaita ʻoia i tuʻati i te huru tuhaʻa "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] ʻAita te ʻatirivite `{ $from }` e faʻaohipahia faʻahou; a faʻaohipa i te `{ $to }`.
+       *[other] [deprecation] ʻAita te ʻatirivite `{ $from }` i roto i te `<{ $component }>` e faʻaohipahia faʻahou; a faʻaohipa i te `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] ʻAita te ʻatirivite `{ $from }` e faʻaohipahia faʻahou ʻe ʻaita e faʻaohipahia nō te mea ua haʻapāpūhia atoʻa te `{ $to }`.
+       *[other] [deprecation] ʻAita te ʻatirivite `{ $from }` i roto i te `<{ $component }>` e faʻaohipahia faʻahou ʻe ʻaita e faʻaohipahia nō te mea ua haʻapāpūhia atoʻa te `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] ʻAita te ʻatirivite `{ $attribute }` i roto i te `<{ $component }>` e faʻaohipahia faʻahou ʻe ʻaita e faʻaohipahia.
+
+deprecated-attribute-to-child = [deprecation] ʻAita te ʻatirivite `{ $attribute }` i roto i te `<{ $component }>` e faʻaohipahia faʻahou; a faʻaohipa i te tamariʻi `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] ʻAita te faito `{ $value }` o te ʻatirivite `{ $attribute }` i roto i te `<{ $component }>` e faʻaohipahia faʻahou; a faʻaohipa i te `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = E nehenehe noa te `<pluralize>` e faʻarahi i te reo Beretane, nō reira ʻaita tōna parau e tauihia i roto i te papaʻiraʻa i papaʻihia na roto i te { $locale }. A papaʻi tōtiʻa i te huru rahi, aore rā a tuʻu i te reira na roto i te ʻatirivite `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = ʻAita te elemata `<{ $tag }>` e elemata Doenet i ʻitehia.
+
+schema-element-not-allowed-at-root = ʻAita te elemata `<{ $tag }>` e faʻatiʻahia i te aʻa o te papaʻiraʻa.
+
+schema-element-not-allowed-inside = ʻAita te elemata `<{ $tag }>` e faʻatiʻahia i roto i te `<{ $parent }>`.
+
+schema-attribute-unrecognized = ʻAita te ʻatirivite tōna iʻoa `{ $attribute }` i roto i te elemata `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] E tiʻa i te ʻatirivite `{ $attribute }` o te elemata `<{ $tag }>` ia riro ei tāpura e riro te mea tāʻitahi ei hōʻē o te: { $allowed }
+       *[other] E tiʻa i te ʻatirivite `{ $attribute }` o te elemata `<{ $tag }>` ia riro ei hōʻē o te: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Iʻoa huru taʻa ê tano ʻore nō te select.  Tē ʻitehia nei te iʻoa huru taʻa ê { $variantName } i roto i te { $numOptions } māʻitiraʻa, e { $numToSelect } rā te rahiraʻa e māʻitihia.
+
+select-variant-name-without-options = Ua haʻapāpūhia te tahi mau huru taʻa ê nō te select, ʻaita rā e māʻitiraʻa i haʻapāpūhia nō te iʻoa huru taʻa ê: { $variantName }.
+
+select-variant-name-not-possible = ʻAita te iʻoa huru taʻa ê { $variantName } i haʻapāpūhia nō te select e iʻoa huru taʻa ê e nehenehe.
+
+select-too-few-options = ʻEita e nehenehe e māʻiti i te { $numToSelect } tuhaʻa nō roto mai i te { $numOptions } ana ʻe.
+
+select-from-sequence-too-few-values = ʻEita e nehenehe e māʻiti i te { $numToSelect } faito nō roto mai i te sequence e { $length } tōna roa.
+
+select-from-sequence-indices-count-mismatch = E tiʻa i te rahiraʻa indeki i haʻapāpūhia nō te select ia tuʻati i te rahiraʻa e māʻitihia
+
+select-from-sequence-indices-not-integers = E tiʻa i te mau indeki ato ʻa i haʻapāpūhia nō te select ia riro ei numera taʻato ʻa
+
+select-from-sequence-index-excluded = Ua haʻapāpūhia te indeki o te selectfromsequence tei faʻaruehia
+
+select-from-sequence-indices-excluded-combination = Ua haʻapāpūhia te mau indeki o te selectfromsequence e tuʻatiraʻa tei faʻaruehia
+
+select-from-sequence-coprime-not-positive-integers = ʻEita e nehenehe e māʻiti i te mau tuʻatiraʻa coprime nō te mea ʻaita e numera taʻato ʻa maitaʻi tē māʻitihia.
+
+select-from-sequence-coprime-common-factor = ʻEita e nehenehe e māʻiti i te mau numera coprime. Hōʻē â faktora tō te mau faito ato ʻa. (E tiʻa i te faito "from" aore rā "to" i haʻapāpūhia ia riro ei coprime e te "step".)
+
+select-from-sequence-coprime-single-number = ʻEita e nehenehe e māʻiti i te mau tuʻatiraʻa coprime nō roto mai i te hōʻē noa numera ʻaore e 1.
+
+select-from-sequence-excluded-too-many-combinations = Ua faʻaruehia hau atu i te 70% o te mau tuʻatiraʻa i roto i te selectFromSequence
+
+select-from-sequence-coprime-none-found = ʻAita i nehenehe i māʻiti i te mau numera coprime. Hōʻē â faktora tō te mau faito ato ʻa.
+
+select-from-sequence-too-few-unique-values = ʻEita e nehenehe e māʻiti i te { $numToSelect } faito otahi nō roto mai i te sequence e { $numPossibleValues } tōna roa
+
+select-prime-numbers-too-few-values = ʻEita e nehenehe e māʻiti i te { $numToSelect } faito nō roto mai i te tāpura numera prime e { $numValues } tōna roa
+
+select-prime-numbers-values-count-mismatch = E tiʻa i te rahiraʻa faito i haʻapāpūhia nō te select ia tuʻati i te rahiraʻa e māʻitihia
+
+select-prime-numbers-values-not-prime = E tiʻa i te mau faito ato ʻa i haʻapāpūhia nō te select prime number ia vai i roto i te tāpura numera prime
+
+select-prime-numbers-values-excluded-combination = Te mau faito o te selectPrimeNumbers i haʻapāpūhia e tuʻatiraʻa tei faʻaruehia
+
+select-prime-numbers-excluded-too-many-combinations = Ua faʻaruehia hau atu i te 70% o te mau tuʻatiraʻa i roto i te selectPrimeNumbers
+
+select-random-combination-fluke = Nō te hōʻē ohipa mea varavara roa, ʻaita i nehenehe i māʻiti i te tuʻatiraʻa o te mau faito taʻiʻiti
+
+select-random-value-fluke = Nō te hōʻē ohipa mea varavara roa, ʻaita i nehenehe i māʻiti i te faito taʻiʻiti

--- a/packages/i18n/locales/ty/editor.ftl
+++ b/packages/i18n/locales/ty/editor.ftl
@@ -1,0 +1,208 @@
+# Tahitian editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Written with the ʻeta and the tārava; see `chrome.ftl`. Tahitian marks no
+# number on the noun, so a `{ $count -> … }` whose two English branches differ
+# only in the noun renders one string here and the select is dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Faʻahoʻi
+       *[update] Faʻaʻāpī
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } i te hiʻoraʻa
+       *[other] { $word } i te hiʻoraʻa { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Huru taʻa ê
+editor-variant-filter = Tāmāmā…
+editor-variant-next = Māʻiti i te huru taʻa ê i muri
+editor-variant-previous = Māʻiti i te huru taʻa ê i mua
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Ua ʻitehia te tahi ofatiraʻa i te ture ʻāravehi WCAG AA. Pāto no te { $action ->
+            [close] ʻōpani
+           *[open] ʻiriti
+        } i te rapo ʻāravehi.
+        [advisories] Pāto no te { $action ->
+            [close] ʻōpani
+           *[open] ʻiriti
+        } i te rapo ʻāravehi. ʻAita e ofatiraʻa WCAG AA i ʻitehia, tērā rā tē vai nei te tahi mau mana ʻo ʻāravehi.
+       *[clean] Pāto no te { $action ->
+            [close] ʻōpani
+           *[open] ʻiriti
+        } i te rapo ʻāravehi. ʻAita e fifi ʻāravehi i ʻitehia.
+    }
+
+# No select on `$count` inside the branches: «ofatiraʻa» and «manaʻo» are the
+# same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] Ua ʻitehia te tahi ofatiraʻa i te ture ʻāravehi WCAG AA. E { $count } ofatiraʻa WCAG AA i ʻitehia. Pāto no te { $action ->
+            [close] ʻōpani
+           *[open] ʻiriti
+        } i te rapo ʻāravehi.
+        [advisories] ʻAita e ofatiraʻa WCAG AA i ʻitehia. E { $count } manaʻo ʻāravehi hau i ʻitehia. Pāto no te { $action ->
+            [close] ʻōpani
+           *[open] ʻiriti
+        } i te rapo ʻāravehi.
+       *[clean] ʻAita e ofatiraʻa WCAG AA i ʻitehia. Pāto no te { $action ->
+            [close] ʻōpani
+           *[open] ʻiriti
+        } i te rapo ʻāravehi.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Huru DoenetML { $version }
+
+editor-tab-help = Tauturu ia au i te tuhaʻa
+editor-tab-help-short = Tuhaʻa
+editor-tab-errors = Hape
+editor-tab-warnings = Faʻaararaʻa
+editor-tab-info = Haʻamāramaramaraʻa
+editor-tab-accessibility = ʻĀravehi
+editor-tab-responses = Pāhonoraʻa i hōpoihia
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Māʻitiraʻa o te papaʻi
+editor-format-as-doenetml = Faʻanaho ei DoenetML
+editor-format-as-xml = Faʻanaho ei XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Reni #{ $line }
+
+editor-no-errors = ʻAita e hape
+editor-no-warnings = ʻAita e faʻaararaʻa
+editor-no-info = ʻAita e haʻamāramaramaraʻa hiʻopoʻa
+
+editor-show-info-annotations = Faʻaʻite i te haʻamāramaramaraʻa hiʻopoʻa i roto i te papaʻi
+editor-show-accessibility-annotations = Faʻaʻite i te hiʻopoʻaraʻa ʻāravehi i roto i te papaʻi
+
+editor-accessibility-learn-more = A haʻapiʻi nāhea Doenet e haʻa nei i te ʻāravehi
+
+editor-accessibility-violations-heading = Ofatiraʻa ʻāravehi ({ $standard })
+
+editor-accessibility-other-heading = Te tahi atu mau fifi ʻāravehi
+editor-none-found = ʻAita i ʻitehia
+
+
+## Submitted responses
+
+editor-no-responses = ʻAita ʻe pāhonoraʻa i hōpoihia
+editor-response-answer-id = Id o te pāhonoraʻa
+editor-response-response = Pāhonoraʻa
+editor-response-credit = Tāpuraʻa
+editor-response-submitted = Ua hōpoihia
+
+
+## The context-help panel
+
+help-placeholder = A tuʻu i te kurusore i niʻa i te iʻoa tag, te ʻatirivite, aore rā te { $ref } no te haʻamāramaramaraʻa.
+
+help-unsupported-ref-chain = ʻAitaʻe te tauturu no te mau faʻahitiraʻa e rave rahi tuhaʻa mai te { $example } i tauturuhia.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] ʻAita i ʻitehia te mea tā te faʻahitiraʻa e faʻataʻa nei: { $ref }.
+        [multiple] E rave rahi mea i ʻitehia tā te faʻahitiraʻa e faʻataʻa nei: { $ref }.
+       *[indeterminate] ʻAita i nehenehe i haʻapāpū eaha tā te { $ref } e faʻataʻa nei.
+    }
+
+help-learn-about-references = A haʻapiʻi nō te mau faʻahitiraʻa →
+help-reference-page = ʻĀpī faʻahitiraʻa →
+
+help-suggestions-header =
+    { $location ->
+        [inside] I roto i te { $element }
+       *[top] I te faito teitei roa
+    }{ $allowed ->
+        [none] { " — ʻaita e mea e nehenehe e tuʻu i ʻōnei." }
+        [text] { " — a papaʻi i te parau i ʻōnei." }
+        [text-and-components] { " — a papaʻi i te parau i ʻōnei, aore rā a tāmata:" }
+       *[components] { " — te mau mea e nehenehe e tāmata:" }
+    }
+
+help-suggestions-footer = A pāto i te { $shortcut } no te hiʻo i te { $total } tuhaʻa ato'a.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] E faʻahitiraʻa te { $ref } i te { $target }.
+       *[other] E faʻahitiraʻa te { $ref } i te { $target } (reni { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ua hōpoihia mai e te { $owner } ei { $role }.
+       *[other] Ua hōpoihia mai e te { $owner } i te reni { $line } ei { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] E faʻahitiraʻa te { $ref } i te huru { $property } o te { $element }.
+       *[other] E faʻahitiraʻa te { $ref } i te huru { $property } o te { $element } (reni { $line }).
+    }
+
+help-kind-attribute = ʻatirivite
+help-kind-snippet = tuhaʻa kōto
+help-kind-array-entry = ʻōmuaraʻa array
+
+help-default = Faito mātauhia:
+help-active-default = Faito mātauhia ʻohipa:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Te mau faito fāriʻihia (hōʻē nō te mea tāʻitahi):
+       *[other] Te mau faito fāriʻihia:
+    }
+
+help-suggested-values = Te mau faito mana ʻohia:
+
+help-inserts = Tē tuʻu nei:
+
+# No select: «tāpaʻoraʻa» is the same word for one and for many.
+help-coordinates = Tāpaʻoraʻa:
+
+help-type = Huru:
+
+help-resolved-style = Huru haʻapāpūhia (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Iʻoa fonotio haʻapāpūhia:
+help-reset-list = Tāpura faʻahoʻiraʻa i roto i teie tuʻuraʻa:
+help-added-on-input = Ua tuʻuhia i roto i teie tuʻuraʻa:
+help-removed-on-input = Ua iritihia i roto i teie tuʻuraʻa:
+
+help-reset-overrides = Nā te { $reset } e mono i te { $additional } ʻe te { $removed }.

--- a/packages/i18n/locales/war/chrome.ftl
+++ b/packages/i18n/locales/war/chrome.ftl
@@ -1,0 +1,150 @@
+# Waray viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in the Latin orthography of Waray publishing and of the Department of
+# Education's mother-tongue materials for Samar and Leyte.
+#
+# Waray marks no number on the noun: plurality is carried by the article «an»
+# against «an mga», and a noun after a numeral stays as it is. So a
+# `{ $count -> … }` whose two English branches differ only in the noun renders
+# one string here and the select is dropped; the count still arrives and is
+# still formatted. A `[0]` branch stays wherever English has one, because "none
+# left" is its own sentence rather than a form of the sentence beside it.
+#
+# The **linker** «nga» joins an adjective to what it describes. It has an
+# enclitic form — `-ng` after a vowel — whose availability the *preceding* word
+# decides, so this catalog writes the free «nga» everywhere. That form is
+# grammatical in both places, which is what makes it safe in front of a
+# placeable. `locales/ilo`, `locales/pam` and `locales/bik` have no such form,
+# and each of those three has to say so. See `content.ftl`.
+
+
+## Answer submission
+
+answer-checking = Ginsususi…
+answer-submitting = Ginpapadara…
+
+answer-checking-status = Ginsususi an baton
+answer-submitting-status = Ginpapadara an baton
+
+answer-correct = Husto
+answer-incorrect = Diri husto
+
+answer-response-saved = Natipigan an baton
+
+answer-percent-credit = { $percent }% nga kredito
+answer-percent-correct = { $percent }% nga husto
+answer-percent-short = { $percent } %
+
+max-credit-available = Pinakahitaas nga kredito nga makukuha: { $percent }%
+
+# No select: «pagsari» is the same word for one and for many. The `[0]` branch
+# stays, because it names none rather than counting.
+attempts-remaining =
+    { $count ->
+        [0] waray na nahabilin nga pagsari
+       *[other] { $count } nga pagsari an nahabilin
+    }
+
+validation-correct = (Husto)
+validation-incorrect = (Diri husto)
+validation-partially-correct = (Husto ha bahin)
+
+# No select, for the reason above. `$answerId` is the author's own name for the
+# answer and is never translated.
+answer-show-responses = Ipakita an { $count } nga baton para ha { $answerId }
+
+
+## Disclosure panels
+
+feedback-heading = Komento
+
+collapsible-click-to-open = (i-klik basi maabrihan)
+collapsible-click-to-close = (i-klik basi masarhan)
+
+collapsible-initializing = Nagtitikang…
+
+footnote-show = Ipakita an footnote
+footnote-hide = Itago an footnote
+
+description-more-information = dugang nga impormasyon
+
+
+## Controls
+
+slider-previous = Nahiuna
+slider-next = Sunod
+
+keyboard-open = Abrihi an teklado
+keyboard-close = Sarhi an teklado
+
+choice-input-remove-choice = Kuhaa an { $choice }
+
+matrix-remove-row = Kuhaa an linya
+matrix-add-row = Dugangi hin linya
+matrix-remove-column = Kuhaa an kolum
+matrix-add-column = Dugangi hin kolum
+
+subset-add-remove-points = Pagdugang/Pagkuha hin mga punto
+subset-toggle-points-intervals = Pagbalyo hin mga punto ngan interbalo
+subset-move-points = Ibalhin an mga punto
+subset-clear = Limpyohi
+
+orbital-add-row = Dugangi hin linya
+orbital-remove-row = Kuhaa an linya
+orbital-add-box = Dugangi hin kahon
+orbital-remove-box = Kuhaa an kahon
+orbital-add-up-arrow = Dugangi hin pana nga pasaka
+orbital-add-down-arrow = Dugangi hin pana nga palugsad
+orbital-remove-arrow = Kuhaa an pana
+
+orbital-row-label = Etiketa para ha linya { $row }
+
+pretzel-answer = Baton
+
+summary-statistics-caption = Sumaryo nga estadistika han { $column }
+
+
+## Math input
+
+math-input-preview-region = pahiuna nga pagkita han ekspresyon nga matematika
+math-input-preview = Pahiuna nga pagkita
+math-input-invalid-expression = Imbalido nga ekspresyon:
+
+
+## Document status
+
+viewer-initializing = Nagtitikang…
+
+
+## Errors
+
+error-heading = Sayop
+
+error-found-at =
+    { $span ->
+        [line] Nakit-an ha linya { $startLine }.
+       *[lines] Nakit-an ha mga linya { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = May-ada sayop ini nga dokumento!
+
+diagnostic-heading-error = Sayop
+diagnostic-heading-warning = Pahamangno
+diagnostic-heading-information = Impormasyon
+diagnostic-heading-hint = Giya
+
+accessibility-heading-level-1 = Paglapas ha aksesibilidad nga WCAG AA
+accessibility-heading-level-2 = Pahamangno mahitungod ha aksesibilidad
+
+something-went-wrong = May-ada nasayop.
+
+renderer-load-failed = may renderer nga waray ma-load. Alayon i-reload an pahina.
+
+core-start-failed = Diri natikang an pagkita han dokumento. Alayon i-reload an pahina.

--- a/packages/i18n/locales/war/content.ftl
+++ b/packages/i18n/locales/war/content.ftl
@@ -1,0 +1,254 @@
+# Waray content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Waray has no grammatical gender and no case, so `noun-gender` answers one
+# token for every noun and nothing here selects on `$gender` or on `$role`.
+#
+# The **linker** «nga» is written in full at every site. Waray also has the
+# enclitic `-ng`, attached to a preceding vowel-final word, but which of the two
+# is available is decided by the word *before* the linker — and in these
+# messages that word is often a placeable. The free form is grammatical
+# wherever the enclitic is, so writing it out is not a compromise: it is the
+# form that can be written without knowing what precedes it. That is the same
+# move `locales/quc` makes with the free relational «rech» in place of the
+# possessive prefix «u-»/«r-».
+#
+# The adjectives **precede** the noun, which is English's order and Waray's
+# ordinary one: «pula nga linya».
+#
+# The geometry vocabulary is largely Spanish-derived, because that is what
+# Philippine mathematics teaching carries in Waray as in Tagalog; the colours
+# and the everyday words are Waray's own.
+
+
+## Style vocabulary
+
+color =
+    .black = itom
+    .white = busag
+    .gray = abuhon
+    .red = pula
+    .orange = kahel
+    .yellow = dalag
+    .green = lunhaw
+    .cyan = sian
+    .blue = asul
+    .purple = lila
+    .pink = rosas
+    .brown = kape
+
+line-width =
+    .thick = baga
+    .thin = manipis
+
+line-style =
+    .dashed = putol-putol
+    .dotted = tulbok-tulbok
+
+# Noun phrases. Waray marks no plural on the noun, so «badlis» is the word for
+# one line and for many alike.
+fill-style =
+    .horizontal = hirag nga badlis
+    .vertical = tindog nga badlis
+    .diagonal = hilis nga badlis
+    .backdiagonal = baliskad nga hilis nga badlis
+    .dots = tulbok
+    .diamonds = diyamante
+
+noun =
+    .line = linya
+    .line-segment = segmento
+    .ray = sinag
+    .vector = bektor
+    .curve = kurba
+    .function = punsyon
+    .parabola = parabola
+    .polyline = polilinya
+    .polygon = poligono
+    .triangle = triyanggulo
+    .rectangle = rektanggulo
+    .circle = sirkulo
+    .region = rehiyon
+    .point = punto
+    .square = kwadrado
+    .diamond = diyamante
+    .cross = krus
+    .plus = plus
+
+# The side count follows the adjectives as a complement, so that they stay
+# beside the noun they describe.
+noun-regular-polygon =
+    { $part ->
+        [tail] nga may { $numSides } nga kilid
+       *[head] regular nga poligono
+    }
+
+# One answer for every noun: Waray has no grammatical gender, so nothing
+# downstream has anything to agree with.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } nga { $lineStyle } nga { $color }
+        [width-color] { $width } nga { $color }
+        [style-color] { $lineStyle } nga { $color }
+        [width-style] { $width } nga { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } nga { $noun } { $nounTail }
+       *[noun] { $description } nga { $noun }
+    }
+
+style-filled-word = puno
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } nga { $color } nga may { $pattern }
+       *[plain] { $filled } nga { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } nga { $color } nga { $noun } nga may { $pattern }
+        [plain-tail] { $filled } nga { $color } nga { $noun } { $nounTail }
+        [pattern-tail] { $filled } nga { $color } nga { $noun } { $nounTail } nga may { $pattern }
+       *[plain] { $filled } nga { $color } nga { $noun }
+    }
+
+# Waray has no article, so the two `-article` branches say what the other two
+# say. They are kept apart because English's distinction is between a first
+# clause and a further one, which this file does mark: «nga may» against «ngan».
+style-border-clause =
+    { $parts ->
+        [with-article] nga may { $border } nga ligid
+        [and] ngan { $border } nga ligid
+        [and-article] ngan { $border } nga ligid
+       *[with] nga may { $border } nga ligid
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } nga { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = diri puno
+
+style-text =
+    { $parts ->
+        [background] { $color } nga may { $background } nga background
+       *[plain] { $color }
+    }
+
+style-background-none = waray
+
+
+## Boolean words
+
+boolean-true = tinuod
+boolean-false = buwa
+
+
+## Answer buttons
+
+answer-submit-label = Susiha an baton
+answer-submit-label-no-correctness = Ipadara an baton
+
+
+## Sectional blocks
+
+# `.exercise` and `.exercises`, and `.problem` and `.problems`, are one word
+# each: Waray marks number on the article rather than on the noun, and a
+# heading carries no article.
+section-name =
+    .activity = Aktibidad
+    .aside = Nota ha ligid
+    .cascade = Kaskada
+    .definition = Depinisyon
+    .example = Ehemplo
+    .exercise = Ehersisyo
+    .exercises = Ehersisyo
+    .given-answer = Baton
+    .note = Nota
+    .objectives = Katuyoan
+    .paragraphs = Parapo
+    .part = Bahin
+    .problem = Problema
+    .problems = Problema
+    .proof = Pamatuod
+    .question = Pakiana
+    .section = Seksyon
+    .solution = Solusyon
+    .task = Buruhaton
+    .theorem = Teorema
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Giya
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Talaan { $enumeration }
+        [numbered-title] Talaan { $enumeration }{ ": " }
+        [unnumbered-title] Talaan{ ": " }
+       *[unnumbered] Talaan
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Pigura { $enumeration }
+        [numbered-caption] Pigura { $enumeration }{ ": " }
+        [unnumbered-caption] Pigura{ ": " }
+       *[unnumbered] Pigura
+    }
+
+
+## Paginator controls
+
+paginator-previous = Nahiuna
+paginator-next = Sunod
+paginator-page = Pahina
+
+paginator-page-status = { $pageLabel } { $currentPage } ha { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = o
+piecewise-condition-if = kon
+piecewise-condition-otherwise = kon diri
+
+
+## Chemistry
+##
+## The 118 element names and the 12 anion names are left to fall back to
+## English. Philippine secondary science is taught in English from the
+## intermediate grades, so the periodic table a Waray pupil meets is the English
+## one — the same reason `locales/fil` and `locales/ceb` leave these keys out.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Imbalido nga simbolo nga kemikal
+chemistry-invalid-ionic-compound = Imbalido nga kompuwesto nga ioniko

--- a/packages/i18n/locales/war/diagnostics.ftl
+++ b/packages/i18n/locales/war/diagnostics.ftl
@@ -1,0 +1,626 @@
+# Waray diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Waray marks no number on the noun, so a counted message whose only English
+# difference is the noun's number renders one string here and the select is
+# dropped. The count still arrives and is still formatted.
+#
+# The linker is written as the free «nga» throughout; see `content.ftl`.
+
+
+## `<lineSegment>`
+
+# No select: «ginsasalikway» does not agree with what is ignored, and the list
+# carries no number of its own.
+line-segment-attributes-ignored-with-endpoints = ginsasalikway an { $attributes } kon gintakda an duha nga punta
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = ginsasalikway an { $attributes } kon gintakda an usa nga punta ngan an butnga
+
+line-segment-midpoint-offset-without-midpoint = waray epekto an midpointOffset kon waray butnga
+
+## `<line>`
+
+line-points-undetermined-dimensions = Linya nga naagi ha mga punto nga diri natukoy an dimensyon.
+
+line-points-too-few-dimensions = Kinahanglan naagi an linya ha mga punto nga may-ada diri maminos ha duha nga dimensyon.
+
+line-points-depend-on-variables = An linya naagi ha mga punto nga nasarig ha mga baryable: { $variables }.
+
+line-equation-invalid-format = Imbalido nga pormat han ekwasyon han linya ha mga baryable nga { $variable1 } ngan { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = An sinag gintakda pinaagi han through, endpoint ngan direction.  Ginsasalikway an gintakda nga through.
+
+ray-dimension-mismatch = diri nagkakaurusa an numDimensions ha sinag.
+
+## `<vector>`
+
+vector-overprescribed-head = An bektor gintakda pinaagi han head, tail ngan displacement.  Ginsasalikway an gintakda nga head.
+
+vector-dimension-mismatch = diri nagkakaurusa an numDimensions ha bektor.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Diri mahimo mag-aghat ngadto ha `<{ $component }>` kay waray ini baryable nga estado nga nearestPoint.
+
+constrain-to-without-nearest-point = Diri mahimo magpugong ngadto ha `<{ $component }>` kay waray ini baryable nga estado nga nearestPoint.
+
+constrain-to-interior-without-nearest-point = Diri mahimo magpugong ngadto ha sulod han `<{ $component }>` kay waray ini baryable nga estado nga nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ginsasalikway an labelPosition para ha choiceInput nga diri inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ginsasalikway an mga indise nga gintakda para ha choiceInput kay diri nagkakaurusa an kadamu han mga indise ngan an kadamu han mga anak nga pilianan.
+
+pretzel-indices-count-mismatch = Ginsasalikway an mga indise nga gintakda para ha problem kay diri nagkakaurusa an kadamu han mga indise ngan an kadamu han mga anak nga problem.
+
+shuffle-indices-count-mismatch = Ginsasalikway an mga indise nga gintakda para ha shuffle kay diri nagkakaurusa an kadamu han mga indise ngan an kadamu han mga komponente.
+
+indices-ignored-out-of-range = Ginsasalikway an mga indise nga gintakda para ha { $component } kay may-ada indise nga labaw ha sakop.
+
+pretzel-indices-repeated = Ginsasalikway an mga indise nga gintakda para ha pretzel kay may-ada indise nga nauulit.
+
+pretzel-circuit-first-index = Ginsasalikway an mga indise nga gintakda para ha pretzel ha mode nga circuit kay kinahanglan 1 an siyahan nga indise.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Basi gumana an `<{ $component }>` ha mga anak nga string, kinahanglan itakda an atributo nga `type`.
+
+invalid-type-defaulting-to-math = Imbalido nga type { $type } para ha komponente nga { $component }. Kinahanglan usa ha math, text, number, o boolean. Ginagamit an math.
+
+string-not-valid-component-to-arrange = An string nga "{ $value }" diri balido nga komponente para ha { $component }. Ginsasalikway.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Imbalido nga type { $type }, ginbubutang an type ha number.
+
+invalid-variable-value = Imbalido nga bili han usa nga baryable: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Kinahanglan numero an indise han baryante nga { $index }
+
+variant-index-must-be-integer = Kinahanglan integer an indise han baryante nga { $index }
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Waray pa ipatuman an `<{ $component }>` para ha absoluto nga sukol. Ginbubutang an mga kahaluag nga relatibo.
+
+side-by-side-absolute-margins = Waray pa ipatuman an `<{ $component }>` para ha absoluto nga sukol. Ginbubutang an mga margin nga relatibo.
+
+side-by-side-no-block-child = Imbalido nga `<{ $component }>`: kinahanglan may-ada ini diri maminos ha usa nga anak nga block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ginsasalikway an atributo nga `for` ha grapikal nga `<label>`.
+
+label-for-must-resolve-to-one = Kinahanglan matudlok an atributo nga `for` ha `<label>` ngadto ha eksakto nga usa nga komponente.
+
+label-for-unresolved = Diri natudlok an atributo nga `for` ha `<label>` ngadto ha usa nga komponente.
+
+label-for-answer-with-authored-inputs = An atributo nga `for` ha `<label>` natudlok ha usa nga `<answer>` nga may-ada mga input nga ginsurat han awtor; tudloka an input mismo.
+
+label-for-answer-without-input = An atributo nga `for` ha `<label>` natudlok ha usa nga `<answer>` nga waray input nga eetiketahan.
+
+label-for-must-reference-input-or-answer = Kinahanglan natudlok an atributo nga `for` ha `<label>` ngadto ha usa nga input o usa nga answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Para ha aksesibilidad, kinahanglan may-ada an `<{ $component }>` halipot nga deskripsyon o gintakda nga dekoratibo.
+
+accessibility-video-short-description = Para ha aksesibilidad, kinahanglan may-ada an `<video>` halipot nga deskripsyon.
+
+accessibility-input-short-description-or-label = Para ha aksesibilidad, kinahanglan may-ada an `<{ $component }>` halipot nga deskripsyon o etiketa.
+
+accessibility-answer-input-short-description-or-label = Para ha aksesibilidad, kinahanglan may-ada halipot nga deskripsyon o etiketa an usa nga `<answer>` nga naghihimo hin input.
+
+accessibility-short-description-contains-math = Diri unta nagsusulod an mga halipot nga deskripsyon hin mga komponente nga matematika sugad han `<{ $component }>`. Isurat ha mga pulong an bisan ano nga matematika.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] Kulang an kontraste han { $colorName } para ha teksto han ulohan han seksyon (madulom nga mode) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginkikinahanglan an diri maminos ha { $threshold }:1).
+       *[other] Kulang an kontraste han { $colorName } para ha teksto han ulohan han seksyon ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginkikinahanglan an diri maminos ha { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Waray pa ipatuman an `<circle>` nga naagi ha { $count } nga punto kon waray numeriko nga bili an mga punto.
+
+circle-too-many-through-points = Diri mahimo kwentahon an sirkulo nga naagi ha sobra ha 3 nga punto.
+
+circle-overprescribed-radius-center-points = Diri mahimo kwentahon an sirkulo nga may gintakda nga radyus, sentro ngan mga punto nga aagian.
+
+circle-center-with-multiple-points = Diri mahimo kwentahon an sirkulo nga may gintakda nga sentro nga naagi ha sobra ha 1 nga punto.
+
+circle-radius-too-small = Diri mahimo kwentahon an sirkulo: tungod kay an distansya han duha nga punto amo an { $distance }, gutiay hinduro an gintakda nga radyus nga { $radius }.
+
+circle-radius-with-many-points = Diri mahimo maghimo hin sirkulo nga naagi ha sobra ha duha nga punto nga may gintakda nga radyus.
+
+circle-invalid-center-or-through-points = Imbalido an sentro o an mga punto nga aagian han sirkulo.
+
+circle-radius-center-with-multiple-points = Diri mahimo kwentahon an radyus han sirkulo nga may gintakda nga sentro nga naagi ha sobra ha 1 nga punto.
+
+circle-change-radius-non-numerical = Diri mahimo baynon an radyus han sirkulo nga naagi ha mga punto nga diri numeriko
+
+circle-radius-with-points-non-numerical = Diri mahimo maghimo hin sirkulo nga naagi ha sobra ha usa nga punto nga may gintakda nga radyus kon waray numeriko nga bili.
+
+circle-change-center-non-numerical = Waray pa ipatuman an pagbag-o han sentro han sirkulo nga naagi ha mga punto nga waray numeriko nga bili.
+
+## `<function>`
+
+# English's two counts multiply out to four sentences; Waray has one, because
+# «interbalo» and «input» do not change for number. Both selects are dropped
+# and both counts still arrive.
+function-domain-insufficient-dimensions = Kulang an dimensyon han domain para ha punsyon. An domain may-ada { $intervals } nga interbalo kondi an punsyon may-ada { $inputs } nga input.
+
+function-domain-invalid-format = Imbalido nga pormat han domain para ha punsyon.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ginsasalikway an diri numeriko nga pinakahitaas han punsyon.
+        [minimum] Ginsasalikway an diri numeriko nga pinakahamubo han punsyon.
+        [extremum] Ginsasalikway an diri numeriko nga ekstremum han punsyon.
+        [point] Ginsasalikway an diri numeriko nga punto han punsyon.
+        [slope] Ginsasalikway an diri numeriko nga hilis han punsyon.
+       *[other] Ginsasalikway an diri numeriko nga { $type } han punsyon.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ginsasalikway an waray sulod nga pinakahitaas han punsyon.
+        [minimum] Ginsasalikway an waray sulod nga pinakahamubo han punsyon.
+        [extremum] Ginsasalikway an waray sulod nga ekstremum han punsyon.
+        [point] Ginsasalikway an waray sulod nga punto han punsyon.
+       *[other] Ginsasalikway an waray sulod nga { $type } han punsyon.
+    }
+
+function-points-too-close = May-ada an punsyon duha nga punto nga hirani hinduro. Diri madepinar an punsyon.
+
+# Both selects dropped, for the reason above.
+function-iterates-input-output-mismatch = Posible la an mga iterasyon han punsyon kon parehas an kadamu han mga input ngan an kadamu han mga output. Ini nga punsyon may-ada { $inputs } nga input ngan { $outputs } nga output.
+
+## `<sequence>`
+
+sequence-invalid-length = Imbalido an kahilaba han sequence.  Kinahanglan diri negatibo nga integer.
+
+sequence-invalid-step = Imbalido an step han sequence.  Kinahanglan numero para ha sequence nga type { $type }.
+
+sequence-invalid-endpoint-number = Imbalido nga "{ $attribute }" han sequence nga numero.  Kinahanglan numero.
+
+sequence-invalid-endpoint-letters = Imbalido nga "{ $attribute }" han sequence nga letra.  Kinahanglan kombinasyon han mga letra.
+
+sequence-invalid-endpoint = Imbalido nga "{ $attribute }" han sequence.
+
+select-from-sequence-coprime-not-numbers = ginsasalikway an coprime kay diri numero an ginpipili
+
+select-from-sequence-coprime-with-exclude-combinations = ginsasalikway an coprime kay gintakda an excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Imbalido nga target para ha `<{ $source }>`: diri makit-an an target.
+
+target-state-variable-not-found = Imbalido nga target para ha `<{ $source }>`: diri makit-an an baryable nga estado nga ginngangaranan hin "{ $property }" ha usa nga `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Kinahanglan lain an mga baryable han `<odeSystem>` ha independente nga baryable.
+
+ode-system-duplicate-variable-names = Diri madepinar an mga punsyon nga RHS han ODE nga parehas an ngaran han mga baryable nga nasarig.
+
+ode-system-rhs-function-error = Diri madepinar an punsyon nga RHS han ODE.  May sayop ha paghimo han punsyon nga mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Diri madepinar an anggulo ha butnga han { $count } nga linya
+
+angle-invalid-through-point = Imbalido nga punto ha through han `<angle>`
+
+parabola-vertex-too-many-points = Waray pa ipatuman an parabola nga may bertise nga naagi ha sobra ha 1 nga punto.
+
+parabola-too-many-points = Waray pa ipatuman an parabola nga naagi ha sobra ha 3 nga punto.
+
+intersection-too-many-items = Waray pa ipatuman an intersection para ha sobra ha duha nga butang
+
+## Other math components
+
+ionic-compound-not-two-ions = Waray pa ipatuman an kompuwesto nga ioniko para ha lain kondi duha nga ion.
+
+ionic-compound-needs-cation-and-anion = Ginpatuman an kompuwesto nga ioniko para la ha usa nga cation ngan usa nga anion.
+
+solve-equations-cannot-evaluate = Diri masulbad an ekwasyon kay diri natimbang an ekwasyon: { $equation }
+
+math-operators-operand-number-required = Kinahanglan itakda an operandNumber kon nagkukuha hin operand nga matematika.
+
+eigen-decomposition-failed = Diri nakwenta an mga eigenvalue han matris
+
+## `<matchesPattern>`
+
+# No select: the parameter list carries no number that the noun would show.
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: an parametro nga { $parameters } waray maagi ha pattern, salit pirmi ini natutugbang ha blangko.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: diri masabtan an grid="{ $grid }". Kinahanglan none, medium, dense, o duha nga positibo nga numero nga ginbulag hin espasyo, sugad han grid="1 0.5". Waray grid nga gindrodrowing.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: waray suporta an xLabelPosition="left" ha renderer nga prefigure; ginagamit an paggawi han tuo nga posisyon.
+
+prefigure-y-label-position-unsupported = `<graph>`: waray suporta an yLabelPosition="bottom" ha renderer nga prefigure; ginagamit an paggawi han igbaw nga posisyon.
+
+prefigure-invalid-axis-bounds = `<graph>`: imbalido an mga utlanan han aksis para ha konbersyon nga prefigure; ginagamit an nakagawian nga bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: imbalido an kahaluag para ha konbersyon nga prefigure; ginagamit an nakagawian nga kahaluag han diagram nga 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: imbalido an aspectRatio para ha konbersyon nga prefigure; ginagamit an nakagawian nga aspect ratio nga 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: gutiay hinduro an butnga han grid para ha mga utlanan han aksis; ginsasalikway an grid ha renderer nga prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: diri marerender an mga annotation kon diri an renderer nga PreFigure an ginagamit.
+
+multiple-annotations-children = Damo nga anak nga `<annotations>` an nakit-an ha `<graph>`; ginsasalikway an ngatanan gawas ha ultimo.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Diri mahimo i-extend o kopyahon an diri kilala nga klase han komponente: { $type }.
+
+copy-prop-not-found = Diri nakit-an an prop nga { $property } ha komponente nga klase { $component }
+
+collect-no-source = Waray nakit-an nga source para ha collect.
+
+collect-invalid-component-type = Diri mahimo tirukon an mga komponente nga klase `<{ $component }>` kay imbalido nga klase han komponente.
+
+reference-index-unavailable = Diri matudlok an indise nga `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Diri matawag an { $action } ha komponente nga `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Imbalido an porma han datos.  Diri parehas an kahilaba han mga linya. Nakit-an ha componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = May parehas nga ngaran han kolum an datos.  Nakit-an ha componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Waray ngaran an usa nga kolum han datos.  Nakit-an ha componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = An award hini nga baton nabase ha mismo nga ginpadara nga baton han answer tag, ngan magdadara ini hin diri ginlalaoman nga paggawi.
+
+answer-max-num-attempts-in-section-wide-check-work = Waray epekto an pagbutang hin `maxNumAttempts` ha usa nga `<answer>` ha sulod han kontenedor nga may `sectionWideCheckWork`, kay an kontenedor an nagkokontrol han kadamu han mga pagsari. Ibutang an `maxNumAttempts` ha kontenedor.
+
+nested-section-wide-check-work-max-num-attempts = Waray epekto an pagbutang hin `maxNumAttempts` ha kontenedor nga may `sectionWideCheckWork` nga aada ha sulod hin lain nga kontenedor nga may `sectionWideCheckWork`, kay an gawas nga kontenedor an nagkokontrol han kadamu han mga pagsari. Ibutang an `maxNumAttempts` ha gawas nga kontenedor.
+
+# No select: «atributo» is the same word for one and for many.
+answer-attributes-need-symbolic-equality = Waray epekto an atributo nga { $attributes } kon waray ibutang an symbolicEquality.
+
+answer-invalid-type = Imbalido nga klase para ha baton: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Tungod kay waray ngaran an komponente nga `<{ $component }>`, diri ini magagamit para ha atributo han module
+
+module-attribute-name-already-defined = Diri magagamit an komponente nga `<{ $component } name="{ $name }">` sugad nga atributo han module kay an klase han komponente nga `<module>` may-ada na atributo nga "{ $name }".
+
+conditional-content-condition-ignored = Ginsasalikway an atributo nga `condition` ha komponente nga `<conditionalContent>` nga may mga anak nga case o else.
+
+slider-markers-type-mismatch = Diri nagkakaurusa an klase han mga marker ngan an klase han slider.
+
+pretzel-problem-needs-statement-and-answer = Imbalido nga pretzel: kinahanglan may sulod an kada `<problem>` nga usa nga `<statement>` ngan usa nga `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Imbalido nga pretzel: ha mode="circuit", diri mahimo distractor an siyahan nga `<problem>`.
+
+## Attribute values
+
+# No select: «bili» is the same word for one and for many.
+attribute-invalid-values = Imbalido nga bili nga { $values } para ha atributo nga `{ $attribute }`; ginsasalikway.
+
+attribute-must-be-references = Imbalido nga bili nga `{ $value }` para ha atributo nga `{ $attribute }`. Kinahanglan binubuo an atributo hin mga reperensya nga natikang ha `$`.
+
+math-input-invalid-function-names = <mathInput>: ginsalikway an mga imbalido nga ngaran han punsyon ha { $attribute }: { $names }. Kinahanglan may-ada an kada ngaran diri maminos ha 2 nga karakter (letra o gitlo); mahimo sumunod an usa nga suffix nga `|<mathspeak alternative>`.
+
+## Building components from the source
+
+component-type-invalid = Imbalido nga klase han komponente: `<{ $componentType }>`
+
+attribute-repeated = Diri mahimo ulitón an atributo nga { $attribute }.
+
+attribute-invalid-for-component = Imbalido nga atributo nga "{ $attribute }" para ha komponente nga klase `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Kulang an kontraste han depinisyon han estilo nga { $styleNumber } para ha { $context ->
+        [text-on-background] kolor han teksto kontra ha kolor han background
+        [high-contrast] kolor nga hitaas an kontraste kontra ha kanbas
+        [line] kolor han linya kontra ha kanbas
+        [marker] kolor han marker kontra ha kanbas
+       *[text-on-canvas] kolor han teksto kontra ha kanbas
+    }{ $mode ->
+        [dark] { " (madulom nga mode)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginkikinahanglan an diri maminos ha { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Bisan kon an depinisyon han estilo nga { $styleNumber } may-ada gintakda nga mga kolor nga igo an kontraste para ha maliwanag nga mode, kulang an kontraste han kolor han teksto kontra ha kolor han background ha mga kolor nga ginkuha para ha madulom nga mode ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginkikinahanglan an diri maminos ha { $threshold }:1). { $suggestion ->
+        [available] Basi igo an kontraste ha madulom nga mode, dugangi an kontraste han maliwanag nga mode (pananglitan, ibutang an { $lightAttribute }="{ $lightColor }") o palitan an kolor han madulom nga mode (pananglitan, ibutang an { $darkAttribute }="{ $darkColor }").
+       *[none] Basi igo an kontraste ha madulom nga mode, dugangi an kontraste han maliwanag nga mode o palitan an mga ginkuha nga kolor pinaagi han textColorDarkMode ngan/o backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Bisan kon an depinisyon han estilo nga { $styleNumber } may-ada gintakda nga kolor han teksto nga igo an kontraste para ha maliwanag nga mode, kulang an kontraste han kolor han teksto nga ginkuha para ha madulom nga mode kontra ha kanbas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ginkikinahanglan an diri maminos ha { $threshold }:1). { $suggestion ->
+        [available] Basi igo an kontraste ha madulom nga mode, dugangi an kontraste han maliwanag nga mode (pananglitan, ibutang an textColor="{ $lightColor }") o palitan an kolor han madulom nga mode (pananglitan, ibutang an textColorDarkMode="{ $darkColor }").
+       *[none] Basi igo an kontraste ha madulom nga mode, dugangi an kontraste han maliwanag nga mode o palitan an ginkuha nga kolor pinaagi han textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Usa la nga <stylePalette> an mahimo pilion han usa nga seksyon; ginagamit an ultimo.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = diri matukoy an mga naurusahan nga baryante han { $component } kay an numToSelect diri integer nga diri negatibo.
+
+variant-num-to-select-not-constant-number = diri matukoy an mga naurusahan nga baryante han { $component } kay an numToSelect diri konstante nga numero.
+
+variant-with-replacement-not-constant-boolean = diri matukoy an mga naurusahan nga baryante han { $component } kay an withReplacement diri konstante nga boolean.
+
+variant-select-weight-disables-unique = Ginpapara an mga naurusahan nga baryante para ha select kon may opsyon nga gintakdaan hin selectWeight o selectForVariants
+
+variant-coprime-undetermined = diri matukoy an mga naurusahan nga baryante han { $component } kay diri matukoy kon pirmi false an coprime.
+
+variant-attribute-not-constant = diri matukoy an mga naurusahan nga baryante han { $component } kay diri konstante an { $attribute }.
+
+variant-attribute-not-number = diri matukoy an mga naurusahan nga baryante han { $component } kay diri numero an { $attribute }.
+
+variant-attribute-wrong-type-for-sequence =
+    diri matukoy an mga naurusahan nga baryante han { $component } nga klase { $type } kay an { $attribute } diri { $expected ->
+        [letters-combination] kombinasyon han mga letra
+        [math-expression] balido nga ekspresyon nga matematika
+        [integer] integer
+       *[number] numero
+    }.
+
+variant-length-not-integer = diri matukoy an mga naurusahan nga baryante han { $component } kay diri integer an length.
+
+variant-sort-not-implemented = waray pa ipatuman an mga naurusahan nga baryante han usa nga { $component } nga may sort
+
+variant-exclude-combinations-not-implemented = waray pa ipatuman an mga naurusahan nga baryante han usa nga { $component } nga may excludeCombinations
+
+variant-math-exclude-not-implemented = waray pa ipatuman an mga naurusahan nga baryante han usa nga { $component } nga klase math nga may exclude
+
+variant-non-constant-exclude-not-implemented = waray pa ipatuman an mga naurusahan nga baryante han usa nga { $component } nga may diri konstante nga exclude
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: waray suporta ha renderer nga prefigure han graph; ginlaktawan an kaliwatan.
+
+prefigure-descendant-invalid-geometry = { $subject }: diri limitado o diri kompleto an heometriya; ginlaktawan an kaliwatan.
+
+prefigure-curve-label-omitted = { $subject }: waray suporta an mga etiketa ha mga nakonberte nga kurba; ginsalikway an etiketa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: waray suporta nga klase han depinisyon han punsyon nga kurba nga '{ $definitionType }'; ginlaktawan an kaliwatan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: waray suporta nga atributo nga flipFunctions ha regionBetweenCurves; ginlaktawan an kaliwatan.
+
+prefigure-region-non-formula-child = { $subject }: an mga anak nga punsyon nga klase formula la an may suporta ha regionBetweenCurves; ginlaktawan an kaliwatan.
+
+prefigure-label-position-unsupported =
+    { $subject }: waray suporta nga labelPosition '{ $labelPosition }' para ha { $labelKind ->
+        [line-family] etiketa han pamilya han linya
+       *[point] etiketa han punto
+    }; ginagamit an nakagawian nga pagpahiuyon han PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: waray suporta an PreFigure ha estilo han sulod nga '{ $fillStyle }'; nabalik ha solido nga sulod.
+
+prefigure-line-style-unknown = { $subject }: diri kilala nga estilo han linya nga '{ $lineStyle }', ginsalikway ha output han PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: ginsumpay an estilo han marker nga '{ $markerStyle }' ha estilo nga 'diamond' han PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: waray suporta an PreFigure ha estilo han marker nga '{ $markerStyle }'; ginagamit an nakagawian nga estilo.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: imbalido nga `ref`; diri matudlok an target. Ginsalikway an annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: natudlok an `ref` ha damo nga target; ginagamit an siyahan nga target.
+
+annotation-ref-outside-graph = `<annotation>`: imbalido nga `ref`; aada an target ha gawas han graph nga nagsusulod hini. Ginsalikway an annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: imbalido nga `ref`; an target diri suportado nga grapikal nga butang ha konbersyon nga prefigure. Ginsalikway an annotation.
+
+annotation-text-missing = `<annotation>`: waray o blangko an `text`; nagpapagawas hin blangko nga teksto.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] May nakit-an nga sirkular nga pagsarig.
+       *[other] May nakit-an nga sirkular nga pagsarig nga naglalakip han komponente nga `<{ $componentType }>`.
+    }
+
+reference-no-referent = Waray nakit-an nga gintutudlok han reperensya: `{ $reference }`
+
+reference-multiple-referents = Damo an nakit-an nga gintutudlok han reperensya: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Imbalido nga pormat han atributo nga { $attribute } han `<{ $componentType }>`.
+
+children-invalid = Imbalido an mga anak han `<{ $componentType }>`: nakit-an an mga imbalido nga anak: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Imbalido nga bili nga `{ $value }` para ha atributo nga `{ $attribute }`, ginagamit an bili nga `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Waray makit-an an bersyon han DoenetML nga { $version }.
+       *[other] Waray makit-an an bersyon han DoenetML nga { $version }. Nabalik ha bersyon nga { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Imbalido nga DoenetML: { $content }
+
+parse-tag-missing-close-tag = Imbalido nga DoenetML: Waray pangsarhan nga tag an tag nga `{ $tag }`. Ginlalaoman an tag nga nagsasarhan ha kalugaringon o tag nga `</{ $tagName }>`.
+
+parse-tag-error = Imbalido nga DoenetML: May sayop ha tag nga `<{ $tagName }>`
+
+parse-attribute-missing-value = Imbalido nga DoenetML: Baga waray bili an imbalido nga atributo nga `{ $attribute }`.
+
+parse-attribute-invalid = Imbalido nga DoenetML: Imbalido nga atributo nga `{ $attribute }`
+
+parse-attribute-value-invalid = Imbalido nga DoenetML: Imbalido nga bili han atributo nga `{ $value }`
+
+parse-attribute-value-quote-mismatch = Imbalido nga DoenetML: Imbalido nga bili han atributo nga `{ $value }`. Diri nagkakaurusa an mga marka han sipi. Baga waray usa nga `{ $quote }`
+
+parse-open-tag-name-missing = Imbalido nga DoenetML: May nakit-an nga tag nga waray ngaran, pananglitan `<`
+
+parse-tag-not-closed = Imbalido nga DoenetML: Waray masarhan an tag nga `{ $tag }` (baga waray `>`).
+
+parse-self-closing-tag-name-missing = Imbalido nga DoenetML: May nakit-an nga tag nga waray ngaran `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Imbalido nga DoenetML: Waray masarhan an tag nga `{ $tag }` (baga waray `/>`).
+
+parse-tag-invalid-attributes = Imbalido nga DoenetML: Diri balido an tag nga `{ $tag }`. Bangin may diri husto nga mga atributo.
+
+parse-close-tag-name-missing = Imbalido nga DoenetML: May nakit-an nga pangsarhan nga tag nga waray ngaran, pananglitan `</`
+
+parse-attribute-value-unquoted = Kinahanglan nakabutang ha sulod han mga marka han sipi an mga bili han atributo: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Imbalido nga DoenetML: May nakit-an nga pangsarhan nga tag nga `{ $tag }`, kondi waray katugbang nga pangabri nga tag
+
+parse-close-tag-mismatched = Imbalido nga DoenetML: Diri magkatugbang an pangsarhan nga tag. Ginlalaoman an `</{ $expected }>`. Nakit-an an `{ $found }`
+
+parser-node-unconvertible = Diri nakonberte an node nga { $node } ngadto ha node nga Dast.
+
+## Names
+
+name-attribute-invalid =
+    Imbalido nga atributo nga name='{ $name }'. { $reason ->
+        [characters] Mahimo la magsulod an mga ngaran hin mga letra, numero, underscore o gitlo.
+       *[start] Kinahanglan natikang an mga ngaran ha letra.
+    }
+
+component-name-invalid-start = Imbalido nga ngaran han komponente nga "{ $name }". Kinahanglan natikang an mga ngaran ha letra.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Kinahanglan may-ada atributo nga video an answer nga type videoWatched
+
+answer-video-watched-video-not-reference = Kinahanglan reperensya an atributo nga video han answer nga type videoWatched
+
+answer-name-not-single-text = Kinahanglan may-ada usa la nga anak nga text an atributo nga name han answer
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Diri nakuha an gawas nga DoenetML tungod ha sobra kadamu nga lebel han pag-ulit-ulit. May sirkular ba nga reperensya?
+
+external-doenetml-unavailable = Diri nakuha an DoenetML tikang ha { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Imbalido nga DoenetML an nakuha tikang ha { $attribute }="{ $uri }": diri ini natugbang ha klase han komponente nga "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Diri na ginagamit an atributo nga `{ $from }`; gamita an `{ $to }`.
+       *[other] [deprecation] Diri na ginagamit an atributo nga `{ $from }` ha `<{ $component }>`; gamita an `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Diri na ginagamit an atributo nga `{ $from }` ngan ginsasalikway kay gintakda liwat an `{ $to }`.
+       *[other] [deprecation] Diri na ginagamit an atributo nga `{ $from }` ha `<{ $component }>` ngan ginsasalikway kay gintakda liwat an `{ $to }`.
+    }
+
+deprecated-attribute-ignored = [deprecation] Diri na ginagamit an atributo nga `{ $attribute }` ha `<{ $component }>` ngan ginsasalikway.
+
+deprecated-attribute-to-child = [deprecation] Diri na ginagamit an atributo nga `{ $attribute }` ha `<{ $component }>`; gamita an anak nga `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Diri na ginagamit an bili nga `{ $value }` han atributo nga `{ $attribute }` ha `<{ $component }>`; gamita an `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = An `<pluralize>` mahimo la magpadamu hin Iningles, salit diri nababag-o an teksto hini ha dokumento nga ginsurat ha { $locale }. Isurat mismo an porma nga damo, o ibutang ini pinaagi han atributo nga `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = An elemento nga `<{ $tag }>` diri kilala nga elemento han Doenet.
+
+schema-element-not-allowed-at-root = Diri gintutugotan an elemento nga `<{ $tag }>` ha gamot han dokumento.
+
+schema-element-not-allowed-inside = Diri gintutugotan an elemento nga `<{ $tag }>` ha sulod han `<{ $parent }>`.
+
+schema-attribute-unrecognized = Waray atributo nga ginngangaranan hin `{ $attribute }` an elemento nga `<{ $tag }>`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Kinahanglan lista an atributo nga `{ $attribute }` han elemento nga `<{ $tag }>` nga an kada butang usa ha: { $allowed }
+       *[other] Kinahanglan usa ha mga ini an atributo nga `{ $attribute }` han elemento nga `<{ $tag }>`: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Imbalido nga ngaran han baryante para ha select.  An ngaran han baryante nga { $variantName } naagi ha { $numOptions } nga opsyon kondi { $numToSelect } an kadamu nga pipilion.
+
+select-variant-name-without-options = May gintakda nga mga baryante para ha select kondi waray gintakda nga opsyon para ha posible nga ngaran han baryante: { $variantName }.
+
+select-variant-name-not-possible = An ngaran han baryante nga { $variantName } nga gintakda para ha select diri posible nga ngaran han baryante.
+
+select-too-few-options = Diri mahimo magpili hin { $numToSelect } nga komponente tikang ha { $numOptions } la.
+
+select-from-sequence-too-few-values = Diri mahimo magpili hin { $numToSelect } nga bili tikang ha sequence nga { $length } an kahilaba.
+
+select-from-sequence-indices-count-mismatch = Kinahanglan magkatugbang an kadamu han mga indise nga gintakda para ha select ngan an kadamu nga pipilion
+
+select-from-sequence-indices-not-integers = Kinahanglan integer an ngatanan nga indise nga gintakda para ha select
+
+select-from-sequence-index-excluded = Gintakda an indise han selectfromsequence nga ginsalikway
+
+select-from-sequence-indices-excluded-combination = Gintakda an mga indise han selectfromsequence nga usa nga ginsalikway nga kombinasyon
+
+select-from-sequence-coprime-not-positive-integers = Diri mahimo magpili hin mga kombinasyon nga coprime kay diri positibo nga integer an ginpipili.
+
+select-from-sequence-coprime-common-factor = Diri mahimo magpili hin mga numero nga coprime. May-ada usa nga paktor nga pareho han ngatanan nga posible nga bili. (Kinahanglan coprime an gintakda nga bili han "from" o "to" ha "step".)
+
+select-from-sequence-coprime-single-number = Diri mahimo magpili hin mga kombinasyon nga coprime tikang ha usa la nga numero nga diri 1.
+
+select-from-sequence-excluded-too-many-combinations = Ginsalikway an sobra ha 70% han mga kombinasyon ha selectFromSequence
+
+select-from-sequence-coprime-none-found = Diri nakapili hin mga numero nga coprime. May-ada usa nga paktor nga pareho han ngatanan nga posible nga bili.
+
+select-from-sequence-too-few-unique-values = Diri mahimo magpili hin { $numToSelect } nga naurusahan nga bili tikang ha sequence nga { $numPossibleValues } an kahilaba
+
+select-prime-numbers-too-few-values = Diri mahimo magpili hin { $numToSelect } nga bili tikang ha lista han mga prime nga { $numValues } an kahilaba
+
+select-prime-numbers-values-count-mismatch = Kinahanglan magkatugbang an kadamu han mga bili nga gintakda para ha select ngan an kadamu nga pipilion
+
+select-prime-numbers-values-not-prime = Kinahanglan aada ha lista han mga prime an ngatanan nga bili nga gintakda para ha select prime number
+
+select-prime-numbers-values-excluded-combination = An gintakda nga mga bili han selectPrimeNumbers usa nga ginsalikway nga kombinasyon
+
+select-prime-numbers-excluded-too-many-combinations = Ginsalikway an sobra ha 70% han mga kombinasyon ha selectPrimeNumbers
+
+select-random-combination-fluke = Tungod ha urusahon nga swerte, waray makapili hin kombinasyon han mga random nga bili
+
+select-random-value-fluke = Tungod ha urusahon nga swerte, waray makapili hin random nga bili

--- a/packages/i18n/locales/war/editor.ftl
+++ b/packages/i18n/locales/war/editor.ftl
@@ -1,0 +1,208 @@
+# Waray editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Waray marks no number on the noun, so a `{ $count -> … }` whose two English
+# branches differ only in the noun renders one string here and the select is
+# dropped.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ibalik
+       *[update] Iupdate
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } an pagkita
+       *[other] { $word } an pagkita { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Baryante
+editor-variant-filter = Sarahon…
+editor-variant-next = Pilia an sunod nga baryante
+editor-variant-previous = Pilia an nahiuna nga baryante
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] May-ada nakit-an nga paglapas ha aksesibilidad nga WCAG AA. I-klik basi { $action ->
+            [close] masarhan
+           *[open] maabrihan
+        } an report han aksesibilidad.
+        [advisories] I-klik basi { $action ->
+            [close] masarhan
+           *[open] maabrihan
+        } an report han aksesibilidad. Waray nakit-an nga paglapas ha WCAG AA, kondi may-ada pa dugang nga rekomendasyon ha aksesibilidad.
+       *[clean] I-klik basi { $action ->
+            [close] masarhan
+           *[open] maabrihan
+        } an report han aksesibilidad. Waray nakit-an nga problema ha aksesibilidad.
+    }
+
+# No select on `$count` inside the branches: «paglapas» and «rekomendasyon» are
+# the same words for one and for many.
+editor-accessibility-label =
+    { $status ->
+        [violations] May-ada nakit-an nga paglapas ha aksesibilidad nga WCAG AA. { $count } nga paglapas ha WCAG AA an nakit-an. I-klik basi { $action ->
+            [close] masarhan
+           *[open] maabrihan
+        } an report han aksesibilidad.
+        [advisories] Waray nakit-an nga paglapas ha WCAG AA. { $count } nga dugang nga rekomendasyon ha aksesibilidad an nakit-an. I-klik basi { $action ->
+            [close] masarhan
+           *[open] maabrihan
+        } an report han aksesibilidad.
+       *[clean] Waray nakit-an nga paglapas ha WCAG AA. I-klik basi { $action ->
+            [close] masarhan
+           *[open] maabrihan
+        } an report han aksesibilidad.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Bersyon han DoenetML { $version }
+
+editor-tab-help = Bulig nga sumala ha konteksto
+editor-tab-help-short = Konteksto
+editor-tab-errors = Sayop
+editor-tab-warnings = Pahamangno
+editor-tab-info = Impormasyon
+editor-tab-accessibility = Aksesibilidad
+editor-tab-responses = Ginpadara nga mga baton
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Mga opsyon han editor
+editor-format-as-doenetml = I-pormat sugad nga DoenetML
+editor-format-as-xml = I-pormat sugad nga XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Linya #{ $line }
+
+editor-no-errors = Waray sayop
+editor-no-warnings = Waray pahamangno
+editor-no-info = Waray diagnostiko nga impormasyon
+
+editor-show-info-annotations = Ipakita an mga diagnostiko nga impormasyon ha editor
+editor-show-accessibility-annotations = Ipakita an mga diagnostiko han aksesibilidad ha editor
+
+editor-accessibility-learn-more = Hibaroi kon paunan-o ginaatubang han Doenet an aksesibilidad
+
+editor-accessibility-violations-heading = Mga paglapas ha aksesibilidad ({ $standard })
+
+editor-accessibility-other-heading = Iba pa nga problema ha aksesibilidad
+editor-none-found = Waray nakit-an
+
+
+## Submitted responses
+
+editor-no-responses = Waray pa ginpadara nga baton
+editor-response-answer-id = Id han baton
+editor-response-response = Baton
+editor-response-credit = Kredito
+editor-response-submitted = Ginpadara
+
+
+## The context-help panel
+
+help-placeholder = Ibutang an kursor ha ngaran han tag, atributo, o { $ref } para ha dokumentasyon.
+
+help-unsupported-ref-chain = Waray pa suporta an bulig para ha mga reperensya nga damo an bahin sugad han { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Waray nakit-an nga gintutudlok han reperensya: { $ref }.
+        [multiple] Damo an nakit-an nga gintutudlok han reperensya: { $ref }.
+       *[indeterminate] Diri natukoy an gintutudlok han { $ref }.
+    }
+
+help-learn-about-references = Hibaroi an mahitungod han mga reperensya →
+help-reference-page = Pahina han reperensya →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ha sulod han { $element }
+       *[top] Ha pinakahitaas nga lebel
+    }{ $allowed ->
+        [none] { " — waray mahihimo ibutang dinhi." }
+        [text] { " — pagsurat hin teksto dinhi." }
+        [text-and-components] { " — pagsurat hin teksto dinhi, o sarihi:" }
+       *[components] { " — mga masarihan:" }
+    }
+
+help-suggestions-footer = Pindota an { $shortcut } basi makita an ngatanan nga { $total } nga komponente.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] An { $ref } usa nga reperensya ha { $target }.
+       *[other] An { $ref } usa nga reperensya ha { $target } (linya { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Gindara han { $owner } sugad nga { $role }.
+       *[other] Gindara han { $owner } ha linya { $line } sugad nga { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] An { $ref } usa nga reperensya ha propyedad nga { $property } han { $element }.
+       *[other] An { $ref } usa nga reperensya ha propyedad nga { $property } han { $element } (linya { $line }).
+    }
+
+help-kind-attribute = atributo
+help-kind-snippet = gutiay nga kodigo
+help-kind-array-entry = entrada ha array
+
+help-default = Nakagawian:
+help-active-default = Aktibo nga nakagawian:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Mga tugot nga bili (tagsa ha kada butang):
+       *[other] Mga tugot nga bili:
+    }
+
+help-suggested-values = Mga ginsusuhestiyon nga bili:
+
+help-inserts = Nagsusulod:
+
+# No select: «koordinado» is the same word for one and for many.
+help-coordinates = Koordinado:
+
+help-type = Klase:
+
+help-resolved-style = Natukoy nga estilo (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Natukoy nga mga ngaran han punsyon:
+help-reset-list = Lista han pagbalik hini nga input:
+help-added-on-input = Gindugang hini nga input:
+help-removed-on-input = Ginkuha hini nga input:
+
+help-reset-overrides = An { $reset } nagpapalit han { $additional } ngan { $removed }.

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -7,6 +7,7 @@
 /** A locale this repository ships a catalog for. */
 export type SupportedLocale =
     | "en"
+    | "ace"
     | "af"
     | "ak"
     | "am"
@@ -16,14 +17,17 @@ export type SupportedLocale =
     | "ast"
     | "ay"
     | "az"
+    | "ban"
     | "be"
     | "bg"
+    | "bik"
     | "bm"
     | "bn"
     | "br"
     | "bs"
     | "ca"
     | "ceb"
+    | "ch"
     | "co"
     | "cs"
     | "cy"
@@ -37,6 +41,7 @@ export type SupportedLocale =
     | "fa"
     | "fi"
     | "fil"
+    | "fj"
     | "fo"
     | "fr"
     | "fy"
@@ -49,6 +54,7 @@ export type SupportedLocale =
     | "haw"
     | "he"
     | "hi"
+    | "hil"
     | "hnj"
     | "hr"
     | "ht"
@@ -56,6 +62,7 @@ export type SupportedLocale =
     | "hy"
     | "id"
     | "ig"
+    | "ilo"
     | "is"
     | "it"
     | "ja"
@@ -72,8 +79,10 @@ export type SupportedLocale =
     | "lo"
     | "lt"
     | "lv"
+    | "mad"
     | "mg"
     | "mi"
+    | "min"
     | "mk"
     | "ml"
     | "mn"
@@ -92,6 +101,7 @@ export type SupportedLocale =
     | "om"
     | "or"
     | "pa"
+    | "pam"
     | "pl"
     | "ps"
     | "pt"
@@ -119,18 +129,23 @@ export type SupportedLocale =
     | "sw"
     | "ta"
     | "te"
+    | "tet"
     | "tg"
     | "th"
     | "ti"
     | "tk"
     | "tn"
+    | "to"
+    | "tpi"
     | "tr"
     | "tt"
+    | "ty"
     | "ug"
     | "uk"
     | "ur"
     | "uz"
     | "vi"
+    | "war"
     | "wo"
     | "xh"
     | "yi"
@@ -177,6 +192,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "English",
     },
     {
+        locale: "ace",
+        englishName: "Acehnese",
+        endonym: "Acehnese",
+        label: "Acehnese",
+    },
+    {
         locale: "af",
         englishName: "Afrikaans",
         endonym: "Afrikaans",
@@ -221,6 +242,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Azerbaijani (azərbaycan)",
     },
     {
+        locale: "ban",
+        englishName: "Balinese",
+        endonym: "Balinese",
+        label: "Balinese",
+    },
+    {
         locale: "be",
         englishName: "Belarusian",
         endonym: "беларуская",
@@ -232,6 +259,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "български",
         label: "Bulgarian (български)",
     },
+    { locale: "bik", englishName: "Bikol", endonym: "Bikol", label: "Bikol" },
     {
         locale: "bm",
         englishName: "Bambara",
@@ -267,6 +295,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Cebuano",
         endonym: "Cebuano",
         label: "Cebuano",
+    },
+    {
+        locale: "ch",
+        englishName: "Chamorro",
+        endonym: "Chamorro",
+        label: "Chamorro",
     },
     {
         locale: "co",
@@ -346,6 +380,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Filipino",
         label: "Filipino",
     },
+    { locale: "fj", englishName: "Fijian", endonym: "Fijian", label: "Fijian" },
     {
         locale: "fo",
         englishName: "Faroese",
@@ -414,6 +449,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Hindi (हिन्दी)",
     },
     {
+        locale: "hil",
+        englishName: "Hiligaynon",
+        endonym: "Hiligaynon",
+        label: "Hiligaynon",
+    },
+    {
         locale: "hnj",
         englishName: "Hmong Njua",
         endonym: "Hmong Njua",
@@ -450,6 +491,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Indonesian (Indonesia)",
     },
     { locale: "ig", englishName: "Igbo", endonym: "Igbo", label: "Igbo" },
+    { locale: "ilo", englishName: "Iloko", endonym: "Iloko", label: "Iloko" },
     {
         locale: "is",
         englishName: "Icelandic",
@@ -542,12 +584,24 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Latvian (latviešu)",
     },
     {
+        locale: "mad",
+        englishName: "Madurese",
+        endonym: "Madurese",
+        label: "Madurese",
+    },
+    {
         locale: "mg",
         englishName: "Malagasy",
         endonym: "Malagasy",
         label: "Malagasy",
     },
     { locale: "mi", englishName: "Māori", endonym: "Māori", label: "Māori" },
+    {
+        locale: "min",
+        englishName: "Minangkabau",
+        endonym: "Minangkabau",
+        label: "Minangkabau",
+    },
     {
         locale: "mk",
         englishName: "Macedonian",
@@ -640,6 +694,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Punjabi",
         endonym: "ਪੰਜਾਬੀ",
         label: "Punjabi (ਪੰਜਾਬੀ)",
+    },
+    {
+        locale: "pam",
+        englishName: "Pampanga",
+        endonym: "Pampanga",
+        label: "Pampanga",
     },
     {
         locale: "pl",
@@ -798,6 +858,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "తెలుగు",
         label: "Telugu (తెలుగు)",
     },
+    { locale: "tet", englishName: "Tetum", endonym: "Tetum", label: "Tetum" },
     {
         locale: "tg",
         englishName: "Tajik",
@@ -824,6 +885,18 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Tswana (Setswana)",
     },
     {
+        locale: "to",
+        englishName: "Tongan",
+        endonym: "lea fakatonga",
+        label: "Tongan (lea fakatonga)",
+    },
+    {
+        locale: "tpi",
+        englishName: "Tok Pisin",
+        endonym: "Tok Pisin",
+        label: "Tok Pisin",
+    },
+    {
         locale: "tr",
         englishName: "Turkish",
         endonym: "Türkçe",
@@ -834,6 +907,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Tatar",
         endonym: "татар",
         label: "Tatar (татар)",
+    },
+    {
+        locale: "ty",
+        englishName: "Tahitian",
+        endonym: "Tahitian",
+        label: "Tahitian",
     },
     {
         locale: "ug",
@@ -865,6 +944,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Tiếng Việt",
         label: "Vietnamese (Tiếng Việt)",
     },
+    { locale: "war", englishName: "Waray", endonym: "Waray", label: "Waray" },
     { locale: "wo", englishName: "Wolof", endonym: "Wolof", label: "Wolof" },
     {
         locale: "xh",

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -54,11 +54,11 @@ const LANGUAGE_ALIASES: Record<string, string> = { no: "nb", tw: "ak" };
  * The rule is published membership rather than a judgement about how close two
  * varieties are, which is what makes it checkable and what distinguishes it from
  * the `nn` and `fat` cases in {@link LANGUAGE_ALIASES}: neither of those is a
- * member of `nb` or `ak`, and both are deliberately left to miss. Four of the
- * five keys — `qu`, `ay`, `gn`, `oj` — are ISO 639-3 macrolanguages and list
- * their macrolanguage members; `nah` is an ISO 639-3 **collection** code rather
- * than a macrolanguage, so it lists the individual Nahuan languages ISO 639-5
- * groups under it.
+ * member of `nb` or `ak`, and both are deliberately left to miss. Five of the
+ * six keys — `qu`, `ay`, `gn`, `oj`, `bik` — are ISO 639-3 macrolanguages and
+ * list their macrolanguage members; `nah` is an ISO 639-3 **collection** code
+ * rather than a macrolanguage, so it lists the individual Nahuan languages ISO
+ * 639-5 groups under it.
  *
  * The one member CLDR already folds is included anyway — `quz`, `ojg`, `gug`,
  * `ayr` — so that each list reads as the whole of a group rather than as the
@@ -165,6 +165,12 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // them, and is left to miss for the `fat` reason — ISO 639-3 gives it a code
     // outside `oj`, so folding it here would be the judgement this map avoids.
     oj: ["ciw", "ojb", "ojc", "ojg", "ojs", "ojw", "otw"],
+    // Bikol. The catalog is Central Bikol (Naga), which is `bcl` — the variety
+    // Bikol publishing, broadcasting and the mother-tongue materials use. These
+    // eight are the whole of the macrolanguage. Tagalog is not among them and
+    // must not be added: `fil` is a language of its own with a catalog of its
+    // own, and folding it here would serve a Tagalog reader Bikol.
+    bik: ["bcl", "bln", "bto", "cts", "fbl", "lbl", "rbl", "ubl"],
 };
 
 /** Flattened once at module load rather than searched per request. */

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -382,7 +382,7 @@ describe("negotiateLocales", () => {
      * needs `MACROLANGUAGE_MEMBERS` for the same reason `qu` and `oj` do. The
      * other fourteen are individual languages and need nothing.
      */
-    describe("the Austronesian batch", () => {
+    describe("the Austronesian batch and its macrolanguage", () => {
         it.each([
             // Bikol. The catalog is Central Bikol, which is `bcl` itself; the
             // rest are Bikol languages of the peninsula that would otherwise

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -439,11 +439,13 @@ describe("negotiateLocales", () => {
          * with catalogs of their own and are members of nothing: `tl`
          * canonicalizes to `fil` before negotiation is reached (see the
          * Filipino case above) and must not touch `bik`, and `ceb` must reach
-         * its own catalog rather than a neighbour's. `pag` is Pangasinan, which
-         * has no catalog and belongs to no macrolanguage that does — it falls
-         * to English, which is the rule working rather than a gap.
+         * its own catalog rather than a neighbour's. `phi` is the ISO 639-5
+         * collection code for the Philippine languages as a group, which is not
+         * a macrolanguage and folds onto nothing, unlike the one collection
+         * code `MACROLANGUAGE_MEMBERS` does carry (`nah`, whose members are
+         * listed there deliberately).
          */
-        it.each(["tl", "ceb", "pag", "phi"])(
+        it.each(["tl", "ceb", "phi"])(
             "does not fold %s onto a neighbouring Philippine catalog",
             (requested) => {
                 const chain = negotiateLocales(
@@ -456,6 +458,9 @@ describe("negotiateLocales", () => {
             },
         );
 
+        // Pangasinan is a Philippine language with no catalog that belongs to
+        // no macrolanguage with one, so it falls all the way to English — the
+        // rule working rather than a gap in it.
         it("leaves Pangasinan on English rather than guessing", () => {
             expect(
                 negotiateLocales([normalizeLocaleTag("pag")], available),

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -374,6 +374,94 @@ describe("negotiateLocales", () => {
             ).toEqual(["en"]);
         });
     });
+
+    /**
+     * The Austronesian batch — five Philippine languages, four of Indonesia,
+     * Tetum, three Polynesian, Chamorro and Tok Pisin. One of the fifteen is a
+     * macrolanguage: `bik` stands over eight individual Bikol languages, so it
+     * needs `MACROLANGUAGE_MEMBERS` for the same reason `qu` and `oj` do. The
+     * other fourteen are individual languages and need nothing.
+     */
+    describe("the Austronesian batch", () => {
+        it.each([
+            // Bikol. The catalog is Central Bikol, which is `bcl` itself; the
+            // rest are Bikol languages of the peninsula that would otherwise
+            // fall to English with a catalog they can read sitting on disk.
+            ["bcl", "bik"],
+            ["bto", "bik"],
+            ["cts", "bik"],
+            ["ubl", "bik"],
+            ["rbl", "bik"],
+            ["bcl-PH", "bik"],
+        ])("folds the Bikol member %s to %s", (requested, expected) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual([expected, "en"]);
+        });
+
+        it.each([
+            ["ilo-PH", "ilo"],
+            ["war-PH", "war"],
+            ["hil-PH", "hil"],
+            ["pam-PH", "pam"],
+            ["bik-PH", "bik"],
+            ["min-ID", "min"],
+            ["mad-ID", "mad"],
+            ["tet-TL", "tet"],
+            ["to-TO", "to"],
+            ["fj-FJ", "fj"],
+            ["ty-PF", "ty"],
+            ["ch-GU", "ch"],
+            ["ch-MP", "ch"],
+            ["tpi-PG", "tpi"],
+            // Both of these are written in more than one script, and both
+            // catalogs are the Latin one — so a reader arriving under the other
+            // script reaches it and gets Latin. That is the asymmetry `pa`,
+            // `sr`, `jv` and `su` already have, and the answer to it is a second
+            // catalog beside the first rather than a rename of it.
+            ["ban-Bali", "ban"],
+            ["ace-Arab", "ace"],
+        ])(
+            "strips the region or script from %s to reach %s",
+            (requested, expected) => {
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual([expected, "en"]);
+            },
+        );
+
+        /**
+         * The negative controls, and the reason the Bikol list keys on
+         * published membership. Tagalog and Cebuano are Philippine languages
+         * with catalogs of their own and are members of nothing: `tl`
+         * canonicalizes to `fil` before negotiation is reached (see the
+         * Filipino case above) and must not touch `bik`, and `ceb` must reach
+         * its own catalog rather than a neighbour's. `pag` is Pangasinan, which
+         * has no catalog and belongs to no macrolanguage that does — it falls
+         * to English, which is the rule working rather than a gap.
+         */
+        it.each(["tl", "ceb", "pag", "phi"])(
+            "does not fold %s onto a neighbouring Philippine catalog",
+            (requested) => {
+                const chain = negotiateLocales(
+                    [normalizeLocaleTag(requested)],
+                    available,
+                );
+                expect(chain).not.toContain("bik");
+                expect(chain).not.toContain("ilo");
+                expect(chain).not.toContain("hil");
+            },
+        );
+
+        it("leaves Pangasinan on English rather than guessing", () => {
+            expect(
+                negotiateLocales([normalizeLocaleTag("pag")], available),
+            ).toEqual(["en"]);
+        });
+    });
 });
 
 describe("resolveDocumentLocale", () => {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -64964,6 +64964,10 @@
                             "description": "English"
                         },
                         {
+                            "value": "ace",
+                            "description": "Acehnese"
+                        },
+                        {
                             "value": "af",
                             "description": "Afrikaans"
                         },
@@ -65000,12 +65004,20 @@
                             "description": "Azerbaijani (azərbaycan)"
                         },
                         {
+                            "value": "ban",
+                            "description": "Balinese"
+                        },
+                        {
                             "value": "be",
                             "description": "Belarusian (беларуская)"
                         },
                         {
                             "value": "bg",
                             "description": "Bulgarian (български)"
+                        },
+                        {
+                            "value": "bik",
+                            "description": "Bikol"
                         },
                         {
                             "value": "bm",
@@ -65030,6 +65042,10 @@
                         {
                             "value": "ceb",
                             "description": "Cebuano"
+                        },
+                        {
+                            "value": "ch",
+                            "description": "Chamorro"
                         },
                         {
                             "value": "co",
@@ -65084,6 +65100,10 @@
                             "description": "Filipino"
                         },
                         {
+                            "value": "fj",
+                            "description": "Fijian"
+                        },
+                        {
                             "value": "fo",
                             "description": "Faroese (føroyskt)"
                         },
@@ -65132,6 +65152,10 @@
                             "description": "Hindi (हिन्दी)"
                         },
                         {
+                            "value": "hil",
+                            "description": "Hiligaynon"
+                        },
+                        {
                             "value": "hnj",
                             "description": "Hmong Njua"
                         },
@@ -65158,6 +65182,10 @@
                         {
                             "value": "ig",
                             "description": "Igbo"
+                        },
+                        {
+                            "value": "ilo",
+                            "description": "Iloko"
                         },
                         {
                             "value": "is",
@@ -65224,12 +65252,20 @@
                             "description": "Latvian (latviešu)"
                         },
                         {
+                            "value": "mad",
+                            "description": "Madurese"
+                        },
+                        {
                             "value": "mg",
                             "description": "Malagasy"
                         },
                         {
                             "value": "mi",
                             "description": "Māori"
+                        },
+                        {
+                            "value": "min",
+                            "description": "Minangkabau"
                         },
                         {
                             "value": "mk",
@@ -65302,6 +65338,10 @@
                         {
                             "value": "pa",
                             "description": "Punjabi (ਪੰਜਾਬੀ)"
+                        },
+                        {
+                            "value": "pam",
+                            "description": "Pampanga"
                         },
                         {
                             "value": "pl",
@@ -65412,6 +65452,10 @@
                             "description": "Telugu (తెలుగు)"
                         },
                         {
+                            "value": "tet",
+                            "description": "Tetum"
+                        },
+                        {
                             "value": "tg",
                             "description": "Tajik (тоҷикӣ)"
                         },
@@ -65432,12 +65476,24 @@
                             "description": "Tswana (Setswana)"
                         },
                         {
+                            "value": "to",
+                            "description": "Tongan (lea fakatonga)"
+                        },
+                        {
+                            "value": "tpi",
+                            "description": "Tok Pisin"
+                        },
+                        {
                             "value": "tr",
                             "description": "Turkish (Türkçe)"
                         },
                         {
                             "value": "tt",
                             "description": "Tatar (татар)"
+                        },
+                        {
+                            "value": "ty",
+                            "description": "Tahitian"
                         },
                         {
                             "value": "ug",
@@ -65458,6 +65514,10 @@
                         {
                             "value": "vi",
                             "description": "Vietnamese (Tiếng Việt)"
+                        },
+                        {
+                            "value": "war",
+                            "description": "Waray"
                         },
                         {
                             "value": "wo",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -1084,6 +1084,178 @@ describe("the Indigenous Americas batch's word order", () => {
     });
 });
 
+describe("the Austronesian batch's word order", () => {
+    const forLocale = (locale: string): Translator =>
+        createTranslatorFromLocaleData(
+            { locale, resources: { [locale]: readCatalog(locale, "content") } },
+            locale,
+        );
+
+    const words = {
+        lineWidthWord: "thick",
+        lineStyleWord: "dashed",
+        colorWord: "red",
+    };
+
+    /**
+     * Fifteen languages of one region and two orders, which is the useful thing
+     * to pin: the five Philippine catalogs and Tok Pisin put their adjectives
+     * **in front of** the noun, and the nine others put them **behind** it. A
+     * batch is not a word order, and neither is a family — `ilo` and `ban` are
+     * both Austronesian and disagree.
+     *
+     * The linker is the other half of the prenominal rows. Each of the five
+     * Philippine languages joins the adjective to what it describes with a
+     * ligature this catalog writes out — «a» in Ilocano and Kapampangan, «nga»
+     * in Waray and Hiligaynon, «na» in Bikol — and these strings are what pins
+     * which form each one chose. See the header of each `content.ftl` for why
+     * only two of the five could pick a form that is right in every position.
+     */
+    const prenominal: [string, string, string][] = [
+        [
+            "ilo",
+            "napuskol a naguris-guris a nalabaga a linia",
+            "napuskol a naguris-guris a nalabaga",
+        ],
+        [
+            "war",
+            "baga nga putol-putol nga pula nga linya",
+            "baga nga putol-putol nga pula",
+        ],
+        [
+            "hil",
+            "madamol nga putol-putol nga pula nga linya",
+            "madamol nga putol-putol nga pula",
+        ],
+        [
+            "pam",
+            "makapal a putul-putul a malutu a linya",
+            "makapal a putul-putul a malutu",
+        ],
+        [
+            "bik",
+            "makapal na putol-putol na pula na linya",
+            "makapal na putol-putol na pula",
+        ],
+        // Tok Pisin, whose adjectives precede the noun because each carries the
+        // attributive suffix «-pela» and cannot be postposed while it does. See
+        // `locales/tpi/content.ftl` for why the predicative form, which drops
+        // the suffix, is unreachable from `$role`.
+        ["tpi", "patpela brukbruk retpela lain", "patpela brukbruk retpela"],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of prenominal) {
+        it(`puts ${locale}'s adjectives in front of the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: true,
+                }),
+            ).toBe(withNoun);
+            expect(withNoun.startsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: false,
+                }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    const postnominal: [string, string, string][] = [
+        ["ban", "garis tebel putus-putus barak", "tebel putus-putus barak"],
+        ["min", "garih taba putuih-putuih sirah", "taba putuih-putuih sirah"],
+        ["ace", "garéh teubai putôh-putôh mirah", "teubai putôh-putôh mirah"],
+        ["mad", "garis kandel pote'-pote' mera", "kandel pote'-pote' mera"],
+        ["tet", "liña grosu traku-traku mean", "grosu traku-traku mean"],
+        ["to", "laine matolu motumotu kulokula", "matolu motumotu kulokula"],
+        ["fj", "laini levu musumusu damudamu", "levu musumusu damudamu"],
+        ["ty", "reni mātotoru motumotu ʻuteʻute", "mātotoru motumotu ʻuteʻute"],
+        ["ch", "liña damo' ma'ipe'-ipe' agaga'", "damo' ma'ipe'-ipe' agaga'"],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of postnominal) {
+        it(`puts ${locale}'s adjectives after the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: true,
+                }),
+            ).toBe(withNoun);
+            expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: false,
+                }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    /**
+     * **All fifteen reach `[noun-tail]`, including the six prenominal ones** —
+     * a combination no earlier batch produced. The Americas batch's six
+     * prenominal catalogs fold the side count into the head and leave the tail
+     * empty, because a count is a modifier there; in every language here it is
+     * a relative clause («nga addaan iti 5 a sikigan», «i gat 5 sait wankain»),
+     * which has to follow the whole phrase whichever side the adjectives sit
+     * on. So the `$part` split is not the postnominal languages' property: it
+     * belongs to the shape of the complement, which is what these rows hold.
+     */
+    it.each([
+        [
+            "ilo",
+            "napuskol a naguris-guris a nalabaga a regular a poligono nga addaan iti 5 a sikigan",
+        ],
+        [
+            "war",
+            "baga nga putol-putol nga pula nga regular nga poligono nga may 5 nga kilid",
+        ],
+        [
+            "hil",
+            "madamol nga putol-putol nga pula nga regular nga poligono nga may 5 nga kilid",
+        ],
+        [
+            "pam",
+            "makapal a putul-putul a malutu a regular a poligono a atin 5 a gilid",
+        ],
+        [
+            "bik",
+            "makapal na putol-putol na pula na regular na poligono na may 5 na gilid",
+        ],
+        ["tpi", "patpela brukbruk retpela poligon i gat 5 sait wankain"],
+        ["ban", "poligon beraturan tebel putus-putus barak ane ngelah 5 sisi"],
+        ["min", "poligon baraturan taba putuih-putuih sirah nan basisi 5"],
+        ["ace", "poligon beuratura teubai putôh-putôh mirah nyang na 5 sagoë"],
+        ["mad", "poligon beraturan kandel pote'-pote' mera se badâ 5 essèna"],
+        ["tet", "polígonu regulár grosu traku-traku mean ho sorin 5"],
+        ["to", "polikoni tatau matolu motumotu kulokula ʻoku tapa 5"],
+        ["fj", "poligani veitautauvata levu musumusu damudamu e 5 na yasana"],
+        ["ty", "poligone ʻaifaito mātotoru motumotu ʻuteʻute e 5 hiti tōna"],
+        [
+            "ch",
+            "poligono regulåt damo' ma'ipe'-ipe' agaga' ni guaha 5 na kanton",
+        ],
+    ])(
+        "closes %s's phrase with the side count behind it",
+        (locale, expected) => {
+            const description = describeStrokedShape(forLocale(locale), words, {
+                noun: { key: "regular-polygon", numSides: 5 },
+                withNoun: true,
+            });
+            expect(description).toBe(expected);
+            // The complement trails the whole phrase rather than sitting between
+            // the noun and the words describing it, which is the whole point of the
+            // split — and it leaves no doubled space behind.
+            expect(description).toContain("5");
+            expect(description).not.toContain("  ");
+            expect(description.trimEnd()).toBe(description);
+        },
+    );
+});
+
 describe("a partly translated locale", () => {
     // A translation is allowed to lag: every key it does not define falls
     // through to English. The split noun is the case where that matters, since
@@ -1201,6 +1373,34 @@ describe("a phrase rendered in two positions", () => {
         quc: forLocale("quc"),
         arn: forLocale("arn"),
         oj: forLocale("oj"),
+    } as const;
+
+    /**
+     * The Austronesian batch, all fifteen on the identity side. Not one of them
+     * inflects an adjective for the position its phrase goes into: nine have no
+     * adjective morphology at all, the five Philippine languages carry a linker
+     * rather than a case, and Tok Pisin's «-pela» is attributive-against-
+     * predicative rather than positional — and the one place that distinction
+     * would show is unreachable, because `standalone` covers both the citation
+     * form and the attributive use. So a `$role` fork in any of the fifteen
+     * would write one string twice, and this is what would catch it.
+     */
+    const austronesian = {
+        ilo: forLocale("ilo"),
+        war: forLocale("war"),
+        hil: forLocale("hil"),
+        pam: forLocale("pam"),
+        bik: forLocale("bik"),
+        ban: forLocale("ban"),
+        min: forLocale("min"),
+        ace: forLocale("ace"),
+        mad: forLocale("mad"),
+        tet: forLocale("tet"),
+        to: forLocale("to"),
+        fj: forLocale("fj"),
+        ty: forLocale("ty"),
+        ch: forLocale("ch"),
+        tpi: forLocale("tpi"),
     } as const;
 
     const borderWords = { colorWord: "black", lineWidthWord: "thick" };
@@ -1640,7 +1840,7 @@ describe("a phrase rendered in two positions", () => {
     // the substring holds even though two animacies are in play — which is the
     // same shape Swahili's «mpaka» case has, and why neither language needs
     // `$role`.
-    it.each(Object.entries(americas))(
+    it.each(Object.entries({ ...americas, ...austronesian }))(
         "leaves %s's adjectives unchanged between the two positions",
         (_locale, t) => {
             const border = bothBorderForms(t);

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -1246,12 +1246,6 @@ describe("the Austronesian batch's word order", () => {
                 withNoun: true,
             });
             expect(description).toBe(expected);
-            // The complement trails the whole phrase rather than sitting between
-            // the noun and the words describing it, which is the whole point of the
-            // split — and it leaves no doubled space behind.
-            expect(description).toContain("5");
-            expect(description).not.toContain("  ");
-            expect(description.trimEnd()).toBe(description);
         },
     );
 });

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -1153,6 +1153,9 @@ describe("the Austronesian batch's word order", () => {
                     withNoun: true,
                 }),
             ).toBe(withNoun);
+            // The same relation the Americas batch above pins: the noun is
+            // appended to the adjectives rather than woven into them, so the
+            // two rows of each pair have to stay in step when either is edited.
             expect(withNoun.startsWith(adjectivesOnly)).toBe(true);
             expect(
                 describeStrokedShape(t, words, {
@@ -1184,6 +1187,8 @@ describe("the Austronesian batch's word order", () => {
                     withNoun: true,
                 }),
             ).toBe(withNoun);
+            // The mirror of the prenominal check: the noun is prepended whole,
+            // with nothing of it reaching in among the adjectives.
             expect(withNoun.endsWith(adjectivesOnly)).toBe(true);
             expect(
                 describeStrokedShape(t, words, {


### PR DESCRIPTION
Add message catalogs for Ilocano, Waray, Hiligaynon, Kapampangan, Bikol, Balinese, Minangkabau, Acehnese, Madurese, Tetum, Tongan, Fijian, Tahitian, Chamorro and Tok Pisin.

Each covers all four namespaces — the viewer chrome, the editor and language-server surfaces, the prose the core computes into a document, and the warnings and errors. `documentLocale="ilo"` and `<document lang="to">` work with nothing configured, and all fifteen reach `<document lang>`'s autocomplete.

These are **unreviewed machine-generated seeds**, and every file says so in its header. Nothing falls back silently: a key a translation is missing renders in English, which is what makes seeding safe.

The batch takes the roster across the Philippines, the Indonesian archipelago, Timor-Leste, Polynesia, Micronesia and Papua New Guinea. Fourteen of the fifteen are Austronesian; Tok Pisin is an English-lexified creole and is here for the region rather than the family.

## The finding: a ligature is an affix too

A Philippine language joins an attributive adjective to what it describes with a **linker**, and a linker has two forms. Which one is right is decided by a *neighbouring* word — which, in these messages, is often a placeable. So the constraint that turned up first as an Arabic case ending and a Czech preposition turns up here as a ligature. `locales/ceb` and `locales/fil` each met it alone — Cebuano calling its uncontracted «nga» "the one place this seed is deliberately stiff", Filipino escaping it by selecting on the side count — and what this batch adds is the five Philippine catalogs side by side, which do not all resolve it the same way:

| | The linker | Decided by | Resolution |
| --- | --- | --- | --- |
| `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», grammatical in both positions |
| `ilo` | «a» / «nga» | the word **after** it | no invariant form; write «a» and name the exception |
| `pam` | «a» / `-ng` | the word **before** it | no invariant form; write «a» and name the exception |
| `bik` | «na» / `-ng` | the word **before** it | no invariant form; write «na» and name the exception |

Two of the five escape it outright, and that is the useful half: Bisayan «nga» is a free word in both positions, so writing it out is not a compromise but *the form that can be written without knowing what stands beside it*. That is the move `locales/ceb` already makes and the move `locales/quc` makes with the free relational «rech» in place of the possessive prefix «u-»/«r-»; with three catalogs taking it, it goes into the README's list of ways out as a **fifth** one — prefer the free allomorph over the bound one. The finding is written up beside the affix rule it belongs to rather than under naming.

The other three cannot, and each header says exactly where its choice comes out wrong rather than leaving a reader to find it. Ilocano's is the sharpest and is **pinned as a test**: every word in its own tables is consonant-initial but «asul», so `styleDescriptionLocale.test.ts` asserts «napunno a asul a sirkulo» — the one place the rule misfires — instead of hiding it. A fix is a change to what the composition messages are handed, not a change to that string, and the test is what would notice the day it becomes possible.

The three are the constraint seen from two ends: Ilocano's linker is decided by what *follows* it (the Kʼicheʼ «u-»/«r-» case), Kapampangan's and Bikol's by what *precedes* it (the Uyghur case-ending case).

## What the fifteen are not

**Two word orders in one region, and neither the region nor the family decides it.** The five Philippine catalogs and Tok Pisin put their adjectives in front of the noun; Balinese, Minangkabau, Acehnese, Madurese, Tetum, Tongan, Fijian, Tahitian and Chamorro put them behind. `ilo` and `ban` are both Austronesian and disagree. `styleDescriptions.test.ts` asserts both groups as identities, which is what would catch someone "correcting" one of them on a hunch about the region.

**All fifteen reach `[noun-tail]`, six of them with their adjectives in front — a combination no earlier batch produced.** In the Americas batch every prenominal catalog folded its side count into the head and left the tail empty, because a count is a modifier there. Here it is a relative clause in all fifteen — «nga addaan iti 5 a sikigan», «i gat 5 sait wankain» — and a clause has to follow the whole phrase whichever side the adjectives sit on. So what decides the `$part` split is the shape of the complement, not the order of the adjectives.

**Tok Pisin is the first catalog that wants `standalone` split in two, and cannot have it.** A Tok Pisin adjective carries «-pela» attributively («retpela lain») and drops it predicatively («lain i ret»). That is exactly what `$role` names — and it is unreachable, because `attachNoun` passes `role: "standalone"` for the phrase it is about to put in front of a noun and `describeColor` passes the same token for the citation form a state variable reports. One token, two positions. The catalog writes the attributive form throughout and its header records the reason rather than the workaround. This is a limitation of the argument rather than of the language, and it is the first concrete motivation for splitting `standalone`.

**Speech level, for the third and fourth time.** Balinese and Madurese choose a register for every sentence, and a file with two registers in it is wrong in both. They are written throughout in **basa andap** and **enjâ'-iyâ**, the unmarked everyday levels — the decision `locales/jv` and `locales/su` already record for ngoko and loma, now made twice more and for the same reason.

**Four colour tables do not fit English's twelve keys, and the Pacific three fail the same way.** Tongan «lanumoana» is the blue of the deep sea and «lanumata» the green of new growth; Fijian «karakarawa» reaches from blue into the greens; Tahitian «ninamu» is the lagoon. In all three `.cyan` sits inside the blue word with nothing of its own, and what is written there is a transliteration a speaker should replace or delete — each header says so. Tetum is the fourth and different: «matak» covers blue and green together, so the catalog assigns it to green and the Portuguese loan «azúl» to blue, which is what Timorese school materials do and is a partition of the spectrum rather than a translation of two English words.

**Chamorro is the roster's most heavily Spanish catalog, and the loans are the language rather than a shortcut in it.** Three centuries of contact left it with «betde», «asut», «amariyu» and Spanish geometry — fully Chamorro words now, taking Chamorro affixes and Chamorro spelling. The seam its header points at is not Chamorro-against-Spanish but where the native word survives beside the loan.

**Two catalogs carry marks that are letters.** Tongan's fakauʻa «ʻ» and Tahitian's ʻeta are U+02BB, not an apostrophe, and both languages write vowel length with a macron. The two render alike and compare unequal, which is the trap `locales/yi` records for its digraphs; the worker test asserts a Tongan string through `setLocaleData` for exactly that reason.

## Chemistry

All fifteen are partial, and they split four ways — three of which are a fact about a school system rather than about a language. Ilocano, Waray, Hiligaynon, Kapampangan, Bikol, Chamorro and Tok Pisin are the English-medium case, which is the `fil` and `ceb` case already in the roster. Balinese, Minangkabau, Acehnese and Madurese are the Indonesian-medium case, and they differ from `jv` and `su` instructively: those two *supply* the Indonesian names because their own vocabulary agrees with Indonesian's often enough; these four do not — Minangkabau says «ameh» where Indonesian says «emas» — so copying the table whole would be neither language. Tetum and Tahitian are the colonial-medium case a third and fourth time, Portuguese and French, which is `locales/ht`'s exactly. Tongan and Fijian are the fourth case and the one about the languages: both are schooled in English, but neither has a settled list of all 118 — the Samoan and Hawaiian case, Pacific languages naming the substances known long before the elements were, with no table over them.

## Negotiation

`bik` is an ISO 639-3 **macrolanguage** over the eight Bikol languages of the peninsula, so it joins `MACROLANGUAGE_MEMBERS` for the same published reason `qu` and `oj` did. The catalog is Central Bikol (Naga) — `bcl` itself — and `bto`, `cts`, `ubl`, `rbl` and the rest reach it. Tagalog is deliberately not in that list and must not be added: `fil` is a language of its own with a catalog of its own, and folding it would serve a Tagalog reader Bikol.

`ban` and `ace` add the script asymmetry `pa`, `sr`, `jv` and `su` already have: both catalogs are Latin, so `ban-Bali` and `ace-Arab` reach them and get Latin.

The naming cases are the `ny`-reads-Nyanja rule again, and two will look like mistakes: `ilo` appears as **Iloko** and `pam` as **Pampanga**, because that is what `Intl.DisplayNames` renders and `supportedLocales.ts` is derived rather than hand-written. Both headers say which language they are. `to` is the only one of the fifteen whose endonym CLDR knows — "Tongan (lea fakatonga)" — and the other fourteen read their English name once, the `co` case fourteen times over. None is right-to-left, so `direction.ts` is untouched.

## Tests

- `packages/i18n/test/negotiate.test.ts`: the Bikol fold across five members and a regional tag, the region and script tags for all fifteen including `ban-Bali` and `ace-Arab`, and the negative controls — `tl` (which canonicalizes to `fil` and must not touch `bik`), `ceb`, `phi` (an ISO 639-5 collection code, which folds onto nothing), and `pag`, held on English because Pangasinan belongs to no macrolanguage with a catalog.
- `packages/utils/test/styleDescriptions.test.ts`: the six prenominal and nine postnominal catalogs asserted as identities, the ligature each Philippine catalog chose pinned in its strings, all fifteen closing their phrase with the side count behind it, and all fifteen added to the two-positions suite on the identity side.
- `packages/doenetml-worker-javascript/.../styleDescriptionLocale.test.ts`: Ilocano and Tongan through the whole worker path — the two ends of the batch's range, one carrying a ligature (and the one string where it misfires) and the other carrying the fakauʻa.

## Docs

`packages/i18n/README.md` gains the fifteen codes in its roster, the chemistry paragraphs for this batch, a naming/script/macrolanguage section, a fifth entry in the list of ways out of the affix rule, the "a ligature is an affix too" section beside that rule, the note on `standalone` covering two positions, and the note that the `$part` split belongs to the complement rather than to the word order.

## Regenerated

`supportedLocales.ts` (147 locales) and `doenet-schema.json`, via codegen → build i18n → build:schema → build static-assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

