### PR TITLE
Let the schema scripts build the packages they read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,7 +551,7 @@ jobs:
             # makes the diff below meaningful. NODE_OPTIONS matches the other
             # build steps in this file, since this step now performs those builds
             # itself when the cache cannot supply them (~21s from nothing at all,
-            # peaking at ~1.5 GB RSS).
+            # peaking at ~1.4 GiB RSS).
             #
             # There is deliberately no `npm run build:all-no-docs` step ahead of
             # this: a pre-built workspace masks an *incomplete dependency list*,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,10 +548,12 @@ jobs:
             # has to be set explicitly — wireit defaults it to "none" whenever
             # CI=true — while build:schema itself declares no files/output, so it
             # always re-runs instead of being served from cache, which is what
-            # makes the diff below meaningful. NODE_OPTIONS matches the other
-            # build steps in this file, since this step now performs those builds
-            # itself when the cache cannot supply them (~21s from nothing at all,
-            # peaking at ~1.4 GiB RSS).
+            # makes the diff below meaningful. NODE_OPTIONS is the value every
+            # runner-side build step in this file uses (the devcontainer jobs
+            # build inside their container and set nothing); it belongs here
+            # because this step now performs those builds itself when the cache
+            # cannot supply them — ~21s from nothing at all, peaking at ~1.4 GiB
+            # RSS, measured locally.
             #
             # There is deliberately no `npm run build:all-no-docs` step ahead of
             # this: a pre-built workspace masks an *incomplete dependency list*,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,11 @@ jobs:
 
             # build:schema imports componentInfoObjects from source, which
             # transitively requires @doenet/utils (and friends) to be built.
-            # Matches the check-docs-coverage cached-build pattern.
+            # It now declares those as wireit dependencies and builds them
+            # itself, so this step is belt-and-braces: it keeps the rest of the
+            # workspace warm in the shared wireit cache, and it is where a
+            # build break shows up as a build failure rather than as a
+            # confusing schema diff.
             - name: Build (cached)
               run: |
                   export NODE_OPTIONS="--max_old_space_size=6114"
@@ -551,8 +555,10 @@ jobs:
                   WIREIT_CACHE: "local"
 
             # Regenerates packages/static-assets/src/generated/* from
-            # componentInfoObjects (read by vite-node). build:schema is
-            # not wireit-wrapped, so a fresh run always executes.
+            # componentInfoObjects (read by vite-node). build:schema is a
+            # wireit script with dependencies but deliberately no files/output,
+            # so it always re-runs instead of being served from cache — this
+            # check is only meaningful against a fresh generation.
             # The runtime guards in get-schema.ts also throw here if any
             # component/attribute/property/attribute-value description is
             # missing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,21 +552,19 @@ jobs:
             # runner-side build step in this file uses (the devcontainer jobs
             # build inside their container and set nothing); it belongs here
             # because this step now performs those builds itself when the cache
-            # cannot supply them — ~21s from nothing at all, peaking at ~1.4 GiB
-            # RSS, measured locally.
+            # cannot supply them.
             #
             # There is deliberately no `npm run build:all-no-docs` step ahead of
             # this: a pre-built workspace masks an *incomplete dependency list*,
             # the bug this job is shaped to catch, and that bug only bites someone
             # who runs build:schema on its own — so CI runs it on its own too.
-            # Nothing is lost by dropping it. A dependency that cannot be restored
+            # Nothing is lost by dropping it. A dependency the cache cannot supply
             # is rebuilt from source; one that fails to build is named by wireit
-            # (`[../i18n:build] exited with exit code 1`, plus the compiler error)
             # and would already have failed the `build` job this one needs; an
-            # *undeclared* one — the single new failure mode — is vite's `Failed to
-            # resolve entry for package "@doenet/utils"`, naming the importing
-            # file. None of the three can masquerade as a stale schema, because
-            # the diff step below never runs.
+            # *undeclared* one — the single new failure mode — fails with vite's
+            # `Failed to resolve entry for package "@doenet/utils"`, naming the
+            # importing file. None of the three can masquerade as a stale schema,
+            # because the diff step below never runs.
             #
             # The runtime guards in get-schema.ts also throw here if any
             # component/attribute/property/attribute-value description is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,27 +542,29 @@ jobs:
 
             # Regenerates packages/static-assets/src/generated/* from
             # componentInfoObjects (read by vite-node). build:schema imports that
-            # from worker source, so @doenet/utils (and friends) have to be
-            # built; it declares those as wireit dependencies and restores them
-            # from the .wireit cache downloaded above. WIREIT_CACHE has to be set
-            # explicitly — wireit defaults it to "none" whenever CI=true — while
-            # build:schema itself declares no files/output, so it always re-runs
-            # instead of being served from cache, which is what makes the diff
-            # below meaningful.
+            # from worker source, so @doenet/utils (and friends) have to be built;
+            # it gets them from a wireit dependency on the worker's build:deps and
+            # restores them from the .wireit cache downloaded above. WIREIT_CACHE
+            # has to be set explicitly — wireit defaults it to "none" whenever
+            # CI=true — while build:schema itself declares no files/output, so it
+            # always re-runs instead of being served from cache, which is what
+            # makes the diff below meaningful. NODE_OPTIONS matches the other
+            # build steps in this file, since this step now performs those builds
+            # itself when the cache cannot supply them (~21s from nothing at all,
+            # peaking at ~1.5 GB RSS).
             #
             # There is deliberately no `npm run build:all-no-docs` step ahead of
             # this: a pre-built workspace masks an *incomplete dependency list*,
             # the bug this job is shaped to catch, and that bug only bites someone
             # who runs build:schema on its own — so CI runs it on its own too.
-            # Nothing is lost by dropping it. A declared dependency the cache
-            # cannot supply is rebuilt from source (~20s from nothing at all); one
-            # that fails to build is named by wireit (`[../i18n:build] exited with
-            # exit code 1`, plus the compiler error) and would already have failed
-            # the `build` job this one needs; an *undeclared* one — the single new
-            # failure mode here — is vite's `Failed to resolve entry for package
-            # "@doenet/utils"` naming the importing file. None of the three can
-            # produce a misleading "schema is stale" diff, because the diff step
-            # below never runs.
+            # Nothing is lost by dropping it. A dependency that cannot be restored
+            # is rebuilt from source; one that fails to build is named by wireit
+            # (`[../i18n:build] exited with exit code 1`, plus the compiler error)
+            # and would already have failed the `build` job this one needs; an
+            # *undeclared* one — the single new failure mode — is vite's `Failed to
+            # resolve entry for package "@doenet/utils"`, naming the importing
+            # file. None of the three can masquerade as a stale schema, because
+            # the diff step below never runs.
             #
             # The runtime guards in get-schema.ts also throw here if any
             # component/attribute/property/attribute-value description is
@@ -571,6 +573,7 @@ jobs:
               run: npm run build:schema -w packages/static-assets
               env:
                   WIREIT_CACHE: "local"
+                  NODE_OPTIONS: "--max_old_space_size=6114"
 
             - name: Assert committed schema is up to date
               run: git diff --exit-code -- packages/static-assets/src/generated/
@@ -611,13 +614,15 @@ jobs:
 
             # The docs-coverage script imports componentInfoObjects from source,
             # which needs @doenet/utils (and friends) built. Like build:schema in
-            # schema-freshness, check:docs-coverage declares those as wireit
-            # dependencies and restores them from the .wireit cache downloaded
+            # schema-freshness, check:docs-coverage gets those through a wireit
+            # dependency and restores them from the .wireit cache downloaded
             # above, so there is no separate build step; see the comments in that
-            # job for the reasoning. The reference pages it checks are the .mdx
-            # sources in packages/docs-nextra/pages/reference, tracked in git, so
-            # nothing else needs building.
+            # job for the reasoning behind that and behind the env below. The
+            # reference pages it checks are the .mdx sources in
+            # packages/docs-nextra/pages/reference, tracked in git, so nothing
+            # else needs building.
             - name: Verify schema components map to /reference/<slug> pages
               run: npm run check:docs-coverage -w packages/static-assets
               env:
                   WIREIT_CACHE: "local"
+                  NODE_OPTIONS: "--max_old_space_size=6114"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,17 +544,21 @@ jobs:
             # componentInfoObjects (read by vite-node). build:schema imports
             # that from worker source, which needs @doenet/utils (and friends)
             # built; it declares those as wireit dependencies, and the artifact
-            # above is the .wireit cache, so WIREIT_CACHE=local restores exactly
-            # the packages the generators import.
+            # above is the .wireit cache, so those dependencies restore from
+            # cache instead of rebuilding. WIREIT_CACHE has to be set
+            # explicitly: wireit defaults it to "none" whenever CI=true.
             #
             # There is deliberately no `npm run build:all-no-docs` step ahead of
             # this. A build break already fails the `build` job this one needs,
-            # and pre-building the whole workspace would mask an incomplete
-            # dependency list — the bug this job exists to catch is one that only
-            # bites someone who runs build:schema on its own, so CI runs it on
-            # its own too. The risk accepted in exchange: a dependency wireit
-            # cannot restore is a hard failure here rather than a quiet cache
-            # hit, which is the intended trade.
+            # so it cannot surface here; what a pre-build would hide is an
+            # *incomplete dependency list*, and that is the bug this PR is
+            # about — it only bites someone who runs build:schema on its own, so
+            # CI runs it on its own too. When the cache cannot supply a declared
+            # dependency wireit just builds it from source (~20s from nothing at
+            # all), so dropping the step costs speed at worst, never a false
+            # pass. An *undeclared* dependency is the one new hard failure, and
+            # it is legible: vite reports `Failed to resolve entry for package
+            # "@doenet/utils"` naming the importing file.
             #
             # build:schema declares dependencies but deliberately no
             # files/output, so it always re-runs instead of being served from
@@ -609,8 +613,9 @@ jobs:
             # schema-freshness, check:docs-coverage declares those as wireit
             # dependencies and restores them from the .wireit cache downloaded
             # above, so there is no separate build step; see the comments in that
-            # job for the reasoning. The reference pages it checks are .mdx
-            # sources in git, so nothing else needs building.
+            # job for the reasoning. The reference pages it checks are the .mdx
+            # sources in packages/docs-nextra/pages/reference, tracked in git, so
+            # nothing else needs building.
             - name: Verify schema components map to /reference/<slug> pages
               run: npm run check:docs-coverage -w packages/static-assets
               env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,30 +540,32 @@ jobs:
               with:
                   name: build-artifacts
 
-            # build:schema imports componentInfoObjects from source, which
-            # transitively requires @doenet/utils (and friends) to be built.
-            # It now declares those as wireit dependencies and builds them
-            # itself, so this step is belt-and-braces: it keeps the rest of the
-            # workspace warm in the shared wireit cache, and it is where a
-            # build break shows up as a build failure rather than as a
-            # confusing schema diff.
-            - name: Build (cached)
-              run: |
-                  export NODE_OPTIONS="--max_old_space_size=6114"
-                  npm run build:all-no-docs
-              env:
-                  WIREIT_CACHE: "local"
-
             # Regenerates packages/static-assets/src/generated/* from
-            # componentInfoObjects (read by vite-node). build:schema is a
-            # wireit script with dependencies but deliberately no files/output,
-            # so it always re-runs instead of being served from cache — this
-            # check is only meaningful against a fresh generation.
+            # componentInfoObjects (read by vite-node). build:schema imports
+            # that from worker source, which needs @doenet/utils (and friends)
+            # built; it declares those as wireit dependencies, and the artifact
+            # above is the .wireit cache, so WIREIT_CACHE=local restores exactly
+            # the packages the generators import.
+            #
+            # There is deliberately no `npm run build:all-no-docs` step ahead of
+            # this. A build break already fails the `build` job this one needs,
+            # and pre-building the whole workspace would mask an incomplete
+            # dependency list — the bug this job exists to catch is one that only
+            # bites someone who runs build:schema on its own, so CI runs it on
+            # its own too. The risk accepted in exchange: a dependency wireit
+            # cannot restore is a hard failure here rather than a quiet cache
+            # hit, which is the intended trade.
+            #
+            # build:schema declares dependencies but deliberately no
+            # files/output, so it always re-runs instead of being served from
+            # cache — this check is only meaningful against a fresh generation.
             # The runtime guards in get-schema.ts also throw here if any
             # component/attribute/property/attribute-value description is
             # missing.
             - name: Regenerate schema
               run: npm run build:schema -w packages/static-assets
+              env:
+                  WIREIT_CACHE: "local"
 
             - name: Assert committed schema is up to date
               run: git diff --exit-code -- packages/static-assets/src/generated/
@@ -602,16 +604,14 @@ jobs:
               with:
                   name: build-artifacts
 
-            # The docs-coverage script imports componentInfoObjects from
-            # source, which transitively requires @doenet/utils and
-            # @doenet/parser to be built. Matches test-main's cached-build
-            # pattern (fast on a wireit cache hit).
-            - name: Build (cached)
-              run: |
-                  export NODE_OPTIONS="--max_old_space_size=6114"
-                  npm run build:all-no-docs
-              env:
-                  WIREIT_CACHE: "local"
-
+            # The docs-coverage script imports componentInfoObjects from source,
+            # which needs @doenet/utils (and friends) built. Like build:schema in
+            # schema-freshness, check:docs-coverage declares those as wireit
+            # dependencies and restores them from the .wireit cache downloaded
+            # above, so there is no separate build step; see the comments in that
+            # job for the reasoning. The reference pages it checks are .mdx
+            # sources in git, so nothing else needs building.
             - name: Verify schema components map to /reference/<slug> pages
               run: npm run check:docs-coverage -w packages/static-assets
