### PR TITLE
Seed catalogs for six more West and Central African languages

### DIFF
--- a/.changeset/seed-west-central-african-catalogs-continued.md
+++ b/.changeset/seed-west-central-african-catalogs-continued.md
@@ -1,0 +1,27 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for six more West and Central African
+languages: Kongo (`kg`), Fon (`fon`), Nigerian Pidgin (`pcm`), Krio (`kri`),
+Kabiyè (`kbp`) and Temne (`tem`). A document declaring one of these languages
+now renders its style descriptions, section headings, boolean words, answer
+buttons, editor chrome and diagnostics in it instead of falling back to English.
+The chemistry element tables are deliberately left out of all six and still fall
+back to English.
+
+Every string is machine-generated and has not been read by a speaker; each
+catalog says so in its header. Correcting one needs no permission.
+
+Kongo is a macrolanguage, so a reader arriving under `kwy`, `ldi`, `kng` or
+`kon` now reaches it as well. Kituba (`ktu`, `mkw`) is deliberately *not* folded
+onto Kongo: it is a creole of Kikongo rather than a variety of it, and a Kituba
+reader would be served a different language.
+
+Kabiyè has no CLDR language name, so it takes a `LOCALE_NAME_FALLBACKS` entry
+and appears as "Kabiye (Kabɩyɛ)" in `<document lang>`'s autocomplete and context
+help rather than as the bare code "kbp".

--- a/.changeset/seed-west-central-african-catalogs-continued.md
+++ b/.changeset/seed-west-central-african-catalogs-continued.md
@@ -23,5 +23,5 @@ onto Kongo: it is a creole of Kikongo rather than a variety of it, and a Kituba
 reader would be served a different language.
 
 Kabiyè has no CLDR language name, so it takes a `LOCALE_NAME_FALLBACKS` entry
-and appears as "Kabiye (Kabɩyɛ)" in `<document lang>`'s autocomplete and context
+and appears as "Kabiyè (Kabɩyɛ)" in `<document lang>`'s autocomplete and context
 help rather than as the bare code "kbp".

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
@@ -517,12 +517,13 @@ describe("style descriptions follow the document locale @group4", () => {
         // What `@doenet/utils` pins is the agreement across the nouns' own
         // classes. What this checks is that the token survives
         // `setLocaleData`, the document's locale and the `translator`
-        // dependency — and, in `sh`,
-        // that a border's linker follows the border's own class rather than
-        // the shape's, which is the mistake the previous batch found in
-        // `locales/tiv` and fixed. In `sh` the circle is class 7 and reads
-        // «kya», while the «lubaku» beside it is class 11 and reads «lwa»; a
-        // linker agreeing with the wrong noun would make those two the same.
+        // dependency — and, in `sh`, that a border's linker follows the
+        // border's own class rather than the shape's, which is the rule
+        // `locales/tiv` states for its own «igbenda» and the one a
+        // border-carrying catalog is easiest to get wrong. In `sh` the circle
+        // is class 7 and reads «kya», while the «lubaku» beside it is class 11
+        // and reads «lwa»; a linker agreeing with the wrong noun would make
+        // those two the same.
         //
         // `st` carries the linker with no noun in front of it, which is the
         // headless form English's bare "thick dashed red" is. A suffix

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
@@ -507,6 +507,35 @@ describe("style descriptions follow the document locale @group4", () => {
         expect(values.fd).eq("utindi bulu");
     });
 
+    it("agrees a Kongo linker through the worker path", async () => {
+        const values = await descriptions(styled, names, "kg");
+        // The lexifier of the Kituba below it, and the reason this batch put
+        // the two in one tree. Kituba's invariable «ya» is Kongo's class-9
+        // linker frozen; Kongo's agrees, and the describing stem behind it
+        // never moves.
+        //
+        // What `@doenet/utils` pins is the agreement across four classes. What
+        // this checks is that the token survives `setLocaleData`, the
+        // document's locale and the `translator` dependency — and, in `sh`,
+        // that a border's linker follows the border's own class rather than
+        // the shape's, which is the mistake the previous batch found in
+        // `locales/tiv` and fixed. In `sh` the circle is class 7 and reads
+        // «kya», while the «lubaku» beside it is class 11 and reads «lwa»; a
+        // linker agreeing with the wrong noun would make those two the same.
+        //
+        // `st` carries the linker with no noun in front of it, which is the
+        // headless form English's bare "thick dashed red" is. A suffix
+        // language hides this and a linker language cannot.
+        expect(values.st).eq("ya nene ya mbwaki ya bitini bitini");
+        expect(values.stn).eq("nsinga ya nene ya mbwaki ya bitini bitini");
+        expect(values.pt).eq("kare kya mayamba");
+        expect(values.sh).eq(
+            "kizunga kyazala kya bule ye tona ye lubaku lwa nene lwa mbwaki ya bitini bitini",
+        );
+        expect(values.bd).eq("lwa nene lwa mbwaki ya bitini bitini");
+        expect(values.fd).eq("tona kya bule");
+    });
+
     it("leaves every Kituba describing word alone through the worker path", async () => {
         const values = await descriptions(styled, names, "ktu");
         // The other end of the same batch, and the reason both rows are here:

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
@@ -514,9 +514,10 @@ describe("style descriptions follow the document locale @group4", () => {
         // linker frozen; Kongo's agrees, and the describing stem behind it
         // never moves.
         //
-        // What `@doenet/utils` pins is the agreement across four classes. What
-        // this checks is that the token survives `setLocaleData`, the
-        // document's locale and the `translator` dependency — and, in `sh`,
+        // What `@doenet/utils` pins is the agreement across the nouns' own
+        // classes. What this checks is that the token survives
+        // `setLocaleData`, the document's locale and the `translator`
+        // dependency — and, in `sh`,
         // that a border's linker follows the border's own class rather than
         // the shape's, which is the mistake the previous batch found in
         // `locales/tiv` and fixed. In `sh` the circle is class 7 and reads
@@ -526,9 +527,14 @@ describe("style descriptions follow the document locale @group4", () => {
         // `st` carries the linker with no noun in front of it, which is the
         // headless form English's bare "thick dashed red" is. A suffix
         // language hides this and a linker language cannot.
+        //
+        // `pt` is a square marker, and «kare» is a French loan, so it takes
+        // the class-9 «ya» that `locales/kg`'s `noun-gender` comment names as
+        // the class a loan joins — not the class-7 «kya» that «kizunga» in
+        // `sh` gets for being a Kikongo ki-/bi- noun.
         expect(values.st).eq("ya nene ya mbwaki ya bitini bitini");
         expect(values.stn).eq("nsinga ya nene ya mbwaki ya bitini bitini");
-        expect(values.pt).eq("kare kya mayamba");
+        expect(values.pt).eq("kare ya mayamba");
         expect(values.sh).eq(
             "kizunga kyazala kya bule ye tona ye lubaku lwa nene lwa mbwaki ya bitini bitini",
         );

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -108,10 +108,9 @@ Mandinka, Ga, Tiv, Kanuri, Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
-English a student meets in their own textbook. Kannada
-has two — native coinages reaching a dozen elements and
-transliterations reaching all 118 — and picking either would misreport the
-other. Punjabi, Filipino and Vietnamese have two as well, and in all three the
+English a student meets in their own textbook. Kannada has two — native
+coinages reaching a dozen elements and transliterations reaching all 118 — and
+picking either would misreport the other. Punjabi, Filipino and Vietnamese have two as well, and in all three the
 current one is English: Punjabi secondary chemistry uses the English terms, the
 Philippines teaches science in English from the intermediate grades, and
 Vietnamese school chemistry has moved from the transliterated names to the
@@ -977,11 +976,11 @@ again, and it is not an error.
 
 All six leave `element-name` and `element-anion-name` out. Four are the ordinary
 school-system case — the DRC, Benin and Togo teach secondary science in French,
-Sierra Leone and Nigeria in English — but `pcm` and `kri` are a shape no earlier
-batch had. Their lexifier *is* English, so the fallback is not merely the
-curriculum, it is very nearly the language: filling those 130 keys in would
-produce entries character-identical to `locales/en` and claim a translation that
-had not happened. Leaving the gap visible is the honest answer, and it is the
+Sierra Leone in English — but `pcm` and `kri` are a shape no earlier batch had.
+Their lexifier *is* English, so the fallback is not merely the curriculum, it is
+very nearly the language: filling those 130 keys in would produce entries
+character-identical to `locales/en` and claim a translation that had not
+happened. Leaving the gap visible is the honest answer, and it is the
 first time that argument has applied.
 
 ### A language with no word for it

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -87,11 +87,11 @@ which is what #1521's translation platform is for. None has been read by a
 speaker. Correcting one needs no permission and no coordination: a wrong string
 is just wrong, and the English is one key away.
 
-A hundred and nine of them are deliberately partial. A hundred and eight are
+A hundred and fifteen of them are deliberately partial. A hundred and fourteen are
 partial in the same place — the two chemistry tables — while Klingon is partial
 almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The hundred
-and eight are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
+and fourteen are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
 Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
@@ -104,7 +104,8 @@ Pisin, Sanskrit, Maithili, Bhojpuri, Konkani, Dogri, Bodo, Manipuri, Santali,
 Kashmiri, Dhivehi, Tibetan, Dzongkha, Northern Sotho, Swati, Venda, Tsonga,
 Kikuyu, Bemba, Luo, Sango, Fula, Kabyle, Standard Moroccan Tamazight,
 Tachelhit, Rundi, Nyankole, Luba-Lulua, Kituba, Mooré, Dagbani, Dyula,
-Mandinka, Ga, Tiv and Kanuri leave `element-name` and `element-anion-name` out,
+Mandinka, Ga, Tiv, Kanuri, Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne
+leave `element-name` and `element-anion-name` out,
 so those 130 keys fall back to English and `lint:i18n` reports the gap. The
 first nine have no settled chemical nomenclature to seed from, and inventing one
 would be worse than the English a student meets in their own textbook. Kannada
@@ -328,7 +329,7 @@ per-language prose. CLDR has no language data at all for a few of the tags this
 repository ships catalogs for, though, and a `<document lang>` autocomplete
 offering a reader "ktu" and expecting them to know what it is helps nobody. So
 `LOCALE_NAME_FALLBACKS`, in `scripts/catalogUtils.ts`, supplies a name for the
-locales CLDR has none for: today `nah`, `dag`, `ktu` and `mnk`.
+locales CLDR has none for: today `nah`, `dag`, `ktu`, `mnk` and `kbp`.
 
 It fills a gap and never overrides one. ICU is asked with `fallback: "none"`, so
 it answers `undefined` where it has nothing — rather than its own rendering of
@@ -873,6 +874,114 @@ choosing any of the three would report which side of which border a reader's
 school is on. `locales/se` reached exactly that place between Norway, Sweden
 and Finland; this is the Northern Sami case in West Africa, and it is the first
 time a batch's chemistry paragraph has split since the South Asian one.
+
+### The batch continued: a creole beside its lexifier
+
+Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne — six more from the same
+region, and where the eleven above were arranged around *where* a language puts
+its agreement, these six are arranged around a sharper question: **what can you
+learn from two catalogs that you cannot learn from either one alone?**
+
+Three pairs answer it.
+
+**`kg` beside `ktu`.** Kituba was seeded in the batch above as the one Bantu
+catalog selecting on neither `$gender` nor `$role`: a describing word is joined
+to its noun by the invariable linker «ya» and never changes shape. Kikongo is
+Kituba's lexifier, and its connective agrees — «dya», «kya», «ya», «lwa» — so
+that «ya» turns out to be Kongo's class-9 row, frozen. The whole of the
+agreement in `locales/kg` is that one syllable, and the describing stem behind
+it never moves:
+
+| class | linker | black         | thick       |
+| ----- | ------ | ------------- | ----------- |
+| 5     | dya    | dya ndombe    | dya nene    |
+| 7     | kya    | kya ndombe    | kya nene    |
+| 9     | ya     | ya ndombe     | ya nene     |
+| 11    | lwa    | lwa ndombe    | lwa nene    |
+
+Putting `color.black` in the two files side by side is the shortest statement of
+what a creole did to its lexifier that this repository can make, and it cost
+nothing but the two files being in the same tree. `catalogLint.test.ts` pins
+both halves — that `kg` forks and that `ktu` does not — because a header can
+drift and a `$gender` fork cannot.
+
+**`pcm` beside `kri`.** Two English-lexifier creoles with much of the same
+grammar: postposed plural, a preverbal completive, `na` for identity. They still
+do not look alike, because Sierra Leone settled on a phonemic orthography and
+Nigeria stayed close to English spelling — «blak/wet/grin» against
+«black/white/green». The seam between them is **orthographic**, where
+`locales/fon`'s internal seam (below) is morphological, and neither is the same
+thing as a difference in grammar. Together they are this repository's shortest
+argument that "English creole" names a family rather than a catalog.
+
+`locales/pcm` is also the catalog most likely to be mistaken for padding, since
+almost every word in it is English. Its header therefore leads with the grammar
+rather than the vocabulary, and asks a reviewer to read the messages aloud.
+
+**`kbp` beside `kg`.** Kabiyè is the third Gur catalog, after Mooré and
+Dagbani, and it spells its class as a suffix as they do — but with five classes
+where Mooré has four and Dagbani three. Read against Kikongo it makes the
+general point the batch above was building towards: the agreement is **one
+morph** in each, and it lands in front of an invariant stem in Kongo, behind one
+in Kabiyè, and as a separate word between the two in Tiv. Three positions, one
+argument, no change to anything outside those files.
+
+**`tem` is the one that can be checked without knowing the language.** Temne's
+concord is *alliterative*: the describing word takes the same prefix the noun
+itself carries, so a rendered description reads «kʌlayn kʌbana-bana kʌbana» —
+the same syllable three times. In every other noun-class catalog here the
+concord and the noun's own prefix are different morphs, and `noun-gender` has to
+be taken on trust; in this one the table can be read straight off `noun` by eye.
+`styleDescriptions.test.ts` pins four rows of it. It is the third Atlantic
+catalog and answers differently from both the others — `ff` suffixes its class
+and `wo` marks it on a determiner.
+
+**`fon` has no agreement at all, and is here for its colour words.** Fon has
+three basic colour terms — «wiwi», «wewe», «vɔvɔ» — all reduplicated statives,
+and the other nine in the file are bare French loans because there is no stem to
+reduplicate. The seam runs through one message and is morphological, so a
+speaker reviewing it should expect to move words across it rather than to find
+the loans wrong as loans.
+
+#### Negotiation, and the exclusion that carries the argument
+
+`kg` is Kongo, an ISO 639-3 macrolanguage, and it joins `MACROLANGUAGE_MEMBERS`
+for the published reason `kr` and the rest did: `kwy` and `ldi` reach it because
+the map lists them, and `kng` because ICU already folds it.
+
+**`ktu` is deliberately absent from that list**, and it is the one exclusion
+here that is not simply "it has a catalog of its own" — though it does. Kituba
+is a creole *of* Kikongo rather than a variety of it, ISO 639-3 gives it a code
+outside `kg`, and folding it would serve a Kituba reader a different language.
+`mkw`, Kituba of the Republic of the Congo, is left to miss for the same reason;
+answering it with `ktu` would be defensible and is not a membership fact, so it
+is not done. `negotiate.test.ts` asserts the exclusion on the *un-normalized*
+tag, which is the only form the mistake would be visible in.
+
+**`son` is the road not taken, and the test says why.** It is the macrolanguage
+over the Songhay varieties, and it is *not* aliased the way `man` was, because
+the justification `man`'s entry rests on does not exist here:
+`new Intl.Locale("son").maximize()` adds no region, so CLDR has no opinion about
+which variety a bare `son` means. Picking one would be the judgement these maps
+avoid. The test asserts the absent region rather than merely the absent entry.
+
+`kbp` has **no CLDR language name** in either English or itself, so it takes the
+fifth entry in [`LOCALE_NAME_FALLBACKS`](#a-language-cldr-has-no-name-for) —
+the mechanism the previous batch added, doing the job it was added for. The
+other five are named by CLDR, and `tem` reads **"Timne"**, which is CLDR's
+spelling rather than the "Temne" its own header uses. That is the "Mossi" case
+again, and it is not an error.
+
+#### The chemistry gap, and the case where the fallback is the language
+
+All six leave `element-name` and `element-anion-name` out. Four are the ordinary
+school-system case — the DRC, Benin and Togo teach secondary science in French,
+Sierra Leone and Nigeria in English — but `pcm` and `kri` are a shape no earlier
+batch had. Their lexifier *is* English, so the fallback is not merely the
+curriculum, it is very nearly the language: filling those 130 keys in would
+produce entries character-identical to `locales/en` and claim a translation that
+had not happened. Leaving the gap visible is the honest answer, and it is the
+first time that argument has applied.
 
 ### A language with no word for it
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -87,9 +87,9 @@ which is what #1521's translation platform is for. None has been read by a
 speaker. Correcting one needs no permission and no coordination: a wrong string
 is just wrong, and the English is one key away.
 
-A hundred and fifteen of them are deliberately partial. A hundred and fourteen are
-partial in the same place — the two chemistry tables — while Klingon is partial
-almost everywhere, for a different reason: see
+A hundred and fifteen of them are deliberately partial. A hundred and fourteen
+are partial in the same place — the two chemistry tables — while Klingon is
+partial almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The hundred
 and fourteen are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
@@ -105,10 +105,10 @@ Kashmiri, Dhivehi, Tibetan, Dzongkha, Northern Sotho, Swati, Venda, Tsonga,
 Kikuyu, Bemba, Luo, Sango, Fula, Kabyle, Standard Moroccan Tamazight,
 Tachelhit, Rundi, Nyankole, Luba-Lulua, Kituba, Mooré, Dagbani, Dyula,
 Mandinka, Ga, Tiv, Kanuri, Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne
-leave `element-name` and `element-anion-name` out,
-so those 130 keys fall back to English and `lint:i18n` reports the gap. The
-first nine have no settled chemical nomenclature to seed from, and inventing one
-would be worse than the English a student meets in their own textbook. Kannada
+leave `element-name` and `element-anion-name` out, so those 130 keys fall back
+to English and `lint:i18n` reports the gap. The first nine have no settled
+chemical nomenclature to seed from, and inventing one would be worse than the
+English a student meets in their own textbook. Kannada
 has two — native coinages reaching a dozen elements and
 transliterations reaching all 118 — and picking either would misreport the
 other. Punjabi, Filipino and Vietnamese have two as well, and in all three the
@@ -931,10 +931,10 @@ concord is *alliterative*: the describing word takes the same prefix the noun
 itself carries, so a rendered description reads «kʌlayn kʌbana-bana kʌbana» —
 the same syllable three times. In every other noun-class catalog here the
 concord and the noun's own prefix are different morphs, and `noun-gender` has to
-be taken on trust; in this one the table can be read straight off `noun` by eye.
-`styleDescriptions.test.ts` pins four rows of it. It is the third Atlantic
-catalog and answers differently from both the others — `ff` suffixes its class
-and `wo` marks it on a determiner.
+be taken on trust; in this one every entry naming a noun can be read straight
+off `noun` by eye. `styleDescriptions.test.ts` pins four rows of it. It is the
+third Atlantic catalog and answers differently from both the others — `ff`
+suffixes its class and `wo` marks it on a determiner.
 
 **`fon` has no agreement at all, and is here for its colour words.** Fon has
 three basic colour terms — «wiwi», «wewe», «vɔvɔ» — all reduplicated statives,

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -938,10 +938,11 @@ suffixes its class and `wo` marks it on a determiner.
 
 **`fon` has no agreement at all, and is here for its colour words.** Fon has
 three basic colour terms — «wiwi», «wewe», «vɔvɔ» — all reduplicated statives,
-and the other nine in the file are bare French loans because there is no stem to
-reduplicate. The seam runs through one message and is morphological, so a
-speaker reviewing it should expect to move words across it rather than to find
-the loans wrong as loans.
+and the other nine in `color` are bare French loans because there is no stem to
+reduplicate. The seam is sharpest there but runs through `noun` and `fill-style`
+as well, and it is morphological rather than orthographic, so a speaker
+reviewing it should expect to move words across it rather than to find the loans
+wrong as loans.
 
 #### Negotiation, and the exclusion that carries the argument
 

--- a/packages/i18n/locales/fon/chrome.ftl
+++ b/packages/i18n/locales/fon/chrome.ftl
@@ -76,7 +76,7 @@ matrix-remove-column = Ðè kɔ́ sín mɛ
 matrix-add-column = Sɔ́ kɔ́ dó
 
 subset-add-remove-points = Sɔ́ tɛ́n dó/Ðè tɛ́n sín mɛ
-subset-toggle-points-intervals = Ðyɔ́ tɛ́n kpó hwenu kpó
+subset-toggle-points-intervals = Ðyɔ́ tɛ́n kpó intervalle kpó
 subset-move-points = Sɛ Tɛ́n Lɛ́ Dó
 subset-clear = Súnsún
 
@@ -99,7 +99,7 @@ summary-statistics-caption = Kplékplé xayi { $column } tɔ̀n
 
 math-input-preview-region = nùnywɛ́xó kpɔ́n jɛ nukɔ́n
 math-input-preview = Kpɔ́n jɛ nukɔ́n
-math-input-invalid-expression = Xógbe e má sɔgbe ǎ é:
+math-input-invalid-expression = Nǔnywɛ́xó e má sɔgbe ǎ é:
 
 
 ## Document status

--- a/packages/i18n/locales/fon/chrome.ftl
+++ b/packages/i18n/locales/fon/chrome.ftl
@@ -1,0 +1,134 @@
+# Fon viewer chrome: buttons, panel headers, and other UI the reader interacts
+# with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the split between Fon's three reduplicated
+# colour statives and its nine French loans, and for what a speaker should
+# check first.
+
+
+## Answer submission
+
+answer-checking = Ðò kpɔ́n wɛ…
+answer-submitting = Ðò sɛ́dó wɛ…
+
+answer-checking-status = È ɖò xósin ɔ́ kpɔ́n wɛ
+answer-submitting-status = È ɖò xósin ɔ́ sɛ́dó wɛ
+
+answer-correct = É sɔgbe
+answer-incorrect = É má sɔgbe ǎ
+
+answer-response-saved = È Bɛ́ Xósin Ɔ́ Dó
+
+answer-percent-credit = { $percent }% Kɛ́ndɛ́
+answer-percent-correct = { $percent }% Sɔgbe
+answer-percent-short = { $percent } %
+
+max-credit-available = Kɛ́ndɛ́ ɖaxó e è sixú mɔ é: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] tɛnkpɔ́n ɖé kpò ǎ
+        [one] tɛnkpɔ́n { $count } kpò
+       *[other] tɛnkpɔ́n { $count } kpò
+    }
+
+validation-correct = (É sɔgbe)
+validation-incorrect = (É má sɔgbe ǎ)
+validation-partially-correct = (É sɔgbe ɖé)
+
+answer-show-responses =
+    { $count ->
+        [one] Ðè xósin { $count } tɔ̀n { $answerId } tɔ̀n xlɛ́
+       *[other] Ðè xósin { $count } tɔ̀n { $answerId } tɔ̀n xlɛ́
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Xósin
+
+collapsible-click-to-open = (zin bo hun)
+collapsible-click-to-close = (zin bo sú)
+
+collapsible-initializing = Ðò bɛ́ wɛ…
+
+footnote-show = Ðè wema dò tɔ̀n xlɛ́
+footnote-hide = Hwlá wema dò tɔ̀n
+
+description-more-information = nǔmɔnú ɖěvo lɛ́
+
+
+## Controls
+
+slider-previous = Yɛ̌yǐ
+slider-next = Bɔ̌dó
+
+keyboard-open = Hun Klavier
+keyboard-close = Sú Klavier
+
+choice-input-remove-choice = Ðè { $choice } sín mɛ
+
+matrix-remove-row = Ðè línu sín mɛ
+matrix-add-row = Sɔ́ línu dó
+matrix-remove-column = Ðè kɔ́ sín mɛ
+matrix-add-column = Sɔ́ kɔ́ dó
+
+subset-add-remove-points = Sɔ́ tɛ́n dó/Ðè tɛ́n sín mɛ
+subset-toggle-points-intervals = Ðyɔ́ tɛ́n kpó hwenu kpó
+subset-move-points = Sɛ Tɛ́n Lɛ́ Dó
+subset-clear = Súnsún
+
+orbital-add-row = Sɔ́ Línu Dó
+orbital-remove-row = Ðè Línu Sín Mɛ
+orbital-add-box = Sɔ́ Gbà Dó
+orbital-remove-box = Ðè Gbà Sín Mɛ
+orbital-add-up-arrow = Sɔ́ Gǎ Yiaji Tɔ̀n Dó
+orbital-add-down-arrow = Sɔ́ Gǎ Yidó Tɔ̀n Dó
+orbital-remove-arrow = Ðè Gǎ Sín Mɛ
+
+orbital-row-label = Nyikɔ́ línu { $row } tɔ̀n
+
+pretzel-answer = Xósin
+
+summary-statistics-caption = Kplékplé xayi { $column } tɔ̀n
+
+
+## Math input
+
+math-input-preview-region = nùnywɛ́xó kpɔ́n jɛ nukɔ́n
+math-input-preview = Kpɔ́n jɛ nukɔ́n
+math-input-invalid-expression = Xógbe e má sɔgbe ǎ é:
+
+
+## Document status
+
+viewer-initializing = Ðò bɛ́ wɛ…
+
+
+## Errors
+
+error-heading = Nùwaɖókpɔ́
+
+error-found-at =
+    { $span ->
+        [line] È mɔ ɖò línu { $startLine } jí.
+       *[lines] È mɔ ɖò línu { $startLine }–{ $endLine } jí.
+    }
+
+document-contains-errors = Wema élɔ́ ɖó nùwaɖókpɔ́ lɛ́!
+
+diagnostic-heading-error = Nùwaɖókpɔ́
+diagnostic-heading-warning = Gbeɖiɖe
+diagnostic-heading-information = Nǔmɔnú
+diagnostic-heading-hint = Alɔdo
+
+accessibility-heading-level-1 = Gbigbà WCAG AA tɔ̀n ɖò Sisɛkpɔ́ mɛ
+accessibility-heading-level-2 = Gbeɖiɖe sisɛkpɔ́ tɔ̀n
+
+something-went-wrong = Nǔɖé má sɔgbe ǎ.
+
+renderer-load-failed = ɖiɖexlɛ́tɔ́ ɔ́ má wá ǎ. Kú dó nú mì, lɛ́ hun wexwɛ ɔ́.
+
+core-start-failed = Wemakpɔ́ntɔ́ ɔ́ má sixú bɛ́ ǎ. Kú dó nú mì, lɛ́ hun wexwɛ ɔ́.

--- a/packages/i18n/locales/fon/content.ftl
+++ b/packages/i18n/locales/fon/content.ftl
@@ -7,12 +7,12 @@
 # `fon` is Fon (Fɔngbe), the largest Gbe language of southern Benin, and the
 # nearest relative of `locales/ee` (Ewe) that this repository carries. Held up
 # against it, the two show how far apart two Gbe catalogs can be while
-# answering `$gender` the same way — which is to say, not at all.
+# inflecting for `$gender` the same way — which is to say, not at all.
 #
-# **This catalog selects on neither argument, and the reason is a fact about
-# its colour words rather than about its grammar.** Fon has no noun class and
-# no gender, so nothing agrees with anything; `$role` goes unused too, since Fon
-# marks no case. That much it shares with `locales/ktu` and `locales/pcm`.
+# **This catalog selects on neither argument.** Fon has no noun class and no
+# gender, so nothing agrees with anything; `$role` goes unused too, since Fon
+# marks no case. That much it shares with `locales/ktu` and `locales/pcm`, and
+# it is not what this file is here for.
 #
 # What is worth reading here is the shape of `color`. Fon has three basic
 # colour terms and no more: «wiwi» black, «wewe» white, «vɔvɔ» red. All three
@@ -22,12 +22,14 @@
 # they are French, which is where a Fon speaker meets them, and they are
 # written bare because there is no stem to reduplicate:
 #
-#   reduplicated stative     wiwi, wewe, vɔvɔ, kléwún, gaga
+#   reduplicated stative     wiwi, wewe, vɔvɔ, gaga
+#   other Fon stative        kléwún
 #   bare French loan         gris, orange, jaune, vert, cyan, bleu, violet,
 #                            rose, marron
 #
-# So the file has a visible seam running through one message, and the seam is
-# morphological rather than orthographic. A speaker reviewing this should
+# So the file has a visible seam running through it — sharpest in `color`, and
+# again in `noun` and `fill-style` — and the seam is morphological rather than
+# orthographic. A speaker reviewing this should
 # expect to move words across it — Fon has descriptive phrases for at least
 # green («amamu», the colour of leaves) and yellow — rather than to find the
 # nine loans wrong as loans.
@@ -61,8 +63,9 @@ color =
     .pink = rose
     .brown = marron
 
-# Both are Fon statives, and both reduplicate: «gaga» from «gá» to be big,
-# «kléwún» from «klé» to be slender.
+# Both are Fon statives, but only one reduplicates: «gaga» doubles «gá» to be
+# big, while «kléwún» is derived from «klé» to be slender without doubling it.
+# That is why the table in the header gives it a row of its own.
 line-width =
     .thick = gaga
     .thin = kléwún

--- a/packages/i18n/locales/fon/content.ftl
+++ b/packages/i18n/locales/fon/content.ftl
@@ -29,10 +29,9 @@
 #
 # So the file has a visible seam running through it — sharpest in `color`, and
 # again in `noun` and `fill-style` — and the seam is morphological rather than
-# orthographic. A speaker reviewing this should
-# expect to move words across it — Fon has descriptive phrases for at least
-# green («amamu», the colour of leaves) and yellow — rather than to find the
-# nine loans wrong as loans.
+# orthographic. A speaker reviewing this should expect to move words across it
+# — Fon has descriptive phrases for at least green («amamu», the colour of
+# leaves) and yellow — rather than to find the nine loans wrong as loans.
 #
 # The determiner «ɔ́» closes a whole noun phrase, behind the describing words.
 # It is left off throughout: these descriptions are read out of context, where

--- a/packages/i18n/locales/fon/content.ftl
+++ b/packages/i18n/locales/fon/content.ftl
@@ -1,0 +1,282 @@
+# Fon content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `fon` is Fon (Fɔngbe), the largest Gbe language of southern Benin, and the
+# nearest relative of `locales/ee` (Ewe) that this repository carries. Held up
+# against it, the two show how far apart two Gbe catalogs can be while
+# answering `$gender` the same way — which is to say, not at all.
+#
+# **This catalog selects on neither argument, and the reason is a fact about
+# its colour words rather than about its grammar.** Fon has no noun class and
+# no gender, so nothing agrees with anything; `$role` goes unused too, since Fon
+# marks no case. That much it shares with `locales/ktu` and `locales/pcm`.
+#
+# What is worth reading here is the shape of `color`. Fon has three basic
+# colour terms and no more: «wiwi» black, «wewe» white, «vɔvɔ» red. All three
+# are reduplicated — the bare stems are the verbs «wí», «wé», «vɔ̀» — and the
+# reduplication is what turns a verb of quality into something that can stand
+# beside a noun. The other nine colours in this file are not Fon words at all;
+# they are French, which is where a Fon speaker meets them, and they are
+# written bare because there is no stem to reduplicate:
+#
+#   reduplicated stative     wiwi, wewe, vɔvɔ, kléwún, gaga
+#   bare French loan         gris, orange, jaune, vert, cyan, bleu, violet,
+#                            rose, marron
+#
+# So the file has a visible seam running through one message, and the seam is
+# morphological rather than orthographic. A speaker reviewing this should
+# expect to move words across it — Fon has descriptive phrases for at least
+# green («amamu», the colour of leaves) and yellow — rather than to find the
+# nine loans wrong as loans.
+#
+# The determiner «ɔ́» closes a whole noun phrase, behind the describing words.
+# It is left off throughout: these descriptions are read out of context, where
+# Fon uses the bare indefinite, and welding a determiner to the end of a phrase
+# that ends in a placeable is the affix problem the README describes. Choosing
+# the indefinite is the way out this catalog takes.
+#
+# The geometry leans on the French loans Benin schooling supplies; where Fon
+# has its own word it is used — «tɛnmɛ» a place, «wlɛ́n» a mark. They are the
+# first thing to check.
+
+
+## Style vocabulary
+##
+## Three reduplicated Fon statives and nine French loans; see the header.
+
+color =
+    .black = wiwi
+    .white = wewe
+    .gray = gris
+    .red = vɔvɔ
+    .orange = orange
+    .yellow = jaune
+    .green = vert
+    .cyan = cyan
+    .blue = bleu
+    .purple = violet
+    .pink = rose
+    .brown = marron
+
+# Both are Fon statives, and both reduplicate: «gaga» from «gá» to be big,
+# «kléwún» from «klé» to be slender.
+line-width =
+    .thick = gaga
+    .thin = kléwún
+
+# Written as «kpó …» phrases rather than as statives, so that they close the
+# description rather than sitting inside it. `style-stroke` puts them last.
+line-style =
+    .dashed = kpó dlɛ̌n kpɛví lɛ́
+    .dotted = kpó tɛ́n lɛ́
+
+fill-style =
+    .horizontal = dlɛ̌n dòdó lɛ́
+    .vertical = dlɛ̌n sítɛ́ lɛ́
+    .diagonal = dlɛ̌n gbɔn lɛ́
+    .backdiagonal = dlɛ̌n gbɔn ɖò alɔ ɖèvo lɛ́
+    .dots = tɛ́n lɛ́
+    .diamonds = diamant lɛ́
+
+noun =
+    .line = dlɛ̌n
+    .line-segment = dlɛ̌n kpɛví
+    .ray = wězé
+    .vector = vecteur
+    .curve = dlɛ̌n glɔ́n
+    .function = fonction
+    .parabola = parabole
+    .polyline = dlɛ̌n gbǎ
+    .polygon = polygone
+    .triangle = triangle
+    .rectangle = rectangle
+    .circle = lɛ̌lɛ̌
+    .region = tɛnmɛ
+    .point = tɛ́n
+    .square = carré
+    .diamond = diamant
+    .cross = akluzu
+    .plus = wlɛ́n plus
+
+# The side count follows the describing words and closes the noun phrase, so it
+# goes in the tail — the position Fon's own determiner would occupy.
+noun-regular-polygon =
+    { $part ->
+        [tail] kpó akpá { $numSides }
+       *[head] polygone jɛ́jɛ́
+    }
+
+# Fon has no noun class and no gender, so every noun answers the same and the
+# answer goes unused — the shape `locales/en` and `locales/ktu` have.
+noun-gender = ɖokpo
+
+
+## Style composition
+
+# The dash pattern is a «kpó …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = gɔ́
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } kpó { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } kpó { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kpó { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «dogbó» is the border. Fon has no indefinite article and joins this clause
+# with the invariable «kpó», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] kpó dogbó { $border }
+        [and] kpó dogbó { $border }
+        [and-article] kpó dogbó { $border }
+       *[with] kpó dogbó { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = mǎ gɔ́ ǎ
+
+style-text =
+    { $parts ->
+        [background] { $color } kpó gudo { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = nǔ ɖé ǎ
+
+
+## Boolean words
+
+boolean-true = nugbó
+boolean-false = adingban
+
+
+## Answer buttons
+
+answer-submit-label = Kpɔ́n Azɔ̌
+answer-submit-label-no-correctness = Sɛ́ Xósin Dó
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Azɔ̌
+    .aside = Xó ɖěvo
+    .cascade = Kpɔ́nkpɔ́n
+    .definition = Tinmɛ
+    .example = Kpɔ́ndéwú
+    .exercise = Azɔ̌kpɔ́n
+    .exercises = Azɔ̌kpɔ́n lɛ́
+    .given-answer = Xósin
+    .note = Wema
+    .objectives = Nǔ e è ba lɛ́
+    .paragraphs = Akpáxwé lɛ́
+    .part = Akpáxwé
+    .problem = Tagba
+    .problems = Tagba lɛ́
+    .proof = Kúnnuɖenú
+    .question = Kanbyɔ́
+    .section = Akpáxwé
+    .solution = Ali
+    .task = Azɔ̌
+    .theorem = Théorème
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Alɔdo
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tableau { $enumeration }
+        [numbered-title] Tableau { $enumeration }{ ": " }
+        [unnumbered-title] Tableau{ ": " }
+       *[unnumbered] Tableau
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ðiɖe { $enumeration }
+        [numbered-caption] Ðiɖe { $enumeration }{ ": " }
+        [unnumbered-caption] Ðiɖe{ ": " }
+       *[unnumbered] Ðiɖe
+    }
+
+
+## Paginator controls
+
+paginator-previous = Yɛ̌yǐ
+paginator-next = Bɔ̌dó
+
+paginator-page = Wexwɛ
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = alǒ
+
+piecewise-condition-if = énɛ́ ɔ́
+
+piecewise-condition-otherwise = ɖò ninɔmɛ ɖě lɛ́ bǐ mɛ
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case. Benin teaches secondary science in French, so a Fon
+## speaker meets the periodic table there and neither Fon nor English is the
+## curriculum — which is why the gap is left visible rather than filled with
+## English words dressed up as Fon ones. `locales/ee` leaves the same gap for
+## the Ghanaian and Togolese ministries.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Wlɛ́n Chimie Tɔ̀n E Má Nyɔ́ Ǎ
+chemistry-invalid-ionic-compound = Kplékplé Ion Tɔ̀n E Má Nyɔ́ Ǎ

--- a/packages/i18n/locales/fon/diagnostics.ftl
+++ b/packages/i18n/locales/fon/diagnostics.ftl
@@ -288,7 +288,7 @@ prefigure-grid-spacing-too-fine = `<graph>`: grid sín tɛnmɛ kpɛ́ dín nú a
 
 prefigure-annotations-not-rendered = `<graph>`: è má ná ɖè annotations lɛ́ xlɛ́ ǎ enyi è ma ɖò PreFigure ɖiɖexlɛ́tɔ́ zán wɛ ǎ.
 
-multiple-annotations-children = È mɔ `<annotations>` ví gègě ɖò `<graph>` mɛ; è jó yě bǐ dó bó hɛn nukɔntɔ́n gudo tɔ́n ɔ́ géé.
+multiple-annotations-children = È mɔ `<annotations>` ví gègě ɖò `<graph>` mɛ; è jó yě bǐ dó bó hɛn gudo tɔ́n ɔ́ géé.
 
 ## Referring to other components
 

--- a/packages/i18n/locales/fon/diagnostics.ftl
+++ b/packages/i18n/locales/fon/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Fon diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] È nɔ jó { $attributes } dó hwenu e è ɖɔ nùwlé wè é
+       *[other] È nɔ jó { $attributes } dó hwenu e è ɖɔ nùwlé wè é
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] È nɔ jó { $attributes } dó hwenu e è ɖɔ nùwlé kpó tɛntin kpó é
+       *[other] È nɔ jó { $attributes } dó hwenu e è ɖɔ nùwlé kpó tɛntin kpó é
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset má nɔ w'azɔ̌ ǎ enyi tɛntin ɖé ma ɖè ǎ
+
+## `<line>`
+
+line-points-undetermined-dimensions = Dlɛ̌n gbɔn tɛ́n e sín ɖaxó è má tuùn ǎ lɛ́ é jí.
+
+line-points-too-few-dimensions = Dlɛ̌n ɖó ná gbɔn tɛ́n e ɖó ɖaxó wè ɖibla lɛ́ é jí.
+
+line-points-depend-on-variables = Dlɛ̌n gbɔn tɛ́n e ɖò nǔɖyɔ́ lɛ́ sí lɛ́ é jí: { $variables }.
+
+line-equation-invalid-format = Dlɛ̌n sín équation sín alɔkpa má sɔgbe ǎ ɖò { $variable1 } kpó { $variable2 } kpó mɛ.
+
+## `<ray>`
+
+ray-overprescribed-through = È ɖɔ wězé ɔ́ gbɔn through, endpoint kpó direction kpó jí.  È jó through e è ɖɔ é dó.
+
+ray-dimension-mismatch = numDimensions má sɔgbe ǎ ɖò wězé mɛ.
+
+## `<vector>`
+
+vector-overprescribed-head = È ɖɔ vecteur ɔ́ gbɔn head, tail kpó displacement kpó jí.  È jó head e è ɖɔ é dó.
+
+vector-dimension-mismatch = numDimensions má sɔgbe ǎ ɖò vecteur mɛ.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = È má sixú dɔn dó `<{ $component }>` wú ǎ, ɖó é ɖó nearestPoint ǎ.
+
+constrain-to-without-nearest-point = È má sixú blá dó `<{ $component }>` wú ǎ, ɖó é ɖó nearestPoint ǎ.
+
+constrain-to-interior-without-nearest-point = È má sixú blá dó `<{ $component }>` mɛ ǎ, ɖó é ɖó nearestPoint ǎ.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = È nɔ jó labelPosition dó nú choiceInput e má nyí inline ǎ é
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = È jó indices e è ɖɔ nú choiceInput lɛ́ é dó, ɖó indices sín kɛ́n má sɔgbe kpó choice ví lɛ́ sín kɛ́n kpó ǎ.
+
+pretzel-indices-count-mismatch = È jó indices e è ɖɔ nú problem lɛ́ é dó, ɖó indices sín kɛ́n má sɔgbe kpó problem ví lɛ́ sín kɛ́n kpó ǎ.
+
+shuffle-indices-count-mismatch = È jó indices e è ɖɔ nú shuffle lɛ́ é dó, ɖó indices sín kɛ́n má sɔgbe kpó nǔ lɛ́ sín kɛ́n kpó ǎ.
+
+indices-ignored-out-of-range = È jó indices e è ɖɔ nú { $component } lɛ́ é dó, ɖó ɖě lɛ́ ɖò dodó ɔ́ gudo.
+
+pretzel-indices-repeated = È jó indices e è ɖɔ nú pretzel lɛ́ é dó, ɖó ɖě lɛ́ vɔ́ wá.
+
+pretzel-circuit-first-index = È jó indices e è ɖɔ nú pretzel ɖò mode="circuit" mɛ lɛ́ é dó, ɖó index nukɔntɔ́n ɔ́ ɖó ná nyí 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Bó ná dó bló nú `<{ $component }>` ná w'azɔ̌ kpó string ví lɛ́ kpó ɔ́, è ɖó ná ɖɔ attribute `type`.
+
+invalid-type-defaulting-to-math = Type { $type } má sɔgbe ǎ nú nǔ { $component }. É ɖó ná nyí math, text, number, alǒ boolean. È ná zán math.
+
+string-not-valid-component-to-arrange = String "{ $value }" má nyí nǔ e sɔgbe nú { $component } é ǎ. È jó dó.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } má sɔgbe ǎ, è sɔ́ type ɔ́ dó number.
+
+invalid-variable-value = Nǔɖyɔ́ ɖé sín nǔ má sɔgbe ǎ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Alɔkpa sín index { $index } ɖó ná nyí kɛ́n
+
+variant-index-must-be-integer = Alɔkpa sín index { $index } ɖó ná nyí kɛ́n blebu
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = È má bló `<{ $component }>` nú jlɛ̌ blebu lɛ́ ǎ. È sɔ́ gbagbá lɛ́ dó jlɛ̌ ɖóxá tɔ̀n.
+
+side-by-side-absolute-margins = È má bló `<{ $component }>` nú jlɛ̌ blebu lɛ́ ǎ. È sɔ́ dodó lɛ́ dó jlɛ̌ ɖóxá tɔ̀n.
+
+side-by-side-no-block-child = `<{ $component }>` má sɔgbe ǎ: é ɖó ná ɖó block ví ɖokpo ɖibla.
+
+## `<label>`
+
+label-for-ignored-on-graphical = È nɔ jó attribute `for` e ɖò `<label>` ɖiɖe tɔ̀n jí é dó.
+
+label-for-must-resolve-to-one = Attribute `for` e ɖò `<label>` jí é ɖó ná yì nǔ ɖokpo géé jí.
+
+label-for-unresolved = Attribute `for` e ɖò `<label>` jí é má sixú mɔ nǔ ɖé ǎ.
+
+label-for-answer-with-authored-inputs = Attribute `for` e ɖò `<label>` jí é ɖɔ xó dó `<answer>` e ɖó input e è wlan lɛ́ é wú; ɖɔ xó dó input ɔ́ tlolo wú.
+
+label-for-answer-without-input = Attribute `for` e ɖò `<label>` jí é ɖɔ xó dó `<answer>` e ɖó input ɖé ǎ é wú.
+
+label-for-must-reference-input-or-answer = Attribute `for` e ɖò `<label>` jí é ɖó ná ɖɔ xó dó input alǒ answer wú.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Nú sisɛkpɔ́ wútu ɔ́, `<{ $component }>` ɖó ná ɖó tinmɛ kpɛví alǒ è ɖó ná ɖɔ ɖɔ é nyí decorative.
+
+accessibility-video-short-description = Nú sisɛkpɔ́ wútu ɔ́, `<video>` ɖó ná ɖó tinmɛ kpɛví.
+
+accessibility-input-short-description-or-label = Nú sisɛkpɔ́ wútu ɔ́, `<{ $component }>` ɖó ná ɖó tinmɛ kpɛví alǒ nyikɔ́.
+
+accessibility-answer-input-short-description-or-label = Nú sisɛkpɔ́ wútu ɔ́, `<answer>` e nɔ bló input é ɖó ná ɖó tinmɛ kpɛví alǒ nyikɔ́.
+
+accessibility-short-description-contains-math = Tinmɛ kpɛví lɛ́ má ɖó ná ɖó nǔnywɛ́ sín nǔ lɛ́ ɖi `<{ $component }>` ǎ. Wlan nǔnywɛ́ ɔ́ kpó xógbe kpó.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } má ɖó vogbingbɔn e kpé é ǎ nú akpáxwé ta sín xógbe (mode zizí tɔ̀n) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; é byɔ́ { $threshold }:1 ɖibla).
+       *[other] { $colorName } má ɖó vogbingbɔn e kpé é ǎ nú akpáxwé ta sín xógbe ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; é byɔ́ { $threshold }:1 ɖibla).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = È má ko bló `<circle>` gbɔn tɛ́n { $count } jí hwenu e tɛ́n lɛ́ má ɖó kɛ́n ǎ é ǎ.
+
+circle-too-many-through-points = È má sixú bló lɛ̌lɛ̌ gbɔn tɛ́n 3 jɛ nukɔ́n jí ǎ.
+
+circle-overprescribed-radius-center-points = È má sixú bló lɛ̌lɛ̌ kpó radius, tɛntin kpó tɛ́n lɛ́ kpó ǎ.
+
+circle-center-with-multiple-points = È má sixú bló lɛ̌lɛ̌ kpó tɛntin kpó gbɔn tɛ́n 1 jɛ nukɔ́n jí ǎ.
+
+circle-radius-too-small = È má sixú bló lɛ̌lɛ̌ ǎ: ɖó zɔ e ɖò tɛ́n wè lɛ́ tɛntin é nyí { $distance }, radius { $radius } e è ɖɔ é kpɛ́ dín.
+
+circle-radius-with-many-points = È má sixú bló lɛ̌lɛ̌ gbɔn tɛ́n wè jɛ nukɔ́n jí kpó radius e è ɖɔ é kpó ǎ.
+
+circle-invalid-center-or-through-points = Lɛ̌lɛ̌ sín tɛntin alǒ tɛ́n lɛ́ má sɔgbe ǎ.
+
+circle-radius-center-with-multiple-points = È má sixú bló lɛ̌lɛ̌ sín radius kpó tɛntin kpó gbɔn tɛ́n 1 jɛ nukɔ́n jí ǎ.
+
+circle-change-radius-non-numerical = È má sixú ɖyɔ́ lɛ̌lɛ̌ sín radius kpó tɛ́n e má ɖó kɛ́n ǎ lɛ́ kpó ǎ
+
+circle-radius-with-points-non-numerical = È má sixú bló lɛ̌lɛ̌ gbɔn tɛ́n ɖokpo jɛ nukɔ́n jí kpó radius kpó hwenu e kɛ́n má ɖè ǎ é ǎ.
+
+circle-change-center-non-numerical = È má ko bló lɛ̌lɛ̌ sín tɛntin ɖiɖyɔ́ gbɔn tɛ́n e má ɖó kɛ́n ǎ lɛ́ é jí ǎ.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Ðaxó má kpé nú fonction sín domain ǎ. Domain ɖó hwenu { $intervals } amɔ̌ fonction ɔ́ ɖó { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+       *[other] Ðaxó má kpé nú fonction sín domain ǎ. Domain ɖó hwenu { $intervals } amɔ̌ fonction ɔ́ ɖó { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Fonction sín domain sín alɔkpa má sɔgbe ǎ.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] È jó fonction sín ɖaxó e má ɖó kɛ́n ǎ é dó.
+        [minimum] È jó fonction sín kpɛví e má ɖó kɛ́n ǎ é dó.
+        [extremum] È jó fonction sín dodó e má ɖó kɛ́n ǎ é dó.
+        [point] È jó fonction sín tɛ́n e má ɖó kɛ́n ǎ é dó.
+        [slope] È jó fonction sín gbɔnkpo e má ɖó kɛ́n ǎ é dó.
+       *[other] È jó fonction sín { $type } e má ɖó kɛ́n ǎ é dó.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] È jó fonction sín ɖaxó e ɖò vɔ̌ é dó.
+        [minimum] È jó fonction sín kpɛví e ɖò vɔ̌ é dó.
+        [extremum] È jó fonction sín dodó e ɖò vɔ̌ é dó.
+        [point] È jó fonction sín tɛ́n e ɖò vɔ̌ é dó.
+       *[other] È jó fonction sín { $type } e ɖò vɔ̌ é dó.
+    }
+
+function-points-too-close = Fonction ɖó tɛ́n wè e sɛkpɔ́ yeɖée dín lɛ́ é. È má sixú tinmɛ fonction ɔ́ ǎ.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] È sixú vɔ́ fonction bló kaka enyi input lɛ́ sín kɛ́n sɔgbe kpó output lɛ́ sín kɛ́n kpó géé wɛ. Fonction élɔ́ ɖó input { $inputs } kpó { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        } kpó.
+       *[other] È sixú vɔ́ fonction bló kaka enyi input lɛ́ sín kɛ́n sɔgbe kpó output lɛ́ sín kɛ́n kpó géé wɛ. Fonction élɔ́ ɖó input { $inputs } kpó { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        } kpó.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Sequence sín gaga má sɔgbe ǎ.  É ɖó ná nyí kɛ́n blebu e má hwe ɖò 0 wú ǎ é.
+
+sequence-invalid-step = Sequence sín step má sɔgbe ǎ.  É ɖó ná nyí kɛ́n nú sequence type { $type } tɔ̀n.
+
+sequence-invalid-endpoint-number = Number sequence sín "{ $attribute }" má sɔgbe ǎ.  É ɖó ná nyí kɛ́n.
+
+sequence-invalid-endpoint-letters = Letters sequence sín "{ $attribute }" má sɔgbe ǎ.  É ɖó ná nyí wékwín kplékplé.
+
+sequence-invalid-endpoint = Sequence sín "{ $attribute }" má sɔgbe ǎ.
+
+select-from-sequence-coprime-not-numbers = È jó coprime dó ɖó è má ɖò kɛ́n cyán wɛ ǎ
+
+select-from-sequence-coprime-with-exclude-combinations = È jó coprime dó ɖó è ɖɔ excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` sín target má sɔgbe ǎ: è má mɔ target ɔ́ ǎ.
+
+target-state-variable-not-found = `<{ $source }>` sín target má sɔgbe ǎ: è má mɔ nǔɖyɔ́ e nɔ nyí "{ $property }" é ɖò `<{ $component }>` jí ǎ.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` sín nǔɖyɔ́ lɛ́ ɖó ná gbɔn vo nú nǔɖyɔ́ mɛɖéesúsú tɔ̀n ɔ́.
+
+ode-system-duplicate-variable-names = È má sixú tinmɛ ODE sín RHS fonction lɛ́ kpó nǔɖyɔ́ nyikɔ́ e vɔ́ wá lɛ́ é kpó ǎ.
+
+ode-system-rhs-function-error = È má sixú tinmɛ ODE sín RHS fonction ǎ.  Nùwaɖókpɔ́ ɖò mathjs fonction bibló mɛ.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = È má sixú tinmɛ agɔ ɖé ɖò dlɛ̌n { $count } tɛntin ǎ
+
+angle-invalid-through-point = Tɛ́n má sɔgbe ǎ ɖò `<angle>` sín through mɛ
+
+parabola-vertex-too-many-points = È má ko bló parabole kpó vertex kpó gbɔn tɛ́n 1 jɛ nukɔ́n jí ǎ.
+
+parabola-too-many-points = È má ko bló parabole gbɔn tɛ́n 3 jɛ nukɔ́n jí ǎ.
+
+intersection-too-many-items = È má ko bló nǔ wè jɛ nukɔ́n sín gbɔnkpo ǎ
+
+## Other math components
+
+ionic-compound-not-two-ions = È má ko bló ion kplékplé nú nǔ ɖěvo e má nyí ion wè ǎ é ǎ.
+
+ionic-compound-needs-cation-and-anion = È bló ion kplékplé nú cation ɖokpo kpó anion ɖokpo kpó géé.
+
+solve-equations-cannot-evaluate = È má sixú ɖè équation ɔ́ gbɔn ǎ ɖó è má sixú jlɛ́ é ǎ: { $equation }
+
+math-operators-operand-number-required = È ɖó ná ɖɔ operandNumber hwenu e è ɖò nǔnywɛ́ sín operand ɖè wɛ é.
+
+eigen-decomposition-failed = È má sixú jlɛ́ matrice ɔ́ sín eigenvalue lɛ́ ǎ
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } má ɖò kpɔ́ndéwú ɔ́ mɛ ǎ, énɛ́ wú ɔ́ é ná sɔgbe kpó vɔ̌ kpó hwebǐnu.
+       *[other] `<matchesPattern>`: parameter { $parameters } má ɖò kpɔ́ndéwú ɔ́ mɛ ǎ, énɛ́ wú ɔ́ yě ná sɔgbe kpó vɔ̌ kpó hwebǐnu.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: è má sixú mɔ nukúnnú jɛ grid="{ $grid }" mɛ ǎ. É ɖó ná nyí none, medium, dense, alǒ kɛ́n wè e hú 0 bɔ tɛnmɛ ɖé klán yě lɛ́ é, ɖi grid="1 0.5". È má bló grid ǎ.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" má nɔ w'azɔ̌ ɖò prefigure ɖiɖexlɛ́tɔ́ mɛ ǎ; è zán ɖisí sín tɛnmɛ.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" má nɔ w'azɔ̌ ɖò prefigure ɖiɖexlɛ́tɔ́ mɛ ǎ; è zán aji sín tɛnmɛ.
+
+prefigure-invalid-axis-bounds = `<graph>`: axis sín dodó má sɔgbe ǎ nú prefigure; è zán bbox e ɖ'ayǐ é (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: gbagbá má sɔgbe ǎ nú prefigure; è zán gbagbá e ɖ'ayǐ é 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio má sɔgbe ǎ nú prefigure; è zán aspect ratio e ɖ'ayǐ é 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: grid sín tɛnmɛ kpɛ́ dín nú axis sín dodó lɛ́; è ɖè grid ɔ́ sín prefigure ɖiɖexlɛ́tɔ́ mɛ.
+
+prefigure-annotations-not-rendered = `<graph>`: è má ná ɖè annotations lɛ́ xlɛ́ ǎ enyi è ma ɖò PreFigure ɖiɖexlɛ́tɔ́ zán wɛ ǎ.
+
+multiple-annotations-children = È mɔ `<annotations>` ví gègě ɖò `<graph>` mɛ; è jó yě bǐ dó bó hɛn nukɔntɔ́n gudo tɔ́n ɔ́ géé.
+
+## Referring to other components
+
+copy-unrecognized-component-type = È má sixú gbló alǒ kpɔ́n nǔ sín alɔkpa e è má tuùn ǎ é ǎ: { $type }.
+
+copy-prop-not-found = È má mɔ prop { $property } ɖò nǔ alɔkpa { $component } tɔ̀n jí ǎ
+
+collect-no-source = È má mɔ dodó ɖé nú collect ǎ.
+
+collect-invalid-component-type = È má sixú kplé nǔ alɔkpa `<{ $component }>` tɔ̀n lɛ́ ǎ ɖó alɔkpa ɔ́ má sɔgbe ǎ.
+
+reference-index-unavailable = È má sixú ɖɔ xó dó index `{ $reference }` wú ǎ
+
+## `<callAction>`
+
+component-action-unavailable = È má sixú ylɔ́ { $action } ɖò nǔ `{ $reference }` jí ǎ
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Nǔmɔnú lɛ́ sín alɔkpa má sɔgbe ǎ.  Línu lɛ́ sín gaga má sɔgbe ǎ. È mɔ ɖò componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Nǔmɔnú lɛ́ ɖó kɔ́ nyikɔ́ e vɔ́ wá lɛ́ é.  È mɔ ɖò componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Nǔmɔnú lɛ́ ɖó kɔ́ nyikɔ́ ɖé ǎ.  È mɔ ɖò componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Xósin élɔ́ sín award junjɔn xósin e answer tag ɔ́ ɖésú sɛ́dó é jí, énɛ́ ná dɔn nǔ e è má ɖó nukún ǎ é wá.
+
+answer-max-num-attempts-in-section-wide-check-work = `maxNumAttempts` sisɔ́ dó `<answer>` e ɖò nǔ ɖé kpó `sectionWideCheckWork` kpó mɛ é jí má nɔ w'azɔ̌ ǎ, ɖó nǔ ɔ́ wɛ nɔ kpé nukún dó tɛnkpɔ́n lɛ́ sín kɛ́n wú. Sɔ́ `maxNumAttempts` dó nǔ ɔ́ jí.
+
+nested-section-wide-check-work-max-num-attempts = `maxNumAttempts` sisɔ́ dó nǔ ɖé kpó `sectionWideCheckWork` kpó e ɖò nǔ ɖěvo kpó `sectionWideCheckWork` kpó mɛ é jí má nɔ w'azɔ̌ ǎ, ɖó nǔ e ɖò gudo é wɛ nɔ kpé nukún dó tɛnkpɔ́n lɛ́ sín kɛ́n wú. Sɔ́ `maxNumAttempts` dó nǔ e ɖò gudo é jí.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Attribute { $attributes } má ná w'azɔ̌ ǎ enyi è ma sɔ́ symbolicEquality ǎ.
+       *[other] Attribute { $attributes } má ná w'azɔ̌ ǎ enyi è ma sɔ́ symbolicEquality ǎ.
+    }
+
+answer-invalid-type = Xósin sín type má sɔgbe ǎ: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ðó nǔ `<{ $component }>` ɖó nyikɔ́ ǎ wútu ɔ́, è má sixú zán ɛ ɖi module sín attribute ǎ
+
+module-attribute-name-already-defined = È má sixú zán nǔ `<{ $component } name="{ $name }">` ɖi module sín attribute ǎ ɖó `<module>` alɔkpa ko ɖó attribute "{ $name }".
+
+conditional-content-condition-ignored = È nɔ jó attribute `condition` dó ɖò `<conditionalContent>` e ɖó case alǒ else ví lɛ́ é jí.
+
+slider-markers-type-mismatch = Markers sín type má sɔgbe kpó slider sín type kpó ǎ.
+
+pretzel-problem-needs-statement-and-answer = Pretzel má sɔgbe ǎ: `<problem>` ɖokpo ɖokpo ɖó ná ɖó `<statement>` ɖokpo kpó `<answer>` ɖokpo kpó.
+
+pretzel-circuit-first-problem-distractor = Pretzel má sɔgbe ǎ: ɖò mode="circuit" mɛ ɔ́, `<problem>` nukɔntɔ́n ɔ́ má sixú nyí distractor ǎ.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Nǔ { $values } má sɔgbe ǎ nú attribute `{ $attribute }`; è jó dó.
+       *[other] Nǔ { $values } má sɔgbe ǎ nú attribute `{ $attribute }`; è jó dó.
+    }
+
+attribute-must-be-references = Nǔ `{ $value }` má sɔgbe ǎ nú attribute `{ $attribute }`. Attribute ɖó ná nyí zɔnlin e nɔ bɛ́ kpó `$` kpó lɛ́ é.
+
+math-input-invalid-function-names = <mathInput>: è jó fonction nyikɔ́ e má sɔgbe ǎ lɛ́ é dó ɖò { $attribute } mɛ: { $names }. Nyikɔ́ ɖokpo ɖokpo ɖó ná ɖó wékwín 2 ɖibla (wékwín alǒ dodólin); `|<mathspeak alternative>` sixú bɔ dó.
+
+## Building components from the source
+
+component-type-invalid = Nǔ sín alɔkpa má sɔgbe ǎ: `<{ $componentType }>`
+
+attribute-repeated = È má sixú vɔ́ attribute { $attribute } ɖɔ ǎ.
+
+attribute-invalid-for-component = Attribute "{ $attribute }" má sɔgbe ǎ nú nǔ alɔkpa `<{ $componentType }>` tɔ̀n.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Alɔkpa tinmɛ { $styleNumber } má ɖó vogbingbɔn e kpé é ǎ nú { $context ->
+        [text-on-background] xógbe sín sinmɛ ɖò gudo sín sinmɛ jí
+        [high-contrast] vogbingbɔn ɖaxó sín sinmɛ ɖò kanvasi jí
+        [line] dlɛ̌n sín sinmɛ ɖò kanvasi jí
+        [marker] wlɛ́n sín sinmɛ ɖò kanvasi jí
+       *[text-on-canvas] xógbe sín sinmɛ ɖò kanvasi jí
+    }{ $mode ->
+        [dark] { " (mode zizí tɔ̀n)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; é byɔ́ { $threshold }:1 ɖibla).
+
+style-definition-dark-mode-text-background-contrast =
+    Alɔkpa tinmɛ { $styleNumber } ɖó sinmɛ e ná vogbingbɔn e kpé é nú mode wěwé tɔ̀n nugbó, amɔ̌ mode zizí tɔ̀n sín sinmɛ e è ɖè sín yě mɛ lɛ́ é má ɖó vogbingbɔn e kpé é ǎ ɖò xógbe sín sinmɛ kpó gudo sín sinmɛ kpó tɛntin ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; é byɔ́ { $threshold }:1 ɖibla). { $suggestion ->
+        [available] Bó ná dó mɔ vogbingbɔn e kpé é ɖò mode zizí tɔ̀n mɛ ɔ́, jǐ mode wěwé tɔ̀n sín vogbingbɔn (ɖi, sɔ́ { $lightAttribute }="{ $lightColor }") alǒ ɖyɔ́ mode zizí tɔ̀n sín sinmɛ (ɖi, sɔ́ { $darkAttribute }="{ $darkColor }").
+       *[none] Bó ná dó mɔ vogbingbɔn e kpé é ɖò mode zizí tɔ̀n mɛ ɔ́, jǐ mode wěwé tɔ̀n sín vogbingbɔn alǒ ɖyɔ́ sinmɛ lɛ́ kpó textColorDarkMode alǒ backgroundColorDarkMode kpó.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Alɔkpa tinmɛ { $styleNumber } ɖó xógbe sín sinmɛ e ná vogbingbɔn e kpé é nú mode wěwé tɔ̀n nugbó, amɔ̌ mode zizí tɔ̀n sín xógbe sinmɛ e è ɖè sín mɛ é má ɖó vogbingbɔn e kpé é ǎ ɖò kanvasi jí ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; é byɔ́ { $threshold }:1 ɖibla). { $suggestion ->
+        [available] Bó ná dó mɔ vogbingbɔn e kpé é ɖò mode zizí tɔ̀n mɛ ɔ́, jǐ mode wěwé tɔ̀n sín vogbingbɔn (ɖi, sɔ́ textColor="{ $lightColor }") alǒ ɖyɔ́ mode zizí tɔ̀n sín sinmɛ (ɖi, sɔ́ textColorDarkMode="{ $darkColor }").
+       *[none] Bó ná dó mɔ vogbingbɔn e kpé é ɖò mode zizí tɔ̀n mɛ ɔ́, jǐ mode wěwé tɔ̀n sín vogbingbɔn alǒ ɖyɔ́ sinmɛ ɔ́ kpó textColorDarkMode kpó.
+    }
+
+section-multiple-style-palettes = Akpáxwé ɖé sixú cyán <stylePalette> ɖokpo géé; è zán gudo tɔ́n ɔ́.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = è má sixú tuùn { $component } sín alɔkpa vovo lɛ́ ǎ ɖó numToSelect má nyí kɛ́n blebu e má hwe ɖò 0 wú ǎ é ǎ.
+
+variant-num-to-select-not-constant-number = è má sixú tuùn { $component } sín alɔkpa vovo lɛ́ ǎ ɖó numToSelect má nyí kɛ́n e má nɔ ɖyɔ́ ǎ é ǎ.
+
+variant-with-replacement-not-constant-boolean = è má sixú tuùn { $component } sín alɔkpa vovo lɛ́ ǎ ɖó withReplacement má nyí boolean e má nɔ ɖyɔ́ ǎ é ǎ.
+
+variant-select-weight-disables-unique = È nɔ sú select sín alɔkpa vovo lɛ́ enyi option ɖé ɖó selectWeight alǒ selectForVariants
+
+variant-coprime-undetermined = è má sixú tuùn { $component } sín alɔkpa vovo lɛ́ ǎ ɖó è má sixú tuùn ɖɔ coprime nyí adingban hwebǐnu ǎ.
+
+variant-attribute-not-constant = è má sixú tuùn { $component } sín alɔkpa vovo lɛ́ ǎ ɖó { $attribute } nɔ ɖyɔ́.
+
+variant-attribute-not-number = è má sixú tuùn { $component } sín alɔkpa vovo lɛ́ ǎ ɖó { $attribute } má nyí kɛ́n ǎ.
+
+variant-attribute-wrong-type-for-sequence =
+    è má sixú tuùn { $component } type { $type } tɔ̀n sín alɔkpa vovo lɛ́ ǎ ɖó { $attribute } má nyí { $expected ->
+        [letters-combination] wékwín kplékplé
+        [math-expression] nǔnywɛ́xó e sɔgbe é
+        [integer] kɛ́n blebu
+       *[number] kɛ́n
+    } ǎ.
+
+variant-length-not-integer = è má sixú tuùn { $component } sín alɔkpa vovo lɛ́ ǎ ɖó length má nyí kɛ́n blebu ǎ.
+
+variant-sort-not-implemented = è má ko bló { $component } kpó sort kpó sín alɔkpa vovo lɛ́ ǎ
+
+variant-exclude-combinations-not-implemented = è má ko bló { $component } kpó excludeCombinations kpó sín alɔkpa vovo lɛ́ ǎ
+
+variant-math-exclude-not-implemented = è má ko bló { $component } type math tɔ̀n kpó exclude kpó sín alɔkpa vovo lɛ́ ǎ
+
+variant-non-constant-exclude-not-implemented = è má ko bló { $component } kpó exclude e nɔ ɖyɔ́ é kpó sín alɔkpa vovo lɛ́ ǎ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: é má nɔ w'azɔ̌ ɖò graph sín prefigure ɖiɖexlɛ́tɔ́ mɛ ǎ; è jó ví ɔ́ dó.
+
+prefigure-descendant-invalid-geometry = { $subject }: alɔkpa má sɔgbe alǒ é ma kpé ǎ; è jó ví ɔ́ dó.
+
+prefigure-curve-label-omitted = { $subject }: nyikɔ́ lɛ́ má nɔ w'azɔ̌ ɖò curve nǔ e è ɖyɔ́ lɛ́ é jí ǎ; è ɖè nyikɔ́ ɔ́ sín mɛ.
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve sín tinmɛ alɔkpa '{ $definitionType }' má nɔ w'azɔ̌ ǎ; è jó ví ɔ́ dó.
+
+prefigure-region-flip-functions-unsupported = { $subject }: attribute flipFunctions ɖò regionBetweenCurves jí má nɔ w'azɔ̌ ǎ; è jó ví ɔ́ dó.
+
+prefigure-region-non-formula-child = { $subject }: fonction ví e ɖó formula lɛ́ é géé wɛ nɔ w'azɔ̌ ɖò regionBetweenCurves jí; è jó ví ɔ́ dó.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' má nɔ w'azɔ̌ ǎ nú { $labelKind ->
+        [line-family] dlɛ̌n hɛnnu sín nyikɔ́
+       *[point] tɛ́n sín nyikɔ́
+    }; è zán PreFigure sín tɛnmɛ e ɖ'ayǐ é.
+
+prefigure-fill-style-unsupported = { $subject }: gɔ́gɔ́ sín alɔkpa '{ $fillStyle }' má nɔ w'azɔ̌ ɖò PreFigure mɛ ǎ; è zán gɔ́gɔ́ blebu.
+
+prefigure-line-style-unknown = { $subject }: dlɛ̌n sín alɔkpa '{ $lineStyle }' e è má tuùn ǎ é, è ɖè sín PreFigure mɛ.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wlɛ́n sín alɔkpa '{ $markerStyle }' hɛn è ɖyɔ́ dó PreFigure sín 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: wlɛ́n sín alɔkpa '{ $markerStyle }' má nɔ w'azɔ̌ ɖò PreFigure mɛ ǎ; è zán alɔkpa e ɖ'ayǐ é.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` má sɔgbe ǎ; è má sixú mɔ target ɔ́ ǎ. È ɖè annotation ɔ́ sín mɛ.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` mɔ target gègě; è zán nukɔntɔ́n ɔ́.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` má sɔgbe ǎ; target ɔ́ ɖò graph ɔ́ gudo. È ɖè annotation ɔ́ sín mɛ.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` má sɔgbe ǎ; target ɔ́ má nyí ɖiɖe sín nǔ e nɔ w'azɔ̌ ɖò prefigure mɛ é ǎ. È ɖè annotation ɔ́ sín mɛ.
+
+annotation-text-missing = `<annotation>`: `text` má ɖè alǒ é ɖò vɔ̌; è wlan xógbe vɔ̌.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] È mɔ lɛ̌lɛ̌ sín kanbyɔ́.
+       *[other] È mɔ lɛ̌lɛ̌ sín kanbyɔ́ kpó nǔ `<{ $componentType }>` kpó.
+    }
+
+reference-no-referent = È má mɔ nǔ ɖé nú zɔnlin ǎ: `{ $reference }`
+
+reference-multiple-referents = È mɔ nǔ gègě nú zɔnlin: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` sín attribute { $attribute } sín alɔkpa má sɔgbe ǎ.
+
+children-invalid = `<{ $componentType }>` sín ví lɛ́ má sɔgbe ǎ: È mɔ ví e má sɔgbe ǎ lɛ́ é: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Nǔ `{ $value }` má sɔgbe ǎ nú attribute `{ $attribute }`, è zán `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] È má mɔ DoenetML alɔkpa { $version } ǎ.
+       *[other] È má mɔ DoenetML alɔkpa { $version } ǎ. È ná zán alɔkpa { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML má sɔgbe ǎ: { $content }
+
+parse-tag-missing-close-tag = DoenetML má sɔgbe ǎ: Tag `{ $tag }` ɖó tag sisú ǎ. È ɖó nukún tag e nɔ sú éɖée é alǒ tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML má sɔgbe ǎ: Nùwaɖókpɔ́ ɖò tag `<{ $tagName }>` mɛ
+
+parse-attribute-missing-value = DoenetML má sɔgbe ǎ: Attribute `{ $attribute }` má sɔgbe ǎ, é cí ɖɔ é ɖó nǔ ɖé ǎ ɖɔhun.
+
+parse-attribute-invalid = DoenetML má sɔgbe ǎ: Attribute `{ $attribute }` má sɔgbe ǎ
+
+parse-attribute-value-invalid = DoenetML má sɔgbe ǎ: Attribute sín nǔ `{ $value }` má sɔgbe ǎ
+
+parse-attribute-value-quote-mismatch = DoenetML má sɔgbe ǎ: Attribute sín nǔ `{ $value }` má sɔgbe ǎ. Xóɖiɖɔ sín wlɛ́n lɛ́ má sɔgbe ǎ. É cí ɖɔ `{ $quote }` ɖé hwedó ɖɔhun
+
+parse-open-tag-name-missing = DoenetML má sɔgbe ǎ: È mɔ tag e ɖó nyikɔ́ ǎ é, ɖi `<`
+
+parse-tag-not-closed = DoenetML má sɔgbe ǎ: È má sú tag `{ $tag }` ǎ (é cí ɖɔ `>` hwedó ɖɔhun).
+
+parse-self-closing-tag-name-missing = DoenetML má sɔgbe ǎ: È mɔ tag e ɖó nyikɔ́ ǎ é `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML má sɔgbe ǎ: È má sú tag `{ $tag }` ǎ (é cí ɖɔ `/>` hwedó ɖɔhun).
+
+parse-tag-invalid-attributes = DoenetML má sɔgbe ǎ: Tag `{ $tag }` má sɔgbe ǎ. É sixú ɖó attribute e má sɔgbe ǎ lɛ́ é.
+
+parse-close-tag-name-missing = DoenetML má sɔgbe ǎ: È mɔ tag sisú e ɖó nyikɔ́ ǎ é, ɖi `</`
+
+parse-attribute-value-unquoted = Attribute sín nǔ lɛ́ ɖó ná ɖò xóɖiɖɔ sín wlɛ́n mɛ: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML má sɔgbe ǎ: È mɔ tag sisú `{ $tag }`, amɔ̌ tag hùnhún ɖé má ɖè ǎ
+
+parse-close-tag-mismatched = DoenetML má sɔgbe ǎ: Tag sisú má sɔgbe ǎ. È ɖó nukún `</{ $expected }>`. È mɔ `{ $found }`
+
+parser-node-unconvertible = È má sixú ɖyɔ́ node { $node } dó Dast sín node ǎ.
+
+## Names
+
+name-attribute-invalid =
+    Nyikɔ́ name='{ $name }' má sɔgbe ǎ. { $reason ->
+        [characters] Nyikɔ́ lɛ́ sixú ɖó wékwín, kɛ́n, dodólin dò tɔ̀n alǒ dodólin géé.
+       *[start] Nyikɔ́ lɛ́ ɖó ná bɛ́ kpó wékwín kpó.
+    }
+
+component-name-invalid-start = Nǔ sín nyikɔ́ "{ $name }" má sɔgbe ǎ. Nyikɔ́ lɛ́ ɖó ná bɛ́ kpó wékwín kpó.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer type videoWatched tɔ̀n ɖó ná ɖó attribute video
+
+answer-video-watched-video-not-reference = Answer type videoWatched tɔ̀n ɖó ná ɖó attribute video e nyí zɔnlin é
+
+answer-name-not-single-text = Answer sín attribute name ɖó ná ɖó text ví ɖokpo géé
+
+## Referencing another document
+
+external-doenetml-recursion-limit = È má sixú mɔ DoenetML tɔ́n tɔ̀n ǎ ɖó vivɔ́ dín. Zɔnlin lɛ̌lɛ̌ tɔ̀n ɖé ɖè à?
+
+external-doenetml-unavailable = È má sixú mɔ DoenetML sín { $attribute }="{ $uri }" ǎ
+
+external-doenetml-type-mismatch = DoenetML e è mɔ sín { $attribute }="{ $uri }" é má sɔgbe ǎ: é má sɔgbe kpó nǔ alɔkpa "{ $componentType }" kpó ǎ
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] È jó attribute `{ $from }` dó; zán `{ $to }`.
+       *[other] [deprecation] È jó attribute `{ $from }` e ɖò `<{ $component }>` jí é dó; zán `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] È jó attribute `{ $from }` dó bo jó é dó ɖó è ɖɔ `{ $to }` lɔ.
+       *[other] [deprecation] È jó attribute `{ $from }` e ɖò `<{ $component }>` jí é dó bo jó é dó ɖó è ɖɔ `{ $to }` lɔ.
+    }
+
+deprecated-attribute-ignored = [deprecation] È jó attribute `{ $attribute }` e ɖò `<{ $component }>` jí é dó bo jó é dó.
+
+deprecated-attribute-to-child = [deprecation] È jó attribute `{ $attribute }` e ɖò `<{ $component }>` jí é dó; zán `<{ $child }>` ví ɖé.
+
+deprecated-attribute-value-renamed = [deprecation] È jó nǔ `{ $value }` attribute `{ $attribute }` tɔ̀n e ɖò `<{ $component }>` jí é dó; zán `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` sixú bló Glɛnsigbe géé sín gègě, énɛ́ wú ɔ́ é jó xógbe tɔ́n dó ɖò wema e è wlan ɖò { $locale } mɛ é mɛ. Wlan gègě sín xógbe ɔ́ tlolo, alǒ sɔ́ ɛ kpó attribute `pluralForm` kpó.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Nǔ `<{ $tag }>` má nyí Doenet sín nǔ e è tuùn é ǎ.
+
+schema-element-not-allowed-at-root = È má yí gbè nú nǔ `<{ $tag }>` ɖò wema ɔ́ tá ǎ.
+
+schema-element-not-allowed-inside = È má yí gbè nú nǔ `<{ $tag }>` ɖò `<{ $parent }>` mɛ ǎ.
+
+schema-attribute-unrecognized = Nǔ `<{ $tag }>` má ɖó attribute e nɔ nyí `{ $attribute }` é ǎ.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Nǔ `<{ $tag }>` sín attribute `{ $attribute }` ɖó ná nyí kplékplé ɖé bɔ nǔ tɔ́n ɖokpo ɖokpo ɖó ná nyí ɖokpo ɖò yě mɛ: { $allowed }
+       *[other] Nǔ `<{ $tag }>` sín attribute `{ $attribute }` ɖó ná nyí ɖokpo ɖò yě mɛ: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select sín alɔkpa nyikɔ́ má sɔgbe ǎ.  Alɔkpa nyikɔ́ { $variantName } tɔ́n ɖò option { $numOptions } mɛ amɔ̌ kɛ́n e è ná cyán é nyí { $numToSelect }.
+
+select-variant-name-without-options = È ɖɔ alɔkpa ɖé lɛ́ nú select amɔ̌ è má ɖɔ option ɖé nú alɔkpa nyikɔ́ e sixú ɖè é ǎ: { $variantName }.
+
+select-variant-name-not-possible = Alɔkpa nyikɔ́ { $variantName } e è ɖɔ nú select é má nyí alɔkpa nyikɔ́ e sixú ɖè é ǎ.
+
+select-too-few-options = È má sixú cyán nǔ { $numToSelect } ɖò { $numOptions } géé mɛ ǎ.
+
+select-from-sequence-too-few-values = È má sixú cyán nǔ { $numToSelect } ɖò sequence e sín gaga nyí { $length } é mɛ ǎ.
+
+select-from-sequence-indices-count-mismatch = Indices e è ɖɔ nú select lɛ́ é sín kɛ́n ɖó ná sɔgbe kpó kɛ́n e è ná cyán é kpó
+
+select-from-sequence-indices-not-integers = Indices e è ɖɔ nú select lɛ́ é bǐ ɖó ná nyí kɛ́n blebu
+
+select-from-sequence-index-excluded = È ɖɔ selectfromsequence sín index e è ɖè sín mɛ é
+
+select-from-sequence-indices-excluded-combination = È ɖɔ selectfromsequence sín indices e nyí kplékplé e è ɖè sín mɛ é
+
+select-from-sequence-coprime-not-positive-integers = È má sixú cyán coprime kplékplé lɛ́ ǎ ɖó è má ɖò kɛ́n blebu e hú 0 lɛ́ é cyán wɛ ǎ.
+
+select-from-sequence-coprime-common-factor = È má sixú cyán coprime kɛ́n lɛ́ ǎ. Kɛ́n e sixú ɖè lɛ́ é bǐ ɖó facteur ɖokpo. ("from" alǒ "to" sín nǔ e è ɖɔ é ɖó ná nyí coprime kpó "step" kpó.)
+
+select-from-sequence-coprime-single-number = È má sixú cyán coprime kplékplé sín kɛ́n ɖokpo géé e má nyí 1 ǎ é mɛ ǎ.
+
+select-from-sequence-excluded-too-many-combinations = È ɖè kplékplé lɛ́ 70% jɛ nukɔ́n sín selectFromSequence mɛ
+
+select-from-sequence-coprime-none-found = È má sixú cyán coprime kɛ́n lɛ́ ǎ. Kɛ́n e sixú ɖè lɛ́ é bǐ ɖó facteur ɖokpo.
+
+select-from-sequence-too-few-unique-values = È má sixú cyán nǔ vovo { $numToSelect } ɖò sequence e sín gaga nyí { $numPossibleValues } é mɛ ǎ
+
+select-prime-numbers-too-few-values = È má sixú cyán nǔ { $numToSelect } ɖò prime kɛ́n kplékplé e sín gaga nyí { $numValues } é mɛ ǎ
+
+select-prime-numbers-values-count-mismatch = Nǔ e è ɖɔ nú select lɛ́ é sín kɛ́n ɖó ná sɔgbe kpó kɛ́n e è ná cyán é kpó
+
+select-prime-numbers-values-not-prime = Nǔ e è ɖɔ nú select prime number lɛ́ é bǐ ɖó ná ɖò prime kɛ́n kplékplé ɔ́ mɛ
+
+select-prime-numbers-values-excluded-combination = È ɖɔ selectPrimeNumbers sín nǔ e nyí kplékplé e è ɖè sín mɛ é
+
+select-prime-numbers-excluded-too-many-combinations = È ɖè kplékplé lɛ́ 70% jɛ nukɔ́n sín selectPrimeNumbers mɛ
+
+select-random-combination-fluke = Gbɔn nǔ e má nɔ jɛ ǎ é gblamɛ, è má sixú cyán kɛ́n mɛɖéesúsú tɔ̀n lɛ́ sín kplékplé ǎ
+
+select-random-value-fluke = Gbɔn nǔ e má nɔ jɛ ǎ é gblamɛ, è má sixú cyán kɛ́n mɛɖéesúsú tɔ̀n ɖé ǎ

--- a/packages/i18n/locales/fon/diagnostics.ftl
+++ b/packages/i18n/locales/fon/diagnostics.ftl
@@ -27,9 +27,9 @@ line-segment-midpoint-offset-without-midpoint = midpointOffset má nɔ w'azɔ̌ 
 
 ## `<line>`
 
-line-points-undetermined-dimensions = Dlɛ̌n gbɔn tɛ́n e sín ɖaxó è má tuùn ǎ lɛ́ é jí.
+line-points-undetermined-dimensions = Dlɛ̌n gbɔn tɛ́n e sín dimension è má tuùn ǎ lɛ́ é jí.
 
-line-points-too-few-dimensions = Dlɛ̌n ɖó ná gbɔn tɛ́n e ɖó ɖaxó wè ɖibla lɛ́ é jí.
+line-points-too-few-dimensions = Dlɛ̌n ɖó ná gbɔn tɛ́n e ɖó dimension wè ɖibla lɛ́ é jí.
 
 line-points-depend-on-variables = Dlɛ̌n gbɔn tɛ́n e ɖò nǔɖyɔ́ lɛ́ sí lɛ́ é jí: { $variables }.
 
@@ -161,11 +161,11 @@ circle-change-center-non-numerical = È má ko bló lɛ̌lɛ̌ sín tɛntin ɖi�
 
 function-domain-insufficient-dimensions =
     { $intervals ->
-        [one] Ðaxó má kpé nú fonction sín domain ǎ. Domain ɖó hwenu { $intervals } amɔ̌ fonction ɔ́ ɖó { $inputs ->
+        [one] Dimension má kpé nú fonction sín domain ǎ. Domain ɖó intervalle { $intervals } amɔ̌ fonction ɔ́ ɖó { $inputs ->
             [one] input { $inputs }
            *[other] input { $inputs }
         }.
-       *[other] Ðaxó má kpé nú fonction sín domain ǎ. Domain ɖó hwenu { $intervals } amɔ̌ fonction ɔ́ ɖó { $inputs ->
+       *[other] Dimension má kpé nú fonction sín domain ǎ. Domain ɖó intervalle { $intervals } amɔ̌ fonction ɔ́ ɖó { $inputs ->
             [one] input { $inputs }
            *[other] input { $inputs }
         }.
@@ -492,8 +492,8 @@ attribute-value-invalid-using-default = Nǔ `{ $value }` má sɔgbe ǎ nú attri
 
 doenetml-version-not-found =
     { $fallback ->
-        [none] È má mɔ DoenetML alɔkpa { $version } ǎ.
-       *[other] È má mɔ DoenetML alɔkpa { $version } ǎ. È ná zán alɔkpa { $fallback }
+        [none] È má mɔ DoenetML version { $version } ǎ.
+       *[other] È má mɔ DoenetML version { $version } ǎ. È ná zán version { $fallback }
     }
 
 ## Reading the DoenetML

--- a/packages/i18n/locales/fon/editor.ftl
+++ b/packages/i18n/locales/fon/editor.ftl
@@ -1,0 +1,208 @@
+# Fon editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Lɛ́ Bló
+       *[update] Vɔ́ Bló
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Wemakpɔ́ntɔ́
+       *[other] { $word } Wemakpɔ́ntɔ́ { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Alɔkpa
+
+editor-variant-filter = Ba…
+
+editor-variant-next = Cyán alɔkpa e bɔ dó é
+
+editor-variant-previous = Cyán alɔkpa e jɛ nukɔ́n é
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] È mɔ gbigbà WCAG AA tɔ̀n. Zin bo { $action ->
+            [close] sú
+           *[open] hun
+        } wema sisɛkpɔ́ tɔ̀n ɔ́.
+        [advisories] Zin bo { $action ->
+            [close] sú
+           *[open] hun
+        } wema sisɛkpɔ́ tɔ̀n ɔ́. È mɔ gbigbà WCAG AA tɔ̀n ɖé ǎ, amɔ̌ wěɖexámɛ sisɛkpɔ́ tɔ̀n ɖěvo lɛ́ ɖè.
+       *[clean] Zin bo { $action ->
+            [close] sú
+           *[open] hun
+        } wema sisɛkpɔ́ tɔ̀n ɔ́. È mɔ tagba sisɛkpɔ́ tɔ̀n ɖé ǎ.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] È mɔ gbigbà WCAG AA tɔ̀n. È mɔ { $count ->
+            [one] gbigbà WCAG AA tɔ̀n { $count }
+           *[other] gbigbà WCAG AA tɔ̀n { $count }
+        }. Zin bo { $action ->
+            [close] sú
+           *[open] hun
+        } wema sisɛkpɔ́ tɔ̀n ɔ́.
+        [advisories] È mɔ gbigbà WCAG AA tɔ̀n ɖé ǎ. È mɔ { $count ->
+            [one] wěɖexámɛ sisɛkpɔ́ tɔ̀n ɖěvo { $count }
+           *[other] wěɖexámɛ sisɛkpɔ́ tɔ̀n ɖěvo { $count }
+        }. Zin bo { $action ->
+            [close] sú
+           *[open] hun
+        } wema sisɛkpɔ́ tɔ̀n ɔ́.
+       *[clean] È mɔ gbigbà WCAG AA tɔ̀n ɖé ǎ. Zin bo { $action ->
+            [close] sú
+           *[open] hun
+        } wema sisɛkpɔ́ tɔ̀n ɔ́.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML alɔkpa { $version }
+
+editor-tab-help = Alɔdo tɛnmɛ tɔ̀n
+editor-tab-help-short = Tɛnmɛ
+editor-tab-errors = Nùwaɖókpɔ́ lɛ́
+editor-tab-warnings = Gbeɖiɖe lɛ́
+editor-tab-info = Nǔmɔnú
+editor-tab-accessibility = Sisɛkpɔ́
+editor-tab-responses = Xósin e è sɛ́dó lɛ́
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Wlantɔ́ sín nǔcyán lɛ́
+editor-format-as-doenetml = Bló ɖi DoenetML
+editor-format-as-xml = Bló ɖi XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Línu #{ $line }
+
+editor-no-errors = Nùwaɖókpɔ́ Ðé Ǎ
+editor-no-warnings = Gbeɖiɖe Ðé Ǎ
+editor-no-info = Nǔmɔnú Ðé Ǎ
+
+editor-show-info-annotations = Ðè nǔmɔnú lɛ́ xlɛ́ ɖò wlantɔ́ mɛ
+editor-show-accessibility-annotations = Ðè tagba sisɛkpɔ́ tɔ̀n lɛ́ xlɛ́ ɖò wlantɔ́ mɛ
+
+editor-accessibility-learn-more = Kplɔ́n lě Doenet nɔ kpé nukún dó sisɛkpɔ́ wú gbɔn é
+
+editor-accessibility-violations-heading = Gbigbà sisɛkpɔ́ tɔ̀n lɛ́ ({ $standard })
+
+editor-accessibility-other-heading = Tagba sisɛkpɔ́ tɔ̀n ɖěvo lɛ́
+editor-none-found = È mɔ ɖé ǎ
+
+
+## Submitted responses
+
+editor-no-responses = È sɛ́ xósin ɖé dó kpɔ́n ǎ
+editor-response-answer-id = Xósin sín nyikɔ́
+editor-response-response = Xósin
+editor-response-credit = Kɛ́ndɛ́
+editor-response-submitted = È sɛ́dó
+
+
+## The context-help panel
+
+help-placeholder = Sɔ́ nùwlanwlantɛn ɔ́ dó tag sín nyikɔ́, attribute, alǒ { $ref } jí bo mɔ wěɖexámɛ.
+
+help-unsupported-ref-chain = È má ko bló alɔdo nú akpáxwé gègě sín zɔnlin ɖi { $example } ǎ.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] È mɔ nǔ ɖé nú { $ref } ǎ.
+        [multiple] È mɔ nǔ gègě nú { $ref }.
+       *[indeterminate] È má sixú tuùn nǔ e { $ref } ɖɔ́ é ǎ.
+    }
+
+help-learn-about-references = Kplɔ́n nǔ dó zɔnlin lɛ́ wú →
+help-reference-page = Wexwɛ wěɖexámɛ tɔ̀n →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ðò { $element } mɛ
+       *[top] Ðò wema ɔ́ tá
+    }{ $allowed ->
+        [none] { " — nǔ ɖé má yì fí ǎ." }
+        [text] { " — wlan xógbe ɖò fí." }
+        [text-and-components] { " — wlan xógbe ɖò fí, alǒ tɛ́n kpɔ́n:" }
+       *[components] { " — nǔ e è sixú tɛ́n kpɔ́n lɛ́ é:" }
+    }
+
+help-suggestions-footer = Zin { $shortcut } bo kpɔ́n nǔ { $total } lɛ́ bǐ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } nyí zɔnlin ɖé yì { $target }.
+       *[other] { $ref } nyí zɔnlin ɖé yì { $target } (línu { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } sɔ́ ɛ dó ɖi { $role }.
+       *[other] { $owner } sɔ́ ɛ dó ɖò línu { $line } jí ɖi { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } nyí zɔnlin ɖé yì akpáxwé { $property } { $element } tɔ̀n.
+       *[other] { $ref } nyí zɔnlin ɖé yì akpáxwé { $property } { $element } tɔ̀n (línu { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = akpáxwé
+help-kind-array-entry = akpáxwé array tɔ̀n
+
+help-default = Nǔ e ɖ'ayǐ é:
+help-active-default = Nǔ e ɖ'ayǐ bo ɖò azɔ̌ wà wɛ é:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Nǔ e è yí gbè ná lɛ́ é (ɖokpo nú nǔ ɖokpo):
+       *[other] Nǔ e è yí gbè ná lɛ́ é:
+    }
+
+help-suggested-values = Nǔ e è ɖè xlɛ́ lɛ́ é:
+
+help-inserts = É nɔ sɔ́ dó:
+
+help-coordinates =
+    { $count ->
+        [one] Tɛnmɛ:
+       *[other] Tɛnmɛ lɛ́:
+    }
+
+help-type = Alɔkpa:
+
+help-resolved-style = Alɔkpa e è mɔ é (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fonction sín nyikɔ́ e è mɔ lɛ́ é:
+help-reset-list = Lɛ́ bló kplékplé ɔ́ ɖò input élɔ́ jí:
+help-added-on-input = È sɔ́ dó ɖò input élɔ́ jí:
+help-removed-on-input = È ɖè sín mɛ ɖò input élɔ́ jí:
+
+help-reset-overrides = { $reset } nɔ ɖu { $additional } kpó { $removed } kpó jí.

--- a/packages/i18n/locales/fon/editor.ftl
+++ b/packages/i18n/locales/fon/editor.ftl
@@ -77,7 +77,7 @@ editor-accessibility-badge = WCAG
 
 ## The footer
 
-editor-version-title = DoenetML alɔkpa { $version }
+editor-version-title = DoenetML version { $version }
 
 editor-tab-help = Alɔdo tɛnmɛ tɔ̀n
 editor-tab-help-short = Tɛnmɛ

--- a/packages/i18n/locales/kbp/chrome.ftl
+++ b/packages/i18n/locales/kbp/chrome.ftl
@@ -1,0 +1,134 @@
+# Kabiyè viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the class-suffix table, for how it sits
+# against the other two Gur catalogs and against `locales/kg`, and for what a
+# speaker should check first.
+
+
+## Answer submission
+
+answer-checking = Pɩmaɣzɩɣ…
+answer-submitting = Pɩtiyiɣ…
+
+answer-checking-status = Pɛwɛɛ pamaɣzɩɣ cosuu
+answer-submitting-status = Pɛwɛɛ patiyiɣ cosuu
+
+answer-correct = Pɩtʋʋ fɛyɩ
+answer-incorrect = Pɩtɩtʋʋzɩ
+
+answer-response-saved = Pasɩɣ Cosuu
+
+answer-percent-credit = { $percent }% Kɩɖɛʋ
+answer-percent-correct = { $percent }% Pɩtʋʋ fɛyɩ
+answer-percent-short = { $percent } %
+
+max-credit-available = Kɩɖɛʋ sɔsɔʋ ŋgʋ ŋpɩzɩɣ ŋhiɣ yɔ: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] maɣzʋʋ natʋyʋ tɩkazɩ
+        [one] maɣzʋʋ { $count } kazɩ
+       *[other] maɣzʋʋ { $count } kazɩ
+    }
+
+validation-correct = (Pɩtʋʋ fɛyɩ)
+validation-incorrect = (Pɩtɩtʋʋzɩ)
+validation-partially-correct = (Pɩtʋʋ fɛyɩ pazɩ)
+
+answer-show-responses =
+    { $count ->
+        [one] Wɩlɩ cosuu { $count } ŋgʋ kɩwɛ { $answerId } taa yɔ
+       *[other] Wɩlɩ cosuu { $count } weyi ɩwɛ { $answerId } taa yɔ
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Cosuu
+
+collapsible-click-to-open = (mabɩ nɛ kɩtʋlɩ)
+collapsible-click-to-close = (mabɩ nɛ kɩtɔlɩ)
+
+collapsible-initializing = Pɩpaɣzɩɣ…
+
+footnote-show = Wɩlɩ tɛɛ takayaɣ
+footnote-hide = Mɛsɩ tɛɛ takayaɣ
+
+description-more-information = tɔm lɛɛtʋ
+
+
+## Controls
+
+slider-previous = Ŋgʋ kɩɖɛwa yɔ
+slider-next = Ŋgʋ kɩkɔŋ yɔ
+
+keyboard-open = Tʋlɩ Klaviye
+keyboard-close = Tɔlɩ Klaviye
+
+choice-input-remove-choice = Lɩzɩ { $choice }
+
+matrix-remove-row = Lɩzɩ ñɔʋ
+matrix-add-row = Sʋsɩ ñɔʋ
+matrix-remove-column = Lɩzɩ kolonjɩ
+matrix-add-column = Sʋsɩ kolonjɩ
+
+subset-add-remove-points = Sʋsɩ/Lɩzɩ yʋsasɩ
+subset-toggle-points-intervals = Lɛɣzɩ yʋsasɩ nɛ alɩwaatɩŋ
+subset-move-points = Ñɔɔzɩ Yʋsasɩ
+subset-clear = Hɩzɩ
+
+orbital-add-row = Sʋsɩ Ñɔʋ
+orbital-remove-row = Lɩzɩ Ñɔʋ
+orbital-add-box = Sʋsɩ Aɖakaɣ
+orbital-remove-box = Lɩzɩ Aɖakaɣ
+orbital-add-up-arrow = Sʋsɩ Yʋsaɣ Ŋga Kɩwɛɛ Ɖoo Yɔ
+orbital-add-down-arrow = Sʋsɩ Yʋsaɣ Ŋga Kɩwɛɛ Tɛɛ Yɔ
+orbital-remove-arrow = Lɩzɩ Yʋsaɣ
+
+orbital-row-label = Ñɔʋ { $row } hɩɖɛ
+
+pretzel-answer = Cosuu
+
+summary-statistics-caption = { $column } ñʋʋ taa kɩɖaŋ
+
+
+## Math input
+
+math-input-preview-region = maɣzɩm tɔm kɩcalʋʋ naʋ
+math-input-preview = Naʋ kɩcalʋʋ
+math-input-invalid-expression = Tɔm kɩdɛkɛdɩtʋ:
+
+
+## Document status
+
+viewer-initializing = Pɩpaɣzɩɣ…
+
+
+## Errors
+
+error-heading = Kɩwɛɛkɩm
+
+error-found-at =
+    { $span ->
+        [line] Panawa ñɔʋ { $startLine } yɔɔ.
+       *[lines] Panawa ñɔŋ { $startLine }–{ $endLine } yɔɔ.
+    }
+
+document-contains-errors = Takayaɣ kanɛ kɛwɛnɩ kɩwɛɛkɩm!
+
+diagnostic-heading-error = Kɩwɛɛkɩm
+diagnostic-heading-warning = Paɣtʋ
+diagnostic-heading-information = Tɔm
+diagnostic-heading-hint = Sɩnʋʋ
+
+accessibility-heading-level-1 = WCAG AA Talʋʋ Paɣtʋ Yɔɔ Maʋ
+accessibility-heading-level-2 = Talʋʋ paɣtʋ
+
+something-went-wrong = Nabʋyʋ tɩɖɔ camɩyɛ.
+
+renderer-load-failed = wɩlɩyʋ nɔɔyʋ tɩkɔɔ. Ɖɩwakɩ-ŋ nɛ ŋtasɩ hɔɔlʋʋ ñʋʋ tʋlʋʋ.
+
+core-start-failed = Takayaɣ wɩlɩyʋ tɩpɩzɩ nɛ ɛpaɣzɩ. Ɖɩwakɩ-ŋ nɛ ŋtasɩ hɔɔlʋʋ ñʋʋ tʋlʋʋ.

--- a/packages/i18n/locales/kbp/content.ftl
+++ b/packages/i18n/locales/kbp/content.ftl
@@ -45,7 +45,7 @@
 
 ## Style vocabulary
 
-# The last nine attributes are French loans. A loan joins class 1 and does not
+# The last eight attributes are French loans. A loan joins class 1 and does not
 # take the suffix, so it is written bare — which is what makes the seam between
 # the four Kabiyè stems and the rest of this message visible at a glance, the
 # way `locales/fon` makes its own seam visible.

--- a/packages/i18n/locales/kbp/content.ftl
+++ b/packages/i18n/locales/kbp/content.ftl
@@ -1,0 +1,356 @@
+# Kabiyè content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `kbp` is Kabiyè, a Gur language of northern Togo and the country's second
+# national language beside Ewe. It is the third Gur catalog here, after
+# `locales/mos` (Mooré) and `locales/dag` (Dagbani), both seeded in #1685.
+#
+# **`$gender` is a noun class spelled as a suffix, which is what the Gur
+# catalogs already established — but the count is different and that is the
+# point.** Mooré answers with four classes and Dagbani with three; Kabiyè
+# answers with five, and it puts the describing word's class suffix in the same
+# slot the noun's own suffix occupies:
+#
+#            c1 (-ʋ)     c2 (-tʋ)    c3 (-ɖɛ)    c4 (-a)     c5 (-m)
+#   kɩkpɛd-   kɩkpɛdʋ     kɩkpɛdɩtʋ   kɩkpɛdɩɖɛ   kɩkpɛda     kɩkpɛdɩm
+#   kɩhʋlʋm-  kɩhʋlʋmʋ    kɩhʋlʋmɩtʋ  kɩhʋlʋmɩɖɛ  kɩhʋlʋma    kɩhʋlʋmɩm
+#
+# So the whole of the agreement is one final morph, as it is in `locales/mos`
+# and `locales/dag`. Held against `locales/kg`, seeded in the same batch, the
+# two are the same fact from opposite ends: Kongo factors its agreement into a
+# linker syllable *in front of* an invariant stem, Kabiyè into a suffix *behind*
+# one, and `locales/tiv` writes it as a separate word between the two. Three
+# positions, one argument, no change to anything outside these files.
+#
+# **The affix rule bites here and the way out is the third one the README
+# lists.** A class suffix cannot be welded to a placeable, so a message whose
+# describing word would have to inflect an argument is not written that way.
+# Every `$gender` fork in this file is over whole words the catalog owns, and
+# the fill patterns and the mathematical nouns — which the catalog does not
+# inflect — are kept out of any position that would demand one.
+#
+# `$role` goes unused: Kabiyè marks no case.
+#
+# ICU has no name for `kbp`, so the roster would label it "kbp" without an
+# entry in `LOCALE_NAME_FALLBACKS`; see `scripts/catalogUtils.ts`. It is the
+# fifth locale in the repository to need one.
+#
+# The geometry leans on the French loans Togolese schooling supplies; where
+# Kabiyè has its own word it is used — «ɖenɖe» a place, «yʋsaɣ» a mark. They
+# are the first thing to check.
+
+
+## Style vocabulary
+
+# The last nine attributes are French loans. A loan joins class 1 and does not
+# take the suffix, so it is written bare — which is what makes the seam between
+# the four Kabiyè stems and the rest of this message visible at a glance, the
+# way `locales/fon` makes its own seam visible.
+#
+# A comment cannot go inside the message beside the attribute it describes:
+# an indented comment line is part of the pattern and renders as a newline,
+# which `lint:i18n` rejects.
+color =
+    .black =
+        { $gender ->
+            [c2] kɩkpɛdɩtʋ
+            [c3] kɩkpɛdɩɖɛ
+            [c4] kɩkpɛda
+            [c5] kɩkpɛdɩm
+           *[c1] kɩkpɛdʋ
+        }
+    .white =
+        { $gender ->
+            [c2] kɩhʋlʋmɩtʋ
+            [c3] kɩhʋlʋmɩɖɛ
+            [c4] kɩhʋlʋma
+            [c5] kɩhʋlʋmɩm
+           *[c1] kɩhʋlʋmʋ
+        }
+    .gray =
+        { $gender ->
+            [c2] kɩñɔʋtʋ
+            [c3] kɩñɔʋɖɛ
+            [c4] kɩñɔʋa
+            [c5] kɩñɔʋm
+           *[c1] kɩñɔʋʋ
+        }
+    .red =
+        { $gender ->
+            [c2] kɩsɛmɩtʋ
+            [c3] kɩsɛmɩɖɛ
+            [c4] kɩsɛma
+            [c5] kɩsɛmɩm
+           *[c1] kɩsɛmʋ
+        }
+    .orange = orangɩ
+    .yellow = jonɩ
+    .green = vɛrɩ
+    .cyan = siyaŋ
+    .blue = blɛɛ
+    .purple = violɛɛ
+    .pink = rozɩ
+    .brown = maroŋ
+
+line-width =
+    .thick =
+        { $gender ->
+            [c2] sɔsɔtʋ
+            [c3] sɔsɔɖɛ
+            [c4] sɔsɔa
+            [c5] sɔsɔm
+           *[c1] sɔsɔʋ
+        }
+    .thin =
+        { $gender ->
+            [c2] pɩŋɩtʋ
+            [c3] pɩŋɩɖɛ
+            [c4] pɩŋa
+            [c5] pɩŋɩm
+           *[c1] pɩŋʋ
+        }
+
+# Written as «nɛ …» phrases rather than as class-marked qualifiers, so that
+# they take no suffix and can close the description. `style-stroke` puts them
+# last.
+line-style =
+    .dashed = nɛ hɔɔlɩŋ cikpeŋ
+    .dotted = nɛ yʋsasɩ
+
+fill-style =
+    .horizontal = ñɔsɩ nzɩ sɩhɩnɩ yɔ
+    .vertical = ñɔsɩ nzɩ sɩsɩŋ yɔ
+    .diagonal = ñɔsɩ nzɩ sɩlɩɣ hɔɔlʋʋ yɔ
+    .backdiagonal = ñɔsɩ nzɩ sɩlɩɣ hɔɔlʋʋ lɛɛkʋ yɔ
+    .dots = yʋsasɩ
+    .diamonds = diyamaanɩwaa
+
+noun =
+    .line = ñɔʋ
+    .line-segment = ñɔʋ hɔɔlʋʋ
+    .ray = mintʋsʋʋ
+    .vector = vɛktɛɛrɩ
+    .curve = ñɔʋ ŋgʋ kɩpɩsɩɣ yɔ
+    .function = fɔŋksɩyɔŋ
+    .parabola = parabolɩ
+    .polyline = ñɔʋ hɔɔlɩŋ sakɩyɛ
+    .polygon = poligɔnɩ
+    .triangle = tirisaŋgɩlɩ
+    .rectangle = rɛktaŋgɩlɩ
+    .circle = kpelaɣ
+    .region = ɖenɖe
+    .point = yʋsaɣ
+    .square = kaaree
+    .diamond = diyamaanɩ
+    .cross = sɩŋgɩyɛ
+    .plus = plisɩ yʋsaɣ
+
+# The side count is a relative clause and closes the noun phrase behind the
+# describing words, so it goes in the tail — which is also what keeps a class
+# suffix from ever needing to land on `{ $numSides }`.
+noun-regular-polygon =
+    { $part ->
+        [tail] ŋgʋ kɩwɛnɩ hɔɔlɩŋ { $numSides } yɔ
+       *[head] poligɔnɩ kɩmaɣzaɣ
+    }
+
+# The noun class. `c1` is the default and the class a French loan joins, which
+# is what an author's own `markerStyleWord` is as far as this catalog is
+# concerned.
+noun-gender =
+    { $noun ->
+        [line-segment] c2
+        [region] c2
+        [text] c2
+        [polygon] c3
+        [regular-polygon] c3
+        [triangle] c3
+        [rectangle] c3
+        [square] c3
+        [circle] c3
+        [point] c4
+        [cross] c4
+        [plus] c4
+        [fill] c5
+        [background] c5
+       *[other] c1
+    }
+
+
+## Style composition
+
+# The dash pattern is a «nɛ …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c2] sʋʋtʋ
+        [c3] sʋʋɖɛ
+        [c4] sʋʋa
+        [c5] sʋʋm
+       *[c1] sʋʋʋ
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } nɛ { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } nɛ { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } nɛ { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «kamaɣ» is the border and leads its own describing words, so they agree with
+# it rather than with the shape it surrounds — which is why `border` answers
+# `c1` in `noun-gender`. Kabiyè has no article and joins this clause with the
+# invariable «nɛ», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] nɛ kamaɣ { $border }
+        [and] nɛ kamaɣ { $border }
+        [and-article] nɛ kamaɣ { $border }
+       *[with] nɛ kamaɣ { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ɛtɩsʋʋ
+
+style-text =
+    { $parts ->
+        [background] { $color } nɛ wayɩ { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = pʋyʋ nabʋyʋ fɛyɩ
+
+
+## Boolean words
+
+boolean-true = toovenim
+boolean-false = cɛtɩm
+
+
+## Answer buttons
+
+answer-submit-label = Maɣzɩ Tʋmɩyɛ
+answer-submit-label-no-correctness = Tiyi Cosuu
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Tʋmɩyɛ
+    .aside = Tɔm lɛɛtʋ
+    .cascade = Kaskaadɩ
+    .definition = Tɔbʋʋ
+    .example = Kɩɖaʋ
+    .exercise = Nʋmɔʋ
+    .exercises = Nʋmɔŋ
+    .given-answer = Cosuu
+    .note = Takayaɣ
+    .objectives = Kaɖʋsɩ
+    .paragraphs = Hɔɔlɩŋ
+    .part = Hɔɔlʋʋ
+    .problem = Kʋñɔŋ
+    .problems = Kʋñɔmɩŋ
+    .proof = Aseɣɖe
+    .question = Tɔm pɔzʋʋ
+    .section = Hɔɔlʋʋ
+    .solution = Nʋmɔʋ kɩbaŋʋ
+    .task = Tʋmɩyɛ
+    .theorem = Teyorɛm
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Sɩnʋʋ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tablo { $enumeration }
+        [numbered-title] Tablo { $enumeration }{ ": " }
+        [unnumbered-title] Tablo{ ": " }
+       *[unnumbered] Tablo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Kɩlɛmʋʋ { $enumeration }
+        [numbered-caption] Kɩlɛmʋʋ { $enumeration }{ ": " }
+        [unnumbered-caption] Kɩlɛmʋʋ{ ": " }
+       *[unnumbered] Kɩlɛmʋʋ
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ŋgʋ kɩɖɛwa yɔ
+paginator-next = Ŋgʋ kɩkɔŋ yɔ
+
+paginator-page = Hɔɔlʋʋ
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = yaa
+
+piecewise-condition-if = ye
+
+piecewise-condition-otherwise = alɩwaatʋ lɛɛtʋ tɩŋa taa
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case. Togo teaches secondary science in French, so a
+## Kabiyè speaker meets the periodic table there and neither Kabiyè nor English
+## is the curriculum. `locales/ee` and `locales/fon` leave the same gap for the
+## same reason.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Siimii Yʋsaɣ Kɩdɛkɛdɩɣ
+chemistry-invalid-ionic-compound = Iyɔŋ Kpɛndʋʋ Kɩdɛkɛdɩɣ

--- a/packages/i18n/locales/kbp/content.ftl
+++ b/packages/i18n/locales/kbp/content.ftl
@@ -159,7 +159,9 @@ noun-regular-polygon =
 
 # The noun class. `c1` is the default and the class a French loan joins, which
 # is what an author's own `markerStyleWord` is as far as this catalog is
-# concerned.
+# concerned. `border` is listed explicitly even though it answers the default,
+# so that `style-border-clause`'s comment below has a row to point at rather
+# than an absence a reader has to infer.
 noun-gender =
     { $noun ->
         [line-segment] c2
@@ -176,6 +178,7 @@ noun-gender =
         [plus] c4
         [fill] c5
         [background] c5
+        [border] c1
        *[other] c1
     }
 

--- a/packages/i18n/locales/kbp/diagnostics.ftl
+++ b/packages/i18n/locales/kbp/diagnostics.ftl
@@ -85,7 +85,7 @@ string-not-valid-component-to-arrange = String "{ $value }" tɩkɛ pʋyʋ kɩba�
 
 invalid-type-defaulting-to-number = Type { $type } tɩtʋʋzɩ, paɖʋ type number.
 
-invalid-variable-value = Lɛɣzɩtʋ pʋyʋ kɩdɛkɛdʋʋ: `{ $value }`
+invalid-variable-value = Lɛɣzɩtʋ pʋyʋ tɩtʋʋzɩ: `{ $value }`
 
 ## Variants
 
@@ -264,8 +264,8 @@ eigen-decomposition-failed = Paapɩzɩɣ pamaɣzɩ matrisɩ aygɛnvaluu
 
 matches-pattern-parameter-not-in-pattern =
     { $parametersCount ->
-        [one] `<matchesPattern>`: parameter { $parameters } fɛyɩ kɩɖaʋ taa, pʋyɔɔ ɛɛmaɣ nɛ falaa paa ɛzɩmtaa.
-       *[other] `<matchesPattern>`: parameter { $parameters } fɛyɩ kɩɖaʋ taa, pʋyɔɔ paamaɣ nɛ falaa paa ɛzɩmtaa.
+        [one] `<matchesPattern>`: parameter { $parameters } fɛyɩ kɩɖaʋ taa, pʋyɔɔ ɛmaɣ nɛ falaa paa ɛzɩmtaa.
+       *[other] `<matchesPattern>`: parameter { $parameters } fɛyɩ kɩɖaʋ taa, pʋyɔɔ pamaɣ nɛ falaa paa ɛzɩmtaa.
     }
 
 ## `<graph>`
@@ -492,8 +492,8 @@ attribute-value-invalid-using-default = Pʋyʋ `{ $value }` tɩtʋʋzɩ attribut
 
 doenetml-version-not-found =
     { $fallback ->
-        [none] Patɩna DoenetML wɛtʋ { $version }.
-       *[other] Patɩna DoenetML wɛtʋ { $version }. Palakɩnɩ wɛtʋ { $fallback }
+        [none] Patɩna DoenetML version { $version }.
+       *[other] Patɩna DoenetML version { $version }. Palakɩnɩ version { $fallback }
     }
 
 ## Reading the DoenetML

--- a/packages/i18n/locales/kbp/diagnostics.ftl
+++ b/packages/i18n/locales/kbp/diagnostics.ftl
@@ -29,7 +29,7 @@ line-segment-midpoint-offset-without-midpoint = midpointOffset ɛɛlakɩ tʋmɩy
 
 line-points-undetermined-dimensions = Ñɔʋ ŋgʋ kɩɖɛɣ yʋsasɩ nzɩ sɩ-ɖaɣlɩkɩŋ patɩna yɔ sɩ-yɔɔ yɔ.
 
-line-points-too-few-dimensions = Pɩwɛɛ se ñɔʋ ɛɖɛɛ yʋsasɩ nzɩ sɩwɛnɩ ɖaɣlɩkɩŋ naalɛ yɔ sɩ-yɔɔ.
+line-points-too-few-dimensions = Pɩwɛɛ se ñɔʋ ɛɖɛɛ yʋsasɩ nzɩ sɩwɛnɩ ɖaɣlɩkɩŋ naalɛ nɛ pɩɖɛɛnɩ ɛzɩma yɔ sɩ-yɔɔ.
 
 line-points-depend-on-variables = Ñɔʋ ɖɛɣ yʋsasɩ nzɩ sɩñɔtɩnɩ lɛɣzɩtʋ yɔ sɩ-yɔɔ: { $variables }.
 
@@ -196,11 +196,11 @@ function-points-too-close = Fɔŋksɩyɔŋ wɛnɩ yʋsasɩ naalɛ nzɩ sɩñɔt�
 
 function-iterates-input-output-mismatch =
     { $inputs ->
-        [one] Fɔŋksɩyɔŋ tasʋʋ pɩzɩɣ pɩla ye input ɖɔʋ nɛ output ɖɔʋ pɛkɛ kʋɖʋm yɔ. Fɔŋksɩyɔŋ kʋnɛ kɩwɛnɩ input { $inputs } nɛ { $outputs ->
+        [one] Fɔŋksɩyɔŋ tasʋʋ pɩzɩɣ pɩla ɖeke ye input ɖɔʋ nɛ output ɖɔʋ pɛkɛ kʋɖʋm yɔ. Fɔŋksɩyɔŋ kʋnɛ kɩwɛnɩ input { $inputs } nɛ { $outputs ->
             [one] output { $outputs }
            *[other] output { $outputs }
         }.
-       *[other] Fɔŋksɩyɔŋ tasʋʋ pɩzɩɣ pɩla ye input ɖɔʋ nɛ output ɖɔʋ pɛkɛ kʋɖʋm yɔ. Fɔŋksɩyɔŋ kʋnɛ kɩwɛnɩ input { $inputs } nɛ { $outputs ->
+       *[other] Fɔŋksɩyɔŋ tasʋʋ pɩzɩɣ pɩla ɖeke ye input ɖɔʋ nɛ output ɖɔʋ pɛkɛ kʋɖʋm yɔ. Fɔŋksɩyɔŋ kʋnɛ kɩwɛnɩ input { $inputs } nɛ { $outputs ->
             [one] output { $outputs }
            *[other] output { $outputs }
         }.

--- a/packages/i18n/locales/kbp/diagnostics.ftl
+++ b/packages/i18n/locales/kbp/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Kabiyè diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] pakpaɣ { $attributes } falaa ye pɔyɔɔdɩ tɛmtʋ naalɛ yɔ
+       *[other] pakpaɣ { $attributes } falaa ye pɔyɔɔdɩ tɛmtʋ naalɛ yɔ
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] pakpaɣ { $attributes } falaa ye pɔyɔɔdɩ tɛmtʋ nɛ hɛkʋ taa yɔ
+       *[other] pakpaɣ { $attributes } falaa ye pɔyɔɔdɩ tɛmtʋ nɛ hɛkʋ taa yɔ
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ɛɛlakɩ tʋmɩyɛ ye hɛkʋ taa fɛyɩ yɔ
+
+## `<line>`
+
+line-points-undetermined-dimensions = Ñɔʋ ŋgʋ kɩɖɛɣ yʋsasɩ nzɩ sɩ-ɖaɣlɩkɩŋ patɩna yɔ sɩ-yɔɔ yɔ.
+
+line-points-too-few-dimensions = Pɩwɛɛ se ñɔʋ ɛɖɛɛ yʋsasɩ nzɩ sɩwɛnɩ ɖaɣlɩkɩŋ naalɛ yɔ sɩ-yɔɔ.
+
+line-points-depend-on-variables = Ñɔʋ ɖɛɣ yʋsasɩ nzɩ sɩñɔtɩnɩ lɛɣzɩtʋ yɔ sɩ-yɔɔ: { $variables }.
+
+line-equation-invalid-format = Ñɔʋ ekwasɩyɔŋ wɛtʋ tɩtʋʋzɩ { $variable1 } nɛ { $variable2 } taa.
+
+## `<ray>`
+
+ray-overprescribed-through = Pɔyɔɔdɩ mintʋsʋʋ nɛ through, endpoint nɛ direction.  Pakpaɣ through weyi pɔyɔɔdaa yɔ falaa.
+
+ray-dimension-mismatch = numDimensions tɩmaɣ mintʋsʋʋ taa.
+
+## `<vector>`
+
+vector-overprescribed-head = Pɔyɔɔdɩ vɛktɛɛrɩ nɛ head, tail nɛ displacement.  Pakpaɣ head weyi pɔyɔɔdaa yɔ falaa.
+
+vector-dimension-mismatch = numDimensions tɩmaɣ vɛktɛɛrɩ taa.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Paapɩzɩɣ pahɔɔ `<{ $component }>` yɔɔ mbʋ pʋyɔɔ yɔ ɛfɛyɩnɩ nearestPoint.
+
+constrain-to-without-nearest-point = Paapɩzɩɣ pahɔkɩ `<{ $component }>` yɔɔ mbʋ pʋyɔɔ yɔ ɛfɛyɩnɩ nearestPoint.
+
+constrain-to-interior-without-nearest-point = Paapɩzɩɣ pahɔkɩ `<{ $component }>` taa mbʋ pʋyɔɔ yɔ ɛfɛyɩnɩ nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = pakpaɣ labelPosition falaa choiceInput weyi ɛtɩkɛ inline yɔ ɛ-yɔɔ
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Pakpaɣ indices wena pɔyɔɔdɩ choiceInput yɔɔ yɔ falaa mbʋ pʋyɔɔ yɔ indices ɖɔʋ tɩmaɣ nɛ choice piya ɖɔʋ.
+
+pretzel-indices-count-mismatch = Pakpaɣ indices wena pɔyɔɔdɩ problem yɔɔ yɔ falaa mbʋ pʋyɔɔ yɔ indices ɖɔʋ tɩmaɣ nɛ problem piya ɖɔʋ.
+
+shuffle-indices-count-mismatch = Pakpaɣ indices wena pɔyɔɔdɩ shuffle yɔɔ yɔ falaa mbʋ pʋyɔɔ yɔ indices ɖɔʋ tɩmaɣ nɛ pʋyʋ ɖɔʋ.
+
+indices-ignored-out-of-range = Pakpaɣ indices wena pɔyɔɔdɩ { $component } yɔɔ yɔ falaa mbʋ pʋyɔɔ yɔ nasɩyɩ wɛ awayɩ.
+
+pretzel-indices-repeated = Pakpaɣ indices wena pɔyɔɔdɩ pretzel yɔɔ yɔ falaa mbʋ pʋyɔɔ yɔ nasɩyɩ tasɩ.
+
+pretzel-circuit-first-index = Pakpaɣ indices wena pɔyɔɔdɩ pretzel yɔɔ mode="circuit" taa yɔ falaa mbʋ pʋyɔɔ yɔ index kajalaɣ ñɩŋgʋ pɩwɛɛ se kɩkɛ 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Se `<{ $component }>` ɛla tʋmɩyɛ nɛ string piya lɛ, pɩwɛɛ se pɔyɔɔdɩ `type` attribute.
+
+invalid-type-defaulting-to-math = Type { $type } tɩtʋʋzɩ { $component } yɔɔ. Pɩwɛɛ se kɩkɛ math, text, number yaa boolean. Paɖʋ math.
+
+string-not-valid-component-to-arrange = String "{ $value }" tɩkɛ pʋyʋ kɩbaŋʋ { $component } yɔɔ. Pakpakɩ-kʋ falaa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } tɩtʋʋzɩ, paɖʋ type number.
+
+invalid-variable-value = Lɛɣzɩtʋ pʋyʋ kɩdɛkɛdʋʋ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Wɛtʋ index { $index } pɩwɛɛ se kɩkɛ ɖɔʋ
+
+variant-index-must-be-integer = Wɛtʋ index { $index } pɩwɛɛ se kɩkɛ ɖɔʋ kʋmʋʋ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Patɩla `<{ $component }>` maɣzɩm kʋmʋʋ yɔɔ. Paɖʋ walanzɩ ɛzɩ maɣzɩm lɛɛkʋ.
+
+side-by-side-absolute-margins = Patɩla `<{ $component }>` maɣzɩm kʋmʋʋ yɔɔ. Paɖʋ kamasɩ ɛzɩ maɣzɩm lɛɛkʋ.
+
+side-by-side-no-block-child = `<{ $component }>` tɩtʋʋzɩ: pɩwɛɛ se ɛwɛɛnɩ block pɩɣa kʋɖʋmaɣ nɛ pɩɖɛɛnɩ ɛzɩma.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Pakpaɣ `for` attribute kɩlɛmʋʋ `<label>` yɔɔ yɔ falaa.
+
+label-for-must-resolve-to-one = `for` attribute `<label>` yɔɔ pɩwɛɛ se kɩwolo pʋyʋ kʋɖʋm yɔɔ.
+
+label-for-unresolved = `for` attribute `<label>` yɔɔ tɩpɩzɩ nɛ kɩwolo pʋyʋ nɔɔyʋ yɔɔ.
+
+label-for-answer-with-authored-inputs = `for` attribute `<label>` yɔɔ yɔɔdʋʋ `<answer>` weyi ɛwɛnɩ input weyi pama yɔ; yɔɔdɩ input yɔɔ kpaagbaa.
+
+label-for-answer-without-input = `for` attribute `<label>` yɔɔ yɔɔdʋʋ `<answer>` weyi ɛfɛyɩnɩ input yɔ.
+
+label-for-must-reference-input-or-answer = `for` attribute `<label>` yɔɔ pɩwɛɛ se kɩyɔɔdɩ input yaa answer yɔɔ.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Talʋʋ yɔɔ lɛ, pɩwɛɛ se `<{ $component }>` ɛwɛɛnɩ tɔbʋʋ kɩcɛkʋʋ yaa se pɔyɔɔdɩ se ɛkɛ decorative.
+
+accessibility-video-short-description = Talʋʋ yɔɔ lɛ, pɩwɛɛ se `<video>` ɛwɛɛnɩ tɔbʋʋ kɩcɛkʋʋ.
+
+accessibility-input-short-description-or-label = Talʋʋ yɔɔ lɛ, pɩwɛɛ se `<{ $component }>` ɛwɛɛnɩ tɔbʋʋ kɩcɛkʋʋ yaa hɩɖɛ.
+
+accessibility-answer-input-short-description-or-label = Talʋʋ yɔɔ lɛ, pɩwɛɛ se `<answer>` weyi ɛlakɩ input yɔ ɛwɛɛnɩ tɔbʋʋ kɩcɛkʋʋ yaa hɩɖɛ.
+
+accessibility-short-description-contains-math = Tɔbʋʋ kɩcɛkʋʋ ɛtaawɛɛnɩ maɣzɩm pʋyʋ ɛzɩ `<{ $component }>`. Ma maɣzɩm nɛ tɔm.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } fɛyɩnɩ lɛɣzɩtʋ ndʋ tɩmaɣ yɔ hɔɔlʋʋ ñʋʋ tɔm yɔɔ (mode kɩlʋmʋʋ) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; pɩpɔzʋʋ { $threshold }:1 nɛ pɩɖɛɛnɩ ɛzɩma).
+       *[other] { $colorName } fɛyɩnɩ lɛɣzɩtʋ ndʋ tɩmaɣ yɔ hɔɔlʋʋ ñʋʋ tɔm yɔɔ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; pɩpɔzʋʋ { $threshold }:1 nɛ pɩɖɛɛnɩ ɛzɩma).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Patɩla `<circle>` ŋgʋ kɩɖɛɣ yʋsasɩ { $count } yɔɔ yɔ alɩwaatʋ ndʋ yʋsasɩ sɩfɛyɩnɩ ɖɔʋ yɔ.
+
+circle-too-many-through-points = Paapɩzɩɣ pamaɣzɩ kpelaɣ ŋga kaɖɛɣ yʋsasɩ 3 yɔɔ nɛ pɩɖɛɛnɩ ɛzɩma yɔ.
+
+circle-overprescribed-radius-center-points = Paapɩzɩɣ pamaɣzɩ kpelaɣ nɛ radius, hɛkʋ taa nɛ yʋsasɩ tɩŋa.
+
+circle-center-with-multiple-points = Paapɩzɩɣ pamaɣzɩ kpelaɣ nɛ hɛkʋ taa ŋga kaɖɛɣ yʋsaɣ 1 yɔɔ nɛ pɩɖɛɛnɩ ɛzɩma yɔ.
+
+circle-radius-too-small = Paapɩzɩɣ pamaɣzɩ kpelaɣ: ɛzɩma poliŋ ŋgʋ kɩwɛ yʋsasɩ naalɛ hɛkʋ taa yɔ kɩkɛ { $distance } yɔ, radius { $radius } weyi pɔyɔɔdaa yɔ ɛpɩŋ pɩdɩɩfɛyɩ.
+
+circle-radius-with-many-points = Paapɩzɩɣ pala kpelaɣ ŋga kaɖɛɣ yʋsasɩ naalɛ yɔɔ nɛ pɩɖɛɛnɩ ɛzɩma nɛ radius weyi pɔyɔɔdaa yɔ.
+
+circle-invalid-center-or-through-points = Kpelaɣ hɛkʋ taa yaa ka-yʋsasɩ tɩtʋʋzɩ.
+
+circle-radius-center-with-multiple-points = Paapɩzɩɣ pamaɣzɩ kpelaɣ radius nɛ hɛkʋ taa ŋga kaɖɛɣ yʋsaɣ 1 yɔɔ nɛ pɩɖɛɛnɩ ɛzɩma yɔ.
+
+circle-change-radius-non-numerical = Paapɩzɩɣ palɛɣzɩ kpelaɣ radius nɛ yʋsasɩ nzɩ sɩfɛyɩnɩ ɖɔʋ yɔ
+
+circle-radius-with-points-non-numerical = Paapɩzɩɣ pala kpelaɣ ŋga kaɖɛɣ yʋsaɣ kʋɖʋmaɣ yɔɔ nɛ pɩɖɛɛnɩ ɛzɩma nɛ radius alɩwaatʋ ndʋ ɖɔʋ fɛyɩ yɔ.
+
+circle-change-center-non-numerical = Patɩla kpelaɣ hɛkʋ taa lɛɣzʋʋ ŋga kaɖɛɣ yʋsasɩ nzɩ sɩfɛyɩnɩ ɖɔʋ yɔ sɩ-yɔɔ yɔ.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Ɖaɣlɩkɩŋ tɩmaɣ fɔŋksɩyɔŋ domain yɔɔ. Domain wɛnɩ alɩwaatʋ { $intervals } ɛlɛ fɔŋksɩyɔŋ wɛnɩ { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+       *[other] Ɖaɣlɩkɩŋ tɩmaɣ fɔŋksɩyɔŋ domain yɔɔ. Domain wɛnɩ alɩwaatʋ { $intervals } ɛlɛ fɔŋksɩyɔŋ wɛnɩ { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Fɔŋksɩyɔŋ domain wɛtʋ tɩtʋʋzɩ.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Pakpakɩ fɔŋksɩyɔŋ sɔsɔʋ ŋgʋ kɩfɛyɩnɩ ɖɔʋ yɔ falaa.
+        [minimum] Pakpakɩ fɔŋksɩyɔŋ pɩŋʋʋ ŋgʋ kɩfɛyɩnɩ ɖɔʋ yɔ falaa.
+        [extremum] Pakpakɩ fɔŋksɩyɔŋ tɛmtʋ ndʋ tɩfɛyɩnɩ ɖɔʋ yɔ falaa.
+        [point] Pakpakɩ fɔŋksɩyɔŋ yʋsaɣ ŋga kafɛyɩnɩ ɖɔʋ yɔ falaa.
+        [slope] Pakpakɩ fɔŋksɩyɔŋ hɔɔlʋʋ ŋgʋ kɩfɛyɩnɩ ɖɔʋ yɔ falaa.
+       *[other] Pakpakɩ fɔŋksɩyɔŋ { $type } ŋgʋ kɩfɛyɩnɩ ɖɔʋ yɔ falaa.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Pakpakɩ fɔŋksɩyɔŋ sɔsɔʋ ŋgʋ kɩfɛyɩ yɔ falaa.
+        [minimum] Pakpakɩ fɔŋksɩyɔŋ pɩŋʋʋ ŋgʋ kɩfɛyɩ yɔ falaa.
+        [extremum] Pakpakɩ fɔŋksɩyɔŋ tɛmtʋ ndʋ tɩfɛyɩ yɔ falaa.
+        [point] Pakpakɩ fɔŋksɩyɔŋ yʋsaɣ ŋga kafɛyɩ yɔ falaa.
+       *[other] Pakpakɩ fɔŋksɩyɔŋ { $type } ŋgʋ kɩfɛyɩ yɔ falaa.
+    }
+
+function-points-too-close = Fɔŋksɩyɔŋ wɛnɩ yʋsasɩ naalɛ nzɩ sɩñɔtɩnɩ ɖama pɩdɩɩfɛyɩ yɔ. Paapɩzɩɣ pɛcɛlɩ fɔŋksɩyɔŋ tɔbʋʋ.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Fɔŋksɩyɔŋ tasʋʋ pɩzɩɣ pɩla ye input ɖɔʋ nɛ output ɖɔʋ pɛkɛ kʋɖʋm yɔ. Fɔŋksɩyɔŋ kʋnɛ kɩwɛnɩ input { $inputs } nɛ { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+       *[other] Fɔŋksɩyɔŋ tasʋʋ pɩzɩɣ pɩla ye input ɖɔʋ nɛ output ɖɔʋ pɛkɛ kʋɖʋm yɔ. Fɔŋksɩyɔŋ kʋnɛ kɩwɛnɩ input { $inputs } nɛ { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Sequence ɖaɣlɩkɩŋ tɩtʋʋzɩ.  Pɩwɛɛ se pɩkɛ ɖɔʋ kʋmʋʋ ŋgʋ kɩtɩpɩsɩ kɩtɛɛ ziro yɔ.
+
+sequence-invalid-step = Sequence step tɩtʋʋzɩ.  Pɩwɛɛ se pɩkɛ ɖɔʋ sequence type { $type } yɔɔ.
+
+sequence-invalid-endpoint-number = Number sequence "{ $attribute }" tɩtʋʋzɩ.  Pɩwɛɛ se pɩkɛ ɖɔʋ.
+
+sequence-invalid-endpoint-letters = Letters sequence "{ $attribute }" tɩtʋʋzɩ.  Pɩwɛɛ se pɩkɛ masɩ kpɛndʋʋ.
+
+sequence-invalid-endpoint = Sequence "{ $attribute }" tɩtʋʋzɩ.
+
+select-from-sequence-coprime-not-numbers = pakpakɩ coprime falaa mbʋ pʋyɔɔ yɔ paalɩzɩɣ ɖɔʋ
+
+select-from-sequence-coprime-with-exclude-combinations = pakpakɩ coprime falaa mbʋ pʋyɔɔ yɔ pɔyɔɔdɩ excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` target tɩtʋʋzɩ: paapɩzɩɣ pana target.
+
+target-state-variable-not-found = `<{ $source }>` target tɩtʋʋzɩ: paapɩzɩɣ pana stet lɛɣzɩtʋ ndʋ tɩ-hɩɖɛ lɛ "{ $property }" yɔ `<{ $component }>` yɔɔ.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Pɩwɛɛ se `<odeSystem>` lɛɣzɩtʋ ɛtaakɛ lɛɣzɩtʋ ndʋ tɩwɛ tɩ-ɖeke yɔ.
+
+ode-system-duplicate-variable-names = Paapɩzɩɣ pɛcɛlɩ ODE RHS fɔŋksɩyɔŋ tɔbʋʋ nɛ lɛɣzɩtʋ hɩla wena atasɩ yɔ.
+
+ode-system-rhs-function-error = Paapɩzɩɣ pɛcɛlɩ ODE RHS fɔŋksɩyɔŋ tɔbʋʋ.  Kɩwɛɛkɩm wɛ mathjs fɔŋksɩyɔŋ labʋ taa.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Paapɩzɩɣ pɛcɛlɩ ñɔŋ { $count } hɛkʋ taa kɔɔnaɣ tɔbʋʋ
+
+angle-invalid-through-point = Yʋsaɣ tɩtʋʋzɩ `<angle>` through taa
+
+parabola-vertex-too-many-points = Patɩla parabolɩ nɛ vertex ŋgʋ kɩɖɛɣ yʋsaɣ 1 yɔɔ nɛ pɩɖɛɛnɩ ɛzɩma yɔ.
+
+parabola-too-many-points = Patɩla parabolɩ ŋgʋ kɩɖɛɣ yʋsasɩ 3 yɔɔ nɛ pɩɖɛɛnɩ ɛzɩma yɔ.
+
+intersection-too-many-items = Patɩla pʋyʋ naalɛ nɛ pɩɖɛɛnɩ ɛzɩma pɔ-kpɛndʋʋ
+
+## Other math components
+
+ionic-compound-not-two-ions = Patɩla iyɔŋ kpɛndʋʋ pʋyʋ lɛɛbʋ yɔɔ ye pɩtɩkɛ iyɔŋ naalɛ yɔ.
+
+ionic-compound-needs-cation-and-anion = Pala iyɔŋ kpɛndʋʋ katiyɔŋ kʋɖʋm nɛ aniyɔŋ kʋɖʋm ɖeke pɔ-yɔɔ.
+
+solve-equations-cannot-evaluate = Paapɩzɩɣ pɔcɔnɩ ekwasɩyɔŋ mbʋ pʋyɔɔ yɔ paapɩzɩɣ pamaɣzɩ-kʋ: { $equation }
+
+math-operators-operand-number-required = Pɩwɛɛ se pɔyɔɔdɩ operandNumber alɩwaatʋ ndʋ palɩzɩɣ maɣzɩm operand yɔ.
+
+eigen-decomposition-failed = Paapɩzɩɣ pamaɣzɩ matrisɩ aygɛnvaluu
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } fɛyɩ kɩɖaʋ taa, pʋyɔɔ ɛɛmaɣ nɛ falaa paa ɛzɩmtaa.
+       *[other] `<matchesPattern>`: parameter { $parameters } fɛyɩ kɩɖaʋ taa, pʋyɔɔ paamaɣ nɛ falaa paa ɛzɩmtaa.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: paapɩzɩɣ pana grid="{ $grid }" tɔbʋʋ. Pɩwɛɛ se pɩkɛ none, medium, dense, yaa ɖɔʋ naalɛ sɔsɔŋ weyi lone kaɣ-wɛ yɔ, ɛzɩ grid="1 0.5". Paalakɩ grid nakʋyʋ.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ɛɛlakɩ tʋmɩyɛ prefigure wɩlɩyʋ taa; palakɩnɩ nɩwaŋ hɔɔlʋʋ.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ɛɛlakɩ tʋmɩyɛ prefigure wɩlɩyʋ taa; palakɩnɩ ɖoo hɔɔlʋʋ.
+
+prefigure-invalid-axis-bounds = `<graph>`: aksɩ kamasɩ tɩtʋʋzɩ prefigure yɔɔ; palakɩnɩ bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: walanzɩ tɩtʋʋzɩ prefigure yɔɔ; palakɩnɩ walanzɩ 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio tɩtʋʋzɩ prefigure yɔɔ; palakɩnɩ aspɛkɩ 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: grid hɛkʋ pɩŋ pɩdɩɩfɛyɩ aksɩ kamasɩ yɔɔ; palɩzɩ grid prefigure wɩlɩyʋ taa.
+
+prefigure-annotations-not-rendered = `<graph>`: paawɩlɩɣ annotations ye paalakɩnɩ PreFigure wɩlɩyʋ yɔ.
+
+multiple-annotations-children = Pana `<annotations>` piya sakɩyɛ `<graph>` taa; pakpakɩ tɩŋa falaa nɛ pɩtalɩ kɛdɛzaɣ ñɩŋga.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Paapɩzɩɣ palɩzɩ yaa pama pʋyʋ wɛtʋ ndʋ patɩna yɔ: { $type }.
+
+copy-prop-not-found = Paapɩzɩɣ pana prop { $property } pʋyʋ wɛtʋ { $component } yɔɔ
+
+collect-no-source = Patɩna lɩʋ collect yɔɔ.
+
+collect-invalid-component-type = Paapɩzɩɣ pakpɛndɩ pʋyʋ wɛtʋ `<{ $component }>` mbʋ pʋyɔɔ yɔ wɛtʋ tɩtʋʋzɩ.
+
+reference-index-unavailable = Paapɩzɩɣ pɔyɔɔdɩ index `{ $reference }` yɔɔ
+
+## `<callAction>`
+
+component-action-unavailable = Paapɩzɩɣ payaa { $action } pʋyʋ `{ $reference }` yɔɔ
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data wɛtʋ tɩtʋʋzɩ.  Ñɔŋ wɛnɩ ɖaɣlɩkɩŋ ndɩ ndɩ. Pana-pʋ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data wɛnɩ kolonjɩ hɩla wena atasɩ yɔ.  Pana-pʋ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Kolonjɩ hɩɖɛ naɖɩyɛ fɛyɩ data taa.  Pana-pʋ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Cosuu kʋnɛ kɩ-award sɩŋnɩ answer tag ɛ-maɣmaɣ ɛ-cosuu ŋgʋ patiyaa yɔ kɩ-yɔɔ, nɛ mbʋ kaɣnɩ kɔnʋʋ kʋñɔŋ ŋgʋ ŋtɩɖaŋ-kʋ yɔ.
+
+answer-max-num-attempts-in-section-wide-check-work = Ye ŋɖʋ `maxNumAttempts` `<answer>` weyi ɛwɛ pʋyʋ ŋgʋ kɩwɛnɩ `sectionWideCheckWork` yɔ kɩ-taa yɔ ɛ-yɔɔ, ɛɛlakɩ tʋmɩyɛ, mbʋ pʋyɔɔ yɔ pʋyʋ ŋgʋ kɩ-tɩnɩ maɣzʋʋ ɖɔʋ. Ɖʋ `maxNumAttempts` pʋyʋ ŋgʋ kɩ-yɔɔ.
+
+nested-section-wide-check-work-max-num-attempts = Ye ŋɖʋ `maxNumAttempts` pʋyʋ ŋgʋ kɩwɛnɩ `sectionWideCheckWork` nɛ kɩwɛ pʋyʋ lɛɛkʋ ŋgʋ kɩwɛnɩ `sectionWideCheckWork` yɔ kɩ-taa yɔ kɩ-yɔɔ, kɩɩlakɩ tʋmɩyɛ, mbʋ pʋyɔɔ yɔ awayɩ pʋyʋ tɩnɩ maɣzʋʋ ɖɔʋ. Ɖʋ `maxNumAttempts` awayɩ pʋyʋ yɔɔ.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] { $attributes } attribute ɛɛlakɩ tʋmɩyɛ ye patɩɖʋ symbolicEquality yɔ.
+       *[other] { $attributes } attribute ɛɛlakɩ tʋmɩyɛ ye patɩɖʋ symbolicEquality yɔ.
+    }
+
+answer-invalid-type = Cosuu type tɩtʋʋzɩ: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ɛzɩma pʋyʋ `<{ $component }>` fɛyɩnɩ hɩɖɛ yɔ, paapɩzɩɣ palakɩnɩ-kʋ module attribute
+
+module-attribute-name-already-defined = Paapɩzɩɣ palakɩnɩ pʋyʋ `<{ $component } name="{ $name }">` module attribute mbʋ pʋyɔɔ yɔ `<module>` tɛm wɛnʋʋ "{ $name }" attribute.
+
+conditional-content-condition-ignored = Pakpakɩ `condition` attribute falaa `<conditionalContent>` weyi ɛwɛnɩ case yaa else piya yɔ ɛ-yɔɔ.
+
+slider-markers-type-mismatch = Markers type tɩmaɣ nɛ slider type.
+
+pretzel-problem-needs-statement-and-answer = Pretzel tɩtʋʋzɩ: pɩwɛɛ se paa `<problem>` weyi lɛ ɛwɛɛnɩ `<statement>` kʋɖʋm nɛ `<answer>` kʋɖʋm.
+
+pretzel-circuit-first-problem-distractor = Pretzel tɩtʋʋzɩ: mode="circuit" taa lɛ, kajalaɣ `<problem>` ɛɛpɩzɩɣ ɛkɛ distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Pʋyʋ { $values } tɩtʋʋzɩ attribute `{ $attribute }` yɔɔ; pakpakɩ-kʋ falaa.
+       *[other] Pʋyʋ { $values } tɩtʋʋzɩ attribute `{ $attribute }` yɔɔ; pakpakɩ-wɛ falaa.
+    }
+
+attribute-must-be-references = Pʋyʋ `{ $value }` tɩtʋʋzɩ attribute `{ $attribute }` yɔɔ. Pɩwɛɛ se attribute ɛkɛ nʋmɔŋ weyi ɩpaɣzɩɣnɩ `$` yɔ.
+
+math-input-invalid-function-names = <mathInput>: pakpaɣ fɔŋksɩyɔŋ hɩla wena atɩtʋʋzɩ yɔ falaa { $attribute } taa: { $names }. Pɩwɛɛ se paa hɩɖɛ nɖɩ ɖɩ-wɩlʋʋ hɔɔlʋʋ ɛwɛɛnɩ masɩ 2 nɛ pɩɖɛɛnɩ ɛzɩma (masɩ yaa kamasɩ); `|<mathspeak alternative>` pɩzɩɣ pɩtɩŋ pɩ-wayɩ.
+
+## Building components from the source
+
+component-type-invalid = Pʋyʋ wɛtʋ tɩtʋʋzɩ: `<{ $componentType }>`
+
+attribute-repeated = Paapɩzɩɣ patasɩ attribute { $attribute }.
+
+attribute-invalid-for-component = Attribute "{ $attribute }" tɩtʋʋzɩ pʋyʋ wɛtʋ `<{ $componentType }>` yɔɔ.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Wɛtʋ tɔbʋʋ { $styleNumber } fɛyɩnɩ lɛɣzɩtʋ ndʋ tɩmaɣ yɔ { $context ->
+        [text-on-background] tɔm tɔlɩm nɛ wayɩ tɔlɩm hɛkʋ taa
+        [high-contrast] lɛɣzɩtʋ sɔsɔtʋ tɔlɩm nɛ kanvasɩ hɛkʋ taa
+        [line] ñɔʋ tɔlɩm nɛ kanvasɩ hɛkʋ taa
+        [marker] yʋsaɣ tɔlɩm nɛ kanvasɩ hɛkʋ taa
+       *[text-on-canvas] tɔm tɔlɩm nɛ kanvasɩ hɛkʋ taa
+    }{ $mode ->
+        [dark] { " (mode kɩlʋmʋʋ)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; pɩpɔzʋʋ { $threshold }:1 nɛ pɩɖɛɛnɩ ɛzɩma).
+
+style-definition-dark-mode-text-background-contrast =
+    Paa wɛtʋ tɔbʋʋ { $styleNumber } ɛwɛnɩ tɔlɩm ndʋ tɩwɛnɩ lɛɣzɩtʋ kɩmaɣzʋʋ mode kɩñɩlɩsʋʋ taa yɔ, mode kɩlʋmʋʋ tɔlɩm ndʋ palɩzɩ tɩ-taa yɔ tɩfɛyɩnɩ lɛɣzɩtʋ kɩmaɣzʋʋ tɔm tɔlɩm nɛ wayɩ tɔlɩm hɛkʋ taa ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; pɩpɔzʋʋ { $threshold }:1 nɛ pɩɖɛɛnɩ ɛzɩma). { $suggestion ->
+        [available] Se ŋhiɣ lɛɣzɩtʋ kɩmaɣzʋʋ mode kɩlʋmʋʋ taa lɛ, sɔsɔzɩ mode kɩñɩlɩsʋʋ lɛɣzɩtʋ (ɛzɩ, ɖʋ { $lightAttribute }="{ $lightColor }") yaa lɛɣzɩ mode kɩlʋmʋʋ tɔlɩm (ɛzɩ, ɖʋ { $darkAttribute }="{ $darkColor }").
+       *[none] Se ŋhiɣ lɛɣzɩtʋ kɩmaɣzʋʋ mode kɩlʋmʋʋ taa lɛ, sɔsɔzɩ mode kɩñɩlɩsʋʋ lɛɣzɩtʋ yaa lɛɣzɩ tɔlɩm nɛ textColorDarkMode yaa backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Paa wɛtʋ tɔbʋʋ { $styleNumber } ɛwɛnɩ tɔm tɔlɩm ndʋ tɩwɛnɩ lɛɣzɩtʋ kɩmaɣzʋʋ mode kɩñɩlɩsʋʋ taa yɔ, mode kɩlʋmʋʋ tɔm tɔlɩm ndʋ palɩzɩ tɩ-taa yɔ tɩfɛyɩnɩ lɛɣzɩtʋ kɩmaɣzʋʋ kanvasɩ yɔɔ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; pɩpɔzʋʋ { $threshold }:1 nɛ pɩɖɛɛnɩ ɛzɩma). { $suggestion ->
+        [available] Se ŋhiɣ lɛɣzɩtʋ kɩmaɣzʋʋ mode kɩlʋmʋʋ taa lɛ, sɔsɔzɩ mode kɩñɩlɩsʋʋ lɛɣzɩtʋ (ɛzɩ, ɖʋ textColor="{ $lightColor }") yaa lɛɣzɩ mode kɩlʋmʋʋ tɔlɩm (ɛzɩ, ɖʋ textColorDarkMode="{ $darkColor }").
+       *[none] Se ŋhiɣ lɛɣzɩtʋ kɩmaɣzʋʋ mode kɩlʋmʋʋ taa lɛ, sɔsɔzɩ mode kɩñɩlɩsʋʋ lɛɣzɩtʋ yaa lɛɣzɩ tɔlɩm nɛ textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Hɔɔlʋʋ pɩzɩɣ kɩlɩzɩ <stylePalette> kʋɖʋm ɖeke; palakɩnɩ kɛdɛzaɣ ñɩŋgʋ.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = paapɩzɩɣ pana { $component } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ numToSelect tɩkɛ ɖɔʋ kʋmʋʋ ŋgʋ kɩtɩpɩsɩ kɩtɛɛ ziro yɔ.
+
+variant-num-to-select-not-constant-number = paapɩzɩɣ pana { $component } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ numToSelect tɩkɛ ɖɔʋ ŋgʋ kɩɩlɛɣzɩɣ yɔ.
+
+variant-with-replacement-not-constant-boolean = paapɩzɩɣ pana { $component } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ withReplacement tɩkɛ boolean ŋgʋ kɩɩlɛɣzɩɣ yɔ.
+
+variant-select-weight-disables-unique = Pɔtɔkɩ select wɛtʋ ndɩ ndɩ ye option nakʋyʋ ɛwɛnɩ selectWeight yaa selectForVariants yɔ
+
+variant-coprime-undetermined = paapɩzɩɣ pana { $component } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ paapɩzɩɣ pana se coprime kɛ cɛtɩm paa ɛzɩmtaa.
+
+variant-attribute-not-constant = paapɩzɩɣ pana { $component } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ { $attribute } lɛɣzɩɣ.
+
+variant-attribute-not-number = paapɩzɩɣ pana { $component } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ { $attribute } tɩkɛ ɖɔʋ.
+
+variant-attribute-wrong-type-for-sequence =
+    paapɩzɩɣ pana { $component } { $type } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ { $attribute } tɩkɛ { $expected ->
+        [letters-combination] masɩ kpɛndʋʋ
+        [math-expression] maɣzɩm tɔm kɩbandʋ
+        [integer] ɖɔʋ kʋmʋʋ
+       *[number] ɖɔʋ
+    }.
+
+variant-length-not-integer = paapɩzɩɣ pana { $component } wɛtʋ ndɩ ndɩ mbʋ pʋyɔɔ yɔ length tɩkɛ ɖɔʋ kʋmʋʋ.
+
+variant-sort-not-implemented = patɩla { $component } nɛ sort pɔ-wɛtʋ ndɩ ndɩ
+
+variant-exclude-combinations-not-implemented = patɩla { $component } nɛ excludeCombinations pɔ-wɛtʋ ndɩ ndɩ
+
+variant-math-exclude-not-implemented = patɩla { $component } type math nɛ exclude pɔ-wɛtʋ ndɩ ndɩ
+
+variant-non-constant-exclude-not-implemented = patɩla { $component } nɛ exclude ŋgʋ kɩlɛɣzɩɣ yɔ pɔ-wɛtʋ ndɩ ndɩ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ɛɛlakɩ tʋmɩyɛ graph prefigure wɩlɩyʋ taa; pɔɖɔ pɩɣa yɔɔ.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiyomɛtrii tɩtalɩ yaa tɩtʋʋzɩ; pɔɖɔ pɩɣa yɔɔ.
+
+prefigure-curve-label-omitted = { $subject }: hɩla ɛɛlakɩ tʋmɩyɛ curve pʋyʋ weyi palɛɣzaa yɔ ɛ-yɔɔ; palɩzɩ hɩɖɛ.
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve fɔŋksɩyɔŋ tɔbʋʋ wɛtʋ '{ $definitionType }' ɛɛlakɩ tʋmɩyɛ; pɔɖɔ pɩɣa yɔɔ.
+
+prefigure-region-flip-functions-unsupported = { $subject }: flipFunctions attribute regionBetweenCurves yɔɔ ɛɛlakɩ tʋmɩyɛ; pɔɖɔ pɩɣa yɔɔ.
+
+prefigure-region-non-formula-child = { $subject }: formula-wɛtʋ piya fɔŋksɩyɔŋ ɖeke lakɩnɩ tʋmɩyɛ regionBetweenCurves yɔɔ; pɔɖɔ pɩɣa yɔɔ.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ɛɛlakɩ tʋmɩyɛ { $labelKind ->
+        [line-family] ñɔŋ hɔʋ hɩɖɛ
+       *[point] yʋsaɣ hɩɖɛ
+    } yɔɔ; palakɩnɩ PreFigure ñɔɔzʋʋ.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure ɛɛsɩŋ sʋʋ wɛtʋ '{ $fillStyle }'; palakɩnɩ sʋʋ kʋmʋʋ.
+
+prefigure-line-style-unknown = { $subject }: paasɩŋ ñɔʋ wɛtʋ '{ $lineStyle }', pʋyɔɔ palɩzɩ-tʋ PreFigure taa.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: palɛɣzɩ yʋsaɣ wɛtʋ '{ $markerStyle }' nɛ pɩpɩsɩ PreFigure wɛtʋ 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure ɛɛsɩŋ yʋsaɣ wɛtʋ '{ $markerStyle }'; palakɩnɩ wɛtʋ kɩcalɩtʋ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` tɩtʋʋzɩ; paapɩzɩɣ pana target. Palɩzɩ annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` wolo target sakɩyɛ yɔɔ; palakɩnɩ kajalaɣ ñɩŋgʋ.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` tɩtʋʋzɩ; target wɛ graph awayɩ. Palɩzɩ annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` tɩtʋʋzɩ; target tɩkɛ kɩlɛmʋʋ pʋyʋ ŋgʋ prefigure sɩm-kʋ yɔ. Palɩzɩ annotation.
+
+annotation-text-missing = `<annotation>`: `text` fɛyɩ yaa kɩfɛyɩnɩ pʋyʋ; pama tɔm falaa.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Pana kpelaɣ ñɔtʋʋ.
+       *[other] Pana kpelaɣ ñɔtʋʋ nɛ pʋyʋ `<{ $componentType }>`.
+    }
+
+reference-no-referent = Patɩna pʋyʋ nʋmɔʋ yɔɔ: `{ $reference }`
+
+reference-multiple-referents = Pana pʋyʋ sakɩyɛ nʋmɔʋ yɔɔ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` attribute { $attribute } wɛtʋ tɩtʋʋzɩ.
+
+children-invalid = `<{ $componentType }>` piya tɩtʋʋzɩ: Pana piya nzɩ sɩtɩtʋʋzɩ yɔ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Pʋyʋ `{ $value }` tɩtʋʋzɩ attribute `{ $attribute }` yɔɔ, palakɩnɩ `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Patɩna DoenetML wɛtʋ { $version }.
+       *[other] Patɩna DoenetML wɛtʋ { $version }. Palakɩnɩ wɛtʋ { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML tɩtʋʋzɩ: { $content }
+
+parse-tag-missing-close-tag = DoenetML tɩtʋʋzɩ: Tag `{ $tag }` fɛyɩnɩ tag ŋgʋ kɩtɔkɩ yɔ. Paɖaŋ tag ŋgʋ kɩtɔkɩ kɩ-tɩ yɔ yaa `</{ $tagName }>` tag.
+
+parse-tag-error = DoenetML tɩtʋʋzɩ: Kɩwɛɛkɩm wɛ tag `<{ $tagName }>` taa
+
+parse-attribute-missing-value = DoenetML tɩtʋʋzɩ: Attribute `{ $attribute }` tɩtʋʋzɩ, pɩwɛ ɛzɩ ɛfɛyɩnɩ pʋyʋ.
+
+parse-attribute-invalid = DoenetML tɩtʋʋzɩ: Attribute `{ $attribute }` tɩtʋʋzɩ
+
+parse-attribute-value-invalid = DoenetML tɩtʋʋzɩ: Attribute pʋyʋ `{ $value }` tɩtʋʋzɩ
+
+parse-attribute-value-quote-mismatch = DoenetML tɩtʋʋzɩ: Attribute pʋyʋ `{ $value }` tɩtʋʋzɩ. Yɔɔdaɣ yʋsasɩ tɩmaɣ. Pɩwɛ ɛzɩ `{ $quote }` fɛyɩ
+
+parse-open-tag-name-missing = DoenetML tɩtʋʋzɩ: Pana tag ŋgʋ kɩfɛyɩnɩ hɩɖɛ yɔ, ɛzɩ `<`
+
+parse-tag-not-closed = DoenetML tɩtʋʋzɩ: Patɩtɔ tag `{ $tag }` (pɩwɛ ɛzɩ `>` fɛyɩ).
+
+parse-self-closing-tag-name-missing = DoenetML tɩtʋʋzɩ: Pana tag ŋgʋ kɩfɛyɩnɩ hɩɖɛ yɔ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML tɩtʋʋzɩ: Patɩtɔ tag `{ $tag }` (pɩwɛ ɛzɩ `/>` fɛyɩ).
+
+parse-tag-invalid-attributes = DoenetML tɩtʋʋzɩ: Tag `{ $tag }` tɩtʋʋzɩ. Pɩpɩzɩɣ ɛwɛɛnɩ attribute wena atɩtʋʋzɩ yɔ.
+
+parse-close-tag-name-missing = DoenetML tɩtʋʋzɩ: Pana tag ŋgʋ kɩtɔkɩ nɛ kɩfɛyɩnɩ hɩɖɛ yɔ, ɛzɩ `</`
+
+parse-attribute-value-unquoted = Pɩwɛɛ se attribute pʋyʋ ɛwɛɛ yɔɔdaɣ yʋsasɩ taa: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML tɩtʋʋzɩ: Pana tag ŋgʋ kɩtɔkɩ yɔ `{ $tag }`, ɛlɛ tag ŋgʋ kɩtʋlʋʋ yɔ fɛyɩ
+
+parse-close-tag-mismatched = DoenetML tɩtʋʋzɩ: Tag ŋgʋ kɩtɔkɩ yɔ tɩmaɣ. Paɖaŋ `</{ $expected }>`. Pana `{ $found }`
+
+parser-node-unconvertible = Paapɩzɩɣ palɛɣzɩ node { $node } nɛ pɩpɩsɩ Dast node.
+
+## Names
+
+name-attribute-invalid =
+    Attribute name='{ $name }' tɩtʋʋzɩ. { $reason ->
+        [characters] Hɩla pɩzɩɣ awɛɛnɩ masɩ, ɖɔʋ, tɛɛ kamaɣ yaa kamaɣ ɖeke.
+       *[start] Pɩwɛɛ se hɩla ɩpaɣzɩnɩ mayaɣ.
+    }
+
+component-name-invalid-start = Pʋyʋ hɩɖɛ "{ $name }" tɩtʋʋzɩ. Pɩwɛɛ se hɩla ɩpaɣzɩnɩ mayaɣ.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Pɩwɛɛ se answer type videoWatched ɛwɛɛnɩ video attribute
+
+answer-video-watched-video-not-reference = Pɩwɛɛ se answer type videoWatched ɛwɛɛnɩ video attribute weyi ɛkɛ nʋmɔʋ yɔ
+
+answer-name-not-single-text = Pɩwɛɛ se answer name attribute ɛwɛɛnɩ text pɩɣa kʋɖʋmaɣ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Paapɩzɩɣ pahiɣ awayɩ DoenetML mbʋ pʋyɔɔ yɔ tasʋʋ ɖɔwa pɩdɩɩfɛyɩ. Kpelaɣ nʋmɔʋ wɛɛ?
+
+external-doenetml-unavailable = Paapɩzɩɣ pahiɣ DoenetML { $attribute }="{ $uri }" taa
+
+external-doenetml-type-mismatch = DoenetML ŋgʋ pahiɣ { $attribute }="{ $uri }" taa yɔ kɩtɩtʋʋzɩ: kɩtɩmaɣ nɛ pʋyʋ wɛtʋ "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` kpaɖɩ; labɩnɩ tʋmɩyɛ `{ $to }`.
+       *[other] [deprecation] Attribute `{ $from }` `<{ $component }>` yɔɔ kpaɖɩ; labɩnɩ tʋmɩyɛ `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` kpaɖɩ nɛ pakpaɣ-kʋ falaa mbʋ pʋyɔɔ yɔ `{ $to }` ɖɔɖɔ wɛɛ.
+       *[other] [deprecation] Attribute `{ $from }` `<{ $component }>` yɔɔ kpaɖɩ nɛ pakpaɣ-kʋ falaa mbʋ pʋyɔɔ yɔ `{ $to }` ɖɔɖɔ wɛɛ.
+    }
+
+deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` `<{ $component }>` yɔɔ kpaɖɩ nɛ pakpaɣ-kʋ falaa.
+
+deprecated-attribute-to-child = [deprecation] Attribute `{ $attribute }` `<{ $component }>` yɔɔ kpaɖɩ; labɩnɩ tʋmɩyɛ `<{ $child }>` pɩɣa.
+
+deprecated-attribute-value-renamed = [deprecation] Pʋyʋ `{ $value }` attribute `{ $attribute }` `<{ $component }>` yɔɔ kpaɖɩ; labɩnɩ tʋmɩyɛ `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` pɩzɩɣ kɩla Anglɛɛ ɖeke sakɩyɛ, pʋyɔɔ kɩ-tɔm ɛɛlɛɣzɩɣ takayaɣ ŋga pamawa { $locale } taa yɔ ka-taa. Ma sakɩyɛ wɛtʋ kpaagbaa, yaa ɖʋ-tʋ nɛ `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Pʋyʋ `<{ $tag }>` tɩkɛ Doenet pʋyʋ ŋgʋ pasɩm-kʋ yɔ.
+
+schema-element-not-allowed-at-root = Paahaɣ nʋmɔʋ pʋyʋ `<{ $tag }>` takayaɣ ñʋʋ taa.
+
+schema-element-not-allowed-inside = Paahaɣ nʋmɔʋ pʋyʋ `<{ $tag }>` `<{ $parent }>` taa.
+
+schema-attribute-unrecognized = Pʋyʋ `<{ $tag }>` fɛyɩnɩ attribute ŋgʋ payaɣ se `{ $attribute }` yɔ.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Pɩwɛɛ se pʋyʋ `<{ $tag }>` attribute `{ $attribute }` ɛkɛ lɩzʋʋ ŋgʋ kɩ-taa pʋyʋ kʋɖʋm kʋɖʋm kɛ kʋɖʋm ɛ-taa yɔ: { $allowed }
+       *[other] Pɩwɛɛ se pʋyʋ `<{ $tag }>` attribute `{ $attribute }` ɛkɛ kʋɖʋm ɛ-taa: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select wɛtʋ hɩɖɛ tɩtʋʋzɩ.  Wɛtʋ hɩɖɛ { $variantName } wɛ option { $numOptions } taa ɛlɛ ɖɔʋ ŋgʋ palɩzɩɣ yɔ kɩkɛ { $numToSelect }.
+
+select-variant-name-without-options = Pɔyɔɔdɩ wɛtʋ natʋyʋ select yɔɔ ɛlɛ patɩyɔɔdɩ option nakʋyʋ wɛtʋ hɩɖɛ nɖɩ ɖɩpɩzɩɣ ɖɩwɛɛ yɔ ɖɩ-yɔɔ: { $variantName }.
+
+select-variant-name-not-possible = Wɛtʋ hɩɖɛ { $variantName } nɖɩ pɔyɔɔdɩ select yɔɔ yɔ ɖɩtɩkɛ wɛtʋ hɩɖɛ nɖɩ ɖɩpɩzɩɣ ɖɩwɛɛ yɔ.
+
+select-too-few-options = Paapɩzɩɣ palɩzɩ pʋyʋ { $numToSelect } { $numOptions } ɖeke taa.
+
+select-from-sequence-too-few-values = Paapɩzɩɣ palɩzɩ pʋyʋ { $numToSelect } sequence ŋgʋ kɩ-ɖaɣlɩkɩŋ kɛ { $length } yɔ kɩ-taa.
+
+select-from-sequence-indices-count-mismatch = Pɩwɛɛ se indices ɖɔʋ ŋgʋ pɔyɔɔdɩ select yɔɔ yɔ kɩmaɣ nɛ ɖɔʋ ŋgʋ palɩzɩɣ yɔ
+
+select-from-sequence-indices-not-integers = Pɩwɛɛ se indices tɩŋa wena pɔyɔɔdɩ select yɔɔ yɔ akɛ ɖɔʋ kʋmʋʋ
+
+select-from-sequence-index-excluded = Pɔyɔɔdɩ selectfromsequence index weyi palɩzɩ-ɩ yɔ
+
+select-from-sequence-indices-excluded-combination = Pɔyɔɔdɩ selectfromsequence indices wena akɛ kpɛndʋʋ ŋgʋ palɩzaa yɔ
+
+select-from-sequence-coprime-not-positive-integers = Paapɩzɩɣ palɩzɩ coprime kpɛndʋʋ mbʋ pʋyɔɔ yɔ paalɩzɩɣ ɖɔʋ kʋmʋʋ sɔsɔŋ.
+
+select-from-sequence-coprime-common-factor = Paapɩzɩɣ palɩzɩ coprime ɖɔʋ. Ɖɔʋ ŋgʋ kɩpɩzɩɣ kɩwɛɛ yɔ kɩ-tɩŋa wɛnɩ faktɛɛrɩ kʋɖʋm. (Pɩwɛɛ se "from" yaa "to" pʋyʋ ŋgʋ pɔyɔɔdaa yɔ kɩkɛ coprime nɛ "step".)
+
+select-from-sequence-coprime-single-number = Paapɩzɩɣ palɩzɩ coprime kpɛndʋʋ ɖɔʋ kʋɖʋm ŋgʋ kɩtɩkɛ 1 yɔ kɩ-taa.
+
+select-from-sequence-excluded-too-many-combinations = Palɩzɩ kpɛndʋʋ 70% nɛ pɩɖɛɛnɩ ɛzɩma selectFromSequence taa
+
+select-from-sequence-coprime-none-found = Paapɩzɩɣ palɩzɩ coprime ɖɔʋ. Ɖɔʋ ŋgʋ kɩpɩzɩɣ kɩwɛɛ yɔ kɩ-tɩŋa wɛnɩ faktɛɛrɩ kʋɖʋm.
+
+select-from-sequence-too-few-unique-values = Paapɩzɩɣ palɩzɩ pʋyʋ ndɩ ndɩ { $numToSelect } sequence ŋgʋ kɩ-ɖaɣlɩkɩŋ kɛ { $numPossibleValues } yɔ kɩ-taa
+
+select-prime-numbers-too-few-values = Paapɩzɩɣ palɩzɩ pʋyʋ { $numToSelect } praymɩ lɩzʋʋ ŋgʋ kɩ-ɖaɣlɩkɩŋ kɛ { $numValues } yɔ kɩ-taa
+
+select-prime-numbers-values-count-mismatch = Pɩwɛɛ se pʋyʋ ɖɔʋ ŋgʋ pɔyɔɔdɩ select yɔɔ yɔ kɩmaɣ nɛ ɖɔʋ ŋgʋ palɩzɩɣ yɔ
+
+select-prime-numbers-values-not-prime = Pɩwɛɛ se pʋyʋ tɩŋa mbʋ pɔyɔɔdɩ select prime number yɔɔ yɔ pɩwɛɛ praymɩ lɩzʋʋ taa
+
+select-prime-numbers-values-excluded-combination = Pʋyʋ mbʋ pɔyɔɔdɩ selectPrimeNumbers yɔɔ yɔ pɩkɛ kpɛndʋʋ ŋgʋ palɩzaa yɔ
+
+select-prime-numbers-excluded-too-many-combinations = Palɩzɩ kpɛndʋʋ 70% nɛ pɩɖɛɛnɩ ɛzɩma selectPrimeNumbers taa
+
+select-random-combination-fluke = Ɛzɩ pɩɩpɩzɩɣ pɩla yɔ, paapɩzɩ palɩzɩ ɖɔʋ ndɩ ndɩ kpɛndʋʋ
+
+select-random-value-fluke = Ɛzɩ pɩɩpɩzɩɣ pɩla yɔ, paapɩzɩ palɩzɩ ɖɔʋ ndɩ ndɩ nakʋyʋ

--- a/packages/i18n/locales/kbp/editor.ftl
+++ b/packages/i18n/locales/kbp/editor.ftl
@@ -1,0 +1,208 @@
+# Kabiyè editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ñɔɔzɩ
+       *[update] Lɛɣzɩ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Wɩlɩyʋ
+       *[other] { $word } Wɩlɩyʋ { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Wɛtʋ
+
+editor-variant-filter = Ñɩnɩ…
+
+editor-variant-next = Lɩzɩ wɛtʋ ndʋ tɩkɔŋ yɔ
+
+editor-variant-previous = Lɩzɩ wɛtʋ ndʋ tɩɖɛwa yɔ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Panawa WCAG AA talʋʋ paɣtʋ yɔɔ maʋ. Mabɩ nɛ { $action ->
+            [close] tɔlɩ
+           *[open] tʋlɩ
+        } talʋʋ takayaɣ.
+        [advisories] Mabɩ nɛ { $action ->
+            [close] tɔlɩ
+           *[open] tʋlɩ
+        } talʋʋ takayaɣ. Patɩna WCAG AA paɣtʋ yɔɔ maʋ nabʋyʋ, ɛlɛ lɔŋ tasʋʋ lɛɛŋ wɛɛ talʋʋ yɔɔ.
+       *[clean] Mabɩ nɛ { $action ->
+            [close] tɔlɩ
+           *[open] tʋlɩ
+        } talʋʋ takayaɣ. Patɩna talʋʋ kʋñɔŋ nabʋyʋ.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Panawa WCAG AA talʋʋ paɣtʋ yɔɔ maʋ. Panawa { $count ->
+            [one] WCAG AA paɣtʋ yɔɔ maʋ { $count }
+           *[other] WCAG AA paɣtʋ yɔɔ maʋ { $count }
+        }. Mabɩ nɛ { $action ->
+            [close] tɔlɩ
+           *[open] tʋlɩ
+        } talʋʋ takayaɣ.
+        [advisories] Patɩna WCAG AA paɣtʋ yɔɔ maʋ nabʋyʋ. Panawa { $count ->
+            [one] lɔŋ tasʋʋ lɛɛkʋ { $count } talʋʋ yɔɔ
+           *[other] lɔŋ tasʋʋ lɛɛŋ { $count } talʋʋ yɔɔ
+        }. Mabɩ nɛ { $action ->
+            [close] tɔlɩ
+           *[open] tʋlɩ
+        } talʋʋ takayaɣ.
+       *[clean] Patɩna WCAG AA paɣtʋ yɔɔ maʋ nabʋyʋ. Mabɩ nɛ { $action ->
+            [close] tɔlɩ
+           *[open] tʋlɩ
+        } talʋʋ takayaɣ.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML wɛtʋ { $version }
+
+editor-tab-help = Sɩnʋʋ ɖenɖe ŋwɛɛ yɔ
+editor-tab-help-short = Ɖenɖe
+editor-tab-errors = Kɩwɛɛkɩm
+editor-tab-warnings = Paɣtʋ
+editor-tab-info = Tɔm
+editor-tab-accessibility = Talʋʋ
+editor-tab-responses = Cosuu weyi patiyaa yɔ
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Mayʋ lɩzʋʋ
+editor-format-as-doenetml = Ñɔɔzɩ ɛzɩ DoenetML
+editor-format-as-xml = Ñɔɔzɩ ɛzɩ XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Ñɔʋ #{ $line }
+
+editor-no-errors = Kɩwɛɛkɩm Fɛyɩ
+editor-no-warnings = Paɣtʋ Fɛyɩ
+editor-no-info = Tɔm Fɛyɩ
+
+editor-show-info-annotations = Wɩlɩ tɔm mayʋ taa
+editor-show-accessibility-annotations = Wɩlɩ talʋʋ kʋñɔmɩŋ mayʋ taa
+
+editor-accessibility-learn-more = Kpɛlɩkɩ ɛzɩma Doenet ñakɩ pana talʋʋ yɔɔ yɔ
+
+editor-accessibility-violations-heading = Talʋʋ paɣtʋ yɔɔ maʋ ({ $standard })
+
+editor-accessibility-other-heading = Talʋʋ kʋñɔmɩŋ lɛɛŋ
+editor-none-found = Patɩna nabʋyʋ
+
+
+## Submitted responses
+
+editor-no-responses = Patɩtiyi cosuu nabʋyʋ
+editor-response-answer-id = Cosuu hɩɖɛ
+editor-response-response = Cosuu
+editor-response-credit = Kɩɖɛʋ
+editor-response-submitted = Patiyaa
+
+
+## The context-help panel
+
+help-placeholder = Sɩɩ ñɔɔzɩyɛ tag hɩɖɛ, attribute, yaa { $ref } yɔɔ nɛ ŋna takayaɣ.
+
+help-unsupported-ref-chain = Sɩnʋʋ tɔm ndʋ tɩwɛnɩ hɔɔlɩŋ sakɩyɛ ɛzɩ { $example } yɔ tɩtɩtalɩ.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Patɩna nabʋyʋ { $ref } yɔɔ.
+        [multiple] Pana pʋyʋ sakɩyɛ { $ref } yɔɔ.
+       *[indeterminate] Patɩpɩzɩ nɛ pana { $ref } tɔbʋʋ.
+    }
+
+help-learn-about-references = Kpɛlɩkɩ tɔm ndʋ tɩñɔtɩnɩ nʋmɔŋ yɔ →
+help-reference-page = Takayaɣ hɔɔlʋʋ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } taa
+       *[top] Takayaɣ ñʋʋ taa
+    }{ $allowed ->
+        [none] { " — pʋyʋ nabʋyʋ ɛɛwɛɛ cɩnɛ." }
+        [text] { " — ma tɔm cɩnɛ." }
+        [text-and-components] { " — ma tɔm cɩnɛ, yaa maɣzɩ:" }
+       *[components] { " — mbʋ ŋpɩzɩɣ ŋmaɣzɩ yɔ:" }
+    }
+
+help-suggestions-footer = Maɣ { $shortcut } nɛ ŋna pʋyʋ { $total } tɩŋa.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } kɛ nʋmɔʋ ŋgʋ kɩwolo { $target } yɔɔ yɔ.
+       *[other] { $ref } kɛ nʋmɔʋ ŋgʋ kɩwolo { $target } yɔɔ yɔ (ñɔʋ { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } kɔnɩ-kʋ ɛzɩ { $role }.
+       *[other] { $owner } kɔnɩ-kʋ ñɔʋ { $line } yɔɔ ɛzɩ { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } kɛ nʋmɔʋ ŋgʋ kɩwolo { $element } { $property } yɔɔ yɔ.
+       *[other] { $ref } kɛ nʋmɔʋ ŋgʋ kɩwolo { $element } { $property } yɔɔ yɔ (ñɔʋ { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = hɔɔlʋʋ
+help-kind-array-entry = array hɔɔlʋʋ
+
+help-default = Ndʋ tɩwɛɛ yɔ:
+help-active-default = Ndʋ tɩwɛɛ nɛ tɩlakɩ tʋmɩyɛ yɔ:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Mbʋ paha nʋmɔʋ yɔ (kʋɖʋm pʋyʋ kʋɖʋm yɔɔ):
+       *[other] Mbʋ paha nʋmɔʋ yɔ:
+    }
+
+help-suggested-values = Mbʋ pɔtɔŋ se ŋlabɩ yɔ:
+
+help-inserts = Pɩsʋʋnɩ:
+
+help-coordinates =
+    { $count ->
+        [one] Ɖenɖe:
+       *[other] Ɖeɖe:
+    }
+
+help-type = Wɛtʋ:
+
+help-resolved-style = Wɛtʋ ndʋ pana yɔ (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fɔŋksɩyɔŋ hɩla wena pana yɔ:
+help-reset-list = Ñɔɔzɩ lɩzʋʋ input kʋnɛ kɩ-yɔɔ:
+help-added-on-input = Pasʋsɩ input kʋnɛ kɩ-yɔɔ:
+help-removed-on-input = Palɩzɩ input kʋnɛ kɩ-yɔɔ:
+
+help-reset-overrides = { $reset } ɖɛɣnɩ { $additional } nɛ { $removed } nɔɔ.

--- a/packages/i18n/locales/kbp/editor.ftl
+++ b/packages/i18n/locales/kbp/editor.ftl
@@ -77,7 +77,7 @@ editor-accessibility-badge = WCAG
 
 ## The footer
 
-editor-version-title = DoenetML wɛtʋ { $version }
+editor-version-title = DoenetML version { $version }
 
 editor-tab-help = Sɩnʋʋ ɖenɖe ŋwɛɛ yɔ
 editor-tab-help-short = Ɖenɖe

--- a/packages/i18n/locales/kbp/editor.ftl
+++ b/packages/i18n/locales/kbp/editor.ftl
@@ -193,7 +193,7 @@ help-inserts = Pɩsʋʋnɩ:
 help-coordinates =
     { $count ->
         [one] Ɖenɖe:
-       *[other] Ɖeɖe:
+       *[other] Ɖenɖe:
     }
 
 help-type = Wɛtʋ:

--- a/packages/i18n/locales/kg/chrome.ftl
+++ b/packages/i18n/locales/kg/chrome.ftl
@@ -1,0 +1,133 @@
+# Kongo viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the connective table, for what separates this
+# catalog from `locales/ktu`, and for what a speaker should check first.
+
+
+## Answer submission
+
+answer-checking = Kufyongunuka…
+answer-submitting = Kutinda…
+
+answer-checking-status = Mvutu yifyongunukwanga
+answer-submitting-status = Mvutu yitindwanga
+
+answer-correct = Ya kyedika
+answer-incorrect = Ya luvunu
+
+answer-response-saved = Mvutu Yibumbulu
+
+answer-percent-credit = { $percent }% ya Ntalu
+answer-percent-correct = { $percent }% Ya kyedika
+answer-percent-short = { $percent } %
+
+max-credit-available = Ntalu yanene yilenda baka: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] kuna ntonta ve
+        [one] ntonta { $count } yasyala
+       *[other] bintonta { $count } byasyala
+    }
+
+validation-correct = (Ya kyedika)
+validation-incorrect = (Ya luvunu)
+validation-partially-correct = (Ya kyedika mu ndambu)
+
+answer-show-responses =
+    { $count ->
+        [one] Songa mvutu { $count } ya { $answerId }
+       *[other] Songa mivutu { $count } ya { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Mvutu ya Nlongi
+
+collapsible-click-to-open = (buta sambu na kuzibula)
+collapsible-click-to-close = (buta sambu na kukanga)
+
+collapsible-initializing = Kuyantika…
+
+footnote-show = Songa nsonokono ya nsi
+footnote-hide = Swekisa nsonokono ya nsi
+
+description-more-information = nsangu zankaka
+
+
+## Controls
+
+slider-previous = Yavita
+slider-next = Yalanda
+
+keyboard-open = Zibula Klavye
+keyboard-close = Kanga Klavye
+
+choice-input-remove-choice = Katula { $choice }
+
+matrix-remove-row = Katula nkonso
+matrix-add-row = Yika nkonso
+matrix-remove-column = Katula ntandu
+matrix-add-column = Yika ntandu
+
+subset-add-remove-points = Yika/Katula matona
+subset-toggle-points-intervals = Soba matona ye bintangu
+subset-move-points = Nikisa Matona
+subset-clear = Katula byonso
+
+orbital-add-row = Yika Nkonso
+orbital-remove-row = Katula Nkonso
+orbital-add-box = Yika Sanduku
+orbital-remove-box = Katula Sanduku
+orbital-add-up-arrow = Yika Nsonga ya Ntandu
+orbital-add-down-arrow = Yika Nsonga ya Nsi
+orbital-remove-arrow = Katula Nsonga
+
+orbital-row-label = Nkumbu ya nkonso { $row }
+
+pretzel-answer = Mvutu
+
+summary-statistics-caption = Nkanda wa mitangu mya { $column }
+
+
+## Math input
+
+math-input-preview-region = mona ntete mvovo wa mitangu
+math-input-preview = Mona ntete
+math-input-invalid-expression = Mvovo wambi:
+
+
+## Document status
+
+viewer-initializing = Kuyantika…
+
+
+## Errors
+
+error-heading = Mbi
+
+error-found-at =
+    { $span ->
+        [line] Yamonana va nsinga { $startLine }.
+       *[lines] Yamonana va nsinga { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Mukanda wawu wina ye mambi!
+
+diagnostic-heading-error = Mbi
+diagnostic-heading-warning = Nlubuka
+diagnostic-heading-information = Nsangu
+diagnostic-heading-hint = Lusadisu
+
+accessibility-heading-level-1 = Mbundamusu ya WCAG AA mu Nswalu
+accessibility-heading-level-2 = Nlubuka wa nswalu
+
+something-went-wrong = Kima kyankaka kyabwa.
+
+renderer-load-failed = nsongi kalendi kwiza ko. Vutukisa lukaya.
+
+core-start-failed = Nsongi wa mukanda kalendi yantika ko. Vutukisa lukaya.

--- a/packages/i18n/locales/kg/chrome.ftl
+++ b/packages/i18n/locales/kg/chrome.ftl
@@ -46,7 +46,7 @@ answer-show-responses =
 
 ## Disclosure panels
 
-feedback-heading = Mvutu ya Nlongi
+feedback-heading = Mvutu ya Kisalu
 
 collapsible-click-to-open = (buta sambu na kuzibula)
 collapsible-click-to-close = (buta sambu na kukanga)

--- a/packages/i18n/locales/kg/content.ftl
+++ b/packages/i18n/locales/kg/content.ftl
@@ -261,8 +261,8 @@ style-filled-with-noun =
     }
 
 # «lubaku» is the border and leads its own describing words, so they agree with
-# it rather than with the shape it surrounds — which is why `lubaku` is class
-# 11 in `noun-gender` and why `border` answers `c11` there. Kongo has no
+# it rather than with the shape it surrounds — which is why `border` answers
+# `c11` in `noun-gender`, matching «lubaku»'s own «lu-». Kongo has no
 # article and joins this clause with the invariable «ye», so all four branches
 # read alike.
 style-border-clause =

--- a/packages/i18n/locales/kg/content.ftl
+++ b/packages/i18n/locales/kg/content.ftl
@@ -24,9 +24,10 @@
 #   nene      dya nene   kya nene   ya nene    lwa nene
 #
 # So the whole of the agreement in this catalog is one syllable, and it is
-# always the same syllable: the describing stem never moves. Kituba kept the
-# class-9 row and threw the other three away. Putting `color.black` in the two
-# files side by side is the shortest statement of what a creole did to its
+# always in the same place: the describing stem behind it never moves, and only
+# the linker in front of it changes shape. Kituba kept the class-9 row and
+# threw the other three away. Putting `color.black` in the two files side by
+# side is the shortest statement of what a creole did to its
 # lexifier that this repository can make, and it costs nothing but the two
 # files being in the same tree.
 #
@@ -170,7 +171,7 @@ noun =
     .line-segment = kitini kya nsinga
     .ray = nsemo
     .vector = vektele
-    .curve = nsinga wa nkubama
+    .curve = nsinga ya nkubama
     .function = fonksio
     .parabola = palabole
     .polyline = nsinga mia bitini
@@ -196,18 +197,18 @@ noun-regular-polygon =
 
 # The noun class. `c9` is the default and the class a French loan joins, which
 # is what an author's own `markerStyleWord` is as far as this catalog is
-# concerned — and it is also the row Kituba kept.
+# concerned — and it is also the row Kituba kept. So «kare» and «kuluse» are
+# unlisted on purpose: they are loans and take «ya», where «sinsu» and
+# «kizunga» are Kikongo ki-/bi- nouns and take «kya».
 noun-gender =
     { $noun ->
         [line-segment] c7
-        [square] c7
         [region] c7
         [circle] c7
+        [plus] c7
         [fill] c7
         [point] c5
         [diamond] c5
-        [cross] c5
-        [plus] c5
         [text] c5
         [border] c11
        *[other] c9

--- a/packages/i18n/locales/kg/content.ftl
+++ b/packages/i18n/locales/kg/content.ftl
@@ -1,0 +1,393 @@
+# Kongo content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `kg` is Kongo (Kikongo), of the lower Congo in the DRC, the Republic of the
+# Congo and northern Angola. It is a macrolanguage; this catalog is written
+# towards the Kikongo ya Bandundu written standard, and `negotiate.ts` folds
+# `kng`, `kwy` and `ldi` onto it.
+#
+# **Read this file beside `locales/ktu`.** Kituba is the creole whose lexifier
+# is Kikongo, and it was seeded in the previous batch (#1685) as the one Bantu
+# catalog here that selects on neither `$gender` nor `$role`: a describing word
+# is joined to its noun by the invariable linker «ya» and never changes shape.
+#
+# That «ya» is *this* language's class-9 linker, frozen. Kongo joins a
+# describing word to its noun with a connective built on «-a», and the
+# connective agrees:
+#
+#            c5 (di-)   c7 (ki-)   c9 (n-)    c11 (lu-)
+#   linker    dya        kya        ya         lwa
+#   ndombe    dya ndombe kya ndombe ya ndombe  lwa ndombe
+#   nene      dya nene   kya nene   ya nene    lwa nene
+#
+# So the whole of the agreement in this catalog is one syllable, and it is
+# always the same syllable: the describing stem never moves. Kituba kept the
+# class-9 row and threw the other three away. Putting `color.black` in the two
+# files side by side is the shortest statement of what a creole did to its
+# lexifier that this repository can make, and it costs nothing but the two
+# files being in the same tree.
+#
+# **Only the words joined by that connective fork.** The fill patterns are
+# whole phrases with their own internal head, and the mathematical nouns are
+# nouns, so neither takes a linker. This catalog forks on fifteen words — every
+# colour, both widths and the filled word — which is `locales/zu`'s shape
+# rather than `locales/ts`'s.
+#
+# `$role` goes unused: Kongo marks no case.
+#
+# The geometry leans on the French loans DRC schooling supplies, since that is
+# where a Kongo speaker meets these words; where Kikongo has its own word it is
+# used — «kizunga» a circle, «fulu» a place, «sinsu» a sign. They are the first
+# thing to check.
+
+
+## Style vocabulary
+
+# The stem never changes. Only the connective in front of it does.
+color =
+    .black =
+        { $gender ->
+            [c5] dya ndombe
+            [c7] kya ndombe
+            [c11] lwa ndombe
+           *[c9] ya ndombe
+        }
+    .white =
+        { $gender ->
+            [c5] dya mpembe
+            [c7] kya mpembe
+            [c11] lwa mpembe
+           *[c9] ya mpembe
+        }
+    .gray =
+        { $gender ->
+            [c5] dya mvindu
+            [c7] kya mvindu
+            [c11] lwa mvindu
+           *[c9] ya mvindu
+        }
+    .red =
+        { $gender ->
+            [c5] dya mbwaki
+            [c7] kya mbwaki
+            [c11] lwa mbwaki
+           *[c9] ya mbwaki
+        }
+    .orange =
+        { $gender ->
+            [c5] dya olanze
+            [c7] kya olanze
+            [c11] lwa olanze
+           *[c9] ya olanze
+        }
+    .yellow =
+        { $gender ->
+            [c5] dya nzole
+            [c7] kya nzole
+            [c11] lwa nzole
+           *[c9] ya nzole
+        }
+    .green =
+        { $gender ->
+            [c5] dya mayamba
+            [c7] kya mayamba
+            [c11] lwa mayamba
+           *[c9] ya mayamba
+        }
+    .cyan =
+        { $gender ->
+            [c5] dya sayani
+            [c7] kya sayani
+            [c11] lwa sayani
+           *[c9] ya sayani
+        }
+    .blue =
+        { $gender ->
+            [c5] dya bule
+            [c7] kya bule
+            [c11] lwa bule
+           *[c9] ya bule
+        }
+    .purple =
+        { $gender ->
+            [c5] dya viole
+            [c7] kya viole
+            [c11] lwa viole
+           *[c9] ya viole
+        }
+    .pink =
+        { $gender ->
+            [c5] dya loze
+            [c7] kya loze
+            [c11] lwa loze
+           *[c9] ya loze
+        }
+    .brown =
+        { $gender ->
+            [c5] dya ntoto
+            [c7] kya ntoto
+            [c11] lwa ntoto
+           *[c9] ya ntoto
+        }
+
+line-width =
+    .thick =
+        { $gender ->
+            [c5] dya nene
+            [c7] kya nene
+            [c11] lwa nene
+           *[c9] ya nene
+        }
+    .thin =
+        { $gender ->
+            [c5] dya fyoti
+            [c7] kya fyoti
+            [c11] lwa fyoti
+           *[c9] ya fyoti
+        }
+
+# Written as «ya + noun» phrases with their own frozen class-9 linker, the way
+# Kituba writes everything: these describe a manner rather than a quality, and
+# a speaker does not agree them with the shape. They therefore take no
+# `$gender`, and `style-stroke` puts them last so nothing follows them.
+line-style =
+    .dashed = ya bitini bitini
+    .dotted = ya tona tona
+
+fill-style =
+    .horizontal = nsinga miayalumuka
+    .vertical = nsinga miatelama
+    .diagonal = nsinga miasengoloka
+    .backdiagonal = nsinga miasengoloka ku ndambu yankaka
+    .dots = tona
+    .diamonds = madiama
+
+noun =
+    .line = nsinga
+    .line-segment = kitini kya nsinga
+    .ray = nsemo
+    .vector = vektele
+    .curve = nsinga wa nkubama
+    .function = fonksio
+    .parabola = palabole
+    .polyline = nsinga mia bitini
+    .polygon = poligone
+    .triangle = triangele
+    .rectangle = rektangele
+    .circle = kizunga
+    .region = fulu
+    .point = tona
+    .square = kare
+    .diamond = diama
+    .cross = kuluse
+    .plus = sinsu kya kuvukisa
+
+# The side count is a counted complement and closes the noun phrase behind the
+# describing words, so it goes in the tail. «-a» agrees here too, but the head
+# noun is always the same word, so the form is fixed and needs no fork.
+noun-regular-polygon =
+    { $part ->
+        [tail] ya makonso { $numSides }
+       *[head] poligone yafwanana
+    }
+
+# The noun class. `c9` is the default and the class a French loan joins, which
+# is what an author's own `markerStyleWord` is as far as this catalog is
+# concerned — and it is also the row Kituba kept.
+noun-gender =
+    { $noun ->
+        [line-segment] c7
+        [square] c7
+        [region] c7
+        [circle] c7
+        [fill] c7
+        [point] c5
+        [diamond] c5
+        [cross] c5
+        [plus] c5
+        [text] c5
+        [border] c11
+       *[other] c9
+    }
+
+
+## Style composition
+
+# The dash pattern is a «ya …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it. Two
+# connective phrases in a row simply stand side by side; Kongo needs no
+# conjunction between them.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c5] dyazala
+        [c7] kyazala
+        [c11] lwazala
+       *[c9] yazala
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ye { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ye { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ye { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «lubaku» is the border and leads its own describing words, so they agree with
+# it rather than with the shape it surrounds — which is why `lubaku` is class
+# 11 in `noun-gender` and why `border` answers `c11` there. Kongo has no
+# article and joins this clause with the invariable «ye», so all four branches
+# read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] ye lubaku { $border }
+        [and] ye lubaku { $border }
+        [and-article] ye lubaku { $border }
+       *[with] ye lubaku { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = kyazala ve
+
+style-text =
+    { $parts ->
+        [background] { $color } ye nima { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = ata kima ve
+
+
+## Boolean words
+
+boolean-true = kyedika
+boolean-false = luvunu
+
+
+## Answer buttons
+
+answer-submit-label = Fyongunuka Kisalu
+answer-submit-label-no-correctness = Tinda Mvutu
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Kisalu
+    .aside = Diambu dyankaka
+    .cascade = Ndiakana
+    .definition = Nsasa
+    .example = Kifwani
+    .exercise = Ntonta
+    .exercises = Bintonta
+    .given-answer = Mvutu
+    .note = Nsonokono
+    .objectives = Bilomba
+    .paragraphs = Bitini
+    .part = Ndambu
+    .problem = Diambu
+    .problems = Mambu
+    .proof = Kimbangi
+    .question = Kyuvu
+    .section = Kitini
+    .solution = Nsukulu
+    .task = Mfunu
+    .theorem = Tewoleme
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Lusadisu
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabele { $enumeration }
+        [numbered-title] Tabele { $enumeration }{ ": " }
+        [unnumbered-title] Tabele{ ": " }
+       *[unnumbered] Tabele
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Kifwani { $enumeration }
+        [numbered-caption] Kifwani { $enumeration }{ ": " }
+        [unnumbered-caption] Kifwani{ ": " }
+       *[unnumbered] Kifwani
+    }
+
+
+## Paginator controls
+
+paginator-previous = Yavita
+paginator-next = Yalanda
+
+paginator-page = Lukaya
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = to
+
+piecewise-condition-if = kana
+
+piecewise-condition-otherwise = mu mambu mankaka mawonso
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case. The DRC teaches secondary science in French, so a
+## Kongo speaker meets the periodic table there and neither Kikongo nor English
+## is the curriculum — which is why the gap is left visible rather than filled
+## with English words dressed up as Kikongo ones. `locales/ln` and `locales/lua`
+## leave the same gap for the same ministry.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Sinsu kya Simi Kyambi
+chemistry-invalid-ionic-compound = Kivukanu kya Ioni Kyambi

--- a/packages/i18n/locales/kg/diagnostics.ftl
+++ b/packages/i18n/locales/kg/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Kongo diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } yivezwanga kana nsuka zole zatelwa
+       *[other] { $attributes } byivezwanga kana nsuka zole zatelwa
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } yivezwanga kana nsuka ye kati byatelwa byonso
+       *[other] { $attributes } byivezwanga kana nsuka ye kati byatelwa byonso
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset kena mfunu ve kana kati kena ve
+
+## `<line>`
+
+line-points-undetermined-dimensions = Nsinga wa matona mana nene yawu kazabakene ko.
+
+line-points-too-few-dimensions = Nsinga fweti vyoka matona ma nene zole na kunsi.
+
+line-points-depend-on-variables = Nsinga wa matona mana kwendaka na bina bisobanga: { $variables }.
+
+line-equation-invalid-format = Mpila yambi ya kifwanisu kya nsinga mu { $variable1 } ye { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Nsemo yatelwa kwa through, endpoint ye direction.  Through yatelwa yivezwanga.
+
+ray-dimension-mismatch = numDimensions kafwanani ve mu nsemo.
+
+## `<vector>`
+
+vector-overprescribed-head = Vektele yatelwa kwa head, tail ye displacement.  Head yatelwa yivezwanga.
+
+vector-dimension-mismatch = numDimensions kafwanani ve mu vektele.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Kilendi benda na `<{ $component }>` ko kadi kena ye nearestPoint ve.
+
+constrain-to-without-nearest-point = Kilendi kanga na `<{ $component }>` ko kadi kena ye nearestPoint ve.
+
+constrain-to-interior-without-nearest-point = Kilendi kanga na kati kwa `<{ $component }>` ko kadi kena ye nearestPoint ve.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition yivezwanga mu choiceInput yina ya inline ve
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indices zatelwa mu choiceInput zivezwanga kadi ntalu ya indices kafwanani ve ye ntalu ya bana ba choice.
+
+pretzel-indices-count-mismatch = Indices zatelwa mu problem zivezwanga kadi ntalu ya indices kafwanani ve ye ntalu ya bana ba problem.
+
+shuffle-indices-count-mismatch = Indices zatelwa mu shuffle zivezwanga kadi ntalu ya indices kafwanani ve ye ntalu ya bima.
+
+indices-ignored-out-of-range = Indices zatelwa mu { $component } zivezwanga kadi zankaka zina ku nganda ya nzila.
+
+pretzel-indices-repeated = Indices zatelwa mu pretzel zivezwanga kadi zankaka zavutukila.
+
+pretzel-circuit-first-index = Indices zatelwa mu pretzel mu mode="circuit" zivezwanga kadi index yantete fweti vwanda 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Sambu `<{ $component }>` yisala ye bana ba string, attribute `type` fweti telwa.
+
+invalid-type-defaulting-to-math = Type yambi { $type } mu kima { $component }. Fweti vwanda mosi mu math, text, number, to boolean. Kwenda na math.
+
+string-not-valid-component-to-arrange = String "{ $value }" kena kima kyambote ve sambu na { $component }. Yivezwanga.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type yambi { $type }, type yitulwa na number.
+
+invalid-variable-value = Ntalu yambi ya kima kisobanga: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Index ya mpila { $index } fweti vwanda ntalu
+
+variant-index-must-be-integer = Index ya mpila { $index } fweti vwanda ntalu yamvimba
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` yasalwa ve mu bitezo bya kimosi. Bunene bwatulwa na kifwani.
+
+side-by-side-absolute-margins = `<{ $component }>` yasalwa ve mu bitezo bya kimosi. Ndilu zatulwa na kifwani.
+
+side-by-side-no-block-child = `<{ $component }>` yambi: yifweti vwanda ti mwana mosi ya block na kunsi.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Attribute `for` va `<label>` ya kifwanisu yivezwanga.
+
+label-for-must-resolve-to-one = Attribute `for` va `<label>` fweti kwenda na kima kimosi kaka.
+
+label-for-unresolved = Attribute `for` va `<label>` kalendi kwenda na kima ko.
+
+label-for-answer-with-authored-inputs = Attribute `for` va `<label>` yitubila `<answer>` yina ye inputs zasonikwa; tubila input kibeni.
+
+label-for-answer-without-input = Attribute `for` va `<label>` yitubila `<answer>` yina kena ye input ya kutula nkumbu ve.
+
+label-for-must-reference-input-or-answer = Attribute `for` va `<label>` fweti tubila input to answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Sambu na nswalu, `<{ $component }>` fweti vwanda ye nsasa yankufi to yatelwa bonso decorative.
+
+accessibility-video-short-description = Sambu na nswalu, `<video>` fweti vwanda ye nsasa yankufi.
+
+accessibility-input-short-description-or-label = Sambu na nswalu, `<{ $component }>` fweti vwanda ye nsasa yankufi to nkumbu.
+
+accessibility-answer-input-short-description-or-label = Sambu na nswalu, `<answer>` yina yisalanga input fweti vwanda ye nsasa yankufi to nkumbu.
+
+accessibility-short-description-contains-math = Nsasa zankufi kafweti vwanda ye bima bya mitangu bonso `<{ $component }>` ve. Sonika mitangu mu mambu.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } kena ye luswaswanu lwafwana ve mu mambu ma ntu wa kitini (mode ya mpimpa) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi).
+       *[other] { $colorName } kena ye luswaswanu lwafwana ve mu mambu ma ntu wa kitini ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` yavyoka matona { $count } yasalwa ve kana matona mena ye mitangu ve.
+
+circle-too-many-through-points = Kilendi tanga kizunga kyavyoka matona kuluta 3 ko.
+
+circle-overprescribed-radius-center-points = Kilendi tanga kizunga ye radius, kati ye matona byonso byatelwa ko.
+
+circle-center-with-multiple-points = Kilendi tanga kizunga ye kati kyatelwa kyavyoka tona kuluta 1 ko.
+
+circle-radius-too-small = Kilendi tanga kizunga ko: ntama ya kati kwa matona zole kele { $distance }, radius yatelwa { $radius } kele yafyoti kibeni.
+
+circle-radius-with-many-points = Kilendi sala kizunga kyavyoka matona kuluta zole ye radius yatelwa ko.
+
+circle-invalid-center-or-through-points = Kati to matona ma kizunga mambi.
+
+circle-radius-center-with-multiple-points = Kilendi tanga radius ya kizunga ye kati kyatelwa kyavyoka tona kuluta 1 ko.
+
+circle-change-radius-non-numerical = Kilendi soba radius ya kizunga ye matona mana ye mitangu ve ko
+
+circle-radius-with-points-non-numerical = Kilendi sala kizunga kyavyoka tona kuluta mosi ye radius yatelwa kana mitangu kena ve ko.
+
+circle-change-center-non-numerical = Kusoba kati kya kizunga kyavyoka matona mana ye mitangu ve yasalwa ve.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Bunene bwafwana ve mu domain ya fonksio. Domain yina ye ntangu { $intervals } kansi fonksio yina ye { $inputs ->
+            [one] input { $inputs }
+           *[other] inputs { $inputs }
+        }.
+       *[other] Bunene bwafwana ve mu domain ya fonksio. Domain yina ye bintangu { $intervals } kansi fonksio yina ye { $inputs ->
+            [one] input { $inputs }
+           *[other] inputs { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Mpila yambi ya domain ya fonksio.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Kuveza bunene bwa fonksio bwina ye ntalu ve.
+        [minimum] Kuveza bufyoti bwa fonksio bwina ye ntalu ve.
+        [extremum] Kuveza nsuka ya fonksio yina ye ntalu ve.
+        [point] Kuveza tona kya fonksio kyina ye ntalu ve.
+        [slope] Kuveza nsengoloko ya fonksio yina ye ntalu ve.
+       *[other] Kuveza { $type } ya fonksio yina ye ntalu ve.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Kuveza bunene bwa fonksio bwina bwampamba.
+        [minimum] Kuveza bufyoti bwa fonksio bwina bwampamba.
+        [extremum] Kuveza nsuka ya fonksio yina yampamba.
+        [point] Kuveza tona kya fonksio kyina kyampamba.
+       *[other] Kuveza { $type } ya fonksio yina yampamba.
+    }
+
+function-points-too-close = Fonksio yina ye matona zole mana pene-pene kibeni. Kilendi tela fonksio ko.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Mavutukilu ma fonksio malenda kaka kana ntalu ya inputs yifwanana ye ntalu ya outputs. Fonksio yayi yina ye input { $inputs } ye { $outputs ->
+            [one] output { $outputs }
+           *[other] outputs { $outputs }
+        }.
+       *[other] Mavutukilu ma fonksio malenda kaka kana ntalu ya inputs yifwanana ye ntalu ya outputs. Fonksio yayi yina ye inputs { $inputs } ye { $outputs ->
+            [one] output { $outputs }
+           *[other] outputs { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Bunda bwambi bwa sequence.  Fweti vwanda ntalu yamvimba yina ya nsi ya nulu ve.
+
+sequence-invalid-step = Step yambi ya sequence.  Fweti vwanda ntalu mu sequence ya type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" yambi ya sequence ya number.  Fweti vwanda ntalu.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" yambi ya sequence ya letters.  Fweti vwanda ndonga ya bisono.
+
+sequence-invalid-endpoint = "{ $attribute }" yambi ya sequence.
+
+select-from-sequence-coprime-not-numbers = coprime yivezwanga kadi mitangu misolwanga ve
+
+select-from-sequence-coprime-with-exclude-combinations = coprime yivezwanga kadi excludeCombinations yatelwa
+
+## Resolving a `target`
+
+target-not-found = Target yambi mu `<{ $source }>`: kilendi mona target ko.
+
+target-state-variable-not-found = Target yambi mu `<{ $source }>`: kilendi mona kitini kya nkumbu "{ $property }" va `<{ $component }>` ko.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Bisobanga bya `<odeSystem>` fweti swaswana ye kisobanga kya kimpwanza.
+
+ode-system-duplicate-variable-names = Kilendi tela fonksio za RHS za ODE ye nkumbu zavutukila ko.
+
+ode-system-rhs-function-error = Kilendi tela fonksio ya RHS ya ODE ko.  Mbi mu kusala fonksio ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Kilendi tela kona kati kwa nsinga { $count } ko
+
+angle-invalid-through-point = Tona kyambi mu through ya `<angle>`
+
+parabola-vertex-too-many-points = Palabole ye vertex yavyoka tona kuluta 1 yasalwa ve.
+
+parabola-too-many-points = Palabole yavyoka matona kuluta 3 yasalwa ve.
+
+intersection-too-many-items = Ndwakanu ya bima kuluta zole yasalwa ve
+
+## Other math components
+
+ionic-compound-not-two-ions = Kivukanu kya ioni kya bima yankaka ke ioni zole yasalwa ve.
+
+ionic-compound-needs-cation-and-anion = Kivukanu kya ioni kyasalwa kaka mu cation mosi ye anion mosi.
+
+solve-equations-cannot-evaluate = Kilendi sukisa kifwanisu ko kadi kilendi tanga kifwanisu ko: { $equation }
+
+math-operators-operand-number-required = Fweti tela operandNumber kana yikatula operand ya mitangu.
+
+eigen-decomposition-failed = Kilendi tanga bitangu bya kimeneka bya matelese ko
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } kena mu kifwani ve, yo yifwanana ntangu yonso ye kima kyampamba.
+       *[other] `<matchesPattern>`: parameters { $parameters } byena mu kifwani ve, byo bifwanana ntangu yonso ye kima kyampamba.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: kilendi bakisa grid="{ $grid }" ko. Fweti vwanda none, medium, dense, to mitangu zole ya nene yakabulwa na fulu, bonso grid="1 0.5". Grid yisonwa ve.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" yatambulwa ve mu nsongi prefigure; kifwani kya lweke lwa kimalata kyisadilwa.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" yatambulwa ve mu nsongi prefigure; kifwani kya zulu kyisadilwa.
+
+prefigure-invalid-axis-bounds = `<graph>`: ndilu zambi za axis mu prefigure; bbox ya kimenga (-10,-10,10,10) yisadilwa.
+
+prefigure-invalid-width = `<graph>`: bunene bwambi mu prefigure; bunene bwa kimenga 425 bwisadilwa.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio yambi mu prefigure; aspect ratio ya kimenga 1 yisadilwa.
+
+prefigure-grid-spacing-too-fine = `<graph>`: mpasukusu ya grid kele yafyoti kibeni mu ndilu za axis; grid yikatulwa mu nsongi prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: mansonokono kasonwa ve kana nsongi PreFigure kasadilwa ve.
+
+multiple-annotations-children = Bana ba `<annotations>` bawombo bamonana mu `<graph>`; bonso ke yandi ya nsuka bivezwanga.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Kilendi yikula to kopiya mpila ya kima yizabakene ko: { $type }.
+
+copy-prop-not-found = Kilendi mona prop { $property } va kima kya mpila { $component } ko
+
+collect-no-source = Nto yamonana ve mu collect.
+
+collect-invalid-component-type = Kilendi vukisa bima bya mpila `<{ $component }>` ko kadi kele mpila yambi.
+
+reference-index-unavailable = Kilendi tubila index `{ $reference }` ko
+
+## `<callAction>`
+
+component-action-unavailable = Kilendi bokila { $action } va kima `{ $reference }` ko
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Nsangu zina ye mpila yambi.  Nkonso zina ye bunda bwaswaswana. Byamonana mu componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Nsangu zina ye nkumbu za ntandu zavutukila.  Byamonana mu componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Nsangu zikonda nkumbu ya ntandu.  Byamonana mu componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award ya mvutu yayi yina yatulama va mvutu ya answer tag yandi kibeni, yo yitwala mambu makaka.
+
+answer-max-num-attempts-in-section-wide-check-work = Kutula `maxNumAttempts` va `<answer>` na kati kwa kima ye `sectionWideCheckWork` kena mfunu ve, kadi ntalu ya bintonta yitwadiswa kwa kima kina. Tula `maxNumAttempts` va kima kina.
+
+nested-section-wide-check-work-max-num-attempts = Kutula `maxNumAttempts` va kima ye `sectionWideCheckWork` kina na kati kwa kima kyankaka ye `sectionWideCheckWork` kena mfunu ve, kadi ntalu ya bintonta yitwadiswa kwa kima kya nganda. Tula `maxNumAttempts` va kima kya nganda.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Attribute { $attributes } kena ye mfunu ve kana symbolicEquality yatulwa ve.
+       *[other] Attributes { $attributes } byena ye mfunu ve kana symbolicEquality yatulwa ve.
+    }
+
+answer-invalid-type = Type yambi mu mvutu: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Kadi kima `<{ $component }>` kena ye nkumbu ve, kilendi sadilwa bonso attribute ya module ko
+
+module-attribute-name-already-defined = Kima `<{ $component } name="{ $name }">` kilendi sadilwa bonso attribute ya module ko kadi mpila `<module>` yina ntete ye attribute "{ $name }".
+
+conditional-content-condition-ignored = Attribute `condition` yivezwanga va `<conditionalContent>` yina ye bana ba case to else.
+
+slider-markers-type-mismatch = Type ya markers kafwanani ve ye type ya slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel yambi: konso `<problem>` fweti vwanda ye `<statement>` mosi ye `<answer>` mosi.
+
+pretzel-circuit-first-problem-distractor = Pretzel yambi: mu mode="circuit", `<problem>` yantete kalendi vwanda distractor ve.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Ntalu yambi { $values } mu attribute `{ $attribute }`; yivezwanga.
+       *[other] Ntalu zambi { $values } mu attribute `{ $attribute }`; zivezwanga.
+    }
+
+attribute-must-be-references = Ntalu yambi `{ $value }` mu attribute `{ $attribute }`. Attribute fweti vwanda ye bantinu bina biyantika ye `$`.
+
+math-input-invalid-function-names = <mathInput>: nkumbu zambi za fonksio zivezwanga mu { $attribute }: { $names }. Konso nkumbu fweti vwanda ye bisono 2 na kunsi (bisono to bindilu); `|<mathspeak alternative>` yilenda landa.
+
+## Building components from the source
+
+component-type-invalid = Mpila yambi ya kima: `<{ $componentType }>`
+
+attribute-repeated = Kilendi vutukila attribute { $attribute } ko.
+
+attribute-invalid-for-component = Attribute yambi "{ $attribute }" mu kima kya mpila `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Nsasa ya mpila { $styleNumber } yina ye luswaswanu lwafwana ve mu { $context ->
+        [text-on-background] mbala ya mambu va mbala ya nima
+        [high-contrast] mbala ya luswaswanu lwanene va kanevasi
+        [line] mbala ya nsinga va kanevasi
+        [marker] mbala ya sinsu va kanevasi
+       *[text-on-canvas] mbala ya mambu va kanevasi
+    }{ $mode ->
+        [dark] { " (mode ya mpimpa)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi).
+
+style-definition-dark-mode-text-background-contrast =
+    Ata nsasa ya mpila { $styleNumber } yina ye mbala zina ye luswaswanu lwafwana mu mode ya mwinda, mbala za mode ya mpimpa zabakwa na zawu zina ye luswaswanu lwafwana ve kati kwa mbala ya mambu ye mbala ya nima ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi). { $suggestion ->
+        [available] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda (mu kifwani, tula { $lightAttribute }="{ $lightColor }") to soba mbala ya mode ya mpimpa (mu kifwani, tula { $darkAttribute }="{ $darkColor }").
+       *[none] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda to soba mbala zabakwa ye textColorDarkMode to backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Ata nsasa ya mpila { $styleNumber } yina ye mbala ya mambu yina ye luswaswanu lwafwana mu mode ya mwinda, mbala ya mambu ya mode ya mpimpa yabakwa na yawu yina ye luswaswanu lwafwana ve va kanevasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi). { $suggestion ->
+        [available] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda (mu kifwani, tula textColor="{ $lightColor }") to soba mbala ya mode ya mpimpa (mu kifwani, tula textColorDarkMode="{ $darkColor }").
+       *[none] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda to soba mbala yabakwa ye textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Kitini kilenda sola kaka <stylePalette> mosi; yandi ya nsuka yisadilwa.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = kilendi zaba mpila zaswaswana za { $component } ko kadi numToSelect kena ntalu yamvimba yina ya nsi ya nulu ve ko.
+
+variant-num-to-select-not-constant-number = kilendi zaba mpila zaswaswana za { $component } ko kadi numToSelect kena ntalu yasoba ve ko.
+
+variant-with-replacement-not-constant-boolean = kilendi zaba mpila zaswaswana za { $component } ko kadi withReplacement kena boolean yasoba ve ko.
+
+variant-select-weight-disables-unique = Mpila zaswaswana za select zikangwa kana option yina ye selectWeight to selectForVariants yatelwa
+
+variant-coprime-undetermined = kilendi zaba mpila zaswaswana za { $component } ko kadi kilendi zaba nde coprime kele luvunu ntangu yonso ko.
+
+variant-attribute-not-constant = kilendi zaba mpila zaswaswana za { $component } ko kadi { $attribute } kasobaka ve ko.
+
+variant-attribute-not-number = kilendi zaba mpila zaswaswana za { $component } ko kadi { $attribute } kena ntalu ve.
+
+variant-attribute-wrong-type-for-sequence =
+    kilendi zaba mpila zaswaswana za { $component } ya type { $type } ko kadi { $attribute } kena { $expected ->
+        [letters-combination] ndonga ya bisono
+        [math-expression] mvovo wambote wa mitangu
+        [integer] ntalu yamvimba
+       *[number] ntalu
+    } ve.
+
+variant-length-not-integer = kilendi zaba mpila zaswaswana za { $component } ko kadi length kena ntalu yamvimba ve.
+
+variant-sort-not-implemented = mpila zaswaswana za { $component } ye sort zasalwa ve
+
+variant-exclude-combinations-not-implemented = mpila zaswaswana za { $component } ye excludeCombinations zasalwa ve
+
+variant-math-exclude-not-implemented = mpila zaswaswana za { $component } ya type math ye exclude zasalwa ve
+
+variant-non-constant-exclude-not-implemented = mpila zaswaswana za { $component } ye exclude yasobanga zasalwa ve
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: yatambulwa ve mu nsongi prefigure ya graph; mwana yavyokwa.
+
+prefigure-descendant-invalid-geometry = { $subject }: mpila ya kimalata yina yampamba to yalunga ve; mwana yavyokwa.
+
+prefigure-curve-label-omitted = { $subject }: nkumbu zatambulwa ve va bima bya curve byasobwa; nkumbu yavyokwa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: mpila ya nsasa ya curve '{ $definitionType }' yatambulwa ve; mwana yavyokwa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: attribute flipFunctions va regionBetweenCurves yatambulwa ve; mwana yavyokwa.
+
+prefigure-region-non-formula-child = { $subject }: kaka bana ba fonksio ya formula batambulwanga va regionBetweenCurves; mwana yavyokwa.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' yatambulwa ve mu { $labelKind ->
+        [line-family] nkumbu ya dibuta dya nsinga
+       *[point] nkumbu ya tona
+    }; ndwelolo ya kimenga ya PreFigure yisadilwa.
+
+prefigure-fill-style-unsupported = { $subject }: mpila ya nzadisa '{ $fillStyle }' yatambulwa ve kwa PreFigure; nzadisa ya kimosi yisadilwa.
+
+prefigure-line-style-unknown = { $subject }: mpila ya nsinga '{ $lineStyle }' yizabakene ko yakatulwa mu PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: mpila ya sinsu '{ $markerStyle }' yasobwa na mpila 'diamond' ya PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: mpila ya sinsu '{ $markerStyle }' yatambulwa ve kwa PreFigure; mpila ya kimenga yisadilwa.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` yambi; kilendi mona target ko. Nsonokono yavyokwa.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` yamonana ye ba target bawombo; ya ntete yisadilwa.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` yambi; target kena ku nganda ya graph. Nsonokono yavyokwa.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` yambi; target kena kima kyatambulwa mu prefigure ve. Nsonokono yavyokwa.
+
+annotation-text-missing = `<annotation>`: `text` yikonda to yampamba; mambu mampamba masonwa.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Ndiakana ya kizunga yamonana.
+       *[other] Ndiakana ya kizunga yamonana ye kima `<{ $componentType }>`.
+    }
+
+reference-no-referent = Kima ve kyamonana mu ntinu: `{ $reference }`
+
+reference-multiple-referents = Bima biwombo byamonana mu ntinu: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Mpila yambi ya attribute { $attribute } ya `<{ $componentType }>`.
+
+children-invalid = Bana bambi mu `<{ $componentType }>`: Bana bambi bamonana: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ntalu yambi `{ $value }` mu attribute `{ $attribute }`, ntalu `{ $default }` yisadilwa
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Mpila ya DoenetML { $version } yamonana ve.
+       *[other] Mpila ya DoenetML { $version } yamonana ve. Kukwenda na mpila { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML yambi: { $content }
+
+parse-tag-missing-close-tag = DoenetML yambi: Tag `{ $tag }` kena ye tag ya kukanga ve. Tag yakukanga yandi kibeni to tag `</{ $tagName }>` yifwana.
+
+parse-tag-error = DoenetML yambi: Mbi mu tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML yambi: Attribute yambi `{ $attribute }` yimonikina bonso yikonda ntalu.
+
+parse-attribute-invalid = DoenetML yambi: Attribute yambi `{ $attribute }`
+
+parse-attribute-value-invalid = DoenetML yambi: Ntalu yambi ya attribute `{ $value }`
+
+parse-attribute-value-quote-mismatch = DoenetML yambi: Ntalu yambi ya attribute `{ $value }`. Bisinsu bya kutanga bifwanani ve. Yimonikina nde `{ $quote }` yikonda
+
+parse-open-tag-name-missing = DoenetML yambi: Tag yikonda nkumbu yamonana, bonso `<`
+
+parse-tag-not-closed = DoenetML yambi: Tag `{ $tag }` yakangwa ve (`>` yimonikina bonso yikonda).
+
+parse-self-closing-tag-name-missing = DoenetML yambi: Tag yikonda nkumbu yamonana `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML yambi: Tag `{ $tag }` yakangwa ve (`/>` yimonikina bonso yikonda).
+
+parse-tag-invalid-attributes = DoenetML yambi: Tag `{ $tag }` kele yambote ve. Yilenda vwanda ye attributes zambi.
+
+parse-close-tag-name-missing = DoenetML yambi: Tag ya kukanga yikonda nkumbu yamonana, bonso `</`
+
+parse-attribute-value-unquoted = Ntalu za attribute fweti vwanda na kati kwa bisinsu bya kutanga: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML yambi: Tag ya kukanga `{ $tag }` yamonana, kansi tag ya kuzibula yamonana ve
+
+parse-close-tag-mismatched = DoenetML yambi: Tag ya kukanga yifwanani ve. `</{ $expected }>` yavingilwa. `{ $found }` yamonana
+
+parser-node-unconvertible = Kilendi soba node { $node } na node ya Dast ko.
+
+## Names
+
+name-attribute-invalid =
+    Nkumbu yambi name='{ $name }'. { $reason ->
+        [characters] Nkumbu zilenda vwanda kaka ye bisono, mitangu, bindilu bya nsi to bindilu.
+       *[start] Nkumbu fweti yantika ye kisono.
+    }
+
+component-name-invalid-start = Nkumbu yambi ya kima "{ $name }". Nkumbu fweti yantika ye kisono.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer ya type videoWatched fweti vwanda ye attribute video
+
+answer-video-watched-video-not-reference = Answer ya type videoWatched fweti vwanda ye attribute video yina ntinu
+
+answer-name-not-single-text = Attribute name ya answer fweti vwanda ye mwana mosi ya text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Kilendi baka DoenetML ya nganda ko kadi mavutukilu mena mawombo kibeni. Ntinu wa kizunga wina?
+
+external-doenetml-unavailable = Kilendi baka DoenetML na { $attribute }="{ $uri }" ko
+
+external-doenetml-type-mismatch = DoenetML yambi yabakwa na { $attribute }="{ $uri }": yifwanani ve ye mpila ya kima "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` yavezwa; sadila `{ $to }`.
+       *[other] [deprecation] Attribute `{ $from }` va `<{ $component }>` yavezwa; sadila `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` yavezwa ye yivezwanga kadi `{ $to }` yatelwa mpi.
+       *[other] [deprecation] Attribute `{ $from }` va `<{ $component }>` yavezwa ye yivezwanga kadi `{ $to }` yatelwa mpi.
+    }
+
+deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` va `<{ $component }>` yavezwa ye yivezwanga.
+
+deprecated-attribute-to-child = [deprecation] Attribute `{ $attribute }` va `<{ $component }>` yavezwa; sadila mwana `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Ntalu `{ $value }` ya attribute `{ $attribute }` va `<{ $component }>` yavezwa; sadila `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` yilenda kaka kitula mambu ma Kingelesi mu buwombo, yo yina mambu mandi mabikala bonso mu mukanda wasonikwa mu { $locale }. Sonika mpila ya buwombo kibeni, to tula yo ye attribute `pluralForm`.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Kima `<{ $tag }>` kena kima kya Doenet kizabakene ko.
+
+schema-element-not-allowed-at-root = Kima `<{ $tag }>` kitambulwanga ve va zulu kya mukanda.
+
+schema-element-not-allowed-inside = Kima `<{ $tag }>` kitambulwanga ve na kati kwa `<{ $parent }>`.
+
+schema-attribute-unrecognized = Kima `<{ $tag }>` kena ye attribute ya nkumbu `{ $attribute }` ve.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Attribute `{ $attribute }` ya kima `<{ $tag }>` fweti vwanda nkanda ya bitini bina konso kimosi mu: { $allowed }
+       *[other] Attribute `{ $attribute }` ya kima `<{ $tag }>` fweti vwanda mosi mu: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Nkumbu yambi ya mpila mu select.  Nkumbu ya mpila { $variantName } yimonana mu options { $numOptions } kansi ntalu ya kusola kele { $numToSelect }.
+
+select-variant-name-without-options = Mpila zankaka zatelwa mu select kansi options zatelwa ve mu nkumbu ya mpila: { $variantName }.
+
+select-variant-name-not-possible = Nkumbu ya mpila { $variantName } yatelwa mu select kena nkumbu yalenda vwanda ve.
+
+select-too-few-options = Kilendi sola bima { $numToSelect } mu { $numOptions } kaka ko.
+
+select-from-sequence-too-few-values = Kilendi sola ntalu { $numToSelect } mu sequence ya bunda { $length } ko.
+
+select-from-sequence-indices-count-mismatch = Ntalu ya indices zatelwa mu select fweti fwanana ye ntalu ya kusola
+
+select-from-sequence-indices-not-integers = Indices zonso zatelwa mu select fweti vwanda mitangu myamvimba
+
+select-from-sequence-index-excluded = Index yatelwa ya selectfromsequence yina yakatulwa
+
+select-from-sequence-indices-excluded-combination = Indices zatelwa za selectfromsequence zina ndonga yakatulwa
+
+select-from-sequence-coprime-not-positive-integers = Kilendi sola ndonga za coprime ko kadi mitangu myamvimba mya zulu ya nulu misolwanga ve.
+
+select-from-sequence-coprime-common-factor = Kilendi sola mitangu mya coprime ko. Mitangu myonso myalenda vwanda mina ye kifwani kya kimosi. (Ntalu zatelwa za "from" to "to" fweti vwanda coprime ye "step".)
+
+select-from-sequence-coprime-single-number = Kilendi sola ndonga za coprime mu ntalu mosi yina kele 1 ve ko.
+
+select-from-sequence-excluded-too-many-combinations = Kuluta 70% ya ndonga yakatulwa mu selectFromSequence
+
+select-from-sequence-coprime-none-found = Kilendi sola mitangu mya coprime ko. Mitangu myonso myalenda vwanda mina ye kifwani kya kimosi.
+
+select-from-sequence-too-few-unique-values = Kilendi sola ntalu { $numToSelect } zaswaswana mu sequence ya bunda { $numPossibleValues } ko
+
+select-prime-numbers-too-few-values = Kilendi sola ntalu { $numToSelect } mu nkanda wa mitangu mya prime wa bunda { $numValues } ko
+
+select-prime-numbers-values-count-mismatch = Ntalu ya bitangu byatelwa mu select fweti fwanana ye ntalu ya kusola
+
+select-prime-numbers-values-not-prime = Bitangu byonso byatelwa mu select prime number fweti vwanda mu nkanda wa mitangu mya prime
+
+select-prime-numbers-values-excluded-combination = Bitangu byatelwa bya selectPrimeNumbers byina ndonga yakatulwa
+
+select-prime-numbers-excluded-too-many-combinations = Kuluta 70% ya ndonga yakatulwa mu selectPrimeNumbers
+
+select-random-combination-fluke = Mu diambu dyalenda bwa ve, kilendi sola ndonga ya bitangu bya kimpwanza ko
+
+select-random-value-fluke = Mu diambu dyalenda bwa ve, kilendi sola kitangu kya kimpwanza ko

--- a/packages/i18n/locales/kg/diagnostics.ftl
+++ b/packages/i18n/locales/kg/diagnostics.ftl
@@ -99,7 +99,7 @@ side-by-side-absolute-widths = `<{ $component }>` yasalwa ve mu bitezo bya kimos
 
 side-by-side-absolute-margins = `<{ $component }>` yasalwa ve mu bitezo bya kimosi. Ndilu zatulwa na kifwani.
 
-side-by-side-no-block-child = `<{ $component }>` yambi: yifweti vwanda ti mwana mosi ya block na zulu.
+side-by-side-no-block-child = `<{ $component }>` yambi: yifweti vwanda ye mwana mosi ya block na zulu.
 
 ## `<label>`
 
@@ -396,15 +396,15 @@ section-multiple-style-palettes = Kitini kilenda sola kaka <stylePalette> mosi; 
 
 variant-num-to-select-not-non-negative-integer = kilendi zaba mpila zaswaswana za { $component } ko kadi numToSelect kena ntalu yamvimba yina ya nsi ya nulu ve ko.
 
-variant-num-to-select-not-constant-number = kilendi zaba mpila zaswaswana za { $component } ko kadi numToSelect kena ntalu yasoba ve ko.
+variant-num-to-select-not-constant-number = kilendi zaba mpila zaswaswana za { $component } ko kadi numToSelect kena ntalu yasikama ve ko.
 
-variant-with-replacement-not-constant-boolean = kilendi zaba mpila zaswaswana za { $component } ko kadi withReplacement kena boolean yasoba ve ko.
+variant-with-replacement-not-constant-boolean = kilendi zaba mpila zaswaswana za { $component } ko kadi withReplacement kena boolean yasikama ve ko.
 
 variant-select-weight-disables-unique = Mpila zaswaswana za select zikangwa kana option yina ye selectWeight to selectForVariants yatelwa
 
 variant-coprime-undetermined = kilendi zaba mpila zaswaswana za { $component } ko kadi kilendi zaba nde coprime kele luvunu ntangu yonso ko.
 
-variant-attribute-not-constant = kilendi zaba mpila zaswaswana za { $component } ko kadi { $attribute } kasobaka ve ko.
+variant-attribute-not-constant = kilendi zaba mpila zaswaswana za { $component } ko kadi { $attribute } kena kima kyasikama ve ko.
 
 variant-attribute-not-number = kilendi zaba mpila zaswaswana za { $component } ko kadi { $attribute } kena ntalu ve.
 
@@ -492,8 +492,8 @@ attribute-value-invalid-using-default = Ntalu yambi `{ $value }` mu attribute `{
 
 doenetml-version-not-found =
     { $fallback ->
-        [none] Mpila ya DoenetML { $version } yamonana ve.
-       *[other] Mpila ya DoenetML { $version } yamonana ve. Kukwenda na mpila { $fallback }
+        [none] version ya DoenetML { $version } yamonana ve.
+       *[other] version ya DoenetML { $version } yamonana ve. Kukwenda na version { $fallback }
     }
 
 ## Reading the DoenetML

--- a/packages/i18n/locales/kg/diagnostics.ftl
+++ b/packages/i18n/locales/kg/diagnostics.ftl
@@ -29,7 +29,7 @@ line-segment-midpoint-offset-without-midpoint = midpointOffset kena mfunu ve kan
 
 line-points-undetermined-dimensions = Nsinga wa matona mana nene yawu kazabakene ko.
 
-line-points-too-few-dimensions = Nsinga fweti vyoka matona ma nene zole na kunsi.
+line-points-too-few-dimensions = Nsinga fweti vyoka matona ma nene zole na zulu.
 
 line-points-depend-on-variables = Nsinga wa matona mana kwendaka na bina bisobanga: { $variables }.
 
@@ -99,7 +99,7 @@ side-by-side-absolute-widths = `<{ $component }>` yasalwa ve mu bitezo bya kimos
 
 side-by-side-absolute-margins = `<{ $component }>` yasalwa ve mu bitezo bya kimosi. Ndilu zatulwa na kifwani.
 
-side-by-side-no-block-child = `<{ $component }>` yambi: yifweti vwanda ti mwana mosi ya block na kunsi.
+side-by-side-no-block-child = `<{ $component }>` yambi: yifweti vwanda ti mwana mosi ya block na zulu.
 
 ## `<label>`
 
@@ -129,8 +129,8 @@ accessibility-short-description-contains-math = Nsasa zankufi kafweti vwanda ye 
 
 accessibility-section-title-insufficient-contrast =
     { $mode ->
-        [dark] { $colorName } kena ye luswaswanu lwafwana ve mu mambu ma ntu wa kitini (mode ya mpimpa) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi).
-       *[other] { $colorName } kena ye luswaswanu lwafwana ve mu mambu ma ntu wa kitini ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi).
+        [dark] { $colorName } kena ye luswaswanu lwafwana ve mu mambu ma ntu wa kitini (mode ya mpimpa) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na zulu).
+       *[other] { $colorName } kena ye luswaswanu lwafwana ve mu mambu ma ntu wa kitini ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na zulu).
     }
 
 ## `<circle>`
@@ -270,7 +270,7 @@ matches-pattern-parameter-not-in-pattern =
 
 ## `<graph>`
 
-graph-grid-invalid = `<graph>`: kilendi bakisa grid="{ $grid }" ko. Fweti vwanda none, medium, dense, to mitangu zole ya nene yakabulwa na fulu, bonso grid="1 0.5". Grid yisonwa ve.
+graph-grid-invalid = `<graph>`: kilendi bakisa grid="{ $grid }" ko. Fweti vwanda none, medium, dense, to mitangu zole mya zulu ya nulu yakabulwa na fulu, bonso grid="1 0.5". Grid yisonwa ve.
 
 ## PreFigure renderer
 
@@ -354,7 +354,7 @@ attribute-invalid-values =
 
 attribute-must-be-references = Ntalu yambi `{ $value }` mu attribute `{ $attribute }`. Attribute fweti vwanda ye bantinu bina biyantika ye `$`.
 
-math-input-invalid-function-names = <mathInput>: nkumbu zambi za fonksio zivezwanga mu { $attribute }: { $names }. Konso nkumbu fweti vwanda ye bisono 2 na kunsi (bisono to bindilu); `|<mathspeak alternative>` yilenda landa.
+math-input-invalid-function-names = <mathInput>: nkumbu zambi za fonksio zivezwanga mu { $attribute }: { $names }. Konso nkumbu fweti vwanda ye bisono 2 na zulu (bisono to bindilu); `|<mathspeak alternative>` yilenda landa.
 
 ## Building components from the source
 
@@ -376,16 +376,16 @@ style-definition-insufficient-contrast =
     }{ $mode ->
         [dark] { " (mode ya mpimpa)" }
        *[light] { "" }
-    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi).
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na zulu).
 
 style-definition-dark-mode-text-background-contrast =
-    Ata nsasa ya mpila { $styleNumber } yina ye mbala zina ye luswaswanu lwafwana mu mode ya mwinda, mbala za mode ya mpimpa zabakwa na zawu zina ye luswaswanu lwafwana ve kati kwa mbala ya mambu ye mbala ya nima ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi). { $suggestion ->
+    Ata nsasa ya mpila { $styleNumber } yina ye mbala zina ye luswaswanu lwafwana mu mode ya mwinda, mbala za mode ya mpimpa zabakwa na zawu zina ye luswaswanu lwafwana ve kati kwa mbala ya mambu ye mbala ya nima ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na zulu). { $suggestion ->
         [available] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda (mu kifwani, tula { $lightAttribute }="{ $lightColor }") to soba mbala ya mode ya mpimpa (mu kifwani, tula { $darkAttribute }="{ $darkColor }").
        *[none] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda to soba mbala zabakwa ye textColorDarkMode to backgroundColorDarkMode.
     }
 
 style-definition-dark-mode-text-canvas-contrast =
-    Ata nsasa ya mpila { $styleNumber } yina ye mbala ya mambu yina ye luswaswanu lwafwana mu mode ya mwinda, mbala ya mambu ya mode ya mpimpa yabakwa na yawu yina ye luswaswanu lwafwana ve va kanevasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na kunsi). { $suggestion ->
+    Ata nsasa ya mpila { $styleNumber } yina ye mbala ya mambu yina ye luswaswanu lwafwana mu mode ya mwinda, mbala ya mambu ya mode ya mpimpa yabakwa na yawu yina ye luswaswanu lwafwana ve va kanevasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; yifweti { $threshold }:1 na zulu). { $suggestion ->
         [available] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda (mu kifwani, tula textColor="{ $lightColor }") to soba mbala ya mode ya mpimpa (mu kifwani, tula textColorDarkMode="{ $darkColor }").
        *[none] Sambu na luswaswanu lwafwana mu mode ya mpimpa, yikula luswaswanu lwa mode ya mwinda to soba mbala yabakwa ye textColorDarkMode.
     }

--- a/packages/i18n/locales/kg/editor.ftl
+++ b/packages/i18n/locales/kg/editor.ftl
@@ -1,0 +1,208 @@
+# Kongo editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Vutula
+       *[update] Kitula
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Nsongi
+       *[other] { $word } Nsongi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Mpila
+
+editor-variant-filter = Sola…
+
+editor-variant-next = Sola mpila yalanda
+
+editor-variant-previous = Sola mpila yavita
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Mbundamusu ya WCAG AA yamonana. Buta sambu na { $action ->
+            [close] kukanga
+           *[open] kuzibula
+        } nkanda wa nswalu.
+        [advisories] Buta sambu na { $action ->
+            [close] kukanga
+           *[open] kuzibula
+        } nkanda wa nswalu. Mbundamusu ya WCAG AA yamonana ve, kansi malongi mankaka ma nswalu mena.
+       *[clean] Buta sambu na { $action ->
+            [close] kukanga
+           *[open] kuzibula
+        } nkanda wa nswalu. Diambu dya nswalu dyamonana ve.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Mbundamusu ya WCAG AA yamonana. { $count ->
+            [one] mbundamusu { $count } ya WCAG AA
+           *[other] bimbundamusu { $count } bya WCAG AA
+        } byamonana. Buta sambu na { $action ->
+            [close] kukanga
+           *[open] kuzibula
+        } nkanda wa nswalu.
+        [advisories] Mbundamusu ya WCAG AA yamonana ve. { $count ->
+            [one] dilongi { $count } dyankaka dya nswalu
+           *[other] malongi { $count } mankaka ma nswalu
+        } mamonana. Buta sambu na { $action ->
+            [close] kukanga
+           *[open] kuzibula
+        } nkanda wa nswalu.
+       *[clean] Mbundamusu ya WCAG AA yamonana ve. Buta sambu na { $action ->
+            [close] kukanga
+           *[open] kuzibula
+        } nkanda wa nswalu.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Mpila ya DoenetML { $version }
+
+editor-tab-help = Lusadisu lwa fulu
+editor-tab-help-short = Fulu
+editor-tab-errors = Mambi
+editor-tab-warnings = Malubuka
+editor-tab-info = Nsangu
+editor-tab-accessibility = Nswalu
+editor-tab-responses = Mivutu mitindwa
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Nsola za nsoniki
+editor-format-as-doenetml = Fwanisa bonso DoenetML
+editor-format-as-xml = Fwanisa bonso XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Nsinga #{ $line }
+
+editor-no-errors = Mambi Ve
+editor-no-warnings = Malubuka Ve
+editor-no-info = Nsangu Ve
+
+editor-show-info-annotations = Songa nsangu mu nsoniki
+editor-show-accessibility-annotations = Songa mambu ma nswalu mu nsoniki
+
+editor-accessibility-learn-more = Longuka mutindu Doenet kelandanga nswalu
+
+editor-accessibility-violations-heading = Bimbundamusu bya nswalu ({ $standard })
+
+editor-accessibility-other-heading = Mambu mankaka ma nswalu
+editor-none-found = Kima ve
+
+
+## Submitted responses
+
+editor-no-responses = Mivutu mitindwa ve nate
+editor-response-answer-id = Nkumbu ya mvutu
+editor-response-response = Mvutu
+editor-response-credit = Ntalu
+editor-response-submitted = Yitindwa
+
+
+## The context-help panel
+
+help-placeholder = Tula nsonga va nkumbu ya tag, va attribute, to va { $ref } sambu na malongi.
+
+help-unsupported-ref-chain = Lusadisu mu mambu ma bitini biwombo bonso { $example } luena ntete ve.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Kima ve kyamonana mu { $ref }.
+        [multiple] Bima biwombo byamonana mu { $ref }.
+       *[indeterminate] Kima kya { $ref } kalendi zabakana ko.
+    }
+
+help-learn-about-references = Longuka mambu ma bantinu →
+help-reference-page = Lukaya lwa malongi →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Na kati kwa { $element }
+       *[top] Va zulu kya mukanda
+    }{ $allowed ->
+        [none] { " — kima kekwenda vava ve." }
+        [text] { " — sonika mambu vava." }
+        [text-and-components] { " — sonika mambu vava, to meka:" }
+       *[components] { " — bima bya kumeka:" }
+    }
+
+help-suggestions-footer = Buta { $shortcut } sambu na kumona bima { $total } byonso.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } kele ntinu kwa { $target }.
+       *[other] { $ref } kele ntinu kwa { $target } (nsinga { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Yatulwa kwa { $owner } bonso { $role }.
+       *[other] Yatulwa kwa { $owner } va nsinga { $line } bonso { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } kele ntinu kwa kitini { $property } kya { $element }.
+       *[other] { $ref } kele ntinu kwa kitini { $property } kya { $element } (nsinga { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = kitini
+help-kind-array-entry = kitini kya array
+
+help-default = Ya kimenga:
+help-active-default = Ya kimenga yasalanga:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ntalu zalombwa (mosi konso kitini):
+       *[other] Ntalu zalombwa:
+    }
+
+help-suggested-values = Ntalu zalongwa:
+
+help-inserts = Yitulanga:
+
+help-coordinates =
+    { $count ->
+        [one] Fulu:
+       *[other] Bifulu:
+    }
+
+help-type = Mpila:
+
+help-resolved-style = Mpila yasolwa (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Nkumbu za fonksio zasolwa:
+help-reset-list = Nkanda wa vutula va input yayi:
+help-added-on-input = Yayikwa va input yayi:
+help-removed-on-input = Yakatulwa va input yayi:
+
+help-reset-overrides = { $reset } yilutanga { $additional } ye { $removed }.

--- a/packages/i18n/locales/kg/editor.ftl
+++ b/packages/i18n/locales/kg/editor.ftl
@@ -25,7 +25,7 @@ editor-update-viewer-title =
 
 editor-variant = Mpila
 
-editor-variant-filter = Sola…
+editor-variant-filter = Sosa…
 
 editor-variant-next = Sola mpila yalanda
 
@@ -77,7 +77,7 @@ editor-accessibility-badge = WCAG
 
 ## The footer
 
-editor-version-title = Mpila ya DoenetML { $version }
+editor-version-title = version ya DoenetML { $version }
 
 editor-tab-help = Lusadisu lwa fulu
 editor-tab-help-short = Fulu
@@ -182,8 +182,8 @@ help-style-number-annotation = { " " }(styleNumber { $styleNumber })
 
 help-allowed-values =
     { $perItem ->
-        [true] Ntalu zalombwa (mosi konso kitini):
-       *[other] Ntalu zalombwa:
+        [true] Ntalu zatambulwa (mosi konso kitini):
+       *[other] Ntalu zatambulwa:
     }
 
 help-suggested-values = Ntalu zalongwa:

--- a/packages/i18n/locales/kri/chrome.ftl
+++ b/packages/i18n/locales/kri/chrome.ftl
@@ -1,0 +1,135 @@
+# Krio viewer chrome: buttons, panel headers, and other UI the reader interacts
+# with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the orthography this catalog commits to, for
+# what separates it from `locales/pcm`, and for what a speaker should check
+# first. The short version: an English word that slipped back in unspelt is
+# the failure to look for.
+
+
+## Answer submission
+
+answer-checking = De chɛk…
+answer-submitting = De sɛn…
+
+answer-checking-status = Wi de chɛk di ansa
+answer-submitting-status = Wi de sɛn di ansa
+
+answer-correct = I kɔrɛkt
+answer-incorrect = I nɔ kɔrɛkt
+
+answer-response-saved = Wi Dɔn Sev Yu Ansa
+
+answer-percent-credit = { $percent }% Krɛdit
+answer-percent-correct = { $percent }% Kɔrɛkt
+answer-percent-short = { $percent } %
+
+max-credit-available = Di mɔs krɛdit we yu kin gɛt: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] nɔ tray lɛf
+        [one] { $count } tray lɛf
+       *[other] { $count } tray lɛf
+    }
+
+validation-correct = (I kɔrɛkt)
+validation-incorrect = (I nɔ kɔrɛkt)
+validation-partially-correct = (I kɔrɛkt smɔl)
+
+answer-show-responses =
+    { $count ->
+        [one] Sho { $count } ansa fɔ { $answerId }
+       *[other] Sho { $count } ansa fɔ { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Fidbak
+
+collapsible-click-to-open = (klik fɔ opin)
+collapsible-click-to-close = (klik fɔ klos)
+
+collapsible-initializing = I de stat…
+
+footnote-show = Sho di fut-not
+footnote-hide = Ayd di fut-not
+
+description-more-information = mɔ infɔmeshɔn
+
+
+## Controls
+
+slider-previous = Di wan we dɔn pas
+slider-next = Nɛks
+
+keyboard-open = Opin Kibɔd
+keyboard-close = Klos Kibɔd
+
+choice-input-remove-choice = Pul { $choice }
+
+matrix-remove-row = Pul ro
+matrix-add-row = Ad ro
+matrix-remove-column = Pul kɔlum
+matrix-add-column = Ad kɔlum
+
+subset-add-remove-points = Ad/Pul pɔynt dɛn
+subset-toggle-points-intervals = Chenj bitwin pɔynt ɛn intaval
+subset-move-points = Muv Di Pɔynt Dɛn
+subset-clear = Kliya
+
+orbital-add-row = Ad Ro
+orbital-remove-row = Pul Ro
+orbital-add-box = Ad Bɔks
+orbital-remove-box = Pul Bɔks
+orbital-add-up-arrow = Ad Aro We Fes Ɔp
+orbital-add-down-arrow = Ad Aro We Fes Dɔŋ
+orbital-remove-arrow = Pul Aro
+
+orbital-row-label = Nem fɔ ro { $row }
+
+pretzel-answer = Ansa
+
+summary-statistics-caption = Sɔmari statistiks fɔ { $column }
+
+
+## Math input
+
+math-input-preview-region = privyu pan di mat ɛkspreshɔn
+math-input-preview = Privyu
+math-input-invalid-expression = Ɛkspreshɔn we nɔ kɔrɛkt:
+
+
+## Document status
+
+viewer-initializing = I de stat…
+
+
+## Errors
+
+error-heading = Ɛra
+
+error-found-at =
+    { $span ->
+        [line] Wi si am pan layn { $startLine }.
+       *[lines] Wi si am pan layn { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dis dɔkyumɛnt gɛt ɛra insay!
+
+diagnostic-heading-error = Ɛra
+diagnostic-heading-warning = Wɔnin
+diagnostic-heading-information = Infɔ
+diagnostic-heading-hint = Klu
+
+accessibility-heading-level-1 = WCAG AA Aksɛsibiliti Vayoleshɔn
+accessibility-heading-level-2 = Aksɛsibiliti alat
+
+something-went-wrong = Sɔntin nɔ go fayn.
+
+renderer-load-failed = wan rɛndara nɔ lod. Duya lod di pej bak.
+
+core-start-failed = Di dɔkyumɛnt viwa nɔ ebul fɔ stat. Duya lod di pej bak.

--- a/packages/i18n/locales/kri/content.ftl
+++ b/packages/i18n/locales/kri/content.ftl
@@ -11,7 +11,8 @@
 # has the same lexifier and much of the same grammar — postposed plural, a
 # preverbal completive, `na` for identity — and the two catalogs still do not
 # look alike, because Sierra Leone settled on a phonemic orthography and
-# Nigeria did not:
+# Nigeria stayed close to English spelling. The two diverge wherever the
+# spelling does, which is not everywhere:
 #
 #              kri          pcm
 #   black      blak         black

--- a/packages/i18n/locales/kri/content.ftl
+++ b/packages/i18n/locales/kri/content.ftl
@@ -55,12 +55,13 @@ line-width =
     .thick = tik
     .thin = tin
 
-# «we» is the relativizer and «de» the imperfective: a dash pattern is
-# something the line does rather than something it is, so it comes out as a
-# clause. `style-stroke` puts it last, where a clause belongs.
+# Reduplication used attributively, the same move `locales/pcm` makes. A «we de
+# brok-brok» clause would be the more literal rendering and is wrong here: the
+# description is *followed* by the noun, so a relative clause would sit in front
+# of the thing it modifies and attach to nothing.
 line-style =
-    .dashed = we de brok-brok
-    .dotted = we de dɔt-dɔt
+    .dashed = brok-brok
+    .dotted = dɔt-dɔt
 
 fill-style =
     .horizontal = layn dɛn we lidɔm
@@ -105,13 +106,14 @@ noun-gender = wan
 
 ## Style composition
 
-# The dash pattern is a «we …» clause and closes the description, so it moves
-# behind the colour rather than sitting between the width and it.
+# Krio stacks modifiers in front of the noun in the order English does, and
+# `line-style` is a bare modifier rather than a clause, so nothing needs to be
+# moved to the end here.
 style-stroke =
     { $parts ->
-        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-style-color] { $width } { $lineStyle } { $color }
         [width-color] { $width } { $color }
-        [style-color] { $color } { $lineStyle }
+        [style-color] { $lineStyle } { $color }
         [width-style] { $width } { $lineStyle }
         [width] { $width }
         [style] { $lineStyle }

--- a/packages/i18n/locales/kri/content.ftl
+++ b/packages/i18n/locales/kri/content.ftl
@@ -1,0 +1,278 @@
+# Krio content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `kri` is Krio, the English-lexifier creole of Sierra Leone and the language
+# very nearly everyone in the country shares, whatever they grew up speaking.
+#
+# **Read it beside `locales/pcm`, seeded in the same batch.** Nigerian Pidgin
+# has the same lexifier and much of the same grammar — postposed plural, a
+# preverbal completive, `na` for identity — and the two catalogs still do not
+# look alike, because Sierra Leone settled on a phonemic orthography and
+# Nigeria did not:
+#
+#              kri          pcm
+#   black      blak         black
+#   white      wet          white
+#   green      grin         green
+#   answer     ansa         ansa
+#   page       pej          pej
+#
+# So the seam between the two is orthographic where `locales/fon`'s internal
+# seam is morphological, and neither is the same thing as a difference in
+# grammar. A speaker reviewing this file should be checking that it stays in
+# the Krio spelling throughout — the failure mode here is an English word
+# slipping back in unspelt, and `color.black` is where it would show first.
+#
+# Krio writes `ɛ` and `ɔ` as full letters, and this catalog uses them. It is
+# the orthography of the Krio Bible and the university's own materials, and it
+# is the one decision in this file most likely to be contested.
+#
+# Krio has no noun class, no gender and no case, so `$gender` and `$role` both
+# go unused. Number is `dɛn`, postposed and only where it is needed; the
+# describing words do not carry it.
+
+
+## Style vocabulary
+
+color =
+    .black = blak
+    .white = wet
+    .gray = gre
+    .red = rɛd
+    .orange = ɔrenj
+    .yellow = yala
+    .green = grin
+    .cyan = sayan
+    .blue = blu
+    .purple = pɔpul
+    .pink = pink
+    .brown = braun
+
+line-width =
+    .thick = tik
+    .thin = tin
+
+# «we» is the relativizer and «de» the imperfective: a dash pattern is
+# something the line does rather than something it is, so it comes out as a
+# clause. `style-stroke` puts it last, where a clause belongs.
+line-style =
+    .dashed = we de brok-brok
+    .dotted = we de dɔt-dɔt
+
+fill-style =
+    .horizontal = layn dɛn we lidɔm
+    .vertical = layn dɛn we tinap
+    .diagonal = layn dɛn we slant
+    .backdiagonal = layn dɛn we slant di ɔda say
+    .dots = dɔt dɛn
+    .diamonds = dayamɔn dɛn
+
+noun =
+    .line = layn
+    .line-segment = pis pan layn
+    .ray = re
+    .vector = vɛkta
+    .curve = layn we bɛnd
+    .function = fɔnkshɔn
+    .parabola = parabola
+    .polyline = layn we gɛt bɔku pis
+    .polygon = pɔligɔn
+    .triangle = trayangul
+    .rectangle = rɛktangul
+    .circle = raun
+    .region = eria
+    .point = pɔynt
+    .square = skwea
+    .diamond = dayamɔn
+    .cross = krɔs
+    .plus = plɔs mak
+
+# The side count is a relative clause and closes the noun phrase behind the
+# describing words, so it goes in the tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] we gɛt { $numSides } say
+       *[head] pɔligɔn we ɔl di say dɛn na wan
+    }
+
+# Krio has no noun class and no gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = wan
+
+
+## Style composition
+
+# The dash pattern is a «we …» clause and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+# «dɔn ful» — the completive `dɔn` rather than an English passive. There is no
+# adjective here to inflect; the whole word is a verb phrase, as it is in
+# `locales/pcm`.
+style-filled-word = dɔn ful
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } wit { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } wit { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wit { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+# Krio has no indefinite article where English wants one here, so the
+# `-article` branches read the same as their bare counterparts. The «wit» /
+# «ɛn» distinction — first clause against a further one — is real and survives.
+style-border-clause =
+    { $parts ->
+        [with-article] wit { $border } bɔda
+        [and] ɛn { $border } bɔda
+        [and-article] ɛn { $border } bɔda
+       *[with] wit { $border } bɔda
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = i nɔ ful
+
+style-text =
+    { $parts ->
+        [background] { $color } wit { $background } bakgrɔn
+       *[plain] { $color }
+    }
+
+style-background-none = natin
+
+
+## Boolean words
+##
+## `true` and `false` stay English everywhere as DoenetML syntax; only what the
+## reader sees moves.
+
+boolean-true = na tru
+boolean-false = na lay
+
+
+## Answer buttons
+
+answer-submit-label = Chɛk Wok
+answer-submit-label-no-correctness = Sɛn Ansa
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktiviti
+    .aside = Say Tɔk
+    .cascade = Kasked
+    .definition = Minin
+    .example = Ɛgzampul
+    .exercise = Ɛksasayz
+    .exercises = Ɛksasayz dɛn
+    .given-answer = Ansa
+    .note = Not
+    .objectives = Wetin wi want fɔ du
+    .paragraphs = Paragraf dɛn
+    .part = Pat
+    .problem = Prɔblɛm
+    .problems = Prɔblɛm dɛn
+    .proof = Pruf
+    .question = Kwɛstiɔn
+    .section = Sɛkshɔn
+    .solution = Ansa fɔ di prɔblɛm
+    .task = Wok
+    .theorem = Tiɔrɛm
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Klu
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tebul { $enumeration }
+        [numbered-title] Tebul { $enumeration }{ ": " }
+        [unnumbered-title] Tebul{ ": " }
+       *[unnumbered] Tebul
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Piksho { $enumeration }
+        [numbered-caption] Piksho { $enumeration }{ ": " }
+        [unnumbered-caption] Piksho{ ": " }
+       *[unnumbered] Piksho
+    }
+
+
+## Paginator controls
+
+paginator-previous = Di wan we dɔn pas
+paginator-next = Nɛks
+
+paginator-page = Pej
+
+paginator-page-status = { $pageLabel } { $currentPage } pan { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ɔ
+
+piecewise-condition-if = if
+
+piecewise-condition-otherwise = if i nɔ so
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case. Sierra Leone teaches secondary science in English,
+## and Krio's lexifier is English, so the fallback is both the curriculum and
+## very nearly the language — the same reasoning `locales/pcm` records for
+## Nigeria, and the reason neither file spells out 130 keys that would come
+## back all but identical to `locales/en`.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kɛmistri Simbɔl We Nɔ Kɔrɛkt
+chemistry-invalid-ionic-compound = Ayɔnik Kɔmpaun We Nɔ Kɔrɛkt

--- a/packages/i18n/locales/kri/diagnostics.ftl
+++ b/packages/i18n/locales/kri/diagnostics.ftl
@@ -79,7 +79,7 @@ string-children-need-type = Fɔ mek `<{ $component }>` wok wit string pikin, yu 
 
 invalid-type-defaulting-to-math = Tayp { $type } nɔ kɔrɛkt fɔ { $component } kɔmponɛnt. I fɔ bi math, text, number ɔ boolean. Wi go yuz math.
 
-string-not-valid-component-to-arrange = String "{ $value }" nɔ to valid kɔmponɛnt fɔ { $component }. Wi de ignɔ am.
+string-not-valid-component-to-arrange = String "{ $value }" nɔ to kɔmponɛnt we kɔrɛkt fɔ { $component }. Wi de ignɔ am.
 
 ## Types and variables
 
@@ -210,7 +210,7 @@ function-iterates-input-output-mismatch =
 
 sequence-invalid-length = Di lɛnt pan di sequence nɔ kɔrɛkt.  I fɔ bi ɔl nɔmba we nɔ de bilo ziro.
 
-sequence-invalid-step = Di step pan di sequence nɔ kɔrɛkt.  I fɔ bi nɔmba fɔ sequence pan type { $type }.
+sequence-invalid-step = Di step pan di sequence nɔ kɔrɛkt.  I fɔ bi nɔmba fɔ sequence pan tayp { $type }.
 
 sequence-invalid-endpoint-number = Di "{ $attribute }" pan di number sequence nɔ kɔrɛkt.  I fɔ bi nɔmba.
 
@@ -300,7 +300,7 @@ collect-no-source = Wi nɔ si sɔs fɔ collect.
 
 collect-invalid-component-type = Wi nɔ ebul fɔ kɔlɛkt kɔmponɛnt pan tayp `<{ $component }>` bikɔs di tayp nɔ kɔrɛkt.
 
-reference-index-unavailable = Wi nɔ ebul fɔ rɛfarɛns index `{ $reference }`
+reference-index-unavailable = Wi nɔ ebul fɔ rɛfrɛns index `{ $reference }`
 
 ## `<callAction>`
 
@@ -411,7 +411,7 @@ variant-attribute-not-number = wi nɔ ebul fɔ no di yunik vɛriant pan { $compo
 variant-attribute-wrong-type-for-sequence =
     wi nɔ ebul fɔ no di yunik vɛriant pan { $component } pan { $type } tayp bikɔs { $attribute } nɔ to { $expected ->
         [letters-combination] lɛta kɔmbineshɔn
-        [math-expression] valid mat ɛkspreshɔn
+        [math-expression] mat ɛkspreshɔn we kɔrɛkt
         [integer] ɔl nɔmba
        *[number] nɔmba
     }.
@@ -520,7 +520,7 @@ parse-self-closing-tag-name-missing = DoenetML nɔ kɔrɛkt: Wi si tag we nɔ g�
 
 parse-self-closing-tag-not-closed = DoenetML nɔ kɔrɛkt: Dɛn nɔ klos di tag `{ $tag }` (i tan lɛk se `/>` nɔ de).
 
-parse-tag-invalid-attributes = DoenetML nɔ kɔrɛkt: Di tag `{ $tag }` nɔ valid. I kin gɛt attribute we nɔ kɔrɛkt.
+parse-tag-invalid-attributes = DoenetML nɔ kɔrɛkt: Di tag `{ $tag }` nɔ kɔrɛkt. I kin gɛt attribute we nɔ kɔrɛkt.
 
 parse-close-tag-name-missing = DoenetML nɔ kɔrɛkt: Wi si klosin tag we nɔ gɛt nem, lɛk `</`
 

--- a/packages/i18n/locales/kri/diagnostics.ftl
+++ b/packages/i18n/locales/kri/diagnostics.ftl
@@ -49,11 +49,11 @@ vector-dimension-mismatch = numDimensions nɔ mach fɔ di vɛkta.
 
 ## Attracting and constraining
 
-attract-to-without-nearest-point = Wi nɔ ebul fɔ atrakt to `<{ $component }>` bikɔs i nɔ gɛt nearestPoint.
+attract-to-without-nearest-point = Wi nɔ ebul fɔ atrakt to `<{ $component }>` bikɔs i nɔ gɛt nearestPoint stet vɛriabul.
 
-constrain-to-without-nearest-point = Wi nɔ ebul fɔ kɔnstren to `<{ $component }>` bikɔs i nɔ gɛt nearestPoint.
+constrain-to-without-nearest-point = Wi nɔ ebul fɔ kɔnstren to `<{ $component }>` bikɔs i nɔ gɛt nearestPoint stet vɛriabul.
 
-constrain-to-interior-without-nearest-point = Wi nɔ ebul fɔ kɔnstren to di insay pan `<{ $component }>` bikɔs i nɔ gɛt nearestPoint.
+constrain-to-interior-without-nearest-point = Wi nɔ ebul fɔ kɔnstren to di insay pan `<{ $component }>` bikɔs i nɔ gɛt nearestPoint stet vɛriabul.
 
 ## `<choiceInput>`
 
@@ -77,13 +77,13 @@ pretzel-circuit-first-index = Wi de ignɔ di indices we yu gi pretzel na mode="c
 
 string-children-need-type = Fɔ mek `<{ $component }>` wok wit string pikin, yu fɔ gi am `type` attribute.
 
-invalid-type-defaulting-to-math = Type { $type } nɔ kɔrɛkt fɔ { $component } kɔmponɛnt. I fɔ bi math, text, number ɔ boolean. Wi go yuz math.
+invalid-type-defaulting-to-math = Tayp { $type } nɔ kɔrɛkt fɔ { $component } kɔmponɛnt. I fɔ bi math, text, number ɔ boolean. Wi go yuz math.
 
 string-not-valid-component-to-arrange = String "{ $value }" nɔ to valid kɔmponɛnt fɔ { $component }. Wi de ignɔ am.
 
 ## Types and variables
 
-invalid-type-defaulting-to-number = Type { $type } nɔ kɔrɛkt, wi dɔn sɛt di type to number.
+invalid-type-defaulting-to-number = Tayp { $type } nɔ kɔrɛkt, wi dɔn sɛt di tayp to number.
 
 invalid-variable-value = Vɛriabul valyu we nɔ kɔrɛkt: `{ $value }`
 
@@ -109,7 +109,7 @@ label-for-must-resolve-to-one = Di `for` attribute pan `<label>` fɔ pɔynt to �
 
 label-for-unresolved = Di `for` attribute pan `<label>` nɔ ebul fɔ pɔynt to ɛni kɔmponɛnt.
 
-label-for-answer-with-authored-inputs = Di `for` attribute pan `<label>` de pɔynt to `<answer>` we gɛt input dɛn we di ɔda pɔsin rayt; pɔynt to di input daytrɛkt.
+label-for-answer-with-authored-inputs = Di `for` attribute pan `<label>` de pɔynt to `<answer>` we gɛt input dɛn we di ɔtɔ rayt insɛf; pɔynt to di input daytrɛkt.
 
 label-for-answer-without-input = Di `for` attribute pan `<label>` de pɔynt to `<answer>` we nɔ gɛt input fɔ lebul.
 

--- a/packages/i18n/locales/kri/diagnostics.ftl
+++ b/packages/i18n/locales/kri/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Krio diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] wi de ignɔ { $attributes } we yu dɔn gi tu ɛndpɔynt
+       *[other] wi de ignɔ { $attributes } we yu dɔn gi tu ɛndpɔynt
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] wi de ignɔ { $attributes } we yu gi ɛndpɔynt ɛn midpɔynt togɛda
+       *[other] wi de ignɔ { $attributes } we yu gi ɛndpɔynt ɛn midpɔynt togɛda
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset nɔ de du natin if midpɔynt nɔ de
+
+## `<line>`
+
+line-points-undetermined-dimensions = Layn we pas pɔynt dɛn we wi nɔ no dɛn daymɛnshɔn.
+
+line-points-too-few-dimensions = Layn fɔ pas pɔynt dɛn we gɛt at lis tu daymɛnshɔn.
+
+line-points-depend-on-variables = Layn de pas pɔynt dɛn we dipɛn pan vɛriabul dɛn: { $variables }.
+
+line-equation-invalid-format = Di fɔmat fɔ di layn ikweshɔn nɔ kɔrɛkt fɔ vɛriabul { $variable1 } ɛn { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Yu dɔn gi di re through, endpoint ɛn direction.  Wi de ignɔ di through we yu gi.
+
+ray-dimension-mismatch = numDimensions nɔ mach fɔ di re.
+
+## `<vector>`
+
+vector-overprescribed-head = Yu dɔn gi di vɛkta head, tail ɛn displacement.  Wi de ignɔ di head we yu gi.
+
+vector-dimension-mismatch = numDimensions nɔ mach fɔ di vɛkta.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Wi nɔ ebul fɔ atrakt to `<{ $component }>` bikɔs i nɔ gɛt nearestPoint.
+
+constrain-to-without-nearest-point = Wi nɔ ebul fɔ kɔnstren to `<{ $component }>` bikɔs i nɔ gɛt nearestPoint.
+
+constrain-to-interior-without-nearest-point = Wi nɔ ebul fɔ kɔnstren to di insay pan `<{ $component }>` bikɔs i nɔ gɛt nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = wi de ignɔ labelPosition fɔ choiceInput we nɔ to inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Wi de ignɔ di indices we yu gi choiceInput bikɔs di nɔmba pan indices nɔ mach di nɔmba pan choice pikin.
+
+pretzel-indices-count-mismatch = Wi de ignɔ di indices we yu gi problem bikɔs di nɔmba pan indices nɔ mach di nɔmba pan problem pikin.
+
+shuffle-indices-count-mismatch = Wi de ignɔ di indices we yu gi shuffle bikɔs di nɔmba pan indices nɔ mach di nɔmba pan kɔmponɛnt.
+
+indices-ignored-out-of-range = Wi de ignɔ di indices we yu gi { $component } bikɔs sɔm pan dɛn de ɔt pan renj.
+
+pretzel-indices-repeated = Wi de ignɔ di indices we yu gi pretzel bikɔs sɔm pan dɛn ripit.
+
+pretzel-circuit-first-index = Wi de ignɔ di indices we yu gi pretzel na mode="circuit" bikɔs di fɔs index fɔ bi 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Fɔ mek `<{ $component }>` wok wit string pikin, yu fɔ gi am `type` attribute.
+
+invalid-type-defaulting-to-math = Type { $type } nɔ kɔrɛkt fɔ { $component } kɔmponɛnt. I fɔ bi math, text, number ɔ boolean. Wi go yuz math.
+
+string-not-valid-component-to-arrange = String "{ $value }" nɔ to valid kɔmponɛnt fɔ { $component }. Wi de ignɔ am.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } nɔ kɔrɛkt, wi dɔn sɛt di type to number.
+
+invalid-variable-value = Vɛriabul valyu we nɔ kɔrɛkt: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Vɛriant index { $index } fɔ bi nɔmba
+
+variant-index-must-be-integer = Vɛriant index { $index } fɔ bi ɔl nɔmba
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Wi nɔ implimɛnt `<{ $component }>` yet fɔ absolut mɛzhɔmɛnt. Wi dɔn sɛt di wit to rɛlativ.
+
+side-by-side-absolute-margins = Wi nɔ implimɛnt `<{ $component }>` yet fɔ absolut mɛzhɔmɛnt. Wi dɔn sɛt di majin to rɛlativ.
+
+side-by-side-no-block-child = `<{ $component }>` nɔ kɔrɛkt: i fɔ gɛt at lis wan block pikin.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Wi de ignɔ di `for` attribute pan grafikal `<label>`.
+
+label-for-must-resolve-to-one = Di `for` attribute pan `<label>` fɔ pɔynt to ɛgzaktli wan kɔmponɛnt.
+
+label-for-unresolved = Di `for` attribute pan `<label>` nɔ ebul fɔ pɔynt to ɛni kɔmponɛnt.
+
+label-for-answer-with-authored-inputs = Di `for` attribute pan `<label>` de pɔynt to `<answer>` we gɛt input dɛn we di ɔda pɔsin rayt; pɔynt to di input daytrɛkt.
+
+label-for-answer-without-input = Di `for` attribute pan `<label>` de pɔynt to `<answer>` we nɔ gɛt input fɔ lebul.
+
+label-for-must-reference-input-or-answer = Di `for` attribute pan `<label>` fɔ pɔynt to input ɔ answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Fɔ aksɛsibiliti, `<{ $component }>` fɔ gɛt shɔt dɛskripshɔn ɔ yu fɔ mak am lɛk decorative.
+
+accessibility-video-short-description = Fɔ aksɛsibiliti, `<video>` fɔ gɛt shɔt dɛskripshɔn.
+
+accessibility-input-short-description-or-label = Fɔ aksɛsibiliti, `<{ $component }>` fɔ gɛt shɔt dɛskripshɔn ɔ lebul.
+
+accessibility-answer-input-short-description-or-label = Fɔ aksɛsibiliti, `<answer>` we de mek input fɔ gɛt shɔt dɛskripshɔn ɔ lebul.
+
+accessibility-short-description-contains-math = Shɔt dɛskripshɔn nɔ fɔ gɛt mat kɔmponɛnt lɛk `<{ $component }>`. Rayt di mat wit wɔd.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } nɔ gɛt inɔf kɔntras fɔ di sɛkshɔn edin tɛks (dak mod) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nid at lis { $threshold }:1).
+       *[other] { $colorName } nɔ gɛt inɔf kɔntras fɔ di sɛkshɔn edin tɛks ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nid at lis { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wi nɔ implimɛnt `<circle>` yet we de pas { $count } pɔynt we di pɔynt dɛn nɔ gɛt nɔmba valyu.
+
+circle-too-many-through-points = Wi nɔ ebul fɔ kalkulet raun we de pas mɔ dan 3 pɔynt.
+
+circle-overprescribed-radius-center-points = Wi nɔ ebul fɔ kalkulet raun we yu gi radius, sɛnta ɛn pɔynt dɛn togɛda.
+
+circle-center-with-multiple-points = Wi nɔ ebul fɔ kalkulet raun wit sɛnta we de pas mɔ dan 1 pɔynt.
+
+circle-radius-too-small = Wi nɔ ebul fɔ kalkulet di raun: sins di distans bitwin di tu pɔynt na { $distance }, di radius { $radius } we yu gi tumɔs smɔl.
+
+circle-radius-with-many-points = Wi nɔ ebul fɔ mek raun we de pas mɔ dan tu pɔynt wit radius we yu gi.
+
+circle-invalid-center-or-through-points = Di sɛnta ɔ di pɔynt dɛn pan di raun nɔ kɔrɛkt.
+
+circle-radius-center-with-multiple-points = Wi nɔ ebul fɔ kalkulet di radius pan raun wit sɛnta we de pas mɔ dan 1 pɔynt.
+
+circle-change-radius-non-numerical = Wi nɔ ebul fɔ chenj di radius pan raun we di pɔynt dɛn nɔ gɛt nɔmba valyu
+
+circle-radius-with-points-non-numerical = Wi nɔ ebul fɔ mek raun we de pas mɔ dan wan pɔynt wit radius we nɔmba valyu nɔ de.
+
+circle-change-center-non-numerical = Wi nɔ implimɛnt yet aw fɔ chenj di sɛnta pan raun we de pas pɔynt dɛn we nɔ gɛt nɔmba valyu.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Di daymɛnshɔn nɔ inɔf fɔ di domain pan di fɔnkshɔn. Di domain gɛt { $intervals } intaval bɔt di fɔnkshɔn gɛt { $inputs ->
+            [one] { $inputs } input
+           *[other] { $inputs } input
+        }.
+       *[other] Di daymɛnshɔn nɔ inɔf fɔ di domain pan di fɔnkshɔn. Di domain gɛt { $intervals } intaval bɔt di fɔnkshɔn gɛt { $inputs ->
+            [one] { $inputs } input
+           *[other] { $inputs } input
+        }.
+    }
+
+function-domain-invalid-format = Di fɔmat pan di domain pan di fɔnkshɔn nɔ kɔrɛkt.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Wi de ignɔ di maksimɔm pan di fɔnkshɔn we nɔ to nɔmba.
+        [minimum] Wi de ignɔ di minimɔm pan di fɔnkshɔn we nɔ to nɔmba.
+        [extremum] Wi de ignɔ di ɛkstrimɔm pan di fɔnkshɔn we nɔ to nɔmba.
+        [point] Wi de ignɔ di pɔynt pan di fɔnkshɔn we nɔ to nɔmba.
+        [slope] Wi de ignɔ di slop pan di fɔnkshɔn we nɔ to nɔmba.
+       *[other] Wi de ignɔ di { $type } pan di fɔnkshɔn we nɔ to nɔmba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Wi de ignɔ di ɛmti maksimɔm pan di fɔnkshɔn.
+        [minimum] Wi de ignɔ di ɛmti minimɔm pan di fɔnkshɔn.
+        [extremum] Wi de ignɔ di ɛmti ɛkstrimɔm pan di fɔnkshɔn.
+        [point] Wi de ignɔ di ɛmti pɔynt pan di fɔnkshɔn.
+       *[other] Wi de ignɔ di ɛmti { $type } pan di fɔnkshɔn.
+    }
+
+function-points-too-close = Di fɔnkshɔn gɛt tu pɔynt we tumɔs nia dɛnsɛf. Wi nɔ ebul fɔ difayn di fɔnkshɔn.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Fɔnkshɔn itaret kin apin ɔnli if di nɔmba pan input mach di nɔmba pan output. Dis fɔnkshɔn gɛt { $inputs } input ɛn { $outputs ->
+            [one] { $outputs } output
+           *[other] { $outputs } output
+        }.
+       *[other] Fɔnkshɔn itaret kin apin ɔnli if di nɔmba pan input mach di nɔmba pan output. Dis fɔnkshɔn gɛt { $inputs } input ɛn { $outputs ->
+            [one] { $outputs } output
+           *[other] { $outputs } output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Di lɛnt pan di sequence nɔ kɔrɛkt.  I fɔ bi ɔl nɔmba we nɔ de bilo ziro.
+
+sequence-invalid-step = Di step pan di sequence nɔ kɔrɛkt.  I fɔ bi nɔmba fɔ sequence pan type { $type }.
+
+sequence-invalid-endpoint-number = Di "{ $attribute }" pan di number sequence nɔ kɔrɛkt.  I fɔ bi nɔmba.
+
+sequence-invalid-endpoint-letters = Di "{ $attribute }" pan di letters sequence nɔ kɔrɛkt.  I fɔ bi lɛta kɔmbineshɔn.
+
+sequence-invalid-endpoint = Di "{ $attribute }" pan di sequence nɔ kɔrɛkt.
+
+select-from-sequence-coprime-not-numbers = wi de ignɔ coprime bikɔs wi nɔ de pik nɔmba
+
+select-from-sequence-coprime-with-exclude-combinations = wi de ignɔ coprime bikɔs yu dɔn gi excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Di target fɔ `<{ $source }>` nɔ kɔrɛkt: wi nɔ ebul fɔ si di target.
+
+target-state-variable-not-found = Di target fɔ `<{ $source }>` nɔ kɔrɛkt: wi nɔ ebul fɔ si stet vɛriabul we nem na "{ $property }" pan `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Di vɛriabul dɛn pan `<odeSystem>` fɔ difrɛn frɔm di indipɛndɛnt vɛriabul.
+
+ode-system-duplicate-variable-names = Wi nɔ ebul fɔ difayn ODE RHS fɔnkshɔn wit dipɛndɛnt vɛriabul nem we ripit.
+
+ode-system-rhs-function-error = Wi nɔ ebul fɔ difayn ODE RHS fɔnkshɔn.  Ɛra de we wi de mek di mathjs fɔnkshɔn.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Wi nɔ ebul fɔ difayn angul bitwin { $count } layn
+
+angle-invalid-through-point = Di pɔynt na di through pan `<angle>` nɔ kɔrɛkt
+
+parabola-vertex-too-many-points = Wi nɔ implimɛnt parabola yet wit vertex we de pas mɔ dan 1 pɔynt.
+
+parabola-too-many-points = Wi nɔ implimɛnt parabola yet we de pas mɔ dan 3 pɔynt.
+
+intersection-too-many-items = Wi nɔ implimɛnt intasɛkshɔn yet fɔ mɔ dan tu tin
+
+## Other math components
+
+ionic-compound-not-two-ions = Wi nɔ implimɛnt ayɔnik kɔmpaun yet fɔ ɛnitin ɔda dan tu ayɔn.
+
+ionic-compound-needs-cation-and-anion = Wi implimɛnt ayɔnik kɔmpaun ɔnli fɔ wan katayɔn ɛn wan anayɔn.
+
+solve-equations-cannot-evaluate = Wi nɔ ebul fɔ sɔlv di ikweshɔn bikɔs wi nɔ ebul fɔ ivaluet am: { $equation }
+
+math-operators-operand-number-required = Yu fɔ gi operandNumber we yu de ɛkstrakt mat operand.
+
+eigen-decomposition-failed = Wi nɔ ebul fɔ kalkulet di aygɛnvalyu pan di matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: di parameter { $parameters } nɔ de insay di patan, so i go ɔlwez mach blank.
+       *[other] `<matchesPattern>`: di parameter { $parameters } nɔ de insay di patan, so dɛn go ɔlwez mach blank.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: wi nɔ ebul fɔ ɔndastand grid="{ $grid }". I fɔ bi none, medium, dense, ɔ tu pɔzitiv nɔmba we spes divayd dɛn, lɛk grid="1 0.5". Wi nɔ go draw ɛni grid.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" nɔ de wok fɔ di prefigure rɛndara; wi de yuz di rayt-say bihevia.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" nɔ de wok fɔ di prefigure rɛndara; wi de yuz di tɔp bihevia.
+
+prefigure-invalid-axis-bounds = `<graph>`: di aksis baun nɔ kɔrɛkt fɔ prefigure; wi de yuz di difɔlt bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: di wit nɔ kɔrɛkt fɔ prefigure; wi de yuz di difɔlt dayagram wit 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: di aspectRatio nɔ kɔrɛkt fɔ prefigure; wi de yuz di difɔlt aspɛkt reshio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: di grid spesin tumɔs fayn fɔ di aksis limit; wi nɔ go put di grid na di prefigure rɛndara.
+
+prefigure-annotations-not-rendered = `<graph>`: annotations nɔ go sho if yu nɔ de yuz di PreFigure rɛndara.
+
+multiple-annotations-children = Wi si bɔku `<annotations>` pikin insay `<graph>`; wi de ignɔ ɔl bɔt di las wan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Wi nɔ ebul fɔ ɛkstɛnd ɔ kɔpi kɔmponɛnt tayp we wi nɔ no: { $type }.
+
+copy-prop-not-found = Wi nɔ ebul fɔ si prop { $property } pan kɔmponɛnt pan tayp { $component }
+
+collect-no-source = Wi nɔ si sɔs fɔ collect.
+
+collect-invalid-component-type = Wi nɔ ebul fɔ kɔlɛkt kɔmponɛnt pan tayp `<{ $component }>` bikɔs di tayp nɔ kɔrɛkt.
+
+reference-index-unavailable = Wi nɔ ebul fɔ rɛfarɛns index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Wi nɔ ebul fɔ kɔl { $action } pan kɔmponɛnt `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Di data shep nɔ kɔrɛkt.  Di ro dɛn gɛt difrɛn lɛnt. Wi si am na componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Di data gɛt kɔlum nem we ripit.  Wi si am na componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wan kɔlum nem nɔ de na di data.  Wi si am na componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Wan award fɔ dis ansa de bes pan di answer tag in on ansa we dɛn sɛn, ɛn dat go kɔz trɔbul we yu nɔ ɛkspɛkt.
+
+answer-max-num-attempts-in-section-wide-check-work = If yu sɛt `maxNumAttempts` pan `<answer>` we de insay kɔntena we gɛt `sectionWideCheckWork`, i nɔ go du natin, bikɔs na di kɔntena de kɔntrol di nɔmba pan tray. Sɛt `maxNumAttempts` pan di kɔntena instɛd.
+
+nested-section-wide-check-work-max-num-attempts = If yu sɛt `maxNumAttempts` pan kɔntena we gɛt `sectionWideCheckWork` ɛn we de insay ɔda kɔntena we gɛt `sectionWideCheckWork`, i nɔ go du natin, bikɔs na di ɔtsay kɔntena de kɔntrol di nɔmba pan tray. Sɛt `maxNumAttempts` pan di ɔtsay kɔntena instɛd.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Di { $attributes } attribute nɔ go du natin if symbolicEquality nɔ de sɛt.
+       *[other] Di { $attributes } attribute nɔ go du natin if symbolicEquality nɔ de sɛt.
+    }
+
+answer-invalid-type = Di tayp fɔ di ansa nɔ kɔrɛkt: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sins di kɔmponɛnt `<{ $component }>` nɔ gɛt nem, yu nɔ ebul fɔ yuz am fɔ module attribute
+
+module-attribute-name-already-defined = Yu nɔ ebul fɔ yuz di kɔmponɛnt `<{ $component } name="{ $name }">` lɛk attribute fɔ module bikɔs `<module>` dɔn gɛt "{ $name }" attribute.
+
+conditional-content-condition-ignored = Wi de ignɔ di `condition` attribute pan `<conditionalContent>` we gɛt case ɔ else pikin.
+
+slider-markers-type-mismatch = Di markers tayp nɔ mach di slider tayp.
+
+pretzel-problem-needs-statement-and-answer = Di pretzel nɔ kɔrɛkt: ɛvri `<problem>` fɔ gɛt wan `<statement>` ɛn wan `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Di pretzel nɔ kɔrɛkt: na mode="circuit", di fɔs `<problem>` nɔ ebul fɔ bi distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Di valyu { $values } nɔ kɔrɛkt fɔ attribute `{ $attribute }`; wi de ignɔ am.
+       *[other] Di valyu { $values } nɔ kɔrɛkt fɔ attribute `{ $attribute }`; wi de ignɔ dɛn.
+    }
+
+attribute-must-be-references = Di valyu `{ $value }` nɔ kɔrɛkt fɔ attribute `{ $attribute }`. Di attribute fɔ bi rɛfrɛns we stat wit `$`.
+
+math-input-invalid-function-names = <mathInput>: wi de ignɔ fɔnkshɔn nem we nɔ kɔrɛkt na { $attribute }: { $names }. Ɛvri nem in sho-pat fɔ gɛt at lis 2 karakta (lɛta ɔ dash); `|<mathspeak alternative>` kin fala am.
+
+## Building components from the source
+
+component-type-invalid = Di kɔmponɛnt tayp nɔ kɔrɛkt: `<{ $componentType }>`
+
+attribute-repeated = Yu nɔ ebul fɔ ripit di attribute { $attribute }.
+
+attribute-invalid-for-component = Di attribute "{ $attribute }" nɔ kɔrɛkt fɔ kɔmponɛnt pan tayp `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Stayl dɛfinishɔn { $styleNumber } nɔ gɛt inɔf kɔntras fɔ { $context ->
+        [text-on-background] di tɛks kɔla agens di bakgrɔn kɔla
+        [high-contrast] di ay-kɔntras kɔla agens di kanvas
+        [line] di layn kɔla agens di kanvas
+        [marker] di maka kɔla agens di kanvas
+       *[text-on-canvas] di tɛks kɔla agens di kanvas
+    }{ $mode ->
+        [dark] { " (dak mod)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nid at lis { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Ivin dɔ stayl dɛfinishɔn { $styleNumber } gɛt kɔla dɛn we gɛt inɔf kɔntras fɔ layt mod, di dak-mod kɔla dɛn we kɔmɔt frɔm dɛn nɔ gɛt inɔf kɔntras fɔ di tɛks kɔla agens di bakgrɔn kɔla ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nid at lis { $threshold }:1). { $suggestion ->
+        [available] Fɔ gɛt inɔf kɔntras na dak mod, ɛda yu inkris di layt-mod kɔntras (fɔ ɛgzampul, sɛt { $lightAttribute }="{ $lightColor }") ɔ yu ovarayt di dak-mod kɔla (fɔ ɛgzampul, sɛt { $darkAttribute }="{ $darkColor }").
+       *[none] Fɔ gɛt inɔf kɔntras na dak mod, inkris di layt-mod kɔntras ɔ ovarayt di kɔla dɛn wit textColorDarkMode ɛn/ɔ backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Ivin dɔ stayl dɛfinishɔn { $styleNumber } gɛt tɛks kɔla we gɛt inɔf kɔntras fɔ layt mod, di dak-mod tɛks kɔla we kɔmɔt frɔm am nɔ gɛt inɔf kɔntras agens di kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i nid at lis { $threshold }:1). { $suggestion ->
+        [available] Fɔ gɛt inɔf kɔntras na dak mod, ɛda yu inkris di layt-mod kɔntras (fɔ ɛgzampul, sɛt textColor="{ $lightColor }") ɔ yu ovarayt di dak-mod kɔla (fɔ ɛgzampul, sɛt textColorDarkMode="{ $darkColor }").
+       *[none] Fɔ gɛt inɔf kɔntras na dak mod, inkris di layt-mod kɔntras ɔ ovarayt di kɔla wit textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wan sɛkshɔn kin pik ɔnli wan <stylePalette>; wi de yuz di las wan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = wi nɔ ebul fɔ no di yunik vɛriant pan { $component } bikɔs numToSelect nɔ to ɔl nɔmba we nɔ de bilo ziro.
+
+variant-num-to-select-not-constant-number = wi nɔ ebul fɔ no di yunik vɛriant pan { $component } bikɔs numToSelect nɔ to kɔnstant nɔmba.
+
+variant-with-replacement-not-constant-boolean = wi nɔ ebul fɔ no di yunik vɛriant pan { $component } bikɔs withReplacement nɔ to kɔnstant boolean.
+
+variant-select-weight-disables-unique = Yunik vɛriant fɔ select de ɔf if ɛni option gɛt selectWeight ɔ selectForVariants
+
+variant-coprime-undetermined = wi nɔ ebul fɔ no di yunik vɛriant pan { $component } bikɔs wi nɔ ebul fɔ no se coprime ɔlwez na fɔls.
+
+variant-attribute-not-constant = wi nɔ ebul fɔ no di yunik vɛriant pan { $component } bikɔs { $attribute } nɔ to kɔnstant.
+
+variant-attribute-not-number = wi nɔ ebul fɔ no di yunik vɛriant pan { $component } bikɔs { $attribute } nɔ to nɔmba.
+
+variant-attribute-wrong-type-for-sequence =
+    wi nɔ ebul fɔ no di yunik vɛriant pan { $component } pan { $type } tayp bikɔs { $attribute } nɔ to { $expected ->
+        [letters-combination] lɛta kɔmbineshɔn
+        [math-expression] valid mat ɛkspreshɔn
+        [integer] ɔl nɔmba
+       *[number] nɔmba
+    }.
+
+variant-length-not-integer = wi nɔ ebul fɔ no di yunik vɛriant pan { $component } bikɔs length nɔ to ɔl nɔmba.
+
+variant-sort-not-implemented = wi nɔ implimɛnt yet di yunik vɛriant fɔ { $component } wit sort
+
+variant-exclude-combinations-not-implemented = wi nɔ implimɛnt yet di yunik vɛriant fɔ { $component } wit excludeCombinations
+
+variant-math-exclude-not-implemented = wi nɔ implimɛnt yet di yunik vɛriant fɔ { $component } pan tayp math wit exclude
+
+variant-non-constant-exclude-not-implemented = wi nɔ implimɛnt yet di yunik vɛriant fɔ { $component } wit exclude we nɔ to kɔnstant
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: i nɔ de wok fɔ di graph prefigure rɛndara; wi dɔn skip di dɛsɛndant.
+
+prefigure-descendant-invalid-geometry = { $subject }: di jiɔmɛtri nɔ finit ɔ i nɔ kɔmplit; wi dɔn skip di dɛsɛndant.
+
+prefigure-curve-label-omitted = { $subject }: lebul nɔ de wok fɔ curve ɛlimɛnt we wi kɔnvat; wi dɔn lɛf di lebul.
+
+prefigure-curve-unsupported-definition-type = { $subject }: di curve fɔnkshɔn dɛfinishɔn tayp '{ $definitionType }' nɔ de wok; wi dɔn skip di dɛsɛndant.
+
+prefigure-region-flip-functions-unsupported = { $subject }: di flipFunctions attribute pan regionBetweenCurves nɔ de wok; wi dɔn skip di dɛsɛndant.
+
+prefigure-region-non-formula-child = { $subject }: na ɔnli formula-tayp pikin fɔnkshɔn de wok pan regionBetweenCurves; wi dɔn skip di dɛsɛndant.
+
+prefigure-label-position-unsupported =
+    { $subject }: di labelPosition '{ $labelPosition }' nɔ de wok fɔ { $labelKind ->
+        [line-family] layn-famili lebul
+       *[point] pɔynt lebul
+    }; wi de yuz di difɔlt PreFigure alaynmɛnt.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure nɔ no di fil stayl '{ $fillStyle }'; wi de fɔlbak to solid fil.
+
+prefigure-line-style-unknown = { $subject }: wi nɔ no di layn stayl '{ $lineStyle }', so wi lɛf am ɔt pan di PreFigure ɔtput.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wi dɔn map di maka stayl '{ $markerStyle }' to di PreFigure stayl 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure nɔ no di maka stayl '{ $markerStyle }'; wi de yuz di difɔlt stayl.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: di `ref` nɔ kɔrɛkt; wi nɔ ebul fɔ si di target. Wi dɔn lɛf di annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: di `ref` pɔynt to bɔku target; wi de yuz di fɔs wan.
+
+annotation-ref-outside-graph = `<annotation>`: di `ref` nɔ kɔrɛkt; di target de ɔtsay di graph. Wi dɔn lɛf di annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: di `ref` nɔ kɔrɛkt; di target nɔ to grafikal ɔbjɛkt we prefigure no. Wi dɔn lɛf di annotation.
+
+annotation-text-missing = `<annotation>`: di `text` nɔ de ɔ i ɛmti; wi de put ɛmti tɛks.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wi si sakula dipɛndɛnsi.
+       *[other] Wi si sakula dipɛndɛnsi we invɔlv `<{ $componentType }>` kɔmponɛnt.
+    }
+
+reference-no-referent = Wi nɔ si wetin dis rɛfrɛns de pɔynt to: `{ $reference }`
+
+reference-multiple-referents = Wi si bɔku tin we dis rɛfrɛns kin de pɔynt to: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Di fɔmat pan di attribute { $attribute } pan `<{ $componentType }>` nɔ kɔrɛkt.
+
+children-invalid = Di pikin dɛn pan `<{ $componentType }>` nɔ kɔrɛkt: Wi si pikin we nɔ kɔrɛkt: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Di valyu `{ $value }` nɔ kɔrɛkt fɔ attribute `{ $attribute }`, wi de yuz `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Wi nɔ si DoenetML vɛrshɔn { $version }.
+       *[other] Wi nɔ si DoenetML vɛrshɔn { $version }. Wi go fɔlbak to vɛrshɔn { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML nɔ kɔrɛkt: { $content }
+
+parse-tag-missing-close-tag = DoenetML nɔ kɔrɛkt: Di tag `{ $tag }` nɔ gɛt klosin tag. Wi ɛkspɛkt sɛlf-klosin tag ɔ `</{ $tagName }>` tag.
+
+parse-tag-error = DoenetML nɔ kɔrɛkt: Ɛra de insay tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML nɔ kɔrɛkt: Di attribute `{ $attribute }` nɔ kɔrɛkt, i tan lɛk se i nɔ gɛt valyu.
+
+parse-attribute-invalid = DoenetML nɔ kɔrɛkt: Di attribute `{ $attribute }` nɔ kɔrɛkt
+
+parse-attribute-value-invalid = DoenetML nɔ kɔrɛkt: Di attribute valyu `{ $value }` nɔ kɔrɛkt
+
+parse-attribute-value-quote-mismatch = DoenetML nɔ kɔrɛkt: Di attribute valyu `{ $value }` nɔ kɔrɛkt. Di kwot mak nɔ mach. I tan lɛk se `{ $quote }` nɔ de
+
+parse-open-tag-name-missing = DoenetML nɔ kɔrɛkt: Wi si tag we nɔ gɛt nem, lɛk `<`
+
+parse-tag-not-closed = DoenetML nɔ kɔrɛkt: Dɛn nɔ klos di tag `{ $tag }` (i tan lɛk se `>` nɔ de).
+
+parse-self-closing-tag-name-missing = DoenetML nɔ kɔrɛkt: Wi si tag we nɔ gɛt nem `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML nɔ kɔrɛkt: Dɛn nɔ klos di tag `{ $tag }` (i tan lɛk se `/>` nɔ de).
+
+parse-tag-invalid-attributes = DoenetML nɔ kɔrɛkt: Di tag `{ $tag }` nɔ valid. I kin gɛt attribute we nɔ kɔrɛkt.
+
+parse-close-tag-name-missing = DoenetML nɔ kɔrɛkt: Wi si klosin tag we nɔ gɛt nem, lɛk `</`
+
+parse-attribute-value-unquoted = Attribute valyu fɔ de insay kwot: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML nɔ kɔrɛkt: Wi si klosin tag `{ $tag }`, bɔt opinin tag nɔ de
+
+parse-close-tag-mismatched = DoenetML nɔ kɔrɛkt: Di klosin tag nɔ mach. Wi ɛkspɛkt `</{ $expected }>`. Wi si `{ $found }`
+
+parser-node-unconvertible = Wi nɔ ebul fɔ kɔnvat node { $node } to Dast node.
+
+## Names
+
+name-attribute-invalid =
+    Di attribute name='{ $name }' nɔ kɔrɛkt. { $reason ->
+        [characters] Nem kin gɛt ɔnli lɛta, nɔmba, ɔndaskɔ ɔ ayfɛn.
+       *[start] Nem fɔ stat wit lɛta.
+    }
+
+component-name-invalid-start = Di kɔmponɛnt nem "{ $name }" nɔ kɔrɛkt. Nem fɔ stat wit lɛta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer we gɛt type videoWatched fɔ gɛt video attribute
+
+answer-video-watched-video-not-reference = Answer we gɛt type videoWatched fɔ gɛt video attribute we na rɛfrɛns
+
+answer-name-not-single-text = Di answer name attribute fɔ gɛt wan text pikin
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Wi nɔ ebul fɔ gɛt di ɛkstanal DoenetML bikɔs rikɔshɔn tumɔs. Sakula rɛfrɛns de?
+
+external-doenetml-unavailable = Wi nɔ ebul fɔ gɛt DoenetML frɔm { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Di DoenetML we wi gɛt frɔm { $attribute }="{ $uri }" nɔ kɔrɛkt: i nɔ mach di kɔmponɛnt tayp "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Di attribute `{ $from }` dɔn ol; yuz `{ $to }` instɛd.
+       *[other] [deprecation] Di attribute `{ $from }` pan `<{ $component }>` dɔn ol; yuz `{ $to }` instɛd.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Di attribute `{ $from }` dɔn ol ɛn wi de ignɔ am bikɔs `{ $to }` de bak.
+       *[other] [deprecation] Di attribute `{ $from }` pan `<{ $component }>` dɔn ol ɛn wi de ignɔ am bikɔs `{ $to }` de bak.
+    }
+
+deprecated-attribute-ignored = [deprecation] Di attribute `{ $attribute }` pan `<{ $component }>` dɔn ol ɛn wi de ignɔ am.
+
+deprecated-attribute-to-child = [deprecation] Di attribute `{ $attribute }` pan `<{ $component }>` dɔn ol; yuz `<{ $child }>` pikin instɛd.
+
+deprecated-attribute-value-renamed = [deprecation] Di valyu `{ $value }` pan attribute `{ $attribute }` pan `<{ $component }>` dɔn ol; yuz `{ $to }` instɛd.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` kin ɔnli pluralayz Inglish, so i lɛf di tɛks di we yu rayt am na dɔkyumɛnt we dɛn rayt na { $locale }. Rayt di plural fɔm daytrɛkt, ɔ sɛt am wit di `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Di ɛlimɛnt `<{ $tag }>` nɔ to Doenet ɛlimɛnt we wi no.
+
+schema-element-not-allowed-at-root = Dɛn nɔ alaw di ɛlimɛnt `<{ $tag }>` na di rut pan di dɔkyumɛnt.
+
+schema-element-not-allowed-inside = Dɛn nɔ alaw di ɛlimɛnt `<{ $tag }>` insay `<{ $parent }>`.
+
+schema-attribute-unrecognized = Di ɛlimɛnt `<{ $tag }>` nɔ gɛt attribute we dɛn kɔl `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Di attribute `{ $attribute }` pan ɛlimɛnt `<{ $tag }>` fɔ bi lis we ɛvri aytɛm insay am na wan pan dɛn ya: { $allowed }
+       *[other] Di attribute `{ $attribute }` pan ɛlimɛnt `<{ $tag }>` fɔ bi wan pan dɛn ya: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Di vɛriant nem fɔ select nɔ kɔrɛkt.  Di vɛriant nem { $variantName } de sho na { $numOptions } option bɔt di nɔmba we wi go pik na { $numToSelect }.
+
+select-variant-name-without-options = Yu dɔn gi select sɔm vɛriant bɔt yu nɔ gi ɛni option fɔ di posibul vɛriant nem: { $variantName }.
+
+select-variant-name-not-possible = Di vɛriant nem { $variantName } we yu gi select nɔ to posibul vɛriant nem.
+
+select-too-few-options = Wi nɔ ebul fɔ pik { $numToSelect } kɔmponɛnt frɔm ɔnli { $numOptions }.
+
+select-from-sequence-too-few-values = Wi nɔ ebul fɔ pik { $numToSelect } valyu frɔm sequence we in lɛnt na { $length }.
+
+select-from-sequence-indices-count-mismatch = Di nɔmba pan indices we yu gi select fɔ mach di nɔmba we wi go pik
+
+select-from-sequence-indices-not-integers = Ɔl di indices we yu gi select fɔ bi ɔl nɔmba
+
+select-from-sequence-index-excluded = Yu gi selectfromsequence index we dɛn dɔn ɛksklud
+
+select-from-sequence-indices-excluded-combination = Yu gi selectfromsequence indices we na kɔmbineshɔn we dɛn dɔn ɛksklud
+
+select-from-sequence-coprime-not-positive-integers = Wi nɔ ebul fɔ pik coprime kɔmbineshɔn bikɔs wi nɔ de pik pɔzitiv ɔl nɔmba.
+
+select-from-sequence-coprime-common-factor = Wi nɔ ebul fɔ pik coprime nɔmba. Ɔl di posibul valyu de shea wan kɔmɔn faktɔ. (Di valyu we yu gi fɔ "from" ɔ "to" fɔ bi coprime wit "step".)
+
+select-from-sequence-coprime-single-number = Wi nɔ ebul fɔ pik coprime kɔmbineshɔn frɔm sinjul nɔmba we nɔ to 1.
+
+select-from-sequence-excluded-too-many-combinations = Dɛn dɔn ɛksklud ova 70% pan di kɔmbineshɔn insay selectFromSequence
+
+select-from-sequence-coprime-none-found = Wi nɔ ebul fɔ pik coprime nɔmba. Ɔl di posibul valyu de shea wan kɔmɔn faktɔ.
+
+select-from-sequence-too-few-unique-values = Wi nɔ ebul fɔ pik { $numToSelect } yunik valyu frɔm sequence we in lɛnt na { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Wi nɔ ebul fɔ pik { $numToSelect } valyu frɔm praym lis we in lɛnt na { $numValues }
+
+select-prime-numbers-values-count-mismatch = Di nɔmba pan valyu we yu gi select fɔ mach di nɔmba we wi go pik
+
+select-prime-numbers-values-not-prime = Ɔl di valyu we yu gi select prime number fɔ de insay di praym lis
+
+select-prime-numbers-values-excluded-combination = Di valyu we yu gi selectPrimeNumbers na kɔmbineshɔn we dɛn dɔn ɛksklud
+
+select-prime-numbers-excluded-too-many-combinations = Dɛn dɔn ɛksklud ova 70% pan di kɔmbineshɔn insay selectPrimeNumbers
+
+select-random-combination-fluke = Na wanda we nɔ fɔ apin: wi nɔ ebul fɔ pik kɔmbineshɔn pan randɔm valyu
+
+select-random-value-fluke = Na wanda we nɔ fɔ apin: wi nɔ ebul fɔ pik randɔm valyu

--- a/packages/i18n/locales/kri/editor.ftl
+++ b/packages/i18n/locales/kri/editor.ftl
@@ -4,8 +4,9 @@
 #
 # DoenetML element names, attribute names and `styleNumber` are identifiers of
 # the language and stay in English exactly as written. Krio's phonemic spelling
-# makes that seam easy to see here: `attribute` inside a sentence is the
-# DoenetML word, and anything spelt Krio around it is prose.
+# makes that seam easy to see here: an identifier like `styleNumber` keeps its
+# English spelling inside a sentence, and everything spelt Krio around it —
+# «atribyut», «snipɛt» — is prose.
 
 
 ## The viewer's controls
@@ -173,7 +174,7 @@ help-property-is-reference =
        *[other] { $ref } na rɛfrɛns to di { $property } prɔpati pan { $element } (layn { $line }).
     }
 
-help-kind-attribute = attribute
+help-kind-attribute = atribyut
 help-kind-snippet = snipɛt
 help-kind-array-entry = array ɛntri
 

--- a/packages/i18n/locales/kri/editor.ftl
+++ b/packages/i18n/locales/kri/editor.ftl
@@ -6,7 +6,11 @@
 # the language and stay in English exactly as written. Krio's phonemic spelling
 # makes that seam easy to see here: an identifier like `styleNumber` keeps its
 # English spelling inside a sentence, and everything spelt Krio around it —
-# «atribyut», «snipɛt» — is prose.
+# «atribyut», «snipɛt» — is prose. That spelling is this file's convention and
+# is applied throughout it. `diagnostics.ftl` keeps the English `attribute`
+# instead, since there the word names the piece of DoenetML the message is
+# reporting on rather than a kind of completion the editor offers; the two
+# files are each consistent, and a speaker changing one should change both.
 
 
 ## The viewer's controls
@@ -127,7 +131,7 @@ editor-response-submitted = Dɛn sɛn am
 
 ## The context-help panel
 
-help-placeholder = Put yu kɔsɔ pan tag nem, attribute, ɔ { $ref } fɔ si di dɔkyumɛnteshɔn.
+help-placeholder = Put yu kɔsɔ pan tag nem, atribyut, ɔ { $ref } fɔ si di dɔkyumɛnteshɔn.
 
 help-unsupported-ref-chain = Wi nɔ gɛt ɛlp yet fɔ rɛfrɛns we gɛt bɔku pat lɛk { $example }.
 
@@ -201,7 +205,7 @@ help-coordinates =
 
 help-type = Tayp:
 
-help-resolved-style = Stayl we wi wok am ɔt (styleNumber { $styleNumber }):
+help-resolved-style = Stayl we wi wok ɔt (styleNumber { $styleNumber }):
 
 help-resolved-function-names = Fɔnkshɔn nem dɛn we wi wok ɔt:
 help-reset-list = Risɛt lis pan dis input:

--- a/packages/i18n/locales/kri/editor.ftl
+++ b/packages/i18n/locales/kri/editor.ftl
@@ -1,0 +1,210 @@
+# Krio editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written. Krio's phonemic spelling
+# makes that seam easy to see here: `attribute` inside a sentence is the
+# DoenetML word, and anything spelt Krio around it is prose.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Risɛt
+       *[update] Updet
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Viwa
+       *[other] { $word } Viwa { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Vɛriant
+
+editor-variant-filter = Filta…
+
+editor-variant-next = Pik di nɛks vɛriant
+
+editor-variant-previous = Pik di vɛriant we dɔn pas
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wi si WCAG AA aksɛsibiliti vayoleshɔn. Klik fɔ { $action ->
+            [close] klos
+           *[open] opin
+        } di aksɛsibiliti ripɔt.
+        [advisories] Klik fɔ { $action ->
+            [close] klos
+           *[open] opin
+        } di aksɛsibiliti ripɔt. Wi nɔ si ɛni WCAG AA vayoleshɔn, bɔt wi gɛt ɔda aksɛsibiliti advays.
+       *[clean] Klik fɔ { $action ->
+            [close] klos
+           *[open] opin
+        } di aksɛsibiliti ripɔt. Wi nɔ si ɛni aksɛsibiliti trɔbul.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wi si WCAG AA aksɛsibiliti vayoleshɔn. Wi si { $count ->
+            [one] { $count } WCAG AA vayoleshɔn
+           *[other] { $count } WCAG AA vayoleshɔn
+        }. Klik fɔ { $action ->
+            [close] klos
+           *[open] opin
+        } di aksɛsibiliti ripɔt.
+        [advisories] Wi nɔ si ɛni WCAG AA vayoleshɔn. Wi si { $count ->
+            [one] { $count } ɔda aksɛsibiliti advays
+           *[other] { $count } ɔda aksɛsibiliti advays
+        }. Klik fɔ { $action ->
+            [close] klos
+           *[open] opin
+        } di aksɛsibiliti ripɔt.
+       *[clean] Wi nɔ si ɛni WCAG AA vayoleshɔn. Klik fɔ { $action ->
+            [close] klos
+           *[open] opin
+        } di aksɛsibiliti ripɔt.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML vɛrshɔn { $version }
+
+editor-tab-help = Ɛlp fɔ usay yu de
+editor-tab-help-short = Kɔntɛks
+editor-tab-errors = Ɛra dɛn
+editor-tab-warnings = Wɔnin dɛn
+editor-tab-info = Infɔ
+editor-tab-accessibility = Aksɛsibiliti
+editor-tab-responses = Ansa we dɛn sɛn
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Ɛdita ɔpshɔn dɛn
+editor-format-as-doenetml = Fɔmat am lɛk DoenetML
+editor-format-as-xml = Fɔmat am lɛk XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Layn #{ $line }
+
+editor-no-errors = Nɔ Ɛra
+editor-no-warnings = Nɔ Wɔnin
+editor-no-info = Nɔ Infɔ
+
+editor-show-info-annotations = Sho di infɔ dɛn na di ɛdita
+editor-show-accessibility-annotations = Sho di aksɛsibiliti trɔbul dɛn na di ɛdita
+
+editor-accessibility-learn-more = Lan aw Doenet de tek kia ɔf aksɛsibiliti
+
+editor-accessibility-violations-heading = Aksɛsibiliti vayoleshɔn dɛn ({ $standard })
+
+editor-accessibility-other-heading = Ɔda aksɛsibiliti trɔbul dɛn
+editor-none-found = Wi nɔ si ɛni
+
+
+## Submitted responses
+
+editor-no-responses = Nɔbɔdi nɔ sɛn ansa yet
+editor-response-answer-id = Ansa Id
+editor-response-response = Ansa
+editor-response-credit = Krɛdit
+editor-response-submitted = Dɛn sɛn am
+
+
+## The context-help panel
+
+help-placeholder = Put yu kɔsɔ pan tag nem, attribute, ɔ { $ref } fɔ si di dɔkyumɛnteshɔn.
+
+help-unsupported-ref-chain = Wi nɔ gɛt ɛlp yet fɔ rɛfrɛns we gɛt bɔku pat lɛk { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Wi nɔ si wetin { $ref } de pɔynt to.
+        [multiple] Wi si bɔku tin we { $ref } kin de pɔynt to.
+       *[indeterminate] Wi nɔ ebul fɔ no wetin { $ref } de pɔynt to.
+    }
+
+help-learn-about-references = Lan bɔt rɛfrɛns dɛn →
+help-reference-page = Rɛfrɛns pej →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Insay { $element }
+       *[top] Na di tɔp lɛvul
+    }{ $allowed ->
+        [none] { " — natin nɔ de go ya." }
+        [text] { " — rayt tɛks ya." }
+        [text-and-components] { " — rayt tɛks ya, ɔ tray:" }
+       *[components] { " — tin we yu kin tray:" }
+    }
+
+help-suggestions-footer = Prɛs { $shortcut } fɔ si ɔl di { $total } kɔmponɛnt dɛn.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } na rɛfrɛns to { $target }.
+       *[other] { $ref } na rɛfrɛns to { $target } (layn { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } bring am lɛk { $role }.
+       *[other] { $owner } bring am pan layn { $line } lɛk { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } na rɛfrɛns to di { $property } prɔpati pan { $element }.
+       *[other] { $ref } na rɛfrɛns to di { $property } prɔpati pan { $element } (layn { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snipɛt
+help-kind-array-entry = array ɛntri
+
+help-default = Difɔlt:
+help-active-default = Difɔlt we de wok:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valyu dɛn we dɛn alaw (wan fɔ ɛvri aytɛm):
+       *[other] Valyu dɛn we dɛn alaw:
+    }
+
+help-suggested-values = Valyu dɛn we wi de sɔjɛst:
+
+help-inserts = I de put:
+
+help-coordinates =
+    { $count ->
+        [one] Kɔɔdinet:
+       *[other] Kɔɔdinet dɛn:
+    }
+
+help-type = Tayp:
+
+help-resolved-style = Stayl we wi wok am ɔt (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fɔnkshɔn nem dɛn we wi wok ɔt:
+help-reset-list = Risɛt lis pan dis input:
+help-added-on-input = Dɛn ad am pan dis input:
+help-removed-on-input = Dɛn pul am pan dis input:
+
+help-reset-overrides = { $reset } de ovarayt { $additional } ɛn { $removed }.

--- a/packages/i18n/locales/pcm/chrome.ftl
+++ b/packages/i18n/locales/pcm/chrome.ftl
@@ -1,0 +1,135 @@
+# Nigerian Pidgin viewer chrome: buttons, panel headers, and other UI the
+# reader interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the grammar this catalog turns on, for what
+# separates it from `locales/kri`, and for what a speaker should check first.
+# The short version: read these aloud. The vocabulary is English and the
+# grammar is not.
+
+
+## Answer submission
+
+answer-checking = Dey chẹk…
+answer-submitting = Dey sẹnd…
+
+answer-checking-status = Wi dey chẹk di ansa
+answer-submitting-status = Wi dey sẹnd di ansa
+
+answer-correct = E korẹkt
+answer-incorrect = E no korẹkt
+
+answer-response-saved = Wi Don Sev Yọ Ansa
+
+answer-percent-credit = { $percent }% Krẹdit
+answer-percent-correct = { $percent }% Korẹkt
+answer-percent-short = { $percent } %
+
+max-credit-available = Di mọst krẹdit wey yu fit gẹt: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] no tray rẹmen
+        [one] { $count } tray rẹmen
+       *[other] { $count } tray rẹmen
+    }
+
+validation-correct = (E korẹkt)
+validation-incorrect = (E no korẹkt)
+validation-partially-correct = (E korẹkt smọl)
+
+answer-show-responses =
+    { $count ->
+        [one] Sho { $count } ansa fọ { $answerId }
+       *[other] Sho { $count } ansa fọ { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Fidbak
+
+collapsible-click-to-open = (klik make e opin)
+collapsible-click-to-close = (klik make e klos)
+
+collapsible-initializing = E dey stat…
+
+footnote-show = Sho di fut-not
+footnote-hide = Haid di fut-not
+
+description-more-information = mọ infọmeshọn
+
+
+## Controls
+
+slider-previous = Wan Wey Pass
+slider-next = Nẹks
+
+keyboard-open = Opin Kibọd
+keyboard-close = Klos Kibọd
+
+choice-input-remove-choice = Rimuv { $choice }
+
+matrix-remove-row = Rimuv ro
+matrix-add-row = Add ro
+matrix-remove-column = Rimuv kọlum
+matrix-add-column = Add kọlum
+
+subset-add-remove-points = Add/Rimuv point dem
+subset-toggle-points-intervals = Switch bitwin point an intaval
+subset-move-points = Muv Point Dem
+subset-clear = Kliar
+
+orbital-add-row = Add Ro
+orbital-remove-row = Rimuv Ro
+orbital-add-box = Add Bọks
+orbital-remove-box = Rimuv Bọks
+orbital-add-up-arrow = Add Aro Wey Fes Ọp
+orbital-add-down-arrow = Add Aro Wey Fes Daun
+orbital-remove-arrow = Rimuv Aro
+
+orbital-row-label = Nem fọ ro { $row }
+
+pretzel-answer = Ansa
+
+summary-statistics-caption = Sọmari statistiks fọ { $column }
+
+
+## Math input
+
+math-input-preview-region = privyu of di mat ẹkspreshọn
+math-input-preview = Privyu
+math-input-invalid-expression = Ẹkspreshọn wey no korẹkt:
+
+
+## Document status
+
+viewer-initializing = E dey stat…
+
+
+## Errors
+
+error-heading = Ẹra
+
+error-found-at =
+    { $span ->
+        [line] Wi si am fọ lain { $startLine }.
+       *[lines] Wi si am fọ lain { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Dis dọkyumẹnt gẹt ẹra insai am!
+
+diagnostic-heading-error = Ẹra
+diagnostic-heading-warning = Wọnin
+diagnostic-heading-information = Infọ
+diagnostic-heading-hint = Hint
+
+accessibility-heading-level-1 = WCAG AA Aksẹsibiliti Vayolashọn
+accessibility-heading-level-2 = Aksẹsibiliti alat
+
+something-went-wrong = Sọmtin no go wẹl.
+
+renderer-load-failed = wan rẹndara no lod. Abeg rilod di pej.
+
+core-start-failed = Di dọkyumẹnt viwa no fit stat. Abeg rilod di pej.

--- a/packages/i18n/locales/pcm/content.ftl
+++ b/packages/i18n/locales/pcm/content.ftl
@@ -7,9 +7,9 @@
 #
 # `pcm` is Nigerian Pidgin (Naijá), an English-lexifier creole and the most
 # widely spoken language in Nigeria — a first language for millions and a
-# second one for tens of millions more, across every one of the three
-# languages this repository already carries from that country (`locales/ha`,
-# `locales/ig`, `locales/yo`) and `locales/tiv` besides.
+# second one for tens of millions more, spoken across the communities of every
+# Nigerian language this repository already carries (`locales/ha`,
+# `locales/ig`, `locales/yo`, `locales/tiv`).
 #
 # **The thing to be careful about in this catalog is that it looks like
 # English.** The lexifier shows through in almost every word, so a reader
@@ -19,11 +19,12 @@
 #
 #   plural            no `-s`; number is carried by `dem` or by a numeral
 #                     («two lain», not «two lines»)
-#   tense and aspect  preverbal `don`, `dey`, `go` — «e don full», not
-#                     «it is filled»
-#   negation          `no be` and `no`, never `-n't`
+#   tense and aspect  preverbal `don`, `dey`, `go` — «don full», not
+#                     «is filled»
+#   negation          `no bi` and `no`, never `-n't`
 #   copula            `na` for identity, `dey` for location and state
-#   possession        `of` is rare; juxtaposition or `fọ` does the work
+#   possession        `of` and `fọ` both occur, and juxtaposition does a lot of
+#                     the work («plọs mak», not «mark of a plus»)
 #
 # So `style-unfilled` is «e no full» rather than «unfilled», and
 # `boolean-false` is «na lai» rather than «false». A speaker reviewing this
@@ -90,7 +91,7 @@ noun =
     .curve = lain wey bend
     .function = fọnkshọn
     .parabola = parabola
-    .polyline = lain wey get many pis
+    .polyline = lain wey gẹt many pis
     .polygon = poligọn
     .triangle = trayangul
     .rectangle = rẹktangul
@@ -107,8 +108,8 @@ noun =
 # place `locales/tiv` puts its own.
 noun-regular-polygon =
     { $part ->
-        [tail] wey get { $numSides } sait
-       *[head] poligọn wey ẹvri sait dey de sem
+        [tail] wey gẹt { $numSides } sait
+       *[head] poligọn wey ẹvri sait dey di sem
     }
 
 # Nigerian Pidgin has no noun class and no gender, so every noun answers the

--- a/packages/i18n/locales/pcm/content.ftl
+++ b/packages/i18n/locales/pcm/content.ftl
@@ -1,0 +1,293 @@
+# Nigerian Pidgin content catalog: the prose the core computes into the
+# document. Selected by `documentLocale` — the language the activity was
+# written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `pcm` is Nigerian Pidgin (Naijá), an English-lexifier creole and the most
+# widely spoken language in Nigeria — a first language for millions and a
+# second one for tens of millions more, across every one of the three
+# languages this repository already carries from that country (`locales/ha`,
+# `locales/ig`, `locales/yo`) and `locales/tiv` besides.
+#
+# **The thing to be careful about in this catalog is that it looks like
+# English.** The lexifier shows through in almost every word, so a reader
+# skimming it can conclude that nothing has been translated and that the file
+# is padding. It is not, and the places to look are the grammar rather than
+# the vocabulary:
+#
+#   plural            no `-s`; number is carried by `dem` or by a numeral
+#                     («two lain», not «two lines»)
+#   tense and aspect  preverbal `don`, `dey`, `go` — «e don full», not
+#                     «it is filled»
+#   negation          `no be` and `no`, never `-n't`
+#   copula            `na` for identity, `dey` for location and state
+#   possession        `of` is rare; juxtaposition or `fọ` does the work
+#
+# So `style-unfilled` is «e no full» rather than «unfilled», and
+# `boolean-false` is «na lie» rather than «false». A speaker reviewing this
+# should be reading for register — this is written Naijá, not English with the
+# spelling roughened — and the fastest way to check a message is to read it
+# aloud.
+#
+# **Read it beside `locales/kri`.** Krio has the same lexifier and a different
+# answer, because Sierra Leone's written tradition is phonemic where Nigeria's
+# stays close to English spelling: «blak» there, «black» here. The two files
+# together are this repository's shortest argument that "English creole" names
+# a family rather than a catalog.
+#
+# Nigerian Pidgin has no noun class, no gender and no case, so `$gender` and
+# `$role` both go unused — the shape `locales/en` and `locales/ktu` have.
+#
+# The orthography is the one Naijá writing on the web actually uses, with the
+# subdot vowels `ẹ` and `ọ` where a word needs them. It is not the harmonized
+# NLC orthography, and that is the first thing a speaker should decide about.
+
+
+## Style vocabulary
+
+color =
+    .black = black
+    .white = white
+    .gray = gray
+    .red = red
+    .orange = orange
+    .yellow = yellow
+    .green = green
+    .cyan = cyan
+    .blue = blue
+    .purple = purple
+    .pink = pink
+    .brown = brown
+
+line-width =
+    .thick = thick
+    .thin = thin
+
+# «wey» is the relativizer and «dey» the stative marker: a dash pattern is
+# something the line *does*, not something it is, so it comes out as a clause
+# rather than as an adjective. `style-stroke` puts it last, where a clause
+# belongs.
+line-style =
+    .dashed = wey dey brok-brok
+    .dotted = wey dey dot-dot
+
+fill-style =
+    .horizontal = lain wey lie down
+    .vertical = lain wey stand up
+    .diagonal = lain wey slant
+    .backdiagonal = lain wey slant di oda way
+    .dots = dot dem
+    .diamonds = daimon dem
+
+noun =
+    .line = lain
+    .line-segment = pis of lain
+    .ray = re
+    .vector = vẹkta
+    .curve = lain wey bend
+    .function = fọnkshọn
+    .parabola = parabola
+    .polyline = lain wey get many pis
+    .polygon = poligọn
+    .triangle = trayangul
+    .rectangle = rẹktangul
+    .circle = raun
+    .region = eria
+    .point = point
+    .square = skwea
+    .diamond = daimon
+    .cross = kros
+    .plus = plọs mak
+
+# The side count is a relative clause and closes the noun phrase behind the
+# describing words rather than opening it, so it goes in the tail — the same
+# place `locales/tiv` puts its own.
+noun-regular-polygon =
+    { $part ->
+        [tail] wey get { $numSides } sait
+       *[head] poligọn wey ẹvri sait dey de sem
+    }
+
+# Nigerian Pidgin has no noun class and no gender, so every noun answers the
+# same and the answer goes unused.
+noun-gender = wan
+
+
+## Style composition
+
+# The dash pattern is a «wey …» clause and closes the description, so it moves
+# behind the colour rather than sitting between the width and it. Two clauses
+# in a row simply stand side by side.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+# «don full» — the completive `don` rather than an English passive. There is no
+# adjective here to inflect; the whole word is a verb phrase.
+style-filled-word = don full
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } wit { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $filled } { $color } { $noun } wit { $pattern }
+        [plain-tail] { $filled } { $color } { $noun } { $nounTail }
+        [pattern-tail] { $filled } { $color } { $noun } { $nounTail } wit { $pattern }
+       *[plain] { $filled } { $color } { $noun }
+    }
+
+# Naijá has no indefinite article where English wants one here, so the
+# `-article` branches read the same as their bare counterparts. The distinction
+# `$parts` carries is still a real one — «wit» opens a clause and «an» chains a
+# further one — and that half of it survives.
+style-border-clause =
+    { $parts ->
+        [with-article] wit { $border } bọda
+        [and] an { $border } bọda
+        [and-article] an { $border } bọda
+       *[with] wit { $border } bọda
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $color } { $pattern }
+       *[plain] { $color }
+    }
+
+style-unfilled = e no full
+
+style-text =
+    { $parts ->
+        [background] { $color } wit { $background } bakgraun
+       *[plain] { $color }
+    }
+
+style-background-none = nọtin
+
+
+## Boolean words
+##
+## `true` and `false` stay English everywhere as DoenetML syntax; only what the
+## reader sees moves. In Naijá the displayed words are the two verdicts a
+## speaker actually gives, which are not the words the source uses.
+
+boolean-true = na tru
+boolean-false = na lai
+
+
+## Answer buttons
+
+answer-submit-label = Chẹk Wọk
+answer-submit-label-no-correctness = Sẹnd Ansa
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Aktiviti
+    .aside = Sait Tok
+    .cascade = Kasked
+    .definition = Meanin
+    .example = Ẹgzampul
+    .exercise = Ẹksasaiz
+    .exercises = Ẹksasaiz dem
+    .given-answer = Ansa
+    .note = Not
+    .objectives = Wetin Wi Wan Achiv
+    .paragraphs = Paragraf dem
+    .part = Pat
+    .problem = Prọblẹm
+    .problems = Prọblẹm dem
+    .proof = Prọf
+    .question = Kwẹstiọn
+    .section = Sẹkshọn
+    .solution = Solushọn
+    .task = Task
+    .theorem = Tiọrẹm
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Hint
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tebul { $enumeration }
+        [numbered-title] Tebul { $enumeration }{ ": " }
+        [unnumbered-title] Tebul{ ": " }
+       *[unnumbered] Tebul
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Figọ { $enumeration }
+        [numbered-caption] Figọ { $enumeration }{ ": " }
+        [unnumbered-caption] Figọ{ ": " }
+       *[unnumbered] Figọ
+    }
+
+
+## Paginator controls
+
+paginator-previous = Wan Wey Pass
+paginator-next = Nẹks
+
+paginator-page = Pej
+
+paginator-page-status = { $pageLabel } { $currentPage } fọ { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ọ
+
+piecewise-condition-if = if
+
+piecewise-condition-otherwise = if no bi so
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case, and the clearest one in the repository: Nigeria
+## teaches secondary science in English, and Naijá's lexifier *is* English, so
+## the fallback is both the curriculum and very nearly the language. Filling
+## these in would produce 130 keys character-identical to `locales/en` and
+## claim a translation that had not happened. `locales/ha`, `locales/ig`,
+## `locales/yo` and `locales/tiv` leave the same gap for the same ministry.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kẹmistri Simbọl Wey No Korẹkt
+chemistry-invalid-ionic-compound = Ayọnik Kompaun Wey No Korẹkt

--- a/packages/i18n/locales/pcm/content.ftl
+++ b/packages/i18n/locales/pcm/content.ftl
@@ -26,7 +26,7 @@
 #   possession        `of` is rare; juxtaposition or `fọ` does the work
 #
 # So `style-unfilled` is «e no full» rather than «unfilled», and
-# `boolean-false` is «na lie» rather than «false». A speaker reviewing this
+# `boolean-false` is «na lai» rather than «false». A speaker reviewing this
 # should be reading for register — this is written Naijá, not English with the
 # spelling roughened — and the fastest way to check a message is to read it
 # aloud.
@@ -65,13 +65,14 @@ line-width =
     .thick = thick
     .thin = thin
 
-# «wey» is the relativizer and «dey» the stative marker: a dash pattern is
-# something the line *does*, not something it is, so it comes out as a clause
-# rather than as an adjective. `style-stroke` puts it last, where a clause
-# belongs.
+# Reduplication used attributively, which is how Naijá makes a modifier out of
+# a verb without building a relative clause. A «wey dey brok-brok» clause would
+# be the more literal rendering and is wrong here: the description is *followed*
+# by the noun in this catalog, so a relative clause would sit in front of the
+# thing it modifies and attach to nothing.
 line-style =
-    .dashed = wey dey brok-brok
-    .dotted = wey dey dot-dot
+    .dashed = brok-brok
+    .dotted = dot-dot
 
 fill-style =
     .horizontal = lain wey lie down
@@ -117,14 +118,14 @@ noun-gender = wan
 
 ## Style composition
 
-# The dash pattern is a «wey …» clause and closes the description, so it moves
-# behind the colour rather than sitting between the width and it. Two clauses
-# in a row simply stand side by side.
+# Naijá stacks modifiers in front of the noun in the order English does, and
+# `line-style` is a bare modifier rather than a clause, so nothing needs to be
+# moved to the end here.
 style-stroke =
     { $parts ->
-        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-style-color] { $width } { $lineStyle } { $color }
         [width-color] { $width } { $color }
-        [style-color] { $color } { $lineStyle }
+        [style-color] { $lineStyle } { $color }
         [width-style] { $width } { $lineStyle }
         [width] { $width }
         [style] { $lineStyle }

--- a/packages/i18n/locales/pcm/diagnostics.ftl
+++ b/packages/i18n/locales/pcm/diagnostics.ftl
@@ -1,0 +1,649 @@
+# Nigerian Pidgin diagnostics: errors and warnings surfaced to the reader or
+# author. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written. In this catalog that rule has to be applied by eye rather than by
+# looking for a foreign word, since the prose is English-lexified too.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] wi dey ignọ { $attributes } wen yu don gi two ẹndpoint
+       *[other] wi dey ignọ { $attributes } wen yu don gi two ẹndpoint
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] wi dey ignọ { $attributes } wen yu gi ẹndpoint an midpoint togẹda
+       *[other] wi dey ignọ { $attributes } wen yu gi ẹndpoint an midpoint togẹda
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset no dey do enitin if midpoint no dey
+
+## `<line>`
+
+line-points-undetermined-dimensions = Lain wey pass point wey wi no sabi dia daimẹnshọn.
+
+line-points-too-few-dimensions = Lain must pass point wey gẹt at list two daimẹnshọn.
+
+line-points-depend-on-variables = Lain dey pass point wey dipẹnd ọn vẹriabul dem: { $variables }.
+
+line-equation-invalid-format = Di fọmat of di lain ikweshọn no korẹkt fọ vẹriabul { $variable1 } an { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Yu don gi di re through, endpoint an direction.  Wi dey ignọ di through wey yu gi.
+
+ray-dimension-mismatch = numDimensions no mach fọ di re.
+
+## `<vector>`
+
+vector-overprescribed-head = Yu don gi di vẹkta head, tail an displacement.  Wi dey ignọ di head wey yu gi.
+
+vector-dimension-mismatch = numDimensions no mach fọ di vẹkta.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Wi no fit atrakt to `<{ $component }>` bikọs e no gẹt nearestPoint.
+
+constrain-to-without-nearest-point = Wi no fit kọnstren to `<{ $component }>` bikọs e no gẹt nearestPoint.
+
+constrain-to-interior-without-nearest-point = Wi no fit kọnstren to di insai of `<{ $component }>` bikọs e no gẹt nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = wi dey ignọ labelPosition fọ choiceInput wey no bi inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Wi dey ignọ di indices wey yu gi choiceInput bikọs di nọmba of indices no mach di nọmba of choice pikin.
+
+pretzel-indices-count-mismatch = Wi dey ignọ di indices wey yu gi problem bikọs di nọmba of indices no mach di nọmba of problem pikin.
+
+shuffle-indices-count-mismatch = Wi dey ignọ di indices wey yu gi shuffle bikọs di nọmba of indices no mach di nọmba of kọmponẹnt.
+
+indices-ignored-out-of-range = Wi dey ignọ di indices wey yu gi { $component } bikọs sọm of dem dey aut of renj.
+
+pretzel-indices-repeated = Wi dey ignọ di indices wey yu gi pretzel bikọs sọm of dem ripit.
+
+pretzel-circuit-first-index = Wi dey ignọ di indices wey yu gi pretzel fọ mode="circuit" bikọs di fẹst index must bi 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Fọ make `<{ $component }>` wọk wit string pikin, yu must gi am `type` attribute.
+
+invalid-type-defaulting-to-math = Type { $type } no korẹkt fọ { $component } kọmponẹnt. E must bi math, text, number ọ boolean. Wi go yuz math.
+
+string-not-valid-component-to-arrange = String "{ $value }" no bi valid kọmponẹnt fọ { $component }. Wi dey ignọ am.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } no korẹkt, wi don sẹt di type to number.
+
+invalid-variable-value = Vẹriabul valyu wey no korẹkt: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Vẹriant index { $index } must bi nọmba
+
+variant-index-must-be-integer = Vẹriant index { $index } must bi hol nọmba
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Wi neva impliment `<{ $component }>` fọ absolut mẹzhọmẹnt. Wi don sẹt di widt to rẹlativ.
+
+side-by-side-absolute-margins = Wi neva impliment `<{ $component }>` fọ absolut mẹzhọmẹnt. Wi don sẹt di majin to rẹlativ.
+
+side-by-side-no-block-child = `<{ $component }>` no korẹkt: e must gẹt at list wan block pikin.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Wi dey ignọ di `for` attribute ọn grafikal `<label>`.
+
+label-for-must-resolve-to-one = Di `for` attribute ọn `<label>` must point to ẹgzaktli wan kọmponẹnt.
+
+label-for-unresolved = Di `for` attribute ọn `<label>` no fit point to eni kọmponẹnt.
+
+label-for-answer-with-authored-inputs = Di `for` attribute ọn `<label>` dey point to `<answer>` wey gẹt input wey di ọda pẹsin rait; point to di input dairẹkt.
+
+label-for-answer-without-input = Di `for` attribute ọn `<label>` dey point to `<answer>` wey no gẹt input to lebul.
+
+label-for-must-reference-input-or-answer = Di `for` attribute ọn `<label>` must point to input ọ answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Fọ aksẹsibiliti, `<{ $component }>` must gẹt shọt dẹskripshọn ọ yu must mak am as decorative.
+
+accessibility-video-short-description = Fọ aksẹsibiliti, `<video>` must gẹt shọt dẹskripshọn.
+
+accessibility-input-short-description-or-label = Fọ aksẹsibiliti, `<{ $component }>` must gẹt shọt dẹskripshọn ọ lebul.
+
+accessibility-answer-input-short-description-or-label = Fọ aksẹsibiliti, `<answer>` wey dey krieat input must gẹt shọt dẹskripshọn ọ lebul.
+
+accessibility-short-description-contains-math = Shọt dẹskripshọn no supoz gẹt mat kọmponẹnt lai `<{ $component }>`. Rait di mat wit wọd.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } no gẹt inọf kọntrast fọ di sẹkshọn hedin tẹks (dak mod) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e nid at list { $threshold }:1).
+       *[other] { $colorName } no gẹt inọf kọntrast fọ di sẹkshọn hedin tẹks ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e nid at list { $threshold }:1).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Wi neva impliment `<circle>` wey pass { $count } point wen di point dem no gẹt nọmba valyu.
+
+circle-too-many-through-points = Wi no fit kalkulet raun wey pass mọ dan 3 point.
+
+circle-overprescribed-radius-center-points = Wi no fit kalkulet raun wen yu gi radius, sẹnta an point togẹda.
+
+circle-center-with-multiple-points = Wi no fit kalkulet raun wit sẹnta wey pass mọ dan 1 point.
+
+circle-radius-too-small = Wi no fit kalkulet di raun: sins di distans bitwin di two point na { $distance }, di radius { $radius } wey yu gi smọl too mọch.
+
+circle-radius-with-many-points = Wi no fit krieat raun wey pass mọ dan two point wit radius wey yu gi.
+
+circle-invalid-center-or-through-points = Di sẹnta ọ di point dem of di raun no korẹkt.
+
+circle-radius-center-with-multiple-points = Wi no fit kalkulet di radius of raun wit sẹnta wey pass mọ dan 1 point.
+
+circle-change-radius-non-numerical = Wi no fit chenj di radius of raun wey di point dem no gẹt nọmba valyu
+
+circle-radius-with-points-non-numerical = Wi no fit krieat raun wey pass mọ dan wan point wit radius wen nọmba valyu no dey.
+
+circle-change-center-non-numerical = Wi neva impliment chenjin di sẹnta of raun wey pass point wey no gẹt nọmba valyu.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Di daimẹnshọn no inọf fọ di domain of di fọnkshọn. Di domain gẹt { $intervals } intaval bọt di fọnkshọn gẹt { $inputs ->
+            [one] { $inputs } input
+           *[other] { $inputs } input
+        }.
+       *[other] Di daimẹnshọn no inọf fọ di domain of di fọnkshọn. Di domain gẹt { $intervals } intaval bọt di fọnkshọn gẹt { $inputs ->
+            [one] { $inputs } input
+           *[other] { $inputs } input
+        }.
+    }
+
+function-domain-invalid-format = Di fọmat of di domain of di fọnkshọn no korẹkt.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Wi dey ignọ di maksimọm of di fọnkshọn wey no bi nọmba.
+        [minimum] Wi dey ignọ di minimọm of di fọnkshọn wey no bi nọmba.
+        [extremum] Wi dey ignọ di ẹkstrimọm of di fọnkshọn wey no bi nọmba.
+        [point] Wi dey ignọ di point of di fọnkshọn wey no bi nọmba.
+        [slope] Wi dey ignọ di slop of di fọnkshọn wey no bi nọmba.
+       *[other] Wi dey ignọ di { $type } of di fọnkshọn wey no bi nọmba.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Wi dey ignọ di ẹmti maksimọm of di fọnkshọn.
+        [minimum] Wi dey ignọ di ẹmti minimọm of di fọnkshọn.
+        [extremum] Wi dey ignọ di ẹmti ẹkstrimọm of di fọnkshọn.
+        [point] Wi dey ignọ di ẹmti point of di fọnkshọn.
+       *[other] Wi dey ignọ di ẹmti { $type } of di fọnkshọn.
+    }
+
+function-points-too-close = Di fọnkshọn gẹt two point wey nia dẹmsẹf too mọch. Wi no fit difain di fọnkshọn.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Fọnkshọn itaret dey posibul ọnli if di nọmba of input mach di nọmba of output. Dis fọnkshọn gẹt { $inputs } input an { $outputs ->
+            [one] { $outputs } output
+           *[other] { $outputs } output
+        }.
+       *[other] Fọnkshọn itaret dey posibul ọnli if di nọmba of input mach di nọmba of output. Dis fọnkshọn gẹt { $inputs } input an { $outputs ->
+            [one] { $outputs } output
+           *[other] { $outputs } output
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Di lẹnt of di sequence no korẹkt.  E must bi hol nọmba wey no dey bilo ziro.
+
+sequence-invalid-step = Di step of di sequence no korẹkt.  E must bi nọmba fọ sequence of type { $type }.
+
+sequence-invalid-endpoint-number = Di "{ $attribute }" of di number sequence no korẹkt.  E must bi nọmba.
+
+sequence-invalid-endpoint-letters = Di "{ $attribute }" of di letters sequence no korẹkt.  E must bi lẹta kọmbineshọn.
+
+sequence-invalid-endpoint = Di "{ $attribute }" of di sequence no korẹkt.
+
+select-from-sequence-coprime-not-numbers = wi dey ignọ coprime bikọs wi no dey pik nọmba
+
+select-from-sequence-coprime-with-exclude-combinations = wi dey ignọ coprime bikọs yu don gi excludeCombinations
+
+## Resolving a `target`
+
+target-not-found = Di target fọ `<{ $source }>` no korẹkt: wi no fit si di target.
+
+target-state-variable-not-found = Di target fọ `<{ $source }>` no korẹkt: wi no fit si stet vẹriabul wey nem bi "{ $property }" ọn `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Di vẹriabul of `<odeSystem>` must difrẹnt frọm di indipẹndẹnt vẹriabul.
+
+ode-system-duplicate-variable-names = Wi no fit difain ODE RHS fọnkshọn wit dipẹndẹnt vẹriabul nem wey ripit.
+
+ode-system-rhs-function-error = Wi no fit difain ODE RHS fọnkshọn.  Ẹra dey wen wi dey krieat di mathjs fọnkshọn.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Wi no fit difain angul bitwin { $count } lain
+
+angle-invalid-through-point = Di point fọ di through of `<angle>` no korẹkt
+
+parabola-vertex-too-many-points = Wi neva impliment parabola wit vertex wey pass mọ dan 1 point.
+
+parabola-too-many-points = Wi neva impliment parabola wey pass mọ dan 3 point.
+
+intersection-too-many-items = Wi neva impliment intasẹkshọn fọ mọ dan two tin
+
+## Other math components
+
+ionic-compound-not-two-ions = Wi neva impliment ayọnik kompaun fọ enitin ọda dan two ayọn.
+
+ionic-compound-needs-cation-and-anion = Wi impliment ayọnik kompaun ọnli fọ wan katayọn an wan anayọn.
+
+solve-equations-cannot-evaluate = Wi no fit sọlv di ikweshọn bikọs wi no fit ivaluet am: { $equation }
+
+math-operators-operand-number-required = Yu must gi operandNumber wen yu dey ẹkstrakt mat operand.
+
+eigen-decomposition-failed = Wi no fit kalkulet di aigẹnvalyu of di matriks
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: di parameter { $parameters } no dey insai di patan, so e go ọlweiz mach blank.
+       *[other] `<matchesPattern>`: di parameter { $parameters } no dey insai di patan, so dem go ọlweiz mach blank.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: wi no fit ọndastand grid="{ $grid }". E must bi none, medium, dense, ọ two positiv nọmba wey spes divaid dem, lai grid="1 0.5". Wi no go draw eni grid.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" no dey wọk fọ di prefigure rẹndara; wi dey yuz di rait-sait bihevia.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" no dey wọk fọ di prefigure rẹndara; wi dey yuz di tọp bihevia.
+
+prefigure-invalid-axis-bounds = `<graph>`: di aksis baun no korẹkt fọ prefigure; wi dey yuz di difọlt bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: di widt no korẹkt fọ prefigure; wi dey yuz di difọlt daiagram widt 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: di aspectRatio no korẹkt fọ prefigure; wi dey yuz di difọlt aspẹkt reshio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: di grid spesin fain too mọch fọ di aksis limit; wi no go put di grid fọ di prefigure rẹndara.
+
+prefigure-annotations-not-rendered = `<graph>`: annotations no go sho if yu no dey yuz di PreFigure rẹndara.
+
+multiple-annotations-children = Wi si many `<annotations>` pikin insai `<graph>`; wi dey ignọ ọl ẹksẹpt di last wan.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Wi no fit ẹkstẹnd ọ kopi kọmponẹnt taip wey wi no sabi: { $type }.
+
+copy-prop-not-found = Wi no fit si prop { $property } ọn kọmponẹnt of taip { $component }
+
+collect-no-source = Wi no si sọs fọ collect.
+
+collect-invalid-component-type = Wi no fit kolẹkt kọmponẹnt of taip `<{ $component }>` bikọs di taip no korẹkt.
+
+reference-index-unavailable = Wi no fit rẹfarẹns index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Wi no fit kọl { $action } ọn kọmponẹnt `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Di data shep no korẹkt.  Di ro dem gẹt difrẹnt lẹnt. Wi si am fọ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Di data gẹt kọlum nem wey ripit.  Wi si am fọ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Wan kọlum nem no dey fọ di data.  Wi si am fọ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Wan award fọ dis ansa dey bes ọn di answer tag ọn ansa wey dem sẹnd, an dat wan go kọz wahala wey yu no ẹkspẹkt.
+
+answer-max-num-attempts-in-section-wide-check-work = If yu sẹt `maxNumAttempts` ọn `<answer>` wey dey insai kọntena wey gẹt `sectionWideCheckWork`, e no go do enitin, bikọs na di kọntena dey kọntrol di nọmba of tray. Sẹt `maxNumAttempts` ọn di kọntena instẹd.
+
+nested-section-wide-check-work-max-num-attempts = If yu sẹt `maxNumAttempts` ọn kọntena wey gẹt `sectionWideCheckWork` an wey dey insai anoda kọntena wey gẹt `sectionWideCheckWork`, e no go do enitin, bikọs na di autsai kọntena dey kọntrol di nọmba of tray. Sẹt `maxNumAttempts` ọn di autsai kọntena instẹd.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] Di { $attributes } attribute no go do enitin if symbolicEquality no dey sẹt.
+       *[other] Di { $attributes } attribute no go do enitin if symbolicEquality no dey sẹt.
+    }
+
+answer-invalid-type = Di taip fọ di ansa no korẹkt: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Sins di kọmponẹnt `<{ $component }>` no gẹt nem, yu no fit yuz am fọ module attribute
+
+module-attribute-name-already-defined = Yu no fit yuz di kọmponẹnt `<{ $component } name="{ $name }">` as attribute fọ module bikọs `<module>` don gẹt "{ $name }" attribute.
+
+conditional-content-condition-ignored = Wi dey ignọ di `condition` attribute ọn `<conditionalContent>` wey gẹt case ọ else pikin.
+
+slider-markers-type-mismatch = Di markers taip no mach di slider taip.
+
+pretzel-problem-needs-statement-and-answer = Di pretzel no korẹkt: ich `<problem>` must gẹt wan `<statement>` an wan `<answer>`.
+
+pretzel-circuit-first-problem-distractor = Di pretzel no korẹkt: fọ mode="circuit", di fẹst `<problem>` no fit bi distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Di valyu { $values } no korẹkt fọ attribute `{ $attribute }`; wi dey ignọ am.
+       *[other] Di valyu { $values } no korẹkt fọ attribute `{ $attribute }`; wi dey ignọ dem.
+    }
+
+attribute-must-be-references = Di valyu `{ $value }` no korẹkt fọ attribute `{ $attribute }`. Di attribute must bi rẹfrẹns wey stat wit `$`.
+
+math-input-invalid-function-names = <mathInput>: wi dey ignọ fọnkshọn nem wey no korẹkt fọ { $attribute }: { $names }. Ich nem sho-pat must gẹt at list 2 karakta (lẹta ọ dash); `|<mathspeak alternative>` fit fọlo am.
+
+## Building components from the source
+
+component-type-invalid = Di kọmponẹnt taip no korẹkt: `<{ $componentType }>`
+
+attribute-repeated = Yu no fit ripit di attribute { $attribute }.
+
+attribute-invalid-for-component = Di attribute "{ $attribute }" no korẹkt fọ kọmponẹnt of taip `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Stail dẹfinishọn { $styleNumber } no gẹt inọf kọntrast fọ { $context ->
+        [text-on-background] di tẹks kọla agenst di bakgraun kọla
+        [high-contrast] di hai-kọntrast kọla agenst di kanvas
+        [line] di lain kọla agenst di kanvas
+        [marker] di maka kọla agenst di kanvas
+       *[text-on-canvas] di tẹks kọla agenst di kanvas
+    }{ $mode ->
+        [dark] { " (dak mod)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e nid at list { $threshold }:1).
+
+style-definition-dark-mode-text-background-contrast =
+    Even dou stail dẹfinishọn { $styleNumber } gẹt kọla wey gẹt inọf kọntrast fọ lait mod, di dak-mod kọla wey kọm frọm dem no gẹt inọf kọntrast fọ di tẹks kọla agenst di bakgraun kọla ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e nid at list { $threshold }:1). { $suggestion ->
+        [available] To gẹt inọf kọntrast fọ dak mod, eda yu inkris di lait-mod kọntrast (fọ ẹgzampul, sẹt { $lightAttribute }="{ $lightColor }") ọ yu ovarait di dak-mod kọla (fọ ẹgzampul, sẹt { $darkAttribute }="{ $darkColor }").
+       *[none] To gẹt inọf kọntrast fọ dak mod, inkris di lait-mod kọntrast ọ ovarait di kọla wit textColorDarkMode an/ọ backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Even dou stail dẹfinishọn { $styleNumber } gẹt tẹks kọla wey gẹt inọf kọntrast fọ lait mod, di dak-mod tẹks kọla wey kọm frọm am no gẹt inọf kọntrast agenst di kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; e nid at list { $threshold }:1). { $suggestion ->
+        [available] To gẹt inọf kọntrast fọ dak mod, eda yu inkris di lait-mod kọntrast (fọ ẹgzampul, sẹt textColor="{ $lightColor }") ọ yu ovarait di dak-mod kọla (fọ ẹgzampul, sẹt textColorDarkMode="{ $darkColor }").
+       *[none] To gẹt inọf kọntrast fọ dak mod, inkris di lait-mod kọntrast ọ ovarait di kọla wit textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Wan sẹkshọn fit pik ọnli wan <stylePalette>; wi dey yuz di last wan.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = wi no fit sabi di yunik vẹriant of { $component } bikọs numToSelect no bi hol nọmba wey no dey bilo ziro.
+
+variant-num-to-select-not-constant-number = wi no fit sabi di yunik vẹriant of { $component } bikọs numToSelect no bi kọnstant nọmba.
+
+variant-with-replacement-not-constant-boolean = wi no fit sabi di yunik vẹriant of { $component } bikọs withReplacement no bi kọnstant boolean.
+
+variant-select-weight-disables-unique = Yunik vẹriant fọ select dey ọf if eni option gẹt selectWeight ọ selectForVariants
+
+variant-coprime-undetermined = wi no fit sabi di yunik vẹriant of { $component } bikọs wi no fit sabi sey coprime ọlweiz bi fọls.
+
+variant-attribute-not-constant = wi no fit sabi di yunik vẹriant of { $component } bikọs { $attribute } no bi kọnstant.
+
+variant-attribute-not-number = wi no fit sabi di yunik vẹriant of { $component } bikọs { $attribute } no bi nọmba.
+
+variant-attribute-wrong-type-for-sequence =
+    wi no fit sabi di yunik vẹriant of { $component } of { $type } taip bikọs { $attribute } no bi { $expected ->
+        [letters-combination] lẹta kọmbineshọn
+        [math-expression] valid mat ẹkspreshọn
+        [integer] hol nọmba
+       *[number] nọmba
+    }.
+
+variant-length-not-integer = wi no fit sabi di yunik vẹriant of { $component } bikọs length no bi hol nọmba.
+
+variant-sort-not-implemented = wi neva impliment yunik vẹriant fọ { $component } wit sort
+
+variant-exclude-combinations-not-implemented = wi neva impliment yunik vẹriant fọ { $component } wit excludeCombinations
+
+variant-math-exclude-not-implemented = wi neva impliment yunik vẹriant fọ { $component } of taip math wit exclude
+
+variant-non-constant-exclude-not-implemented = wi neva impliment yunik vẹriant fọ { $component } wit exclude wey no bi kọnstant
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: e no dey wọk fọ di graph prefigure rẹndara; wi don skip di dẹsẹndant.
+
+prefigure-descendant-invalid-geometry = { $subject }: di jiọmẹtri no finit ọ e no kọmplit; wi don skip di dẹsẹndant.
+
+prefigure-curve-label-omitted = { $subject }: lebul no dey wọk fọ curve ẹlimẹnt wey wi kọnvat; wi don lef di lebul.
+
+prefigure-curve-unsupported-definition-type = { $subject }: di curve fọnkshọn dẹfinishọn taip '{ $definitionType }' no dey wọk; wi don skip di dẹsẹndant.
+
+prefigure-region-flip-functions-unsupported = { $subject }: di flipFunctions attribute ọn regionBetweenCurves no dey wọk; wi don skip di dẹsẹndant.
+
+prefigure-region-non-formula-child = { $subject }: na ọnli formula-taip pikin fọnkshọn dey wọk ọn regionBetweenCurves; wi don skip di dẹsẹndant.
+
+prefigure-label-position-unsupported =
+    { $subject }: di labelPosition '{ $labelPosition }' no dey wọk fọ { $labelKind ->
+        [line-family] lain-famili lebul
+       *[point] point lebul
+    }; wi dey yuz di difọlt PreFigure alainmẹnt.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure no sabi di fil stail '{ $fillStyle }'; wi dey fọlbak to solid fil.
+
+prefigure-line-style-unknown = { $subject }: wi no sabi di lain stail '{ $lineStyle }', so wi lef am aut of di PreFigure autput.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: wi don map di maka stail '{ $markerStyle }' to di PreFigure stail 'diamond'.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure no sabi di maka stail '{ $markerStyle }'; wi dey yuz di difọlt stail.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: di `ref` no korẹkt; wi no fit si di target. Wi don lef di annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: di `ref` point to many target; wi dey yuz di fẹst wan.
+
+annotation-ref-outside-graph = `<annotation>`: di `ref` no korẹkt; di target dey autsai di graph. Wi don lef di annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: di `ref` no korẹkt; di target no bi grafikal ọbjẹkt wey prefigure sabi. Wi don lef di annotation.
+
+annotation-text-missing = `<annotation>`: di `text` no dey ọ e ẹmti; wi dey put ẹmti tẹks.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Wi si sakula dipẹndẹnsi.
+       *[other] Wi si sakula dipẹndẹnsi wey invọlv `<{ $componentType }>` kọmponẹnt.
+    }
+
+reference-no-referent = Wi no si wetin dis rẹfrẹns dey point to: `{ $reference }`
+
+reference-multiple-referents = Wi si many tin wey dis rẹfrẹns fit dey point to: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Di fọmat of di attribute { $attribute } of `<{ $componentType }>` no korẹkt.
+
+children-invalid = Di pikin of `<{ $componentType }>` no korẹkt: Wi si pikin wey no korẹkt: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Di valyu `{ $value }` no korẹkt fọ attribute `{ $attribute }`, wi dey yuz `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Wi no si DoenetML vẹrshọn { $version }.
+       *[other] Wi no si DoenetML vẹrshọn { $version }. Wi go fọlbak to vẹrshọn { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML no korẹkt: { $content }
+
+parse-tag-missing-close-tag = DoenetML no korẹkt: Di tag `{ $tag }` no gẹt klosin tag. Wi ẹkspẹkt sẹlf-klosin tag ọ `</{ $tagName }>` tag.
+
+parse-tag-error = DoenetML no korẹkt: Ẹra dey insai tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML no korẹkt: Di attribute `{ $attribute }` no korẹkt, e lai sey e no gẹt valyu.
+
+parse-attribute-invalid = DoenetML no korẹkt: Di attribute `{ $attribute }` no korẹkt
+
+parse-attribute-value-invalid = DoenetML no korẹkt: Di attribute valyu `{ $value }` no korẹkt
+
+parse-attribute-value-quote-mismatch = DoenetML no korẹkt: Di attribute valyu `{ $value }` no korẹkt. Di kwot mak no mach. E lai sey `{ $quote }` no dey
+
+parse-open-tag-name-missing = DoenetML no korẹkt: Wi si tag wey no gẹt nem, lai `<`
+
+parse-tag-not-closed = DoenetML no korẹkt: Dem no klos di tag `{ $tag }` (e lai sey `>` no dey).
+
+parse-self-closing-tag-name-missing = DoenetML no korẹkt: Wi si tag wey no gẹt nem `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML no korẹkt: Dem no klos di tag `{ $tag }` (e lai sey `/>` no dey).
+
+parse-tag-invalid-attributes = DoenetML no korẹkt: Di tag `{ $tag }` no valid. E fit gẹt attribute wey no korẹkt.
+
+parse-close-tag-name-missing = DoenetML no korẹkt: Wi si klosin tag wey no gẹt nem, lai `</`
+
+parse-attribute-value-unquoted = Attribute valyu must dey insai kwot: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML no korẹkt: Wi si klosin tag `{ $tag }`, bọt opinin tag no dey
+
+parse-close-tag-mismatched = DoenetML no korẹkt: Di klosin tag no mach. Wi ẹkspẹkt `</{ $expected }>`. Wi si `{ $found }`
+
+parser-node-unconvertible = Wi no fit kọnvat node { $node } to Dast node.
+
+## Names
+
+name-attribute-invalid =
+    Di attribute name='{ $name }' no korẹkt. { $reason ->
+        [characters] Nem fit gẹt ọnli lẹta, nọmba, ọndaskọ ọ haifẹn.
+       *[start] Nem must stat wit lẹta.
+    }
+
+component-name-invalid-start = Di kọmponẹnt nem "{ $name }" no korẹkt. Nem must stat wit lẹta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer wey gẹt type videoWatched must gẹt video attribute
+
+answer-video-watched-video-not-reference = Answer wey gẹt type videoWatched must gẹt video attribute wey bi rẹfrẹns
+
+answer-name-not-single-text = Di answer name attribute must gẹt wan text pikin
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Wi no fit gẹt di ẹkstanal DoenetML bikọs rikọshọn plẹnti too mọch. Sakula rẹfrẹns dey?
+
+external-doenetml-unavailable = Wi no fit gẹt DoenetML frọm { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = Di DoenetML wey wi gẹt frọm { $attribute }="{ $uri }" no korẹkt: e no mach di kọmponẹnt taip "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Di attribute `{ $from }` don ol; yuz `{ $to }` instẹd.
+       *[other] [deprecation] Di attribute `{ $from }` ọn `<{ $component }>` don ol; yuz `{ $to }` instẹd.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Di attribute `{ $from }` don ol an wi dey ignọ am bikọs `{ $to }` dey too.
+       *[other] [deprecation] Di attribute `{ $from }` ọn `<{ $component }>` don ol an wi dey ignọ am bikọs `{ $to }` dey too.
+    }
+
+deprecated-attribute-ignored = [deprecation] Di attribute `{ $attribute }` ọn `<{ $component }>` don ol an wi dey ignọ am.
+
+deprecated-attribute-to-child = [deprecation] Di attribute `{ $attribute }` ọn `<{ $component }>` don ol; yuz `<{ $child }>` pikin instẹd.
+
+deprecated-attribute-value-renamed = [deprecation] Di valyu `{ $value }` of attribute `{ $attribute }` ọn `<{ $component }>` don ol; yuz `{ $to }` instẹd.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` fit ọnli pluralaiz Inglish, so e lef di tẹks di way yu rait am fọ dọkyumẹnt wey dem rait fọ { $locale }. Rait di plural fọm dairẹkt, ọ sẹt am wit di `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Di ẹlimẹnt `<{ $tag }>` no bi Doenet ẹlimẹnt wey wi sabi.
+
+schema-element-not-allowed-at-root = Dem no alaw di ẹlimẹnt `<{ $tag }>` fọ di rut of di dọkyumẹnt.
+
+schema-element-not-allowed-inside = Dem no alaw di ẹlimẹnt `<{ $tag }>` insai `<{ $parent }>`.
+
+schema-attribute-unrecognized = Di ẹlimẹnt `<{ $tag }>` no gẹt attribute wey dem kọl `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Di attribute `{ $attribute }` of ẹlimẹnt `<{ $tag }>` must bi list wey ich aitẹm insai am bi wan of dis: { $allowed }
+       *[other] Di attribute `{ $attribute }` of ẹlimẹnt `<{ $tag }>` must bi wan of dis: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Di vẹriant nem fọ select no korẹkt.  Di vẹriant nem { $variantName } dey sho fọ { $numOptions } option bọt di nọmba wey wi go pik na { $numToSelect }.
+
+select-variant-name-without-options = Yu don gi select sọm vẹriant bọt yu no gi eni option fọ di posibul vẹriant nem: { $variantName }.
+
+select-variant-name-not-possible = Di vẹriant nem { $variantName } wey yu gi select no bi posibul vẹriant nem.
+
+select-too-few-options = Wi no fit pik { $numToSelect } kọmponẹnt frọm ọnli { $numOptions }.
+
+select-from-sequence-too-few-values = Wi no fit pik { $numToSelect } valyu frọm sequence wey lẹnt bi { $length }.
+
+select-from-sequence-indices-count-mismatch = Di nọmba of indices wey yu gi select must mach di nọmba wey wi go pik
+
+select-from-sequence-indices-not-integers = Ọl di indices wey yu gi select must bi hol nọmba
+
+select-from-sequence-index-excluded = Yu gi selectfromsequence index wey dem don ẹksklud
+
+select-from-sequence-indices-excluded-combination = Yu gi selectfromsequence indices wey bi kọmbineshọn wey dem don ẹksklud
+
+select-from-sequence-coprime-not-positive-integers = Wi no fit pik coprime kọmbineshọn bikọs wi no dey pik positiv hol nọmba.
+
+select-from-sequence-coprime-common-factor = Wi no fit pik coprime nọmba. Ọl di posibul valyu dey shea wan kọmọn faktọ. (Di valyu wey yu gi fọ "from" ọ "to" must bi coprime wit "step".)
+
+select-from-sequence-coprime-single-number = Wi no fit pik coprime kọmbineshọn frọm sinjul nọmba wey no bi 1.
+
+select-from-sequence-excluded-too-many-combinations = Dem don ẹksklud ova 70% of di kọmbineshọn insai selectFromSequence
+
+select-from-sequence-coprime-none-found = Wi no fit pik coprime nọmba. Ọl di posibul valyu dey shea wan kọmọn faktọ.
+
+select-from-sequence-too-few-unique-values = Wi no fit pik { $numToSelect } yunik valyu frọm sequence wey lẹnt bi { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Wi no fit pik { $numToSelect } valyu frọm praim list wey lẹnt bi { $numValues }
+
+select-prime-numbers-values-count-mismatch = Di nọmba of valyu wey yu gi select must mach di nọmba wey wi go pik
+
+select-prime-numbers-values-not-prime = Ọl di valyu wey yu gi select prime number must dey insai di praim list
+
+select-prime-numbers-values-excluded-combination = Di valyu wey yu gi selectPrimeNumbers bi kọmbineshọn wey dem don ẹksklud
+
+select-prime-numbers-excluded-too-many-combinations = Dem don ẹksklud ova 70% of di kọmbineshọn insai selectPrimeNumbers
+
+select-random-combination-fluke = Na wanda wey no supoz hapun: wi no fit pik kọmbineshọn of randọm valyu
+
+select-random-value-fluke = Na wanda wey no supoz hapun: wi no fit pik randọm valyu

--- a/packages/i18n/locales/pcm/diagnostics.ftl
+++ b/packages/i18n/locales/pcm/diagnostics.ftl
@@ -50,11 +50,11 @@ vector-dimension-mismatch = numDimensions no mach fọ di vẹkta.
 
 ## Attracting and constraining
 
-attract-to-without-nearest-point = Wi no fit atrakt to `<{ $component }>` bikọs e no gẹt nearestPoint.
+attract-to-without-nearest-point = Wi no fit atrakt to `<{ $component }>` bikọs e no gẹt nearestPoint stet vẹriabul.
 
-constrain-to-without-nearest-point = Wi no fit kọnstren to `<{ $component }>` bikọs e no gẹt nearestPoint.
+constrain-to-without-nearest-point = Wi no fit kọnstren to `<{ $component }>` bikọs e no gẹt nearestPoint stet vẹriabul.
 
-constrain-to-interior-without-nearest-point = Wi no fit kọnstren to di insai of `<{ $component }>` bikọs e no gẹt nearestPoint.
+constrain-to-interior-without-nearest-point = Wi no fit kọnstren to di insai of `<{ $component }>` bikọs e no gẹt nearestPoint stet vẹriabul.
 
 ## `<choiceInput>`
 
@@ -78,13 +78,13 @@ pretzel-circuit-first-index = Wi dey ignọ di indices wey yu gi pretzel fọ mo
 
 string-children-need-type = Fọ make `<{ $component }>` wọk wit string pikin, yu must gi am `type` attribute.
 
-invalid-type-defaulting-to-math = Type { $type } no korẹkt fọ { $component } kọmponẹnt. E must bi math, text, number ọ boolean. Wi go yuz math.
+invalid-type-defaulting-to-math = Taip { $type } no korẹkt fọ { $component } kọmponẹnt. E must bi math, text, number ọ boolean. Wi go yuz math.
 
-string-not-valid-component-to-arrange = String "{ $value }" no bi valid kọmponẹnt fọ { $component }. Wi dey ignọ am.
+string-not-valid-component-to-arrange = String "{ $value }" no bi kọmponẹnt wey korẹkt fọ { $component }. Wi dey ignọ am.
 
 ## Types and variables
 
-invalid-type-defaulting-to-number = Type { $type } no korẹkt, wi don sẹt di type to number.
+invalid-type-defaulting-to-number = Taip { $type } no korẹkt, wi don sẹt di taip to number.
 
 invalid-variable-value = Vẹriabul valyu wey no korẹkt: `{ $value }`
 
@@ -301,7 +301,7 @@ collect-no-source = Wi no si sọs fọ collect.
 
 collect-invalid-component-type = Wi no fit kolẹkt kọmponẹnt of taip `<{ $component }>` bikọs di taip no korẹkt.
 
-reference-index-unavailable = Wi no fit rẹfarẹns index `{ $reference }`
+reference-index-unavailable = Wi no fit rẹfrẹns index `{ $reference }`
 
 ## `<callAction>`
 
@@ -412,7 +412,7 @@ variant-attribute-not-number = wi no fit sabi di yunik vẹriant of { $component
 variant-attribute-wrong-type-for-sequence =
     wi no fit sabi di yunik vẹriant of { $component } of { $type } taip bikọs { $attribute } no bi { $expected ->
         [letters-combination] lẹta kọmbineshọn
-        [math-expression] valid mat ẹkspreshọn
+        [math-expression] mat ẹkspreshọn wey korẹkt
         [integer] hol nọmba
        *[number] nọmba
     }.
@@ -521,7 +521,7 @@ parse-self-closing-tag-name-missing = DoenetML no korẹkt: Wi si tag wey no g�
 
 parse-self-closing-tag-not-closed = DoenetML no korẹkt: Dem no klos di tag `{ $tag }` (e lai sey `/>` no dey).
 
-parse-tag-invalid-attributes = DoenetML no korẹkt: Di tag `{ $tag }` no valid. E fit gẹt attribute wey no korẹkt.
+parse-tag-invalid-attributes = DoenetML no korẹkt: Di tag `{ $tag }` no korẹkt. E fit gẹt attribute wey no korẹkt.
 
 parse-close-tag-name-missing = DoenetML no korẹkt: Wi si klosin tag wey no gẹt nem, lai `</`
 

--- a/packages/i18n/locales/pcm/diagnostics.ftl
+++ b/packages/i18n/locales/pcm/diagnostics.ftl
@@ -110,7 +110,7 @@ label-for-must-resolve-to-one = Di `for` attribute ọn `<label>` must point to 
 
 label-for-unresolved = Di `for` attribute ọn `<label>` no fit point to eni kọmponẹnt.
 
-label-for-answer-with-authored-inputs = Di `for` attribute ọn `<label>` dey point to `<answer>` wey gẹt input wey di ọda pẹsin rait; point to di input dairẹkt.
+label-for-answer-with-authored-inputs = Di `for` attribute ọn `<label>` dey point to `<answer>` wey gẹt input wey di ọtọ rait wit im on han; point to di input dairẹkt.
 
 label-for-answer-without-input = Di `for` attribute ọn `<label>` dey point to `<answer>` wey no gẹt input to lebul.
 

--- a/packages/i18n/locales/pcm/editor.ftl
+++ b/packages/i18n/locales/pcm/editor.ftl
@@ -1,0 +1,211 @@
+# Nigerian Pidgin editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written — which in this catalog
+# is a distinction that has to be made deliberately, since the prose around
+# them is English-lexified too. `attribute` inside a sentence is the DoenetML
+# word; `atribyut` is not used anywhere, so the seam stays visible.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Risẹt
+       *[update] Updet
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Viwa
+       *[other] { $word } Viwa { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Vẹriant
+
+editor-variant-filter = Filta…
+
+editor-variant-next = Pik di nẹks vẹriant
+
+editor-variant-previous = Pik di vẹriant wey pass
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Wi si WCAG AA aksẹsibiliti vayolashọn. Klik make yu { $action ->
+            [close] klos
+           *[open] opin
+        } di aksẹsibiliti ripọt.
+        [advisories] Klik make yu { $action ->
+            [close] klos
+           *[open] opin
+        } di aksẹsibiliti ripọt. Wi no si eni WCAG AA vayolashọn, bọt wi gẹt oda aksẹsibiliti advais.
+       *[clean] Klik make yu { $action ->
+            [close] klos
+           *[open] opin
+        } di aksẹsibiliti ripọt. Wi no si eni aksẹsibiliti wahala.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Wi si WCAG AA aksẹsibiliti vayolashọn. Wi si { $count ->
+            [one] { $count } WCAG AA vayolashọn
+           *[other] { $count } WCAG AA vayolashọn
+        }. Klik make yu { $action ->
+            [close] klos
+           *[open] opin
+        } di aksẹsibiliti ripọt.
+        [advisories] Wi no si eni WCAG AA vayolashọn. Wi si { $count ->
+            [one] { $count } oda aksẹsibiliti advais
+           *[other] { $count } oda aksẹsibiliti advais
+        }. Klik make yu { $action ->
+            [close] klos
+           *[open] opin
+        } di aksẹsibiliti ripọt.
+       *[clean] Wi no si eni WCAG AA vayolashọn. Klik make yu { $action ->
+            [close] klos
+           *[open] opin
+        } di aksẹsibiliti ripọt.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML vẹrshọn { $version }
+
+editor-tab-help = Hẹlp fọ wia yu dey
+editor-tab-help-short = Kọntẹks
+editor-tab-errors = Ẹra dem
+editor-tab-warnings = Wọnin dem
+editor-tab-info = Infọ
+editor-tab-accessibility = Aksẹsibiliti
+editor-tab-responses = Ansa wey dem sẹnd
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Ẹdita ọpshọn dem
+editor-format-as-doenetml = Fọmat am as DoenetML
+editor-format-as-xml = Fọmat am as XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Lain #{ $line }
+
+editor-no-errors = No Ẹra
+editor-no-warnings = No Wọnin
+editor-no-info = No Infọ
+
+editor-show-info-annotations = Sho infọ dem fọ di ẹdita
+editor-show-accessibility-annotations = Sho aksẹsibiliti wahala dem fọ di ẹdita
+
+editor-accessibility-learn-more = Lan haw Doenet dey handul aksẹsibiliti
+
+editor-accessibility-violations-heading = Aksẹsibiliti vayolashọn dem ({ $standard })
+
+editor-accessibility-other-heading = Oda aksẹsibiliti wahala dem
+editor-none-found = Wi no si eni
+
+
+## Submitted responses
+
+editor-no-responses = Nobody don sẹnd ansa yẹt
+editor-response-answer-id = Ansa Id
+editor-response-response = Ansa
+editor-response-credit = Krẹdit
+editor-response-submitted = Dem sẹnd am
+
+
+## The context-help panel
+
+help-placeholder = Put yọ kọsọ fọ tag nem, attribute, ọ { $ref } make yu si di dọkumẹnteshọn.
+
+help-unsupported-ref-chain = Wi neva gẹt hẹlp fọ rẹfrẹns wey gẹt many pat lai { $example }.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Wi no si wetin { $ref } dey point to.
+        [multiple] Wi si many tin wey { $ref } fit dey point to.
+       *[indeterminate] Wi no fit sabi wetin { $ref } dey point to.
+    }
+
+help-learn-about-references = Lan about rẹfrẹns dem →
+help-reference-page = Rẹfrẹns pej →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Insai { $element }
+       *[top] Fọ di tọp lẹvul
+    }{ $allowed ->
+        [none] { " — nọtin dey go hia." }
+        [text] { " — tayp tẹks hia." }
+        [text-and-components] { " — tayp tẹks hia, ọ tray:" }
+       *[components] { " — tin wey yu fit tray:" }
+    }
+
+help-suggestions-footer = Prẹs { $shortcut } make yu si ọl { $total } kọmponẹnt dem.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } na rẹfrẹns to { $target }.
+       *[other] { $ref } na rẹfrẹns to { $target } (lain { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } bring am as { $role }.
+       *[other] { $owner } bring am fọ lain { $line } as { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } na rẹfrẹns to di { $property } prọpati of { $element }.
+       *[other] { $ref } na rẹfrẹns to di { $property } prọpati of { $element } (lain { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = snipẹt
+help-kind-array-entry = array ẹntri
+
+help-default = Difọlt:
+help-active-default = Difọlt wey dey wọk:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Valyu wey dem alaw (wan fọ ich aitẹm):
+       *[other] Valyu wey dem alaw:
+    }
+
+help-suggested-values = Valyu wey wi dey sọjẹst:
+
+help-inserts = E dey put:
+
+help-coordinates =
+    { $count ->
+        [one] Kọọdinet:
+       *[other] Kọọdinet dem:
+    }
+
+help-type = Taip:
+
+help-resolved-style = Stail wey wi wọk aut (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fọnkshọn nem wey wi wọk aut:
+help-reset-list = Risẹt list fọ dis input:
+help-added-on-input = Dem add am fọ dis input:
+help-removed-on-input = Dem rimuv am fọ dis input:
+
+help-reset-overrides = { $reset } dey ovarait { $additional } an { $removed }.

--- a/packages/i18n/locales/pcm/editor.ftl
+++ b/packages/i18n/locales/pcm/editor.ftl
@@ -127,7 +127,7 @@ editor-response-submitted = Dem sẹnd am
 
 ## The context-help panel
 
-help-placeholder = Put yọ kọsọ fọ tag nem, attribute, ọ { $ref } make yu si di dọkumẹnteshọn.
+help-placeholder = Put yọ kọsọ fọ tag nem, attribute, ọ { $ref } make yu si di dọkyumẹnteshọn.
 
 help-unsupported-ref-chain = Wi neva gẹt hẹlp fọ rẹfrẹns wey gẹt many pat lai { $example }.
 
@@ -147,8 +147,8 @@ help-suggestions-header =
        *[top] Fọ di tọp lẹvul
     }{ $allowed ->
         [none] { " — nọtin dey go hia." }
-        [text] { " — tayp tẹks hia." }
-        [text-and-components] { " — tayp tẹks hia, ọ tray:" }
+        [text] { " — taip tẹks hia." }
+        [text-and-components] { " — taip tẹks hia, ọ tray:" }
        *[components] { " — tin wey yu fit tray:" }
     }
 

--- a/packages/i18n/locales/tem/chrome.ftl
+++ b/packages/i18n/locales/tem/chrome.ftl
@@ -1,0 +1,134 @@
+# Temne viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the alliterative-concord table, for why that
+# makes `noun-gender` checkable against `noun` by eye, and for what a speaker
+# should check first.
+
+
+## Answer submission
+
+answer-checking = Ɔ chɛk…
+answer-submitting = Ɔ sɔŋ…
+
+answer-checking-status = Ɔ chɛk ʌŋlipi
+answer-submitting-status = Ɔ sɔŋ ʌŋlipi
+
+answer-correct = Kʌ tɔfɔ
+answer-incorrect = Kʌ tɔfɔ bɔm
+
+answer-response-saved = Ʌŋlipi Ma Sɔŋɔ
+
+answer-percent-credit = { $percent }% Kʌbay
+answer-percent-correct = { $percent }% Tɔfɔ
+answer-percent-short = { $percent } %
+
+max-credit-available = Kʌbay kʌbana kʌ mʌ bata: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] kʌtʌmpa kʌ bɔm
+        [one] kʌtʌmpa { $count } kʌ dəni
+       *[other] tʌtʌmpa { $count } tʌ dəni
+    }
+
+validation-correct = (Kʌ tɔfɔ)
+validation-incorrect = (Kʌ tɔfɔ bɔm)
+validation-partially-correct = (Kʌ tɔfɔ kʌpath)
+
+answer-show-responses =
+    { $count ->
+        [one] Yira ʌŋlipi { $count } ka { $answerId }
+       *[other] Yira ʌŋlipi { $count } ka { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Ʌŋlipi ka kʌkarante
+
+collapsible-click-to-open = (tɔth ma kʌ tuli)
+collapsible-click-to-close = (tɔth ma kʌ kanti)
+
+collapsible-initializing = Kʌ təŋ…
+
+footnote-show = Yira kʌsɔŋ kʌ kʌtəp
+footnote-hide = Kunthu kʌsɔŋ kʌ kʌtəp
+
+description-more-information = tʌkəre tʌbʌŋ
+
+
+## Controls
+
+slider-previous = Kʌ pʌ
+slider-next = Kʌ tʌŋ
+
+keyboard-open = Tuli Kibɔd
+keyboard-close = Kanti Kibɔd
+
+choice-input-remove-choice = Bɔth { $choice }
+
+matrix-remove-row = Bɔth kʌro
+matrix-add-row = Fɔth kʌro
+matrix-remove-column = Bɔth kʌkɔlum
+matrix-add-column = Fɔth kʌkɔlum
+
+subset-add-remove-points = Fɔth/Bɔth tʌtoni
+subset-toggle-points-intervals = Firi tʌtoni na tʌintaval
+subset-move-points = Bʌŋ Tʌtoni
+subset-clear = Sana
+
+orbital-add-row = Fɔth Kʌro
+orbital-remove-row = Bɔth Kʌro
+orbital-add-box = Fɔth Kʌbɔks
+orbital-remove-box = Bɔth Kʌbɔks
+orbital-add-up-arrow = Fɔth Kʌaro Kʌ Kʌtɔŋ
+orbital-add-down-arrow = Fɔth Kʌaro Kʌ Kʌtəp
+orbital-remove-arrow = Bɔth Kʌaro
+
+orbital-row-label = Ʌŋes ka kʌro { $row }
+
+pretzel-answer = Ʌŋlipi
+
+summary-statistics-caption = Ʌŋkəbath ka tʌnamba tʌ { $column }
+
+
+## Math input
+
+math-input-preview-region = yira ʌŋkəre ka mat pʌ
+math-input-preview = Yira pʌ
+math-input-invalid-expression = Ʌŋkəre ka bana bɔm:
+
+
+## Document status
+
+viewer-initializing = Kʌ təŋ…
+
+
+## Errors
+
+error-heading = Kʌwuni
+
+error-found-at =
+    { $span ->
+        [line] Ma bata ka kʌlayn { $startLine }.
+       *[lines] Ma bata ka tʌlayn { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Kʌbuk kʌnɛ kʌ na tʌwuni!
+
+diagnostic-heading-error = Kʌwuni
+diagnostic-heading-warning = Kʌmɔŋ
+diagnostic-heading-information = Ʌŋkəre
+diagnostic-heading-hint = Kʌsandi
+
+accessibility-heading-level-1 = WCAG AA Kʌwuni ka Kʌsɔth
+accessibility-heading-level-2 = Kʌmɔŋ ka kʌsɔth
+
+something-went-wrong = Kʌbʌŋ kʌ bana bɔm.
+
+renderer-load-failed = kʌyiraŋ kʌbʌŋ kʌ ba bɔm. Bɔŋɔ, firi kʌpej.
+
+core-start-failed = Kʌyiraŋ ka kʌbuk kʌ təŋ bɔm. Bɔŋɔ, firi kʌpej.

--- a/packages/i18n/locales/tem/chrome.ftl
+++ b/packages/i18n/locales/tem/chrome.ftl
@@ -99,7 +99,7 @@ summary-statistics-caption = Ʌŋkəbath ka tʌnamba tʌ { $column }
 
 math-input-preview-region = yira ʌŋkəre ka mat pʌ
 math-input-preview = Yira pʌ
-math-input-invalid-expression = Ʌŋkəre ka bana bɔm:
+math-input-invalid-expression = Ʌŋkəre kʌ bana bɔm:
 
 
 ## Document status

--- a/packages/i18n/locales/tem/content.ftl
+++ b/packages/i18n/locales/tem/content.ftl
@@ -1,0 +1,341 @@
+# Temne content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `tem` is Temne (Themne), an Atlantic language of northern Sierra Leone and
+# the country's largest first language. CLDR spells it "Timne", which is why
+# the roster says that and this header does not.
+#
+# **`$gender` is a noun class again, and the concord is *alliterative*.** The
+# describing word takes the same prefix the noun itself carries, syllable for
+# syllable:
+#
+#            c1 (kʌ-)      c2 (tʌ-)      c3 (rʌ-)      c4 (ʌŋ-)
+#   noun      kʌ-bath       tʌ-bath       rʌ-th        ʌŋ-fəm
+#   -fith     kʌfith        tʌfith        rʌfith        ʌŋfith
+#   -fera     kʌfera        tʌfera        rʌfera        ʌŋfera
+#
+# **That is the property worth having a catalog for.** In `locales/kg` the
+# class is a separate linker word, in `locales/kbp` a suffix, in `locales/tiv`
+# a particle: in each of those the concord and the noun's own prefix are
+# different morphs, so a reviewer has to take `noun-gender`'s table on trust.
+# Here the two are the same syllable, so `noun-gender` can be *checked against
+# `noun`* by eye — every entry below assigns a noun to the class its own
+# written prefix names, and a reviewer who finds one that does not has found a
+# bug without needing to know Temne.
+#
+# It is the third Atlantic catalog here and answers differently from both the
+# others: `locales/ff` spells its class as a suffix and `locales/wo` on a
+# determiner beside the noun, and neither is alliterative with the noun's own
+# shape the way this is.
+#
+# `$role` goes unused: Temne marks no case.
+#
+# The geometry leans on the English loans Sierra Leonean schooling supplies —
+# the same ministry `locales/kri` records — with Temne words where they are
+# solid: «ro-» a place, «ʌŋ-mark» a mark. They are the first thing to check.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [c2] tʌfith
+            [c3] rʌfith
+            [c4] ʌŋfith
+           *[c1] kʌfith
+        }
+    .white =
+        { $gender ->
+            [c2] tʌfera
+            [c3] rʌfera
+            [c4] ʌŋfera
+           *[c1] kʌfera
+        }
+    .gray =
+        { $gender ->
+            [c2] tʌthupu
+            [c3] rʌthupu
+            [c4] ʌŋthupu
+           *[c1] kʌthupu
+        }
+    .red =
+        { $gender ->
+            [c2] tʌbana
+            [c3] rʌbana
+            [c4] ʌŋbana
+           *[c1] kʌbana
+        }
+    .orange = ɔrenji
+    .yellow = yɛlo
+    .green = grin
+    .cyan = sayan
+    .blue = blu
+    .purple = pəpul
+    .pink = pink
+    .brown = braun
+
+line-width =
+    .thick =
+        { $gender ->
+            [c2] tʌbana-bana
+            [c3] rʌbana-bana
+            [c4] ʌŋbana-bana
+           *[c1] kʌbana-bana
+        }
+    .thin =
+        { $gender ->
+            [c2] tʌkəni
+            [c3] rʌkəni
+            [c4] ʌŋkəni
+           *[c1] kʌkəni
+        }
+
+# Written as «na …» phrases rather than as prefixed qualifiers, so that they
+# take no concord and can close the description. `style-stroke` puts them last.
+line-style =
+    .dashed = na ʌŋpath-pathi
+    .dotted = na ʌŋtoni
+
+fill-style =
+    .horizontal = ʌŋlayn ŋa ŋi lay
+    .vertical = ʌŋlayn ŋa ŋi yema
+    .diagonal = ʌŋlayn ŋa ŋi kəri
+    .backdiagonal = ʌŋlayn ŋa ŋi kəri ka pʌŋ ʌŋbʌŋ
+    .dots = ʌŋtoni
+    .diamonds = ʌŋdayamɔn
+
+# Every noun below carries its class prefix in writing, so `noun-gender`'s
+# table can be read straight off this message. That is the alliterative-concord
+# property the header describes, and it is what makes this catalog checkable.
+noun =
+    .line = kʌlayn
+    .line-segment = kʌpath kʌ layn
+    .ray = kʌre
+    .vector = kʌvɛkta
+    .curve = kʌlayn kʌ kəri
+    .function = kʌfɔnkshɔn
+    .parabola = kʌparabola
+    .polyline = tʌlayn tʌ path
+    .polygon = tʌpɔligɔn
+    .triangle = tʌtrayangul
+    .rectangle = tʌrɛktangul
+    .circle = tʌkərəŋ
+    .region = rʌro
+    .point = rʌtoni
+    .square = tʌskwea
+    .diamond = rʌdayamɔn
+    .cross = rʌkrɔs
+    .plus = rʌmark rʌ plɔs
+
+# The side count is a relative and closes the noun phrase behind the describing
+# words, so it goes in the tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] tʌ na tʌbʌŋ { $numSides }
+       *[head] tʌpɔligɔn tʌ kɔmɔ
+    }
+
+# The noun class. Read it against `noun` above: each entry names the class the
+# noun's own written prefix carries, and `regular-polygon` takes `c2` because
+# `noun-regular-polygon`'s head is «tʌpɔligɔn». `c1` is the default and the
+# class an English loan joins, which is what an author's own `markerStyleWord`
+# is as far as this catalog is concerned.
+noun-gender =
+    { $noun ->
+        [polyline] c2
+        [polygon] c2
+        [regular-polygon] c2
+        [triangle] c2
+        [rectangle] c2
+        [circle] c2
+        [square] c2
+        [region] c3
+        [point] c3
+        [diamond] c3
+        [cross] c3
+        [plus] c3
+        [text] c3
+        [fill] c4
+        [background] c4
+        [border] c4
+       *[other] c1
+    }
+
+
+## Style composition
+
+# The dash pattern is a «na …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c2] tʌwuni
+        [c3] rʌwuni
+        [c4] ʌŋwuni
+       *[c1] kʌwuni
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } na { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } na { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } na { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «ʌŋbʌŋ» is the border and leads its own describing words, so they agree with
+# it rather than with the shape it surrounds — which is why `border` answers
+# `c4` in `noun-gender`, matching that word's own «ʌŋ-». Temne has no article
+# and joins this clause with the invariable «na», so all four branches read
+# alike.
+style-border-clause =
+    { $parts ->
+        [with-article] na ʌŋbʌŋ { $border }
+        [and] na ʌŋbʌŋ { $border }
+        [and-article] na ʌŋbʌŋ { $border }
+       *[with] na ʌŋbʌŋ { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = kʌwuni bɔm
+
+style-text =
+    { $parts ->
+        [background] { $color } na ʌŋkəbaka { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = kəm bɔm
+
+
+## Boolean words
+
+boolean-true = ʌŋtɔfɔ
+boolean-false = ʌŋgbɔl
+
+
+## Answer buttons
+
+answer-submit-label = Chɛk Ʌŋpaŋth
+answer-submit-label-no-correctness = Sɔŋ Ʌŋlipi
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Ʌŋpaŋth
+    .aside = Ʌŋkəre kʌbʌŋ
+    .cascade = Kasked
+    .definition = Ʌŋkəbath
+    .example = Kʌmisal
+    .exercise = Kʌtʌmpa
+    .exercises = Tʌtʌmpa
+    .given-answer = Ʌŋlipi
+    .note = Kʌsɔŋ
+    .objectives = Tʌgbap
+    .paragraphs = Tʌpath
+    .part = Kʌpath
+    .problem = Kʌwuni
+    .problems = Tʌwuni
+    .proof = Kʌyilaŋ
+    .question = Kʌmɔthɔ
+    .section = Kʌpath
+    .solution = Ʌŋsɔlushɔn
+    .task = Ʌŋpaŋth
+    .theorem = Tiɔrɛm
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Kʌsandi
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tebul { $enumeration }
+        [numbered-title] Tebul { $enumeration }{ ": " }
+        [unnumbered-title] Tebul{ ": " }
+       *[unnumbered] Tebul
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Kʌmisal { $enumeration }
+        [numbered-caption] Kʌmisal { $enumeration }{ ": " }
+        [unnumbered-caption] Kʌmisal{ ": " }
+       *[unnumbered] Kʌmisal
+    }
+
+
+## Paginator controls
+
+paginator-previous = Kʌ pʌ
+paginator-next = Kʌ tʌŋ
+
+paginator-page = Kʌpej
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ɔ
+
+piecewise-condition-if = ma
+
+piecewise-condition-otherwise = ka tʌbʌŋ tʌ pəŋ
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case. Sierra Leone teaches secondary science in English,
+## so a Temne speaker meets the periodic table there and the fallback *is* the
+## curriculum — the same answer `locales/kri` gives from the same ministry.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kʌmark kʌ Kɛmistri kʌ Bana Bɔm
+chemistry-invalid-ionic-compound = Kʌthɔfi kʌ Ayɔn kʌ Bana Bɔm

--- a/packages/i18n/locales/tem/content.ftl
+++ b/packages/i18n/locales/tem/content.ftl
@@ -13,7 +13,7 @@
 # syllable:
 #
 #            c1 (kʌ-)      c2 (tʌ-)      c3 (rʌ-)      c4 (ʌŋ-)
-#   noun      kʌ-bath       tʌ-bath       rʌ-th        ʌŋ-fəm
+#   noun      kʌ-bath       tʌ-bath       rʌ-th         ʌŋ-fəm
 #   -fith     kʌfith        tʌfith        rʌfith        ʌŋfith
 #   -fera     kʌfera        tʌfera        rʌfera        ʌŋfera
 #

--- a/packages/i18n/locales/tem/content.ftl
+++ b/packages/i18n/locales/tem/content.ftl
@@ -22,9 +22,16 @@
 # a particle: in each of those the concord and the noun's own prefix are
 # different morphs, so a reviewer has to take `noun-gender`'s table on trust.
 # Here the two are the same syllable, so `noun-gender` can be *checked against
-# `noun`* by eye — every entry below assigns a noun to the class its own
-# written prefix names, and a reviewer who finds one that does not has found a
-# bug without needing to know Temne.
+# `noun`* by eye — every entry naming one of `noun`'s attributes assigns it the
+# class that attribute's own written prefix carries, and a reviewer who finds
+# one that does not has found a bug without needing to know Temne.
+#
+# The four entries that name a phrase head rather than a noun are outside that
+# check, since `noun` does not spell them: `border` and `background` can still
+# be read against the words this file writes for them — «ʌŋbʌŋ» in
+# `style-border-clause` and «ʌŋkəbaka» in `style-text`, both `ʌŋ-` and both
+# `c4` — but `text` and `fill` head phrases this catalog writes no word for, so
+# their classes have to be taken on trust the way every other catalog's are.
 #
 # It is the third Atlantic catalog here and answers differently from both the
 # others: `locales/ff` spells its class as a suffix and `locales/wo` on a
@@ -139,9 +146,12 @@ noun-regular-polygon =
        *[head] tʌpɔligɔn tʌ kɔmɔ
     }
 
-# The noun class. Read it against `noun` above: each entry names the class the
-# noun's own written prefix carries, and `regular-polygon` takes `c2` because
-# `noun-regular-polygon`'s head is «tʌpɔligɔn». `c1` is the default and the
+# The noun class. Read it against `noun` above: each entry that names one of
+# `noun`'s attributes takes the class that attribute's own written prefix
+# carries, and `regular-polygon` takes `c2` because `noun-regular-polygon`'s
+# head is «tʌpɔligɔn». The last four name phrase heads instead — see the
+# header for which of them `noun` can be read against and which cannot.
+# `c1` is the default and the
 # class an English loan joins, which is what an author's own `markerStyleWord`
 # is as far as this catalog is concerned.
 noun-gender =

--- a/packages/i18n/locales/tem/content.ftl
+++ b/packages/i18n/locales/tem/content.ftl
@@ -61,6 +61,17 @@
 # `line-width`, `style-filled-word`, and these four colours — supplies all four
 # classes.
 #
+# `.red` is the entry to settle before any of the others. Its stem «-bana» is
+# also this catalog's word for *big*: `diagnostics.ftl` renders a function's
+# `[maximum]` as «kʌbana» against `[minimum]` «kʌkəni», and `line-width` below
+# reduplicates the same two stems for `.thick` and `.thin`. So a stroked red
+# line renders «kʌlayn kʌbana-bana kʌbana», where only the repeated `kʌ-` is
+# meant to be the concord and the repeated «bana» is not meant to be anything.
+# Either «-bana» really is the colour term as well and the pair is a homonym a
+# speaker can leave alone, or `.red` wants its own stem; a speaker deciding the
+# second way should expect `styleDescriptions.test.ts` and
+# `styleDescriptionLocale.test.ts` to need their pinned Temne strings updated.
+#
 # A comment cannot go inside the message beside the attribute it describes: an
 # indented comment line is part of the pattern and renders as a newline, which
 # `lint:i18n` rejects.

--- a/packages/i18n/locales/tem/content.ftl
+++ b/packages/i18n/locales/tem/content.ftl
@@ -26,12 +26,16 @@
 # class that attribute's own written prefix carries, and a reviewer who finds
 # one that does not has found a bug without needing to know Temne.
 #
+# The eight colour words that are English loans are the exception, and they are
+# written bare rather than prefixed; see the comment above `color`.
+#
 # The four entries that name a phrase head rather than a noun are outside that
 # check, since `noun` does not spell them: `border` and `background` can still
 # be read against the words this file writes for them — «ʌŋbʌŋ» in
-# `style-border-clause` and «ʌŋkəbaka» in `style-text`, both `ʌŋ-` and both
-# `c4` — but `text` and `fill` head phrases this catalog writes no word for, so
-# their classes have to be taken on trust the way every other catalog's are.
+# `style-border-clause`, `ʌŋ-` and so `c4`, and «kʌbaka» in `style-text`, `kʌ-`
+# and so `c1` — but `text` and `fill` head phrases this catalog writes no word
+# for, so their classes have to be taken on trust the way every other
+# catalog's are.
 #
 # It is the third Atlantic catalog here and answers differently from both the
 # others: `locales/ff` spells its class as a suffix and `locales/wo` on a
@@ -41,12 +45,24 @@
 # `$role` goes unused: Temne marks no case.
 #
 # The geometry leans on the English loans Sierra Leonean schooling supplies —
-# the same ministry `locales/kri` records — with Temne words where they are
-# solid: «ro-» a place, «ʌŋ-mark» a mark. They are the first thing to check.
+# the same ministry `locales/kri` draws its own English from — with Temne words
+# where they are solid: «rʌ-ro» a place, «rʌ-mark» a mark. They are the first
+# thing to check.
 
 
 ## Style vocabulary
 
+# The last eight attributes are English loans. A loan is written bare and takes
+# no concord prefix, so the alliteration the header describes runs through the
+# four Temne stems and stops at the seam — which is the same shape
+# `locales/kbp` gives its French loans, and it is the first thing a speaker
+# should either confirm or undo. Every word this catalog does inflect —
+# `line-width`, `style-filled-word`, and these four colours — supplies all four
+# classes.
+#
+# A comment cannot go inside the message beside the attribute it describes: an
+# indented comment line is part of the pattern and renders as a newline, which
+# `lint:i18n` rejects.
 color =
     .black =
         { $gender ->
@@ -143,17 +159,17 @@ noun =
 noun-regular-polygon =
     { $part ->
         [tail] tʌ na tʌbʌŋ { $numSides }
-       *[head] tʌpɔligɔn tʌ kɔmɔ
+       *[head] tʌpɔligɔn tʌ nɔŋ
     }
 
 # The noun class. Read it against `noun` above: each entry that names one of
 # `noun`'s attributes takes the class that attribute's own written prefix
 # carries, and `regular-polygon` takes `c2` because `noun-regular-polygon`'s
-# head is «tʌpɔligɔn». The last four name phrase heads instead — see the
-# header for which of them `noun` can be read against and which cannot.
-# `c1` is the default and the
-# class an English loan joins, which is what an author's own `markerStyleWord`
-# is as far as this catalog is concerned.
+# head is «tʌpɔligɔn». The last four name phrase heads instead, and the header
+# says which of those this file writes a word for and which have to be taken on
+# trust. `c1` is the default, and it is the class an English loan joins — which
+# is what an author's own `markerStyleWord` is as far as this catalog is
+# concerned.
 noun-gender =
     { $noun ->
         [polyline] c2
@@ -170,7 +186,6 @@ noun-gender =
         [plus] c3
         [text] c3
         [fill] c4
-        [background] c4
         [border] c4
        *[other] c1
     }
@@ -242,7 +257,7 @@ style-unfilled = kʌwuni bɔm
 
 style-text =
     { $parts ->
-        [background] { $color } na ʌŋkəbaka { $background }
+        [background] { $color } na kʌbaka { $background }
        *[plain] { $color }
     }
 

--- a/packages/i18n/locales/tem/content.ftl
+++ b/packages/i18n/locales/tem/content.ftl
@@ -29,13 +29,14 @@
 # The eight colour words that are English loans are the exception, and they are
 # written bare rather than prefixed; see the comment above `color`.
 #
-# The four entries that name a phrase head rather than a noun are outside that
-# check, since `noun` does not spell them: `border` and `background` can still
-# be read against the words this file writes for them — «ʌŋbʌŋ» in
-# `style-border-clause`, `ʌŋ-` and so `c4`, and «kʌbaka» in `style-text`, `kʌ-`
-# and so `c1` — but `text` and `fill` head phrases this catalog writes no word
-# for, so their classes have to be taken on trust the way every other
-# catalog's are.
+# The classes that belong to a phrase head rather than to a noun are outside
+# that check, since `noun` does not spell them. Two of them can still be read
+# against the words this file writes for the heads themselves: «ʌŋbʌŋ» in
+# `style-border-clause` is `ʌŋ-`, and `border` answers `c4`; «kʌbaka» in
+# `style-text` is `kʌ-`, and `background` is left to the `*[other] c1` default,
+# which is that same class. But `text` and `fill` head phrases this catalog
+# writes no word for, so their two rows have to be taken on trust the way every
+# other catalog's are.
 #
 # It is the third Atlantic catalog here and answers differently from both the
 # others: `locales/ff` spells its class as a suffix and `locales/wo` on a
@@ -165,11 +166,12 @@ noun-regular-polygon =
 # The noun class. Read it against `noun` above: each entry that names one of
 # `noun`'s attributes takes the class that attribute's own written prefix
 # carries, and `regular-polygon` takes `c2` because `noun-regular-polygon`'s
-# head is «tʌpɔligɔn». The last four name phrase heads instead, and the header
+# head is «tʌpɔligɔn». The last three name phrase heads instead, and the header
 # says which of those this file writes a word for and which have to be taken on
-# trust. `c1` is the default, and it is the class an English loan joins — which
-# is what an author's own `markerStyleWord` is as far as this catalog is
-# concerned.
+# trust. `c1` is the default. It is the class an English loan joins — which is
+# what an author's own `markerStyleWord` is as far as this catalog is concerned
+# — and it is also `background`'s class, which is why that head has no row of
+# its own: «kʌbaka» in `style-text` already carries `kʌ-`.
 noun-gender =
     { $noun ->
         [polyline] c2

--- a/packages/i18n/locales/tem/diagnostics.ftl
+++ b/packages/i18n/locales/tem/diagnostics.ftl
@@ -492,8 +492,8 @@ attribute-value-invalid-using-default = Ʌŋbʌŋ `{ $value }` kʌ bana bɔm ka 
 
 doenetml-version-not-found =
     { $fallback ->
-        [none] Ma bata DoenetML kʌmʌŋ { $version } bɔm.
-       *[other] Ma bata DoenetML kʌmʌŋ { $version } bɔm. Ma bay kʌmʌŋ { $fallback }
+        [none] Ma bata DoenetML version { $version } bɔm.
+       *[other] Ma bata DoenetML version { $version } bɔm. Ma bay version { $fallback }
     }
 
 ## Reading the DoenetML

--- a/packages/i18n/locales/tem/diagnostics.ftl
+++ b/packages/i18n/locales/tem/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Temne diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] ma bɔth { $attributes } ma tʌtəp tʌrʌŋ ma sɔŋɔ
+       *[other] ma bɔth { $attributes } ma tʌtəp tʌrʌŋ ma sɔŋɔ
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] ma bɔth { $attributes } ma kʌtəp na kʌkəri ma sɔŋɔ tʌpəŋ
+       *[other] ma bɔth { $attributes } ma kʌtəp na kʌkəri ma sɔŋɔ tʌpəŋ
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset kʌ paŋth bɔm ma kʌkəri kʌ na bɔm
+
+## `<line>`
+
+line-points-undetermined-dimensions = Kʌlayn kʌ kəri tʌtoni tʌ ma bata tʌbana tʌ bɔm.
+
+line-points-too-few-dimensions = Kʌlayn kʌ fɔ kəri tʌtoni tʌ na tʌbana tʌrʌŋ ɔ tʌbana.
+
+line-points-depend-on-variables = Kʌlayn kʌ kəri tʌtoni tʌ nəŋ tʌfiri: { $variables }.
+
+line-equation-invalid-format = Ʌŋbay ka ikweshɔn ka kʌlayn kʌ bana bɔm ka { $variable1 } na { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Kʌre kʌ sɔŋɔ na through, endpoint na direction.  Ma bɔth through kʌ ma sɔŋɔ.
+
+ray-dimension-mismatch = numDimensions kʌ nɔŋ bɔm ka kʌre.
+
+## `<vector>`
+
+vector-overprescribed-head = Kʌvɛkta kʌ sɔŋɔ na head, tail na displacement.  Ma bɔth head kʌ ma sɔŋɔ.
+
+vector-dimension-mismatch = numDimensions kʌ nɔŋ bɔm ka kʌvɛkta.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ma tɔŋ `<{ $component }>` bɔm bɛkɔs kʌ na nearestPoint bɔm.
+
+constrain-to-without-nearest-point = Ma kanti `<{ $component }>` bɔm bɛkɔs kʌ na nearestPoint bɔm.
+
+constrain-to-interior-without-nearest-point = Ma kanti ka rɔ `<{ $component }>` bɔm bɛkɔs kʌ na nearestPoint bɔm.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ma bɔth labelPosition ka choiceInput kʌ bana inline bɔm
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ma bɔth indices tʌ ma sɔŋɔ ka choiceInput bɛkɔs ʌŋnamba ka indices kʌ nɔŋ bɔm na ʌŋnamba ka tʌwan tʌ choice.
+
+pretzel-indices-count-mismatch = Ma bɔth indices tʌ ma sɔŋɔ ka problem bɛkɔs ʌŋnamba ka indices kʌ nɔŋ bɔm na ʌŋnamba ka tʌwan tʌ problem.
+
+shuffle-indices-count-mismatch = Ma bɔth indices tʌ ma sɔŋɔ ka shuffle bɛkɔs ʌŋnamba ka indices kʌ nɔŋ bɔm na ʌŋnamba ka tʌbʌŋ.
+
+indices-ignored-out-of-range = Ma bɔth indices tʌ ma sɔŋɔ ka { $component } bɛkɔs tʌbʌŋ tʌ na ka kʌrɛnj kʌbʌŋ.
+
+pretzel-indices-repeated = Ma bɔth indices tʌ ma sɔŋɔ ka pretzel bɛkɔs tʌbʌŋ tʌ ripit.
+
+pretzel-circuit-first-index = Ma bɔth indices tʌ ma sɔŋɔ ka pretzel ka mode="circuit" bɛkɔs index kʌ təŋ kʌ fɔ bana 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Kʌ `<{ $component }>` kʌ paŋth na tʌwan tʌ string, `type` attribute kʌ fɔ sɔŋɔ.
+
+invalid-type-defaulting-to-math = Type { $type } kʌ bana bɔm ka { $component }. Kʌ fɔ bana math, text, number ɔ boolean. Ma bay math.
+
+string-not-valid-component-to-arrange = String "{ $value }" kʌ bana kʌbʌŋ kʌbana bɔm ka { $component }. Ma bɔth kʌ.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } kʌ bana bɔm, ma bay type number.
+
+invalid-variable-value = Ʌŋbʌŋ ka kʌfiri kʌ bana bɔm: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Kʌmʌŋ index { $index } kʌ fɔ bana ʌŋnamba
+
+variant-index-must-be-integer = Kʌmʌŋ index { $index } kʌ fɔ bana ʌŋnamba kʌpəŋ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` kʌ bay bɔm ka tʌjɔth tʌpəŋ. Ma bay tʌbana kʌ tʌnəŋ.
+
+side-by-side-absolute-margins = `<{ $component }>` kʌ bay bɔm ka tʌjɔth tʌpəŋ. Ma bay tʌbʌŋ kʌ tʌnəŋ.
+
+side-by-side-no-block-child = `<{ $component }>` kʌ bana bɔm: kʌ fɔ na kʌwan kʌ block kʌrɔŋ ɔ kʌbana.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ma bɔth `for` attribute ka `<label>` ka kʌmisal.
+
+label-for-must-resolve-to-one = `for` attribute ka `<label>` kʌ fɔ nəŋ kʌbʌŋ kʌrɔŋ dɔm.
+
+label-for-unresolved = `for` attribute ka `<label>` kʌ nəŋ kʌbʌŋ bɔm.
+
+label-for-answer-with-authored-inputs = `for` attribute ka `<label>` kʌ nəŋ `<answer>` kʌ na input tʌ ma sɔŋɔ; nəŋ input kʌ kʌpəŋ.
+
+label-for-answer-without-input = `for` attribute ka `<label>` kʌ nəŋ `<answer>` kʌ na input bɔm.
+
+label-for-must-reference-input-or-answer = `for` attribute ka `<label>` kʌ fɔ nəŋ input ɔ answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ka kʌsɔth, `<{ $component }>` kʌ fɔ na ʌŋkəbath ka kʌbath ɔ kʌ fɔ sɔŋɔ kʌ decorative.
+
+accessibility-video-short-description = Ka kʌsɔth, `<video>` kʌ fɔ na ʌŋkəbath ka kʌbath.
+
+accessibility-input-short-description-or-label = Ka kʌsɔth, `<{ $component }>` kʌ fɔ na ʌŋkəbath ka kʌbath ɔ ʌŋes.
+
+accessibility-answer-input-short-description-or-label = Ka kʌsɔth, `<answer>` kʌ bay input kʌ fɔ na ʌŋkəbath ka kʌbath ɔ ʌŋes.
+
+accessibility-short-description-contains-math = Ʌŋkəbath ka kʌbath kʌ fɔ na tʌbʌŋ tʌ mat kʌ `<{ $component }>` bɔm. Sɔŋ mat na tʌkəre.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } kʌ na kʌfiri kʌbana bɔm ka ʌŋkəre ka kʌtɔŋ ka kʌpath (mode kʌ fith) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʌ fen { $threshold }:1 ɔ kʌbana).
+       *[other] { $colorName } kʌ na kʌfiri kʌbana bɔm ka ʌŋkəre ka kʌtɔŋ ka kʌpath ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʌ fen { $threshold }:1 ɔ kʌbana).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` kʌ kəri tʌtoni { $count } kʌ bay bɔm ma tʌtoni tʌ na tʌnamba bɔm.
+
+circle-too-many-through-points = Ma jɔth tʌkərəŋ kʌ kəri tʌtoni tʌ pas 3 bɔm.
+
+circle-overprescribed-radius-center-points = Ma jɔth tʌkərəŋ na radius, kʌkəri na tʌtoni tʌpəŋ bɔm.
+
+circle-center-with-multiple-points = Ma jɔth tʌkərəŋ na kʌkəri kʌ kəri kʌtoni kʌ pas 1 bɔm.
+
+circle-radius-too-small = Ma jɔth tʌkərəŋ bɔm: ʌŋtɔŋ ka tʌtoni tʌrʌŋ kʌ bana { $distance }, radius { $radius } kʌ ma sɔŋɔ kʌ kəni tʌbana.
+
+circle-radius-with-many-points = Ma bay tʌkərəŋ kʌ kəri tʌtoni tʌ pas tʌrʌŋ na radius kʌ ma sɔŋɔ bɔm.
+
+circle-invalid-center-or-through-points = Kʌkəri ɔ tʌtoni tʌ tʌkərəŋ tʌ bana bɔm.
+
+circle-radius-center-with-multiple-points = Ma jɔth radius ka tʌkərəŋ na kʌkəri kʌ kəri kʌtoni kʌ pas 1 bɔm.
+
+circle-change-radius-non-numerical = Ma firi radius ka tʌkərəŋ na tʌtoni tʌ na tʌnamba bɔm
+
+circle-radius-with-points-non-numerical = Ma bay tʌkərəŋ kʌ kəri kʌtoni kʌ pas kʌrɔŋ na radius ma tʌnamba tʌ na bɔm.
+
+circle-change-center-non-numerical = Kʌfiri kʌkəri ka tʌkərəŋ kʌ kəri tʌtoni tʌ na tʌnamba bɔm kʌ bay bɔm.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Tʌbana tʌ fen bɔm ka domain ka kʌfɔnkshɔn. Domain kʌ na intaval { $intervals } kɛrɛ kʌfɔnkshɔn kʌ na { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+       *[other] Tʌbana tʌ fen bɔm ka domain ka kʌfɔnkshɔn. Domain kʌ na intaval { $intervals } kɛrɛ kʌfɔnkshɔn kʌ na { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Ʌŋbay ka domain ka kʌfɔnkshɔn kʌ bana bɔm.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ma bɔth kʌbana kʌ kʌfɔnkshɔn kʌ na ʌŋnamba bɔm.
+        [minimum] Ma bɔth kʌkəni kʌ kʌfɔnkshɔn kʌ na ʌŋnamba bɔm.
+        [extremum] Ma bɔth kʌtəp kʌ kʌfɔnkshɔn kʌ na ʌŋnamba bɔm.
+        [point] Ma bɔth kʌtoni kʌ kʌfɔnkshɔn kʌ na ʌŋnamba bɔm.
+        [slope] Ma bɔth kʌkəri kʌ kʌfɔnkshɔn kʌ na ʌŋnamba bɔm.
+       *[other] Ma bɔth { $type } kʌ kʌfɔnkshɔn kʌ na ʌŋnamba bɔm.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ma bɔth kʌbana kʌ kʌfɔnkshɔn kʌ na kəm bɔm.
+        [minimum] Ma bɔth kʌkəni kʌ kʌfɔnkshɔn kʌ na kəm bɔm.
+        [extremum] Ma bɔth kʌtəp kʌ kʌfɔnkshɔn kʌ na kəm bɔm.
+        [point] Ma bɔth kʌtoni kʌ kʌfɔnkshɔn kʌ na kəm bɔm.
+       *[other] Ma bɔth { $type } kʌ kʌfɔnkshɔn kʌ na kəm bɔm.
+    }
+
+function-points-too-close = Kʌfɔnkshɔn kʌ na tʌtoni tʌrʌŋ tʌ nɔŋ tʌbana. Ma bath kʌfɔnkshɔn bɔm.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Tʌripit tʌ kʌfɔnkshɔn tʌ paŋth dɔm ma ʌŋnamba ka input kʌ nɔŋ na ʌŋnamba ka output. Kʌfɔnkshɔn kʌnɛ kʌ na input { $inputs } na { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+       *[other] Tʌripit tʌ kʌfɔnkshɔn tʌ paŋth dɔm ma ʌŋnamba ka input kʌ nɔŋ na ʌŋnamba ka output. Kʌfɔnkshɔn kʌnɛ kʌ na input { $inputs } na { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Ʌŋtɔŋ ka sequence kʌ bana bɔm.  Kʌ fɔ bana ʌŋnamba kʌpəŋ kʌ təp ziro bɔm.
+
+sequence-invalid-step = Step ka sequence kʌ bana bɔm.  Kʌ fɔ bana ʌŋnamba ka sequence ka type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" ka number sequence kʌ bana bɔm.  Kʌ fɔ bana ʌŋnamba.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" ka letters sequence kʌ bana bɔm.  Kʌ fɔ bana tʌmark tʌ thɔfi.
+
+sequence-invalid-endpoint = "{ $attribute }" ka sequence kʌ bana bɔm.
+
+select-from-sequence-coprime-not-numbers = ma bɔth coprime bɛkɔs ma fen tʌnamba bɔm
+
+select-from-sequence-coprime-with-exclude-combinations = ma bɔth coprime bɛkɔs excludeCombinations kʌ sɔŋɔ
+
+## Resolving a `target`
+
+target-not-found = Target ka `<{ $source }>` kʌ bana bɔm: ma bata target bɔm.
+
+target-state-variable-not-found = Target ka `<{ $source }>` kʌ bana bɔm: ma bata kʌfiri kʌ na ʌŋes "{ $property }" ka `<{ $component }>` bɔm.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Tʌfiri tʌ `<odeSystem>` tʌ fɔ bana tʌbʌŋ ka kʌfiri kʌ na kʌtɔfɔ.
+
+ode-system-duplicate-variable-names = Ma bath tʌfɔnkshɔn tʌ ODE RHS na ʌŋes ka tʌfiri tʌ ripit bɔm.
+
+ode-system-rhs-function-error = Ma bath kʌfɔnkshɔn ka ODE RHS bɔm.  Kʌwuni ka kʌbay ka kʌfɔnkshɔn ka mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ma bath kʌangul ka tʌlayn { $count } bɔm
+
+angle-invalid-through-point = Kʌtoni kʌ bana bɔm ka through ka `<angle>`
+
+parabola-vertex-too-many-points = Kʌparabola na vertex kʌ kəri kʌtoni kʌ pas 1 kʌ bay bɔm.
+
+parabola-too-many-points = Kʌparabola kʌ kəri tʌtoni tʌ pas 3 kʌ bay bɔm.
+
+intersection-too-many-items = Kʌthɔfi ka tʌbʌŋ tʌ pas tʌrʌŋ kʌ bay bɔm
+
+## Other math components
+
+ionic-compound-not-two-ions = Kʌthɔfi ka ayɔn ka kʌbʌŋ kʌ bana tʌayɔn tʌrʌŋ bɔm kʌ bay bɔm.
+
+ionic-compound-needs-cation-and-anion = Kʌthɔfi ka ayɔn kʌ bay ka katayɔn kʌrɔŋ na anayɔn kʌrɔŋ dɔm.
+
+solve-equations-cannot-evaluate = Ma sɔlv ikweshɔn bɔm bɛkɔs ma jɔth kʌ bɔm: { $equation }
+
+math-operators-operand-number-required = operandNumber kʌ fɔ sɔŋɔ ma ma bɔth operand ka mat.
+
+eigen-decomposition-failed = Ma jɔth tʌaygɛnvalyu tʌ matriks bɔm
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } kʌ na ka kʌpatan bɔm, kʌ nɔŋ kəm bɔm dɔm.
+       *[other] `<matchesPattern>`: parameter { $parameters } tʌ na ka kʌpatan bɔm, tʌ nɔŋ kəm bɔm dɔm.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ma bath grid="{ $grid }" bɔm. Kʌ fɔ bana none, medium, dense, ɔ tʌnamba tʌrʌŋ tʌbana tʌ na kʌro kʌ kanti tʌ, kʌ grid="1 0.5". Ma bay grid bɔm.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" kʌ paŋth bɔm ka kʌyiraŋ ka prefigure; ma bay kʌ kʌbʌŋ ka kʌgbɔn.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" kʌ paŋth bɔm ka kʌyiraŋ ka prefigure; ma bay kʌ kʌbʌŋ ka kʌtɔŋ.
+
+prefigure-invalid-axis-bounds = `<graph>`: tʌbʌŋ tʌ aksis tʌ bana bɔm ka prefigure; ma bay bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: ʌŋbana kʌ bana bɔm ka prefigure; ma bay ʌŋbana 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio kʌ bana bɔm ka prefigure; ma bay aspɛkt reshio 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: kʌro ka grid kʌ kəni tʌbana ka tʌbʌŋ tʌ aksis; ma bɔth grid ka kʌyiraŋ ka prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotations tʌ yira bɔm ma kʌyiraŋ ka PreFigure kʌ bay bɔm.
+
+multiple-annotations-children = Ma bata tʌwan tʌ `<annotations>` tʌbana ka `<graph>`; ma bɔth tʌpəŋ nɛ kʌ tʌtəp.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ma fɔth ɔ ma kɔpi kʌmʌŋ ka kʌbʌŋ kʌ ma bata bɔm: { $type }.
+
+copy-prop-not-found = Ma bata prop { $property } ka kʌbʌŋ ka kʌmʌŋ { $component } bɔm
+
+collect-no-source = Ma bata kʌtəŋ ka collect bɔm.
+
+collect-invalid-component-type = Ma thɔfi tʌbʌŋ tʌ kʌmʌŋ `<{ $component }>` bɔm bɛkɔs kʌmʌŋ kʌ bana bɔm.
+
+reference-index-unavailable = Ma nəŋ index `{ $reference }` bɔm
+
+## `<callAction>`
+
+component-action-unavailable = Ma yira { $action } ka kʌbʌŋ `{ $reference }` bɔm
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Ʌŋbay ka data kʌ bana bɔm.  Tʌro tʌ na tʌtɔŋ tʌbʌŋ. Ma bata ka componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data kʌ na ʌŋes ka tʌkɔlum tʌ ripit.  Ma bata ka componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = ʌŋes ka kʌkɔlum kʌ na bɔm ka data.  Ma bata ka componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award ka ʌŋlipi kʌnɛ kʌ nəŋ ʌŋlipi ka answer tag kʌpəŋ, na kʌ ba na tʌbʌŋ tʌ mʌ mɔŋ bɔm.
+
+answer-max-num-attempts-in-section-wide-check-work = Ma mʌ bay `maxNumAttempts` ka `<answer>` kʌ na ka rɔ kʌbʌŋ kʌ na `sectionWideCheckWork`, kʌ paŋth bɔm, bɛkɔs kʌbʌŋ kʌ tɔŋ ʌŋnamba ka tʌtʌmpa. Bay `maxNumAttempts` ka kʌbʌŋ.
+
+nested-section-wide-check-work-max-num-attempts = Ma mʌ bay `maxNumAttempts` ka kʌbʌŋ kʌ na `sectionWideCheckWork` na kʌ na ka rɔ kʌbʌŋ kʌbʌŋ kʌ na `sectionWideCheckWork`, kʌ paŋth bɔm, bɛkɔs kʌbʌŋ ka kʌgbɔn kʌ tɔŋ ʌŋnamba ka tʌtʌmpa. Bay `maxNumAttempts` ka kʌbʌŋ ka kʌgbɔn.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] { $attributes } attribute kʌ paŋth bɔm ma symbolicEquality kʌ bay bɔm.
+       *[other] { $attributes } attribute tʌ paŋth bɔm ma symbolicEquality kʌ bay bɔm.
+    }
+
+answer-invalid-type = Type ka ʌŋlipi kʌ bana bɔm: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Ma kʌbʌŋ `<{ $component }>` kʌ na ʌŋes bɔm, ma bay kʌ kʌ attribute ka module bɔm
+
+module-attribute-name-already-defined = Ma bay kʌbʌŋ `<{ $component } name="{ $name }">` kʌ attribute ka module bɔm bɛkɔs `<module>` kʌ na "{ $name }" attribute nɛ.
+
+conditional-content-condition-ignored = Ma bɔth `condition` attribute ka `<conditionalContent>` kʌ na tʌwan tʌ case ɔ else.
+
+slider-markers-type-mismatch = Type ka markers kʌ nɔŋ bɔm na type ka slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel kʌ bana bɔm: kʌ `<problem>` kʌrɔŋ kʌrɔŋ kʌ fɔ na `<statement>` kʌrɔŋ na `<answer>` kʌrɔŋ.
+
+pretzel-circuit-first-problem-distractor = Pretzel kʌ bana bɔm: ka mode="circuit", `<problem>` kʌ təŋ kʌ bana distractor bɔm.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Ʌŋbʌŋ { $values } kʌ bana bɔm ka attribute `{ $attribute }`; ma bɔth kʌ.
+       *[other] Tʌbʌŋ { $values } tʌ bana bɔm ka attribute `{ $attribute }`; ma bɔth tʌ.
+    }
+
+attribute-must-be-references = Ʌŋbʌŋ `{ $value }` kʌ bana bɔm ka attribute `{ $attribute }`. Attribute kʌ fɔ bana tʌnəŋ tʌ təŋ na `$`.
+
+math-input-invalid-function-names = <mathInput>: ma bɔth ʌŋes ka tʌfɔnkshɔn tʌ bana bɔm ka { $attribute }: { $names }. Kʌpath ka kʌyiraŋ ka ʌŋes kʌrɔŋ kʌrɔŋ kʌ fɔ na tʌmark tʌrʌŋ ɔ tʌbana (tʌmark ɔ tʌdash); `|<mathspeak alternative>` kʌ tʌŋ.
+
+## Building components from the source
+
+component-type-invalid = Kʌmʌŋ ka kʌbʌŋ kʌ bana bɔm: `<{ $componentType }>`
+
+attribute-repeated = Ma ripit attribute { $attribute } bɔm.
+
+attribute-invalid-for-component = Attribute "{ $attribute }" kʌ bana bɔm ka kʌbʌŋ ka kʌmʌŋ `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Ʌŋkəbath ka kʌmʌŋ { $styleNumber } kʌ na kʌfiri kʌbana bɔm ka { $context ->
+        [text-on-background] ʌŋkəbaka ka ʌŋkəre ka ʌŋkəbaka ka kʌbaka
+        [high-contrast] ʌŋkəbaka ka kʌfiri kʌbana ka kanvas
+        [line] ʌŋkəbaka ka kʌlayn ka kanvas
+        [marker] ʌŋkəbaka ka kʌmark ka kanvas
+       *[text-on-canvas] ʌŋkəbaka ka ʌŋkəre ka kanvas
+    }{ $mode ->
+        [dark] { " (mode kʌ fith)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʌ fen { $threshold }:1 ɔ kʌbana).
+
+style-definition-dark-mode-text-background-contrast =
+    Ma ʌŋkəbath ka kʌmʌŋ { $styleNumber } kʌ na tʌkəbaka tʌ na kʌfiri kʌbana ka mode kʌ fera, tʌkəbaka tʌ mode kʌ fith tʌ ma bɔth ka tʌ tʌ na kʌfiri kʌbana bɔm ka ʌŋkəbaka ka ʌŋkəre na ʌŋkəbaka ka kʌbaka ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʌ fen { $threshold }:1 ɔ kʌbana). { $suggestion ->
+        [available] Kʌ mʌ bata kʌfiri kʌbana ka mode kʌ fith, bana kʌfiri ka mode kʌ fera (kʌ kʌmisal, bay { $lightAttribute }="{ $lightColor }") ɔ firi ʌŋkəbaka ka mode kʌ fith (kʌ kʌmisal, bay { $darkAttribute }="{ $darkColor }").
+       *[none] Kʌ mʌ bata kʌfiri kʌbana ka mode kʌ fith, bana kʌfiri ka mode kʌ fera ɔ firi tʌkəbaka na textColorDarkMode ɔ backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Ma ʌŋkəbath ka kʌmʌŋ { $styleNumber } kʌ na ʌŋkəbaka ka ʌŋkəre kʌ na kʌfiri kʌbana ka mode kʌ fera, ʌŋkəbaka ka ʌŋkəre ka mode kʌ fith kʌ ma bɔth ka kʌ kʌ na kʌfiri kʌbana bɔm ka kanvas ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kʌ fen { $threshold }:1 ɔ kʌbana). { $suggestion ->
+        [available] Kʌ mʌ bata kʌfiri kʌbana ka mode kʌ fith, bana kʌfiri ka mode kʌ fera (kʌ kʌmisal, bay textColor="{ $lightColor }") ɔ firi ʌŋkəbaka ka mode kʌ fith (kʌ kʌmisal, bay textColorDarkMode="{ $darkColor }").
+       *[none] Kʌ mʌ bata kʌfiri kʌbana ka mode kʌ fith, bana kʌfiri ka mode kʌ fera ɔ firi ʌŋkəbaka na textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Kʌpath kʌ fen <stylePalette> kʌrɔŋ dɔm; ma bay kʌ kʌtəp.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } bɔm bɛkɔs numToSelect kʌ bana ʌŋnamba kʌpəŋ kʌ təp ziro bɔm bɔm.
+
+variant-num-to-select-not-constant-number = ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } bɔm bɛkɔs numToSelect kʌ bana ʌŋnamba kʌ firi bɔm bɔm.
+
+variant-with-replacement-not-constant-boolean = ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } bɔm bɛkɔs withReplacement kʌ bana boolean kʌ firi bɔm bɔm.
+
+variant-select-weight-disables-unique = Tʌmʌŋ tʌbʌŋ tʌ select tʌ kanti ma option kʌbʌŋ kʌ na selectWeight ɔ selectForVariants
+
+variant-coprime-undetermined = ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } bɔm bɛkɔs ma bata kʌ coprime kʌ bana ʌŋgbɔl dɔm bɔm.
+
+variant-attribute-not-constant = ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } bɔm bɛkɔs { $attribute } kʌ firi.
+
+variant-attribute-not-number = ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } bɔm bɛkɔs { $attribute } kʌ bana ʌŋnamba bɔm.
+
+variant-attribute-wrong-type-for-sequence =
+    ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } ka type { $type } bɔm bɛkɔs { $attribute } kʌ bana { $expected ->
+        [letters-combination] tʌmark tʌ thɔfi
+        [math-expression] ʌŋkəre ka mat kʌ bana
+        [integer] ʌŋnamba kʌpəŋ
+       *[number] ʌŋnamba
+    } bɔm.
+
+variant-length-not-integer = ma bata tʌmʌŋ tʌbʌŋ tʌ { $component } bɔm bɛkɔs length kʌ bana ʌŋnamba kʌpəŋ bɔm.
+
+variant-sort-not-implemented = tʌmʌŋ tʌbʌŋ tʌ { $component } na sort tʌ bay bɔm
+
+variant-exclude-combinations-not-implemented = tʌmʌŋ tʌbʌŋ tʌ { $component } na excludeCombinations tʌ bay bɔm
+
+variant-math-exclude-not-implemented = tʌmʌŋ tʌbʌŋ tʌ { $component } ka type math na exclude tʌ bay bɔm
+
+variant-non-constant-exclude-not-implemented = tʌmʌŋ tʌbʌŋ tʌ { $component } na exclude kʌ firi tʌ bay bɔm
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: kʌ paŋth bɔm ka kʌyiraŋ ka graph prefigure; ma bɔth kʌwan.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiɔmɛtri kʌ bana bɔm ɔ kʌ pəŋ bɔm; ma bɔth kʌwan.
+
+prefigure-curve-label-omitted = { $subject }: ʌŋes kʌ paŋth bɔm ka tʌbʌŋ tʌ curve tʌ ma firi; ma bɔth ʌŋes.
+
+prefigure-curve-unsupported-definition-type = { $subject }: kʌmʌŋ ka ʌŋkəbath ka kʌfɔnkshɔn ka curve '{ $definitionType }' kʌ paŋth bɔm; ma bɔth kʌwan.
+
+prefigure-region-flip-functions-unsupported = { $subject }: flipFunctions attribute ka regionBetweenCurves kʌ paŋth bɔm; ma bɔth kʌwan.
+
+prefigure-region-non-formula-child = { $subject }: tʌfɔnkshɔn tʌwan tʌ formula dɔm tʌ paŋth ka regionBetweenCurves; ma bɔth kʌwan.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' kʌ paŋth bɔm ka { $labelKind ->
+        [line-family] ʌŋes ka kʌthɔfi ka tʌlayn
+       *[point] ʌŋes ka kʌtoni
+    }; ma bay kʌbʌŋ ka PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure kʌ bata kʌmʌŋ ka kʌwuni '{ $fillStyle }' bɔm; ma bay kʌwuni kʌpəŋ.
+
+prefigure-line-style-unknown = { $subject }: ma bata kʌmʌŋ ka kʌlayn '{ $lineStyle }' bɔm, ma bɔth kʌ ka PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: ma firi kʌmʌŋ ka kʌmark '{ $markerStyle }' kʌ kʌmʌŋ 'diamond' ka PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure kʌ bata kʌmʌŋ ka kʌmark '{ $markerStyle }' bɔm; ma bay kʌmʌŋ kʌ na pʌ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` kʌ bana bɔm; ma bata target bɔm. Ma bɔth annotation.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` kʌ nəŋ tʌtarget tʌbana; ma bay kʌ kʌtəŋ.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` kʌ bana bɔm; target kʌ na ka kʌgbɔn ka graph. Ma bɔth annotation.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` kʌ bana bɔm; target kʌ bana kʌbʌŋ ka kʌmisal kʌ prefigure kʌ bata bɔm. Ma bɔth annotation.
+
+annotation-text-missing = `<annotation>`: `text` kʌ na bɔm ɔ kʌ na kəm bɔm; ma sɔŋ ʌŋkəre ka kəm bɔm.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Ma bata kʌnəŋ ka tʌkərəŋ.
+       *[other] Ma bata kʌnəŋ ka tʌkərəŋ na kʌbʌŋ `<{ $componentType }>`.
+    }
+
+reference-no-referent = Ma bata kəm bɔm ka kʌnəŋ: `{ $reference }`
+
+reference-multiple-referents = Ma bata tʌbʌŋ tʌbana ka kʌnəŋ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Ʌŋbay ka attribute { $attribute } ka `<{ $componentType }>` kʌ bana bɔm.
+
+children-invalid = Tʌwan tʌ `<{ $componentType }>` tʌ bana bɔm: Ma bata tʌwan tʌ bana bɔm: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ʌŋbʌŋ `{ $value }` kʌ bana bɔm ka attribute `{ $attribute }`, ma bay `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ma bata DoenetML kʌmʌŋ { $version } bɔm.
+       *[other] Ma bata DoenetML kʌmʌŋ { $version } bɔm. Ma bay kʌmʌŋ { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML kʌ bana bɔm: { $content }
+
+parse-tag-missing-close-tag = DoenetML kʌ bana bɔm: Tag `{ $tag }` kʌ na tag ka kʌkanti bɔm. Ma mɔŋ tag kʌ kanti kʌpəŋ ɔ tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML kʌ bana bɔm: Kʌwuni ka tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML kʌ bana bɔm: Attribute `{ $attribute }` kʌ bana bɔm, kʌ yira kʌ na ʌŋbʌŋ bɔm.
+
+parse-attribute-invalid = DoenetML kʌ bana bɔm: Attribute `{ $attribute }` kʌ bana bɔm
+
+parse-attribute-value-invalid = DoenetML kʌ bana bɔm: Ʌŋbʌŋ ka attribute `{ $value }` kʌ bana bɔm
+
+parse-attribute-value-quote-mismatch = DoenetML kʌ bana bɔm: Ʌŋbʌŋ ka attribute `{ $value }` kʌ bana bɔm. Tʌmark tʌ kwot tʌ nɔŋ bɔm. Kʌ yira kʌ `{ $quote }` kʌ na bɔm
+
+parse-open-tag-name-missing = DoenetML kʌ bana bɔm: Ma bata tag kʌ na ʌŋes bɔm, kʌ `<`
+
+parse-tag-not-closed = DoenetML kʌ bana bɔm: Ma kanti tag `{ $tag }` bɔm (kʌ yira kʌ `>` kʌ na bɔm).
+
+parse-self-closing-tag-name-missing = DoenetML kʌ bana bɔm: Ma bata tag kʌ na ʌŋes bɔm `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML kʌ bana bɔm: Ma kanti tag `{ $tag }` bɔm (kʌ yira kʌ `/>` kʌ na bɔm).
+
+parse-tag-invalid-attributes = DoenetML kʌ bana bɔm: Tag `{ $tag }` kʌ bana bɔm. Kʌ na tʌattribute tʌ bana bɔm.
+
+parse-close-tag-name-missing = DoenetML kʌ bana bɔm: Ma bata tag ka kʌkanti kʌ na ʌŋes bɔm, kʌ `</`
+
+parse-attribute-value-unquoted = Tʌbʌŋ tʌ attribute tʌ fɔ na ka rɔ tʌkwot: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML kʌ bana bɔm: Ma bata tag ka kʌkanti `{ $tag }`, kɛrɛ tag ka kʌtuli kʌ na bɔm
+
+parse-close-tag-mismatched = DoenetML kʌ bana bɔm: Tag ka kʌkanti kʌ nɔŋ bɔm. Ma mɔŋ `</{ $expected }>`. Ma bata `{ $found }`
+
+parser-node-unconvertible = Ma firi node { $node } kʌ node ka Dast bɔm.
+
+## Names
+
+name-attribute-invalid =
+    Attribute name='{ $name }' kʌ bana bɔm. { $reason ->
+        [characters] Ʌŋes kʌ na tʌmark, tʌnamba, tʌandaskɔ ɔ tʌdash dɔm.
+       *[start] Ʌŋes kʌ fɔ təŋ na kʌmark.
+    }
+
+component-name-invalid-start = Ʌŋes ka kʌbʌŋ "{ $name }" kʌ bana bɔm. Ʌŋes kʌ fɔ təŋ na kʌmark.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer ka type videoWatched kʌ fɔ na video attribute
+
+answer-video-watched-video-not-reference = Answer ka type videoWatched kʌ fɔ na video attribute kʌ bana kʌnəŋ
+
+answer-name-not-single-text = Answer name attribute kʌ fɔ na kʌwan ka text kʌrɔŋ dɔm
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ma bata DoenetML ka kʌgbɔn bɔm bɛkɔs tʌripit tʌ bana tʌbana. Kʌnəŋ ka tʌkərəŋ kʌ na?
+
+external-doenetml-unavailable = Ma bata DoenetML ka { $attribute }="{ $uri }" bɔm
+
+external-doenetml-type-mismatch = DoenetML kʌ ma bata ka { $attribute }="{ $uri }" kʌ bana bɔm: kʌ nɔŋ bɔm na kʌmʌŋ ka kʌbʌŋ "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` kʌ kɔmɔ; bay `{ $to }`.
+       *[other] [deprecation] Attribute `{ $from }` ka `<{ $component }>` kʌ kɔmɔ; bay `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` kʌ kɔmɔ na ma bɔth kʌ bɛkɔs `{ $to }` kʌ na tʌpəŋ.
+       *[other] [deprecation] Attribute `{ $from }` ka `<{ $component }>` kʌ kɔmɔ na ma bɔth kʌ bɛkɔs `{ $to }` kʌ na tʌpəŋ.
+    }
+
+deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` ka `<{ $component }>` kʌ kɔmɔ na ma bɔth kʌ.
+
+deprecated-attribute-to-child = [deprecation] Attribute `{ $attribute }` ka `<{ $component }>` kʌ kɔmɔ; bay kʌwan `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Ʌŋbʌŋ `{ $value }` ka attribute `{ $attribute }` ka `<{ $component }>` kʌ kɔmɔ; bay `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` kʌ bay Inglish tʌbana dɔm, kʌ dəni ʌŋkəre kʌ mʌ sɔŋ kʌ ka kʌbuk kʌ ma sɔŋ ka { $locale }. Sɔŋ ʌŋbay ka tʌbana kʌpəŋ, ɔ bay kʌ na `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Kʌbʌŋ `<{ $tag }>` kʌ bana kʌbʌŋ ka Doenet kʌ ma bata bɔm.
+
+schema-element-not-allowed-at-root = Ma yifi kʌbʌŋ `<{ $tag }>` ka kʌtɔŋ ka kʌbuk bɔm.
+
+schema-element-not-allowed-inside = Ma yifi kʌbʌŋ `<{ $tag }>` ka rɔ `<{ $parent }>` bɔm.
+
+schema-attribute-unrecognized = Kʌbʌŋ `<{ $tag }>` kʌ na attribute kʌ na ʌŋes `{ $attribute }` bɔm.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Attribute `{ $attribute }` ka kʌbʌŋ `<{ $tag }>` kʌ fɔ bana kʌlist kʌ tʌbʌŋ tʌ rɔ tʌ bana kʌrɔŋ ka: { $allowed }
+       *[other] Attribute `{ $attribute }` ka kʌbʌŋ `<{ $tag }>` kʌ fɔ bana kʌrɔŋ ka: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Ʌŋes ka kʌmʌŋ ka select kʌ bana bɔm.  Ʌŋes ka kʌmʌŋ { $variantName } kʌ yira ka option { $numOptions } kɛrɛ ʌŋnamba ka kʌfen kʌ bana { $numToSelect }.
+
+select-variant-name-without-options = Tʌmʌŋ tʌbʌŋ tʌ sɔŋɔ ka select kɛrɛ option kʌ sɔŋɔ bɔm ka ʌŋes ka kʌmʌŋ: { $variantName }.
+
+select-variant-name-not-possible = Ʌŋes ka kʌmʌŋ { $variantName } kʌ ma sɔŋɔ ka select kʌ bana ʌŋes ka kʌmʌŋ kʌ paŋth bɔm.
+
+select-too-few-options = Ma fen tʌbʌŋ { $numToSelect } ka { $numOptions } dɔm bɔm.
+
+select-from-sequence-too-few-values = Ma fen tʌbʌŋ { $numToSelect } ka sequence ka ʌŋtɔŋ { $length } bɔm.
+
+select-from-sequence-indices-count-mismatch = Ʌŋnamba ka indices tʌ ma sɔŋɔ ka select kʌ fɔ nɔŋ na ʌŋnamba ka kʌfen
+
+select-from-sequence-indices-not-integers = Indices tʌpəŋ tʌ ma sɔŋɔ ka select tʌ fɔ bana tʌnamba tʌpəŋ
+
+select-from-sequence-index-excluded = Index ka selectfromsequence kʌ ma bɔth kʌ sɔŋɔ
+
+select-from-sequence-indices-excluded-combination = Indices tʌ selectfromsequence tʌ bana kʌthɔfi kʌ ma bɔth tʌ sɔŋɔ
+
+select-from-sequence-coprime-not-positive-integers = Ma fen tʌthɔfi tʌ coprime bɔm bɛkɔs ma fen tʌnamba tʌpəŋ tʌ pas ziro bɔm.
+
+select-from-sequence-coprime-common-factor = Ma fen tʌnamba tʌ coprime bɔm. Tʌbʌŋ tʌpəŋ tʌ na faktɔ kʌrɔŋ. (Tʌbʌŋ tʌ "from" ɔ "to" tʌ fɔ bana coprime na "step".)
+
+select-from-sequence-coprime-single-number = Ma fen tʌthɔfi tʌ coprime ka ʌŋnamba kʌrɔŋ kʌ bana 1 bɔm bɔm.
+
+select-from-sequence-excluded-too-many-combinations = Ma bɔth tʌthɔfi tʌ pas 70% ka selectFromSequence
+
+select-from-sequence-coprime-none-found = Ma fen tʌnamba tʌ coprime bɔm. Tʌbʌŋ tʌpəŋ tʌ na faktɔ kʌrɔŋ.
+
+select-from-sequence-too-few-unique-values = Ma fen tʌbʌŋ tʌbʌŋ { $numToSelect } ka sequence ka ʌŋtɔŋ { $numPossibleValues } bɔm
+
+select-prime-numbers-too-few-values = Ma fen tʌbʌŋ { $numToSelect } ka kʌlist ka tʌpraym ka ʌŋtɔŋ { $numValues } bɔm
+
+select-prime-numbers-values-count-mismatch = Ʌŋnamba ka tʌbʌŋ tʌ ma sɔŋɔ ka select kʌ fɔ nɔŋ na ʌŋnamba ka kʌfen
+
+select-prime-numbers-values-not-prime = Tʌbʌŋ tʌpəŋ tʌ ma sɔŋɔ ka select prime number tʌ fɔ na ka kʌlist ka tʌpraym
+
+select-prime-numbers-values-excluded-combination = Tʌbʌŋ tʌ ma sɔŋɔ ka selectPrimeNumbers tʌ bana kʌthɔfi kʌ ma bɔth
+
+select-prime-numbers-excluded-too-many-combinations = Ma bɔth tʌthɔfi tʌ pas 70% ka selectPrimeNumbers
+
+select-random-combination-fluke = Ka kʌbʌŋ kʌ paŋth bɔm, ma fen kʌthɔfi ka tʌbʌŋ tʌbʌŋ bɔm
+
+select-random-value-fluke = Ka kʌbʌŋ kʌ paŋth bɔm, ma fen ʌŋbʌŋ kʌbʌŋ bɔm

--- a/packages/i18n/locales/tem/editor.ftl
+++ b/packages/i18n/locales/tem/editor.ftl
@@ -1,0 +1,208 @@
+# Temne editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Firi bɛk
+       *[update] Firi
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Kʌyiraŋ
+       *[other] { $word } Kʌyiraŋ { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Kʌmʌŋ
+
+editor-variant-filter = Fen…
+
+editor-variant-next = Fen kʌmʌŋ kʌ tʌŋ
+
+editor-variant-previous = Fen kʌmʌŋ kʌ pʌ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Ma bata WCAG AA kʌwuni ka kʌsɔth. Tɔth ma kʌ { $action ->
+            [close] kanti
+           *[open] tuli
+        } kʌsɔŋ ka kʌsɔth.
+        [advisories] Tɔth ma kʌ { $action ->
+            [close] kanti
+           *[open] tuli
+        } kʌsɔŋ ka kʌsɔth. Ma bata WCAG AA kʌwuni bɔm, kɛrɛ tʌsandi tʌbʌŋ tʌ kʌsɔth tʌ na.
+       *[clean] Tɔth ma kʌ { $action ->
+            [close] kanti
+           *[open] tuli
+        } kʌsɔŋ ka kʌsɔth. Ma bata kʌwuni ka kʌsɔth bɔm.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Ma bata WCAG AA kʌwuni ka kʌsɔth. Ma bata { $count ->
+            [one] kʌwuni { $count } ka WCAG AA
+           *[other] tʌwuni { $count } tʌ WCAG AA
+        }. Tɔth ma kʌ { $action ->
+            [close] kanti
+           *[open] tuli
+        } kʌsɔŋ ka kʌsɔth.
+        [advisories] Ma bata WCAG AA kʌwuni bɔm. Ma bata { $count ->
+            [one] kʌsandi { $count } kʌbʌŋ ka kʌsɔth
+           *[other] tʌsandi { $count } tʌbʌŋ tʌ kʌsɔth
+        }. Tɔth ma kʌ { $action ->
+            [close] kanti
+           *[open] tuli
+        } kʌsɔŋ ka kʌsɔth.
+       *[clean] Ma bata WCAG AA kʌwuni bɔm. Tɔth ma kʌ { $action ->
+            [close] kanti
+           *[open] tuli
+        } kʌsɔŋ ka kʌsɔth.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML kʌmʌŋ { $version }
+
+editor-tab-help = Kʌsandi ka ro mʌ na
+editor-tab-help-short = Ro
+editor-tab-errors = Tʌwuni
+editor-tab-warnings = Tʌmɔŋ
+editor-tab-info = Ʌŋkəre
+editor-tab-accessibility = Kʌsɔth
+editor-tab-responses = Ʌŋlipi ma sɔŋɔ
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Tʌfen tʌ kʌsɔŋɛr
+editor-format-as-doenetml = Bay kʌ DoenetML
+editor-format-as-xml = Bay kʌ XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Kʌlayn #{ $line }
+
+editor-no-errors = Tʌwuni Tʌ Bɔm
+editor-no-warnings = Tʌmɔŋ Tʌ Bɔm
+editor-no-info = Ʌŋkəre Ka Bɔm
+
+editor-show-info-annotations = Yira ʌŋkəre ka kʌsɔŋɛr
+editor-show-accessibility-annotations = Yira tʌwuni tʌ kʌsɔth ka kʌsɔŋɛr
+
+editor-accessibility-learn-more = Kalan kʌ Doenet kʌ bay kʌsɔth
+
+editor-accessibility-violations-heading = Tʌwuni tʌ kʌsɔth ({ $standard })
+
+editor-accessibility-other-heading = Tʌwuni tʌbʌŋ tʌ kʌsɔth
+editor-none-found = Ma bata kəm bɔm
+
+
+## Submitted responses
+
+editor-no-responses = Ʌŋlipi ma sɔŋɔ bɔm nɛ
+editor-response-answer-id = Ʌŋes ka ʌŋlipi
+editor-response-response = Ʌŋlipi
+editor-response-credit = Kʌbay
+editor-response-submitted = Ma sɔŋɔ
+
+
+## The context-help panel
+
+help-placeholder = Bʌŋ kʌkəri ka ʌŋes ka tag, ka attribute, ɔ ka { $ref } kʌ mʌ bata ʌŋkəre.
+
+help-unsupported-ref-chain = Kʌsandi ka tʌkəre tʌ tʌpath tʌbana kʌ { $example } kʌ na bɔm nɛ.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ma bata kəm bɔm ka { $ref }.
+        [multiple] Ma bata tʌbʌŋ tʌbana ka { $ref }.
+       *[indeterminate] Ma bata ʌŋkəbath ka { $ref } bɔm.
+    }
+
+help-learn-about-references = Kalan tʌkəre tʌ tʌnəŋ →
+help-reference-page = Kʌpej ka ʌŋkəre →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Ka rɔ { $element }
+       *[top] Ka kʌtɔŋ ka kʌbuk
+    }{ $allowed ->
+        [none] { " — kəm kʌ ba ro bɔm." }
+        [text] { " — sɔŋ ʌŋkəre ro." }
+        [text-and-components] { " — sɔŋ ʌŋkəre ro, ɔ tʌmpa:" }
+       *[components] { " — tʌbʌŋ tʌ mʌ tʌmpa:" }
+    }
+
+help-suggestions-footer = Tɔth { $shortcut } kʌ mʌ yira tʌbʌŋ { $total } tʌ pəŋ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } kʌ nəŋ ka { $target }.
+       *[other] { $ref } kʌ nəŋ ka { $target } (kʌlayn { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } kʌ fɔth kʌ kʌ { $role }.
+       *[other] { $owner } kʌ fɔth kʌ ka kʌlayn { $line } kʌ { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } kʌ nəŋ ka { $property } ka { $element }.
+       *[other] { $ref } kʌ nəŋ ka { $property } ka { $element } (kʌlayn { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = kʌpath
+help-kind-array-entry = kʌpath ka array
+
+help-default = Kʌ na pʌ:
+help-active-default = Kʌ na pʌ na kʌ paŋth:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Tʌbʌŋ tʌ ma yifi (kʌmɔth ka kʌmɔth):
+       *[other] Tʌbʌŋ tʌ ma yifi:
+    }
+
+help-suggested-values = Tʌbʌŋ tʌ ma sandi:
+
+help-inserts = Kʌ fɔth:
+
+help-coordinates =
+    { $count ->
+        [one] Kʌro:
+       *[other] Tʌro:
+    }
+
+help-type = Kʌmʌŋ:
+
+help-resolved-style = Kʌmʌŋ kʌ ma bata (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Ʌŋes ka tʌfɔnkshɔn tʌ ma bata:
+help-reset-list = Firi bɛk kʌlist ka input kʌnɛ:
+help-added-on-input = Ma fɔth ka input kʌnɛ:
+help-removed-on-input = Ma bɔth ka input kʌnɛ:
+
+help-reset-overrides = { $reset } kʌ pas { $additional } na { $removed }.

--- a/packages/i18n/locales/tem/editor.ftl
+++ b/packages/i18n/locales/tem/editor.ftl
@@ -77,7 +77,7 @@ editor-accessibility-badge = WCAG
 
 ## The footer
 
-editor-version-title = DoenetML kʌmʌŋ { $version }
+editor-version-title = DoenetML version { $version }
 
 editor-tab-help = Kʌsandi ka ro mʌ na
 editor-tab-help-short = Ro
@@ -100,7 +100,7 @@ editor-diagnostic-line = Kʌlayn #{ $line }
 
 editor-no-errors = Tʌwuni Tʌ Bɔm
 editor-no-warnings = Tʌmɔŋ Tʌ Bɔm
-editor-no-info = Ʌŋkəre Ka Bɔm
+editor-no-info = Ʌŋkəre Kʌ Bɔm
 
 editor-show-info-annotations = Yira ʌŋkəre ka kʌsɔŋɛr
 editor-show-accessibility-annotations = Yira tʌwuni tʌ kʌsɔth ka kʌsɔŋɛr
@@ -182,7 +182,7 @@ help-style-number-annotation = { " " }(styleNumber { $styleNumber })
 
 help-allowed-values =
     { $perItem ->
-        [true] Tʌbʌŋ tʌ ma yifi (kʌmɔth ka kʌmɔth):
+        [true] Tʌbʌŋ tʌ ma yifi (kʌrɔŋ ka kʌmɔth):
        *[other] Tʌbʌŋ tʌ ma yifi:
     }
 

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -659,7 +659,10 @@ export const LOCALE_NAME_FALLBACKS: Record<
     dag: { englishName: "Dagbani", endonym: "Dagbanli" },
     ktu: { englishName: "Kituba", endonym: "Kikongo ya leta" },
     mnk: { englishName: "Mandinka", endonym: "Mandinkakaŋo" },
-    kbp: { englishName: "Kabiye", endonym: "Kabɩyɛ" },
+    // ISO 639-3's reference name, which is also what `locales/kbp`'s header
+    // and the README call it; the grave is part of the spelling rather than a
+    // French borrowing of it.
+    kbp: { englishName: "Kabiyè", endonym: "Kabɩyɛ" },
 };
 
 /**

--- a/packages/i18n/scripts/catalogUtils.ts
+++ b/packages/i18n/scripts/catalogUtils.ts
@@ -659,6 +659,7 @@ export const LOCALE_NAME_FALLBACKS: Record<
     dag: { englishName: "Dagbani", endonym: "Dagbanli" },
     ktu: { englishName: "Kituba", endonym: "Kikongo ya leta" },
     mnk: { englishName: "Mandinka", endonym: "Mandinkakaŋo" },
+    kbp: { englishName: "Kabiye", endonym: "Kabɩyɛ" },
 };
 
 /**

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -53,6 +53,7 @@ export type SupportedLocale =
     | "fil"
     | "fj"
     | "fo"
+    | "fon"
     | "fr"
     | "fy"
     | "ga"
@@ -80,6 +81,8 @@ export type SupportedLocale =
     | "jv"
     | "ka"
     | "kab"
+    | "kbp"
+    | "kg"
     | "ki"
     | "kk"
     | "km"
@@ -87,6 +90,7 @@ export type SupportedLocale =
     | "ko"
     | "kok"
     | "kr"
+    | "kri"
     | "ks"
     | "ktu"
     | "ky"
@@ -127,6 +131,7 @@ export type SupportedLocale =
     | "or"
     | "pa"
     | "pam"
+    | "pcm"
     | "pl"
     | "ps"
     | "pt"
@@ -160,6 +165,7 @@ export type SupportedLocale =
     | "sw"
     | "ta"
     | "te"
+    | "tem"
     | "tet"
     | "tg"
     | "th"
@@ -468,6 +474,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "føroyskt",
         label: "Faroese (føroyskt)",
     },
+    { locale: "fon", englishName: "Fon", endonym: "Fon", label: "Fon" },
     {
         locale: "fr",
         englishName: "French",
@@ -611,6 +618,13 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Kabyle (Taqbaylit)",
     },
     {
+        locale: "kbp",
+        englishName: "Kabiye",
+        endonym: "Kabɩyɛ",
+        label: "Kabiye (Kabɩyɛ)",
+    },
+    { locale: "kg", englishName: "Kongo", endonym: "Kongo", label: "Kongo" },
+    {
         locale: "ki",
         englishName: "Kikuyu",
         endonym: "Gikuyu",
@@ -647,6 +661,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Konkani (कोंकणी)",
     },
     { locale: "kr", englishName: "Kanuri", endonym: "Kanuri", label: "Kanuri" },
+    { locale: "kri", englishName: "Krio", endonym: "Krio", label: "Krio" },
     {
         locale: "ks",
         englishName: "Kashmiri",
@@ -863,6 +878,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Pampanga",
     },
     {
+        locale: "pcm",
+        englishName: "Nigerian Pidgin",
+        endonym: "Naijíriá Píjin",
+        label: "Nigerian Pidgin (Naijíriá Píjin)",
+    },
+    {
         locale: "pl",
         englishName: "Polish",
         endonym: "polski",
@@ -1050,6 +1071,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "తెలుగు",
         label: "Telugu (తెలుగు)",
     },
+    { locale: "tem", englishName: "Timne", endonym: "Timne", label: "Timne" },
     { locale: "tet", englishName: "Tetum", endonym: "Tetum", label: "Tetum" },
     {
         locale: "tg",

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -619,9 +619,9 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     },
     {
         locale: "kbp",
-        englishName: "Kabiye",
+        englishName: "Kabiyè",
         endonym: "Kabɩyɛ",
-        label: "Kabiye (Kabɩyɛ)",
+        label: "Kabiyè (Kabɩyɛ)",
     },
     { locale: "kg", englishName: "Kongo", endonym: "Kongo", label: "Kongo" },
     {

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -68,9 +68,9 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * The rule is published membership rather than a judgement about how close two
  * varieties are, which is what makes it checkable and what distinguishes it from
  * the `nn` and `fat` cases in {@link LANGUAGE_ALIASES}: neither of those is a
- * member of `nb` or `ak`, and both are deliberately left to miss. Nine of the
- * eleven keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr` — are
- * ISO 639-3 macrolanguages and list their macrolanguage members; `nah` is an
+ * member of `nb` or `ak`, and both are deliberately left to miss. Ten of the
+ * twelve keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`, `kg` —
+ * are ISO 639-3 macrolanguages and list their macrolanguage members; `nah` is an
  * ISO 639-3 **collection** code rather than a macrolanguage, so it lists the
  * individual Nahuan languages ISO 639-5 groups under it; and `mnk` is neither,
  * being a *member* of `man` that this repository happens to name a catalog
@@ -224,6 +224,19 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // `man`, so it would reach Mandinka through the alias anyway, and naming it
     // keeps the list the whole of a group rather than the leftovers of one.
     mnk: ["emk", "mku", "mlq", "msc", "mwk"],
+    // Kongo. The catalog is written towards the Kikongo ya Bandundu standard.
+    // These three are the whole of the macrolanguage; `kng` is the one
+    // `Intl.getCanonicalLocales` already folds to `kg`, and it is listed for
+    // the reason the other already-folded codes above are.
+    //
+    // `ktu` (Kituba) is deliberately absent, and this is the one exclusion here
+    // that is not simply "it has a catalog of its own" — though it does, added
+    // in #1685. Kituba is a creole *of* Kikongo rather than a variety of it,
+    // ISO 639-3 gives it a code outside `kg`, and folding it would be the
+    // judgement this map avoids. `mkw` (Kituba of the Republic of the Congo) is
+    // absent for the same reason and is left to miss; answering it with `ktu`
+    // would be defensible and is not a membership fact, so it is not done here.
+    kg: ["kng", "kwy", "ldi"],
 };
 
 /** Flattened once at module load rather than searched per request. */

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -572,6 +572,37 @@ describe("the noun-class reachability rule", () => {
 
         expect(offenders).toEqual([]);
     });
+
+    /**
+     * The other half of the same claim, added when `locales/kg` arrived: what
+     * makes Kituba's flatness worth reading is that its *lexifier* is not flat.
+     * The two headers say so, and the assertion is what keeps the pair honest,
+     * since a header can drift and a `$gender` fork cannot.
+     *
+     * `color` is the message the two headers point a reader at, so it is the
+     * one pinned. Asserting on the count rather than on the exact variants
+     * leaves a speaker free to fix Kongo's four class rows — the whole file is
+     * an unreviewed seed — without failing here, while still catching the one
+     * change that would make the pair meaningless.
+     */
+    it("has Kongo fork `color` where its creole does not", () => {
+        const genderForks = (locale: string) => {
+            const source = readCatalog(locale, "content") ?? "";
+            const color = parse(source, { withSpans: false }).body.find(
+                (entry) =>
+                    entry.type === "Message" && entry.id.name === "color",
+            );
+            expect(color, `${locale} defines color`).toBeDefined();
+            return selectExpressions(color!).filter(
+                (select) =>
+                    select.selector.type === "VariableReference" &&
+                    select.selector.id.name === "gender",
+            ).length;
+        };
+
+        expect(genderForks("kg")).toBeGreaterThan(0);
+        expect(genderForks("ktu")).toBe(0);
+    });
 });
 
 describe("counted messages", () => {

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -285,9 +285,9 @@ describe("renderSupportedLocalesModule", () => {
 describe("LOCALE_NAME_FALLBACKS", () => {
     /**
      * The gap this table closes, held shut for the roster rather than for the
-     * handful of entries that close it today. A future batch adding a language CLDR
-     * has no data for fails here until someone supplies a name — which is the
-     * whole point, since the alternative is a `<document lang>` autocomplete
+     * handful of entries that close it today. A future batch adding a language
+     * CLDR has no data for fails here until someone supplies a name — which is
+     * the whole point, since the alternative is a `<document lang>` autocomplete
      * that offers a reader "ktu" and expects them to know what it is.
      */
     it("leaves no locale labelled with its own code", () => {

--- a/packages/i18n/test/catalogLint.test.ts
+++ b/packages/i18n/test/catalogLint.test.ts
@@ -285,7 +285,7 @@ describe("renderSupportedLocalesModule", () => {
 describe("LOCALE_NAME_FALLBACKS", () => {
     /**
      * The gap this table closes, held shut for the roster rather than for the
-     * four entries that close it today. A future batch adding a language CLDR
+     * handful of entries that close it today. A future batch adding a language CLDR
      * has no data for fails here until someone supplies a name — which is the
      * whole point, since the alternative is a `<document lang>` autocomplete
      * that offers a reader "ktu" and expects them to know what it is.

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -878,9 +878,8 @@ describe("negotiateLocales", () => {
          * The near misses for this batch. `bin` (Edo) and `efi` (Efik) are
          * Nigerian neighbours of `pcm` and `tiv`; `men` (Mende) is a Sierra
          * Leonean neighbour of `kri` and `tem`; `gej` (Gen) is a Gbe language
-         * beside `fon` and `ee`; `ncu` and `bib` are Atlantic and Mande
-         * neighbours. Every one falls to English rather than being folded onto
-         * a language it is merely near.
+         * beside `fon` and `ee`. Every one falls to English rather than being
+         * folded onto a language it is merely near.
          *
          * `son` is here for a different reason and is the interesting row: it
          * is the ISO 639-3 macrolanguage over the Songhay varieties, and this

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -814,6 +814,98 @@ describe("negotiateLocales", () => {
             },
         );
     });
+
+    describe("the West and Central African batch, continued", () => {
+        it.each([
+            // Kongo is a macrolanguage, and `kng` — Koongo — is the one member
+            // `Intl.getCanonicalLocales` folds to `kg` on its own, `run`'s case
+            // rather than `bms`'s. The other two reach the catalog only because
+            // `MACROLANGUAGE_MEMBERS` lists them.
+            ["kg", "kg"],
+            ["kng", "kg"],
+            ["kwy", "kg"],
+            ["ldi", "kg"],
+            // `kon` is the ISO 639-2/T code for the macrolanguage itself, which
+            // canonicalizes to `kg` before negotiation is reached.
+            ["kon", "kg"],
+            // The rest have no two-letter code and arrive under the tag their
+            // directory is named for.
+            ["fon", "fon"],
+            ["pcm", "pcm"],
+            ["kri", "kri"],
+            ["kbp", "kbp"],
+            ["tem", "tem"],
+            // Region tags, which filter without help.
+            ["kg-CD", "kg"],
+            ["fon-BJ", "fon"],
+            ["pcm-NG", "pcm"],
+            ["kri-SL", "kri"],
+            ["kbp-TG", "kbp"],
+            ["tem-SL", "tem"],
+        ])("reaches %s's catalog as %s", (requested, expected) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual([expected, "en"]);
+        });
+
+        /**
+         * The exclusion that carries this batch's argument, and the one most
+         * likely to be "fixed" by someone who does not know why it is there.
+         *
+         * Kituba is a creole *of* Kikongo rather than a variety of it — see the
+         * two catalogs' headers — and ISO 639-3 gives it a code outside the
+         * `kg` macrolanguage. Listing it among `kg`'s members would serve a
+         * Kituba reader Kikongo, which is a different language and not a
+         * dialect of the one they asked for.
+         *
+         * Asserted on the *un-normalized* tag for the reason the `bam` guard
+         * above records: `negotiateLocales` is public and a host may hand it a
+         * raw `navigator.languages` entry, so the members list really is
+         * consulted for it. The `ktu → ktu` row in the previous batch's block
+         * would pass whether or not `ktu` were listed, since `ktu` has a
+         * catalog of its own and wins on an exact match before any folding.
+         */
+        it.each(["ktu", "mkw"])(
+            "keeps %s out of Kongo's members list",
+            (requested) => {
+                expect(negotiateLocales([requested], available)).not.toContain(
+                    "kg",
+                );
+            },
+        );
+
+        /**
+         * The near misses for this batch. `bin` (Edo) and `efi` (Efik) are
+         * Nigerian neighbours of `pcm` and `tiv`; `men` (Mende) is a Sierra
+         * Leonean neighbour of `kri` and `tem`; `gej` (Gen) is a Gbe language
+         * beside `fon` and `ee`; `ncu` and `bib` are Atlantic and Mande
+         * neighbours. Every one falls to English rather than being folded onto
+         * a language it is merely near.
+         *
+         * `son` is here for a different reason and is the interesting row: it
+         * is the ISO 639-3 macrolanguage over the Songhay varieties, and this
+         * repository has no catalog for any of them. It is *not* aliased the
+         * way `man` is, because the justification `man`'s entry rests on does
+         * not exist here — `new Intl.Locale("son").maximize()` adds no region,
+         * so CLDR has no opinion about which variety a bare `son` means, and
+         * picking one would be the judgement these maps avoid.
+         */
+        it.each(["bin", "efi", "men", "gej", "son"])(
+            "leaves %s on English rather than folding it onto a neighbour",
+            (requested) => {
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual(["en"]);
+            },
+        );
+
+        it("has no CLDR region for `son`, which is why it is not aliased", () => {
+            expect(new Intl.Locale("son").maximize().region).toBeUndefined();
+        });
+    });
 });
 
 describe("resolveDocumentLocale", () => {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65261,7 +65261,7 @@
                         },
                         {
                             "value": "kbp",
-                            "description": "Kabiye (Kabɩyɛ)"
+                            "description": "Kabiyè (Kabɩyɛ)"
                         },
                         {
                             "value": "kg",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65148,6 +65148,10 @@
                             "description": "Faroese (føroyskt)"
                         },
                         {
+                            "value": "fon",
+                            "description": "Fon"
+                        },
+                        {
                             "value": "fr",
                             "description": "French (français)"
                         },
@@ -65256,6 +65260,14 @@
                             "description": "Kabyle (Taqbaylit)"
                         },
                         {
+                            "value": "kbp",
+                            "description": "Kabiye (Kabɩyɛ)"
+                        },
+                        {
+                            "value": "kg",
+                            "description": "Kongo"
+                        },
+                        {
                             "value": "ki",
                             "description": "Kikuyu (Gikuyu)"
                         },
@@ -65282,6 +65294,10 @@
                         {
                             "value": "kr",
                             "description": "Kanuri"
+                        },
+                        {
+                            "value": "kri",
+                            "description": "Krio"
                         },
                         {
                             "value": "ks",
@@ -65444,6 +65460,10 @@
                             "description": "Pampanga"
                         },
                         {
+                            "value": "pcm",
+                            "description": "Nigerian Pidgin (Naijíriá Píjin)"
+                        },
+                        {
                             "value": "pl",
                             "description": "Polish (polski)"
                         },
@@ -65574,6 +65594,10 @@
                         {
                             "value": "te",
                             "description": "Telugu (తెలుగు)"
+                        },
+                        {
+                            "value": "tem",
+                            "description": "Timne"
                         },
                         {
                             "value": "tet",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -2997,3 +2997,149 @@ describe("the West and Central African batch", () => {
         ).toBe(expected);
     });
 });
+
+describe("the West and Central African batch, continued", () => {
+    const forLocale = (locale: string): Translator =>
+        createTranslatorFromLocaleData(
+            { locale, resources: { [locale]: readCatalog(locale, "content") } },
+            locale,
+        );
+
+    const words = {
+        lineWidthWord: "thick",
+        lineStyleWord: "dashed",
+        colorWord: "red",
+    };
+
+    const described = (locale: string, key: NounKey) =>
+        describeStrokedShape(forLocale(locale), words, {
+            noun: { key },
+            withNoun: true,
+        });
+
+    /**
+     * **A creole beside its lexifier, which is what this batch was assembled
+     * to show.** `locales/ktu` was seeded in the previous batch as the one
+     * Bantu catalog selecting on nothing: Kituba joins a describing word to
+     * its noun with an invariable «ya». That «ya» is Kongo's class-9 linker,
+     * frozen — and here the linker moves while the stem does not.
+     *
+     * Four rows, four classes, and «nene» and «mbwaki» are constant across all
+     * of them: the whole of the agreement in Kikongo is that first syllable.
+     * The dash pattern stays «ya …» in every row, because it is written as a
+     * frozen class-9 phrase — which is to say, as Kituba writes everything.
+     */
+    it("moves only Kongo's linker syllable, never the stem behind it", () => {
+        expect(described("kg", "line")).toBe(
+            "nsinga ya nene ya mbwaki ya bitini bitini",
+        );
+        expect(described("kg", "circle")).toBe(
+            "kizunga kya nene kya mbwaki ya bitini bitini",
+        );
+        expect(described("kg", "point")).toBe(
+            "tona dya nene dya mbwaki ya bitini bitini",
+        );
+        expect(described("kg", "region")).toBe(
+            "fulu kya nene kya mbwaki ya bitini bitini",
+        );
+    });
+
+    /**
+     * The same argument from the other end: a class spelled as a suffix, which
+     * `locales/mos` and `locales/dag` already do with four classes and three.
+     * Kabiyè answers with five, and the stem is again constant — «sɔsɔ-» and
+     * «kɩsɛm-» never move, only what follows them.
+     *
+     * Reading this against the Kongo rows above is the point of having both in
+     * one batch: the agreement is one morph in each, and it lands in front in
+     * one and behind in the other.
+     */
+    it("moves only Kabiyè's class suffix, never the stem in front of it", () => {
+        expect(described("kbp", "line")).toBe(
+            "ñɔʋ sɔsɔʋ kɩsɛmʋ nɛ hɔɔlɩŋ cikpeŋ",
+        );
+        expect(described("kbp", "circle")).toBe(
+            "kpelaɣ sɔsɔɖɛ kɩsɛmɩɖɛ nɛ hɔɔlɩŋ cikpeŋ",
+        );
+        expect(described("kbp", "point")).toBe(
+            "yʋsaɣ sɔsɔa kɩsɛma nɛ hɔɔlɩŋ cikpeŋ",
+        );
+        expect(described("kbp", "region")).toBe(
+            "ɖenɖe sɔsɔtʋ kɩsɛmɩtʋ nɛ hɔɔlɩŋ cikpeŋ",
+        );
+    });
+
+    /**
+     * **Alliterative concord, which is visible in the rendered string and in no
+     * other locale here.** The noun's own prefix and both describing words'
+     * prefixes are the same syllable, three times over in each row:
+     * «kʌlayn kʌbana-bana kʌbana», «rʌtoni rʌbana-bana rʌbana».
+     *
+     * That is why `locales/tem`'s header can claim its `noun-gender` table is
+     * checkable by eye against `noun`, and these rows are what would catch the
+     * table drifting away from the nouns it describes.
+     */
+    it("repeats the Temne noun's own prefix on every describing word", () => {
+        expect(described("tem", "line")).toBe(
+            "kʌlayn kʌbana-bana kʌbana na ʌŋpath-pathi",
+        );
+        expect(described("tem", "circle")).toBe(
+            "tʌkərəŋ tʌbana-bana tʌbana na ʌŋpath-pathi",
+        );
+        expect(described("tem", "point")).toBe(
+            "rʌtoni rʌbana-bana rʌbana na ʌŋpath-pathi",
+        );
+        expect(described("tem", "region")).toBe(
+            "rʌro rʌbana-bana rʌbana na ʌŋpath-pathi",
+        );
+    });
+
+    /**
+     * The three that fork on nothing, one row each, since a second row would
+     * only restate the first.
+     *
+     * The two creoles are worth having side by side even though neither
+     * inflects: same lexifier, same word order, and every content word spelled
+     * differently. That is the whole of what separates them, and it is exactly
+     * what a reader skimming `locales/pcm` and concluding "this is English"
+     * would miss.
+     */
+    it.each([
+        ["fon", "dlɛ̌n gaga vɔvɔ kpó dlɛ̌n kpɛví lɛ́"],
+        ["pcm", "thick brok-brok red lain"],
+        ["kri", "tik brok-brok rɛd layn"],
+    ])("leaves %s's describing words alone", (locale, expected) => {
+        expect(described(locale, "line")).toBe(expected);
+    });
+
+    /**
+     * All six reach `[noun-tail]`, the side count being a complement in every
+     * one of them — which is now the eighteenth consecutive catalog to do so
+     * across three batches and a dozen families.
+     *
+     * The Kabiyè row is the one to read: «kɩsɛmɩɖɛ» carries class 3, and so
+     * does the head «poligɔnɩ kɩmaɣzaɣ» that `noun-gender` assigns
+     * `regular-polygon` to. A colour that disagreed with its own head would be
+     * the defect the previous batch found in `locales/tiv`, and this row is
+     * what would catch it here.
+     */
+    it.each([
+        ["kg", "poligone yafwanana ya mbwaki ya makonso 5"],
+        ["fon", "polygone jɛ́jɛ́ vɔvɔ kpó akpá 5"],
+        ["pcm", "red poligọn wey ẹvri sait dey de sem wey get 5 sait"],
+        ["kri", "rɛd pɔligɔn we ɔl di say dɛn na wan we gɛt 5 say"],
+        ["kbp", "poligɔnɩ kɩmaɣzaɣ kɩsɛmɩɖɛ ŋgʋ kɩwɛnɩ hɔɔlɩŋ 5 yɔ"],
+        ["tem", "tʌpɔligɔn tʌ kɔmɔ tʌbana tʌ na tʌbʌŋ 5"],
+    ])("closes %s's phrase with the side count", (locale, expected) => {
+        expect(
+            describeStrokedShape(
+                forLocale(locale),
+                { colorWord: "red" },
+                {
+                    noun: { key: "regular-polygon", numSides: 5 },
+                    withNoun: true,
+                },
+            ),
+        ).toBe(expected);
+    });
+});

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3120,11 +3120,14 @@ describe("the West and Central African batch, continued", () => {
      * two English-lexifier creoles, which is the one shape that batch had no
      * example of.
      *
-     * The Kabiyè row is the one to read: «kɩsɛmɩɖɛ» carries class 3, and so
-     * does the head «poligɔnɩ kɩmaɣzaɣ» that `noun-gender` assigns
-     * `regular-polygon` to. A colour that disagreed with its own head would be
-     * the defect the previous batch found in `locales/tiv`, and this row is
-     * what would catch it here.
+     * The Kabiyè row is the one to read: the colour «kɩsɛmɩɖɛ» ends in the
+     * `-ɖɛ` the header's table gives class 3, which is the class
+     * `noun-gender` assigns `regular-polygon` — the head «poligɔnɩ kɩmaɣzaɣ»
+     * that `noun-regular-polygon` writes. (Kabiyè is not alliterative the way
+     * `locales/tem` is, so that head does not itself display the class; only
+     * the suffix does.) A colour agreeing with something other than its own
+     * head is the easiest defect to write into a class catalog, and this row
+     * is what would catch it here.
      */
     it.each([
         ["kg", "poligone yafwanana ya mbwaki ya makonso 5"],

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3024,10 +3024,12 @@ describe("the West and Central African batch, continued", () => {
      * its noun with an invariable «ya». That «ya» is Kongo's class-9 linker,
      * frozen — and here the linker moves while the stem does not.
      *
-     * Four rows, four classes, and «nene» and «mbwaki» are constant across all
-     * of them: the whole of the agreement in Kikongo is that first syllable.
-     * The dash pattern stays «ya …» in every row, because it is written as a
-     * frozen class-9 phrase — which is to say, as Kituba writes everything.
+     * Four rows and three of the four classes — `circle` and `region` are both
+     * class 7, and class 11 belongs to `border`, which the worker-path test's
+     * `sh` row exercises. «nene» and «mbwaki» are constant across all four:
+     * the whole of the agreement in Kikongo is that first syllable. The dash
+     * pattern stays «ya …» in every row, because it is written as a frozen
+     * class-9 phrase — which is to say, as Kituba writes everything.
      */
     it("moves only Kongo's linker syllable, never the stem behind it", () => {
         expect(described("kg", "line")).toBe(
@@ -3127,10 +3129,10 @@ describe("the West and Central African batch, continued", () => {
     it.each([
         ["kg", "poligone yafwanana ya mbwaki ya makonso 5"],
         ["fon", "polygone jɛ́jɛ́ vɔvɔ kpó akpá 5"],
-        ["pcm", "red poligọn wey ẹvri sait dey de sem wey get 5 sait"],
+        ["pcm", "red poligọn wey ẹvri sait dey di sem wey gẹt 5 sait"],
         ["kri", "rɛd pɔligɔn we ɔl di say dɛn na wan we gɛt 5 say"],
         ["kbp", "poligɔnɩ kɩmaɣzaɣ kɩsɛmɩɖɛ ŋgʋ kɩwɛnɩ hɔɔlɩŋ 5 yɔ"],
-        ["tem", "tʌpɔligɔn tʌ kɔmɔ tʌbana tʌ na tʌbʌŋ 5"],
+        ["tem", "tʌpɔligɔn tʌ nɔŋ tʌbana tʌ na tʌbʌŋ 5"],
     ])("closes %s's phrase with the side count", (locale, expected) => {
         expect(
             describeStrokedShape(

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3114,8 +3114,9 @@ describe("the West and Central African batch, continued", () => {
 
     /**
      * All six reach `[noun-tail]`, the side count being a complement in every
-     * one of them — which is now the eighteenth consecutive catalog to do so
-     * across three batches and a dozen families.
+     * one of them, as it was in all eleven of the batch above — including the
+     * two English-lexifier creoles, which is the one shape that batch had no
+     * example of.
      *
      * The Kabiyè row is the one to read: «kɩsɛmɩɖɛ» carries class 3, and so
      * does the head «poligɔnɩ kɩmaɣzaɣ» that `noun-gender` assigns


### PR DESCRIPTION
Continues #1685, which seeded eleven West and Central African languages, with
six more: **Kongo (`kg`), Fon (`fon`), Nigerian Pidgin (`pcm`), Krio (`kri`),
Kabiyè (`kbp`) and Temne (`tem`)**.

Every string is machine-generated and **has not been read by a speaker**. Each
catalog says so in its header, in the words the previous batches used. The value
is that a document declaring one of these languages stops falling back to
English; the cost is that some of it is wrong, and correcting it needs no
permission.

## Scope note

The ask was 12–15 languages. **This lands six.** I stopped authoring at six so
that the supporting work — negotiation, the name fallback, the tests, the README
and the changeset — would land complete rather than leaving a dozen catalogs
wired to nothing. That is the same trade #1685 made when it cut twenty to eleven.
The remaining candidates for a third batch are noted at the bottom.

## Where the eleven asked "where does agreement go", these six ask "what do two catalogs tell you that one cannot"

Three pairs answer it.

### `kg` beside `ktu` — a creole beside its lexifier

Kituba landed in #1685 as the one Bantu catalog selecting on neither `$gender`
nor `$role`: a describing word is joined to its noun by the invariable linker
«ya» and never changes shape.

Kikongo is Kituba's lexifier, and its connective **agrees**. That «ya» turns out
to be Kongo's class-9 row, frozen:

| class | linker | black      | thick    |
| ----- | ------ | ---------- | -------- |
| 5     | dya    | dya ndombe | dya nene |
| 7     | kya    | kya ndombe | kya nene |
| 9     | ya     | ya ndombe  | ya nene  |
| 11    | lwa    | lwa ndombe | lwa nene |

The whole of the agreement is that one syllable; the stem behind it never moves.
Putting `color.black` in the two files side by side is the shortest statement of
what a creole did to its lexifier that this repository can make, and it cost
nothing but the two files being in the same tree. `catalogLint.test.ts` pins
both halves — that `kg` forks and that `ktu` does not — because a header can
drift and a `$gender` fork cannot.

### `pcm` beside `kri` — same lexifier, different answer

Both are English-lexifier creoles with much of the same grammar. They still do
not look alike, because Sierra Leone settled on a phonemic orthography and
Nigeria stayed close to English spelling: «blak/wet/grin» against
«black/white/green». The seam between them is **orthographic**, where `fon`'s
internal seam is **morphological**, and neither is a difference in grammar.

`pcm` is the catalog most likely to be mistaken for padding, since almost every
word in it is English. Its header therefore leads with the grammar it actually
turns on — no plural `-s`, preverbal `don`/`dey`/`go`, `no bi` negation, `na`
for identity — and asks a reviewer to read the messages aloud.

### `kbp` beside `kg` — one morph, opposite ends

Kabiyè is the third Gur catalog and spells its class as a suffix as Mooré and
Dagbani do, with **five** classes where they have four and three. Read against
Kikongo it completes the argument #1685 was building: the agreement is one morph
in each, and it lands **in front of** an invariant stem in Kongo, **behind** one
in Kabiyè, and as a **separate word between** the two in Tiv.

### `tem` — the one you can check without knowing the language

Temne's concord is *alliterative*: the describing word takes the same prefix the
noun itself carries, so a description renders as «kʌlayn kʌbana-bana kʌbana» —
the same syllable three times. Everywhere else here the concord and the noun's
prefix are different morphs and `noun-gender` has to be taken on trust; in this
one every entry naming a noun can be read straight off `noun` by eye. The
classes belonging to a phrase head rather than a noun are outside that check:
`border` can still be read against «ʌŋbʌŋ» and `background` against «kʌbaka»,
but `text` and `fill` head phrases this catalog writes no word for, and the
header says which is which. Four rows are pinned.

### `fon` — no agreement, and here for its colour words

Fon has three basic colour terms — «wiwi», «wewe», «vɔvɔ» — all reduplicated
statives; the other nine are bare French loans, because there is no stem to
reduplicate. A speaker reviewing it should expect to move words across that seam
rather than to find the loans wrong as loans.

## Negotiation

`kg` is a macrolanguage and joins `MACROLANGUAGE_MEMBERS`, so `kwy`, `ldi`,
`kng` and `kon` reach it.

**`ktu` is deliberately excluded**, and it is the one exclusion here that is not
simply "it has a catalog of its own" — though it does. Kituba is a creole *of*
Kikongo rather than a variety of it, ISO 639-3 codes it outside `kg`, and
folding it would serve a Kituba reader a different language. `mkw` is left to
miss for the same reason. The guard asserts this on the **un-normalized** tag,
which is the only form the mistake is visible in — the lesson from #1685's third
review cycle, where a test passed with and without the bug.

**`son` is the road not taken.** It is the Songhay macrolanguage and is *not*
aliased the way `man` was, because the justification `man`'s entry rests on does
not exist here: `new Intl.Locale("son").maximize()` adds no region, so CLDR has
no opinion about which variety a bare `son` means. The test asserts the absent
region, not merely the absent entry.

`kbp` has no CLDR name, so it takes the **fifth** `LOCALE_NAME_FALLBACKS` entry
and reads "Kabiyè (Kabɩyɛ)" rather than "kbp" — the mechanism #1685 added, doing
the job it was added for. `tem` reads **"Timne"**, CLDR's spelling rather than
the "Temne" its own header uses; that is the "Mossi" case again and is not an
error.

## A defect the tests caught

Probing the rendered strings rather than assuming them found a real bug in my
own work: `pcm` and `kri` had written `line-style` as a «wey dey brok-brok»
relative clause. Both catalogs put the description *before* the noun, so the
clause landed in front of the thing it modified and attached to nothing —
"thick red wey dey brok-brok lain". Both now use attributive reduplication:
"thick brok-brok red lain".

## Chemistry

All six leave `element-name` and `element-anion-name` out, so those 130 keys
fall back to English and `lint:i18n` reports the gap. Four are the ordinary
school-system case. `pcm` and `kri` are a shape no earlier batch had: their
lexifier *is* English, so filling those keys in would produce entries
character-identical to `locales/en` and claim a translation that had not
happened.

## Verification

- `lint:i18n` clean; all six at 432/562 keys, the same coverage as #1685.
- `@doenet/i18n` 510 tests, `@doenet/utils` styleDescriptions 242,
  worker-path styleDescriptionLocale 29.
- `tsc --noEmit` and `prettier --check` clean; regeneration leaves an empty diff.
- Every new guard was **mutation-checked**, and the third review cycle redid
  this exhaustively: dropping `kg`'s `MACROLANGUAGE_MEMBERS` entry, listing
  `ktu`/`mkw` under it, folding each near-miss tag (`bin`, `efi`, `men`, `gej`,
  `son`) onto a neighbour, flattening `kg`'s `color` forks, giving `ktu` one,
  and moving `tem`'s and `kbp`'s `noun-gender` rows each turn exactly the
  intended assertion red. No added assertion survived its own mutation.

## Corrections from review

A second review pass read each catalog's messages against their English
originals, looking for meaning drift rather than style. What it found:

**Quantifiers inverted or dropped.** `kg` rendered "at least" as «na kunsi» —
"and below" — in seven diagnostics, turning every lower bound into an upper one;
its own vocabulary elsewhere (`select-from-sequence-coprime-not-positive-integers`)
fixes «zulu» as "above", so the correction is checkable from inside the file.
`kg`'s `graph-grid-invalid` said "two **large** numbers" for "two positive
numbers". `kbp` dropped "at least" from `line-points-too-few-dimensions`, making
a 3-D line an error, and dropped "only" from both branches of
`function-iterates-input-output-mismatch`.

**A branch contradicting itself.** `fon`'s `multiple-annotations-children` kept
«nukɔntɔ́n gudo tɔ́n» — "the first the last" — where English keeps only the last.

**A word that means something else in the same catalog.** `tem` wrote
`style-text`'s background as «ʌŋkəbaka», which its own `diagnostics.ftl` uses a
dozen times for *colour* («ʌŋkəbaka ka ʌŋkəre ka ʌŋkəbaka ka kʌbaka» — colour of
the text against colour of the background). It now uses «kʌbaka», and since that
carries `kʌ-`, `background` moves from `c4` to the `c1` default and the header's
certified `ʌŋ-` pair drops to `border` alone. Likewise `tem`'s
`noun-regular-polygon` head used «kɔmɔ», the word this catalog uses five times
for *deprecated*.

**A third party invented.** `pcm` and `kri` both rendered "explicitly authored
inputs" as inputs "the other person wrote", naming someone not in the sentence.

**Nouns disagreeing with their own `noun-gender` row.** `kg` assigned `plus` to
class 5, but its noun «sinsu kya kuvukisa» carries the class-7 linker in the
same line and pluralizes «bisinsu» in `diagnostics.ftl`; and it assigned `square`
and `cross` classes, though «kare» and «kuluse» are French loans and the file's
own comment names class 9 as the class a loan joins. `kbp`'s
`style-border-clause` comment claimed `border` "answers `c1` in `noun-gender`"
when `noun-gender` had no such row; it has one now.

**Headers overstating their own files.** `kg` said the agreeing syllable was
"always the same syllable" three lines under a table showing it change. `fon`
gave a grammatical reason and called it "a fact about its colour words rather
than about its grammar", filed the non-reduplicating «kléwún» under
"reduplicated stative", and located a seam "running through one message" that
runs through three. `pcm` claimed `of` is rare in a file using it 83 times, and
counted three Nigerian languages in the repository before naming a fourth in the
same sentence. `tem`'s `noun-gender` comment had been left mid-sentence by the
previous cycle, its header cited two noun prefixes («ro-», «ʌŋ-mark») that appear
nowhere in the file, and it asserted alliterative concord flatly while eight
loan colour words take no prefix — that exception is now written down where
`locales/kbp` writes its own. `kri`'s `editor.ftl` header called `attribute` a
DoenetML identifier to justify leaving `help-kind-attribute` untranslated beside
its two Krio-ized siblings.

Also: `kri` spelled *type* two ways in one file and dropped "state variable"
from three `nearestPoint` messages; `kbp`'s `help-coordinates` had a one-character
typo («Ɖeɖe» for «Ɖenɖe»); a `negotiate.test.ts` comment named two near-miss tags
the assertion does not test; and the `styleDescriptions.test.ts` docstring
claimed "four rows, four classes" where two of the four rows are class 7.

Three pinned strings moved as a result — `pcm`'s and `tem`'s regular-polygon
rows and `kg`'s square marker — and the goldens were updated with a note saying
why «kare» takes «ya».

## Corrections from the third review cycle

The third cycle re-derived every added assertion by introducing the bug it
claims to catch; all of them went red, so nothing was strengthened or deleted.
What it did find was drift left by the second cycle, and one inconsistency
nobody had read end-to-end:

- `tem`'s header and its `noun-gender` comment still said **four** entries name
  a phrase head. The second cycle deleted the `[background] c4` row, so there
  are three, and `background` reaches `c1` through the `*[other]` default —
  which is «kʌbaka»'s own class, so the two still agree. Both comments now say
  that instead of counting wrong.
- `kg`'s `style-border-clause` comment said «lubaku» is class 11 "in
  `noun-gender`", where `noun-gender` keys on `border` and never spells the
  word. Reworded to `tem`'s shape, which states the same fact accurately.
- Two test comments claimed a mis-agreeing colour was "the mistake the previous
  batch found in `locales/tiv` and fixed". #1685 landed `locales/tiv` in one
  commit and no such fix is in the history; both now cite `tiv` as the
  precedent rather than as a repaired defect. The `kbp` one also said the head
  «poligɔnɩ kɩmaɣzaɣ» "carries class 3" — Kabiyè is not alliterative, so the
  head does not display its class; only the colour's suffix does.
- `LOCALE_NAME_FALLBACKS` spelled the English name **"Kabiye"** while the
  catalog header, the README and this description all write **"Kabiyè"**. Since
  that name is chosen by this repository rather than by CLDR, there was nothing
  for the mismatch to mean; it is now "Kabiyè" throughout, and the roster and
  schema were regenerated.
- The `leaves no locale labelled with its own code` docstring counted "the four
  entries that close it today", which `kbp` made five. It no longer counts.

## Corrections from the fourth review cycle

The first three cycles concentrated on `content.ftl`, where the linguistic
argument lives, and on the test and doc changes. The fourth read the other
three namespaces — `chrome.ftl`, `editor.ftl` and `diagnostics.ftl` across all
six locales, about 6,000 lines — against `locales/en`.

**Mechanically clean.** Every `$placeable`, every select-branch key, every
backticked literal and the `[deprecation]` marker already matched English
exactly in all eighteen files; so did every DoenetML identifier and every
reserved value (`math`, `text`, `number`, `boolean`, `none`, `medium`, `dense`,
`left`, `bottom`, `circuit`, `videoWatched`). No branch carried another
branch's text.

**Two meaning inversions, both findable from inside their own file.**

- `kg`'s three "isn't constant" messages negated the *changing* word rather
  than the clause: `numToSelect kena ntalu yasoba ve ko` reads "is not a
  **changing** number", asserting the opposite of what the message reports.
  `variant-non-constant-exclude-not-implemented` fixes «soba» as *non-constant*
  in the same file, so the reading is checkable without knowing Kikongo.
- `kbp`'s `matches-pattern-parameter-not-in-pattern` carried the negative
  imperfective «ɛɛmaɣ»/«paamaɣ», turning "will **always** match a blank" into
  "will **never**". The file's own `ɛɛlakɩ tʋmɩyɛ` ("has no effect") against
  `kɩmaɣ` ("must match") is what fixes the prefix's sense.

**One concept, two words — the class cycle 2 found in `tem`, recurring.**

- **A word doing a second job.** `fon` used «hwenu» — its own conjunction
  *when* — for a mathematical *interval*, so "the domain has 2 intervals" read
  "has 2 times"; and `math-input-invalid-expression` reached for «xógbe», the
  catalog's word for plain *text*, two lines from the «nǔnywɛ́xó» it uses for a
  math expression. `fon` also had «ɖaxó» serving as both *dimension* and
  *maximum*, in adjacent messages. All now take the French loans the file
  already leans on for mathematical vocabulary.
- **Version, everywhere.** `kg`, `fon`, `kbp` and `tem` each rendered
  `DoenetML version { $version }` with the same word they use for a *variant*,
  so `doenetml-version-not-found` and the whole `variant-*` family became
  indistinguishable. `pcm` and `kri` already had a distinct word; the other
  four now keep the English `version`, as they keep every other borrowed term.
- **Spelling splits in the two English-lexified creoles**, where orthography is
  the only thing separating the catalog from its lexifier: `pcm` spelled *type*
  as both «taip» (14×) and «tayp» (2×), *reference* as both «rẹfrẹns» (11×) and
  «rẹfarẹns» (1×), and *documentation* off its own «dọkyu-» stem; `kri` had the
  matching «rɛfarɛns» and one prose `type` where the file says «tayp» 15 times.
  Both left bare English `valid` in three sentences whose sixty-odd siblings
  say «korẹkt»/«kɔrɛkt», and `pcm` dropped "state variable" from the three
  `nearestPoint` messages that cycle 2 had already fixed in `kri`.
- **Smaller ones.** `kg`'s `feedback-heading` read «Mvutu ya Nlongi» — *the
  teacher's reply* — naming someone the English does not and narrowing what
  Doenet feedback is; its `editor-variant-filter` used the same verb as
  `editor-variant-next`, so the filter box read as a Select command; its
  `help-allowed-values` said «zalombwa» (*requested*) one letter from
  `help-suggested-values`' «zalongwa», which is the pair the English comment
  asks a translator to keep apart; and `side-by-side-no-block-child` had «ti»
  where every sibling has «ye». `kbp`'s `invalid-variable-value` was the one
  message in 55 to say «kɩdɛkɛdʋʋ» rather than «tɩtʋʋzɩ» for *invalid*. `tem`
  had two `Ka`/`Kʌ` concord slips against fifty parallel strings, and wrote
  "(one per item)" as one noun repeated.
- **`kri`'s two spellings of *attribute*** were left as they are, and the
  reason is now written down: `editor.ftl` says «atribyut» and now uses it in
  `help-placeholder` too, and its header records that `diagnostics.ftl` keeps
  the English `attribute` deliberately, since there the word names the piece of
  DoenetML being reported on rather than a kind of completion.

**Recorded rather than fixed.** `tem`'s `.red` is «-bana», which is also that
catalog's word for *big* — `diagnostics.ftl` renders a function's `[maximum]`
as «kʌbana» against `[minimum]` «kʌkəni», and `line-width` reduplicates those
same two stems. So the row `styleDescriptions.test.ts` pins reads
«kʌlayn kʌbana-bana kʌbana», where only the repeated `kʌ-` is meant to be
concord. Whether that is a homonym or a defect is a question for a Temne
speaker rather than for a reviewer, so it is written into the comment above
`color`, together with a note that deciding it the second way means updating
both golden suites. The same is true of a longer list of term collisions these
seeds share — *renderer* against *viewer*, *name* against *label*, *answer*
against *response* — which are recorded here rather than guessed at.

**One doc claim.** The README said `fon`'s morphological seam "runs through one
message"; cycle 2 had already corrected the catalog's own header to say it runs
through `color`, `noun` and `fill-style`. The README now says the same thing.

## Corrections from the fifth review cycle

The last cycle read the whole diff end to end as one document, looking for
places where four cycles of edits by four reviewers had left two statements
disagreeing. Two:

- The README's chemistry paragraph for this batch said the four ordinary
  school-system cases are "the DRC, Benin and Togo … in French, Sierra Leone
  and Nigeria in English". Nigeria's only catalog here is `pcm`, which is one
  of the *two* exceptional cases in the next clause, not one of the four. The
  sentence now names Sierra Leone alone, which is `tem`.
- `locales/tem`'s header noun-class table had one column a space out of
  alignment, and an earlier cycle's edit had left three README lines wrapped
  mid-paragraph. Both re-flowed.

Everything else was re-checked and left alone: the 114-name chemistry list and
its "hundred and fifteen"/"hundred and fourteen" counts match the tree, the
twelve `MACROLANGUAGE_MEMBERS` keys match `negotiate.ts`'s doc comment, the
`kg` table in this description matches the one in the catalog header and the
README, and every header claim about class counts, loan words and the
alliterative check reads the same in all three places. The verification numbers
above were re-run and are current.

## If a third batch follows

The candidates I had scoped and did not reach: Umbundu (`umb`), Kimbundu
(`kmb`), Ewondo (`ewo`), Efik (`efi`), Mende (`men`), Jola-Fonyi (`dyo`) and
Zarma (`dje`). `men` is the interesting one — Mende's definite suffix attaches
to whatever word ends the noun phrase, which runs straight into the affix rule
the README documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8