+              env:
+                  WIREIT_CACHE: "local"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,9 +551,9 @@ jobs:
             # There is deliberately no `npm run build:all-no-docs` step ahead of
             # this. A build break already fails the `build` job this one needs,
             # so it cannot surface here; what a pre-build would hide is an
-            # *incomplete dependency list*, and that is the bug this PR is
-            # about — it only bites someone who runs build:schema on its own, so
-            # CI runs it on its own too. When the cache cannot supply a declared
+            # *incomplete dependency list*, which is the bug this job is shaped
+            # to catch — it only bites someone who runs build:schema on its own,
+            # so CI runs it on its own too. When the cache cannot supply a declared
             # dependency wireit just builds it from source (~20s from nothing at
             # all), so dropping the step costs speed at worst, never a false
             # pass. An *undeclared* dependency is the one new hard failure, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,28 +541,29 @@ jobs:
                   name: build-artifacts
 
             # Regenerates packages/static-assets/src/generated/* from
-            # componentInfoObjects (read by vite-node). build:schema imports
-            # that from worker source, which needs @doenet/utils (and friends)
-            # built; it declares those as wireit dependencies, and the artifact
-            # above is the .wireit cache, so those dependencies restore from
-            # cache instead of rebuilding. WIREIT_CACHE has to be set
-            # explicitly: wireit defaults it to "none" whenever CI=true.
+            # componentInfoObjects (read by vite-node). build:schema imports that
+            # from worker source, so @doenet/utils (and friends) have to be
+            # built; it declares those as wireit dependencies and restores them
+            # from the .wireit cache downloaded above. WIREIT_CACHE has to be set
+            # explicitly — wireit defaults it to "none" whenever CI=true — while
+            # build:schema itself declares no files/output, so it always re-runs
+            # instead of being served from cache, which is what makes the diff
+            # below meaningful.
             #
             # There is deliberately no `npm run build:all-no-docs` step ahead of
-            # this. A build break already fails the `build` job this one needs,
-            # so it cannot surface here; what a pre-build would hide is an
-            # *incomplete dependency list*, which is the bug this job is shaped
-            # to catch — it only bites someone who runs build:schema on its own,
-            # so CI runs it on its own too. When the cache cannot supply a declared
-            # dependency wireit just builds it from source (~20s from nothing at
-            # all), so dropping the step costs speed at worst, never a false
-            # pass. An *undeclared* dependency is the one new hard failure, and
-            # it is legible: vite reports `Failed to resolve entry for package
-            # "@doenet/utils"` naming the importing file.
+            # this: a pre-built workspace masks an *incomplete dependency list*,
+            # the bug this job is shaped to catch, and that bug only bites someone
+            # who runs build:schema on its own — so CI runs it on its own too.
+            # Nothing is lost by dropping it. A declared dependency the cache
+            # cannot supply is rebuilt from source (~20s from nothing at all); one
+            # that fails to build is named by wireit (`[../i18n:build] exited with
+            # exit code 1`, plus the compiler error) and would already have failed
+            # the `build` job this one needs; an *undeclared* one — the single new
+            # failure mode here — is vite's `Failed to resolve entry for package
+            # "@doenet/utils"` naming the importing file. None of the three can
+            # produce a misleading "schema is stale" diff, because the diff step
+            # below never runs.
             #
-            # build:schema declares dependencies but deliberately no
-            # files/output, so it always re-runs instead of being served from
-            # cache — this check is only meaningful against a fresh generation.
             # The runtime guards in get-schema.ts also throw here if any
             # component/attribute/property/attribute-value description is
             # missing.

--- a/docs/PR_REVIEW_GUIDELINES.md
+++ b/docs/PR_REVIEW_GUIDELINES.md
@@ -26,6 +26,6 @@ Review whether the PR includes adequate tests:
 Review whether the PR updates or adds documentation as needed:
 
 - If the PR changes user-visible behavior (new features, changed defaults, renamed attributes, etc.), check whether the corresponding page(s) in `packages/docs-nextra/` need updating.
-- If the PR adds a new component, ensure a reference page exists or is created under `packages/docs-nextra/src/pages/reference/`.
+- If the PR adds a new component, ensure a reference page exists or is created under `packages/docs-nextra/pages/reference/`.
 - If the PR changes how an existing component behaves (e.g. new attribute, changed default, fixed edge case), update the relevant reference or guide page.
 - Documentation changes are not required for purely internal refactors or fixes with no user-visible effect.

--- a/packages/doenetml-worker-javascript/package.json
+++ b/packages/doenetml-worker-javascript/package.json
@@ -29,6 +29,13 @@
         "build": "wireit"
     },
     "wireit": {
+        "build:deps": {
+            "dependencies": [
+                "../i18n:build",
+                "../utils:build",
+                "../parser:build"
+            ]
+        },
         "build": {
             "command": "vite build",
             "files": [
@@ -44,9 +51,7 @@
                 "dist/**/*.json"
             ],
             "dependencies": [
-                "../i18n:build",
-                "../utils:build",
-                "../parser:build"
+                "build:deps"
             ]
         }
     },

--- a/packages/static-assets/README.md
+++ b/packages/static-assets/README.md
@@ -26,14 +26,13 @@ npm run build:assets
 worker's component definitions, which they import as **source**
 (`doenetml-worker-javascript/src/utils/componentInfoObjects`). That source
 resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to their built
-`dist/`, so running a generator against a stale sibling silently generates from
-old code — a regenerated schema can come out *missing* entries a branch just
+`dist/`, so a generator run against a stale sibling silently generates from old
+code — the regenerated schema can come out *missing* entries the branch just
 added, which reads as "the committed schema is stale" when the stale thing is
-`@doenet/i18n/dist`.
+`@doenet/i18n/dist`. All three are therefore wireit scripts that declare those
+builds as dependencies, and declare no `files`/`output` so wireit always re-runs
+them rather than serving a cached no-op.
 
-All three are therefore wireit scripts that declare those builds as
-dependencies, so they build what they read. They deliberately declare no
-`files`/`output`, which is what makes wireit always re-run them: a schema
-freshness check served from a cache would check nothing.
-`test/generator-script-dependencies.test.ts` documents the trade-offs in full
-and fails if the declarations drift from the worker's own.
+`test/generator-script-dependencies.test.ts` is where the reasoning lives in
+full — `package.json` cannot carry comments — and it fails if the declarations
+drift from the worker's own.

--- a/packages/static-assets/README.md
+++ b/packages/static-assets/README.md
@@ -19,3 +19,21 @@ To build snippets and other assets:
 cd packages/static-assets
 npm run build:assets
 ```
+
+## Why the generator scripts are wireit scripts
+
+`build:schema`, `build:assets` and `check:docs-coverage` generate from the
+worker's component definitions, which they import as **source**
+(`doenetml-worker-javascript/src/utils/componentInfoObjects`). That source
+resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to their built
+`dist/`, so running a generator against a stale sibling silently generates from
+old code — a regenerated schema can come out *missing* entries a branch just
+added, which reads as "the committed schema is stale" when the stale thing is
+`@doenet/i18n/dist`.
+
+All three are therefore wireit scripts that declare those builds as
+dependencies, so they build what they read. They deliberately declare no
+`files`/`output`, which is what makes wireit always re-run them: a schema
+freshness check served from a cache would check nothing.
+`test/generator-script-dependencies.test.ts` documents the trade-offs in full
+and fails if the declarations drift from the worker's own.

--- a/packages/static-assets/README.md
+++ b/packages/static-assets/README.md
@@ -22,8 +22,8 @@ npm run build:assets
 
 ## Why the generator scripts are wireit scripts
 
-`build:schema`, `build:assets` and `check:docs-coverage` generate from the
-worker's component definitions, which they import as **source**
+`build:schema`, `build:assets` and `check:docs-coverage` all read the worker's
+component definitions, which they import as **source**
 (`doenetml-worker-javascript/src/utils/componentInfoObjects`). That source
 resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to their built
 `dist/`, so a generator run against a stale sibling silently generates from old

--- a/packages/static-assets/README.md
+++ b/packages/static-assets/README.md
@@ -29,10 +29,13 @@ resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to their built
 `dist/`, so a generator run against a stale sibling silently generates from old
 code — the regenerated schema can come out *missing* entries the branch just
 added, which reads as "the committed schema is stale" when the stale thing is
-`@doenet/i18n/dist`. All three are therefore wireit scripts that declare those
-builds as dependencies, and declare no `files`/`output` so wireit always re-runs
-them rather than serving a cached no-op.
+`@doenet/i18n/dist`. All three are therefore wireit scripts that depend on
+`../doenetml-worker-javascript:build:deps` — the aggregator naming the sibling
+builds the worker's source needs, which the worker's own `build` depends on too,
+so the list has one home — and declare no `files`/`output` so wireit always
+re-runs them rather than serving a cached no-op.
 
 `test/generator-script-dependencies.test.ts` is where the reasoning lives in
-full — `package.json` cannot carry comments — and it fails if the declarations
-drift from the worker's own.
+full — `package.json` cannot carry comments — and it fails if a generator stops
+declaring that dependency, or if the aggregator stops being the worker's only
+source of sibling builds.

--- a/packages/static-assets/package.json
+++ b/packages/static-assets/package.json
@@ -40,10 +40,26 @@
         "test": "vitest",
         "build": "wireit",
         "build:assets": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-entity-map.ts && vite-node ./scripts/generate-completion-snippets.ts && vite-node ./scripts/generate-math-assets.ts",
-        "build:schema": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-relaxng-schema.ts && vite-node ./scripts/generate-entity-map.ts",
-        "check:docs-coverage": "vite-node ./scripts/check-docs-coverage.ts"
+        "build:schema": "wireit",
+        "check:docs-coverage": "wireit"
     },
     "wireit": {
+        "build:schema": {
+            "command": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-relaxng-schema.ts && vite-node ./scripts/generate-entity-map.ts",
+            "dependencies": [
+                "../i18n:build",
+                "../utils:build",
+                "../parser:build"
+            ]
+        },
+        "check:docs-coverage": {
+            "command": "vite-node ./scripts/check-docs-coverage.ts",
+            "dependencies": [
+                "../i18n:build",
+                "../utils:build",
+                "../parser:build"
+            ]
+        },
         "build": {
             "command": "vite build",
             "files": [

--- a/packages/static-assets/package.json
+++ b/packages/static-assets/package.json
@@ -39,11 +39,19 @@
     "scripts": {
         "test": "vitest",
         "build": "wireit",
-        "build:assets": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-entity-map.ts && vite-node ./scripts/generate-completion-snippets.ts && vite-node ./scripts/generate-math-assets.ts",
+        "build:assets": "wireit",
         "build:schema": "wireit",
         "check:docs-coverage": "wireit"
     },
     "wireit": {
+        "build:assets": {
+            "command": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-entity-map.ts && vite-node ./scripts/generate-completion-snippets.ts && vite-node ./scripts/generate-math-assets.ts",
+            "dependencies": [
+                "../i18n:build",
+                "../utils:build",
+                "../parser:build"
+            ]
+        },
         "build:schema": {
             "command": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-relaxng-schema.ts && vite-node ./scripts/generate-entity-map.ts",
             "dependencies": [

--- a/packages/static-assets/package.json
+++ b/packages/static-assets/package.json
@@ -47,25 +47,19 @@
         "build:assets": {
             "command": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-entity-map.ts && vite-node ./scripts/generate-completion-snippets.ts && vite-node ./scripts/generate-math-assets.ts",
             "dependencies": [
-                "../i18n:build",
-                "../utils:build",
-                "../parser:build"
+                "../doenetml-worker-javascript:build:deps"
             ]
         },
         "build:schema": {
             "command": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-relaxng-schema.ts && vite-node ./scripts/generate-entity-map.ts",
             "dependencies": [
-                "../i18n:build",
-                "../utils:build",
-                "../parser:build"
+                "../doenetml-worker-javascript:build:deps"
             ]
         },
         "check:docs-coverage": {
             "command": "vite-node ./scripts/check-docs-coverage.ts",
             "dependencies": [
-                "../i18n:build",
-                "../utils:build",
-                "../parser:build"
+                "../doenetml-worker-javascript:build:deps"
             ]
         },
         "build": {

--- a/packages/static-assets/scripts/check-docs-coverage.ts
+++ b/packages/static-assets/scripts/check-docs-coverage.ts
@@ -13,8 +13,8 @@
  * Run via `npm run check:docs-coverage -w packages/static-assets`. That is a
  * wireit script, because importing worker source below reaches sibling packages
  * that resolve to their built `dist/` — see the header of
- * `test/generator-script-dependencies.test.ts` for why the dependency list
- * looks the way it does, and what keeps it honest.
+ * `test/generator-script-dependencies.test.ts` for the dependency it declares
+ * and what keeps that honest.
  */
 
 import * as fs from "node:fs";

--- a/packages/static-assets/scripts/check-docs-coverage.ts
+++ b/packages/static-assets/scripts/check-docs-coverage.ts
@@ -10,7 +10,11 @@
  *   - The allow-list contains an entry that's now redundant (component has docs
  *     or no longer exists).
  *
- * Run via `npm run check:docs-coverage -w packages/static-assets`.
+ * Run via `npm run check:docs-coverage -w packages/static-assets`. That is a
+ * wireit script, because importing worker source below reaches sibling packages
+ * that resolve to their built `dist/` — see the header of
+ * `test/generator-script-dependencies.test.ts` for why the dependency list
+ * looks the way it does, and what keeps it honest.
  */
 
 import * as fs from "node:fs";

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -10,7 +10,7 @@
  * dependencies. See the header of
  * `test/generator-script-dependencies.test.ts` for the full reasoning and the
  * test that keeps the declarations in step with the worker's own. (The `test`
- * script reaches this module too and is not yet covered; see that header.)
+ * script reaches this module too and is not yet covered — Doenet/DoenetML#1675.)
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -6,11 +6,11 @@
  * their built `dist/`. Generating against an unbuilt or stale sibling therefore
  * produces a schema built from old code instead of failing, so the npm scripts
  * that run the generators — `build:schema`, `build:assets` and
- * `check:docs-coverage` — are wireit scripts that declare those builds as
- * dependencies. See the header of
+ * `check:docs-coverage` — are wireit scripts that depend on the worker's
+ * `build:deps`, which names those builds. See the header of
  * `test/generator-script-dependencies.test.ts` for the full reasoning and the
- * test that keeps the declarations in step with the worker's own. (The `test`
- * script reaches this module too and is not yet covered — Doenet/DoenetML#1675.)
+ * test that keeps the wiring honest. (The `test` script reaches this module too
+ * and is not yet covered — Doenet/DoenetML#1675.)
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -3,10 +3,14 @@
  *
  * The `createComponentInfoObjects` import below reaches the worker's *source*,
  * which in turn resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to
- * their built `dist/`. Every npm script that runs this module is therefore a
- * wireit script that declares those builds as dependencies; see the header of
+ * their built `dist/`. Generating against an unbuilt or stale sibling therefore
+ * produces a schema built from old code instead of failing, so the npm scripts
+ * that run the generators — `build:schema`, `build:assets` and
+ * `check:docs-coverage` — are wireit scripts that declare those builds as
+ * dependencies. See the header of
  * `test/generator-script-dependencies.test.ts` for the full reasoning and the
- * test that keeps the declarations in step with the worker's own.
+ * test that keeps the declarations in step with the worker's own. (The `test`
+ * script reaches this module too and is not yet covered; see that header.)
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -1,3 +1,13 @@
+/*
+ * Builds the DoenetML schema from the worker's component definitions.
+ *
+ * The `createComponentInfoObjects` import below reaches the worker's *source*,
+ * which in turn resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to
+ * their built `dist/`. Every npm script that runs this module is therefore a
+ * wireit script that declares those builds as dependencies; see the header of
+ * `test/generator-script-dependencies.test.ts` for the full reasoning and the
+ * test that keeps the declarations in step with the worker's own.
+ */
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -5,11 +5,11 @@
  * import `createComponentInfoObjects` from `doenetml-worker-javascript/src`
  * (see `scripts/get-schema.ts` and `scripts/check-docs-coverage.ts`). That
  * source resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to their
- * *built* `dist/` — each exports `"." → "./dist/index.js"` and there is no
- * source alias anywhere in the repo — so running a generator against an
- * unbuilt or stale sibling quietly generates from old code instead of failing.
- * That is how regenerating the schema on top of a new locale catalog could
- * *delete* the entry the branch had just added.
+ * *built* `dist/` — each exports `"." → "./dist/index.js"`, and nothing in the
+ * config these generators run under aliases those specifiers to source — so
+ * running a generator against an unbuilt or stale sibling quietly generates from
+ * old code instead of failing. That is how regenerating the schema on top of a
+ * new locale catalog could *delete* the entry the branch had just added.
  *
  * Each generator script therefore declares the same wireit `dependencies` as
  * `@doenet/doenetml-worker-javascript`'s own `build`. Depending on
@@ -51,26 +51,12 @@
  *   not a silent stale read, and CI runs these scripts without pre-building the
  *   workspace so it sees it too.
  *
- * Not covered: this package's `test` script, which reaches the same worker
- * source through `scripts/get-schema.ts`, and every other plain `test`/Cypress
- * script in the repo that imports a `@doenet/*` package. Converting those is a
- * separate change, and the blocker is not the one you might expect:
- *
- * - Argument forwarding is fine. `npm run test -- --run <file>` reaches the
- *   underlying command (wireit README, *Extra arguments*), so the targeted-run
- *   workflow survives. On Node 24 it does make wireit emit a `DEP0190`
- *   deprecation warning, because wireit spawns with `shell: true` *and* args.
- * - CI cost is ~nil. Both test jobs already build against the downloaded
- *   `.wireit` cache before testing — `test-main` runs `build:all-no-docs`, and
- *   `test-worker-js` runs `build -w packages/doenetml-worker`, which reaches
- *   `../doenetml-worker-javascript:build` and so the same three packages — so
- *   the dependencies would be fresh by the time a wireit `test` looked.
- * - The real blocker is the terminal. Wireit spawns the command with piped
- *   stdio (`script-child-process.ts` passes no `stdio` option), so the child
- *   sees no TTY and no stdin. These scripts are a bare `vitest`, i.e. watch
- *   mode, whose interactive keypress UI would stop working — for the one
- *   command developers spend all day in. Fixing that likely means splitting
- *   watch and single-run entry points, which is why it is its own change.
+ * Not covered: this package's own `test` script, which reaches the same worker
+ * source through `scripts/get-schema.ts`, nor any other plain `test`/Cypress
+ * script in the repo that imports a `@doenet/*` package — all of them read the
+ * same possibly-stale `dist/`. Converting them is its own change (the blocker
+ * is watch mode: wireit spawns with piped stdio, so a wrapped bare `vitest`
+ * loses its interactive keypress UI); tracked in Doenet/DoenetML#1675.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -103,6 +89,9 @@ type PackageJson = {
     >;
 };
 
+/** The npm script a wireit dependency names, with its package resolved. */
+type ScriptRef = { packageDir: string; script: string };
+
 function readPackageJson(packageDir: string): PackageJson {
     return JSON.parse(
         fs.readFileSync(path.join(packageDir, "package.json"), "utf-8"),
@@ -128,49 +117,58 @@ const staticAssetsPkg = readPackageJson(STATIC_ASSETS_DIR);
 const workerPkg = readPackageJson(WORKER_DIR);
 
 /**
- * Rewrite a wireit dependency into a form that can be compared across
- * packages.
+ * Resolve a wireit dependency to the script it names, so that lists declared by
+ * two different packages can be compared.
  *
- * Dependency names are resolved relative to the package that declares them:
- * `"../i18n:build"` in `packages/utils` and `"../i18n:build"` in
- * `packages/static-assets` happen to agree, but `"build:wasm"` (a
- * same-package dependency, a form several packages here use) means a different
- * script depending on who wrote it. Resolving to `<package-name>:<script>`
- * makes the comparison mean what it says, and makes a failure message name the
- * script a reader has to go add.
+ * A dependency is interpreted relative to whoever declares it: `"../i18n:build"`
+ * in `packages/utils` and in `packages/static-assets` agree only by coincidence,
+ * and a bare `"build:rust"` — a same-package dependency, a form several packages
+ * here use — names a different script depending on who wrote it.
  *
- * The two cases are split exactly as wireit splits them (`analyzer.ts`): a name
- * starting with `"."` is cross-package and divides at its *first* colon;
- * anything else is a script in the declaring package, colons and all.
+ * The split follows wireit's documented dependency syntax, not an internal of
+ * its implementation: "Dependencies can refer to scripts in other npm packages
+ * by using a relative path with the syntax `<relative-path>:<script-name>`. All
+ * cross-package dependencies should start with a `"."`" (`wireit/schema.json`).
+ * So a name starting with `"."` divides at its *first* colon; anything else is a
+ * script in the declaring package, colons and all. A cross-package name with no
+ * colon at all is a config error wireit rejects outright — here it falls through
+ * as an oddly-named same-package script and trips the existence check below.
  */
-function canonicalizeDependency(
+function resolveDependency(
     dependency: WireitDependency,
     declaringPackageDir: string,
-): string {
+): ScriptRef {
     const name =
         typeof dependency === "string" ? dependency : dependency.script;
     const separator = name.startsWith(".") ? name.indexOf(":") : -1;
     const relativeDir = separator === -1 ? "." : name.slice(0, separator);
     const script = separator === -1 ? name : name.slice(separator + 1);
-    const packageDir = path.resolve(declaringPackageDir, relativeDir);
+    return {
+        packageDir: path.resolve(declaringPackageDir, relativeDir),
+        script,
+    };
+}
+
+/** `<package-dir>:<script>` — comparable, and readable in a failure message. */
+function refKey({ packageDir, script }: ScriptRef): string {
     return `${path.relative(PACKAGES_DIR, packageDir)}:${script}`;
 }
 
-function canonicalDependenciesOf(
+function dependenciesOf(
     pkg: PackageJson,
     packageDir: string,
     script: string,
-): string[] {
+): ScriptRef[] {
     return (pkg.wireit?.[script]?.dependencies ?? []).map((dependency) =>
-        canonicalizeDependency(dependency, packageDir),
+        resolveDependency(dependency, packageDir),
     );
 }
 
-const workerBuildDependencies = canonicalDependenciesOf(
+const workerBuildDependencies = dependenciesOf(
     workerPkg,
     WORKER_DIR,
     "build",
-);
+).map(refKey);
 
 describe("generator script wireit wiring", () => {
     it("has dependencies to mirror", () => {
@@ -181,7 +179,7 @@ describe("generator script wireit wiring", () => {
 
     for (const script of GENERATOR_SCRIPTS) {
         describe(script, () => {
-            const dependencies = canonicalDependenciesOf(
+            const dependencies = dependenciesOf(
                 staticAssetsPkg,
                 STATIC_ASSETS_DIR,
                 script,
@@ -193,7 +191,7 @@ describe("generator script wireit wiring", () => {
             });
 
             it("declares every build @doenet/doenetml-worker-javascript needs", () => {
-                expect(dependencies).toEqual(
+                expect(dependencies.map(refKey)).toEqual(
                     expect.arrayContaining(workerBuildDependencies),
                 );
             });
@@ -202,18 +200,10 @@ describe("generator script wireit wiring", () => {
                 // A superset assertion alone would accept a typo'd or dangling
                 // entry. Wireit rejects those, but only when the script runs.
                 for (const dependency of dependencies) {
-                    // Canonical form is `<package-dir>:<script>`; directory
-                    // names hold no colon, so the first one divides them.
-                    const separator = dependency.indexOf(":");
                     expect(
-                        scriptNamesIn(
-                            path.join(
-                                PACKAGES_DIR,
-                                dependency.slice(0, separator),
-                            ),
-                        ),
-                        `${dependency} names a script that does not exist`,
-                    ).toContain(dependency.slice(separator + 1));
+                        scriptNamesIn(dependency.packageDir),
+                        `${refKey(dependency)} names a script that does not exist`,
+                    ).toContain(dependency.script);
                 }
             });
 

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -11,25 +11,36 @@
  * old code instead of failing. That is how regenerating the schema on top of a
  * new locale catalog could *delete* the entry the branch had just added.
  *
- * Each generator script therefore declares the same wireit `dependencies` as
- * `@doenet/doenetml-worker-javascript`'s own `build`. Depending on
- * `../doenetml-worker-javascript:build` instead would track those transitively
- * and could never drift, and it is not expensive — measured at ~10s of vite on
- * top of a `build:schema` that takes ~20s from a completely cold cache. We
- * mirror anyway because these scripts consume the worker's *source*: its 7 MB
- * bundle is never loaded, so that 10s is pure waste on every schema
- * regeneration, which is the inner loop when adding or documenting a component.
- * The price of mirroring is that the list can drift when the worker gains a
- * dependency, and this test is what makes that drift fail loudly rather than
- * silently. Revisit the trade if the mirroring ever costs more than it saves.
+ * Each generator therefore declares one wireit dependency:
+ * `../doenetml-worker-javascript:build:deps`, a no-command aggregator naming the
+ * sibling builds the worker's source needs in order to be importable. The
+ * worker's own `build` depends on it too, so the list has exactly one home and
+ * cannot drift out of step with what the worker actually needs. Two alternatives
+ * were weighed and rejected:
  *
- * The mirror is deliberately verbatim, not minimal. `../utils:build` already
- * pulls in `../parser:build` and `../i18n:build` transitively, so two of the
- * three entries are redundant today — but "the same list the worker declares"
- * is a rule this test can check, and "the minimal list that happens to work"
- * is not. Don't prune it.
+ * - **Depending on `../doenetml-worker-javascript:build`.** Also drift-proof,
+ *   but it adds a vite pass — measured at ~11s, on top of a `build:schema` that
+ *   takes ~20s from a completely cold cache — to produce a 7 MB bundle these
+ *   scripts never load, because they consume the worker's *source*. That is pure
+ *   waste on every schema regeneration, which is the inner loop when adding or
+ *   documenting a component, and it is at its most expensive exactly when the
+ *   worker's source just changed.
+ * - **Restating the three sibling builds here** (what earlier revisions of this
+ *   PR did, once per generator). It needs no change to another package, but it
+ *   puts the same list in four places and needs a test to compare them — the
+ *   drift the aggregator makes impossible. A local aggregator in this package
+ *   would cut that to two copies, which is still one too many.
  *
- * Three further requirements this test pins down:
+ * The aggregator only helps while it stays authoritative, so this test also
+ * pins that down: the worker's `build` must name no sibling build directly, or a
+ * dependency added there would reach the worker and not the generators. It does
+ * not check that the names *inside* `build:deps` resolve: wireit rejects a
+ * dangling dependency when the script runs, and `build:deps` is on the worker
+ * `build`'s path, which CI runs in the `build` job. (A typo in a list only these
+ * generators depended on would have been invisible, since CI never runs
+ * `build:assets`.)
+ *
+ * Two further requirements:
  *
  * - The generators declare **no `files`/`output`**, which is what makes wireit
  *   always re-run them rather than serve them from its cache ("If a script
@@ -37,19 +48,15 @@
  *   _always_ run" — wireit README, *Incremental build*). The CI
  *   `schema-freshness` job depends on that: comparing the committed schema
  *   against a cached no-op would check nothing.
- * - Every declared dependency names a script that actually exists. Wireit
- *   fails loudly on a dangling dependency, but only when the script is run,
- *   and CI never runs `build:assets` — so a typo there would sit unnoticed
- *   until a human ran it.
- * - `@doenet/static-assets`' own `build` is *not* listed, yet the generators do
- *   need `dist/atom-database.js` (worker `utils/chemistry.ts` imports
- *   `@doenet/static-assets/atom-database` at runtime). It arrives transitively:
- *   `../utils:build` → `../parser:build` → `../static-assets:build`. Listing it
- *   here would be circular in spirit — `build` consumes `src/generated/*.json`,
- *   which is exactly what `build:schema` writes. If that chain ever breaks the
- *   failure is loud (vite's `Failed to resolve entry for package "@doenet/…"`),
- *   not a silent stale read, and CI runs these scripts without pre-building the
- *   workspace so it sees it too.
+ * - `@doenet/static-assets`' own `build` is *not* a dependency, yet the
+ *   generators do need `dist/atom-database.js` (worker `utils/chemistry.ts`
+ *   imports `@doenet/static-assets/atom-database` at runtime). It arrives
+ *   transitively: `build:deps` → `../utils:build` → `../parser:build` →
+ *   `../static-assets:build`. Declaring it here would be circular in spirit —
+ *   `build` consumes `src/generated/*.json`, which is exactly what `build:schema`
+ *   writes. If that chain ever breaks the failure is loud (vite's `Failed to
+ *   resolve entry for package "@doenet/…"`), not a silent stale read, and CI
+ *   runs these scripts without pre-building the workspace so it sees it too.
  *
  * Not covered: this package's own `test` script, which reaches the same worker
  * source through `scripts/get-schema.ts`, or any other plain `test`/Cypress
@@ -66,17 +73,28 @@ import { describe, expect, it } from "vitest";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGES_DIR = path.resolve(__dirname, "../..");
 
+/** The one dependency every generator in this package declares. */
+const WORKER_BUILD_DEPS = "../doenetml-worker-javascript:build:deps";
+
 /**
- * How a generator script is recognized: it runs one of `scripts/` under
- * `vite-node`. Deriving the list rather than hard-coding it means a *newly
- * added* generator is covered on arrival — `build:assets` had this same gap for
- * as long as it existed and was only noticed by hand.
+ * How a generator script is recognized: its command runs a file out of this
+ * package's `scripts/` directory, whatever runner it uses (`vite-node
+ * ./scripts/x.ts`, `tsx scripts/x.ts`, `node --import tsx ./scripts/x.ts`, or
+ * any of those chained after another command). A path reaching outside the
+ * package (`../../scripts/…`, the repo-wide helpers) is deliberately not a
+ * match.
  *
- * A script that runs `vite-node` without reaching worker source would be a
- * false positive, and would be asked for dependencies it does not need. That is
- * loud, and the fix is to narrow this pattern.
+ * Deriving the list rather than hard-coding it means a *newly added* generator
+ * is covered on arrival — `build:assets` had this exact gap for as long as it
+ * existed and was only noticed by hand, in review. An explicit list plus a test
+ * that the list is complete would need this same pattern anyway, and one more
+ * place to edit.
+ *
+ * A script that runs out of `scripts/` without importing worker source is a
+ * false positive: it will be asked for a dependency it does not need. The
+ * failure messages below say what to do about it.
  */
-const GENERATOR_COMMAND = /vite-node\s+\.\/scripts\//;
+const GENERATOR_COMMAND = /(?:^|[\s'"])(?:\.\/)?scripts\//;
 
 /** A wireit dependency entry: `"../i18n:build"` or `{ script: "…" }`. */
 type WireitDependency = string | { script: string; cascade?: boolean };
@@ -94,86 +112,27 @@ type PackageJson = {
     >;
 };
 
-/** The npm script a wireit dependency names, with its package resolved. */
-type ScriptRef = { packageDir: string; script: string };
-
 function readPackageJson(packageDir: string): PackageJson {
     return JSON.parse(
         fs.readFileSync(path.join(packageDir, "package.json"), "utf-8"),
     ) as PackageJson;
 }
 
-/**
- * Script names the package in `packageDir` declares — empty when there is no
- * package there at all, so a dependency naming a nonexistent package fails as
- * a missing script rather than as an unhandled `ENOENT`.
- */
-function scriptNamesIn(packageDir: string): string[] {
-    if (!fs.existsSync(path.join(packageDir, "package.json"))) {
-        return [];
-    }
-    return Object.keys(readPackageJson(packageDir).scripts ?? {});
+const staticAssetsPkg = readPackageJson(
+    path.join(PACKAGES_DIR, "static-assets"),
+);
+const workerPkg = readPackageJson(
+    path.join(PACKAGES_DIR, "doenetml-worker-javascript"),
+);
+
+/** The script a wireit dependency names, in either of the two allowed forms. */
+function dependencyName(dependency: WireitDependency): string {
+    return typeof dependency === "string" ? dependency : dependency.script;
 }
 
-const STATIC_ASSETS_DIR = path.join(PACKAGES_DIR, "static-assets");
-const WORKER_DIR = path.join(PACKAGES_DIR, "doenetml-worker-javascript");
-
-const staticAssetsPkg = readPackageJson(STATIC_ASSETS_DIR);
-const workerPkg = readPackageJson(WORKER_DIR);
-
-/**
- * Resolve a wireit dependency to the script it names, so that lists declared by
- * two different packages can be compared.
- *
- * A dependency is interpreted relative to whoever declares it: `"../i18n:build"`
- * in `packages/utils` and in `packages/static-assets` agree only by coincidence,
- * and a bare `"build:rust"` — a same-package dependency, a form several packages
- * here use — names a different script depending on who wrote it.
- *
- * The split follows wireit's documented dependency syntax, not an internal of
- * its implementation: "Dependencies can refer to scripts in other npm packages
- * by using a relative path with the syntax `<relative-path>:<script-name>`. All
- * cross-package dependencies should start with a `"."`" (`wireit/schema.json`).
- * So a name starting with `"."` divides at its *first* colon; anything else is a
- * script in the declaring package, colons and all. A cross-package name with no
- * colon at all is a config error wireit rejects outright — here it falls through
- * as an oddly-named same-package script and trips the existence check below.
- */
-function resolveDependency(
-    dependency: WireitDependency,
-    declaringPackageDir: string,
-): ScriptRef {
-    const name =
-        typeof dependency === "string" ? dependency : dependency.script;
-    const separator = name.startsWith(".") ? name.indexOf(":") : -1;
-    const relativeDir = separator === -1 ? "." : name.slice(0, separator);
-    const script = separator === -1 ? name : name.slice(separator + 1);
-    return {
-        packageDir: path.resolve(declaringPackageDir, relativeDir),
-        script,
-    };
+function dependenciesOf(pkg: PackageJson, script: string): string[] {
+    return (pkg.wireit?.[script]?.dependencies ?? []).map(dependencyName);
 }
-
-/** `<package-dir>:<script>` — comparable, and readable in a failure message. */
-function refKey({ packageDir, script }: ScriptRef): string {
-    return `${path.relative(PACKAGES_DIR, packageDir)}:${script}`;
-}
-
-function dependenciesOf(
-    pkg: PackageJson,
-    packageDir: string,
-    script: string,
-): ScriptRef[] {
-    return (pkg.wireit?.[script]?.dependencies ?? []).map((dependency) =>
-        resolveDependency(dependency, packageDir),
-    );
-}
-
-const workerBuildDependencies = dependenciesOf(
-    workerPkg,
-    WORKER_DIR,
-    "build",
-).map(refKey);
 
 /** What an npm script runs, looking through the `wireit` indirection. */
 function commandOf(pkg: PackageJson, script: string): string {
@@ -187,47 +146,57 @@ const GENERATOR_SCRIPTS = Object.keys(staticAssetsPkg.scripts ?? {}).filter(
     (script) => GENERATOR_COMMAND.test(commandOf(staticAssetsPkg, script)),
 );
 
-describe("generator script wireit wiring", () => {
-    it("has dependencies to mirror", () => {
-        // If the worker's build ever stops declaring dependencies, the
-        // superset assertions below would pass vacuously.
-        expect(workerBuildDependencies.length).toBeGreaterThan(0);
+describe("the worker's build:deps aggregator", () => {
+    it("names the sibling builds the worker's source needs", () => {
+        // Also keeps the per-generator assertions below from passing against an
+        // aggregator that has been emptied or renamed away.
+        expect(
+            dependenciesOf(workerPkg, "build:deps"),
+            "packages/doenetml-worker-javascript's wireit build:deps must list the sibling builds its source needs (../i18n:build, ../utils:build, ../parser:build); the generator scripts in @doenet/static-assets depend on it to get them",
+        ).not.toEqual([]);
     });
 
+    it("is the only place the worker's build names a sibling build", () => {
+        // Sibling builds reach the generators only through build:deps, so one
+        // added straight to `build` would silently leave them behind.
+        expect(
+            dependenciesOf(workerPkg, "build").filter((name) =>
+                name.startsWith("."),
+            ),
+            "add cross-package dependencies to packages/doenetml-worker-javascript's wireit build:deps rather than to its build, so the generator scripts in @doenet/static-assets get them too",
+        ).toEqual([]);
+    });
+});
+
+describe("generator script wireit wiring", () => {
     it("recognizes the generator scripts", () => {
         // A canary for GENERATOR_COMMAND going stale: matching nothing would
         // make every assertion below disappear rather than fail.
-        expect(GENERATOR_SCRIPTS).toContain("build:schema");
+        expect(GENERATOR_SCRIPTS).toEqual(
+            expect.arrayContaining([
+                "build:schema",
+                "build:assets",
+                "check:docs-coverage",
+            ]),
+        );
     });
 
     for (const script of GENERATOR_SCRIPTS) {
         describe(script, () => {
-            const dependencies = dependenciesOf(
-                staticAssetsPkg,
-                STATIC_ASSETS_DIR,
-                script,
-            );
+            const advice = `${script} runs a file from packages/static-assets/scripts/, which is taken to mean it imports worker source. Make it a wireit script depending on ${WORKER_BUILD_DEPS} — or, if it does not import worker source, narrow GENERATOR_COMMAND in this test`;
 
             it("is a wireit script", () => {
-                expect(staticAssetsPkg.scripts?.[script]).toBe("wireit");
+                expect(staticAssetsPkg.scripts?.[script], advice).toBe(
+                    "wireit",
+                );
                 expect(staticAssetsPkg.wireit?.[script]?.command).toBeTruthy();
             });
 
-            it("declares every build @doenet/doenetml-worker-javascript needs", () => {
-                expect(dependencies.map(refKey)).toEqual(
-                    expect.arrayContaining(workerBuildDependencies),
-                );
-            });
-
-            it("declares only dependencies that exist", () => {
-                // A superset assertion alone would accept a typo'd or dangling
-                // entry. Wireit rejects those, but only when the script runs.
-                for (const dependency of dependencies) {
-                    expect(
-                        scriptNamesIn(dependency.packageDir),
-                        `${refKey(dependency)} names a script that does not exist`,
-                    ).toContain(dependency.script);
-                }
+            it("depends on the worker's build:deps", () => {
+                expect(
+                    dependenciesOf(staticAssetsPkg, script),
+                    advice,
+                ).toContain(WORKER_BUILD_DEPS);
             });
 
             it("declares no files/output so wireit always re-runs it", () => {

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -34,6 +34,14 @@
  *   which is exactly what `build:schema` writes. If that chain ever breaks the
  *   failure is loud (`ERR_MODULE_NOT_FOUND`), not a silent stale read, and CI
  *   runs these scripts without pre-building the workspace so it sees it too.
+ *
+ * Not covered: this package's `test` script, which reaches the same worker
+ * source through `scripts/get-schema.ts`, and every other plain `test`/Cypress
+ * script in the repo that imports a `@doenet/*` package. Converting those is a
+ * separate change — wireit forwards extra arguments after `--` so the
+ * `-- --run <file>` workflow survives, but its cost in CI (where `npm ci`
+ * leaves no `.wireit` state) and its effect on `vitest` watch output want
+ * measuring first.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -12,13 +12,16 @@
  * *delete* the entry the branch had just added.
  *
  * Each generator script therefore declares the same wireit `dependencies` as
- * `@doenet/doenetml-worker-javascript`'s own `build`. We mirror that list
- * rather than depending on `../doenetml-worker-javascript:build` because these
- * scripts consume the worker's *source*: its bundle is never loaded, and
- * building it (plus the Rust/WASM core it pulls in) would add minutes to a
- * command that takes ~20s from a completely cold cache. The price of mirroring
- * is that the list can drift when the worker gains a dependency, and this test
- * is what makes that drift fail loudly instead of silently.
+ * `@doenet/doenetml-worker-javascript`'s own `build`. Depending on
+ * `../doenetml-worker-javascript:build` instead would track those transitively
+ * and could never drift, and it is not expensive — measured at ~10s of vite on
+ * top of a `build:schema` that takes ~20s from a completely cold cache. We
+ * mirror anyway because these scripts consume the worker's *source*: its 7 MB
+ * bundle is never loaded, so that 10s is pure waste on every schema
+ * regeneration, which is the inner loop when adding or documenting a component.
+ * The price of mirroring is that the list can drift when the worker gains a
+ * dependency, and this test is what makes that drift fail loudly rather than
+ * silently. Revisit the trade if the mirroring ever costs more than it saves.
  *
  * Two further requirements this test pins down:
  *

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -189,7 +189,10 @@ describe("generator script wireit wiring", () => {
                 expect(staticAssetsPkg.scripts?.[script], advice).toBe(
                     "wireit",
                 );
-                expect(staticAssetsPkg.wireit?.[script]?.command).toBeTruthy();
+                expect(
+                    staticAssetsPkg.wireit?.[script]?.command,
+                    advice,
+                ).toBeTruthy();
             });
 
             it("depends on the worker's build:deps", () => {

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -101,28 +101,29 @@ type PackageJson = {
     >;
 };
 
-/** Undefined when `packageDir` holds no `package.json`. */
-function readPackageJson(packageDir: string): PackageJson | undefined {
-    const file = path.join(packageDir, "package.json");
-    if (!fs.existsSync(file)) {
-        return undefined;
-    }
-    return JSON.parse(fs.readFileSync(file, "utf-8")) as PackageJson;
+function readPackageJson(packageDir: string): PackageJson {
+    return JSON.parse(
+        fs.readFileSync(path.join(packageDir, "package.json"), "utf-8"),
+    ) as PackageJson;
 }
 
-function readRequiredPackageJson(packageDir: string): PackageJson {
-    const pkg = readPackageJson(packageDir);
-    if (pkg === undefined) {
-        throw new Error(`No package.json in ${packageDir}`);
+/**
+ * Script names the package in `packageDir` declares — empty when there is no
+ * package there at all, so a dependency naming a nonexistent package fails as
+ * a missing script rather than as an unhandled `ENOENT`.
+ */
+function scriptNamesIn(packageDir: string): string[] {
+    if (!fs.existsSync(path.join(packageDir, "package.json"))) {
+        return [];
     }
-    return pkg;
+    return Object.keys(readPackageJson(packageDir).scripts ?? {});
 }
 
 const STATIC_ASSETS_DIR = path.join(PACKAGES_DIR, "static-assets");
 const WORKER_DIR = path.join(PACKAGES_DIR, "doenetml-worker-javascript");
 
-const staticAssetsPkg = readRequiredPackageJson(STATIC_ASSETS_DIR);
-const workerPkg = readRequiredPackageJson(WORKER_DIR);
+const staticAssetsPkg = readPackageJson(STATIC_ASSETS_DIR);
+const workerPkg = readPackageJson(WORKER_DIR);
 
 /**
  * Rewrite a wireit dependency into a form that can be compared across
@@ -178,17 +179,18 @@ describe("generator script wireit wiring", () => {
 
     for (const script of GENERATOR_SCRIPTS) {
         describe(script, () => {
+            const dependencies = canonicalDependenciesOf(
+                staticAssetsPkg,
+                STATIC_ASSETS_DIR,
+                script,
+            );
+
             it("is a wireit script", () => {
                 expect(staticAssetsPkg.scripts?.[script]).toBe("wireit");
                 expect(staticAssetsPkg.wireit?.[script]?.command).toBeTruthy();
             });
 
             it("declares every build @doenet/doenetml-worker-javascript needs", () => {
-                const dependencies = canonicalDependenciesOf(
-                    staticAssetsPkg,
-                    STATIC_ASSETS_DIR,
-                    script,
-                );
                 expect(dependencies).toEqual(
                     expect.arrayContaining(workerBuildDependencies),
                 );
@@ -197,24 +199,19 @@ describe("generator script wireit wiring", () => {
             it("declares only dependencies that exist", () => {
                 // A superset assertion alone would accept a typo'd or dangling
                 // entry. Wireit rejects those, but only when the script runs.
-                const dependencies = canonicalDependenciesOf(
-                    staticAssetsPkg,
-                    STATIC_ASSETS_DIR,
-                    script,
-                );
                 for (const dependency of dependencies) {
                     // Canonical form is `<package-dir>:<script>`; directory
                     // names hold no colon, so the first one divides them.
                     const separator = dependency.indexOf(":");
-                    const packageName = dependency.slice(0, separator);
-                    const scriptName = dependency.slice(separator + 1);
-                    const pkg = readPackageJson(
-                        path.join(PACKAGES_DIR, packageName),
-                    );
                     expect(
-                        Object.keys(pkg?.scripts ?? {}),
+                        scriptNamesIn(
+                            path.join(
+                                PACKAGES_DIR,
+                                dependency.slice(0, separator),
+                            ),
+                        ),
                         `${dependency} names a script that does not exist`,
-                    ).toContain(scriptName);
+                    ).toContain(dependency.slice(separator + 1));
                 }
             });
 

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -66,12 +66,17 @@ import { describe, expect, it } from "vitest";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGES_DIR = path.resolve(__dirname, "../..");
 
-/** Scripts in this package that run a generator over worker source. */
-const GENERATOR_SCRIPTS = [
-    "build:assets",
-    "build:schema",
-    "check:docs-coverage",
-] as const;
+/**
+ * How a generator script is recognized: it runs one of `scripts/` under
+ * `vite-node`. Deriving the list rather than hard-coding it means a *newly
+ * added* generator is covered on arrival — `build:assets` had this same gap for
+ * as long as it existed and was only noticed by hand.
+ *
+ * A script that runs `vite-node` without reaching worker source would be a
+ * false positive, and would be asked for dependencies it does not need. That is
+ * loud, and the fix is to narrow this pattern.
+ */
+const GENERATOR_COMMAND = /vite-node\s+\.\/scripts\//;
 
 /** A wireit dependency entry: `"../i18n:build"` or `{ script: "…" }`. */
 type WireitDependency = string | { script: string; cascade?: boolean };
@@ -170,11 +175,29 @@ const workerBuildDependencies = dependenciesOf(
     "build",
 ).map(refKey);
 
+/** What an npm script runs, looking through the `wireit` indirection. */
+function commandOf(pkg: PackageJson, script: string): string {
+    const npmCommand = pkg.scripts?.[script] ?? "";
+    return npmCommand === "wireit"
+        ? (pkg.wireit?.[script]?.command ?? "")
+        : npmCommand;
+}
+
+const GENERATOR_SCRIPTS = Object.keys(staticAssetsPkg.scripts ?? {}).filter(
+    (script) => GENERATOR_COMMAND.test(commandOf(staticAssetsPkg, script)),
+);
+
 describe("generator script wireit wiring", () => {
     it("has dependencies to mirror", () => {
         // If the worker's build ever stops declaring dependencies, the
         // superset assertions below would pass vacuously.
         expect(workerBuildDependencies.length).toBeGreaterThan(0);
+    });
+
+    it("recognizes the generator scripts", () => {
+        // A canary for GENERATOR_COMMAND going stale: matching nothing would
+        // make every assertion below disappear rather than fail.
+        expect(GENERATOR_SCRIPTS).toContain("build:schema");
     });
 
     for (const script of GENERATOR_SCRIPTS) {

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -17,11 +17,11 @@
  * worker's own `build` depends on it too, so the list has exactly one home and
  * cannot drift out of step with what the worker actually needs. Depending on the
  * worker's `build` instead would be equally drift-proof, but it adds a vite pass
- * — ~11s, on top of a `build:schema` that takes ~20s from a completely cold
- * cache — to produce a 7 MB bundle these scripts never load, since they consume
- * the worker's *source*: waste on every schema regeneration, which is the inner
- * loop when adding or documenting a component, and worst exactly when the
- * worker's source just changed.
+ * — on its own about as expensive as a cold `build:schema` in full — to produce a
+ * 7 MB bundle these scripts never load, since they consume the worker's
+ * *source*: waste on every schema regeneration, which is the inner loop when
+ * adding or documenting a component, and worst exactly when the worker's source
+ * just changed.
  *
  * The aggregator only helps while it stays authoritative, so this test also
  * pins that down: the worker's `build` must name no sibling build directly, or a

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -15,30 +15,20 @@
  * `../doenetml-worker-javascript:build:deps`, a no-command aggregator naming the
  * sibling builds the worker's source needs in order to be importable. The
  * worker's own `build` depends on it too, so the list has exactly one home and
- * cannot drift out of step with what the worker actually needs. Two alternatives
- * were weighed and rejected:
- *
- * - **Depending on `../doenetml-worker-javascript:build`.** Also drift-proof,
- *   but it adds a vite pass — measured at ~11s, on top of a `build:schema` that
- *   takes ~20s from a completely cold cache — to produce a 7 MB bundle these
- *   scripts never load, because they consume the worker's *source*. That is pure
- *   waste on every schema regeneration, which is the inner loop when adding or
- *   documenting a component, and it is at its most expensive exactly when the
- *   worker's source just changed.
- * - **Restating the three sibling builds here** (what earlier revisions of this
- *   PR did, once per generator). It needs no change to another package, but it
- *   puts the same list in four places and needs a test to compare them — the
- *   drift the aggregator makes impossible. A local aggregator in this package
- *   would cut that to two copies, which is still one too many.
+ * cannot drift out of step with what the worker actually needs. Depending on the
+ * worker's `build` instead would be equally drift-proof, but it adds a vite pass
+ * — ~11s, on top of a `build:schema` that takes ~20s from a completely cold
+ * cache — to produce a 7 MB bundle these scripts never load, since they consume
+ * the worker's *source*: waste on every schema regeneration, which is the inner
+ * loop when adding or documenting a component, and worst exactly when the
+ * worker's source just changed.
  *
  * The aggregator only helps while it stays authoritative, so this test also
  * pins that down: the worker's `build` must name no sibling build directly, or a
  * dependency added there would reach the worker and not the generators. It does
  * not check that the names *inside* `build:deps` resolve: wireit rejects a
  * dangling dependency when the script runs, and `build:deps` is on the worker
- * `build`'s path, which CI runs in the `build` job. (A typo in a list only these
- * generators depended on would have been invisible, since CI never runs
- * `build:assets`.)
+ * `build`'s path, which CI runs in the `build` job.
  *
  * Two further requirements:
  *
@@ -85,10 +75,9 @@ const WORKER_BUILD_DEPS = "../doenetml-worker-javascript:build:deps";
  * match.
  *
  * Deriving the list rather than hard-coding it means a *newly added* generator
- * is covered on arrival — `build:assets` had this exact gap for as long as it
- * existed and was only noticed by hand, in review. An explicit list plus a test
- * that the list is complete would need this same pattern anyway, and one more
- * place to edit.
+ * is covered on arrival: `build:assets` carried this exact gap for as long as it
+ * existed. An explicit list plus a test that the list is complete would need
+ * this same pattern anyway, and one more place to edit.
  *
  * A script that runs out of `scripts/` without importing worker source is a
  * false positive: it will be asked for a dependency it does not need. The
@@ -125,13 +114,11 @@ const workerPkg = readPackageJson(
     path.join(PACKAGES_DIR, "doenetml-worker-javascript"),
 );
 
-/** The script a wireit dependency names, in either of the two allowed forms. */
-function dependencyName(dependency: WireitDependency): string {
-    return typeof dependency === "string" ? dependency : dependency.script;
-}
-
+/** The scripts a wireit script depends on, in either of the two allowed forms. */
 function dependenciesOf(pkg: PackageJson, script: string): string[] {
-    return (pkg.wireit?.[script]?.dependencies ?? []).map(dependencyName);
+    return (pkg.wireit?.[script]?.dependencies ?? []).map((dependency) =>
+        typeof dependency === "string" ? dependency : dependency.script,
+    );
 }
 
 /** What a script runs, looking through the `wireit` indirection. */

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -23,28 +23,52 @@
  * dependency, and this test is what makes that drift fail loudly rather than
  * silently. Revisit the trade if the mirroring ever costs more than it saves.
  *
- * Two further requirements this test pins down:
+ * The mirror is deliberately verbatim, not minimal. `../utils:build` already
+ * pulls in `../parser:build` and `../i18n:build` transitively, so two of the
+ * three entries are redundant today — but "the same list the worker declares"
+ * is a rule this test can check, and "the minimal list that happens to work"
+ * is not. Don't prune it.
+ *
+ * Three further requirements this test pins down:
  *
  * - The generators declare **no `files`/`output`**, which is what makes wireit
- *   always re-run them rather than serve them from its cache. The CI
+ *   always re-run them rather than serve them from its cache ("If a script
+ *   doesn't have a `files` or `output` list defined at all, then it will
+ *   _always_ run" — wireit README, *Incremental build*). The CI
  *   `schema-freshness` job depends on that: comparing the committed schema
  *   against a cached no-op would check nothing.
+ * - Every declared dependency names a script that actually exists. Wireit
+ *   fails loudly on a dangling dependency, but only when the script is run,
+ *   and CI never runs `build:assets` — so a typo there would sit unnoticed
+ *   until a human ran it.
  * - `@doenet/static-assets`' own `build` is *not* listed, yet the generators do
  *   need `dist/atom-database.js` (worker `utils/chemistry.ts` imports
  *   `@doenet/static-assets/atom-database` at runtime). It arrives transitively:
  *   `../utils:build` → `../parser:build` → `../static-assets:build`. Listing it
  *   here would be circular in spirit — `build` consumes `src/generated/*.json`,
  *   which is exactly what `build:schema` writes. If that chain ever breaks the
- *   failure is loud (`ERR_MODULE_NOT_FOUND`), not a silent stale read, and CI
- *   runs these scripts without pre-building the workspace so it sees it too.
+ *   failure is loud (vite's `Failed to resolve entry for package "@doenet/…"`),
+ *   not a silent stale read, and CI runs these scripts without pre-building the
+ *   workspace so it sees it too.
  *
  * Not covered: this package's `test` script, which reaches the same worker
  * source through `scripts/get-schema.ts`, and every other plain `test`/Cypress
  * script in the repo that imports a `@doenet/*` package. Converting those is a
- * separate change — wireit forwards extra arguments after `--` so the
- * `-- --run <file>` workflow survives, but its cost in CI (where `npm ci`
- * leaves no `.wireit` state) and its effect on `vitest` watch output want
- * measuring first.
+ * separate change, and the blocker is not the one you might expect:
+ *
+ * - Argument forwarding is fine. `npm run test -- --run <file>` reaches the
+ *   underlying command (wireit README, *Extra arguments*), so the targeted-run
+ *   workflow survives. On Node 24 it does make wireit emit a `DEP0190`
+ *   deprecation warning, because wireit spawns with `shell: true` *and* args.
+ * - CI cost is ~nil. Both `test-main` and `test-worker-js` already run
+ *   `build:all-no-docs` against the downloaded `.wireit` cache before testing,
+ *   so the dependencies would be fresh by the time a wireit `test` looked.
+ * - The real blocker is the terminal. Wireit spawns the command with piped
+ *   stdio (`script-child-process.ts` passes no `stdio` option), so the child
+ *   sees no TTY and no stdin. These scripts are a bare `vitest`, i.e. watch
+ *   mode, whose interactive keypress UI would stop working — for the one
+ *   command developers spend all day in. Fixing that likely means splitting
+ *   watch and single-run entry points, which is why it is its own change.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -52,6 +76,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGES_DIR = path.resolve(__dirname, "../..");
 
 /** Scripts in this package that run a generator over worker source. */
 const GENERATOR_SCRIPTS = [
@@ -60,37 +85,89 @@ const GENERATOR_SCRIPTS = [
     "check:docs-coverage",
 ] as const;
 
+/** A wireit dependency entry: `"../i18n:build"` or `{ script: "…" }`. */
+type WireitDependency = string | { script: string; cascade?: boolean };
+
 type PackageJson = {
     scripts?: Record<string, string>;
     wireit?: Record<
         string,
         {
             command?: string;
-            dependencies?: string[];
+            dependencies?: WireitDependency[];
             files?: string[];
             output?: string[];
         }
     >;
 };
 
-function readPackageJson(relativeDir: string): PackageJson {
-    return JSON.parse(
-        fs.readFileSync(
-            path.resolve(__dirname, relativeDir, "package.json"),
-            "utf-8",
-        ),
-    ) as PackageJson;
+/** Undefined when `packageDir` holds no `package.json`. */
+function readPackageJson(packageDir: string): PackageJson | undefined {
+    const file = path.join(packageDir, "package.json");
+    if (!fs.existsSync(file)) {
+        return undefined;
+    }
+    return JSON.parse(fs.readFileSync(file, "utf-8")) as PackageJson;
 }
 
-const staticAssetsPkg = readPackageJson("..");
-const workerPkg = readPackageJson("../../doenetml-worker-javascript");
+function readRequiredPackageJson(packageDir: string): PackageJson {
+    const pkg = readPackageJson(packageDir);
+    if (pkg === undefined) {
+        throw new Error(`No package.json in ${packageDir}`);
+    }
+    return pkg;
+}
+
+const STATIC_ASSETS_DIR = path.join(PACKAGES_DIR, "static-assets");
+const WORKER_DIR = path.join(PACKAGES_DIR, "doenetml-worker-javascript");
+
+const staticAssetsPkg = readRequiredPackageJson(STATIC_ASSETS_DIR);
+const workerPkg = readRequiredPackageJson(WORKER_DIR);
 
 /**
- * Wireit dependency names are relative to the package they are declared in.
- * Both packages sit in `packages/`, so the worker's `../i18n:build` and this
- * package's `../i18n:build` name the same script and can be compared directly.
+ * Rewrite a wireit dependency into a form that can be compared across
+ * packages.
+ *
+ * Dependency names are resolved relative to the package that declares them:
+ * `"../i18n:build"` in `packages/utils` and `"../i18n:build"` in
+ * `packages/static-assets` happen to agree, but `"build:wasm"` (a
+ * same-package dependency, a form several packages here use) means a different
+ * script depending on who wrote it. Resolving to `<package-name>:<script>`
+ * makes the comparison mean what it says, and makes a failure message name the
+ * script a reader has to go add.
+ *
+ * The two cases are split exactly as wireit splits them (`analyzer.ts`): a name
+ * starting with `"."` is cross-package and divides at its *first* colon;
+ * anything else is a script in the declaring package, colons and all.
  */
-const workerBuildDependencies = workerPkg.wireit?.build?.dependencies ?? [];
+function canonicalizeDependency(
+    dependency: WireitDependency,
+    declaringPackageDir: string,
+): string {
+    const name =
+        typeof dependency === "string" ? dependency : dependency.script;
+    const separator = name.startsWith(".") ? name.indexOf(":") : -1;
+    const relativeDir = separator === -1 ? "." : name.slice(0, separator);
+    const script = separator === -1 ? name : name.slice(separator + 1);
+    const packageDir = path.resolve(declaringPackageDir, relativeDir);
+    return `${path.relative(PACKAGES_DIR, packageDir)}:${script}`;
+}
+
+function canonicalDependenciesOf(
+    pkg: PackageJson,
+    packageDir: string,
+    script: string,
+): string[] {
+    return (pkg.wireit?.[script]?.dependencies ?? []).map((dependency) =>
+        canonicalizeDependency(dependency, packageDir),
+    );
+}
+
+const workerBuildDependencies = canonicalDependenciesOf(
+    workerPkg,
+    WORKER_DIR,
+    "build",
+);
 
 describe("generator script wireit wiring", () => {
     it("has dependencies to mirror", () => {
@@ -107,11 +184,38 @@ describe("generator script wireit wiring", () => {
             });
 
             it("declares every build @doenet/doenetml-worker-javascript needs", () => {
-                const dependencies =
-                    staticAssetsPkg.wireit?.[script]?.dependencies ?? [];
+                const dependencies = canonicalDependenciesOf(
+                    staticAssetsPkg,
+                    STATIC_ASSETS_DIR,
+                    script,
+                );
                 expect(dependencies).toEqual(
                     expect.arrayContaining(workerBuildDependencies),
                 );
+            });
+
+            it("declares only dependencies that exist", () => {
+                // A superset assertion alone would accept a typo'd or dangling
+                // entry. Wireit rejects those, but only when the script runs.
+                const dependencies = canonicalDependenciesOf(
+                    staticAssetsPkg,
+                    STATIC_ASSETS_DIR,
+                    script,
+                );
+                for (const dependency of dependencies) {
+                    // Canonical form is `<package-dir>:<script>`; directory
+                    // names hold no colon, so the first one divides them.
+                    const separator = dependency.indexOf(":");
+                    const packageName = dependency.slice(0, separator);
+                    const scriptName = dependency.slice(separator + 1);
+                    const pkg = readPackageJson(
+                        path.join(PACKAGES_DIR, packageName),
+                    );
+                    expect(
+                        Object.keys(pkg?.scripts ?? {}),
+                        `${dependency} names a script that does not exist`,
+                    ).toContain(scriptName);
+                }
             });
 
             it("declares no files/output so wireit always re-runs it", () => {

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -60,9 +60,11 @@
  *   underlying command (wireit README, *Extra arguments*), so the targeted-run
  *   workflow survives. On Node 24 it does make wireit emit a `DEP0190`
  *   deprecation warning, because wireit spawns with `shell: true` *and* args.
- * - CI cost is ~nil. Both `test-main` and `test-worker-js` already run
- *   `build:all-no-docs` against the downloaded `.wireit` cache before testing,
- *   so the dependencies would be fresh by the time a wireit `test` looked.
+ * - CI cost is ~nil. Both test jobs already build against the downloaded
+ *   `.wireit` cache before testing — `test-main` runs `build:all-no-docs`, and
+ *   `test-worker-js` runs `build -w packages/doenetml-worker`, which reaches
+ *   `../doenetml-worker-javascript:build` and so the same three packages — so
+ *   the dependencies would be fresh by the time a wireit `test` looked.
  * - The real blocker is the terminal. Wireit spawns the command with piped
  *   stdio (`script-child-process.ts` passes no `stdio` option), so the child
  *   sees no TTY and no stdin. These scripts are a bare `vitest`, i.e. watch

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Guards the wireit wiring of the generator scripts in this package.
+ *
+ * `build:schema`, `build:assets` and `check:docs-coverage` all run scripts that
+ * import `createComponentInfoObjects` from `doenetml-worker-javascript/src`
+ * (see `scripts/get-schema.ts` and `scripts/check-docs-coverage.ts`). That
+ * source resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to their
+ * *built* `dist/` — each exports `"." → "./dist/index.js"` and there is no
+ * source alias anywhere in the repo — so running a generator against an
+ * unbuilt or stale sibling quietly generates from old code instead of failing.
+ * That is how regenerating the schema on top of a new locale catalog could
+ * *delete* the entry the branch had just added.
+ *
+ * Each generator script therefore declares the same wireit `dependencies` as
+ * `@doenet/doenetml-worker-javascript`'s own `build`. We mirror that list
+ * rather than depending on `../doenetml-worker-javascript:build` because these
+ * scripts consume the worker's *source*: its bundle is never loaded, and
+ * building it (plus the Rust/WASM core it pulls in) would add minutes to a
+ * command that takes ~20s from a completely cold cache. The price of mirroring
+ * is that the list can drift when the worker gains a dependency, and this test
+ * is what makes that drift fail loudly instead of silently.
+ *
+ * Two further requirements this test pins down:
+ *
+ * - The generators declare **no `files`/`output`**, which is what makes wireit
+ *   always re-run them rather than serve them from its cache. The CI
+ *   `schema-freshness` job depends on that: comparing the committed schema
+ *   against a cached no-op would check nothing.
+ * - `@doenet/static-assets`' own `build` is *not* listed, yet the generators do
+ *   need `dist/atom-database.js` (worker `utils/chemistry.ts` imports
+ *   `@doenet/static-assets/atom-database` at runtime). It arrives transitively:
+ *   `../utils:build` → `../parser:build` → `../static-assets:build`. Listing it
+ *   here would be circular in spirit — `build` consumes `src/generated/*.json`,
+ *   which is exactly what `build:schema` writes. If that chain ever breaks the
+ *   failure is loud (`ERR_MODULE_NOT_FOUND`), not a silent stale read, and CI
+ *   runs these scripts without pre-building the workspace so it sees it too.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Scripts in this package that run a generator over worker source. */
+const GENERATOR_SCRIPTS = [
+    "build:assets",
+    "build:schema",
+    "check:docs-coverage",
+] as const;
+
+type PackageJson = {
+    scripts?: Record<string, string>;
+    wireit?: Record<
+        string,
+        {
+            command?: string;
+            dependencies?: string[];
+            files?: string[];
+            output?: string[];
+        }
+    >;
+};
+
+function readPackageJson(relativeDir: string): PackageJson {
+    return JSON.parse(
+        fs.readFileSync(
+            path.resolve(__dirname, relativeDir, "package.json"),
+            "utf-8",
+        ),
+    ) as PackageJson;
+}
+
+const staticAssetsPkg = readPackageJson("..");
+const workerPkg = readPackageJson("../../doenetml-worker-javascript");
+
+/**
+ * Wireit dependency names are relative to the package they are declared in.
+ * Both packages sit in `packages/`, so the worker's `../i18n:build` and this
+ * package's `../i18n:build` name the same script and can be compared directly.
+ */
+const workerBuildDependencies = workerPkg.wireit?.build?.dependencies ?? [];
+
+describe("generator script wireit wiring", () => {
+    it("has dependencies to mirror", () => {
+        // If the worker's build ever stops declaring dependencies, the
+        // superset assertions below would pass vacuously.
+        expect(workerBuildDependencies.length).toBeGreaterThan(0);
+    });
+
+    for (const script of GENERATOR_SCRIPTS) {
+        describe(script, () => {
+            it("is a wireit script", () => {
+                expect(staticAssetsPkg.scripts?.[script]).toBe("wireit");
+                expect(staticAssetsPkg.wireit?.[script]?.command).toBeTruthy();
+            });
+
+            it("declares every build @doenet/doenetml-worker-javascript needs", () => {
+                const dependencies =
+                    staticAssetsPkg.wireit?.[script]?.dependencies ?? [];
+                expect(dependencies).toEqual(
+                    expect.arrayContaining(workerBuildDependencies),
+                );
+            });
+
+            it("declares no files/output so wireit always re-runs it", () => {
+                const config = staticAssetsPkg.wireit?.[script];
+                expect(config?.files).toBeUndefined();
+                expect(config?.output).toBeUndefined();
+            });
+        });
+    }
+});

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -134,16 +134,25 @@ function dependenciesOf(pkg: PackageJson, script: string): string[] {
     return (pkg.wireit?.[script]?.dependencies ?? []).map(dependencyName);
 }
 
-/** What an npm script runs, looking through the `wireit` indirection. */
+/** What a script runs, looking through the `wireit` indirection. */
 function commandOf(pkg: PackageJson, script: string): string {
-    const npmCommand = pkg.scripts?.[script] ?? "";
-    return npmCommand === "wireit"
+    const npmCommand = pkg.scripts?.[script];
+    // `undefined` covers a wireit-only script — valid, and usable as a
+    // dependency of another wireit script — whose command lives only in the
+    // wireit section.
+    return npmCommand === undefined || npmCommand === "wireit"
         ? (pkg.wireit?.[script]?.command ?? "")
         : npmCommand;
 }
 
-const GENERATOR_SCRIPTS = Object.keys(staticAssetsPkg.scripts ?? {}).filter(
-    (script) => GENERATOR_COMMAND.test(commandOf(staticAssetsPkg, script)),
+/** Every script name this package declares, in either section. */
+const DECLARED_SCRIPTS = new Set([
+    ...Object.keys(staticAssetsPkg.scripts ?? {}),
+    ...Object.keys(staticAssetsPkg.wireit ?? {}),
+]);
+
+const GENERATOR_SCRIPTS = [...DECLARED_SCRIPTS].filter((script) =>
+    GENERATOR_COMMAND.test(commandOf(staticAssetsPkg, script)),
 );
 
 describe("the worker's build:deps aggregator", () => {
@@ -185,10 +194,15 @@ describe("generator script wireit wiring", () => {
         describe(script, () => {
             const advice = `${script} runs a file from packages/static-assets/scripts/, which is taken to mean it imports worker source. Make it a wireit script depending on ${WORKER_BUILD_DEPS} — or, if it does not import worker source, narrow GENERATOR_COMMAND in this test`;
 
-            it("is a wireit script", () => {
-                expect(staticAssetsPkg.scripts?.[script], advice).toBe(
-                    "wireit",
-                );
+            it("runs under wireit", () => {
+                // Its command has to live in the wireit section, which is the
+                // only place dependencies can be declared. An npm script gets
+                // there by being the literal "wireit"; a wireit-only script is
+                // already there.
+                expect(
+                    staticAssetsPkg.scripts?.[script] ?? "wireit",
+                    advice,
+                ).toBe("wireit");
                 expect(
                     staticAssetsPkg.wireit?.[script]?.command,
                     advice,

--- a/packages/static-assets/test/generator-script-dependencies.test.ts
+++ b/packages/static-assets/test/generator-script-dependencies.test.ts
@@ -52,7 +52,7 @@
  *   workspace so it sees it too.
  *
  * Not covered: this package's own `test` script, which reaches the same worker
- * source through `scripts/get-schema.ts`, nor any other plain `test`/Cypress
+ * source through `scripts/get-schema.ts`, or any other plain `test`/Cypress
  * script in the repo that imports a `@doenet/*` package — all of them read the
  * same possibly-stale `dist/`. Converting them is its own change (the blocker
  * is watch mode: wireit spawns with piped stdio, so a wrapped bare `vitest`

--- a/scripts/ensure-consistency.ts
+++ b/scripts/ensure-consistency.ts
@@ -147,7 +147,7 @@ for (const tsconfig of TSCONFIG_FILES) {
             const expected = doenetImports.map(
                 (dep) => `../${dep.split("/")[1]}:build`,
             );
-            const existing = wireitBuild.dependencies ?? [];
+            const existing = crossPackageDependencies(packageJson, "build");
             const missing = expected.filter((x) => !existing.includes(x));
             const excessive = existing.filter((x) => !expected.includes(x));
 
@@ -174,6 +174,44 @@ for (const tsconfig of TSCONFIG_FILES) {
             }
         }
     }
+}
+
+/**
+ * The cross-package builds a package's wireit `script` pulls in, looking through
+ * same-package dependencies.
+ *
+ * A dependency name without a leading `"."` is a script in the same package
+ * (wireit's rule: "All cross-package dependencies should start with a `\".\"`" —
+ * `wireit/schema.json`), and packages here use one to group dependencies:
+ * `@doenet/standalone`'s `build` reaches `../doenetml:build` through
+ * `build:main`, and `@doenet/doenetml-worker-javascript` keeps the sibling
+ * builds its source needs in a no-command `build:deps` so that the generator
+ * scripts in `@doenet/static-assets` can depend on exactly that set (see
+ * `packages/static-assets/test/generator-script-dependencies.test.ts`). Reading
+ * only `build`'s own list would report those groups as missing dependencies.
+ */
+function crossPackageDependencies(
+    packageJson: {
+        wireit?: Record<
+            string,
+            { dependencies?: (string | { script: string })[] }
+        >;
+    },
+    script: string,
+    visited: Set<string> = new Set(),
+): string[] {
+    if (visited.has(script)) {
+        return [];
+    }
+    visited.add(script);
+    const dependencies = packageJson.wireit?.[script]?.dependencies ?? [];
+    return dependencies.flatMap((dependency) => {
+        const name =
+            typeof dependency === "string" ? dependency : dependency.script;
+        return name.startsWith(".")
+            ? [name]
+            : crossPackageDependencies(packageJson, name, visited);
+    });
 }
 
 /**

--- a/scripts/ensure-consistency.ts
+++ b/scripts/ensure-consistency.ts
@@ -189,6 +189,9 @@ for (const tsconfig of TSCONFIG_FILES) {
  * scripts in `@doenet/static-assets` can depend on exactly that set (see
  * `packages/static-assets/test/generator-script-dependencies.test.ts`). Reading
  * only `build`'s own list would report those groups as missing dependencies.
+ *
+ * `visited` is what keeps a cyclic group — which wireit itself rejects when the
+ * script runs — from recursing forever here.
  */
 function crossPackageDependencies(
     packageJson: {


### PR DESCRIPTION
## Summary

`npm run build:schema -w packages/static-assets` could silently read stale code. `generate-schema.ts` (via `get-schema.ts`) and `check-docs-coverage.ts` both import `createComponentInfoObjects` from `doenetml-worker-javascript/src`, and that source resolves `@doenet/utils`, `@doenet/i18n` and `@doenet/parser` to their **built** `dist/` — those packages export `"." → "./dist/index.js"`, and nothing in the config these generators run under (`packages/static-assets/vite.config.ts`, which `vite-node` loads) aliases a `@doenet/*` specifier to source. Neither script was a wireit script, so neither declared those builds as dependencies.

The result is a confusing failure rather than a loud one. Pull a branch that adds a locale catalog, run `build:schema`, and the regenerated schema comes out *missing* the new entries — so `git diff` makes it look like the committed schema is stale when what is actually stale is `@doenet/i18n/dist`. I hit exactly this on #1669's Klingon catalog: regenerating deleted the `tlh` entry.

CI never saw it because both jobs built the whole workspace first. That is also why it stayed invisible: it only bit someone running the command the way `docs/PR_REVIEW_GUIDELINES.md` and the `doenetml-docs-authoring` skill tell them to.

## Change

**The three generator scripts in `@doenet/static-assets` become wireit scripts** — `build:schema`, `check:docs-coverage` and `build:assets` — each declaring one dependency: `../doenetml-worker-javascript:build:deps`.

**`build:deps` is a new no-command wireit aggregator in `@doenet/doenetml-worker-javascript`** naming the sibling builds its source needs in order to be importable (`../i18n:build`, `../utils:build`, `../parser:build`). The worker's own `build` now depends on it instead of naming those three directly, so the list has exactly one home: a build the worker's source needs cannot reach the worker without also reaching the generators. Wireit treats a no-command script as fully tracked (`lib/fingerprint.js`: "A no-command script. Doesn't ever do anything itself, so always fully tracked"), so the worker's `build` remains cacheable — verified below.

`build:assets` runs `generate-schema.ts` too and had the identical gap. It is not dead code: `packages/static-assets/README.md` documents it as the way to rebuild snippets and math assets, so it is fixed rather than left alone or deleted.

Deliberately **no `files`/`output`** on any of the three, so they always re-run instead of being served from the cache. This is documented wireit behaviour, not luck — "If a script doesn't have a `files` or `output` list defined at all, then it will _always_ run" (wireit README, *Incremental build*) — and it also means caching never engages for them, so `WIREIT_CACHE=local` is a no-op on the scripts themselves while still serving their dependencies. The freshness check is only meaningful against a fresh generation, and `check:docs-coverage` reads `.mdx` pages from disk that are not modelled as inputs.

**Both CI jobs drop their `npm run build:all-no-docs` step** and set `WIREIT_CACHE: "local"` (wireit defaults it to `"none"` whenever `CI=true`) and `NODE_OPTIONS: "--max_old_space_size=6114"` on the step that remains. `schema-freshness` and `check-docs-coverage` both `needs: build`, so a build break already fails there; the `build-artifacts` artifact is the `.wireit` cache (not `dist/`), which is what lets the declared dependencies restore. Pre-building the whole workspace only masked an incomplete dependency list — and since the bug this PR is about is one that only bites someone who runs the script on its own, CI now runs it on its own too. There is **no** correctness risk in the removal, and an earlier version of this description claimed there was: when the cache cannot supply a declared dependency, wireit builds it from source rather than failing. `NODE_OPTIONS` is there because those builds now happen *inside* these steps on a total cache miss, and the dropped step was where the setting used to live; it is the value every runner-side build step in the workflow uses (the two devcontainer jobs build inside their container and set nothing).

**`test/generator-script-dependencies.test.ts`** guards what the aggregator cannot: that each generator is a wireit script, declares the aggregator, and declares no `files`/`output`; and that the worker's `build` names no sibling build directly, since one added there would reach the worker and not the generators. Which scripts count as generators is *derived* — anything this package declares, in `scripts` or in `wireit`, whose command runs a file out of `scripts/`, whatever the runner — rather than hard-coded, so a fourth generator is covered the moment it is added, in any shape it could arrive. Hard-coding was the same shape as the bug being fixed: `build:assets` carried this gap for as long as it existed and was caught by hand, in review. A false positive (a script under `scripts/` that does not import worker source) fails with a message telling the next person to either declare the dependency or narrow the pattern. Its header is where the reasoning lives, since `package.json` cannot carry comments; `get-schema.ts`, `check-docs-coverage.ts` and the package README point at it.

**`scripts/ensure-consistency.ts` learns to follow a dependency group.** That report compares a package's wireit `build` dependencies against the `@doenet/*` imports found in its source, reading only `build`'s own list — so a same-package group looks like a missing dependency plus an unexpected entry. `@doenet/standalone` already tripped it (`build` reaches `../doenetml:build` through `build:main`), and `build:deps` would have been the second instance. Following same-package dependencies first makes `standalone`'s and `doenetml-print`'s reports disappear as the false positives they were, makes `doenetml-worker-rust`'s accurate about what it reaches, and leaves `doenetml-worker-javascript` reporting exactly what it did before this branch: 14 reports become 13. The tool is informational (`npx vite-node scripts/ensure-consistency.ts`, per the root README) and not in CI; the three entries it still reports for the worker (`../doenetml-worker:build` and `../static-assets:build` missing, `../parser:build` unexpected) predate this branch and are left alone — verified by running the base script against the base `package.json`s and diffing.

## Why the aggregator, and not the three cheaper shapes

Earlier revisions of this PR restated the three sibling builds in each generator and used the test to compare the copies against the worker's list. Four copies of one list, kept in step by ~90 lines of dependency-name resolution, is worse than having one copy, so that is gone. The alternatives, settled here rather than left as an open question:

- **Depend on `../doenetml-worker-javascript:build`.** Also drift-proof and needs no new script, but it adds a vite pass — 11.1s in one run, 13.7s in another, against a cold `build:schema` of 20-21s, i.e. about as much again as the whole generation it feeds — to produce a 6.9 MB bundle these scripts never load, since they consume the worker's *source*. That is waste on every schema regeneration, which is the inner loop when adding or documenting a component, and it is at its most expensive exactly when the worker's source has just changed. Rejected.
- **A local aggregator in `@doenet/static-assets`.** Cuts four copies to two rather than one, still needs the guard to compare them, and puts the list in the package that does not own it. Rejected.
- **Keep mirroring, keep the drift guard.** Rejected: the guard was ~240 lines to detect a divergence that the aggregator makes impossible, and its most subtle assertion (canonicalizing dependency names so a same-package `build:codegen` in the worker is not demanded of `@doenet/static-assets`) existed only to serve the comparison.

What the aggregator costs is one indirection in the worker's `package.json` and the invariant that new sibling builds go into `build:deps`, not into `build` — which the test asserts, with a failure message that says exactly that. The dropped existence check (`../i18n:buidl` names no script) is no longer needed: `build:deps` sits on the worker `build`'s path, which CI runs in the `build` job, and wireit rejects a dangling dependency there. That is strictly better than before, when a typo could hide in a list only `build:assets` used and CI never ran it.

## Verification

Run locally on the current head, output as reported:

- **Fully cold, with `CI=true`.** `npm run clean:cache` plus `rm -rf packages/{i18n,utils,parser,static-assets}/dist`, then `CI=true WIREIT_CACHE=local npm run build:schema -w packages/static-assets`: `Ran 5 scripts and skipped 0 in 20.1s`, all five files in `src/generated/` byte-identical against a recorded `sha256sum` baseline, `git status` clean. So the wiring is complete, not just plausible, with nothing cached to hide behind. Peak RSS of the heaviest process in the tree was 1,493,932 KB ≈ 1.4 GiB (`/usr/bin/time -v`). Run twice, on two heads of this branch, agreeing to within a second and to the byte on every generated file.
- **`check:docs-coverage` in the same state**: `2.6s`, `Docs coverage: 247 schema components; 267 reference pages; 0 on allow-list; 0 unresolved.`
- **The aggregator resolves cross-package, and its shape is idiomatic here.** `build:deps` is defined in the worker's `wireit` section but not in its `scripts` — a shape this repo already uses four times (`@doenet/standalone`'s `build:main`, `@doenet/prefigure`'s `fetch-wheels` and `fetch-liblouis`, `@doenet/doenetml-print`'s `build:python`) and one wireit resolves directly: its analyzer looks for a `wireit` entry before a `scripts` entry (`lib/analyzer.js`), `command` is not required by `wireit/schema.json`, and `lib/fingerprint.js` has an explicit branch for a no-command script. `build:schema` resolves and runs it (no new public script appears in the worker's `npm run` list, and no wireit warning).
- **The worker's build is still cacheable and skippable** with a no-command script in its dependency graph: `npm run build -w packages/doenetml-worker-javascript` → `Ran 1 script and skipped 4 in 11.9s` (14.7s on a later run; the vite pass is essentially all of it), then immediately again → `Ran 0 scripts and skipped 5 in 0.2s`. Wireit's watch mode, the workflow the root README documents for this, also still resolves the graph with the no-command script in it (`Ran 0 scripts and skipped 5`, then watching).
- **`build:assets`, the script CI never runs**, under the new wiring: `Ran 1 script and skipped 4 in 4.6s`, regenerating schema, entity map, completion snippets and math assets, with all five committed files still byte-identical.
- **Re-run behaviour of the generators.** A second immediate `build:schema` re-executes the generator rather than serving it from cache, as the missing `files`/`output` requires.
- **A source change in `@doenet/i18n` is picked up.** Deleting the `tlh` entry from `packages/i18n/src/generated/supportedLocales.ts` and running `build:schema` rebuilt `../i18n:build`, cascaded through `utils`/`parser`, and dropped `tlh` from `doenet-schema.json` (`grep -c` 1 → 0); restoring the source brought it back (0 → 1) with a clean tree. This is the exact failure from #1669, now impossible.
- **The guard, mutation-tested on thirteen distinct cases** across two sweeps — eight of them re-run from scratch at the final head by a script that reverts after each case and then checks both `package.json`s are byte-identical again (they were). Every intended failure fires, naming what to do: `build:schema` losing the aggregator; the aggregator emptied, or renamed away; `../ui-components:build` added straight to the worker's `build` (“add cross-package dependencies to … build:deps rather than to its build”); `files` added to `build:assets`; `check:docs-coverage` reverted to a plain script; and a new generator arriving in any of three shapes — plain `vite-node ./scripts/generate-extra.ts`, `tsx scripts/generate-extra.ts` (different runner, no `./`, which is what broadening the pattern bought), or declared *only* in the `wireit` section. Every intended pass passes: the unmutated baseline, a dependency in the object form `{ script: …, cascade: true }`, and `"lint:helper": "node ../../scripts/some-repo-helper.js"` — the repo-wide `scripts/`, not this package's, so not mistaken for a generator.
- **What the guard deliberately leaves to wireit, checked against wireit.** A dangling name inside `build:deps` (`../i18n:buidl`) makes `build:schema` exit 1 — `Cannot find script named …` (`lib/analyzer.js`) — and so does a cyclic same-package group (`Cycle detected in dependencies of …`). Both were run.
- **`scripts/ensure-consistency.ts`, before and after, against the real base.** With the base script *and* the base `package.json`s restored, the report has 14 wireit findings; on this head it has 13. Diffing the two outputs: `@doenet/standalone`'s and `@doenet/doenetml-print`'s findings disappear (they were false positives from a same-package group), `@doenet/doenetml-worker-rust`'s becomes accurate about what it actually reaches, and `@doenet/doenetml-worker-javascript`'s block is character-for-character what it was before the branch. Its new traversal also terminates on a synthetic cyclic group (`visited`), which is the only input shape that could hang it.
- **`packages/static-assets`' own suite**: `5 files / 57 tests` green (the guard contributes 12). It runs in CI: `Test Main`'s log shows `✓ test/generator-script-dependencies.test.ts (12 tests)`, and both reshaped jobs — `Verify schema regenerated` and `Check Reference Docs Coverage` — pass on this head with no pre-build step.
- **Workspace rebuilt afterwards** with `npm run build:all-no-docs`, so the checkout is left usable.

Carried over from earlier cycles, still true of this head and not re-run:

- **What an undeclared dependency looks like in the job.** With `../utils:build` removed and `packages/utils/dist` gone, the job's remaining steps exit 1 on vite's `Failed to resolve entry for package "@doenet/utils"`, `plugin: 'vite:import-analysis'`, with `id: …/doenetml-worker-javascript/src/components/Text.js` and a code frame on the `from "@doenet/utils"` line. The `git diff` step never runs, so this cannot masquerade as a stale schema.
- **A sibling that genuinely fails to build**: a syntax error appended to `packages/i18n/src/index.ts` gives `❌ [../i18n:build] exited with exit code 1` followed by the esbuild error with file, line and code frame — and that break would already have failed the `build` job this one `needs`.
- **The dropped CI step measured.** `Build (cached)` cost 9s and `Regenerate schema` 7s in the old shape; in the run on this head `Regenerate schema` alone is 8s and the docs-coverage check 5s. The step was cheap, so its removal is not a performance change — what it buys is coverage. Both jobs' wall time is dominated by `npm ci` (47-49s of a 1m15-1m23s job).
- **`WIREIT_CACHE` from wireit's own behaviour**: `lib/cli-options.js` reads it and, when unset, returns `process.env.CI === 'true' ? 'none' : 'local'`; the local cache lives under `.wireit/<script-name-hex>/cache/<key>` (`lib/caching/local-cache.js`), which the `build-artifacts` glob `./packages/*/.wireit/**/*` includes.
- **Argument forwarding works** through wireit (`npm run {script} -- {args}`), so the conversion changes no caller — and every invocation site of these scripts is argument-free anyway: `ci.yml`, `docs/PR_REVIEW_GUIDELINES.md`, `.github/skills/doenetml-docs-authoring/SKILL.md`, `packages/static-assets/README.md`, `packages/docs-nextra/README.md`.
- **A corrupt (rather than missing) artifact is unchanged by this PR.** The old pre-build step and the surviving step obtain sibling `dist/` from the same `.wireit` cache entries, so the exposure is identical either way.

Left to CI: everything else. This PR touches no runtime code — the worker's diff is six lines of `wireit` config — so the worker vitest suite and the Cypress groups were not run locally.

## Corrections to earlier versions of this description

- **Wireit *can* forward CLI arguments.** An earlier draft gave that as the reason the same fix is not applied to the `test` scripts. It is wrong: `npm run {script} -- {script args}` forwards to the underlying command (wireit README, *Extra arguments*), and extra arguments are part of the fingerprint. The real reason for leaving the `test` scripts alone is below.
- **The removal of the CI build step was not an accepted risk.** An earlier draft said a dependency wireit cannot restore would become a hard failure in these jobs. It does not; wireit builds it.
- **`build:assets` was not unreferenced.** An earlier draft said nothing in the repo invokes it; `packages/static-assets/README.md` documents it for humans. It is fixed in this PR.
- **The repo is not free of `@doenet/*` source aliases, and the root does have tsconfig `paths`.** An earlier draft said no `resolve.alias` or tsconfig path anywhere maps a `@doenet/*` specifier to source. Both wrong: `packages/doenetml/cypress.config.ts` aliases `@doenet/codemirror` to source, and `tsconfig.build.json` / `tsconfig.test.json` both map `@doenet/*` → `./packages/*/dist`. The conclusion survives — every mapping that touches the generators resolves to `dist`, and the generators run under a config with no aliases at all — but the absolute claims are gone.
- **`packages/i18n`'s `check:instances` is not an instance of this bug.** An earlier draft listed it as one, calling it a bug that silently passes over unbuilt packages. `scripts/check-bundle-instances.ts` says otherwise: skipping a package nobody built is deliberate and documented in its header, the number of packages scanned is printed, and a scan that finds *nothing* is an explicit failure. Corrected here and in #1675.
- **The guard's test count.** An earlier draft cited `13 tests` in the `Test Main` log and `58` for the package. Both moved with the guard; it is 12 and 57 now.
- **The wireit README does not document the wireit-only script.** An earlier draft justified `build:deps` having no `scripts` entry by citing the README. It says no such thing. The shape is justified instead by repo precedent (four existing entries) and by wireit's own resolution order, both cited above.
- **The config count was wrong.** An earlier draft said 37 tracked vite/vitest/cypress configs; it is 46 under the glob above (34 if only the exact `vite.config.*` / `vitest.config.*` / `cypress.config.*` basenames count). The claim that rests on it — exactly one maps a `@doenet/*` specifier to source — was re-checked over all 46 and holds.

## Not in scope: how far this class of bug reaches

Almost nothing in the repo is exempt by configuration: of the 46 tracked `vite*.config.*` / `vitest.config.*` / `cypress.config.*` files, exactly one maps a `@doenet/*` specifier to source (`packages/doenetml/cypress.config.ts`, for `@doenet/codemirror` only, for an unrelated reason it documents inline), and all three `@doenet/*` `tsconfig` path mappings point at `dist`. So every plain npm script that reaches a sibling package can run against stale output: every `test` script whose specs reach a `@doenet/*` import (most consequentially `doenetml-worker-javascript`'s `test` / `test:group1-4`, and `packages/static-assets`' own `test`, which reaches worker source through `scripts/get-schema.ts`), and every Cypress runner (`packages/test-cypress/vite.config.ts` hard-codes `../standalone/dist/*` — the hazard `TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md`'s "rebuild before Cypress runs" rule papers over). `packages/utils/test/styleDescriptions.test.ts:32-34` already carries a comment admitting the hazard and telling the reader to run `npm run build -w @doenet/i18n` by hand. `packages/memory-benchmark`'s `benchmark` is the exemplar of the right pattern already: wireit, with `../standalone:build` and `../doenetml-iframe:build` declared.

None of that is fixed here, deliberately. It is filed as **Doenet/DoenetML#1675** with the survey, a concrete fix shape (leave `test` a plain `vitest` for watch mode; add a wireit `test:run` per package; point CI and the root aggregate scripts at it), and the one real blocker: wireit spawns with piped stdio (`lib/script-child-process.js` passes no `stdio` option, so the default `pipe` applies, and on Linux it also spawns `detached`), so a wrapped bare `vitest` loses the interactive keypress UI of the command developers spend all day in. The issue also records what is *not* a blocker — CI cost, the quiet logger swallowing output, argument forwarding — since earlier drafts of this description got two of those wrong.

Also not diagnosed here: the `@doenet/test-cypress` staleness reported in #1668's review is a different failure mode — that `build` **is** wireit, yet reported `Ran 0 scripts and skipped 24` while leaving a pre-revert bundle in `dist`. Wireit 0.14.13 checks an output manifest before declaring a script fresh, so a deleted `dist/` cannot be skipped, but a `dist/` holding another build's files can be if the fingerprint failed to change across the revert. That points at an input missing from a `files` list, which is a different investigation.

## One line of unrelated repair

`docs/PR_REVIEW_GUIDELINES.md` told reviewers that new component reference pages live under `packages/docs-nextra/src/pages/reference/`. That directory has never existed — the pages are in `packages/docs-nextra/pages/reference/`, which is what `check-docs-coverage.ts` reads and what this PR's own workflow comment says. Fixed here rather than filed: it is one line, it is in the file this PR's review process runs on, and it contradicted a path this diff asserts elsewhere.

## Scope, and the one file without a test

Nine files, one change: the wiring (two `package.json`s), the two CI jobs that exercise it, the guard that pins it, the README and the two script headers that explain it, and `scripts/ensure-consistency.ts`, which reports on exactly the dependency lists this PR reshapes and would otherwise start reporting the aggregator as a mistake. Splitting the consistency-report fix out would land a branch that knowingly makes a repo tool wrong. The one-line `docs/PR_REVIEW_GUIDELINES.md` path fix is the only piece that could stand alone; it is kept because it is in the file this PR's own review runs from and it contradicted a path this diff asserts elsewhere.

`scripts/ensure-consistency.ts` has no test and is not in CI, and there is no root-level test project to add one to (the root `test` script only fans out to workspaces). Rather than invent that infrastructure here, the 20-line pure function was verified by output: base-vs-head runs of the whole report on the real repo (above), every same-package group the report reaches today (`standalone` `build:main`, `worker-rust` `build:rust`/`build:js`, `doenetml-print` `build:python`, the new `build:deps`; `prefigure`'s `fetch-wheels`/`fetch-liblouis` group is the fifth in the repo, but that package imports no `@doenet/*` so the check never runs on it), and a synthetic cycle. It stays informational; if it ever moves into CI it should get a test then.

## Changeset

None. Per `.github/skills/changesets`, the two packages this PR edits are both internal — checked against both of the skill's reliable signals: neither `packages/static-assets/vite.config.ts` nor `packages/doenetml-worker-javascript/vite.config.ts` runs `scripts/transform-package-json.ts`, and neither package appears among the publish targets in `.github/workflows/publish.yml`. In any case this PR changes only build wiring, CI configuration, a test, a root maintenance script and docs; no package `src/` is touched, so no shipped package's contents change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



