### PR TITLE
Seed catalogs for four more African languages

### DIFF
--- a/.changeset/seed-angolan-sierra-leonean-songhay-catalogs.md
+++ b/.changeset/seed-angolan-sierra-leonean-songhay-catalogs.md
@@ -22,5 +22,5 @@ is deliberately still served English: CLDR has no opinion about which Songhay
 variety it means, so choosing one would be a guess rather than a published
 fact.
 
-Umbundu and Kimbundu are the first Angolan languages in the roster, and Mende
-the third Sierra Leonean one.
+Umbundu and Kimbundu are the first catalogs in the roster centred on Angola,
+and Mende the third for a language of Sierra Leone.

--- a/.changeset/seed-angolan-sierra-leonean-songhay-catalogs.md
+++ b/.changeset/seed-angolan-sierra-leonean-songhay-catalogs.md
@@ -1,0 +1,26 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for four more African languages: Mende
+(`men`), Umbundu (`umb`), Kimbundu (`kmb`) and Zarma (`dje`). A document
+declaring one of these languages now renders its style descriptions, section
+headings, boolean words, answer buttons, editor chrome and diagnostics in it
+instead of falling back to English. The chemistry element tables are
+deliberately left out of all four and still fall back to English.
+
+Every string is machine-generated and has not been read by a speaker; each
+catalog says so in its header. Correcting one needs no permission.
+
+Zarma is a member of the Songhay macrolanguage, so readers arriving under
+`ddn`, `hmb`, `khq`, `ses`, `tda` or `twq` now reach it as well. A bare `son`
+is deliberately still served English: CLDR has no opinion about which Songhay
+variety it means, so choosing one would be a guess rather than a published
+fact.
+
+Umbundu and Kimbundu are the first Angolan languages in the roster, and Mende
+the third Sierra Leonean one.

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleDescriptionLocale.test.ts
@@ -507,6 +507,29 @@ describe("style descriptions follow the document locale @group4", () => {
         expect(values.fd).eq("utindi bulu");
     });
 
+    it("prefixes an Umbundu class through the worker path", async () => {
+        const values = await descriptions(styled, names, "umb");
+        // The third place this repository has put a Bantu class, and the one
+        // its own batch is built to contrast: Umbundu prefixes the class
+        // straight onto the describing stem, where `locales/kmb` next door
+        // moves a connective in front of an unchanged stem and `locales/kg`
+        // does the same a thousand kilometres north.
+        //
+        // What `@doenet/utils` pins is the agreement across three classes.
+        // What this checks is that the token survives `setLocaleData`, the
+        // document's locale and the `translator` dependency — and, in `sh`,
+        // that a border's concord follows the border's own class rather than
+        // the shape's.
+        expect(values.st).eq("yinene yikusuka lo olongoli vitito");
+        expect(values.stn).eq("ongoli yinene yikusuka lo olongoli vitito");
+        expect(values.pt).eq("kwadradu verdi");
+        expect(values.sh).eq(
+            "ocilinganya ciyukisiwa azulu lo olondimbu lo onele yinene yikusuka lo olongoli vitito",
+        );
+        expect(values.bd).eq("yinene yikusuka lo olongoli vitito");
+        expect(values.fd).eq("olondimbu azulu");
+    });
+
     it("agrees a Kongo linker through the worker path", async () => {
         const values = await descriptions(styled, names, "kg");
         // The lexifier of the Kituba below it, and the reason this batch put

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1077,6 +1077,42 @@ Umbundu one is the substitution this whole seeding effort is careful not to
 make. It is the clearest case in the repository for a real translator, and
 `locales/umb` records it at the foot of its own file so #1521 can find it.
 
+#### What reading the prose caught, and what it could not
+
+Reviewing these four message by message against `locales/en` turned up one
+defect in **all four at once**, which is worth recording because it is the
+first time a single mistranslation has been unanimous: `graph-grid-invalid`
+rendered "two **positive** numbers" as "two **big** numbers" in Mende,
+Umbundu, Kimbundu and Zarma alike — and the message's own example,
+`grid="1 0.5"`, contradicts it. Every one of the four already had the right
+idiom a few keys away, in
+`select-from-sequence-coprime-not-positive-integers`, so the fix was to reuse
+each catalog's own words rather than to invent any.
+
+The rest of what review fixed is the same shape: a clause the English has and
+the translation dropped (`attract-to-without-nearest-point` and its two
+`constrain-to-*` siblings lost "state variable" in all four), a quantifier
+that changed which claim it made ("will **always** match a blank" became
+"matches **only** a blank"), a complaint that reversed
+(`function-domain-insufficient-dimensions` read "dimensions are not
+*required*"), and buttons whose word belonged to a different control — the
+orbital spin arrows were labelled with `umb`'s, `kmb`'s and `dje`'s word for
+*point*, three lines from a real points control.
+
+**What review deliberately did not fix is the larger finding**, and it is a
+limit of seeding rather than a bug in these four. Each catalog spreads one
+word across several English concepts that the UI shows *at the same time*:
+`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry *variant*,
+*version*, *type* and *style* together, and `men`'s «wotela» carries
+*variant*, *version* and *variable*, so in all four the editor's version
+footer and its variant picker are labelled identically. Three of the
+four also head the feedback panel with their word for *answer*, and all four
+use one noun for both *viewer* and *renderer*, so the whole-page failure and
+the one-component failure read alike. Separating these needs new words chosen
+by someone who speaks the language; picking them here would be the
+substitution the chemistry tables are left out to avoid. They are named here
+so #1521 has them.
+
 ### A language with no word for it
 
 `tlh` is **Klingon**, and it is the roster's first constructed language. Nothing

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -87,11 +87,11 @@ which is what #1521's translation platform is for. None has been read by a
 speaker. Correcting one needs no permission and no coordination: a wrong string
 is just wrong, and the English is one key away.
 
-A hundred and fifteen of them are deliberately partial. A hundred and fourteen
+A hundred and nineteen of them are deliberately partial. A hundred and eighteen
 are partial in the same place — the two chemistry tables — while Klingon is
 partial almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The hundred
-and fourteen are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
+and eighteen are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
 Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
@@ -104,7 +104,8 @@ Pisin, Sanskrit, Maithili, Bhojpuri, Konkani, Dogri, Bodo, Manipuri, Santali,
 Kashmiri, Dhivehi, Tibetan, Dzongkha, Northern Sotho, Swati, Venda, Tsonga,
 Kikuyu, Bemba, Luo, Sango, Fula, Kabyle, Standard Moroccan Tamazight,
 Tachelhit, Rundi, Nyankole, Luba-Lulua, Kituba, Mooré, Dagbani, Dyula,
-Mandinka, Ga, Tiv, Kanuri, Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne
+Mandinka, Ga, Tiv, Kanuri, Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè, Temne,
+Mende, Umbundu, Kimbundu and Zarma
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
@@ -982,6 +983,97 @@ very nearly the language: filling those 130 keys in would produce entries
 character-identical to `locales/en` and claim a translation that had not
 happened. Leaving the gap visible is the honest answer, and it is the
 first time that argument has applied.
+
+### Angola, Sierra Leone and the Songhay
+
+Mende, Umbundu, Kimbundu and Zarma — four more, and where the last two batches
+asked where agreement goes and what a pair of catalogs shows, this one is
+arranged around **what a family does and does not predict**.
+
+**`umb` beside `kmb`** is the whole argument in two files. Umbundu and Kimbundu
+are the two largest languages of Angola, both Bantu, both with the same noun
+class system, spoken next door to one another — and Umbundu prefixes the class
+straight onto the describing stem while Kimbundu leaves the stem alone and moves
+an agreeing connective in front of it:
+
+| | line (c9) | circle (c7) | point (c5) |
+| --- | --- | --- | --- |
+| `umb` | ongoli **yi**nene | ocilinganya **ci**nene | ondimbu **li**nene |
+| `kmb` | nlonji **ya** nene | kizenge **kya** nene | kimbanza **kya** nene |
+
+And Kimbundu's shape is `locales/kg`'s exactly — an agreeing «-a» connective a
+thousand kilometres north, in another country. So **family does not predict the
+shape of agreement, and neither does geography.** That was #1686's lesson about
+a creole and its lexifier; this is the same lesson with the creole taken out,
+which makes it a fact about Bantu rather than about creolization.
+`styleDescriptions.test.ts` pins both halves.
+
+**`men` is the clearest instance of the affix rule in the tree.** Mende's
+definite marker is a suffix that attaches not to the noun but to whichever word
+*ends* the noun phrase, and a describing word follows its noun here — so a style
+description ends in a placeable, and «{ $color }i» is exactly what
+[An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
+forbids. The catalog is therefore written **entirely in the indefinite**, which
+is the "choose the words that land there" way out taken at the level of a whole
+file rather than of one message. That is defensible on its own terms: a style
+description is read out of context — "thick red line", not "the thick red
+line" — and the indefinite is what Mende uses there.
+
+Mende is also the fourth Mande catalog, and like `bm`, `dyu` and `mnk` it forks
+on nothing. Four Mande catalogs, four flat `noun-gender` messages: that is a
+family predicting something about agreement for once, and it is the only one in
+this repository that does.
+
+**`dje` is here for where it sits rather than for what it does.** Every other
+language in these three batches is Niger-Congo or an English-lexifier creole
+built on one. Songhay is neither, and its wider affiliation is genuinely
+unsettled — often filed under Nilo-Saharan, often argued to be an isolate that
+borrowed heavily from Mande and Berber. It forks on nothing, and its header says
+so plainly rather than hunting for an argument: a batch that only ever added
+forking catalogs would be selecting its languages for the argument rather than
+for the readers.
+
+#### Negotiation: a second member-shaped macrolanguage, and a road still not taken
+
+`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a *member*
+catalog carrying its siblings, rather than a macrolanguage carrying its members.
+`ddn`, `hmb`, `khq`, `ses`, `tda` and `twq` reach Zarma, and ICU folds none of
+them on its own, so every one of those six depends on the entry existing.
+
+**`son` is still not aliased**, and that is the half worth reading. #1686
+recorded the reason when no Songhay catalog existed; Zarma's arrival makes the
+alias *possible* and no more justified. `man` earns its alias because CLDR
+decides for itself which member a bare macrolanguage means —
+`new Intl.Locale("man").maximize()` is `man-Latn-GM`, Mandinka's country.
+`new Intl.Locale("son").maximize()` adds no region at all, so CLDR has no
+opinion, and picking Zarma because it is the largest would be the judgement
+these maps exist to avoid. The test asserts the absent region rather than the
+absent entry, so a change in ICU data — not a change of mind — is what would
+reopen it.
+
+`tda` is this batch's script debt: Tadaksahak maximizes to `tda-Tfng-NE`, so a
+reader CLDR expects in Tifinagh is served Latin. That is `locales/kr`'s
+asymmetry with `kby` in Ajami and `locales/ff`'s in Adlam, and the answer is a
+second catalog rather than a change here.
+
+Three codes came *off* negative-control lists this batch — `men`, `umb` and
+`kmb` were all asserted to fall to English until they got catalogs of their own.
+That is the only thing that should ever shorten such a list, and `nyn` set the
+precedent two batches ago.
+
+#### The chemistry gap reaches Portuguese
+
+All four leave `element-name` and `element-anion-name` out. Mende and Zarma are
+ordinary school-system cases — Sierra Leone teaches secondary science in English
+and Niger in French. **Umbundu and Kimbundu are a third shape and a sharper
+one.** Angola teaches in Portuguese, so the English fallback is neither the
+language nor the curriculum: it answers nobody.
+
+That is an argument for filling those keys in from Portuguese, not for leaving
+them — and they are left anyway, because a Portuguese table dressed as an
+Umbundu one is the substitution this whole seeding effort is careful not to
+make. It is the clearest case in the repository for a real translator, and
+`locales/umb` records it at the foot of its own file so #1521 can find it.
 
 ### A language with no word for it
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1014,8 +1014,9 @@ definite marker is a suffix that attaches not to the noun but to whichever word
 *ends* the noun phrase, and a describing word follows its noun here — so a style
 description ends in a placeable, and «{ $color }i» is exactly what
 [An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
-forbids. The catalog is therefore written **entirely in the indefinite**, which
-is the "choose the words that land there" way out taken at the level of a whole
+forbids. The catalog therefore leaves **every describing word indefinite**, so
+that no description ends in the suffix and the suffix is never written against a
+placeable — the "choose the words that land there" way out taken at the level of a whole
 file rather than of one message. That is defensible on its own terms: a style
 description is read out of context — "thick red line", not "the thick red
 line" — and the indefinite is what Mende uses there.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1001,8 +1001,9 @@ an agreeing connective in front of it:
 | `umb` | ongoli **yi**nene | ocilinganya **ci**nene | ondimbu **li**nene |
 | `kmb` | nlonji **ya** nene | kizenge **kya** nene | kimbanza **kya** nene |
 
-And Kimbundu's shape is `locales/kg`'s exactly — an agreeing «-a» connective a
-thousand kilometres north, in another country. So **family does not predict the
+And Kimbundu's mechanism is `locales/kg`'s exactly — an agreeing «-a»
+connective a thousand kilometres north, in another country, differing only in
+which classes the two catalogs happen to fork on. So **family does not predict the
 shape of agreement, and neither does geography.** That was #1686's lesson about
 a creole and its lexifier; this is the same lesson with the creole taken out,
 which makes it a fact about Bantu rather than about creolization.
@@ -1025,10 +1026,11 @@ family predicting something about agreement for once, and it is the only one in
 this repository that does.
 
 **`dje` is here for where it sits rather than for what it does.** Every other
-language in these three batches is Niger-Congo or an English-lexifier creole
-built on one. Songhay is neither, and its wider affiliation is genuinely
-unsettled — often filed under Nilo-Saharan, often argued to be an isolate that
-borrowed heavily from Mande and Berber. It forks on nothing, and its header says
+language in these three batches but one is Niger-Congo or an English-lexifier
+creole built on one; the exception is `locales/kr`, the Nilo-Saharan catalog
+#1685 seeded. Songhay is neither Niger-Congo nor securely anything else — its
+affiliation is genuinely unsettled, often filed under Nilo-Saharan, often
+argued to be an isolate that borrowed heavily from Mande and Berber. It forks on nothing, and its header says
 so plainly rather than hunting for an argument: a batch that only ever added
 forking catalogs would be selecting its languages for the argument rather than
 for the readers.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1717,7 +1717,7 @@ what that value turns out to *be*:
 | The catalog wants | The language | Why it cannot |
 | --- | --- | --- |
 | a case ending on the value | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
-| the definite article on the value | `ro` | the article is a suffix — «secțiune» → «secțiunea» |
+| the definite article on the value | `ro`, `men` | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai» |
 | a preposition before the value | `cs`, `sk` | «v»/«ve» and «s»/«se» vocalize according to what follows |
 | a compound with the value | `fi` | Finnish writes a compound as one word |
 | a case particle after the value | `bo`, `dz` | the particle has four shapes, picked by the final letter of the syllable before it |
@@ -1785,7 +1785,11 @@ There are five ways out, and every catalog here takes one of them:
   Hungarian («ehhez: { $answerId }»).
 - **Choose the words that land there.** Czech's pattern for horizontal lines is
   «horizontální čáry» rather than «vodorovné čáry», because «v vodorovné» would
-  have wanted «ve».
+  have wanted «ve». `locales/men` takes the same way out across a whole file
+  rather than one message, staying in the indefinite so that no description ever
+  ends in a definite suffix — see
+  [Angola, Sierra Leone and the Songhay](#angola-sierra-leone-and-the-songhay)
+  for why that is the right reading of Mende rather than a dodge.
 - **Write both forms.** Hungarian's «a(z)» is the standard orthographic answer
   to exactly this problem, and predates software by a long way.
 - **Prefer the free allomorph over the bound one.** Where the affix has a

--- a/packages/i18n/locales/dje/chrome.ftl
+++ b/packages/i18n/locales/dje/chrome.ftl
@@ -1,0 +1,134 @@
+# Zarma viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for why this catalog is in the roster, for the
+# `son` macrolanguage decision it carries, and for what a speaker should check
+# first.
+
+
+## Answer submission
+
+answer-checking = Goo ma guna…
+answer-submitting = Goo ma samba…
+
+answer-checking-status = I goo ga tuuruyaŋo guna
+answer-submitting-status = I goo ga tuuruyaŋo samba
+
+answer-correct = A ga cimi
+answer-incorrect = A si cimi
+
+answer-response-saved = Tuuruyaŋo Gaay
+
+answer-percent-credit = { $percent }% Nooru
+answer-percent-correct = { $percent }% Cimi
+answer-percent-short = { $percent } %
+
+max-credit-available = Nooru beeri kaŋ ni ga du: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] dooni kulu si cindi
+        [one] dooni { $count } cindi
+       *[other] dooni { $count } cindi
+    }
+
+validation-correct = (A ga cimi)
+validation-incorrect = (A si cimi)
+validation-partially-correct = (A ga cimi kayna)
+
+answer-show-responses =
+    { $count ->
+        [one] Cabe tuuruyaŋ { $count } { $answerId } se
+       *[other] Cabe tuuruyaŋ { $count } { $answerId } se
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Tuuruyaŋ
+
+collapsible-click-to-open = (kar zama a ma feeri)
+collapsible-click-to-close = (kar zama a ma daabu)
+
+collapsible-initializing = Goo ma sintin…
+
+footnote-show = Cabe ganda hantumo
+footnote-hide = Tugu ganda hantumo
+
+description-more-information = bayrandi fo
+
+
+## Controls
+
+slider-previous = Kaŋ bisa
+slider-next = Kaŋ ga kaa
+
+keyboard-open = Feeri Klaviye
+keyboard-close = Daabu Klaviye
+
+choice-input-remove-choice = Kaa { $choice }
+
+matrix-remove-row = Kaa kar
+matrix-add-row = Tonton kar
+matrix-remove-column = Kaa kolon
+matrix-add-column = Tonton kolon
+
+subset-add-remove-points = Tonton/Kaa alaama-yaŋ
+subset-toggle-points-intervals = Barmay alaama-yaŋ nda alwaati-yaŋ
+subset-move-points = Ganandi Alaama-yaŋ
+subset-clear = Tuusu
+
+orbital-add-row = Tonton Kar
+orbital-remove-row = Kaa Kar
+orbital-add-box = Tonton Sanduku
+orbital-remove-box = Kaa Sanduku
+orbital-add-up-arrow = Tonton Beene Alaama
+orbital-add-down-arrow = Tonton Ganda Alaama
+orbital-remove-arrow = Kaa Alaama
+
+orbital-row-label = Kar { $row } maa
+
+pretzel-answer = Tuuruyaŋ
+
+summary-statistics-caption = { $column } lasaabu feerijandi
+
+
+## Math input
+
+math-input-preview-region = lasaabu sanni jina guna
+math-input-preview = Guna jina
+math-input-invalid-expression = Sanni kaŋ si boori:
+
+
+## Document status
+
+viewer-initializing = Goo ma sintin…
+
+
+## Errors
+
+error-heading = Taali
+
+error-found-at =
+    { $span ->
+        [line] I du a kar { $startLine } ga.
+       *[lines] I du a kar { $startLine }–{ $endLine } ga.
+    }
+
+document-contains-errors = Tira woo gonda taali-yaŋ!
+
+diagnostic-heading-error = Taali
+diagnostic-heading-warning = Yaamar
+diagnostic-heading-information = Bayrandi
+diagnostic-heading-hint = Faada
+
+accessibility-heading-level-1 = WCAG AA Duyaŋ Sanno Ŋwaarey
+accessibility-heading-level-2 = Duyaŋ yaamar
+
+something-went-wrong = Hay fo mana boori.
+
+renderer-load-failed = cabeko fo mana kaa. Ay ga ni ŋwaaray, ye moo ga zumandi.
+
+core-start-failed = Tira cabeko mana hin ka sintin. Ay ga ni ŋwaaray, ye moo ga zumandi.

--- a/packages/i18n/locales/dje/chrome.ftl
+++ b/packages/i18n/locales/dje/chrome.ftl
@@ -84,9 +84,9 @@ orbital-add-row = Tonton Kar
 orbital-remove-row = Kaa Kar
 orbital-add-box = Tonton Sanduku
 orbital-remove-box = Kaa Sanduku
-orbital-add-up-arrow = Tonton Beene Alaama
-orbital-add-down-arrow = Tonton Ganda Alaama
-orbital-remove-arrow = Kaa Alaama
+orbital-add-up-arrow = Tonton Beene Hangaw
+orbital-add-down-arrow = Tonton Ganda Hangaw
+orbital-remove-arrow = Kaa Hangaw
 
 orbital-row-label = Kar { $row } maa
 

--- a/packages/i18n/locales/dje/content.ftl
+++ b/packages/i18n/locales/dje/content.ftl
@@ -5,17 +5,20 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # `dje` is Zarma (Zarmaciine), the largest Songhay variety and the most widely
-# spoken language of Niger after Hausa. It is the second Nigerien catalog here,
-# after `locales/kr` (Kanuri) in #1685.
+# spoken language of Niger after Hausa. It is the second catalog here for a
+# language of Niger, after `locales/kr` (Kanuri, whose range crosses eastern
+# Niger) in #1685.
 #
 # **Songhay is the reason this catalog is here, and the reason is
 # classificatory rather than morphological.** Every other language in these
-# three batches is Niger-Congo — Bantu, Gur, Mande, Atlantic, Kwa,
-# Benue-Congo — or an English-lexifier creole built on one. Songhay is none of
-# those. Its wider affiliation is genuinely unsettled: it is often filed under
-# Nilo-Saharan, and it is just as often argued to be an isolate that borrowed
-# heavily from Mande and Berber. `locales/kr` is the only neighbour here under
-# the same disputed label, and the two are not close.
+# three batches but one is Niger-Congo — Bantu, Gur, Mande, Atlantic, Kwa,
+# Benue-Congo — or an English-lexifier creole built on one. Songhay is not, and
+# neither is the exception: `locales/kr`, which #1685 seeded as the one
+# Nilo-Saharan catalog of its batch. Zarma's own affiliation is genuinely
+# unsettled — often filed under Nilo-Saharan too, and just as often argued to
+# be an isolate that borrowed heavily from Mande and Berber — so `locales/kr`
+# is the only neighbour here under the same disputed label, and the two are not
+# close.
 #
 # **`$gender` and `$role` both go unused.** Zarma has no noun class and no
 # gender, and marks no case; a describing word follows its noun and never

--- a/packages/i18n/locales/dje/content.ftl
+++ b/packages/i18n/locales/dje/content.ftl
@@ -1,0 +1,281 @@
+# Zarma content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `dje` is Zarma (Zarmaciine), the largest Songhay variety and the most widely
+# spoken language of Niger after Hausa. It is the second Nigerien catalog here,
+# after `locales/kr` (Kanuri) in #1685.
+#
+# **Songhay is the reason this catalog is here, and the reason is
+# classificatory rather than morphological.** Every other language in these
+# three batches is Niger-Congo — Bantu, Gur, Mande, Atlantic, Kwa,
+# Benue-Congo — or an English-lexifier creole built on one. Songhay is none of
+# those. Its wider affiliation is genuinely unsettled: it is often filed under
+# Nilo-Saharan, and it is just as often argued to be an isolate that borrowed
+# heavily from Mande and Berber. `locales/kr` is the only neighbour here under
+# the same disputed label, and the two are not close.
+#
+# **`$gender` and `$role` both go unused.** Zarma has no noun class and no
+# gender, and marks no case; a describing word follows its noun and never
+# changes shape. So the catalog looks like `locales/men` or `locales/pcm` from
+# the outside — and that is worth saying plainly, because the interesting fact
+# about this file is *where it sits in the roster*, not what it does with
+# `$gender`. A batch that only ever added forking catalogs would be selecting
+# its languages for the argument rather than for the readers.
+#
+# **The negotiation entry is this file's real contribution**, and it is the
+# shape `locales/mnk` introduced. `son` is the ISO 639-3 macrolanguage over the
+# Songhay varieties; this repository now has a catalog for one *member* and
+# none for the macrolanguage. #1686 recorded that `son` was deliberately not
+# aliased, because `new Intl.Locale("son").maximize()` adds no region and CLDR
+# therefore has no opinion about which variety a bare `son` means — the
+# opposite of `man`, which maximizes to the Gambia and so decides for itself.
+# That reasoning is unchanged by this catalog's arrival and the test still
+# asserts it. What *is* new is that `dje` can now carry its sibling members —
+# `ddn`, `khq`, `ses`, `twq` and the rest — the way `mnk` carries the other
+# Manding varieties. See `negotiate.ts`.
+#
+# Zarma writes in the official Nigerien Latin orthography, with «ɲ» and the
+# open vowels. Colour terms are few — «bi» black, «kwaaray» white, «ciray» red
+# — and the rest are French, which is where a Zarma speaker meets them.
+#
+# The geometry leans on those French loans; where Zarma has its own word it is
+# used — «nangu» a place, «alaama» a sign. They are the first thing to check.
+
+
+## Style vocabulary
+
+color =
+    .black = bi
+    .white = kwaaray
+    .gray = boosu
+    .red = ciray
+    .orange = oranji
+    .yellow = jooni
+    .green = veer
+    .cyan = siyaŋ
+    .blue = bulu
+    .purple = violee
+    .pink = roozu
+    .brown = maroŋ
+
+line-width =
+    .thick = beeri
+    .thin = kayna
+
+# Written as «nda …» phrases rather than as bare qualifiers, so that they close
+# the description. `style-stroke` puts them last.
+line-style =
+    .dashed = nda dumbu-dumbu
+    .dotted = nda alaama-alaama
+
+fill-style =
+    .horizontal = kar-yaŋ kaŋ ga kani
+    .vertical = kar-yaŋ kaŋ ga kay
+    .diagonal = kar-yaŋ kaŋ ga daŋ banda
+    .backdiagonal = kar-yaŋ kaŋ ga daŋ banda kambu fo ra
+    .dots = alaama-yaŋ
+    .diamonds = diyaman-yaŋ
+
+noun =
+    .line = kar
+    .line-segment = kar dumbu
+    .ray = hayni
+    .vector = vekteer
+    .curve = kar kaŋ ga gungum
+    .function = fonksiyon
+    .parabola = parabol
+    .polyline = kar dumbu boobo
+    .polygon = poligon
+    .triangle = triyangul
+    .rectangle = rektangul
+    .circle = windi
+    .region = nangu
+    .point = alaama
+    .square = kaare
+    .diamond = diyaman
+    .cross = gurumey
+    .plus = tontoni alaama
+
+# The side count is a relative and closes the noun phrase behind the describing
+# words, so it goes in the tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] kaŋ gonda kambu { $numSides }
+       *[head] poligon saawa
+    }
+
+# Zarma has no noun class and no gender, so every noun answers the same and the
+# answer goes unused — the shape `locales/en`, `locales/men` and `locales/pcm`
+# have.
+noun-gender = afo
+
+
+## Style composition
+
+# The dash pattern is a «nda …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = toonante
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } nda { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } nda { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } nda { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «hirri» is the border and leads its own describing words. Zarma has no
+# article and joins this clause with the invariable «nda», so all four branches
+# read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] nda hirri { $border }
+        [and] nda hirri { $border }
+        [and-article] nda hirri { $border }
+       *[with] nda hirri { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = mana too
+
+style-text =
+    { $parts ->
+        [background] { $color } nda banda { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = hay kulu si
+
+
+## Boolean words
+
+boolean-true = cimi
+boolean-false = tangari
+
+
+## Answer buttons
+
+answer-submit-label = Guna Goyo
+answer-submit-label-no-correctness = Samba Tuuruyaŋ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Goy
+    .aside = Sanni fo
+    .cascade = Kaskad
+    .definition = Feerijandi
+    .example = Misal
+    .exercise = Dooni
+    .exercises = Dooni-yaŋ
+    .given-answer = Tuuruyaŋ
+    .note = Hantum
+    .objectives = Miila-yaŋ
+    .paragraphs = Dumbu-yaŋ
+    .part = Dumbu
+    .problem = Taabi
+    .problems = Taabi-yaŋ
+    .proof = Seeda
+    .question = Hã
+    .section = Dumbu
+    .solution = Feeriji
+    .task = Goy
+    .theorem = Teorem
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Faada
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tablo { $enumeration }
+        [numbered-title] Tablo { $enumeration }{ ": " }
+        [unnumbered-title] Tablo{ ": " }
+       *[unnumbered] Tablo
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Biiyaŋ { $enumeration }
+        [numbered-caption] Biiyaŋ { $enumeration }{ ": " }
+        [unnumbered-caption] Biiyaŋ{ ": " }
+       *[unnumbered] Biiyaŋ
+    }
+
+
+## Paginator controls
+
+paginator-previous = Kaŋ bisa
+paginator-next = Kaŋ ga kaa
+
+paginator-page = Moo
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = wala
+
+piecewise-condition-if = da
+
+piecewise-condition-otherwise = hari fo kulu ra
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case. Niger teaches secondary science in French, so a
+## Zarma speaker meets the periodic table there and neither Zarma nor English
+## is the curriculum — the same answer `locales/kr` gives from the same
+## ministry, and `locales/kg`, `locales/fon` and `locales/kbp` from theirs.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Simi Alaama Kaŋ Si Boori
+chemistry-invalid-ionic-compound = Iyon Margayaŋ Kaŋ Si Boori

--- a/packages/i18n/locales/dje/content.ftl
+++ b/packages/i18n/locales/dje/content.ftl
@@ -40,8 +40,11 @@
 # `ddn`, `khq`, `ses`, `twq` and the rest — the way `mnk` carries the other
 # Manding varieties. See `negotiate.ts`.
 #
-# Zarma writes in the official Nigerien Latin orthography, with «ɲ» and the
-# open vowels. Colour terms are few — «bi» black, «kwaaray» white, «ciray» red
+# Zarma writes in the official Nigerien Latin orthography. The one letter in it
+# outside ASCII is «ŋ», which is common — «kaŋ», «ŋwaarey», «duyaŋ» — while «ɲ»
+# and the open vowels «ɛ» and «ɔ» happen not to occur anywhere in these four
+# files, so a reviewer editing them will type plain ASCII almost throughout.
+# Colour terms are few — «bi» black, «kwaaray» white, «ciray» red
 # — and the rest are French, which is where a Zarma speaker meets them.
 #
 # The geometry leans on those French loans; where Zarma has its own word it is

--- a/packages/i18n/locales/dje/content.ftl
+++ b/packages/i18n/locales/dje/content.ftl
@@ -42,8 +42,9 @@
 #
 # Zarma writes in the official Nigerien Latin orthography. The one letter in it
 # outside ASCII is «ŋ», which is common — «kaŋ», «ŋwaarey», «duyaŋ» — while «ɲ»
-# and the open vowels «ɛ» and «ɔ» happen not to occur anywhere in these four
-# files, so a reviewer editing them will type plain ASCII almost throughout.
+# and the open vowels «ɛ» and «ɔ» happen not to occur in any message of these
+# four files (the only three in the tree are the ones named in this sentence),
+# so a reviewer editing them will type plain ASCII almost throughout.
 # Colour terms are few — «bi» black, «kwaaray» white, «ciray» red
 # — and the rest are French, which is where a Zarma speaker meets them.
 #

--- a/packages/i18n/locales/dje/diagnostics.ftl
+++ b/packages/i18n/locales/dje/diagnostics.ftl
@@ -49,11 +49,11 @@ vector-dimension-mismatch = numDimensions si saba vekteero ra.
 
 ## Attracting and constraining
 
-attract-to-without-nearest-point = I si hin ka candi `<{ $component }>` ga zama a sinda nearestPoint.
+attract-to-without-nearest-point = I si hin ka candi `<{ $component }>` ga zama a sinda nearestPoint stet barmayyaŋ.
 
-constrain-to-without-nearest-point = I si hin ka haw `<{ $component }>` ga zama a sinda nearestPoint.
+constrain-to-without-nearest-point = I si hin ka haw `<{ $component }>` ga zama a sinda nearestPoint stet barmayyaŋ.
 
-constrain-to-interior-without-nearest-point = I si hin ka haw `<{ $component }>` ra zama a sinda nearestPoint.
+constrain-to-interior-without-nearest-point = I si hin ka haw `<{ $component }>` ra zama a sinda nearestPoint stet barmayyaŋ.
 
 ## `<choiceInput>`
 
@@ -264,13 +264,13 @@ eigen-decomposition-failed = I mana hin ka matris aygenvalue-yaŋ lasaabu
 
 matches-pattern-parameter-not-in-pattern =
     { $parametersCount ->
-        [one] `<matchesPattern>`: parameter { $parameters } si dumo ra, woodin se a ga saba nda hay kulu si alwaati kulu.
-       *[other] `<matchesPattern>`: parameters { $parameters } si dumo ra, woodin se i ga saba nda hay kulu si alwaati kulu.
+        [one] `<matchesPattern>`: parameter { $parameters } si dumo ra, woodin se a ga saba nda nangu koonu alwaati kulu.
+       *[other] `<matchesPattern>`: parameters { $parameters } si dumo ra, woodin se i ga saba nda nangu koonu alwaati kulu.
     }
 
 ## `<graph>`
 
-graph-grid-invalid = `<graph>`: i si hin ka grid="{ $grid }" faham. A ga hima ka ciya none, medium, dense, wala lasaabu hinka beeri kaŋ nangu na i fay, danga grid="1 0.5". I si grid kulu te.
+graph-grid-invalid = `<graph>`: i si hin ka grid="{ $grid }" faham. A ga hima ka ciya none, medium, dense, wala lasaabu hinka kaŋ go beene ziro ga kaŋ nangu na i fay, danga grid="1 0.5". I si grid kulu te.
 
 ## PreFigure renderer
 

--- a/packages/i18n/locales/dje/diagnostics.ftl
+++ b/packages/i18n/locales/dje/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Zarma diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] i ga { $attributes } furu waati kaŋ i na me hinka ci
+       *[other] i ga { $attributes } furu waati kaŋ i na me hinka ci
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] i ga { $attributes } furu waati kaŋ i na me nda bindi ci care banda
+       *[other] i ga { $attributes } furu waati kaŋ i na me nda bindi ci care banda
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset si goy da bindi si no
+
+## `<line>`
+
+line-points-undetermined-dimensions = Kar kaŋ ga bisa alaama-yaŋ kaŋ i beero mana bay ga.
+
+line-points-too-few-dimensions = Kar ga hima ka bisa alaama-yaŋ kaŋ gonda beeray hinka wala ka bisa.
+
+line-points-depend-on-variables = Kar ga bisa alaama-yaŋ kaŋ ga barmayyaŋ gaay: { $variables }.
+
+line-equation-invalid-format = Kar ekwasiyon dumo si boori { $variable1 } nda { $variable2 } ra.
+
+## `<ray>`
+
+ray-overprescribed-through = I na hayno ci nda through, endpoint nda direction.  I ga through kaŋ i ci furu.
+
+ray-dimension-mismatch = numDimensions si saba hayno ra.
+
+## `<vector>`
+
+vector-overprescribed-head = I na vekteero ci nda head, tail nda displacement.  I ga head kaŋ i ci furu.
+
+vector-dimension-mismatch = numDimensions si saba vekteero ra.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = I si hin ka candi `<{ $component }>` ga zama a sinda nearestPoint.
+
+constrain-to-without-nearest-point = I si hin ka haw `<{ $component }>` ga zama a sinda nearestPoint.
+
+constrain-to-interior-without-nearest-point = I si hin ka haw `<{ $component }>` ra zama a sinda nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = i ga labelPosition furu choiceInput kaŋ manti inline se
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = I ga indices kaŋ i ci choiceInput se furu zama indices lasaabo si saba nda choice izey lasaabo.
+
+pretzel-indices-count-mismatch = I ga indices kaŋ i ci problem se furu zama indices lasaabo si saba nda problem izey lasaabo.
+
+shuffle-indices-count-mismatch = I ga indices kaŋ i ci shuffle se furu zama indices lasaabo si saba nda hariyey lasaabo.
+
+indices-ignored-out-of-range = I ga indices kaŋ i ci { $component } se furu zama afooyaŋ go taray.
+
+pretzel-indices-repeated = I ga indices kaŋ i ci pretzel se furu zama afooyaŋ ye ka kaa.
+
+pretzel-circuit-first-index = I ga indices kaŋ i ci pretzel se mode="circuit" ra furu zama index sintina ga hima ka ciya 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Zama `<{ $component }>` ma goy nda string izey, i ga hima ka `type` attribute ci.
+
+invalid-type-defaulting-to-math = Type { $type } si boori { $component } se. A ga hima ka ciya math, text, number wala boolean. I ga math goy.
+
+string-not-valid-component-to-arrange = String "{ $value }" manti hari hanno no { $component } se. I g'a furu.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } si boori, i na type daŋ number ga.
+
+invalid-variable-value = Barmayyaŋ hari kaŋ si boori: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Dumi index { $index } ga hima ka ciya lasaabu
+
+variant-index-must-be-integer = Dumi index { $index } ga hima ka ciya lasaabu timme
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = I mana `<{ $component }>` te neesiji timmey se. I na beerayey daŋ neesiji fo-yaŋ ga.
+
+side-by-side-absolute-margins = I mana `<{ $component }>` te neesiji timmey se. I na hirriyey daŋ neesiji fo-yaŋ ga.
+
+side-by-side-no-block-child = `<{ $component }>` si boori: a ga hima ka block ize folloŋ wala ka bisa du.
+
+## `<label>`
+
+label-for-ignored-on-graphical = I ga `for` attribute biiyaŋ `<label>` ga furu.
+
+label-for-must-resolve-to-one = `for` attribute `<label>` ga ga hima ka koy hari folloŋ hinne ga.
+
+label-for-unresolved = `for` attribute `<label>` ga mana hin ka koy hari kulu ga.
+
+label-for-answer-with-authored-inputs = `for` attribute `<label>` ga ga `<answer>` kaŋ gonda inputs kaŋ i hantum ci; ma input bumbo ci.
+
+label-for-answer-without-input = `for` attribute `<label>` ga ga `<answer>` kaŋ sinda input ci.
+
+label-for-must-reference-input-or-answer = `for` attribute `<label>` ga ga hima ka input wala answer ci.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Duyaŋ se, `<{ $component }>` ga hima ka feerijandi dunbu du wala i m'a ci danga decorative.
+
+accessibility-video-short-description = Duyaŋ se, `<video>` ga hima ka feerijandi dunbu du.
+
+accessibility-input-short-description-or-label = Duyaŋ se, `<{ $component }>` ga hima ka feerijandi dunbu wala maa du.
+
+accessibility-answer-input-short-description-or-label = Duyaŋ se, `<answer>` kaŋ ga input te ga hima ka feerijandi dunbu wala maa du.
+
+accessibility-short-description-contains-math = Feerijandi dunbu-yaŋ si hima ka lasaabu hari-yaŋ du danga `<{ $component }>`. Ma lasaabo hantum nda sanni.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } sinda fayanka kaŋ ga wasa dumbu boŋ sanno se (mode bi) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ga { $threshold }:1 wala ka bisa ŋwaaray).
+       *[other] { $colorName } sinda fayanka kaŋ ga wasa dumbu boŋ sanno se ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ga { $threshold }:1 wala ka bisa ŋwaaray).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = I mana `<circle>` kaŋ ga bisa alaama { $count } ga te waati kaŋ alaamey sinda lasaabu.
+
+circle-too-many-through-points = I si hin ka windi lasaabu kaŋ ga bisa alaama 3 ka bisa ga.
+
+circle-overprescribed-radius-center-points = I si hin ka windi lasaabu nda radius, bindi nda alaamey care banda.
+
+circle-center-with-multiple-points = I si hin ka windi lasaabu nda bindi kaŋ ga bisa alaama 1 ka bisa ga.
+
+circle-radius-too-small = I si hin ka windo lasaabu: zama nangu kaŋ go alaama hinka game ra ga ti { $distance }, radius { $radius } kaŋ i ci ga kayna gumo.
+
+circle-radius-with-many-points = I si hin ka windi te kaŋ ga bisa alaama hinka ka bisa ga nda radius kaŋ i ci.
+
+circle-invalid-center-or-through-points = Windo bindi wala a alaamey si boori.
+
+circle-radius-center-with-multiple-points = I si hin ka windo radius lasaabu nda bindi kaŋ ga bisa alaama 1 ka bisa ga.
+
+circle-change-radius-non-numerical = I si hin ka windo radius barmay nda alaama-yaŋ kaŋ sinda lasaabu
+
+circle-radius-with-points-non-numerical = I si hin ka windi te kaŋ ga bisa alaama folloŋ ka bisa ga nda radius waati kaŋ lasaabey si no.
+
+circle-change-center-non-numerical = I mana windo bindi barmayyaŋ te kaŋ ga bisa alaama-yaŋ kaŋ sinda lasaabu ga.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Beerayey si wasa fonksiyon domain se. Domain gonda alwaati { $intervals } amma fonksiyono gonda { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+       *[other] Beerayey si wasa fonksiyon domain se. Domain gonda alwaati { $intervals } amma fonksiyono gonda { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Fonksiyon domain dumo si boori.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] I ga fonksiyono beero kaŋ sinda lasaabu furu.
+        [minimum] I ga fonksiyono kaynayaŋo kaŋ sinda lasaabu furu.
+        [extremum] I ga fonksiyono meyo kaŋ sinda lasaabu furu.
+        [point] I ga fonksiyono alaamo kaŋ sinda lasaabu furu.
+        [slope] I ga fonksiyono gungumyaŋo kaŋ sinda lasaabu furu.
+       *[other] I ga fonksiyono { $type } kaŋ sinda lasaabu furu.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] I ga fonksiyono beero kaŋ sinda hay kulu furu.
+        [minimum] I ga fonksiyono kaynayaŋo kaŋ sinda hay kulu furu.
+        [extremum] I ga fonksiyono meyo kaŋ sinda hay kulu furu.
+        [point] I ga fonksiyono alaamo kaŋ sinda hay kulu furu.
+       *[other] I ga fonksiyono { $type } kaŋ sinda hay kulu furu.
+    }
+
+function-points-too-close = Fonksiyono gonda alaama hinka kaŋ ga maan care gumo. I si hin ka fonksiyono feeri.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Fonksiyon yeyaŋ ga hin hinne da inputs lasaabo ga saba nda outputs lasaabo. Fonksiyon woo gonda input { $inputs } nda { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+       *[other] Fonksiyon yeyaŋ ga hin hinne da inputs lasaabo ga saba nda outputs lasaabo. Fonksiyon woo gonda inputs { $inputs } nda { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Sequence salaŋo si boori.  A ga hima ka ciya lasaabu timme kaŋ si ganda ziro ga.
+
+sequence-invalid-step = Sequence step si boori.  A ga hima ka ciya lasaabu sequence type { $type } se.
+
+sequence-invalid-endpoint-number = Number sequence "{ $attribute }" si boori.  A ga hima ka ciya lasaabu.
+
+sequence-invalid-endpoint-letters = Letters sequence "{ $attribute }" si boori.  A ga hima ka ciya hantum alaama margayaŋ.
+
+sequence-invalid-endpoint = Sequence "{ $attribute }" si boori.
+
+select-from-sequence-coprime-not-numbers = i ga coprime furu zama i si lasaabu-yaŋ suuban
+
+select-from-sequence-coprime-with-exclude-combinations = i ga coprime furu zama i na excludeCombinations ci
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` target si boori: i si hin ka targeto du.
+
+target-state-variable-not-found = `<{ $source }>` target si boori: i si hin ka stet barmayyaŋ kaŋ maa ga ti "{ $property }" du `<{ $component }>` ga.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` barmayyaŋey ga hima ka fay nda barmayyaŋ kaŋ ga tun nga boŋ se.
+
+ode-system-duplicate-variable-names = I si hin ka ODE RHS fonksiyon-yaŋ feeri nda barmayyaŋ maa-yaŋ kaŋ ye ka kaa.
+
+ode-system-rhs-function-error = I si hin ka ODE RHS fonksiyon feeri.  Taali go mathjs fonksiyon teeyaŋ ra.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = I si hin ka kanjari feeri kar { $count } game ra
+
+angle-invalid-through-point = Alaama si boori `<angle>` through ra
+
+parabola-vertex-too-many-points = I mana parabol nda vertex kaŋ ga bisa alaama 1 ka bisa ga te.
+
+parabola-too-many-points = I mana parabol kaŋ ga bisa alaama 3 ka bisa ga te.
+
+intersection-too-many-items = I mana hari hinka ka bisa margayaŋ te
+
+## Other math components
+
+ionic-compound-not-two-ions = I mana iyon margayaŋ te hari fo se kaŋ manti iyon hinka.
+
+ionic-compound-needs-cation-and-anion = I na iyon margayaŋ te katiyon folloŋ nda aniyon folloŋ se hinne.
+
+solve-equations-cannot-evaluate = I si hin ka ekwasiyono feeri zama i si hin k'a lasaabu: { $equation }
+
+math-operators-operand-number-required = I ga hima ka operandNumber ci waati kaŋ i ga lasaabu operand kaa.
+
+eigen-decomposition-failed = I mana hin ka matris aygenvalue-yaŋ lasaabu
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } si dumo ra, woodin se a ga saba nda hay kulu si alwaati kulu.
+       *[other] `<matchesPattern>`: parameters { $parameters } si dumo ra, woodin se i ga saba nda hay kulu si alwaati kulu.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: i si hin ka grid="{ $grid }" faham. A ga hima ka ciya none, medium, dense, wala lasaabu hinka beeri kaŋ nangu na i fay, danga grid="1 0.5". I si grid kulu te.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" si goy prefigure cabeko ra; i ga kambe ŋwaari kambo goy.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" si goy prefigure cabeko ra; i ga beene kambo goy.
+
+prefigure-invalid-axis-bounds = `<graph>`: aksis hirriyey si boori prefigure se; i ga bbox (-10,-10,10,10) goy.
+
+prefigure-invalid-width = `<graph>`: beeray si boori prefigure se; i ga beeray 425 goy.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio si boori prefigure se; i ga aspekt rasiyo 1 goy.
+
+prefigure-grid-spacing-too-fine = `<graph>`: grid nanguyaŋo ga kayna gumo aksis hirriyey se; i ga grid kaa prefigure cabeko ra.
+
+prefigure-annotations-not-rendered = `<graph>`: i si annotations cabe da i si PreFigure cabeko goy.
+
+multiple-annotations-children = I du `<annotations>` ize boobo `<graph>` ra; i g'i kulu furu kala kaŋ ga ban.
+
+## Referring to other components
+
+copy-unrecognized-component-type = I si hin ka hari dumi kaŋ i mana bay tonton wala ka duplika: { $type }.
+
+copy-prop-not-found = I mana hin ka prop { $property } du hari dumi { $component } ga
+
+collect-no-source = I mana tunyaŋ du collect se.
+
+collect-invalid-component-type = I si hin ka hari dumi `<{ $component }>` margu zama dumo si boori.
+
+reference-index-unavailable = I si hin ka index `{ $reference }` ci
+
+## `<callAction>`
+
+component-action-unavailable = I si hin ka { $action } ce hari `{ $reference }` ga
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Bayrandi dumo si boori.  Karey gonda salaŋ waani-waani. I du a componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Bayrandey gonda kolon maa-yaŋ kaŋ ye ka kaa.  I du a componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Kolon maa folloŋ si bayrandey ra.  I du a componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Tuuruyaŋ woo award ga answer tag bumbo tuuruyaŋo kaŋ i samba gaay, woodin ga hari kaŋ ni mana batu kande.
+
+answer-max-num-attempts-in-section-wide-check-work = Da ni na `maxNumAttempts` daŋ `<answer>` kaŋ go hari kaŋ gonda `sectionWideCheckWork` ra ga, a si goy, zama haro din no ga dooni lasaabo gaay. Ma `maxNumAttempts` daŋ haro din ga.
+
+nested-section-wide-check-work-max-num-attempts = Da ni na `maxNumAttempts` daŋ hari kaŋ gonda `sectionWideCheckWork` kaŋ go hari fo kaŋ gonda `sectionWideCheckWork` ra ga, a si goy, zama taray haro no ga dooni lasaabo gaay. Ma `maxNumAttempts` daŋ taray haro ga.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] { $attributes } attribute si goy da i mana symbolicEquality daŋ.
+       *[other] { $attributes } attributes si goy da i mana symbolicEquality daŋ.
+    }
+
+answer-invalid-type = Tuuruyaŋ type si boori: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Zama hari `<{ $component }>` sinda maa, i si hin k'a goy danga module attribute
+
+module-attribute-name-already-defined = I si hin ka hari `<{ $component } name="{ $name }">` goy danga module attribute zama `<module>` gonda "{ $name }" attribute za jina.
+
+conditional-content-condition-ignored = I ga `condition` attribute furu `<conditionalContent>` kaŋ gonda case wala else izey ga.
+
+slider-markers-type-mismatch = Markers type si saba nda slider type.
+
+pretzel-problem-needs-statement-and-answer = Pretzel si boori: `<problem>` kulu ga hima ka `<statement>` folloŋ nda `<answer>` folloŋ du.
+
+pretzel-circuit-first-problem-distractor = Pretzel si boori: mode="circuit" ra, `<problem>` sintina si hin ka ciya distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Hari { $values } si boori attribute `{ $attribute }` se; i g'a furu.
+       *[other] Hari-yaŋ { $values } si boori attribute `{ $attribute }` se; i g'i furu.
+    }
+
+attribute-must-be-references = Hari `{ $value }` si boori attribute `{ $attribute }` se. Attribute ga hima ka ciya sanni-yaŋ kaŋ ga sintin nda `$`.
+
+math-input-invalid-function-names = <mathInput>: i ga fonksiyon maa-yaŋ kaŋ si boori furu { $attribute } ra: { $names }. Maa kulu a cabeyaŋ dumbo ga hima ka hantum alaama hinka wala ka bisa du (hantum alaama wala dash); `|<mathspeak alternative>` ga hin k'a gana.
+
+## Building components from the source
+
+component-type-invalid = Hari dumi si boori: `<{ $componentType }>`
+
+attribute-repeated = I si hin ka attribute { $attribute } ye ka ci.
+
+attribute-invalid-for-component = Attribute "{ $attribute }" si boori hari dumi `<{ $componentType }>` se.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Dumi feerijandi { $styleNumber } sinda fayanka kaŋ ga wasa { $context ->
+        [text-on-background] sanni nooro nda banda nooro game ra
+        [high-contrast] fayanka beeri nooro nda kanvas game ra
+        [line] kar nooro nda kanvas game ra
+        [marker] alaama nooro nda kanvas game ra
+       *[text-on-canvas] sanni nooro nda kanvas game ra
+    }{ $mode ->
+        [dark] { " (mode bi)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ga { $threshold }:1 wala ka bisa ŋwaaray).
+
+style-definition-dark-mode-text-background-contrast =
+    Baa kaŋ dumi feerijandi { $styleNumber } gonda noor-yaŋ kaŋ gonda fayanka kaŋ ga wasa mode kwaaray se, mode bi noorey kaŋ i kaa i ra sinda fayanka kaŋ ga wasa sanni nooro nda banda nooro game ra ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ga { $threshold }:1 wala ka bisa ŋwaaray). { $suggestion ->
+        [available] Zama fayanka ma wasa mode bi ra, ma mode kwaaray fayanka tonton (danga, ma { $lightAttribute }="{ $lightColor }" daŋ) wala ma mode bi nooro barmay (danga, ma { $darkAttribute }="{ $darkColor }" daŋ).
+       *[none] Zama fayanka ma wasa mode bi ra, ma mode kwaaray fayanka tonton wala ma noorey barmay nda textColorDarkMode wala backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Baa kaŋ dumi feerijandi { $styleNumber } gonda sanni noor kaŋ gonda fayanka kaŋ ga wasa mode kwaaray se, mode bi sanni nooro kaŋ i kaa a ra sinda fayanka kaŋ ga wasa kanvas ga ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; a ga { $threshold }:1 wala ka bisa ŋwaaray). { $suggestion ->
+        [available] Zama fayanka ma wasa mode bi ra, ma mode kwaaray fayanka tonton (danga, ma textColor="{ $lightColor }" daŋ) wala ma mode bi nooro barmay (danga, ma textColorDarkMode="{ $darkColor }" daŋ).
+       *[none] Zama fayanka ma wasa mode bi ra, ma mode kwaaray fayanka tonton wala ma nooro barmay nda textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Dumbu ga hin ka <stylePalette> folloŋ hinne suuban; i ga kaŋ ga ban goy.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = i si hin ka { $component } dumi waani-waaney bay zama numToSelect manti lasaabu timme kaŋ si ganda ziro ga.
+
+variant-num-to-select-not-constant-number = i si hin ka { $component } dumi waani-waaney bay zama numToSelect manti lasaabu kaŋ si barmay.
+
+variant-with-replacement-not-constant-boolean = i si hin ka { $component } dumi waani-waaney bay zama withReplacement manti boolean kaŋ si barmay.
+
+variant-select-weight-disables-unique = I ga select dumi waani-waaney daabu da option fo gonda selectWeight wala selectForVariants
+
+variant-coprime-undetermined = i si hin ka { $component } dumi waani-waaney bay zama i si hin ka bay hala coprime ga ciya tangari alwaati kulu.
+
+variant-attribute-not-constant = i si hin ka { $component } dumi waani-waaney bay zama { $attribute } ga barmay.
+
+variant-attribute-not-number = i si hin ka { $component } dumi waani-waaney bay zama { $attribute } manti lasaabu.
+
+variant-attribute-wrong-type-for-sequence =
+    i si hin ka { $component } type { $type } dumi waani-waaney bay zama { $attribute } manti { $expected ->
+        [letters-combination] hantum alaama margayaŋ
+        [math-expression] lasaabu sanni hanno
+        [integer] lasaabu timme
+       *[number] lasaabu
+    }.
+
+variant-length-not-integer = i si hin ka { $component } dumi waani-waaney bay zama length manti lasaabu timme.
+
+variant-sort-not-implemented = i mana { $component } nda sort dumi waani-waaney te
+
+variant-exclude-combinations-not-implemented = i mana { $component } nda excludeCombinations dumi waani-waaney te
+
+variant-math-exclude-not-implemented = i mana { $component } type math nda exclude dumi waani-waaney te
+
+variant-non-constant-exclude-not-implemented = i mana { $component } nda exclude kaŋ ga barmay dumi waani-waaney te
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: a si goy graph prefigure cabeko ra; i na izo furu.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiyometri si boori wala a mana timme; i na izo furu.
+
+prefigure-curve-label-omitted = { $subject }: maa-yaŋ si goy curve hari-yaŋ kaŋ i barmay ga; i na maa kaa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve fonksiyon feerijandi dumi '{ $definitionType }' si goy; i na izo furu.
+
+prefigure-region-flip-functions-unsupported = { $subject }: flipFunctions attribute regionBetweenCurves ga si goy; i na izo furu.
+
+prefigure-region-non-formula-child = { $subject }: formula-dumi ize fonksiyon-yaŋ hinne no ga goy regionBetweenCurves ga; i na izo furu.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' si goy { $labelKind ->
+        [line-family] kar dumi maa
+       *[point] alaama maa
+    } se; i ga PreFigure sinjiyaŋ goy.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure si toonandi dumi '{ $fillStyle }' bay; i ga toonandi timme goy.
+
+prefigure-line-style-unknown = { $subject }: i si kar dumi '{ $lineStyle }' bay, woodin se i n'a kaa PreFigure ra.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: i na alaama dumi '{ $markerStyle }' barmay PreFigure dumi 'diamond' ga.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure si alaama dumi '{ $markerStyle }' bay; i ga dumi kaŋ go no za jina goy.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` si boori; i si hin ka targeto du. I na annotation kaa.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` du target boobo; i ga sintina goy.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` si boori; targeto go grapho taray. I na annotation kaa.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` si boori; targeto manti biiyaŋ hari kaŋ prefigure ga bay. I na annotation kaa.
+
+annotation-text-missing = `<annotation>`: `text` si no wala a sinda hay kulu; i ga sanni kaŋ sinda hay kulu hantum.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] I du windi gaayyaŋ.
+       *[other] I du windi gaayyaŋ nda hari `<{ $componentType }>`.
+    }
+
+reference-no-referent = I mana hay kulu du sanno se: `{ $reference }`
+
+reference-multiple-referents = I du hari boobo sanno se: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Attribute { $attribute } dumo `<{ $componentType }>` se si boori.
+
+children-invalid = `<{ $componentType }>` izey si boori: I du ize-yaŋ kaŋ si boori: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Hari `{ $value }` si boori attribute `{ $attribute }` se, i ga `{ $default }` goy
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] I mana DoenetML dumi { $version } du.
+       *[other] I mana DoenetML dumi { $version } du. I ga dumi { $fallback } goy
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML si boori: { $content }
+
+parse-tag-missing-close-tag = DoenetML si boori: Tag `{ $tag }` sinda daabuyaŋ tag. I ga batu tag kaŋ ga nga boŋ daabu wala tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML si boori: Taali go tag `<{ $tagName }>` ra
+
+parse-attribute-missing-value = DoenetML si boori: Attribute `{ $attribute }` si boori, a ga cabe danga a sinda hari.
+
+parse-attribute-invalid = DoenetML si boori: Attribute `{ $attribute }` si boori
+
+parse-attribute-value-invalid = DoenetML si boori: Attribute haro `{ $value }` si boori
+
+parse-attribute-value-quote-mismatch = DoenetML si boori: Attribute haro `{ $value }` si boori. Kwot alaamey si saba. A ga cabe danga `{ $quote }` si no
+
+parse-open-tag-name-missing = DoenetML si boori: I du tag kaŋ sinda maa, danga `<`
+
+parse-tag-not-closed = DoenetML si boori: I mana tag `{ $tag }` daabu (a ga cabe danga `>` si no).
+
+parse-self-closing-tag-name-missing = DoenetML si boori: I du tag kaŋ sinda maa `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML si boori: I mana tag `{ $tag }` daabu (a ga cabe danga `/>` si no).
+
+parse-tag-invalid-attributes = DoenetML si boori: Tag `{ $tag }` si boori. A ga hin ka attributes kaŋ si boori du.
+
+parse-close-tag-name-missing = DoenetML si boori: I du daabuyaŋ tag kaŋ sinda maa, danga `</`
+
+parse-attribute-value-unquoted = Attribute hari-yaŋ ga hima ka goro kwot alaamey ra: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML si boori: I du daabuyaŋ tag `{ $tag }`, amma feeriyaŋ tag si no
+
+parse-close-tag-mismatched = DoenetML si boori: Daabuyaŋ tag si saba. I ga batu `</{ $expected }>`. I du `{ $found }`
+
+parser-node-unconvertible = I si hin ka node { $node } barmay Dast node ga.
+
+## Names
+
+name-attribute-invalid =
+    Attribute name='{ $name }' si boori. { $reason ->
+        [characters] Maa-yaŋ ga hin ka hantum alaama, lasaabu, ganda hirri wala hirri hinne du.
+       *[start] Maa-yaŋ ga hima ka sintin nda hantum alaama.
+    }
+
+component-name-invalid-start = Hari maa "{ $name }" si boori. Maa-yaŋ ga hima ka sintin nda hantum alaama.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer type videoWatched ga hima ka video attribute du
+
+answer-video-watched-video-not-reference = Answer type videoWatched ga hima ka video attribute kaŋ ga ti sanni du
+
+answer-name-not-single-text = Answer name attribute ga hima ka text ize folloŋ hinne du
+
+## Referencing another document
+
+external-doenetml-recursion-limit = I mana hin ka taray DoenetML du zama yeyaŋ ga baa gumo. Windi sanni go no?
+
+external-doenetml-unavailable = I mana hin ka DoenetML du { $attribute }="{ $uri }" ra
+
+external-doenetml-type-mismatch = DoenetML kaŋ i du { $attribute }="{ $uri }" ra si boori: a si saba nda hari dumi "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` zeen; ma `{ $to }` goy.
+       *[other] [deprecation] Attribute `{ $from }` `<{ $component }>` ga zeen; ma `{ $to }` goy.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` zeen nda i g'a furu zama `{ $to }` mo go no.
+       *[other] [deprecation] Attribute `{ $from }` `<{ $component }>` ga zeen nda i g'a furu zama `{ $to }` mo go no.
+    }
+
+deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` `<{ $component }>` ga zeen nda i g'a furu.
+
+deprecated-attribute-to-child = [deprecation] Attribute `{ $attribute }` `<{ $component }>` ga zeen; ma `<{ $child }>` ize goy.
+
+deprecated-attribute-value-renamed = [deprecation] Hari `{ $value }` attribute `{ $attribute }` wano `<{ $component }>` ga zeen; ma `{ $to }` goy.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ga hin ka Inglisi hinne baayaŋ te, woodin se a ga sanno naŋ danga mate kaŋ ni n'a hantum tira kaŋ i hantum { $locale } ra. Ma baayaŋ dumo hantum bumbo, wala m'a daŋ nda `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Hari `<{ $tag }>` manti Doenet hari kaŋ i ga bay.
+
+schema-element-not-allowed-at-root = I si yadda nda hari `<{ $tag }>` tira boŋo ga.
+
+schema-element-not-allowed-inside = I si yadda nda hari `<{ $tag }>` `<{ $parent }>` ra.
+
+schema-attribute-unrecognized = Hari `<{ $tag }>` sinda attribute kaŋ maa ga ti `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Attribute `{ $attribute }` hari `<{ $tag }>` wano ga hima ka ciya lisi kaŋ a hari kulu ga ti afo woone yaŋ ra: { $allowed }
+       *[other] Attribute `{ $attribute }` hari `<{ $tag }>` wano ga hima ka ciya afo woone yaŋ ra: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select dumi maa si boori.  Dumi maa { $variantName } ga cabe option { $numOptions } ra amma suubanyaŋ lasaabo ga ti { $numToSelect }.
+
+select-variant-name-without-options = I na dumi fo-yaŋ ci select se amma i mana option kulu ci dumi maa kaŋ ga hin ka bara se: { $variantName }.
+
+select-variant-name-not-possible = Dumi maa { $variantName } kaŋ i ci select se manti dumi maa kaŋ ga hin ka bara.
+
+select-too-few-options = I si hin ka hari { $numToSelect } suuban { $numOptions } hinne ra.
+
+select-from-sequence-too-few-values = I si hin ka hari { $numToSelect } suuban sequence kaŋ salaŋ ga ti { $length } ra.
+
+select-from-sequence-indices-count-mismatch = Indices lasaabo kaŋ i ci select se ga hima ka saba nda suubanyaŋ lasaabo
+
+select-from-sequence-indices-not-integers = Indices kulu kaŋ i ci select se ga hima ka ciya lasaabu timme-yaŋ
+
+select-from-sequence-index-excluded = I na selectfromsequence index kaŋ i kaa ci
+
+select-from-sequence-indices-excluded-combination = I na selectfromsequence indices kaŋ ga ti margayaŋ kaŋ i kaa ci
+
+select-from-sequence-coprime-not-positive-integers = I si hin ka coprime margayaŋ suuban zama i si lasaabu timme kaŋ go beene ziro ga suuban.
+
+select-from-sequence-coprime-common-factor = I si hin ka coprime lasaabu-yaŋ suuban. Hari kulu kaŋ ga hin ka bara gonda faktoor folloŋ. ("from" wala "to" hari-yaŋ kaŋ i ci ga hima ka ciya coprime nda "step".)
+
+select-from-sequence-coprime-single-number = I si hin ka coprime margayaŋ suuban lasaabu folloŋ kaŋ manti 1 ra.
+
+select-from-sequence-excluded-too-many-combinations = I na margayaŋ 70% ka bisa kaa selectFromSequence ra
+
+select-from-sequence-coprime-none-found = I mana hin ka coprime lasaabu-yaŋ suuban. Hari kulu kaŋ ga hin ka bara gonda faktoor folloŋ.
+
+select-from-sequence-too-few-unique-values = I si hin ka hari waani { $numToSelect } suuban sequence kaŋ salaŋ ga ti { $numPossibleValues } ra
+
+select-prime-numbers-too-few-values = I si hin ka hari { $numToSelect } suuban praym lisi kaŋ salaŋ ga ti { $numValues } ra
+
+select-prime-numbers-values-count-mismatch = Hari-yaŋ lasaabo kaŋ i ci select se ga hima ka saba nda suubanyaŋ lasaabo
+
+select-prime-numbers-values-not-prime = Hari kulu kaŋ i ci select prime number se ga hima ka goro praym liso ra
+
+select-prime-numbers-values-excluded-combination = Hari-yaŋ kaŋ i ci selectPrimeNumbers se ga ti margayaŋ kaŋ i kaa
+
+select-prime-numbers-excluded-too-many-combinations = I na margayaŋ 70% ka bisa kaa selectPrimeNumbers ra
+
+select-random-combination-fluke = Nda hari kaŋ si hima ka te, i mana hin ka hari suuban-suuban margayaŋ suuban
+
+select-random-value-fluke = Nda hari kaŋ si hima ka te, i mana hin ka hari suuban-suuban suuban

--- a/packages/i18n/locales/dje/editor.ftl
+++ b/packages/i18n/locales/dje/editor.ftl
@@ -115,7 +115,7 @@ editor-none-found = I mana du hay kulu
 
 ## Submitted responses
 
-editor-no-responses = Boro kulu mana tuuruyaŋ samba jina
+editor-no-responses = Tuuruyaŋ kaŋ i samba si no jina
 editor-response-answer-id = Tuuruyaŋ maa
 editor-response-response = Tuuruyaŋ
 editor-response-credit = Nooru

--- a/packages/i18n/locales/dje/editor.ftl
+++ b/packages/i18n/locales/dje/editor.ftl
@@ -1,0 +1,208 @@
+# Zarma editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Ye ka sinji
+       *[update] Taagandi
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Cabeko
+       *[other] { $word } Cabeko { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Dumi
+
+editor-variant-filter = Ceeci…
+
+editor-variant-next = Suuban dumi kaŋ ga kaa
+
+editor-variant-previous = Suuban dumi kaŋ bisa
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] I du WCAG AA duyaŋ sanno ŋwaarey. Kar zama ni ma { $action ->
+            [close] daabu
+           *[open] feeri
+        } duyaŋ tira.
+        [advisories] Kar zama ni ma { $action ->
+            [close] daabu
+           *[open] feeri
+        } duyaŋ tira. I mana du WCAG AA ŋwaarey kulu, amma duyaŋ faada fo-yaŋ go no.
+       *[clean] Kar zama ni ma { $action ->
+            [close] daabu
+           *[open] feeri
+        } duyaŋ tira. I mana du duyaŋ taabi kulu.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] I du WCAG AA duyaŋ sanno ŋwaarey. I du { $count ->
+            [one] WCAG AA ŋwaarey { $count }
+           *[other] WCAG AA ŋwaarey { $count }
+        }. Kar zama ni ma { $action ->
+            [close] daabu
+           *[open] feeri
+        } duyaŋ tira.
+        [advisories] I mana du WCAG AA ŋwaarey kulu. I du { $count ->
+            [one] duyaŋ faada fo { $count }
+           *[other] duyaŋ faada fo { $count }
+        }. Kar zama ni ma { $action ->
+            [close] daabu
+           *[open] feeri
+        } duyaŋ tira.
+       *[clean] I mana du WCAG AA ŋwaarey kulu. Kar zama ni ma { $action ->
+            [close] daabu
+           *[open] feeri
+        } duyaŋ tira.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML dumi { $version }
+
+editor-tab-help = Nangu faada
+editor-tab-help-short = Nangu
+editor-tab-errors = Taali-yaŋ
+editor-tab-warnings = Yaamar-yaŋ
+editor-tab-info = Bayrandi
+editor-tab-accessibility = Duyaŋ
+editor-tab-responses = Tuuruyaŋ kaŋ i samba
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Hantumkoo suubanyaŋ
+editor-format-as-doenetml = Hanse danga DoenetML
+editor-format-as-xml = Hanse danga XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Kar #{ $line }
+
+editor-no-errors = Taali Si No
+editor-no-warnings = Yaamar Si No
+editor-no-info = Bayrandi Si No
+
+editor-show-info-annotations = Cabe bayrandi-yaŋ hantumkoo ra
+editor-show-accessibility-annotations = Cabe duyaŋ taabi-yaŋ hantumkoo ra
+
+editor-accessibility-learn-more = Dooni mate kaŋ Doenet ga duyaŋ te
+
+editor-accessibility-violations-heading = Duyaŋ ŋwaarey-yaŋ ({ $standard })
+
+editor-accessibility-other-heading = Duyaŋ taabi fo-yaŋ
+editor-none-found = I mana du hay kulu
+
+
+## Submitted responses
+
+editor-no-responses = Boro kulu mana tuuruyaŋ samba jina
+editor-response-answer-id = Tuuruyaŋ maa
+editor-response-response = Tuuruyaŋ
+editor-response-credit = Nooru
+editor-response-submitted = I n'a samba
+
+
+## The context-help panel
+
+help-placeholder = Daŋ hantumyaŋ alaama tag maa ga, attribute ga, wala { $ref } ga zama ni ma feerijandi du.
+
+help-unsupported-ref-chain = Faada dumbu boobo sanni-yaŋ se danga { $example } mana go no jina.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] I mana du hay kulu { $ref } se.
+        [multiple] I du hari boobo { $ref } se.
+       *[indeterminate] I mana hin ka bay { $ref } hara.
+    }
+
+help-learn-about-references = Dooni sanni-yaŋ boŋ →
+help-reference-page = Feerijandi moo →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } ra
+       *[top] Tira boŋo ga
+    }{ $allowed ->
+        [none] { " — hay kulu si koy ne." }
+        [text] { " — hantum sanni ne." }
+        [text-and-components] { " — hantum sanni ne, wala ma guna:" }
+       *[components] { " — hari-yaŋ kaŋ ni ga hin ka guna:" }
+    }
+
+help-suggestions-footer = Kar { $shortcut } zama ni ma hari { $total } kulu guna.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ya sanni no { $target } se.
+       *[other] { $ref } ya sanni no { $target } se (kar { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } n'a daŋ danga { $role }.
+       *[other] { $owner } n'a daŋ kar { $line } ga danga { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ya sanni no { $element } { $property } se.
+       *[other] { $ref } ya sanni no { $element } { $property } se (kar { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = dumbu
+help-kind-array-entry = array dumbu
+
+help-default = Kaŋ go no za jina:
+help-active-default = Kaŋ go no za jina nda goo ga goy:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Hari-yaŋ kaŋ i yadda (afo hari fo se):
+       *[other] Hari-yaŋ kaŋ i yadda:
+    }
+
+help-suggested-values = Hari-yaŋ kaŋ i cabe:
+
+help-inserts = A ga daŋ:
+
+help-coordinates =
+    { $count ->
+        [one] Nangu:
+       *[other] Nangu-yaŋ:
+    }
+
+help-type = Dumi:
+
+help-resolved-style = Dumi kaŋ i du (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fonksiyon maa-yaŋ kaŋ i du:
+help-reset-list = Ye ka sinji lisi input woo ga:
+help-added-on-input = I n'a tonton input woo ga:
+help-removed-on-input = I n'a kaa input woo ga:
+
+help-reset-overrides = { $reset } ga { $additional } nda { $removed } bisa.

--- a/packages/i18n/locales/kmb/chrome.ftl
+++ b/packages/i18n/locales/kmb/chrome.ftl
@@ -1,0 +1,134 @@
+# Kimbundu viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the connective table, for the two comparisons
+# that cut in opposite directions — `locales/umb` next door and `locales/kg` a
+# thousand kilometres away — and for what a speaker should check first.
+
+
+## Answer submission
+
+answer-checking = Mu kutala…
+answer-submitting = Mu kutuma…
+
+answer-checking-status = O kitambwijilu kya mu talwa
+answer-submitting-status = O kitambwijilu kya mu tumwa
+
+answer-correct = Kya bhonga
+answer-incorrect = Ki kya bhonga ko
+
+answer-response-saved = O Kitambwijilu Kya Lengejelwa
+
+answer-percent-credit = { $percent }% ya Mbandu
+answer-percent-correct = { $percent }% Kya bhonga
+answer-percent-short = { $percent } %
+
+max-credit-available = Mbandu ya dikota i utena kutambula: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] ki kwala kilongelu ko
+        [one] kilongelu { $count } kya sala
+       *[other] ilongelu { $count } ya sala
+    }
+
+validation-correct = (Kya bhonga)
+validation-incorrect = (Ki kya bhonga ko)
+validation-partially-correct = (Kya bhonga mu kitangana)
+
+answer-show-responses =
+    { $count ->
+        [one] Londekesa kitambwijilu { $count } kya { $answerId }
+       *[other] Londekesa itambwijilu { $count } ya { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Kitambwijilu
+
+collapsible-click-to-open = (kwata phala kujikula)
+collapsible-click-to-close = (kwata phala kujika)
+
+collapsible-initializing = Mu kumatekesa…
+
+footnote-show = Londekesa kisonekenu kya boxi
+footnote-hide = Sweka kisonekenu kya boxi
+
+description-more-information = ijimbwete ya mukwa
+
+
+## Controls
+
+slider-previous = Ya bhitile
+slider-next = Ya kaya
+
+keyboard-open = Jikula o Kiteka
+keyboard-close = Jika o Kiteka
+
+choice-input-remove-choice = Katula { $choice }
+
+matrix-remove-row = Katula o nlonji
+matrix-add-row = Bhakela nlonji
+matrix-remove-column = Katula o koluna
+matrix-add-column = Bhakela koluna
+
+subset-add-remove-points = Bhakela/Katula jimbanza
+subset-toggle-points-intervals = Sokolola jimbanza ni jitembu
+subset-move-points = Kunanguna Jimbanza
+subset-clear = Katula yoso
+
+orbital-add-row = Bhakela Nlonji
+orbital-remove-row = Katula Nlonji
+orbital-add-box = Bhakela Kaxa
+orbital-remove-box = Katula Kaxa
+orbital-add-up-arrow = Bhakela Kimbanza kya Bhulu
+orbital-add-down-arrow = Bhakela Kimbanza kya Boxi
+orbital-remove-arrow = Katula Kimbanza
+
+orbital-row-label = Dijina dya nlonji { $row }
+
+pretzel-answer = Kitambwijilu
+
+summary-statistics-caption = Kijilu kya jinumeru ja { $column }
+
+
+## Math input
+
+math-input-preview-region = kutala kwa dyanga o kizwelu kya matematika
+math-input-preview = Tala dyanga
+math-input-invalid-expression = Kizwelu ki kyabhonga ko:
+
+
+## Document status
+
+viewer-initializing = Mu kumatekesa…
+
+
+## Errors
+
+error-heading = Kibhengelu
+
+error-found-at =
+    { $span ->
+        [line] Kya sangwa mu nlonji { $startLine }.
+       *[lines] Kya sangwa mu jinlonji { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = O divulu didi dyala ni ibhengelu!
+
+diagnostic-heading-error = Kibhengelu
+diagnostic-heading-warning = Kidimbu
+diagnostic-heading-information = Kijimbwete
+diagnostic-heading-hint = Kikwatekesu
+
+accessibility-heading-level-1 = Kubhengela kwa WCAG AA mu Kubhixila
+accessibility-heading-level-2 = Kidimbu kya kubhixila
+
+something-went-wrong = Kima kya mukwa ki kya bhonga ko.
+
+renderer-load-failed = o mulondekesi umoxi ki weza ko. Tu ku bhinga, sokolola o kibhamba.
+
+core-start-failed = O mulondekesi wa divulu ki wa tenene kumatekesa ko. Tu ku bhinga, sokolola o kibhamba.

--- a/packages/i18n/locales/kmb/chrome.ftl
+++ b/packages/i18n/locales/kmb/chrome.ftl
@@ -84,9 +84,9 @@ orbital-add-row = Bhakela Nlonji
 orbital-remove-row = Katula Nlonji
 orbital-add-box = Bhakela Kaxa
 orbital-remove-box = Katula Kaxa
-orbital-add-up-arrow = Bhakela Kimbanza kya Bhulu
-orbital-add-down-arrow = Bhakela Kimbanza kya Boxi
-orbital-remove-arrow = Katula Kimbanza
+orbital-add-up-arrow = Bhakela Seta ya Bhulu
+orbital-add-down-arrow = Bhakela Seta ya Boxi
+orbital-remove-arrow = Katula Seta
 
 orbital-row-label = Dijina dya nlonji { $row }
 
@@ -129,6 +129,6 @@ accessibility-heading-level-2 = Kidimbu kya kubhixila
 
 something-went-wrong = Kima kya mukwa ki kya bhonga ko.
 
-renderer-load-failed = o mulondekesi umoxi ki weza ko. Tu ku bhinga, sokolola o kibhamba.
+renderer-load-failed = o mulondekesi umoxi ki weza ko. Tu ku bhinga, vutulula o kibhamba.
 
-core-start-failed = O mulondekesi wa divulu ki wa tenene kumatekesa ko. Tu ku bhinga, sokolola o kibhamba.
+core-start-failed = O mulondekesi wa divulu ki wa tenene kumatekesa ko. Tu ku bhinga, vutulula o kibhamba.

--- a/packages/i18n/locales/kmb/content.ftl
+++ b/packages/i18n/locales/kmb/content.ftl
@@ -1,0 +1,344 @@
+# Kimbundu content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `kmb` is Kimbundu, the language of Luanda and the Kwanza valley and the
+# second-largest in Angola. It arrives beside `locales/umb` (Umbundu) in the
+# same batch, and the pair is the point.
+#
+# **`$gender` is a noun class again, and it lands on a connective rather than
+# on the describing word.** Kimbundu joins a describing word to its noun with a
+# particle built on «-a», and the particle agrees while the stem behind it does
+# not:
+#
+#            c5 (dya)    c7 (kya)    c9 (ya)     c10 (ja)
+#   -ndombe   dya ndombe  kya ndombe  ya ndombe   ja ndombe
+#   -zele     dya zele    kya zele    ya zele     ja zele
+#   -nene     dya nene    kya nene    ya nene     ja nene
+#
+# **Two comparisons, and they cut in opposite directions.**
+#
+# `locales/umb` is Kimbundu's neighbour — the two largest languages of one
+# country, both Bantu, both with the same class system — and Umbundu prefixes
+# the class straight onto the stem («citekãva», «cinene») with no connective at
+# all. So neighbours in one country diverge.
+#
+# `locales/kg` is a thousand kilometres north, in a different country, and does
+# *exactly this*: an agreeing «-a» connective in front of an invariant stem,
+# «dya ndombe» for the same word. So a distant relative converges.
+#
+# Family does not predict the shape of agreement, and neither does geography.
+# That was `locales/kg` and `locales/ktu`'s lesson in #1686 about a creole and
+# its lexifier; this is the same lesson with the creole taken out of it, which
+# is what makes it a fact about Bantu rather than about creolization.
+#
+# `$role` goes unused: Kimbundu marks no case.
+#
+# The chemistry gap here is Portuguese, for the reason `locales/umb` sets out
+# at the foot of its own file.
+#
+# The geometry leans on the Portuguese loans Angolan schooling supplies; where
+# Kimbundu has its own word it is used — «kididi» a place, «kimbanza» a mark.
+# They are the first thing to check.
+
+
+## Style vocabulary
+##
+## The stem never changes; only the connective in front of it does. That is
+## `locales/kg`'s shape exactly, and not `locales/umb`'s.
+
+color =
+    .black =
+        { $gender ->
+            [c5] dya ndombe
+            [c7] kya ndombe
+            [c10] ja ndombe
+           *[c9] ya ndombe
+        }
+    .white =
+        { $gender ->
+            [c5] dya zele
+            [c7] kya zele
+            [c10] ja zele
+           *[c9] ya zele
+        }
+    .gray =
+        { $gender ->
+            [c5] dya mbwe
+            [c7] kya mbwe
+            [c10] ja mbwe
+           *[c9] ya mbwe
+        }
+    .red =
+        { $gender ->
+            [c5] dya kusuka
+            [c7] kya kusuka
+            [c10] ja kusuka
+           *[c9] ya kusuka
+        }
+    .orange = ya laranja
+    .yellow = ya amarelu
+    .green = ya verdi
+    .cyan = ya syanu
+    .blue = ya azulu
+    .purple = ya roxu
+    .pink = ya rosa
+    .brown = ya kastanyu
+
+line-width =
+    .thick =
+        { $gender ->
+            [c5] dya nene
+            [c7] kya nene
+            [c10] ja nene
+           *[c9] ya nene
+        }
+    .thin =
+        { $gender ->
+            [c5] dya tetuka
+            [c7] kya tetuka
+            [c10] ja tetuka
+           *[c9] ya tetuka
+        }
+
+# Written with the frozen class-9 «ya», the way the Portuguese loans above are:
+# these describe a manner rather than a quality, and a speaker does not agree
+# them with the shape. `style-stroke` puts them last so nothing follows them.
+line-style =
+    .dashed = ya jinlonji jitetuka
+    .dotted = ya jimbanza
+
+fill-style =
+    .horizontal = jinlonji ja lala
+    .vertical = jinlonji ja imana
+    .diagonal = jinlonji ja bhita
+    .backdiagonal = jinlonji ja bhita ku mbandu ya mukwa
+    .dots = jimbanza
+    .diamonds = jidiamanti
+
+noun =
+    .line = nlonji
+    .line-segment = kitangana kya nlonji
+    .ray = mwenyu
+    .vector = vetoru
+    .curve = nlonji ya kubhinda
+    .function = funsau
+    .parabola = parabola
+    .polyline = nlonji ya jitangana
+    .polygon = poligonu
+    .triangle = triangulu
+    .rectangle = retangulu
+    .circle = kizenge
+    .region = kididi
+    .point = kimbanza
+    .square = kwadradu
+    .diamond = diamanti
+    .cross = kuluzu
+    .plus = kimbanza kya kubhakela
+
+# The side count is a counted complement and closes the noun phrase behind the
+# describing words, so it goes in the tail. «-a» agrees here too, but the head
+# noun is always the same word, so the form is fixed and needs no fork — which
+# is `locales/kg`'s note on the same message, for the same reason.
+noun-regular-polygon =
+    { $part ->
+        [tail] ya jimbandu { $numSides }
+       *[head] poligonu ya kusokela
+    }
+
+# The noun class. `c9` is the default and the class a Portuguese loan joins,
+# which is what an author's own `markerStyleWord` is as far as this catalog is
+# concerned.
+noun-gender =
+    { $noun ->
+        [line-segment] c7
+        [square] c7
+        [region] c7
+        [circle] c7
+        [point] c7
+        [plus] c7
+        [fill] c7
+        [diamond] c5
+        [cross] c5
+        [text] c5
+        [background] c10
+        [border] c10
+       *[other] c9
+    }
+
+
+## Style composition
+
+# The dash pattern is a «ya …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c5] dya kuizala
+        [c7] kya kuizala
+        [c10] ja kuizala
+       *[c9] ya kuizala
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } ni { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } ni { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } ni { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «jimbandu» is the border and leads its own describing words, so they agree
+# with it rather than with the shape it surrounds — which is why `border`
+# answers `c10` in `noun-gender`. Kimbundu has no article and joins this clause
+# with the invariable «ni», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] ni jimbandu { $border }
+        [and] ni jimbandu { $border }
+        [and-article] ni jimbandu { $border }
+       *[with] ni jimbandu { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ki kya kuizala ko
+
+style-text =
+    { $parts ->
+        [background] { $color } ni kunima { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = kima ki kwala ko
+
+
+## Boolean words
+
+boolean-true = kidi
+boolean-false = makutu
+
+
+## Answer buttons
+
+answer-submit-label = Tala o Kikalakalu
+answer-submit-label-no-correctness = Tuma o Kitambwijilu
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Kikalakalu
+    .aside = Izwelu ya mukwa
+    .cascade = Kaskata
+    .definition = Kijilu
+    .example = Kifika
+    .exercise = Kilongelu
+    .exercises = Ilongelu
+    .given-answer = Kitambwijilu
+    .note = Kisonekenu
+    .objectives = Ibhindamenu
+    .paragraphs = Itangana
+    .part = Kitangana
+    .problem = Kibhidi
+    .problems = Ibhidi
+    .proof = Umbangi
+    .question = Kibhwilu
+    .section = Kitangana
+    .solution = Kisokololwelu
+    .task = Kikalakalu
+    .theorem = Teoremu
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Kikwatekesu
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tabela { $enumeration }
+        [numbered-title] Tabela { $enumeration }{ ": " }
+        [unnumbered-title] Tabela{ ": " }
+       *[unnumbered] Tabela
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Kifika { $enumeration }
+        [numbered-caption] Kifika { $enumeration }{ ": " }
+        [unnumbered-caption] Kifika{ ": " }
+       *[unnumbered] Kifika
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ya bhitile
+paginator-next = Ya kaya
+
+paginator-page = Kibhamba
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = mba
+
+piecewise-condition-if = se
+
+piecewise-condition-otherwise = mu ima yoso ya mukwa
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The Portuguese case, set out in full at the foot of `locales/umb` — Angola
+## teaches secondary science in Portuguese, so the English fallback is neither
+## Kimbundu nor the curriculum, and filling the keys from Portuguese would be
+## the substitution this seeding effort is careful not to make.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kimbanza kya Kimika ki Kyabhonga ko
+chemistry-invalid-ionic-compound = Kibhungu kya Ioni ki Kyabhonga ko

--- a/packages/i18n/locales/kmb/content.ftl
+++ b/packages/i18n/locales/kmb/content.ftl
@@ -27,7 +27,9 @@
 #
 # `locales/kg` is a thousand kilometres north, in a different country, and does
 # *exactly this*: an agreeing «-a» connective in front of an invariant stem,
-# «dya ndombe» for the same word. So a distant relative converges.
+# «dya ndombe» for the same word. The class inventories are not identical —
+# `locales/kg` forks a c11 where this file forks a c10 — but the mechanism is,
+# down to the syllable. So a distant relative converges.
 #
 # Family does not predict the shape of agreement, and neither does geography.
 # That was `locales/kg` and `locales/ktu`'s lesson in #1686 about a creole and
@@ -47,7 +49,7 @@
 ## Style vocabulary
 ##
 ## The stem never changes; only the connective in front of it does. That is
-## `locales/kg`'s shape exactly, and not `locales/umb`'s.
+## `locales/kg`'s mechanism exactly, and not `locales/umb`'s.
 
 color =
     .black =
@@ -148,9 +150,10 @@ noun-regular-polygon =
        *[head] poligonu ya kusokela
     }
 
-# The noun class. `c9` is the default and the class a Portuguese loan joins,
-# which is what an author's own `markerStyleWord` is as far as this catalog is
-# concerned.
+# The noun class. `c9` is the default, which is what an author's own
+# `markerStyleWord` is as far as this catalog is concerned. Every noun with an
+# overt `ki-` — «kizenge», «kididi», «kitangana», «kimbanza» — answers `c7`, so
+# that a head and the words beside it always carry the same class.
 noun-gender =
     { $noun ->
         [line-segment] c7

--- a/packages/i18n/locales/kmb/diagnostics.ftl
+++ b/packages/i18n/locales/kmb/diagnostics.ftl
@@ -49,11 +49,11 @@ vector-dimension-mismatch = numDimensions ki i sokela mu vetoru ko.
 
 ## Attracting and constraining
 
-attract-to-without-nearest-point = Ki tu tena kukwata ku `<{ $component }>` mukonda ki kyala ni nearestPoint ko.
+attract-to-without-nearest-point = Ki tu tena kukwata ku `<{ $component }>` mukonda ki kyala ni kisokololwelu nearestPoint ko.
 
-constrain-to-without-nearest-point = Ki tu tena kukangela ku `<{ $component }>` mukonda ki kyala ni nearestPoint ko.
+constrain-to-without-nearest-point = Ki tu tena kukangela ku `<{ $component }>` mukonda ki kyala ni kisokololwelu nearestPoint ko.
 
-constrain-to-interior-without-nearest-point = Ki tu tena kukangela mukwa `<{ $component }>` mukonda ki kyala ni nearestPoint ko.
+constrain-to-interior-without-nearest-point = Ki tu tena kukangela mukwa `<{ $component }>` mukonda ki kyala ni kisokololwelu nearestPoint ko.
 
 ## `<choiceInput>`
 
@@ -161,11 +161,11 @@ circle-change-center-non-numerical = O kusokolola o kaxaxi ka kizenge kya bhita 
 
 function-domain-insufficient-dimensions =
     { $intervals ->
-        [one] O udikota ki wa tokala ko mu domain ya funsau. O domain yala ni kitembu { $intervals } maji o funsau yala ni { $inputs ->
+        [one] O udikota wala utetuka kyavulu mu domain ya funsau. O domain yala ni kitembu { $intervals } maji o funsau yala ni { $inputs ->
             [one] input { $inputs }
            *[other] input { $inputs }
         }.
-       *[other] O udikota ki wa tokala ko mu domain ya funsau. O domain yala ni itembu { $intervals } maji o funsau yala ni { $inputs ->
+       *[other] O udikota wala utetuka kyavulu mu domain ya funsau. O domain yala ni itembu { $intervals } maji o funsau yala ni { $inputs ->
             [one] input { $inputs }
            *[other] input { $inputs }
         }.
@@ -230,7 +230,7 @@ target-state-variable-not-found = O target ya `<{ $source }>` ki yabhonga ko: ki
 
 ## `<odeSystem>`
 
-ode-system-variables-match-independent = O isokololwelu ya `<odeSystem>` ya tokala kutepa ni kisokololwelu kya muene.
+ode-system-variables-match-independent = O isokololwelu ya `<odeSystem>` ya tokala kutepa ni kisokololwelu ki kolela ku kima kya mukwa ko.
 
 ode-system-duplicate-variable-names = Ki tu tena kujijila o funsau ja ODE RHS ni majina ma isokololwelu ma vutuluka.
 
@@ -264,13 +264,13 @@ eigen-decomposition-failed = Ki tu tenene kusoka o jieigenvalue ja matrisi
 
 matches-pattern-parameter-not-in-pattern =
     { $parametersCount ->
-        [one] `<matchesPattern>`: o parameter { $parameters } ki yala mu kifwa ko, kienyi i sokela ngó ni kima ki kyala ko.
-       *[other] `<matchesPattern>`: o parameters { $parameters } ki yala mu kifwa ko, kienyi i sokela ngó ni kima ki kyala ko.
+        [one] `<matchesPattern>`: o parameter { $parameters } ki yala mu kifwa ko, kienyi i sokela ithangana yoso ni kima ki kyala ko.
+       *[other] `<matchesPattern>`: o parameters { $parameters } ki yala mu kifwa ko, kienyi i sokela ithangana yoso ni kima ki kyala ko.
     }
 
 ## `<graph>`
 
-graph-grid-invalid = `<graph>`: ki tu tena kwijiya grid="{ $grid }". Ya tokala kukala none, medium, dense, mba italu yyadi ya dikota ya tepwa ni kididi, kála grid="1 0.5". Ki tu bhanga grid ko.
+graph-grid-invalid = `<graph>`: ki tu tena kwijiya grid="{ $grid }". Ya tokala kukala none, medium, dense, mba italu yyadi yala bhulu dya ziro ya tepwa ni kididi, kála grid="1 0.5". Ki tu bhanga grid ko.
 
 ## PreFigure renderer
 
@@ -286,7 +286,7 @@ prefigure-invalid-aspect-ratio = `<graph>`: o aspectRatio ki yabhonga ko mu pref
 
 prefigure-grid-spacing-too-fine = `<graph>`: o kididi kya grid kyala kitetuka kyavulu mu jimbandu ja aksi; o grid i katulwa mu mulondekesi prefigure.
 
-prefigure-annotations-not-rendered = `<graph>`: o annotations ki i londekeswa ko se ki tu kalakala ni mulondekesi PreFigure.
+prefigure-annotations-not-rendered = `<graph>`: o annotations ki i londekeswa ko se ki tu kalakala ni mulondekesi PreFigure ko.
 
 multiple-annotations-children = Kwa sangwa an'a avulu a `<annotations>` mu `<graph>`; oso a xisiwa maji o wa sukina.
 
@@ -354,7 +354,7 @@ attribute-invalid-values =
 
 attribute-must-be-references = O kima `{ $value }` ki kyabhonga ko mu attribute `{ $attribute }`. O attribute ya tokala kukala izwelu i matekesa ni `$`.
 
-math-input-invalid-function-names = <mathInput>: majina ma funsau ki mabhonga ko ma xisiwa mu { $attribute }: { $names }. Dijina dyoso o kitangana kya kulondekesa kya tokala kukala ni jisonekenu jyadi mba javulu (jisonekenu mba jimbandu); `|<mathspeak alternative>` i tena kukayela.
+math-input-invalid-function-names = <mathInput>: majina ma funsau ki mabhonga ko ma xisiwa mu { $attribute }: { $names }. Dijina dyoso o kitangana kya kulondekesa kya tokala kukala ni jisonekenu jyadi mba javulu (jisonekenu mba jifeni); `|<mathspeak alternative>` i tena kukayela.
 
 ## Building components from the source
 
@@ -536,7 +536,7 @@ parser-node-unconvertible = Ki tu tena kusokolola o node { $node } ku node ya Da
 
 name-attribute-invalid =
     O dijina name='{ $name }' ki dyabhonga ko. { $reason ->
-        [characters] O majina ma tena kukala ngó ni jisonekenu, italu, jimbandu ja boxi mba jimbandu.
+        [characters] O majina ma tena kukala ngó ni jisonekenu, italu, jinlonji ja boxi mba jifeni.
        *[start] O majina ma tokala kumatekesa ni disonekenu.
     }
 

--- a/packages/i18n/locales/kmb/diagnostics.ftl
+++ b/packages/i18n/locales/kmb/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Kimbundu diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } i xisiwa kyoso jimbandu jyadi ja tumbwa
+       *[other] { $attributes } i xisiwa kyoso jimbandu jyadi ja tumbwa
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } i xisiwa kyoso o mbandu ni o kaxaxi ja tumbwa yoso
+       *[other] { $attributes } i xisiwa kyoso o mbandu ni o kaxaxi ja tumbwa yoso
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ki i kalakala se o kaxaxi ki kyala ko
+
+## `<line>`
+
+line-points-undetermined-dimensions = Nlonji ya bhita mu jimbanza ji ki tu ijiya o udikota wa jo ko.
+
+line-points-too-few-dimensions = O nlonji ya tokala kubhita mu jimbanza ja kala ni udikota wadi mba wavulu.
+
+line-points-depend-on-variables = O nlonji ya bhita mu jimbanza ja kolela ku isokololwelu: { $variables }.
+
+line-equation-invalid-format = O kifwa kya ikwasau ya nlonji ki kyabhonga ko mu { $variable1 } ni { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = O mwenyu wa tumbwa ni through, endpoint ni direction.  O through ya tumbwa i xisiwa.
+
+ray-dimension-mismatch = numDimensions ki i sokela mu mwenyu ko.
+
+## `<vector>`
+
+vector-overprescribed-head = O vetoru ya tumbwa ni head, tail ni displacement.  O head ya tumbwa i xisiwa.
+
+vector-dimension-mismatch = numDimensions ki i sokela mu vetoru ko.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ki tu tena kukwata ku `<{ $component }>` mukonda ki kyala ni nearestPoint ko.
+
+constrain-to-without-nearest-point = Ki tu tena kukangela ku `<{ $component }>` mukonda ki kyala ni nearestPoint ko.
+
+constrain-to-interior-without-nearest-point = Ki tu tena kukangela mukwa `<{ $component }>` mukonda ki kyala ni nearestPoint ko.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition i xisiwa mu choiceInput ki yala inline ko
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = O indices ya tumbwa mu choiceInput i xisiwa mukonda o kitalu kya indices ki kya sokela ni kitalu kya an'a a choice ko.
+
+pretzel-indices-count-mismatch = O indices ya tumbwa mu problem i xisiwa mukonda o kitalu kya indices ki kya sokela ni kitalu kya an'a a problem ko.
+
+shuffle-indices-count-mismatch = O indices ya tumbwa mu shuffle i xisiwa mukonda o kitalu kya indices ki kya sokela ni kitalu kya ima ko.
+
+indices-ignored-out-of-range = O indices ya tumbwa mu { $component } i xisiwa mukonda imoxi yala kanga dya njila.
+
+pretzel-indices-repeated = O indices ya tumbwa mu pretzel i xisiwa mukonda imoxi ya vutuluka.
+
+pretzel-circuit-first-index = O indices ya tumbwa mu pretzel mu mode="circuit" i xisiwa mukonda o index ya dyanga ya tokala kukala 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Phala `<{ $component }>` kukalakala ni an'a a string, o `type` attribute ya tokala kutumbwa.
+
+invalid-type-defaulting-to-math = Type { $type } ki yabhonga ko mu { $component }. Ya tokala kukala math, text, number mba boolean. Tu kalakala ni math.
+
+string-not-valid-component-to-arrange = String "{ $value }" ki kima kyambote ko mu { $component }. Kya xisiwa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } ki yabhonga ko, o type ya bhakelwa ku number.
+
+invalid-variable-value = Kima kya kisokololwelu ki kyabhonga ko: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = O kifwa index { $index } kya tokala kukala kitalu
+
+variant-index-must-be-integer = O kifwa index { $index } kya tokala kukala kitalu kyoso
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ki kya bhangelwe mu isokelu yoso ko. O udikota wa bhakelwa ku isokelu ya mukwa.
+
+side-by-side-absolute-margins = `<{ $component }>` ki kya bhangelwe mu isokelu yoso ko. O jimbandu ja bhakelwa ku isokelu ya mukwa.
+
+side-by-side-no-block-child = `<{ $component }>` ki kyabhonga ko: kya tokala kukala ni mona umoxi mba avulu wa block.
+
+## `<label>`
+
+label-for-ignored-on-graphical = O `for` attribute mu `<label>` ya kifika i xisiwa.
+
+label-for-must-resolve-to-one = O `for` attribute mu `<label>` ya tokala kuya ku kima kimoxi ngó.
+
+label-for-unresolved = O `for` attribute mu `<label>` ki ya tenene kuya ku kima ko.
+
+label-for-answer-with-authored-inputs = O `for` attribute mu `<label>` i zwela `<answer>` yala ni inputs ya sonekwa; zwela ku input muene.
+
+label-for-answer-without-input = O `for` attribute mu `<label>` i zwela `<answer>` ki yala ni input ko.
+
+label-for-must-reference-input-or-answer = O `for` attribute mu `<label>` ya tokala kuzwela input mba answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Phala kubhixila, `<{ $component }>` kya tokala kukala ni kijilu kya kufuka mba kutumbwa kála decorative.
+
+accessibility-video-short-description = Phala kubhixila, `<video>` kya tokala kukala ni kijilu kya kufuka.
+
+accessibility-input-short-description-or-label = Phala kubhixila, `<{ $component }>` kya tokala kukala ni kijilu kya kufuka mba dijina.
+
+accessibility-answer-input-short-description-or-label = Phala kubhixila, `<answer>` i bhanga input ya tokala kukala ni kijilu kya kufuka mba dijina.
+
+accessibility-short-description-contains-math = Ijilu ya kufuka ki ya tokala kukala ni ima ya matematika kála `<{ $component }>` ko. Soneka o matematika ni izwelu.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ki yala ni kutepa kwa tokala ko mu izwelu ya mutwe wa kitangana (mode ya kididima) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kwa bhinga { $threshold }:1 mba kwavulu).
+       *[other] { $colorName } ki yala ni kutepa kwa tokala ko mu izwelu ya mutwe wa kitangana ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kwa bhinga { $threshold }:1 mba kwavulu).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` ya bhita mu jimbanza { $count } ki ya bhangelwe ko kyoso o jimbanza ki jala ni italu ko.
+
+circle-too-many-through-points = Ki tu tena kusoka kizenge kya bhita mu jimbanza javulu ku 3.
+
+circle-overprescribed-radius-center-points = Ki tu tena kusoka kizenge ni radius, kaxaxi ni jimbanza yoso.
+
+circle-center-with-multiple-points = Ki tu tena kusoka kizenge ni kaxaxi kya bhita mu kimbanza kyavulu ku 1.
+
+circle-radius-too-small = Ki tu tena kusoka o kizenge: mukonda o kididi kaxaxi ka jimbanza jyadi kyala { $distance }, o radius { $radius } ya tumbwa yala mutetuka kyavulu.
+
+circle-radius-with-many-points = Ki tu tena kubhanga kizenge kya bhita mu jimbanza javulu ku jyadi ni radius ya tumbwa.
+
+circle-invalid-center-or-through-points = O kaxaxi mba o jimbanza ja kizenge ki jabhonga ko.
+
+circle-radius-center-with-multiple-points = Ki tu tena kusoka o radius ya kizenge ni kaxaxi kya bhita mu kimbanza kyavulu ku 1.
+
+circle-change-radius-non-numerical = Ki tu tena kusokolola o radius ya kizenge ni jimbanza ki jala ni italu ko
+
+circle-radius-with-points-non-numerical = Ki tu tena kubhanga kizenge kya bhita mu kimbanza kyavulu ku kimoxi ni radius kyoso o italu ki yala ko.
+
+circle-change-center-non-numerical = O kusokolola o kaxaxi ka kizenge kya bhita mu jimbanza ki jala ni italu ko ki kya bhangelwe ko.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] O udikota ki wa tokala ko mu domain ya funsau. O domain yala ni kitembu { $intervals } maji o funsau yala ni { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+       *[other] O udikota ki wa tokala ko mu domain ya funsau. O domain yala ni itembu { $intervals } maji o funsau yala ni { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = O kifwa kya domain ya funsau ki kyabhonga ko.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Tu xisa o udikota wa funsau ki wala ni kitalu ko.
+        [minimum] Tu xisa o utetuka wa funsau ki wala ni kitalu ko.
+        [extremum] Tu xisa o mbandu ya funsau ki yala ni kitalu ko.
+        [point] Tu xisa o kimbanza kya funsau ki kyala ni kitalu ko.
+        [slope] Tu xisa o kubhinda kwa funsau ki kwala ni kitalu ko.
+       *[other] Tu xisa o { $type } ya funsau ki yala ni kitalu ko.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Tu xisa o udikota wa funsau ki wala ni kima ko.
+        [minimum] Tu xisa o utetuka wa funsau ki wala ni kima ko.
+        [extremum] Tu xisa o mbandu ya funsau ki yala ni kima ko.
+        [point] Tu xisa o kimbanza kya funsau ki kyala ni kima ko.
+       *[other] Tu xisa o { $type } ya funsau ki yala ni kima ko.
+    }
+
+function-points-too-close = O funsau yala ni jimbanza jyadi ja kala kubhixila kyavulu. Ki tu tena kujijila o funsau.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] O kuvutuluka kwa funsau ku tena ngó se o kitalu kya inputs kya sokela ni kitalu kya outputs. O funsau yiyi yala ni input { $inputs } ni { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+       *[other] O kuvutuluka kwa funsau ku tena ngó se o kitalu kya inputs kya sokela ni kitalu kya outputs. O funsau yiyi yala ni inputs { $inputs } ni { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = O ulephu wa sequence ki wabhonga ko.  Wa tokala kukala kitalu kyoso ki kyala boxi dya ziro ko.
+
+sequence-invalid-step = O step ya sequence ki yabhonga ko.  Ya tokala kukala kitalu mu sequence ya type { $type }.
+
+sequence-invalid-endpoint-number = O "{ $attribute }" ya sequence ya number ki yabhonga ko.  Ya tokala kukala kitalu.
+
+sequence-invalid-endpoint-letters = O "{ $attribute }" ya sequence ya letters ki yabhonga ko.  Ya tokala kukala kibhungu kya jisonekenu.
+
+sequence-invalid-endpoint = O "{ $attribute }" ya sequence ki yabhonga ko.
+
+select-from-sequence-coprime-not-numbers = coprime i xisiwa mukonda ki tu sola italu ko
+
+select-from-sequence-coprime-with-exclude-combinations = coprime i xisiwa mukonda excludeCombinations ya tumbwa
+
+## Resolving a `target`
+
+target-not-found = O target ya `<{ $source }>` ki yabhonga ko: ki tu tena kusanga o target.
+
+target-state-variable-not-found = O target ya `<{ $source }>` ki yabhonga ko: ki tu tena kusanga o kisokololwelu kya dijina "{ $property }" mu `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = O isokololwelu ya `<odeSystem>` ya tokala kutepa ni kisokololwelu kya muene.
+
+ode-system-duplicate-variable-names = Ki tu tena kujijila o funsau ja ODE RHS ni majina ma isokololwelu ma vutuluka.
+
+ode-system-rhs-function-error = Ki tu tena kujijila o funsau ya ODE RHS.  Kibhengelu mu kubhanga o funsau ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ki tu tena kujijila o kanku kaxaxi ka jinlonji { $count }
+
+angle-invalid-through-point = O kimbanza ki kyabhonga ko mu through ya `<angle>`
+
+parabola-vertex-too-many-points = Parabola ni vertex ya bhita mu kimbanza kyavulu ku 1 ki ya bhangelwe ko.
+
+parabola-too-many-points = Parabola ya bhita mu jimbanza javulu ku 3 ki ya bhangelwe ko.
+
+intersection-too-many-items = O kudibhixila kwa ima yavulu ku yyadi ki kwa bhangelwe ko
+
+## Other math components
+
+ionic-compound-not-two-ions = O kibhungu kya ioni mu ima ya mukwa ki yala jioni jyadi ko ki kya bhangelwe ko.
+
+ionic-compound-needs-cation-and-anion = O kibhungu kya ioni kya bhangelwa ngó mu katiau kamoxi ni aniau imoxi.
+
+solve-equations-cannot-evaluate = Ki tu tena kusokolola o ikwasau mukonda ki tu tena kwi soka ko: { $equation }
+
+math-operators-operand-number-required = O operandNumber ya tokala kutumbwa kyoso tu katula o operand ya matematika.
+
+eigen-decomposition-failed = Ki tu tenene kusoka o jieigenvalue ja matrisi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: o parameter { $parameters } ki yala mu kifwa ko, kienyi i sokela ngó ni kima ki kyala ko.
+       *[other] `<matchesPattern>`: o parameters { $parameters } ki yala mu kifwa ko, kienyi i sokela ngó ni kima ki kyala ko.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ki tu tena kwijiya grid="{ $grid }". Ya tokala kukala none, medium, dense, mba italu yyadi ya dikota ya tepwa ni kididi, kála grid="1 0.5". Ki tu bhanga grid ko.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ki i kalakala mu mulondekesi prefigure ko; tu kalakala ni mbandu ya kudilu.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ki i kalakala mu mulondekesi prefigure ko; tu kalakala ni mbandu ya bhulu.
+
+prefigure-invalid-axis-bounds = `<graph>`: o jimbandu ja aksi ki jabhonga ko mu prefigure; tu kalakala ni bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: o udikota ki wabhonga ko mu prefigure; tu kalakala ni udikota 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: o aspectRatio ki yabhonga ko mu prefigure; tu kalakala ni aspektu rasyu 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: o kididi kya grid kyala kitetuka kyavulu mu jimbandu ja aksi; o grid i katulwa mu mulondekesi prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: o annotations ki i londekeswa ko se ki tu kalakala ni mulondekesi PreFigure.
+
+multiple-annotations-children = Kwa sangwa an'a avulu a `<annotations>` mu `<graph>`; oso a xisiwa maji o wa sukina.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ki tu tena kubhakela mba kusokolola o kifwa kya kima ki tu ijiya ko: { $type }.
+
+copy-prop-not-found = Ki tu tenene kusanga o prop { $property } mu kima kya kifwa { $component }
+
+collect-no-source = Ki kwa sangelwe o ditangi dya collect ko.
+
+collect-invalid-component-type = Ki tu tena kubhungula o ima ya kifwa `<{ $component }>` mukonda o kifwa ki kyabhonga ko.
+
+reference-index-unavailable = Ki tu tena kuzwela o index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ki tu tena kwixana { $action } mu kima `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = O kifwa kya ijimbwete ki kyabhonga ko.  O jinlonji jala ni ulephu wa tepa. Kwa sangwa mu componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = O ijimbwete yala ni majina ma koluna ma vutuluka.  Kwa sangwa mu componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = O ijimbwete ki yala ni dijina dya koluna ko.  Kwa sangwa mu componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = O award ya kitambwijilu kiki i kolela ku kitambwijilu kya answer tag muene, kienyi ki bhekela ima ki tu kingile ko.
+
+answer-max-num-attempts-in-section-wide-check-work = Se u bhaka `maxNumAttempts` mu `<answer>` yala mukwa kima kyala ni `sectionWideCheckWork`, ki i kalakala ko, mukonda o kima kyene ki tala o kitalu kya ilongelu. Bhaka `maxNumAttempts` mu kima kyene.
+
+nested-section-wide-check-work-max-num-attempts = Se u bhaka `maxNumAttempts` mu kima kyala ni `sectionWideCheckWork` kyala mukwa kima kya mukwa kyala ni `sectionWideCheckWork`, ki i kalakala ko, mukonda o kima kya kanga ki tala o kitalu kya ilongelu. Bhaka `maxNumAttempts` mu kima kya kanga.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] O { $attributes } attribute ki i kalakala se symbolicEquality ki ya bhakelwe ko.
+       *[other] O { $attributes } attributes ki i kalakala se symbolicEquality ki ya bhakelwe ko.
+    }
+
+answer-invalid-type = O type ya kitambwijilu ki yabhonga ko: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Mukonda o kima `<{ $component }>` ki kyala ni dijina ko, ki tu tena kwi kalakalesa kála module attribute
+
+module-attribute-name-already-defined = Ki tu tena kukalakalesa o kima `<{ $component } name="{ $name }">` kála attribute ya module mukonda `<module>` yala kya ni "{ $name }" attribute.
+
+conditional-content-condition-ignored = O `condition` attribute i xisiwa mu `<conditionalContent>` yala ni an'a a case mba else.
+
+slider-markers-type-mismatch = O type ya markers ki i sokela ni type ya slider ko.
+
+pretzel-problem-needs-statement-and-answer = O pretzel ki yabhonga ko: `<problem>` yoso ya tokala kukala ni `<statement>` yimoxi ni `<answer>` yimoxi.
+
+pretzel-circuit-first-problem-distractor = O pretzel ki yabhonga ko: mu mode="circuit", o `<problem>` ya dyanga ki i tena kukala distractor ko.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] O kima { $values } ki kyabhonga ko mu attribute `{ $attribute }`; kya xisiwa.
+       *[other] O ima { $values } ki yabhonga ko mu attribute `{ $attribute }`; ya xisiwa.
+    }
+
+attribute-must-be-references = O kima `{ $value }` ki kyabhonga ko mu attribute `{ $attribute }`. O attribute ya tokala kukala izwelu i matekesa ni `$`.
+
+math-input-invalid-function-names = <mathInput>: majina ma funsau ki mabhonga ko ma xisiwa mu { $attribute }: { $names }. Dijina dyoso o kitangana kya kulondekesa kya tokala kukala ni jisonekenu jyadi mba javulu (jisonekenu mba jimbandu); `|<mathspeak alternative>` i tena kukayela.
+
+## Building components from the source
+
+component-type-invalid = O kifwa kya kima ki kyabhonga ko: `<{ $componentType }>`
+
+attribute-repeated = Ki tu tena kuvutulula o attribute { $attribute }.
+
+attribute-invalid-for-component = O attribute "{ $attribute }" ki yabhonga ko mu kima kya kifwa `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    O kijilu kya kifwa { $styleNumber } ki kyala ni kutepa kwa tokala ko mu { $context ->
+        [text-on-background] o mbeji ya izwelu ku mbeji ya kunima
+        [high-contrast] o mbeji ya kutepa kwa dikota ku kanvasi
+        [line] o mbeji ya nlonji ku kanvasi
+        [marker] o mbeji ya kimbanza ku kanvasi
+       *[text-on-canvas] o mbeji ya izwelu ku kanvasi
+    }{ $mode ->
+        [dark] { " (mode ya kididima)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kwa bhinga { $threshold }:1 mba kwavulu).
+
+style-definition-dark-mode-text-background-contrast =
+    Sumbala o kijilu kya kifwa { $styleNumber } kyala ni jimbeji jala ni kutepa kwa tokala mu mode ya kyeleka, o jimbeji ja mode ya kididima ja tundu mu jo ki jala ni kutepa kwa tokala ko kaxaxi ka mbeji ya izwelu ni mbeji ya kunima ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kwa bhinga { $threshold }:1 mba kwavulu). { $suggestion ->
+        [available] Phala kukala ni kutepa kwa tokala mu mode ya kididima, bhakela o kutepa kwa mode ya kyeleka (kála, bhaka { $lightAttribute }="{ $lightColor }") mba sokolola o mbeji ya mode ya kididima (kála, bhaka { $darkAttribute }="{ $darkColor }").
+       *[none] Phala kukala ni kutepa kwa tokala mu mode ya kididima, bhakela o kutepa kwa mode ya kyeleka mba sokolola o jimbeji ni textColorDarkMode mba backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Sumbala o kijilu kya kifwa { $styleNumber } kyala ni mbeji ya izwelu yala ni kutepa kwa tokala mu mode ya kyeleka, o mbeji ya izwelu ya mode ya kididima ya tundu mu yo ki yala ni kutepa kwa tokala ko ku kanvasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; kwa bhinga { $threshold }:1 mba kwavulu). { $suggestion ->
+        [available] Phala kukala ni kutepa kwa tokala mu mode ya kididima, bhakela o kutepa kwa mode ya kyeleka (kála, bhaka textColor="{ $lightColor }") mba sokolola o mbeji ya mode ya kididima (kála, bhaka textColorDarkMode="{ $darkColor }").
+       *[none] Phala kukala ni kutepa kwa tokala mu mode ya kididima, bhakela o kutepa kwa mode ya kyeleka mba sokolola o mbeji ni textColorDarkMode.
+    }
+
+section-multiple-style-palettes = O kitangana ki tena kusola ngó <stylePalette> yimoxi; tu kalakala ni ya sukina.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ki tu tena kwijiya o ifwa ya tepa ya { $component } mukonda numToSelect ki kitalu kyoso ki kyala boxi dya ziro ko.
+
+variant-num-to-select-not-constant-number = ki tu tena kwijiya o ifwa ya tepa ya { $component } mukonda numToSelect ki kitalu ki ki sokolola ko.
+
+variant-with-replacement-not-constant-boolean = ki tu tena kwijiya o ifwa ya tepa ya { $component } mukonda withReplacement ki boolean ki i sokolola ko.
+
+variant-select-weight-disables-unique = O ifwa ya tepa ya select i jikwa se o option yimoxi yala ni selectWeight mba selectForVariants
+
+variant-coprime-undetermined = ki tu tena kwijiya o ifwa ya tepa ya { $component } mukonda ki tu tena kwijiya se coprime yala makutu ithangana yoso ko.
+
+variant-attribute-not-constant = ki tu tena kwijiya o ifwa ya tepa ya { $component } mukonda { $attribute } i sokolola.
+
+variant-attribute-not-number = ki tu tena kwijiya o ifwa ya tepa ya { $component } mukonda { $attribute } ki kitalu ko.
+
+variant-attribute-wrong-type-for-sequence =
+    ki tu tena kwijiya o ifwa ya tepa ya { $component } ya type { $type } mukonda { $attribute } ki { $expected ->
+        [letters-combination] kibhungu kya jisonekenu
+        [math-expression] kizwelu kya matematika kyabhonga
+        [integer] kitalu kyoso
+       *[number] kitalu
+    } ko.
+
+variant-length-not-integer = ki tu tena kwijiya o ifwa ya tepa ya { $component } mukonda length ki kitalu kyoso ko.
+
+variant-sort-not-implemented = o ifwa ya tepa ya { $component } ni sort ki ya bhangelwe ko
+
+variant-exclude-combinations-not-implemented = o ifwa ya tepa ya { $component } ni excludeCombinations ki ya bhangelwe ko
+
+variant-math-exclude-not-implemented = o ifwa ya tepa ya { $component } ya type math ni exclude ki ya bhangelwe ko
+
+variant-non-constant-exclude-not-implemented = o ifwa ya tepa ya { $component } ni exclude i sokolola ki ya bhangelwe ko
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ki i kalakala mu mulondekesi prefigure wa graph ko; o mona wa xisiwa.
+
+prefigure-descendant-invalid-geometry = { $subject }: o jiometria ki yabhonga ko mba ki ya zwe ko; o mona wa xisiwa.
+
+prefigure-curve-label-omitted = { $subject }: o majina ki ma kalakala mu ima ya curve ya sokololwa ko; o dijina dya katulwa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: o kifwa kya kijilu kya funsau ya curve '{ $definitionType }' ki i kalakala ko; o mona wa xisiwa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: o flipFunctions attribute mu regionBetweenCurves ki i kalakala ko; o mona wa xisiwa.
+
+prefigure-region-non-formula-child = { $subject }: an'a a funsau ya kifwa formula ngó a kalakala mu regionBetweenCurves; o mona wa xisiwa.
+
+prefigure-label-position-unsupported =
+    { $subject }: o labelPosition '{ $labelPosition }' ki i kalakala ko mu { $labelKind ->
+        [line-family] dijina dya muxi wa jinlonji
+       *[point] dijina dya kimbanza
+    }; tu kalakala ni kisokelu kya PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure ki i ijiya o kifwa kya kuizala '{ $fillStyle }' ko; tu kalakala ni kuizala kwoso.
+
+prefigure-line-style-unknown = { $subject }: o kifwa kya nlonji '{ $lineStyle }' ki tu kyijiya ko, kienyi kya katulwa mu PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: o kifwa kya kimbanza '{ $markerStyle }' kya sokololwa ku kifwa 'diamond' kya PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure ki i ijiya o kifwa kya kimbanza '{ $markerStyle }' ko; tu kalakala ni kifwa kyala dyanga.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: o `ref` ki yabhonga ko; ki tu tena kusanga o target. O annotation ya katulwa.
+
+annotation-ref-multiple-targets = `<annotation>`: o `ref` ya sanga jitarjeti javulu; tu kalakala ni ya dyanga.
+
+annotation-ref-outside-graph = `<annotation>`: o `ref` ki yabhonga ko; o target yala kanga dya graph. O annotation ya katulwa.
+
+annotation-ref-unsupported-target = `<annotation>`: o `ref` ki yabhonga ko; o target ki kima kya kifika ki prefigure i ijiya ko. O annotation ya katulwa.
+
+annotation-text-missing = `<annotation>`: o `text` ki yala ko mba ki yala ni kima ko; tu soneka izwelu ki yala ni kima ko.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Kwa sangwa o kukolela kwa kizenge.
+       *[other] Kwa sangwa o kukolela kwa kizenge ni kima `<{ $componentType }>`.
+    }
+
+reference-no-referent = Ki kwa sangelwe kima ko mu kizwelu: `{ $reference }`
+
+reference-multiple-referents = Kwa sangwa ima yavulu mu kizwelu: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = O kifwa kya attribute { $attribute } ya `<{ $componentType }>` ki kyabhonga ko.
+
+children-invalid = O an'a a `<{ $componentType }>` ki abhonga ko: Kwa sangwa an'a ki abhonga ko: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = O kima `{ $value }` ki kyabhonga ko mu attribute `{ $attribute }`, tu kalakala ni `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ki kwa sangelwe o kifwa kya DoenetML { $version } ko.
+       *[other] Ki kwa sangelwe o kifwa kya DoenetML { $version } ko. Tu kalakala ni kifwa { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ki yabhonga ko: { $content }
+
+parse-tag-missing-close-tag = DoenetML ki yabhonga ko: O tag `{ $tag }` ki yala ni tag ya kujika ko. Tu kingile tag i dijika muene mba tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ki yabhonga ko: Kibhengelu mu tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ki yabhonga ko: O attribute `{ $attribute }` ki yabhonga ko, i moneka kála ki yala ni kima ko.
+
+parse-attribute-invalid = DoenetML ki yabhonga ko: O attribute `{ $attribute }` ki yabhonga ko
+
+parse-attribute-value-invalid = DoenetML ki yabhonga ko: O kima kya attribute `{ $value }` ki kyabhonga ko
+
+parse-attribute-value-quote-mismatch = DoenetML ki yabhonga ko: O kima kya attribute `{ $value }` ki kyabhonga ko. O jimbanza ja kuzwela ki ja sokela ko. I moneka kála `{ $quote }` ki yala ko
+
+parse-open-tag-name-missing = DoenetML ki yabhonga ko: Kwa sangwa tag ki yala ni dijina ko, kála `<`
+
+parse-tag-not-closed = DoenetML ki yabhonga ko: O tag `{ $tag }` ki ya jikilwe ko (i moneka kála `>` ki yala ko).
+
+parse-self-closing-tag-name-missing = DoenetML ki yabhonga ko: Kwa sangwa tag ki yala ni dijina ko `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ki yabhonga ko: O tag `{ $tag }` ki ya jikilwe ko (i moneka kála `/>` ki yala ko).
+
+parse-tag-invalid-attributes = DoenetML ki yabhonga ko: O tag `{ $tag }` ki yabhonga ko. I tena kukala ni attributes ki yabhonga ko.
+
+parse-close-tag-name-missing = DoenetML ki yabhonga ko: Kwa sangwa tag ya kujika ki yala ni dijina ko, kála `</`
+
+parse-attribute-value-unquoted = O ima ya attribute ya tokala kukala mukwa jimbanza ja kuzwela: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ki yabhonga ko: Kwa sangwa tag ya kujika `{ $tag }`, maji o tag ya kujikula ki yala ko
+
+parse-close-tag-mismatched = DoenetML ki yabhonga ko: O tag ya kujika ki i sokela ko. Tu kingile `</{ $expected }>`. Kwa sangwa `{ $found }`
+
+parser-node-unconvertible = Ki tu tena kusokolola o node { $node } ku node ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    O dijina name='{ $name }' ki dyabhonga ko. { $reason ->
+        [characters] O majina ma tena kukala ngó ni jisonekenu, italu, jimbandu ja boxi mba jimbandu.
+       *[start] O majina ma tokala kumatekesa ni disonekenu.
+    }
+
+component-name-invalid-start = O dijina dya kima "{ $name }" ki dyabhonga ko. O majina ma tokala kumatekesa ni disonekenu.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = O answer ya type videoWatched ya tokala kukala ni video attribute
+
+answer-video-watched-video-not-reference = O answer ya type videoWatched ya tokala kukala ni video attribute yala kizwelu
+
+answer-name-not-single-text = O answer name attribute ya tokala kukala ni mona umoxi ngó wa text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ki tu tenene kusanga o DoenetML ya kanga mukonda o kuvutuluka kwavulu. O kizwelu kya kizenge kyala?
+
+external-doenetml-unavailable = Ki tu tenene kusanga o DoenetML mu { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = O DoenetML ya sangwa mu { $attribute }="{ $uri }" ki yabhonga ko: ki i sokela ni kifwa kya kima "{ $componentType }" ko
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] O attribute `{ $from }` ya kukuluka; kalakalesa `{ $to }`.
+       *[other] [deprecation] O attribute `{ $from }` mu `<{ $component }>` ya kukuluka; kalakalesa `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] O attribute `{ $from }` ya kukuluka kienyi ya xisiwa mukonda `{ $to }` yala wó.
+       *[other] [deprecation] O attribute `{ $from }` mu `<{ $component }>` ya kukuluka kienyi ya xisiwa mukonda `{ $to }` yala wó.
+    }
+
+deprecated-attribute-ignored = [deprecation] O attribute `{ $attribute }` mu `<{ $component }>` ya kukuluka kienyi ya xisiwa.
+
+deprecated-attribute-to-child = [deprecation] O attribute `{ $attribute }` mu `<{ $component }>` ya kukuluka; kalakalesa o mona `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] O kima `{ $value }` kya attribute `{ $attribute }` mu `<{ $component }>` kya kukuluka; kalakalesa `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` i tena ngó kubhanga o Ingelezu yavulu, kienyi o izwelu ya i xisa kála wa i soneka mu divulu dya sonekwa mu { $locale }. Soneka o kifwa kyavulu muene, mba ki bhaka ni `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = O kima `<{ $tag }>` ki kima kya Doenet tu ijiya ko.
+
+schema-element-not-allowed-at-root = O kima `<{ $tag }>` ki kya tanwa ko ku bhulu dya divulu.
+
+schema-element-not-allowed-inside = O kima `<{ $tag }>` ki kya tanwa ko mukwa `<{ $parent }>`.
+
+schema-attribute-unrecognized = O kima `<{ $tag }>` ki kyala ni attribute ya dijina `{ $attribute }` ko.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] O attribute `{ $attribute }` ya kima `<{ $tag }>` ya tokala kukala kilundu kyala ni ima yoso yala kimoxi mu: { $allowed }
+       *[other] O attribute `{ $attribute }` ya kima `<{ $tag }>` ya tokala kukala kimoxi mu: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = O dijina dya kifwa dya select ki dyabhonga ko.  O dijina dya kifwa { $variantName } di moneka mu options { $numOptions } maji o kitalu kya kusola kyala { $numToSelect }.
+
+select-variant-name-without-options = Ifwa imoxi ya tumbwa mu select maji ki kwa tumbwile options mu dijina dya kifwa di tena kukala: { $variantName }.
+
+select-variant-name-not-possible = O dijina dya kifwa { $variantName } dya tumbwa mu select ki dijina dya kifwa di tena kukala ko.
+
+select-too-few-options = Ki tu tena kusola ima { $numToSelect } mu { $numOptions } ngó.
+
+select-from-sequence-too-few-values = Ki tu tena kusola ima { $numToSelect } mu sequence ya ulephu { $length }.
+
+select-from-sequence-indices-count-mismatch = O kitalu kya indices ya tumbwa mu select kya tokala kusokela ni kitalu kya kusola
+
+select-from-sequence-indices-not-integers = O indices yoso ya tumbwa mu select ya tokala kukala italu yoso
+
+select-from-sequence-index-excluded = Kwa tumbwa index ya selectfromsequence ya katulwa
+
+select-from-sequence-indices-excluded-combination = Kwa tumbwa indices ya selectfromsequence yala kibhungu kya katulwa
+
+select-from-sequence-coprime-not-positive-integers = Ki tu tena kusola ibhungu ya coprime mukonda ki tu sola italu yoso yala bhulu dya ziro ko.
+
+select-from-sequence-coprime-common-factor = Ki tu tena kusola italu ya coprime. O ima yoso i tena yala ni fatoru yimoxi. (O ima ya tumbwa ya "from" mba "to" ya tokala kukala coprime ni "step".)
+
+select-from-sequence-coprime-single-number = Ki tu tena kusola ibhungu ya coprime mu kitalu kimoxi ki kyala 1 ko.
+
+select-from-sequence-excluded-too-many-combinations = Kwa katulwa ibhungu yavulu ku 70% mu selectFromSequence
+
+select-from-sequence-coprime-none-found = Ki tu tenene kusola italu ya coprime. O ima yoso i tena yala ni fatoru yimoxi.
+
+select-from-sequence-too-few-unique-values = Ki tu tena kusola ima ya tepa { $numToSelect } mu sequence ya ulephu { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Ki tu tena kusola ima { $numToSelect } mu kilundu kya italu ya prime kya ulephu { $numValues }
+
+select-prime-numbers-values-count-mismatch = O kitalu kya ima ya tumbwa mu select kya tokala kusokela ni kitalu kya kusola
+
+select-prime-numbers-values-not-prime = O ima yoso ya tumbwa mu select prime number ya tokala kukala mu kilundu kya italu ya prime
+
+select-prime-numbers-values-excluded-combination = O ima ya tumbwa ya selectPrimeNumbers yala kibhungu kya katulwa
+
+select-prime-numbers-excluded-too-many-combinations = Kwa katulwa ibhungu yavulu ku 70% mu selectPrimeNumbers
+
+select-random-combination-fluke = Ni kima ki tu kingile ko, ki tu tenene kusola o kibhungu kya ima ya kuyapula
+
+select-random-value-fluke = Ni kima ki tu kingile ko, ki tu tenene kusola o kima kya kuyapula

--- a/packages/i18n/locales/kmb/editor.ftl
+++ b/packages/i18n/locales/kmb/editor.ftl
@@ -1,0 +1,208 @@
+# Kimbundu editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Vutula
+       *[update] Sokolola
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } o Mulondekesi
+       *[other] { $word } o Mulondekesi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Kifwa
+
+editor-variant-filter = Sota…
+
+editor-variant-next = Sola kifwa kya kaya
+
+editor-variant-previous = Sola kifwa kya bhitile
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Kwa sangwa kubhengela kwa WCAG AA mu kubhixila. Kwata phala { $action ->
+            [close] kujika
+           *[open] kujikula
+        } o divulu dya kubhixila.
+        [advisories] Kwata phala { $action ->
+            [close] kujika
+           *[open] kujikula
+        } o divulu dya kubhixila. Ki kwa sangelwe kubhengela kwa WCAG AA ko, maji kwala ilongesu ya mukwa ya kubhixila.
+       *[clean] Kwata phala { $action ->
+            [close] kujika
+           *[open] kujikula
+        } o divulu dya kubhixila. Ki kwa sangelwe kibhidi kya kubhixila ko.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Kwa sangwa kubhengela kwa WCAG AA mu kubhixila. Kwa sangwa { $count ->
+            [one] kubhengela { $count } kwa WCAG AA
+           *[other] kubhengela { $count } kwa WCAG AA
+        }. Kwata phala { $action ->
+            [close] kujika
+           *[open] kujikula
+        } o divulu dya kubhixila.
+        [advisories] Ki kwa sangelwe kubhengela kwa WCAG AA ko. Kwa sangwa { $count ->
+            [one] kilongesu { $count } kya mukwa kya kubhixila
+           *[other] ilongesu { $count } ya mukwa ya kubhixila
+        }. Kwata phala { $action ->
+            [close] kujika
+           *[open] kujikula
+        } o divulu dya kubhixila.
+       *[clean] Ki kwa sangelwe kubhengela kwa WCAG AA ko. Kwata phala { $action ->
+            [close] kujika
+           *[open] kujikula
+        } o divulu dya kubhixila.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Kifwa kya DoenetML { $version }
+
+editor-tab-help = Kikwatekesu kya kididi
+editor-tab-help-short = Kididi
+editor-tab-errors = Ibhengelu
+editor-tab-warnings = Idimbu
+editor-tab-info = Ijimbwete
+editor-tab-accessibility = Kubhixila
+editor-tab-responses = Itambwijilu ya tumwa
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Isolelu ya musoneki
+editor-format-as-doenetml = Sokolola kála DoenetML
+editor-format-as-xml = Sokolola kála XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Nlonji #{ $line }
+
+editor-no-errors = Ki Kwala Ibhengelu ko
+editor-no-warnings = Ki Kwala Idimbu ko
+editor-no-info = Ki Kwala Ijimbwete ko
+
+editor-show-info-annotations = Londekesa ijimbwete mu musoneki
+editor-show-accessibility-annotations = Londekesa ibhidi ya kubhixila mu musoneki
+
+editor-accessibility-learn-more = Dilonga kyebhi Doenet i tala o kubhixila
+
+editor-accessibility-violations-heading = Kubhengela kwa kubhixila ({ $standard })
+
+editor-accessibility-other-heading = Ibhidi ya mukwa ya kubhixila
+editor-none-found = Ki kwa sangelwe kima ko
+
+
+## Submitted responses
+
+editor-no-responses = Ki kwala muthu wa tumu kitambwijilu ko
+editor-response-answer-id = Dijina dya kitambwijilu
+editor-response-response = Kitambwijilu
+editor-response-credit = Mbandu
+editor-response-submitted = Kya tumwa
+
+
+## The context-help panel
+
+help-placeholder = Bhaka o kimbanza mu dijina dya tag, mu attribute, mba mu { $ref } phala kusanga o kijilu.
+
+help-unsupported-ref-chain = O kikwatekesu kya izwelu ya itangana yavulu kála { $example } ki kyala hanji ko.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ki kwa sangelwe kima kya { $ref } ko.
+        [multiple] Kwa sangwa ima yavulu ya { $ref }.
+       *[indeterminate] Ki kwa tenene kwijiya o kima kya { $ref } ko.
+    }
+
+help-learn-about-references = Dilonga ia izwelu →
+help-reference-page = Kibhamba kya kijilu →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Mukwa { $element }
+       *[top] Ku bhulu dya divulu
+    }{ $allowed ->
+        [none] { " — ki kwala kima ki kaya bhabha ko." }
+        [text] { " — soneka izwelu bhabha." }
+        [text-and-components] { " — soneka izwelu bhabha, mba tala:" }
+       *[components] { " — ima i utena kutala:" }
+    }
+
+help-suggestions-footer = Kwata { $shortcut } phala kutala ima { $total } yoso.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } kizwelu kya kuya ku { $target }.
+       *[other] { $ref } kizwelu kya kuya ku { $target } (nlonji { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } wa ki bhana kála { $role }.
+       *[other] { $owner } wa ki bhana mu nlonji { $line } kála { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } kizwelu kya kuya ku kima { $property } kya { $element }.
+       *[other] { $ref } kizwelu kya kuya ku kima { $property } kya { $element } (nlonji { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = kitangana
+help-kind-array-entry = kitangana kya array
+
+help-default = Kyala dyanga:
+help-active-default = Kyala dyanga ni kya kalakala:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ima ya itanu (kimoxi ku kima kimoxi):
+       *[other] Ima ya itanu:
+    }
+
+help-suggested-values = Ima ya londekeswa:
+
+help-inserts = I bhakela:
+
+help-coordinates =
+    { $count ->
+        [one] Kididi:
+       *[other] Ididi:
+    }
+
+help-type = Kifwa:
+
+help-resolved-style = Kifwa kya sangwa (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Majina ma funsau ma sangwa:
+help-reset-list = Vutula o kilundu mu input yiyi:
+help-added-on-input = Kya bhakelwa mu input yiyi:
+help-removed-on-input = Kya katulwa mu input yiyi:
+
+help-reset-overrides = { $reset } i bhita { $additional } ni { $removed }.

--- a/packages/i18n/locales/kmb/editor.ftl
+++ b/packages/i18n/locales/kmb/editor.ftl
@@ -115,7 +115,7 @@ editor-none-found = Ki kwa sangelwe kima ko
 
 ## Submitted responses
 
-editor-no-responses = Ki kwala muthu wa tumu kitambwijilu ko
+editor-no-responses = Ki kwala itambwijilu ya tumwa hanji ko
 editor-response-answer-id = Dijina dya kitambwijilu
 editor-response-response = Kitambwijilu
 editor-response-credit = Mbandu
@@ -182,8 +182,8 @@ help-style-number-annotation = { " " }(styleNumber { $styleNumber })
 
 help-allowed-values =
     { $perItem ->
-        [true] Ima ya itanu (kimoxi ku kima kimoxi):
-       *[other] Ima ya itanu:
+        [true] Ima ya tanwa (kimoxi ku kima kimoxi):
+       *[other] Ima ya tanwa:
     }
 
 help-suggested-values = Ima ya londekeswa:

--- a/packages/i18n/locales/men/chrome.ftl
+++ b/packages/i18n/locales/men/chrome.ftl
@@ -3,7 +3,7 @@
 #
 # UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
 #
-# See `content.ftl`'s header for why this catalog is written entirely in the
+# See `content.ftl`'s header for why the describing words here are left
 # indefinite, and for what a speaker should check first.
 
 

--- a/packages/i18n/locales/men/chrome.ftl
+++ b/packages/i18n/locales/men/chrome.ftl
@@ -77,7 +77,7 @@ matrix-add-column = Gbua kɔlum
 subset-add-remove-points = Gbua/Wumbu tɔkpɔisia
 subset-toggle-points-intervals = Wote tɔkpɔisia kɛ wati sia
 subset-move-points = Hiti Tɔkpɔisia
-subset-clear = Gbɔyɔ kpɛlɛ
+subset-clear = Wumbu kpɛlɛ
 
 orbital-add-row = Gbua Lɔlɔi
 orbital-remove-row = Wumbu Lɔlɔi

--- a/packages/i18n/locales/men/chrome.ftl
+++ b/packages/i18n/locales/men/chrome.ftl
@@ -1,0 +1,133 @@
+# Mende viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for why this catalog is written entirely in the
+# indefinite, and for what a speaker should check first.
+
+
+## Answer submission
+
+answer-checking = A gbɔɔ…
+answer-submitting = A ve…
+
+answer-checking-status = Ta njepei gbɔɔ
+answer-submitting-status = Ta njepei ve
+
+answer-correct = A tonya
+answer-incorrect = Ii tonya
+
+answer-response-saved = Njepei Yɛlɛnga
+
+answer-percent-credit = { $percent }% Ndoli
+answer-percent-correct = { $percent }% Tonya
+answer-percent-short = { $percent } %
+
+max-credit-available = Ndoli wa bi majɔɔ: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] gɔɔla gbi ii lɔ
+        [one] gɔɔla { $count } lɔ
+       *[other] gɔɔla { $count } ti lɔ
+    }
+
+validation-correct = (A tonya)
+validation-incorrect = (Ii tonya)
+validation-partially-correct = (A tonya gbua)
+
+answer-show-responses =
+    { $count ->
+        [one] Gɛnɛ njepei { $count } { $answerId } va
+       *[other] Gɛnɛ njepeisia { $count } { $answerId } va
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Njepe woma
+
+collapsible-click-to-open = (tɔkpɔ kɔ i gbɔyɔ)
+collapsible-click-to-close = (tɔkpɔ kɔ i gbɔkɔ)
+
+collapsible-initializing = A yɛpɛ…
+
+footnote-show = Gɛnɛ nyɛingɔ na lɔ kunafɔ
+footnote-hide = Lombi nyɛingɔ na lɔ kunafɔ
+
+description-more-information = hinda gbe hugɔɔla
+
+
+## Controls
+
+slider-previous = Na wa ma
+slider-next = Na wa woma
+
+keyboard-open = Gbɔyɔ Kibɔd
+keyboard-close = Gbɔkɔ Kibɔd
+
+choice-input-remove-choice = Wumbu { $choice }
+
+matrix-remove-row = Wumbu lɔlɔi
+matrix-add-row = Gbua lɔlɔi
+matrix-remove-column = Wumbu kɔlum
+matrix-add-column = Gbua kɔlum
+
+subset-add-remove-points = Gbua/Wumbu tɔkpɔisia
+subset-toggle-points-intervals = Wote tɔkpɔisia kɛ wati sia
+subset-move-points = Hiti Tɔkpɔisia
+subset-clear = Gbɔyɔ kpɛlɛ
+
+orbital-add-row = Gbua Lɔlɔi
+orbital-remove-row = Wumbu Lɔlɔi
+orbital-add-box = Gbua Bɔks
+orbital-remove-box = Wumbu Bɔks
+orbital-add-up-arrow = Gbua Aro Na Lɔ Woma
+orbital-add-down-arrow = Gbua Aro Na Lɔ Kunafɔ
+orbital-remove-arrow = Wumbu Aro
+
+orbital-row-label = Lɔlɔi { $row } biyei
+
+pretzel-answer = Njepei
+
+summary-statistics-caption = { $column } nambasia hugɔɔla
+
+
+## Math input
+
+math-input-preview-region = mat njepei gɛnɛ ma
+math-input-preview = Gɛnɛ ma
+math-input-invalid-expression = Njepe na ii tonya:
+
+
+## Document status
+
+viewer-initializing = A yɛpɛ…
+
+
+## Errors
+
+error-heading = Hinda nyamu
+
+error-found-at =
+    { $span ->
+        [line] Ti majɔɔ laing { $startLine } ma.
+       *[lines] Ti majɔɔ laingsia { $startLine }–{ $endLine } ma.
+    }
+
+document-contains-errors = Buk ji hinda nyamusia lɔ hu!
+
+diagnostic-heading-error = Hinda nyamu
+diagnostic-heading-warning = Ngiti wa
+diagnostic-heading-information = Hugɔɔla
+diagnostic-heading-hint = Ngiti
+
+accessibility-heading-level-1 = WCAG AA Majɔɔla Sawa Wɔlɔla
+accessibility-heading-level-2 = Majɔɔla ngiti wa
+
+something-went-wrong = Hinda yila ii yɛlɛ kɛnɛi.
+
+renderer-load-failed = gɛnɛmɔi yila ii wanga. Kɔ bi pej ji wote.
+
+core-start-failed = Buk gɛnɛmɔi ii gula i yɛpɛ. Kɔ bi pej ji wote.

--- a/packages/i18n/locales/men/content.ftl
+++ b/packages/i18n/locales/men/content.ftl
@@ -26,14 +26,21 @@
 # would render the suffix as literal text against whatever the argument
 # happened to be, and the argument is a whole phrase in most branches anyway.
 #
-# **So this catalog is written entirely in the indefinite**, which is the
-# README's "choose the words that land there" way out, taken at the level of
-# the whole file rather than of one message. That is not a workaround dressed
+# **So every describing word here is indefinite**, which is the README's
+# "choose the words that land there" way out, taken at the level of the whole
+# file rather than of one message: no description ends in the suffix, and the
+# suffix is never written against a placeable. That is not a workaround dressed
 # up as a decision: a style description is read out of context — "thick red
 # line", not "the thick red line" — and the indefinite is what Mende uses
 # there. A speaker who thinks a particular message wants the definite should
 # say so on #1521 rather than adding the suffix here, because the message that
 # wants it is the one whose final word is an argument.
+#
+# The rule is about where the suffix *lands*, not about the letter: a few fixed
+# vocabulary items carry it lexically — «tɔkpɔi» a mark, «laingi ti lɔ va» the
+# horizontal fill — and they are safe because the suffix sits inside a phrase
+# this file writes out, never at the boundary of an argument. A speaker
+# deciding «tɔkpɔ» is wanted there instead should say so on #1521.
 #
 # **`$gender` goes unused.** Mande languages have no noun class, and Mende is
 # no exception — which is worth saying explicitly, because `locales/mnk`,

--- a/packages/i18n/locales/men/content.ftl
+++ b/packages/i18n/locales/men/content.ftl
@@ -1,0 +1,292 @@
+# Mende content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `men` is Mende, a Mande language of southern and eastern Sierra Leone and one
+# of the country's two large regional languages. It is the third Sierra Leonean
+# catalog here, after `locales/kri` and `locales/tem` in #1686, and the three
+# together are that country's usual three-way answer: a creole everyone shares
+# and two regional languages that share almost nothing with it or each other.
+#
+# **This catalog is the clearest instance of the affix rule in the tree, and it
+# is the reason to read it.** Mende's definite marker is a suffix — `-i` after
+# a consonant, `-ei` after a vowel — and it attaches not to the noun but to
+# **whichever word ends the noun phrase**:
+#
+#   pɛlɛ           a house          pɛlɛi          the house
+#   pɛlɛ wa        a big house      pɛlɛ wai       the big house
+#   pɛlɛ wa teli   a big black one  pɛlɛ wa telii  the big black one
+#
+# A describing word follows its noun here, so a style description *ends* in a
+# describing word — and in this catalog that word is almost always a placeable.
+# «{ $color }i» is exactly what
+# [An affix cannot be welded to a placeable](../../README.md) forbids: Fluent
+# would render the suffix as literal text against whatever the argument
+# happened to be, and the argument is a whole phrase in most branches anyway.
+#
+# **So this catalog is written entirely in the indefinite**, which is the
+# README's "choose the words that land there" way out, taken at the level of
+# the whole file rather than of one message. That is not a workaround dressed
+# up as a decision: a style description is read out of context — "thick red
+# line", not "the thick red line" — and the indefinite is what Mende uses
+# there. A speaker who thinks a particular message wants the definite should
+# say so on #1521 rather than adding the suffix here, because the message that
+# wants it is the one whose final word is an argument.
+#
+# **`$gender` goes unused.** Mande languages have no noun class, and Mende is
+# no exception — which is worth saying explicitly, because `locales/mnk`,
+# `locales/bm` and `locales/dyu` are the other three Mande catalogs here and
+# none of them forks either. Four Mande catalogs, four flat `noun-gender`
+# messages: that is a family predicting something about agreement for once,
+# and it is the only family in this repository that does.
+#
+# `$role` goes unused too: Mende marks no case.
+#
+# The geometry leans on the English loans Sierra Leonean schooling supplies —
+# the same ministry `locales/kri` and `locales/tem` record — with Mende words
+# where they are solid: «ndɔlɔ» a place, «tɔkpɔi» a mark. They are the first
+# thing to check.
+
+
+## Style vocabulary
+
+color =
+    .black = teli
+    .white = kɔlɛ
+    .gray = ndabu
+    .red = kpou
+    .orange = ɔrenji
+    .yellow = yɛlo
+    .green = grin
+    .cyan = sayan
+    .blue = blu
+    .purple = pɔpul
+    .pink = pink
+    .brown = braun
+
+line-width =
+    .thick = wa
+    .thin = kulɔ
+
+# Written as «kɛ …» phrases rather than as bare qualifiers, so that they close
+# the description. `style-stroke` puts them last.
+line-style =
+    .dashed = kɛ ngeya-ngeya
+    .dotted = kɛ tɔkpɔ-tɔkpɔ
+
+fill-style =
+    .horizontal = laingi ti lɔ va
+    .vertical = laingi ti lɔ lɔlɔ
+    .diagonal = laingi ti lɔ kpandi
+    .backdiagonal = laingi ti lɔ kpandi na gbe wu
+    .dots = tɔkpɔ
+    .diamonds = dayamɔn
+
+noun =
+    .line = laing
+    .line-segment = laing gbua
+    .ray = re
+    .vector = vɛkta
+    .curve = laing kpandi
+    .function = fɔnkshɔn
+    .parabola = parabola
+    .polyline = laing gbua gbotoma
+    .polygon = pɔligɔn
+    .triangle = trayangul
+    .rectangle = rɛktangul
+    .circle = kolɔ
+    .region = ndɔlɔ
+    .point = tɔkpɔi
+    .square = skwea
+    .diamond = dayamɔn
+    .cross = krɔs
+    .plus = plɔs tɔkpɔi
+
+# The side count is a relative and closes the noun phrase behind the describing
+# words, so it goes in the tail. It is also the one place the definite would
+# have been least awkward — the tail ends in a numeral rather than in a
+# describing word — and it is still left indefinite, so that the file has one
+# rule rather than an exception a reader has to learn.
+noun-regular-polygon =
+    { $part ->
+        [tail] na kɛ gbua { $numSides }
+       *[head] pɔligɔn yekpe
+    }
+
+# Mende has no noun class and no gender, so every noun answers the same and the
+# answer goes unused — the shape `locales/mnk`, `locales/bm` and `locales/dyu`
+# have, and for the same reason.
+noun-gender = yila
+
+
+## Style composition
+
+# The dash pattern is a «kɛ …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+# The noun leads and the describing words follow, which is what puts a
+# placeable at the end of the phrase and keeps the definite suffix out of this
+# file. See the header.
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word = gbuani
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } kɛ { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } kɛ { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } kɛ { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «ngɔwu» is the border and leads its own describing words. Mende has no
+# article and joins this clause with the invariable «kɛ», so all four branches
+# read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] kɛ ngɔwu { $border }
+        [and] kɛ ngɔwu { $border }
+        [and-article] kɛ ngɔwu { $border }
+       *[with] kɛ ngɔwu { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ii gbuani
+
+style-text =
+    { $parts ->
+        [background] { $color } kɛ woma { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = hama gbi ii lɔ
+
+
+## Boolean words
+
+boolean-true = tonya
+boolean-false = ngunya
+
+
+## Answer buttons
+
+answer-submit-label = Gbɔɔ Yenge
+answer-submit-label-no-correctness = Ve Njepei
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Yenge
+    .aside = Njepe gbe
+    .cascade = Kasked
+    .definition = Hugɔɔla
+    .example = Kɛlɛma
+    .exercise = Yenge hu gɔɔla
+    .exercises = Yenge hu gɔɔla nasia
+    .given-answer = Njepei
+    .note = Nyɛingɔ
+    .objectives = Hindeisia ti wote
+    .paragraphs = Njepe gbuasia
+    .part = Gbua
+    .problem = Hinda
+    .problems = Hindeisia
+    .proof = Gɔɔla
+    .question = Mɔli
+    .section = Gbua
+    .solution = Hinda gulɔla
+    .task = Yenge
+    .theorem = Tiɔrɛm
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Ngiti
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Tebul { $enumeration }
+        [numbered-title] Tebul { $enumeration }{ ": " }
+        [unnumbered-title] Tebul{ ": " }
+       *[unnumbered] Tebul
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Kɛlɛma { $enumeration }
+        [numbered-caption] Kɛlɛma { $enumeration }{ ": " }
+        [unnumbered-caption] Kɛlɛma{ ": " }
+       *[unnumbered] Kɛlɛma
+    }
+
+
+## Paginator controls
+
+paginator-previous = Na wa ma
+paginator-next = Na wa woma
+
+paginator-page = Pej
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ɔɔ
+
+piecewise-condition-if = ina
+
+piecewise-condition-otherwise = hinda gbi hu na
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## The school-system case. Sierra Leone teaches secondary science in English,
+## so a Mende speaker meets the periodic table there and the fallback *is* the
+## curriculum — the same answer `locales/kri` and `locales/tem` give from the
+## same ministry.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Kɛmistri Tɔkpɔi Ii Tonya
+chemistry-invalid-ionic-compound = Ayɔn Gbɔɔla Ii Tonya

--- a/packages/i18n/locales/men/content.ftl
+++ b/packages/i18n/locales/men/content.ftl
@@ -11,9 +11,9 @@
 # and two regional languages that share almost nothing with it or each other.
 #
 # **This catalog is the clearest instance of the affix rule in the tree, and it
-# is the reason to read it.** Mende's definite marker is a suffix — `-i` after
-# a consonant, `-ei` after a vowel — and it attaches not to the noun but to
-# **whichever word ends the noun phrase**:
+# is the reason to read it.** Mende's definite marker is a suffix «-i» that
+# fuses with the final vowel of the word it lands on, and it attaches not to the
+# noun but to **whichever word ends the noun phrase**:
 #
 #   pɛlɛ           a house          pɛlɛi          the house
 #   pɛlɛ wa        a big house      pɛlɛ wai       the big house

--- a/packages/i18n/locales/men/diagnostics.ftl
+++ b/packages/i18n/locales/men/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Mende diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] ti { $attributes } wumbu ji ti nsuka fele yɛlɛ
+       *[other] ti { $attributes } wumbu ji ti nsuka fele yɛlɛ
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] ti { $attributes } wumbu ji ti nsuka kɛ ndɛvɛ ti fele yɛlɛ
+       *[other] ti { $attributes } wumbu ji ti nsuka kɛ ndɛvɛ ti fele yɛlɛ
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ii yenge wue ina ndɛvɛ ii lɔ
+
+## `<line>`
+
+line-points-undetermined-dimensions = Laing na a li tɔkpɔisia ma na ti gbotoma ii majɔɔ.
+
+line-points-too-few-dimensions = Laing i lɔ i li tɔkpɔisia ma na ti gbotoma fele ɔɔ na wa woma.
+
+line-points-depend-on-variables = Laing a li tɔkpɔisia ma na ti lɔ wotelasia ma: { $variables }.
+
+line-equation-invalid-format = Laing ikweshɔn mɔla ii tonya { $variable1 } kɛ { $variable2 } hu.
+
+## `<ray>`
+
+ray-overprescribed-through = Ti re yɛlɛ a through, endpoint kɛ direction.  Ti through na ti yɛlɛ wumbu.
+
+ray-dimension-mismatch = numDimensions ii yɛlɛ kɛnɛi re hu.
+
+## `<vector>`
+
+vector-overprescribed-head = Ti vɛkta yɛlɛ a head, tail kɛ displacement.  Ti head na ti yɛlɛ wumbu.
+
+vector-dimension-mismatch = numDimensions ii yɛlɛ kɛnɛi vɛkta hu.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ti ii gula ti li `<{ $component }>` ma va ngi nearestPoint ii lɔ.
+
+constrain-to-without-nearest-point = Ti ii gula ti gbɔkɔ `<{ $component }>` ma va ngi nearestPoint ii lɔ.
+
+constrain-to-interior-without-nearest-point = Ti ii gula ti gbɔkɔ `<{ $component }>` bu va ngi nearestPoint ii lɔ.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ti labelPosition wumbu choiceInput na ii inline va
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Ti indices na ti yɛlɛ choiceInput va wumbu va indices namba ii yɛlɛ kɛnɛi choice ndoisia namba ma.
+
+pretzel-indices-count-mismatch = Ti indices na ti yɛlɛ problem va wumbu va indices namba ii yɛlɛ kɛnɛi problem ndoisia namba ma.
+
+shuffle-indices-count-mismatch = Ti indices na ti yɛlɛ shuffle va wumbu va indices namba ii yɛlɛ kɛnɛi hindeisia namba ma.
+
+indices-ignored-out-of-range = Ti indices na ti yɛlɛ { $component } va wumbu va ti gbesia ti lɔ ndɔlɔ gbe.
+
+pretzel-indices-repeated = Ti indices na ti yɛlɛ pretzel va wumbu va ti gbesia ti yɛlɛ gbɔma.
+
+pretzel-circuit-first-index = Ti indices na ti yɛlɛ pretzel va mode="circuit" hu wumbu va index na lɔ ma i lɔ i yɛlɛ 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Kɔ `<{ $component }>` i yenge wue a string ndoisia, `type` attribute i lɔ i yɛlɛ.
+
+invalid-type-defaulting-to-math = Type { $type } ii tonya { $component } va. I lɔ i yɛlɛ math, text, number ɔɔ boolean. Ti a math wue.
+
+string-not-valid-component-to-arrange = String "{ $value }" ii hinda tonya { $component } va. Ti a ngi wumbu.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } ii tonya, ti type wote number ma.
+
+invalid-variable-value = Wotela hinda na ii tonya: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Wotela index { $index } i lɔ i yɛlɛ namba
+
+variant-index-must-be-integer = Wotela index { $index } i lɔ i yɛlɛ namba kpɛlɛ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = Ti `<{ $component }>` ii yɛlɛ gɔɔla kpɛlɛ va. Ti wala wote gɔɔla gbe ma.
+
+side-by-side-absolute-margins = Ti `<{ $component }>` ii yɛlɛ gɔɔla kpɛlɛ va. Ti ngɔwusia wote gɔɔla gbe ma.
+
+side-by-side-no-block-child = `<{ $component }>` ii tonya: i lɔ i block ndoi yila ɔɔ na wa woma majɔɔ.
+
+## `<label>`
+
+label-for-ignored-on-graphical = Ti `for` attribute na lɔ kɛlɛma `<label>` ma wumbu.
+
+label-for-must-resolve-to-one = `for` attribute na lɔ `<label>` ma i lɔ i li hinda yila pɛ ma.
+
+label-for-unresolved = `for` attribute na lɔ `<label>` ma ii gula i li hinda gbi ma.
+
+label-for-answer-with-authored-inputs = `for` attribute na lɔ `<label>` ma a `<answer>` yɛpɛ na inputsia ti yɛlɛ; yɛpɛ input ma kɛnɛi.
+
+label-for-answer-without-input = `for` attribute na lɔ `<label>` ma a `<answer>` yɛpɛ na input ii lɔ.
+
+label-for-must-reference-input-or-answer = `for` attribute na lɔ `<label>` ma i lɔ i input ɔɔ answer yɛpɛ.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Majɔɔla va, `<{ $component }>` i lɔ i hugɔɔla kulɔ majɔɔ ɔɔ ti yɛlɛ kɛ decorative.
+
+accessibility-video-short-description = Majɔɔla va, `<video>` i lɔ i hugɔɔla kulɔ majɔɔ.
+
+accessibility-input-short-description-or-label = Majɔɔla va, `<{ $component }>` i lɔ i hugɔɔla kulɔ ɔɔ biye majɔɔ.
+
+accessibility-answer-input-short-description-or-label = Majɔɔla va, `<answer>` na a input yɛlɛ i lɔ i hugɔɔla kulɔ ɔɔ biye majɔɔ.
+
+accessibility-short-description-contains-math = Hugɔɔla kulɔsia ti ii lɔ ti mat hindeisia kɛ `<{ $component }>` majɔɔ. Nyɛingɔ mat a njepeisia.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ii wotela wa majɔɔ gbua woma njepei va (mode teli) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i lɔ i yɛlɛ { $threshold }:1 ɔɔ na wa woma).
+       *[other] { $colorName } ii wotela wa majɔɔ gbua woma njepei va ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i lɔ i yɛlɛ { $threshold }:1 ɔɔ na wa woma).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Ti `<circle>` na a li tɔkpɔisia { $count } ma ii yɛlɛ ina tɔkpɔisia ti nambasia ii lɔ.
+
+circle-too-many-through-points = Ti ii gula ti kolɔ gɔɔ na a li tɔkpɔisia 3 ma na wa woma.
+
+circle-overprescribed-radius-center-points = Ti ii gula ti kolɔ gɔɔ a radius, ndɛvɛ kɛ tɔkpɔisia kpɛlɛ.
+
+circle-center-with-multiple-points = Ti ii gula ti kolɔ gɔɔ a ndɛvɛ na a li tɔkpɔi 1 ma na wa woma.
+
+circle-radius-too-small = Ti ii gula ti kolɔ gɔɔ: ina tɔkpɔisia fele ti ndɔlɔ a { $distance }, radius { $radius } na ti yɛlɛ i kulɔ wa.
+
+circle-radius-with-many-points = Ti ii gula ti kolɔ yɛlɛ na a li tɔkpɔisia fele ma na wa woma a radius na ti yɛlɛ.
+
+circle-invalid-center-or-through-points = Kolɔ ndɛvɛ ɔɔ ngi tɔkpɔisia ti ii tonya.
+
+circle-radius-center-with-multiple-points = Ti ii gula ti kolɔ radius gɔɔ a ndɛvɛ na a li tɔkpɔi 1 ma na wa woma.
+
+circle-change-radius-non-numerical = Ti ii gula ti kolɔ radius wote a tɔkpɔisia na ti nambasia ii lɔ
+
+circle-radius-with-points-non-numerical = Ti ii gula ti kolɔ yɛlɛ na a li tɔkpɔi yila ma na wa woma a radius ina nambasia ti ii lɔ.
+
+circle-change-center-non-numerical = Kolɔ ndɛvɛ wotela na a li tɔkpɔisia ma na ti nambasia ii lɔ ii yɛlɛ.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Gbotomasia ti ii gbɔyɔ fɔnkshɔn domain va. Domain a wati gbua { $intervals } majɔɔ kɛɛ fɔnkshɔn a { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        } majɔɔ.
+       *[other] Gbotomasia ti ii gbɔyɔ fɔnkshɔn domain va. Domain a wati gbua { $intervals } majɔɔ kɛɛ fɔnkshɔn a { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        } majɔɔ.
+    }
+
+function-domain-invalid-format = Fɔnkshɔn domain mɔla ii tonya.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ti fɔnkshɔn wai na namba ii lɔ wumbu.
+        [minimum] Ti fɔnkshɔn kulɔi na namba ii lɔ wumbu.
+        [extremum] Ti fɔnkshɔn nsuka na namba ii lɔ wumbu.
+        [point] Ti fɔnkshɔn tɔkpɔi na namba ii lɔ wumbu.
+        [slope] Ti fɔnkshɔn kpandila na namba ii lɔ wumbu.
+       *[other] Ti fɔnkshɔn { $type } na namba ii lɔ wumbu.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ti fɔnkshɔn wai na hinda ii lɔ hu wumbu.
+        [minimum] Ti fɔnkshɔn kulɔi na hinda ii lɔ hu wumbu.
+        [extremum] Ti fɔnkshɔn nsuka na hinda ii lɔ hu wumbu.
+        [point] Ti fɔnkshɔn tɔkpɔi na hinda ii lɔ hu wumbu.
+       *[other] Ti fɔnkshɔn { $type } na hinda ii lɔ hu wumbu.
+    }
+
+function-points-too-close = Fɔnkshɔn a tɔkpɔisia fele majɔɔ na ti gbualɔ kɛnɛi wa. Ti ii gula ti fɔnkshɔn hugɔɔ.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Fɔnkshɔn gbɔmalasia ti gula pɛ ina inputsia namba a yɛlɛ kɛnɛi outputsia namba ma. Fɔnkshɔn ji a input { $inputs } kɛ { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        } majɔɔ.
+       *[other] Fɔnkshɔn gbɔmalasia ti gula pɛ ina inputsia namba a yɛlɛ kɛnɛi outputsia namba ma. Fɔnkshɔn ji a input { $inputs } kɛ { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        } majɔɔ.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Sequence ndɔlɔ ii tonya.  I lɔ i yɛlɛ namba kpɛlɛ na ii lɔ ziro bu.
+
+sequence-invalid-step = Sequence step ii tonya.  I lɔ i yɛlɛ namba sequence type { $type } va.
+
+sequence-invalid-endpoint-number = Number sequence "{ $attribute }" ii tonya.  I lɔ i yɛlɛ namba.
+
+sequence-invalid-endpoint-letters = Letters sequence "{ $attribute }" ii tonya.  I lɔ i yɛlɛ lɛta gbɔɔla.
+
+sequence-invalid-endpoint = Sequence "{ $attribute }" ii tonya.
+
+select-from-sequence-coprime-not-numbers = ti coprime wumbu va ti ii nambasia hɛnda
+
+select-from-sequence-coprime-with-exclude-combinations = ti coprime wumbu va ti excludeCombinations yɛlɛ
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` target ii tonya: ti ii gula ti target majɔɔ.
+
+target-state-variable-not-found = `<{ $source }>` target ii tonya: ti ii gula ti stet wotela na ngi biye a "{ $property }" majɔɔ `<{ $component }>` ma.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` wotelasia ti lɔ ti gbualɔ wotela na lɔ ngi yɔɔ ma.
+
+ode-system-duplicate-variable-names = Ti ii gula ti ODE RHS fɔnkshɔnsia hugɔɔ a wotela biyeisia na ti yɛlɛ gbɔma.
+
+ode-system-rhs-function-error = Ti ii gula ti ODE RHS fɔnkshɔn hugɔɔ.  Hinda nyamu lɔ mathjs fɔnkshɔn yɛlɛla hu.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ti ii gula ti angul hugɔɔ laingsia { $count } gbualɔ
+
+angle-invalid-through-point = Tɔkpɔi ii tonya `<angle>` ngi through hu
+
+parabola-vertex-too-many-points = Parabola a vertex na a li tɔkpɔi 1 ma na wa woma ii yɛlɛ.
+
+parabola-too-many-points = Parabola na a li tɔkpɔisia 3 ma na wa woma ii yɛlɛ.
+
+intersection-too-many-items = Hindeisia fele na wa woma ti gbualɔla ii yɛlɛ
+
+## Other math components
+
+ionic-compound-not-two-ions = Ayɔn gbɔɔla hinda gbe va na ii ayɔn fele ii yɛlɛ.
+
+ionic-compound-needs-cation-and-anion = Ti ayɔn gbɔɔla yɛlɛ katayɔn yila kɛ anayɔn yila pɛ va.
+
+solve-equations-cannot-evaluate = Ti ii gula ti ikweshɔn gulɔ va ti ii gula ti ngi gɔɔ: { $equation }
+
+math-operators-operand-number-required = operandNumber i lɔ i yɛlɛ ina ti mat operand wumbu.
+
+eigen-decomposition-failed = Ti ii gula ti matriks aygɛnvalyusia gɔɔ
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } ii lɔ patan hu, fale i a yɛlɛ kɛnɛi hinda gbi ma wati kpɛlɛ.
+       *[other] `<matchesPattern>`: parameter { $parameters } ti ii lɔ patan hu, fale ti a yɛlɛ kɛnɛi hinda gbi ma wati kpɛlɛ.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ti ii gula ti grid="{ $grid }" hugɔɔ. I lɔ i yɛlɛ none, medium, dense, ɔɔ nambasia fele wa na ndɔlɔ a ti gbualɔ, kɛ grid="1 0.5". Ti grid gbi ii yɛlɛ.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ii yenge wue prefigure gɛnɛmɔi hu; ti a kɔmɛ gbua yenge wue.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ii yenge wue prefigure gɛnɛmɔi hu; ti a woma gbua yenge wue.
+
+prefigure-invalid-axis-bounds = `<graph>`: aksis ngɔwusia ti ii tonya prefigure va; ti a bbox (-10,-10,10,10) wue.
+
+prefigure-invalid-width = `<graph>`: wala ii tonya prefigure va; ti a wala 425 wue.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio ii tonya prefigure va; ti a aspɛkt reshio 1 wue.
+
+prefigure-grid-spacing-too-fine = `<graph>`: grid ndɔlɔi i kulɔ wa aksis ngɔwusia va; ti grid wumbu prefigure gɛnɛmɔi hu.
+
+prefigure-annotations-not-rendered = `<graph>`: annotations ti ii gɛnɛ ina ti ii PreFigure gɛnɛmɔi wue.
+
+multiple-annotations-children = Ti `<annotations>` ndoisia gbotoma majɔɔ `<graph>` hu; ti kpɛlɛ wumbu na lɔ nsuka ma va.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ti ii gula ti hinda mɔla na ti ii majɔɔ hɛnda ɔɔ ti ngi hɛlɛ: { $type }.
+
+copy-prop-not-found = Ti ii gula ti prop { $property } majɔɔ hinda mɔla { $component } ma
+
+collect-no-source = Ti gulɔla gbi ii majɔɔ collect va.
+
+collect-invalid-component-type = Ti ii gula ti hindeisia mɔla `<{ $component }>` gbɔɔ va mɔla ii tonya.
+
+reference-index-unavailable = Ti ii gula ti index `{ $reference }` yɛpɛ
+
+## `<callAction>`
+
+component-action-unavailable = Ti ii gula ti { $action } lolɔ hinda `{ $reference }` ma
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Data mɔla ii tonya.  Lɔlɔisia ti ndɔlɔsia ti gbualɔ. Ti majɔɔ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Data a kɔlum biyeisia na ti yɛlɛ gbɔma majɔɔ.  Ti majɔɔ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Kɔlum biye yila ii lɔ data hu.  Ti majɔɔ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Njepe ji ngi award a lɔ answer tag ngi njepe na i venga ma, na a hinda wa wa na bi ii ma gɔɔ.
+
+answer-max-num-attempts-in-section-wide-check-work = Ina bi `maxNumAttempts` yɛlɛ `<answer>` na lɔ hinda na a `sectionWideCheckWork` majɔɔ bu ma, ii yenge wue, va hinda na a gɔɔlasia namba gbɔɔ. Yɛlɛ `maxNumAttempts` hinda na ma.
+
+nested-section-wide-check-work-max-num-attempts = Ina bi `maxNumAttempts` yɛlɛ hinda na a `sectionWideCheckWork` majɔɔ tao i lɔ hinda gbe na a `sectionWideCheckWork` majɔɔ bu ma, ii yenge wue, va hinda na lɔ kɔmɛ a gɔɔlasia namba gbɔɔ. Yɛlɛ `maxNumAttempts` hinda na lɔ kɔmɛ ma.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] { $attributes } attribute ii yenge wue ina symbolicEquality ii yɛlɛnga.
+       *[other] { $attributes } attribute ti ii yenge wue ina symbolicEquality ii yɛlɛnga.
+    }
+
+answer-invalid-type = Njepei type ii tonya: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Va hinda `<{ $component }>` ngi biye ii lɔ, ti ii gula ti ngi wue kɛ module attribute
+
+module-attribute-name-already-defined = Ti ii gula ti hinda `<{ $component } name="{ $name }">` wue kɛ module attribute va `<module>` a "{ $name }" attribute majɔɔ kunafɔ.
+
+conditional-content-condition-ignored = Ti `condition` attribute wumbu `<conditionalContent>` na a case ɔɔ else ndoisia majɔɔ ma.
+
+slider-markers-type-mismatch = Markers type ii yɛlɛ kɛnɛi slider type ma.
+
+pretzel-problem-needs-statement-and-answer = Pretzel ii tonya: `<problem>` gbi i lɔ i `<statement>` yila kɛ `<answer>` yila majɔɔ.
+
+pretzel-circuit-first-problem-distractor = Pretzel ii tonya: mode="circuit" hu, `<problem>` na lɔ ma ii gula i yɛlɛ distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Hinda { $values } ii tonya attribute `{ $attribute }` va; ti a ngi wumbu.
+       *[other] Hindeisia { $values } ti ii tonya attribute `{ $attribute }` va; ti a ti wumbu.
+    }
+
+attribute-must-be-references = Hinda `{ $value }` ii tonya attribute `{ $attribute }` va. Attribute i lɔ i yɛlɛ hɛndeisia na ti yɛpɛ a `$`.
+
+math-input-invalid-function-names = <mathInput>: ti fɔnkshɔn biyeisia na ti ii tonya wumbu { $attribute } hu: { $names }. Biye gbi ngi gɛnɛla gbua i lɔ i lɛtasia fele ɔɔ na wa woma majɔɔ (lɛtasia ɔɔ dashsia); `|<mathspeak alternative>` a gula i wa woma.
+
+## Building components from the source
+
+component-type-invalid = Hinda mɔla ii tonya: `<{ $componentType }>`
+
+attribute-repeated = Ti ii gula ti attribute { $attribute } yɛlɛ gbɔma.
+
+attribute-invalid-for-component = Attribute "{ $attribute }" ii tonya hinda mɔla `<{ $componentType }>` va.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Mɔla hugɔɔla { $styleNumber } ii wotela wa majɔɔ { $context ->
+        [text-on-background] njepei kala kɛ woma kala ti gbualɔ
+        [high-contrast] wotela wa kala kɛ kanvas ti gbualɔ
+        [line] laing kala kɛ kanvas ti gbualɔ
+        [marker] tɔkpɔi kala kɛ kanvas ti gbualɔ
+       *[text-on-canvas] njepei kala kɛ kanvas ti gbualɔ
+    }{ $mode ->
+        [dark] { " (mode teli)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i lɔ i yɛlɛ { $threshold }:1 ɔɔ na wa woma).
+
+style-definition-dark-mode-text-background-contrast =
+    Kɛɛ mɔla hugɔɔla { $styleNumber } a kalasia majɔɔ na ti wotela wa majɔɔ mode kɔlɛ va, mode teli kalasia na ti wa ti hu ti ii wotela wa majɔɔ njepei kala kɛ woma kala ti gbualɔ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i lɔ i yɛlɛ { $threshold }:1 ɔɔ na wa woma). { $suggestion ->
+        [available] Kɔ wotela wa i majɔɔ mode teli hu, wa mode kɔlɛ wotela ma (kɛlɛma va, yɛlɛ { $lightAttribute }="{ $lightColor }") ɔɔ wote mode teli kala (kɛlɛma va, yɛlɛ { $darkAttribute }="{ $darkColor }").
+       *[none] Kɔ wotela wa i majɔɔ mode teli hu, wa mode kɔlɛ wotela ma ɔɔ wote kalasia a textColorDarkMode ɔɔ backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Kɛɛ mɔla hugɔɔla { $styleNumber } a njepei kala majɔɔ na a wotela wa majɔɔ mode kɔlɛ va, mode teli njepei kala na i wa ngi hu ii wotela wa majɔɔ kanvas ma ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; i lɔ i yɛlɛ { $threshold }:1 ɔɔ na wa woma). { $suggestion ->
+        [available] Kɔ wotela wa i majɔɔ mode teli hu, wa mode kɔlɛ wotela ma (kɛlɛma va, yɛlɛ textColor="{ $lightColor }") ɔɔ wote mode teli kala (kɛlɛma va, yɛlɛ textColorDarkMode="{ $darkColor }").
+       *[none] Kɔ wotela wa i majɔɔ mode teli hu, wa mode kɔlɛ wotela ma ɔɔ wote kala a textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Gbua a gula i <stylePalette> yila pɛ hɛnda; ti a na lɔ nsuka ma wue.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ti ii gula ti { $component } wotela gbesia majɔɔ va numToSelect ii namba kpɛlɛ na ii lɔ ziro bu.
+
+variant-num-to-select-not-constant-number = ti ii gula ti { $component } wotela gbesia majɔɔ va numToSelect ii namba na ii wote.
+
+variant-with-replacement-not-constant-boolean = ti ii gula ti { $component } wotela gbesia majɔɔ va withReplacement ii boolean na ii wote.
+
+variant-select-weight-disables-unique = Ti select wotela gbesia gbɔkɔ ina option gbi a selectWeight ɔɔ selectForVariants majɔɔ
+
+variant-coprime-undetermined = ti ii gula ti { $component } wotela gbesia majɔɔ va ti ii gula ti gɔɔ ina coprime a ngunya wati kpɛlɛ.
+
+variant-attribute-not-constant = ti ii gula ti { $component } wotela gbesia majɔɔ va { $attribute } a wote.
+
+variant-attribute-not-number = ti ii gula ti { $component } wotela gbesia majɔɔ va { $attribute } ii namba.
+
+variant-attribute-wrong-type-for-sequence =
+    ti ii gula ti { $component } type { $type } wotela gbesia majɔɔ va { $attribute } ii { $expected ->
+        [letters-combination] lɛta gbɔɔla
+        [math-expression] mat njepe tonya
+        [integer] namba kpɛlɛ
+       *[number] namba
+    }.
+
+variant-length-not-integer = ti ii gula ti { $component } wotela gbesia majɔɔ va length ii namba kpɛlɛ.
+
+variant-sort-not-implemented = { $component } kɛ sort ti wotela gbesia ti ii yɛlɛ
+
+variant-exclude-combinations-not-implemented = { $component } kɛ excludeCombinations ti wotela gbesia ti ii yɛlɛ
+
+variant-math-exclude-not-implemented = { $component } type math kɛ exclude ti wotela gbesia ti ii yɛlɛ
+
+variant-non-constant-exclude-not-implemented = { $component } kɛ exclude na a wote ti wotela gbesia ti ii yɛlɛ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ii yenge wue graph prefigure gɛnɛmɔi hu; ti ndoi wumbu.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiɔmɛtri ii tonya ɔɔ ii gbɔyɔ; ti ndoi wumbu.
+
+prefigure-curve-label-omitted = { $subject }: biyeisia ti ii yenge wue curve hindeisia na ti wotenga ma; ti biye wumbu.
+
+prefigure-curve-unsupported-definition-type = { $subject }: curve fɔnkshɔn hugɔɔla mɔla '{ $definitionType }' ii yenge wue; ti ndoi wumbu.
+
+prefigure-region-flip-functions-unsupported = { $subject }: flipFunctions attribute na lɔ regionBetweenCurves ma ii yenge wue; ti ndoi wumbu.
+
+prefigure-region-non-formula-child = { $subject }: formula-mɔla ndoi fɔnkshɔnsia pɛ ti yenge wue regionBetweenCurves ma; ti ndoi wumbu.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ii yenge wue { $labelKind ->
+        [line-family] laing bɔndei biye
+       *[point] tɔkpɔi biye
+    } va; ti a PreFigure ndɔlɔ wue.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure ii gbuala mɔla '{ $fillStyle }' majɔɔ; ti a gbuala kpɛlɛ wue.
+
+prefigure-line-style-unknown = { $subject }: ti ii laing mɔla '{ $lineStyle }' majɔɔ, fale ti a ngi wumbu PreFigure hu.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: ti tɔkpɔi mɔla '{ $markerStyle }' wote PreFigure mɔla 'diamond' ma.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure ii tɔkpɔi mɔla '{ $markerStyle }' majɔɔ; ti a mɔla na lɔ pili wue.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ii tonya; ti ii gula ti target majɔɔ. Ti annotation wumbu.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` a targetsia gbotoma majɔɔ; ti a na lɔ ma wue.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ii tonya; target a lɔ graph gbe. Ti annotation wumbu.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ii tonya; target ii kɛlɛma hinda na prefigure a ngi majɔɔ. Ti annotation wumbu.
+
+annotation-text-missing = `<annotation>`: `text` ii lɔ ɔɔ hinda ii lɔ hu; ti njepe hinda ii lɔ hu nyɛingɔ.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Ti kolɔ hɛndela majɔɔ.
+       *[other] Ti kolɔ hɛndela majɔɔ hinda `<{ $componentType }>` kɛ.
+    }
+
+reference-no-referent = Ti hinda gbi ii majɔɔ hɛnde va: `{ $reference }`
+
+reference-multiple-referents = Ti hindeisia gbotoma majɔɔ hɛnde va: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` ngi attribute { $attribute } mɔla ii tonya.
+
+children-invalid = `<{ $componentType }>` ngi ndoisia ti ii tonya: Ti ndoisia na ti ii tonya majɔɔ: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Hinda `{ $value }` ii tonya attribute `{ $attribute }` va, ti a `{ $default }` wue
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ti DoenetML wotela { $version } ii majɔɔ.
+       *[other] Ti DoenetML wotela { $version } ii majɔɔ. Ti a wotela { $fallback } wue
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ii tonya: { $content }
+
+parse-tag-missing-close-tag = DoenetML ii tonya: Tag `{ $tag }` ngi gbɔkɔla tag ii lɔ. Ti a tag na a ngi yɔɔ gbɔkɔ ɔɔ tag `</{ $tagName }>` mahou.
+
+parse-tag-error = DoenetML ii tonya: Hinda nyamu lɔ tag `<{ $tagName }>` hu
+
+parse-attribute-missing-value = DoenetML ii tonya: Attribute `{ $attribute }` ii tonya, a gɛnɛ kɛ ngi hinda ii lɔ.
+
+parse-attribute-invalid = DoenetML ii tonya: Attribute `{ $attribute }` ii tonya
+
+parse-attribute-value-invalid = DoenetML ii tonya: Attribute hinda `{ $value }` ii tonya
+
+parse-attribute-value-quote-mismatch = DoenetML ii tonya: Attribute hinda `{ $value }` ii tonya. Kwot tɔkpɔisia ti ii yɛlɛ kɛnɛi. A gɛnɛ kɛ `{ $quote }` ii lɔ
+
+parse-open-tag-name-missing = DoenetML ii tonya: Ti tag na ngi biye ii lɔ majɔɔ, kɛ `<`
+
+parse-tag-not-closed = DoenetML ii tonya: Ti ii tag `{ $tag }` gbɔkɔ (a gɛnɛ kɛ `>` ii lɔ).
+
+parse-self-closing-tag-name-missing = DoenetML ii tonya: Ti tag na ngi biye ii lɔ majɔɔ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ii tonya: Ti ii tag `{ $tag }` gbɔkɔ (a gɛnɛ kɛ `/>` ii lɔ).
+
+parse-tag-invalid-attributes = DoenetML ii tonya: Tag `{ $tag }` ii tonya. A gula i attributesia na ti ii tonya majɔɔ.
+
+parse-close-tag-name-missing = DoenetML ii tonya: Ti gbɔkɔla tag na ngi biye ii lɔ majɔɔ, kɛ `</`
+
+parse-attribute-value-unquoted = Attribute hindeisia ti lɔ ti yɛlɛ kwotsia bu: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ii tonya: Ti gbɔkɔla tag `{ $tag }` majɔɔ, kɛɛ gbɔyɔla tag ii lɔ
+
+parse-close-tag-mismatched = DoenetML ii tonya: Gbɔkɔla tag ii yɛlɛ kɛnɛi. Ti a `</{ $expected }>` mahou. Ti `{ $found }` majɔɔ
+
+parser-node-unconvertible = Ti ii gula ti node { $node } wote Dast node ma.
+
+## Names
+
+name-attribute-invalid =
+    Attribute name='{ $name }' ii tonya. { $reason ->
+        [characters] Biyeisia ti gula ti lɛtasia, nambasia, andaskɔsia ɔɔ dashsia pɛ majɔɔ.
+       *[start] Biyeisia ti lɔ ti yɛpɛ a lɛta.
+    }
+
+component-name-invalid-start = Hinda biye "{ $name }" ii tonya. Biyeisia ti lɔ ti yɛpɛ a lɛta.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer type videoWatched i lɔ i video attribute majɔɔ
+
+answer-video-watched-video-not-reference = Answer type videoWatched i lɔ i video attribute na a hɛnde majɔɔ
+
+answer-name-not-single-text = Answer name attribute i lɔ i text ndoi yila pɛ majɔɔ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ti ii gula ti DoenetML na lɔ gbe majɔɔ va gbɔmalasia ti gbotoma wa. Kolɔ hɛnde a lɔ?
+
+external-doenetml-unavailable = Ti ii gula ti DoenetML majɔɔ { $attribute }="{ $uri }" hu
+
+external-doenetml-type-mismatch = DoenetML na ti majɔɔ { $attribute }="{ $uri }" hu ii tonya: ii yɛlɛ kɛnɛi hinda mɔla "{ $componentType }" ma
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` a kunafɔ; wue `{ $to }`.
+       *[other] [deprecation] Attribute `{ $from }` na lɔ `<{ $component }>` ma a kunafɔ; wue `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` a kunafɔ tao ti a ngi wumbu va `{ $to }` gboma a lɔ.
+       *[other] [deprecation] Attribute `{ $from }` na lɔ `<{ $component }>` ma a kunafɔ tao ti a ngi wumbu va `{ $to }` gboma a lɔ.
+    }
+
+deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` na lɔ `<{ $component }>` ma a kunafɔ tao ti a ngi wumbu.
+
+deprecated-attribute-to-child = [deprecation] Attribute `{ $attribute }` na lɔ `<{ $component }>` ma a kunafɔ; wue `<{ $child }>` ndoi.
+
+deprecated-attribute-value-renamed = [deprecation] Hinda `{ $value }` na lɔ attribute `{ $attribute }` hu `<{ $component }>` ma a kunafɔ; wue `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` a gula i Inglish pɛ gbotoma, fale i ngi njepei tɔɔ kɛ bi ngi nyɛingɔnga buk na ti nyɛingɔnga { $locale } hu. Nyɛingɔ gbotoma mɔla kɛnɛi, ɔɔ yɛlɛ ngi a `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Hinda `<{ $tag }>` ii Doenet hinda na ti a ngi majɔɔ.
+
+schema-element-not-allowed-at-root = Ti ii hinda `<{ $tag }>` gula buk woma ma.
+
+schema-element-not-allowed-inside = Ti ii hinda `<{ $tag }>` gula `<{ $parent }>` bu.
+
+schema-attribute-unrecognized = Hinda `<{ $tag }>` attribute na ngi biye a `{ $attribute }` ii lɔ.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Hinda `<{ $tag }>` ngi attribute `{ $attribute }` i lɔ i yɛlɛ nyɛingɔ na ngi hindeisia gbi a yila ji hu: { $allowed }
+       *[other] Hinda `<{ $tag }>` ngi attribute `{ $attribute }` i lɔ i yɛlɛ yila ji hu: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Select wotela biye ii tonya.  Wotela biye { $variantName } a gɛnɛ option { $numOptions } hu kɛɛ hɛndela namba a { $numToSelect }.
+
+select-variant-name-without-options = Ti wotela gbesia yɛlɛ select va kɛɛ ti option gbi ii yɛlɛ wotela biye na a gula i lɔ va: { $variantName }.
+
+select-variant-name-not-possible = Wotela biye { $variantName } na ti yɛlɛ select va ii wotela biye na a gula i lɔ.
+
+select-too-few-options = Ti ii gula ti hindeisia { $numToSelect } hɛnda { $numOptions } pɛ hu.
+
+select-from-sequence-too-few-values = Ti ii gula ti hindeisia { $numToSelect } hɛnda sequence na ngi ndɔlɔ a { $length } hu.
+
+select-from-sequence-indices-count-mismatch = Indices namba na ti yɛlɛ select va i lɔ i yɛlɛ kɛnɛi hɛndela namba ma
+
+select-from-sequence-indices-not-integers = Indices kpɛlɛ na ti yɛlɛ select va ti lɔ ti yɛlɛ nambasia kpɛlɛ
+
+select-from-sequence-index-excluded = Ti selectfromsequence index na ti wumbunga yɛlɛ
+
+select-from-sequence-indices-excluded-combination = Ti selectfromsequence indices na ti gbɔɔla ti wumbunga yɛlɛ
+
+select-from-sequence-coprime-not-positive-integers = Ti ii gula ti coprime gbɔɔlasia hɛnda va ti ii nambasia kpɛlɛ na ti lɔ ziro woma hɛnda.
+
+select-from-sequence-coprime-common-factor = Ti ii gula ti coprime nambasia hɛnda. Hindeisia kpɛlɛ na ti gula ti lɔ ti a faktɔ yila majɔɔ. ("from" ɔɔ "to" hindeisia na ti yɛlɛ ti lɔ ti yɛlɛ coprime "step" kɛ.)
+
+select-from-sequence-coprime-single-number = Ti ii gula ti coprime gbɔɔlasia hɛnda namba yila na ii 1 hu.
+
+select-from-sequence-excluded-too-many-combinations = Ti gbɔɔlasia 70% na wa woma wumbu selectFromSequence hu
+
+select-from-sequence-coprime-none-found = Ti ii gula ti coprime nambasia hɛnda. Hindeisia kpɛlɛ na ti gula ti lɔ ti a faktɔ yila majɔɔ.
+
+select-from-sequence-too-few-unique-values = Ti ii gula ti hindeisia gbesia { $numToSelect } hɛnda sequence na ngi ndɔlɔ a { $numPossibleValues } hu
+
+select-prime-numbers-too-few-values = Ti ii gula ti hindeisia { $numToSelect } hɛnda praym nyɛingɔ na ngi ndɔlɔ a { $numValues } hu
+
+select-prime-numbers-values-count-mismatch = Hindeisia namba na ti yɛlɛ select va i lɔ i yɛlɛ kɛnɛi hɛndela namba ma
+
+select-prime-numbers-values-not-prime = Hindeisia kpɛlɛ na ti yɛlɛ select prime number va ti lɔ ti yɛlɛ praym nyɛingɔi hu
+
+select-prime-numbers-values-excluded-combination = Hindeisia na ti yɛlɛ selectPrimeNumbers va ti gbɔɔla na ti wumbunga
+
+select-prime-numbers-excluded-too-many-combinations = Ti gbɔɔlasia 70% na wa woma wumbu selectPrimeNumbers hu
+
+select-random-combination-fluke = Hinda na ii gula i yɛlɛ, ti ii gula ti hinda gbesia gbɔɔla hɛnda
+
+select-random-value-fluke = Hinda na ii gula i yɛlɛ, ti ii gula ti hinda gbe hɛnda

--- a/packages/i18n/locales/men/diagnostics.ftl
+++ b/packages/i18n/locales/men/diagnostics.ftl
@@ -49,11 +49,11 @@ vector-dimension-mismatch = numDimensions ii yɛlɛ kɛnɛi vɛkta hu.
 
 ## Attracting and constraining
 
-attract-to-without-nearest-point = Ti ii gula ti li `<{ $component }>` ma va ngi nearestPoint ii lɔ.
+attract-to-without-nearest-point = Ti ii gula ti li `<{ $component }>` ma va ngi nearestPoint stet wotela ii lɔ.
 
-constrain-to-without-nearest-point = Ti ii gula ti gbɔkɔ `<{ $component }>` ma va ngi nearestPoint ii lɔ.
+constrain-to-without-nearest-point = Ti ii gula ti gbɔkɔ `<{ $component }>` ma va ngi nearestPoint stet wotela ii lɔ.
 
-constrain-to-interior-without-nearest-point = Ti ii gula ti gbɔkɔ `<{ $component }>` bu va ngi nearestPoint ii lɔ.
+constrain-to-interior-without-nearest-point = Ti ii gula ti gbɔkɔ `<{ $component }>` bu va ngi nearestPoint stet wotela ii lɔ.
 
 ## `<choiceInput>`
 
@@ -270,7 +270,7 @@ matches-pattern-parameter-not-in-pattern =
 
 ## `<graph>`
 
-graph-grid-invalid = `<graph>`: ti ii gula ti grid="{ $grid }" hugɔɔ. I lɔ i yɛlɛ none, medium, dense, ɔɔ nambasia fele wa na ndɔlɔ a ti gbualɔ, kɛ grid="1 0.5". Ti grid gbi ii yɛlɛ.
+graph-grid-invalid = `<graph>`: ti ii gula ti grid="{ $grid }" hugɔɔ. I lɔ i yɛlɛ none, medium, dense, ɔɔ nambasia fele na ti lɔ ziro woma na ndɔlɔ a ti gbualɔ, kɛ grid="1 0.5". Ti grid gbi ii yɛlɛ.
 
 ## PreFigure renderer
 

--- a/packages/i18n/locales/men/editor.ftl
+++ b/packages/i18n/locales/men/editor.ftl
@@ -1,0 +1,208 @@
+# Mende editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Wote gbɔma
+       *[update] Yɛlɛ nina
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Gɛnɛmɔi
+       *[other] { $word } Gɛnɛmɔi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Wotela
+
+editor-variant-filter = Gɔɔ…
+
+editor-variant-next = Hɛnda wotela na wa woma
+
+editor-variant-previous = Hɛnda wotela na wa ma
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Ti WCAG AA majɔɔla sawa wɔlɔla majɔɔ. Tɔkpɔ kɔ bi { $action ->
+            [close] gbɔkɔ
+           *[open] gbɔyɔ
+        } majɔɔla nyɛingɔi.
+        [advisories] Tɔkpɔ kɔ bi { $action ->
+            [close] gbɔkɔ
+           *[open] gbɔyɔ
+        } majɔɔla nyɛingɔi. Ti WCAG AA wɔlɔla gbi ii majɔɔ, kɛɛ majɔɔla ngiti gbesia ti lɔ.
+       *[clean] Tɔkpɔ kɔ bi { $action ->
+            [close] gbɔkɔ
+           *[open] gbɔyɔ
+        } majɔɔla nyɛingɔi. Ti majɔɔla hinda gbi ii majɔɔ.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Ti WCAG AA majɔɔla sawa wɔlɔla majɔɔ. Ti { $count ->
+            [one] WCAG AA wɔlɔla { $count }
+           *[other] WCAG AA wɔlɔla { $count }
+        } majɔɔ. Tɔkpɔ kɔ bi { $action ->
+            [close] gbɔkɔ
+           *[open] gbɔyɔ
+        } majɔɔla nyɛingɔi.
+        [advisories] Ti WCAG AA wɔlɔla gbi ii majɔɔ. Ti { $count ->
+            [one] majɔɔla ngiti gbe { $count }
+           *[other] majɔɔla ngiti gbe { $count }
+        } majɔɔ. Tɔkpɔ kɔ bi { $action ->
+            [close] gbɔkɔ
+           *[open] gbɔyɔ
+        } majɔɔla nyɛingɔi.
+       *[clean] Ti WCAG AA wɔlɔla gbi ii majɔɔ. Tɔkpɔ kɔ bi { $action ->
+            [close] gbɔkɔ
+           *[open] gbɔyɔ
+        } majɔɔla nyɛingɔi.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML wotela { $version }
+
+editor-tab-help = Ngiti bi lɔ ndɔlɔ na
+editor-tab-help-short = Ndɔlɔ
+editor-tab-errors = Hinda nyamusia
+editor-tab-warnings = Ngiti wasia
+editor-tab-info = Hugɔɔla
+editor-tab-accessibility = Majɔɔla
+editor-tab-responses = Njepeisia ti venga
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Nyɛingɔmɔi hɛndei
+editor-format-as-doenetml = Yɛlɛ kɛ DoenetML
+editor-format-as-xml = Yɛlɛ kɛ XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Laing #{ $line }
+
+editor-no-errors = Hinda Nyamu Gbi Ii Lɔ
+editor-no-warnings = Ngiti Wa Gbi Ii Lɔ
+editor-no-info = Hugɔɔla Gbi Ii Lɔ
+
+editor-show-info-annotations = Gɛnɛ hugɔɔla nyɛingɔmɔi hu
+editor-show-accessibility-annotations = Gɛnɛ majɔɔla hindeisia nyɛingɔmɔi hu
+
+editor-accessibility-learn-more = Gaa Doenet a majɔɔla gbɔɔ ji
+
+editor-accessibility-violations-heading = Majɔɔla wɔlɔlasia ({ $standard })
+
+editor-accessibility-other-heading = Majɔɔla hinda gbesia
+editor-none-found = Hinda gbi ii majɔɔ
+
+
+## Submitted responses
+
+editor-no-responses = Numu gbi ii njepei ve kpɛlɛ
+editor-response-answer-id = Njepei biyei
+editor-response-response = Njepei
+editor-response-credit = Ndoli
+editor-response-submitted = Ti venga
+
+
+## The context-help panel
+
+help-placeholder = Wa nyɛingɔ tɔkpɔi tag biyei ma, attribute ma, ɔɔ { $ref } ma kɔ bi hugɔɔla majɔɔ.
+
+help-unsupported-ref-chain = Ngiti gbua gbotoma hɛndeisia va kɛ { $example } ii lɔ kpɛlɛ.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ti hinda gbi ii majɔɔ { $ref } va.
+        [multiple] Ti hindeisia gbotoma majɔɔ { $ref } va.
+       *[indeterminate] Ti ii gula ti { $ref } hinda gɔɔ.
+    }
+
+help-learn-about-references = Gaa hɛndeisia ma →
+help-reference-page = Hugɔɔla pej →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } bu
+       *[top] Buk woma ma
+    }{ $allowed ->
+        [none] { " — hinda gbi ii li mba." }
+        [text] { " — nyɛingɔ njepe mba." }
+        [text-and-components] { " — nyɛingɔ njepe mba, ɔɔ gɔɔ:" }
+       *[components] { " — hindeisia bi gɔɔ:" }
+    }
+
+help-suggestions-footer = Tɔkpɔ { $shortcut } kɔ bi hindeisia { $total } kpɛlɛ gɛnɛ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } a hɛnde lɔ { $target } ma.
+       *[other] { $ref } a hɛnde lɔ { $target } ma (laing { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } i wa a ngi kɛ { $role }.
+       *[other] { $owner } i wa a ngi laing { $line } ma kɛ { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } a hɛnde lɔ { $element } ngi { $property } ma.
+       *[other] { $ref } a hɛnde lɔ { $element } ngi { $property } ma (laing { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = gbua
+help-kind-array-entry = array gbua
+
+help-default = Na lɔ pili:
+help-active-default = Na lɔ pili tao a yenge:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Hindeisia ti gula (yila hinda yila va):
+       *[other] Hindeisia ti gula:
+    }
+
+help-suggested-values = Hindeisia ti ngiti:
+
+help-inserts = A wa a:
+
+help-coordinates =
+    { $count ->
+        [one] Ndɔlɔ:
+       *[other] Ndɔlɔsia:
+    }
+
+help-type = Mɔla:
+
+help-resolved-style = Mɔla ti majɔɔ (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Fɔnkshɔn biyeisia ti majɔɔ:
+help-reset-list = Wote gbɔma nyɛingɔi input ji ma:
+help-added-on-input = Ti gbua input ji ma:
+help-removed-on-input = Ti wumbu input ji ma:
+
+help-reset-overrides = { $reset } a { $additional } kɛ { $removed } wumbu.

--- a/packages/i18n/locales/men/editor.ftl
+++ b/packages/i18n/locales/men/editor.ftl
@@ -115,7 +115,7 @@ editor-none-found = Hinda gbi ii majɔɔ
 
 ## Submitted responses
 
-editor-no-responses = Numu gbi ii njepei ve kpɛlɛ
+editor-no-responses = Njepe veninga gbi ii lɔ kpɛlɛ
 editor-response-answer-id = Njepei biyei
 editor-response-response = Njepei
 editor-response-credit = Ndoli

--- a/packages/i18n/locales/umb/chrome.ftl
+++ b/packages/i18n/locales/umb/chrome.ftl
@@ -1,0 +1,133 @@
+# Umbundu viewer chrome: buttons, panel headers, and other UI the reader
+# interacts with. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# See `content.ftl`'s header for the concord table, for what separates this
+# catalog from `locales/kmb`, and for what a speaker should check first.
+
+
+## Answer submission
+
+answer-checking = Oku konomboloya…
+answer-submitting = Oku tuma…
+
+answer-checking-status = Etambululo li kasi oku konomboloyiwa
+answer-submitting-status = Etambululo li kasi oku tumiwa
+
+answer-correct = Cocili
+answer-incorrect = Ka cocili
+
+answer-response-saved = Etambululo Lya Vikiwa
+
+answer-percent-credit = { $percent }% Yolonoso
+answer-percent-correct = { $percent }% Cocili
+answer-percent-short = { $percent } %
+
+max-credit-available = Olonoso vinene o pondola oku tambula: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] kaku sialele elilongiso
+        [one] elilongiso { $count } lya sialele
+       *[other] alilongiso { $count } a sialele
+    }
+
+validation-correct = (Cocili)
+validation-incorrect = (Ka cocili)
+validation-partially-correct = (Cocili konepa)
+
+answer-show-responses =
+    { $count ->
+        [one] Lekisa etambululo { $count } lya { $answerId }
+       *[other] Lekisa atambululo { $count } a { $answerId }
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Etambululo
+
+collapsible-click-to-open = (yeta oco ci yulule)
+collapsible-click-to-close = (yeta oco ci yike)
+
+collapsible-initializing = Oku fetika…
+
+footnote-show = Lekisa esapulo lyokemehi
+footnote-hide = Seluka esapulo lyokemehi
+
+description-more-information = ovina vikwavo
+
+
+## Controls
+
+slider-previous = Yipita
+slider-next = Yikwãma
+
+keyboard-open = Yulula Otekiladu
+keyboard-close = Yika Otekiladu
+
+choice-input-remove-choice = Pindula { $choice }
+
+matrix-remove-row = Pindula ongoli
+matrix-add-row = Vokiya ongoli
+matrix-remove-column = Pindula okoluna
+matrix-add-column = Vokiya okoluna
+
+subset-add-remove-points = Vokiya/Pindula olondimbu
+subset-toggle-points-intervals = Pongolola olondimbu lolotembo
+subset-move-points = Nyingisa Olondimbu
+subset-clear = Yepisa
+
+orbital-add-row = Vokiya Ongoli
+orbital-remove-row = Pindula Ongoli
+orbital-add-box = Vokiya Ocikuta
+orbital-remove-box = Pindula Ocikuta
+orbital-add-up-arrow = Vokiya Ondimbu Yokilu
+orbital-add-down-arrow = Vokiya Ondimbu Yokemehi
+orbital-remove-arrow = Pindula Ondimbu
+
+orbital-row-label = Onduko yongoli { $row }
+
+pretzel-answer = Etambululo
+
+summary-statistics-caption = Elomboloko lyovialua vya { $column }
+
+
+## Math input
+
+math-input-preview-region = oku tala tete ondaka yomatematika
+math-input-preview = Tala tete
+math-input-invalid-expression = Ondaka ka yisungulukile:
+
+
+## Document status
+
+viewer-initializing = Oku fetika…
+
+
+## Errors
+
+error-heading = Eviho
+
+error-found-at =
+    { $span ->
+        [line] Lya sangiwa kongoli { $startLine }.
+       *[lines] Lya sangiwa kolongoli { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Elivulu lilo li kwete oviho!
+
+diagnostic-heading-error = Eviho
+diagnostic-heading-warning = Elungulo
+diagnostic-heading-information = Esapulo
+diagnostic-heading-hint = Ekwatiso
+
+accessibility-heading-level-1 = Elueyo lya WCAG AA Kokupitĩla
+accessibility-heading-level-2 = Elungulo lyokupitĩla
+
+something-went-wrong = Cimwe ka ca lingile ciwa.
+
+renderer-load-failed = ulekisi umwe ka weyile. Tu ku pinga, tiukulula etapa.
+
+core-start-failed = Ulekisi welivulu ka a tẽlele oku fetika. Tu ku pinga, tiukulula etapa.

--- a/packages/i18n/locales/umb/chrome.ftl
+++ b/packages/i18n/locales/umb/chrome.ftl
@@ -83,9 +83,9 @@ orbital-add-row = Vokiya Ongoli
 orbital-remove-row = Pindula Ongoli
 orbital-add-box = Vokiya Ocikuta
 orbital-remove-box = Pindula Ocikuta
-orbital-add-up-arrow = Vokiya Ondimbu Yokilu
-orbital-add-down-arrow = Vokiya Ondimbu Yokemehi
-orbital-remove-arrow = Pindula Ondimbu
+orbital-add-up-arrow = Vokiya Oseta Yokilu
+orbital-add-down-arrow = Vokiya Oseta Yokemehi
+orbital-remove-arrow = Pindula Oseta
 
 orbital-row-label = Onduko yongoli { $row }
 
@@ -98,7 +98,7 @@ summary-statistics-caption = Elomboloko lyovialua vya { $column }
 
 math-input-preview-region = oku tala tete ondaka yomatematika
 math-input-preview = Tala tete
-math-input-invalid-expression = Ondaka ka yisungulukile:
+math-input-invalid-expression = Ondaka ka ya sungulukile:
 
 
 ## Document status
@@ -130,4 +130,4 @@ something-went-wrong = Cimwe ka ca lingile ciwa.
 
 renderer-load-failed = ulekisi umwe ka weyile. Tu ku pinga, tiukulula etapa.
 
-core-start-failed = Ulekisi welivulu ka a tẽlele oku fetika. Tu ku pinga, tiukulula etapa.
+core-start-failed = Ulekisi welivulu ka wa tẽlele oku fetika. Tu ku pinga, tiukulula etapa.

--- a/packages/i18n/locales/umb/content.ftl
+++ b/packages/i18n/locales/umb/content.ftl
@@ -131,10 +131,16 @@ noun =
 
 # The side count is a complement and closes the noun phrase behind the
 # describing words, so it goes in the tail.
+#
+# The head takes `ci-`, not `yi-`: `noun-gender` does not list
+# `regular-polygon`, so it falls to the `c7` default that a Portuguese loan
+# joins, and the head has to carry the same class the adjectives beside it
+# will. A head disagreeing with its own class is the defect #1685 found in
+# `locales/tiv`, and `styleDescriptions.test.ts` pins this row against it.
 noun-regular-polygon =
     { $part ->
         [tail] lo olonele { $numSides }
-       *[head] poligonu yisokisa
+       *[head] poligonu cisokisa
     }
 
 # The noun class. `c7` is the default and the class a Portuguese loan joins,

--- a/packages/i18n/locales/umb/content.ftl
+++ b/packages/i18n/locales/umb/content.ftl
@@ -5,12 +5,13 @@
 # Correct anything here freely; nothing in it was written by a translator.
 #
 # `umb` is Umbundu, the largest Angolan language, spoken across the central
-# highlands. It is the first Angolan catalog in this repository, and it arrives
-# beside `locales/kmb` (Kimbundu) in the same batch.
+# highlands. It is the first catalog here centred on Angola — `locales/kg`
+# reaches northern Angola too, but is written towards a written standard of the
+# DRC — and it arrives beside `locales/kmb` (Kimbundu) in the same batch.
 #
-# **`$gender` is a noun class spelled as a concord prefix**, which is what
-# twenty-odd Bantu catalogs here already do. The stem takes the class's prefix
-# directly, with nothing between:
+# **`$gender` is a noun class spelled as a concord prefix**, which is what most
+# of the twenty-odd Bantu catalogs here already do. The stem takes the class's
+# prefix directly, with nothing between:
 #
 #            c5 (li-)    c7 (ci-)    c9 (yi-)    c10 (vi-)
 #   -tekãva   litekãva    citekãva    yitekãva    vitekãva
@@ -133,9 +134,8 @@ noun =
 # describing words, so it goes in the tail.
 #
 # The head takes `ci-`, not `yi-`: `noun-gender` does not list
-# `regular-polygon`, so it falls to the `c7` default that a Portuguese loan
-# joins, and the head has to carry the same class the adjectives beside it
-# will. A head disagreeing with its own class is the defect #1685 found in
+# `regular-polygon`, so it falls to the `c7` default, and the head has to carry
+# the same class the adjectives beside it will. A head disagreeing with its own class is the defect #1685 found in
 # `locales/tiv`, and `styleDescriptions.test.ts` pins this row against it.
 noun-regular-polygon =
     { $part ->
@@ -143,9 +143,10 @@ noun-regular-polygon =
        *[head] poligonu cisokisa
     }
 
-# The noun class. `c7` is the default and the class a Portuguese loan joins,
-# which is what an author's own `markerStyleWord` is as far as this catalog is
-# concerned.
+# The noun class. `c7` is the default, which is what an author's own
+# `markerStyleWord` is as far as this catalog is concerned. Every noun with an
+# overt `oci-` — «ocilinganya», «ocitumãlo», «ocinepa» — falls to it unlisted,
+# so that a head and the words beside it always carry the same class.
 noun-gender =
     { $noun ->
         [point] c5
@@ -158,7 +159,6 @@ noun-gender =
         [ray] c9
         [polyline] c9
         [border] c9
-        [line-segment] c10
         [fill] c10
         [background] c10
        *[other] c7

--- a/packages/i18n/locales/umb/content.ftl
+++ b/packages/i18n/locales/umb/content.ftl
@@ -1,0 +1,344 @@
+# Umbundu content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `umb` is Umbundu, the largest Angolan language, spoken across the central
+# highlands. It is the first Angolan catalog in this repository, and it arrives
+# beside `locales/kmb` (Kimbundu) in the same batch.
+#
+# **`$gender` is a noun class spelled as a concord prefix**, which is what
+# twenty-odd Bantu catalogs here already do. The stem takes the class's prefix
+# directly, with nothing between:
+#
+#            c5 (li-)    c7 (ci-)    c9 (yi-)    c10 (vi-)
+#   -tekãva   litekãva    citekãva    yitekãva    vitekãva
+#   -yela     liyela      ciyela      yiyela      viyela
+#   -nene     linene      cinene      yinene      vinene
+#
+# **Read it beside `locales/kmb`, which is its neighbour and does not do
+# this.** Kimbundu joins a describing word to its noun with a connective that
+# agrees — «kya», «ya», «dya» — rather than prefixing the stem, so the two
+# largest languages of one country, both Bantu, both with the same class
+# system, put the agreement in different places. That is this batch's version
+# of the point `locales/kg` and `locales/ktu` made in #1686 about a creole and
+# its lexifier: **a shared family predicts the *existence* of agreement and
+# nothing whatever about its shape.**
+#
+# `$role` goes unused: Umbundu marks no case.
+#
+# **The chemistry gap here is Portuguese**, which is new. Every earlier batch's
+# gap was a French or English ministry; Angola teaches secondary science in
+# Portuguese, so `locales/umb` and `locales/kmb` are the first two catalogs
+# whose fallback-to-English is *not* the language of their own curriculum. See
+# the note at the foot of this file.
+#
+# The geometry leans on the Portuguese loans Angolan schooling supplies; where
+# Umbundu has its own word it is used — «ocitumãlo» a place, «ondimbukiso» a
+# sign. They are the first thing to check.
+
+
+## Style vocabulary
+
+color =
+    .black =
+        { $gender ->
+            [c5] litekãva
+            [c9] yitekãva
+            [c10] vitekãva
+           *[c7] citekãva
+        }
+    .white =
+        { $gender ->
+            [c5] liyela
+            [c9] yiyela
+            [c10] viyela
+           *[c7] ciyela
+        }
+    .gray =
+        { $gender ->
+            [c5] limbwe
+            [c9] yimbwe
+            [c10] vimbwe
+           *[c7] cimbwe
+        }
+    .red =
+        { $gender ->
+            [c5] likusuka
+            [c9] yikusuka
+            [c10] vikusuka
+           *[c7] cikusuka
+        }
+    .orange = laranja
+    .yellow = amarelu
+    .green = verdi
+    .cyan = siyanu
+    .blue = azulu
+    .purple = roxu
+    .pink = rosa
+    .brown = kastanyu
+
+line-width =
+    .thick =
+        { $gender ->
+            [c5] linene
+            [c9] yinene
+            [c10] vinene
+           *[c7] cinene
+        }
+    .thin =
+        { $gender ->
+            [c5] litito
+            [c9] yitito
+            [c10] vitito
+           *[c7] citito
+        }
+
+# Written as «lo …» phrases rather than as prefixed qualifiers, so that they
+# take no concord and can close the description. `style-stroke` puts them last.
+line-style =
+    .dashed = lo olongoli vitito
+    .dotted = lo olondimbu
+
+fill-style =
+    .horizontal = olongoli vi kasi vokati
+    .vertical = olongoli vi kasi voku talama
+    .diagonal = olongoli vi kasi voku pita
+    .backdiagonal = olongoli vi kasi voku pita konele yikwavo
+    .dots = olondimbu
+    .diamonds = olodiamanti
+
+noun =
+    .line = ongoli
+    .line-segment = ocinepa congoli
+    .ray = ondavululu
+    .vector = vetoru
+    .curve = ongoli yoku pengula
+    .function = funsão
+    .parabola = parabola
+    .polyline = ongoli yolonepa
+    .polygon = poligonu
+    .triangle = triangulu
+    .rectangle = retangulu
+    .circle = ocilinganya
+    .region = ocitumãlo
+    .point = ondimbu
+    .square = kwadradu
+    .diamond = odiamanti
+    .cross = ekulusu
+    .plus = ondimbukiso yoku vokiya
+
+# The side count is a complement and closes the noun phrase behind the
+# describing words, so it goes in the tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] lo olonele { $numSides }
+       *[head] poligonu yisokisa
+    }
+
+# The noun class. `c7` is the default and the class a Portuguese loan joins,
+# which is what an author's own `markerStyleWord` is as far as this catalog is
+# concerned.
+noun-gender =
+    { $noun ->
+        [point] c5
+        [diamond] c5
+        [cross] c5
+        [plus] c5
+        [text] c5
+        [line] c9
+        [curve] c9
+        [ray] c9
+        [polyline] c9
+        [border] c9
+        [line-segment] c10
+        [fill] c10
+        [background] c10
+       *[other] c7
+    }
+
+
+## Style composition
+
+# The dash pattern is a «lo …» phrase and closes the description, so it moves
+# behind the colour rather than sitting between the width and it.
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $color } { $lineStyle }
+        [width-color] { $width } { $color }
+        [style-color] { $color } { $lineStyle }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $noun } { $description } { $nounTail }
+       *[noun] { $noun } { $description }
+    }
+
+style-filled-word =
+    { $gender ->
+        [c5] liyukisiwa
+        [c9] yiyukisiwa
+        [c10] viyukisiwa
+       *[c7] ciyukisiwa
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $filled } { $color } lo { $pattern }
+       *[plain] { $filled } { $color }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $noun } { $filled } { $color } lo { $pattern }
+        [plain-tail] { $noun } { $nounTail } { $filled } { $color }
+        [pattern-tail] { $noun } { $nounTail } { $filled } { $color } lo { $pattern }
+       *[plain] { $noun } { $filled } { $color }
+    }
+
+# «onele» is the border and leads its own describing words, so they agree with
+# it rather than with the shape it surrounds — which is why `border` answers
+# `c9` in `noun-gender`. Umbundu has no article and joins this clause with the
+# invariable «lo», so all four branches read alike.
+style-border-clause =
+    { $parts ->
+        [with-article] lo onele { $border }
+        [and] lo onele { $border }
+        [and-article] lo onele { $border }
+       *[with] lo onele { $border }
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } { $color }
+       *[plain] { $color }
+    }
+
+style-unfilled = ka ciyukisiwa
+
+style-text =
+    { $parts ->
+        [background] { $color } lo konyima { $background }
+       *[plain] { $color }
+    }
+
+style-background-none = kalimwe
+
+
+## Boolean words
+
+boolean-true = ocili
+boolean-false = uhembi
+
+
+## Answer buttons
+
+answer-submit-label = Konomboloya Upange
+answer-submit-label-no-correctness = Tuma Etambululo
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Upange
+    .aside = Olondaka vikwavo
+    .cascade = Okulokoka
+    .definition = Elomboloko
+    .example = Ongangu
+    .exercise = Elilongiso
+    .exercises = Alilongiso
+    .given-answer = Etambululo
+    .note = Esapulo
+    .objectives = Ovimãho
+    .paragraphs = Olonepa
+    .part = Onepa
+    .problem = Ocitangi
+    .problems = Ovitangi
+    .proof = Uvangi
+    .question = Epulilo
+    .section = Onepa
+    .solution = Etetulwilo
+    .task = Upange
+    .theorem = Teoremu
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ": " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ": " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Ekwatiso
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Otabela { $enumeration }
+        [numbered-title] Otabela { $enumeration }{ ": " }
+        [unnumbered-title] Otabela{ ": " }
+       *[unnumbered] Otabela
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ocifwa { $enumeration }
+        [numbered-caption] Ocifwa { $enumeration }{ ": " }
+        [unnumbered-caption] Ocifwa{ ": " }
+       *[unnumbered] Ocifwa
+    }
+
+
+## Paginator controls
+
+paginator-previous = Yipita
+paginator-next = Yikwãma
+
+paginator-page = Etapa
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = ale
+
+piecewise-condition-if = nda
+
+piecewise-condition-otherwise = kovina vikwavo viosi
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately absent, so all 130
+## keys fall back to English and `lint:i18n` reports the gap.
+##
+## **The Portuguese case, which is new here.** Every earlier batch's chemistry
+## gap was left where the fallback *was* the curriculum: `locales/tiv` and
+## `locales/kri` fall back to the English a Nigerian or Sierra Leonean student
+## meets in their own textbook, and `locales/kg` and `locales/fon` leave the gap
+## rather than fill it with English words a French-educated reader would not
+## recognize. Angola is the second shape and a sharper one: a student here meets
+## the periodic table in **Portuguese**, so English is neither Umbundu nor the
+## curriculum, and the 130 keys fall back to a language that answers nobody.
+##
+## That is an argument for filling them in from Portuguese, not for leaving
+## them — and it is left anyway, because a Portuguese table dressed as an
+## Umbundu one is the substitution this whole seeding effort is careful not to
+## make. It is the clearest case in the repository for a real translator, and it
+## is recorded here so #1521 can find it.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Ondimbukiso ya Kimika ka Yisungulukile
+chemistry-invalid-ionic-compound = Elikongelo lya Ioni ka Lyasungulukile

--- a/packages/i18n/locales/umb/content.ftl
+++ b/packages/i18n/locales/umb/content.ftl
@@ -334,7 +334,7 @@ piecewise-condition-otherwise = kovina vikwavo viosi
 ## `locales/kri` fall back to the English a Nigerian or Sierra Leonean student
 ## meets in their own textbook, and `locales/kg` and `locales/fon` leave the gap
 ## rather than fill it with English words a French-educated reader would not
-## recognize. Angola is the second shape and a sharper one: a student here meets
+## recognize. Angola is the third shape and a sharper one: a student here meets
 ## the periodic table in **Portuguese**, so English is neither Umbundu nor the
 ## curriculum, and the 130 keys fall back to a language that answers nobody.
 ##

--- a/packages/i18n/locales/umb/diagnostics.ftl
+++ b/packages/i18n/locales/umb/diagnostics.ftl
@@ -1,0 +1,648 @@
+# Umbundu diagnostics: errors and warnings surfaced to the reader or author.
+# Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and attribute values — `through`,
+# `endpoint`, `midpointOffset`, `numDimensions`, `math`, `text` and the rest —
+# are part of the language rather than prose, and stay in English exactly as
+# written.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] { $attributes } yi yepiwa eci olonelo vivali vya tukuiwa
+       *[other] { $attributes } vi yepiwa eci olonelo vivali vya tukuiwa
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] { $attributes } yi yepiwa eci onelo lokati vya tukuiwa viosi
+       *[other] { $attributes } vi yepiwa eci onelo lokati vya tukuiwa viosi
+    }
+
+line-segment-midpoint-offset-without-midpoint = midpointOffset ka yi talavaya nda okati ka ku li
+
+## `<line>`
+
+line-points-undetermined-dimensions = Ongoli yi pita polondimbu vina ovinene vyavyo ka vya kũlĩhĩwile.
+
+line-points-too-few-dimensions = Ongoli yi sukila oku pita polondimbu vi kwete ovinene vivali ale valua.
+
+line-points-depend-on-variables = Ongoli yi pita polondimbu vi kolela kolopongoloso: { $variables }.
+
+line-equation-invalid-format = Ocituwa cekwasõla lyongoli ka ca sungulukile vu { $variable1 } la { $variable2 }.
+
+## `<ray>`
+
+ray-overprescribed-through = Ondavululu ya tukuiwa la through, endpoint la direction.  Through ya tukuiwa yi yepiwa.
+
+ray-dimension-mismatch = numDimensions ka yi likwatisa vondavululu.
+
+## `<vector>`
+
+vector-overprescribed-head = Vetoru ya tukuiwa la head, tail la displacement.  Head ya tukuiwa yi yepiwa.
+
+vector-dimension-mismatch = numDimensions ka yi likwatisa vovetoru.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = Ka ci tẽliwa oku kokela ku `<{ $component }>` momo ka ci kwete nearestPoint.
+
+constrain-to-without-nearest-point = Ka ci tẽliwa oku kutika ku `<{ $component }>` momo ka ci kwete nearestPoint.
+
+constrain-to-interior-without-nearest-point = Ka ci tẽliwa oku kutika vokati ka `<{ $component }>` momo ka ci kwete nearestPoint.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = labelPosition yi yepiwa ku choiceInput ka yi kasi inline
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = Indices vya tukuiwa ku choiceInput vi yepiwa momo ocitalatu cindices ka ci likwatisa locitalatu comãla a choice.
+
+pretzel-indices-count-mismatch = Indices vya tukuiwa ku problem vi yepiwa momo ocitalatu cindices ka ci likwatisa locitalatu comãla a problem.
+
+shuffle-indices-count-mismatch = Indices vya tukuiwa ku shuffle vi yepiwa momo ocitalatu cindices ka ci likwatisa locitalatu covina.
+
+indices-ignored-out-of-range = Indices vya tukuiwa ku { $component } vi yepiwa momo vimwe vi kasi kovilu.
+
+pretzel-indices-repeated = Indices vya tukuiwa ku pretzel vi yepiwa momo vimwe vya lilwilwa.
+
+pretzel-circuit-first-index = Indices vya tukuiwa ku pretzel vo mode="circuit" vi yepiwa momo index yatete yi sukila oku kala 1.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = Oco `<{ $component }>` ci talavaye lomãla a string, `type` attribute yi sukila oku tukuiwa.
+
+invalid-type-defaulting-to-math = Type { $type } ka ya sungulukile kocina { $component }. Yi sukila oku kala math, text, number ale boolean. Ku talavaiwa math.
+
+string-not-valid-component-to-arrange = String "{ $value }" ka ci cina cimwe ciwa ku { $component }. Ci yepiwa.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Type { $type } ka ya sungulukile, type ya tumbikiwa ku number.
+
+invalid-variable-value = Ocina copongoloso ka ca sungulukile: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Ocituwa index { $index } ci sukila oku kala ocitalatu
+
+variant-index-must-be-integer = Ocituwa index { $index } ci sukila oku kala ocitalatu ciosi
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` ka ca lingiwile kovisokiso viosi. Ovinene vya tumbikiwa kovisokiso vikwavo.
+
+side-by-side-absolute-margins = `<{ $component }>` ka ca lingiwile kovisokiso viosi. Olonele vya tumbikiwa kovisokiso vikwavo.
+
+side-by-side-no-block-child = `<{ $component }>` ka ca sungulukile: ci sukila oku kwata omõla umwe wa block ale valua.
+
+## `<label>`
+
+label-for-ignored-on-graphical = `for` attribute kocifwa `<label>` yi yepiwa.
+
+label-for-must-resolve-to-one = `for` attribute ku `<label>` yi sukila oku enda kocina cimwe lika.
+
+label-for-unresolved = `for` attribute ku `<label>` ka ya tẽlele oku enda kocina cimwe.
+
+label-for-answer-with-authored-inputs = `for` attribute ku `<label>` yi popia `<answer>` yi kwete inputs vya sonehiwa; popia input muẽle.
+
+label-for-answer-without-input = `for` attribute ku `<label>` yi popia `<answer>` ka yi kwete input.
+
+label-for-must-reference-input-or-answer = `for` attribute ku `<label>` yi sukila oku popia input ale answer.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Kokupitĩla, `<{ $component }>` ci sukila oku kwata elomboloko lisukiwa ale ci tukuiwe ndeci decorative.
+
+accessibility-video-short-description = Kokupitĩla, `<video>` ci sukila oku kwata elomboloko lisukiwa.
+
+accessibility-input-short-description-or-label = Kokupitĩla, `<{ $component }>` ci sukila oku kwata elomboloko lisukiwa ale onduko.
+
+accessibility-answer-input-short-description-or-label = Kokupitĩla, `<answer>` yi linga input yi sukila oku kwata elomboloko lisukiwa ale onduko.
+
+accessibility-short-description-contains-math = Alomboloko asukiwa ka a sukila oku kwata ovina vyomatematika ndeci `<{ $component }>`. Soneha omatematika lolondaka.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ka yi kwete elitepiso lya sukila kolondaka vyosapi yonepa (mode yelaike) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ci sukila { $threshold }:1 ale valua).
+       *[other] { $colorName } ka yi kwete elitepiso lya sukila kolondaka vyosapi yonepa ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ci sukila { $threshold }:1 ale valua).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = `<circle>` yi pita polondimbu { $count } ka ya lingiwile eci olondimbu ka vi kwete ovitalatu.
+
+circle-too-many-through-points = Ka ci tẽliwa oku sokisa ocilinganya ci pita polondimbu vya piti 3.
+
+circle-overprescribed-radius-center-points = Ka ci tẽliwa oku sokisa ocilinganya la radius, okati kuenda olondimbu viosi.
+
+circle-center-with-multiple-points = Ka ci tẽliwa oku sokisa ocilinganya lokati ci pita pondimbu ya piti 1.
+
+circle-radius-too-small = Ka ci tẽliwa oku sokisa ocilinganya: momo ocitumãlo pokati kolondimbu vivali ci kasi { $distance }, radius { $radius } ya tukuiwa yi tito calua.
+
+circle-radius-with-many-points = Ka ci tẽliwa oku linga ocilinganya ci pita polondimbu vya piti vivali la radius ya tukuiwa.
+
+circle-invalid-center-or-through-points = Okati ale olondimbu vyocilinganya ka vya sungulukile.
+
+circle-radius-center-with-multiple-points = Ka ci tẽliwa oku sokisa radius yocilinganya lokati ci pita pondimbu ya piti 1.
+
+circle-change-radius-non-numerical = Ka ci tẽliwa oku pongolola radius yocilinganya lolondimbu ka vi kwete ovitalatu
+
+circle-radius-with-points-non-numerical = Ka ci tẽliwa oku linga ocilinganya ci pita pondimbu ya piti yimwe la radius eci ovitalatu ka vi kasi.
+
+circle-change-center-non-numerical = Epongoloko lyokati kocilinganya ci pita polondimbu ka vi kwete ovitalatu ka lya lingiwile.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Ovinene ka vya sukila kodomain yofunsão. Domain yi kwete otembo { $intervals } pole funsão yi kwete { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+       *[other] Ovinene ka vya sukila kodomain yofunsão. Domain yi kwete olotembo { $intervals } pole funsão yi kwete { $inputs ->
+            [one] input { $inputs }
+           *[other] input { $inputs }
+        }.
+    }
+
+function-domain-invalid-format = Ocituwa cadomain yofunsão ka ca sungulukile.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Ci yepiwa ocinene cofunsão ka ci kwete ocitalatu.
+        [minimum] Ci yepiwa ocitito cofunsão ka ci kwete ocitalatu.
+        [extremum] Ci yepiwa onelo yofunsão ka yi kwete ocitalatu.
+        [point] Ci yepiwa ondimbu yofunsão ka yi kwete ocitalatu.
+        [slope] Ci yepiwa okupengula kwofunsão ka ku kwete ocitalatu.
+       *[other] Ci yepiwa { $type } yofunsão ka yi kwete ocitalatu.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Ci yepiwa ocinene cofunsão ka ci kwete cimwe.
+        [minimum] Ci yepiwa ocitito cofunsão ka ci kwete cimwe.
+        [extremum] Ci yepiwa onelo yofunsão ka yi kwete cimwe.
+        [point] Ci yepiwa ondimbu yofunsão ka yi kwete cimwe.
+       *[other] Ci yepiwa { $type } yofunsão ka yi kwete cimwe.
+    }
+
+function-points-too-close = Funsão yi kwete olondimbu vivali vi likwatele calua. Ka ci tẽliwa oku lomboloka funsão.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Elilwilo lyofunsão li tẽliwa lika nda ocitalatu cinputs ci likwatisa locitalatu coutputs. Funsão eyi yi kwete input { $inputs } la { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+       *[other] Elilwilo lyofunsão li tẽliwa lika nda ocitalatu cinputs ci likwatisa locitalatu coutputs. Funsão eyi yi kwete inputs { $inputs } la { $outputs ->
+            [one] output { $outputs }
+           *[other] output { $outputs }
+        }.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Ocilamba cosequence ka ca sungulukile.  Ci sukila oku kala ocitalatu ciosi ka ci kasi kemehi lya ziro.
+
+sequence-invalid-step = Step yosequence ka ya sungulukile.  Yi sukila oku kala ocitalatu kosequence ya type { $type }.
+
+sequence-invalid-endpoint-number = "{ $attribute }" yosequence ya number ka ya sungulukile.  Yi sukila oku kala ocitalatu.
+
+sequence-invalid-endpoint-letters = "{ $attribute }" yosequence ya letters ka ya sungulukile.  Yi sukila oku kala elikongelo lyovisonehua.
+
+sequence-invalid-endpoint = "{ $attribute }" yosequence ka ya sungulukile.
+
+select-from-sequence-coprime-not-numbers = coprime yi yepiwa momo ka ku nõliwa ovitalatu
+
+select-from-sequence-coprime-with-exclude-combinations = coprime yi yepiwa momo excludeCombinations ya tukuiwa
+
+## Resolving a `target`
+
+target-not-found = Target ya `<{ $source }>` ka ya sungulukile: ka ci tẽliwa oku sanga target.
+
+target-state-variable-not-found = Target ya `<{ $source }>` ka ya sungulukile: ka ci tẽliwa oku sanga opongoloso yonduko "{ $property }" ku `<{ $component }>`.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = Olopongoloso vya `<odeSystem>` vi sukila oku litepa lopongoloso yaco muẽle.
+
+ode-system-duplicate-variable-names = Ka ci tẽliwa oku lomboloka ofunsão vya ODE RHS lolonduko vyolopongoloso vya lilwilwa.
+
+ode-system-rhs-function-error = Ka ci tẽliwa oku lomboloka ofunsão ya ODE RHS.  Eviho vokulinga ofunsão ya mathjs.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = Ka ci tẽliwa oku lomboloka okangulu pokati kolongoli { $count }
+
+angle-invalid-through-point = Ondimbu ka ya sungulukile vo through ya `<angle>`
+
+parabola-vertex-too-many-points = Parabola la vertex yi pita pondimbu ya piti 1 ka ya lingiwile.
+
+parabola-too-many-points = Parabola yi pita polondimbu vya piti 3 ka ya lingiwile.
+
+intersection-too-many-items = Elilwatelo lyovina vya piti vivali ka lya lingiwile
+
+## Other math components
+
+ionic-compound-not-two-ions = Elikongelo lya ioni kovina vikwavo ka vya kala ioni vivali ka lya lingiwile.
+
+ionic-compound-needs-cation-and-anion = Elikongelo lya ioni lya lingiwa lika ku kationi yimwe la anioni yimwe.
+
+solve-equations-cannot-evaluate = Ka ci tẽliwa oku tetulula ekwasõla momo ka ci tẽlele oku li sokisa: { $equation }
+
+math-operators-operand-number-required = operandNumber yi sukila oku tukuiwa eci ku pindiwa operand yomatematika.
+
+eigen-decomposition-failed = Ka ci tẽlele oku sokisa oloeigenvalue vyomatrisi
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: parameter { $parameters } ka yi kasi vocifwa, kuenje yi likwatisa lika lokahandeleko.
+       *[other] `<matchesPattern>`: parameters { $parameters } ka vi kasi vocifwa, kuenje vi likwatisa lika lokahandeleko.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: ka ci tẽliwa oku kũlĩhĩsa grid="{ $grid }". Yi sukila oku kala none, medium, dense, ale ovitalatu vivali vinene vya tepiwa locitumãlo, ndeci grid="1 0.5". Ka ku lingiwa grid.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: xLabelPosition="left" ka yi talavaya vulekisi prefigure; ku talavaiwa onele yondio.
+
+prefigure-y-label-position-unsupported = `<graph>`: yLabelPosition="bottom" ka yi talavaya vulekisi prefigure; ku talavaiwa onele yokilu.
+
+prefigure-invalid-axis-bounds = `<graph>`: olonele vyaksi ka vya sungulukile ku prefigure; ku talavaiwa bbox (-10,-10,10,10).
+
+prefigure-invalid-width = `<graph>`: ocinene ka ca sungulukile ku prefigure; ku talavaiwa ocinene 425.
+
+prefigure-invalid-aspect-ratio = `<graph>`: aspectRatio ka ya sungulukile ku prefigure; ku talavaiwa aspekt rasiu 1.
+
+prefigure-grid-spacing-too-fine = `<graph>`: ocitumãlo cagrid ci tito calua kolonele vyaksi; grid yi pindiwa vulekisi prefigure.
+
+prefigure-annotations-not-rendered = `<graph>`: annotations ka vi lekisiwa nda ka ku talavaiwa ulekisi PreFigure.
+
+multiple-annotations-children = Kwa sangiwa omãla valua va `<annotations>` vu `<graph>`; vosi va yepiwa puãi wasulako.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ka ci tẽliwa oku vokiya ale oku sokisa ocituwa cocina ka ca kũlĩhĩwile: { $type }.
+
+copy-prop-not-found = Ka ci tẽlele oku sanga prop { $property } kocina cocituwa { $component }
+
+collect-no-source = Ka kwa sangiwile onene ku collect.
+
+collect-invalid-component-type = Ka ci tẽliwa oku ongoluila ovina vyocituwa `<{ $component }>` momo ocituwa ka ca sungulukile.
+
+reference-index-unavailable = Ka ci tẽliwa oku popia index `{ $reference }`
+
+## `<callAction>`
+
+component-action-unavailable = Ka ci tẽliwa oku vilikiya { $action } kocina `{ $reference }`
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Ocituwa covilongua ka ca sungulukile.  Olongoli vi kwete ovilamba vya litepa. Vya sangiwa ku componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Ovilongua vi kwete olonduko vyolokoluna vya lilwilwa.  Vya sangiwa ku componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Ovilongua ka vi kwete onduko yokoluna.  Vya sangiwa ku componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Award yetambululo eli yi kolela ketambululo lya answer tag muẽle, kuenje ci nena ovina ka vya lavuiwile.
+
+answer-max-num-attempts-in-section-wide-check-work = Oku tumbika `maxNumAttempts` ku `<answer>` yi kasi vokati kocina ci kwete `sectionWideCheckWork` ka ci talavaya, momo ocina caco ci tenda ocitalatu calilongiso. Tumbika `maxNumAttempts` kocina caco.
+
+nested-section-wide-check-work-max-num-attempts = Oku tumbika `maxNumAttempts` kocina ci kwete `sectionWideCheckWork` kuenda ci kasi vokati kocina cikwavo ci kwete `sectionWideCheckWork` ka ci talavaya, momo ocina cokwenda ci tenda ocitalatu calilongiso. Tumbika `maxNumAttempts` kocina cokwenda.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] { $attributes } attribute ka yi talavaya nda symbolicEquality ka ya tumbikiwile.
+       *[other] { $attributes } attributes ka vi talavaya nda symbolicEquality ka ya tumbikiwile.
+    }
+
+answer-invalid-type = Type yetambululo ka ya sungulukile: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = Momo ocina `<{ $component }>` ka ci kwete onduko, ka ci tẽliwa oku ci talavaya ndeci module attribute
+
+module-attribute-name-already-defined = Ka ci tẽliwa oku talavaya ocina `<{ $component } name="{ $name }">` ndeci attribute ya module momo `<module>` yi kwete ale "{ $name }" attribute.
+
+conditional-content-condition-ignored = `condition` attribute yi yepiwa ku `<conditionalContent>` yi kwete omãla a case ale else.
+
+slider-markers-type-mismatch = Type ya markers ka yi likwatisa la type ya slider.
+
+pretzel-problem-needs-statement-and-answer = Pretzel ka ya sungulukile: `<problem>` yosi yi sukila oku kwata `<statement>` yimwe la `<answer>` yimwe.
+
+pretzel-circuit-first-problem-distractor = Pretzel ka ya sungulukile: vo mode="circuit", `<problem>` yatete ka yi tẽliwa oku kala distractor.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] Ocina { $values } ka ca sungulukile ku attribute `{ $attribute }`; ci yepiwa.
+       *[other] Ovina { $values } ka vya sungulukile ku attribute `{ $attribute }`; vi yepiwa.
+    }
+
+attribute-must-be-references = Ocina `{ $value }` ka ca sungulukile ku attribute `{ $attribute }`. Attribute yi sukila oku kala olondaka vi fetika la `$`.
+
+math-input-invalid-function-names = <mathInput>: olonduko vyofunsão ka vya sungulukile vi yepiwa vu { $attribute }: { $names }. Onduko yosi onepa yayo yokulekisa yi sukila ovisonehua vivali ale valua (ovisonehua ale olondimbu); `|<mathspeak alternative>` yi pondola oku kwãma.
+
+## Building components from the source
+
+component-type-invalid = Ocituwa cocina ka ca sungulukile: `<{ $componentType }>`
+
+attribute-repeated = Ka ci tẽliwa oku lilwila attribute { $attribute }.
+
+attribute-invalid-for-component = Attribute "{ $attribute }" ka ya sungulukile kocina cocituwa `<{ $componentType }>`.
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    Elomboloko lyocituwa { $styleNumber } ka li kwete elitepiso lya sukila ku { $context ->
+        [text-on-background] osoka yolondaka konyima yosoka yokonyima
+        [high-contrast] osoka yelitepiso linene kokanvasi
+        [line] osoka yongoli kokanvasi
+        [marker] osoka yondimbu kokanvasi
+       *[text-on-canvas] osoka yolondaka kokanvasi
+    }{ $mode ->
+        [dark] { " (mode yelaike)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ci sukila { $threshold }:1 ale valua).
+
+style-definition-dark-mode-text-background-contrast =
+    Ndaño okuti elomboloko lyocituwa { $styleNumber } li kwete olosoka vi kwete elitepiso lya sukila ku mode yocinyi, olosoka vya mode yelaike vya tundila kokwavo ka vi kwete elitepiso lya sukila pokati kosoka yolondaka losoka yokonyima ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ci sukila { $threshold }:1 ale valua). { $suggestion ->
+        [available] Oco ku kale elitepiso lya sukila ku mode yelaike, vokiya elitepiso lya mode yocinyi (ndeci, tumbika { $lightAttribute }="{ $lightColor }") ale pongolola osoka ya mode yelaike (ndeci, tumbika { $darkAttribute }="{ $darkColor }").
+       *[none] Oco ku kale elitepiso lya sukila ku mode yelaike, vokiya elitepiso lya mode yocinyi ale pongolola olosoka la textColorDarkMode ale backgroundColorDarkMode.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    Ndaño okuti elomboloko lyocituwa { $styleNumber } li kwete osoka yolondaka yi kwete elitepiso lya sukila ku mode yocinyi, osoka yolondaka ya mode yelaike ya tundila kokwayo ka yi kwete elitepiso lya sukila kokanvasi ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ci sukila { $threshold }:1 ale valua). { $suggestion ->
+        [available] Oco ku kale elitepiso lya sukila ku mode yelaike, vokiya elitepiso lya mode yocinyi (ndeci, tumbika textColor="{ $lightColor }") ale pongolola osoka ya mode yelaike (ndeci, tumbika textColorDarkMode="{ $darkColor }").
+       *[none] Oco ku kale elitepiso lya sukila ku mode yelaike, vokiya elitepiso lya mode yocinyi ale pongolola osoka la textColorDarkMode.
+    }
+
+section-multiple-style-palettes = Onepa yi pondola oku nõla lika <stylePalette> yimwe; ku talavaiwa yasulako.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } momo numToSelect ka ci citalatu ciosi ka ci kasi kemehi lya ziro.
+
+variant-num-to-select-not-constant-number = ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } momo numToSelect ka ci citalatu ka ci pongoloka.
+
+variant-with-replacement-not-constant-boolean = ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } momo withReplacement ka ya boolean ka yi pongoloka.
+
+variant-select-weight-disables-unique = Ovituwa vya litepa vya select vi yikiwa nda option yimwe yi kwete selectWeight ale selectForVariants
+
+variant-coprime-undetermined = ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } momo ka ci tẽliwa oku kũlĩhĩsa nda coprime yi kala uhembi olonjanja viosi.
+
+variant-attribute-not-constant = ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } momo { $attribute } yi pongoloka.
+
+variant-attribute-not-number = ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } momo { $attribute } ka ci citalatu.
+
+variant-attribute-wrong-type-for-sequence =
+    ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } yocituwa { $type } momo { $attribute } ka ya { $expected ->
+        [letters-combination] elikongelo lyovisonehua
+        [math-expression] ondaka yomatematika ya sunguluka
+        [integer] ocitalatu ciosi
+       *[number] ocitalatu
+    }.
+
+variant-length-not-integer = ka ci tẽliwa oku kũlĩhĩsa ovituwa vya litepa vya { $component } momo length ka ci citalatu ciosi.
+
+variant-sort-not-implemented = ovituwa vya litepa vya { $component } la sort ka vya lingiwile
+
+variant-exclude-combinations-not-implemented = ovituwa vya litepa vya { $component } la excludeCombinations ka vya lingiwile
+
+variant-math-exclude-not-implemented = ovituwa vya litepa vya { $component } yotype math la exclude ka vya lingiwile
+
+variant-non-constant-exclude-not-implemented = ovituwa vya litepa vya { $component } la exclude yi pongoloka ka vya lingiwile
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: ka ci talavaya vulekisi prefigure wograph; omõla wa yepiwa.
+
+prefigure-descendant-invalid-geometry = { $subject }: jiometria ka ya sungulukile ale ka ya tẽlisiwile; omõla wa yepiwa.
+
+prefigure-curve-label-omitted = { $subject }: olonduko ka vi talavaya kovina vya curve vya pongololwa; onduko ya pindiwa.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ocituwa celomboloko lyofunsão ya curve '{ $definitionType }' ka ci talavaya; omõla wa yepiwa.
+
+prefigure-region-flip-functions-unsupported = { $subject }: flipFunctions attribute ku regionBetweenCurves ka yi talavaya; omõla wa yepiwa.
+
+prefigure-region-non-formula-child = { $subject }: omãla ofunsão vyocituwa formula lika va talavaya ku regionBetweenCurves; omõla wa yepiwa.
+
+prefigure-label-position-unsupported =
+    { $subject }: labelPosition '{ $labelPosition }' ka yi talavaya ku { $labelKind ->
+        [line-family] onduko yepata lyolongoli
+       *[point] onduko yondimbu
+    }; ku talavaiwa esokiso lya PreFigure.
+
+prefigure-fill-style-unsupported = { $subject }: PreFigure ka yi kũlĩhĩle ocituwa cokuyukisa '{ $fillStyle }'; ku talavaiwa okuyukisa kwosi.
+
+prefigure-line-style-unknown = { $subject }: ocituwa congoli '{ $lineStyle }' ka ca kũlĩhĩwile, kuenje ca pindiwa ku PreFigure.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: ocituwa condimbu '{ $markerStyle }' ca pongololwa kocituwa 'diamond' ca PreFigure.
+
+prefigure-marker-style-unsupported = { $subject }: PreFigure ka yi kũlĩhĩle ocituwa condimbu '{ $markerStyle }'; ku talavaiwa ocituwa ci kasi tete.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: `ref` ka ya sungulukile; ka ci tẽliwa oku sanga target. Annotation ya pindiwa.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ya sanga ovitarjeti vyalua; ku talavaiwa catete.
+
+annotation-ref-outside-graph = `<annotation>`: `ref` ka ya sungulukile; target yi kasi kovilu ka graph. Annotation ya pindiwa.
+
+annotation-ref-unsupported-target = `<annotation>`: `ref` ka ya sungulukile; target ka ci cina cocifwa ci talavaya vo prefigure. Annotation ya pindiwa.
+
+annotation-text-missing = `<annotation>`: `text` ka yi kasi ale ka yi kwete cimwe; ku sonehiwa olondaka ka vi kwete cimwe.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Kwa sangiwa elikolelo lyocilinganya.
+       *[other] Kwa sangiwa elikolelo lyocilinganya locina `<{ $componentType }>`.
+    }
+
+reference-no-referent = Ka kwa sangiwile cimwe kondaka: `{ $reference }`
+
+reference-multiple-referents = Kwa sangiwa ovina vyalua kondaka: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = Ocituwa ca attribute { $attribute } ya `<{ $componentType }>` ka ca sungulukile.
+
+children-invalid = Omãla va `<{ $componentType }>` ka va sungulukile: Kwa sangiwa omãla ka va sungulukile: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = Ocina `{ $value }` ka ca sungulukile ku attribute `{ $attribute }`, ku talavaiwa `{ $default }`
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] Ka kwa sangiwile ocitumbu ca DoenetML { $version }.
+       *[other] Ka kwa sangiwile ocitumbu ca DoenetML { $version }. Ku talavaiwa ocitumbu { $fallback }
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = DoenetML ka ya sungulukile: { $content }
+
+parse-tag-missing-close-tag = DoenetML ka ya sungulukile: Tag `{ $tag }` ka yi kwete tag yokuyika. Ku lavuiwile tag yi liyika muẽle ale tag `</{ $tagName }>`.
+
+parse-tag-error = DoenetML ka ya sungulukile: Eviho vu tag `<{ $tagName }>`
+
+parse-attribute-missing-value = DoenetML ka ya sungulukile: Attribute `{ $attribute }` ka ya sungulukile, yi molẽha ndeci ka yi kwete ocina.
+
+parse-attribute-invalid = DoenetML ka ya sungulukile: Attribute `{ $attribute }` ka ya sungulukile
+
+parse-attribute-value-invalid = DoenetML ka ya sungulukile: Ocina ca attribute `{ $value }` ka ca sungulukile
+
+parse-attribute-value-quote-mismatch = DoenetML ka ya sungulukile: Ocina ca attribute `{ $value }` ka ca sungulukile. Olondimbu vyokupopia ka vi likwatisa. Ci molẽha ndeci `{ $quote }` ka yi kasi
+
+parse-open-tag-name-missing = DoenetML ka ya sungulukile: Kwa sangiwa tag ka yi kwete onduko, ndeci `<`
+
+parse-tag-not-closed = DoenetML ka ya sungulukile: Tag `{ $tag }` ka ya yikiwile (ci molẽha ndeci `>` ka yi kasi).
+
+parse-self-closing-tag-name-missing = DoenetML ka ya sungulukile: Kwa sangiwa tag ka yi kwete onduko `<{ $content }>`
+
+parse-self-closing-tag-not-closed = DoenetML ka ya sungulukile: Tag `{ $tag }` ka ya yikiwile (ci molẽha ndeci `/>` ka yi kasi).
+
+parse-tag-invalid-attributes = DoenetML ka ya sungulukile: Tag `{ $tag }` ka ya sungulukile. Yi pondola oku kwata attributes ka vya sungulukile.
+
+parse-close-tag-name-missing = DoenetML ka ya sungulukile: Kwa sangiwa tag yokuyika ka yi kwete onduko, ndeci `</`
+
+parse-attribute-value-unquoted = Ovina vya attribute vi sukila oku kala pokati kolondimbu vyokupopia: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = DoenetML ka ya sungulukile: Kwa sangiwa tag yokuyika `{ $tag }`, pole tag yokuyulula ka yi kasi
+
+parse-close-tag-mismatched = DoenetML ka ya sungulukile: Tag yokuyika ka yi likwatisa. Ku lavuiwile `</{ $expected }>`. Kwa sangiwa `{ $found }`
+
+parser-node-unconvertible = Ka ci tẽliwa oku pongolola node { $node } ku node ya Dast.
+
+## Names
+
+name-attribute-invalid =
+    Onduko name='{ $name }' ka ya sungulukile. { $reason ->
+        [characters] Olonduko vi pondola oku kwata lika ovisonehua, ovitalatu, olondimbu vyemehi ale olondimbu.
+       *[start] Olonduko vi sukila oku fetika locisonehua.
+    }
+
+component-name-invalid-start = Onduko yocina "{ $name }" ka ya sungulukile. Olonduko vi sukila oku fetika locisonehua.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = Answer yotype videoWatched yi sukila oku kwata video attribute
+
+answer-video-watched-video-not-reference = Answer yotype videoWatched yi sukila oku kwata video attribute yi kala ondaka
+
+answer-name-not-single-text = Answer name attribute yi sukila oku kwata omõla umwe lika wa text
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Ka ci tẽlele oku sanga DoenetML yokovilu momo elilwilo lyalua. Ondaka yocilinganya yi kasi?
+
+external-doenetml-unavailable = Ka ci tẽlele oku sanga DoenetML ku { $attribute }="{ $uri }"
+
+external-doenetml-type-mismatch = DoenetML ya sangiwa ku { $attribute }="{ $uri }" ka ya sungulukile: ka ya likwatisa locituwa cocina "{ $componentType }"
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` ya kukuluka; talavaya `{ $to }`.
+       *[other] [deprecation] Attribute `{ $from }` ku `<{ $component }>` ya kukuluka; talavaya `{ $to }`.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] Attribute `{ $from }` ya kukuluka kuenje ya yepiwa momo `{ $to }` ya tukuiwa vali.
+       *[other] [deprecation] Attribute `{ $from }` ku `<{ $component }>` ya kukuluka kuenje ya yepiwa momo `{ $to }` ya tukuiwa vali.
+    }
+
+deprecated-attribute-ignored = [deprecation] Attribute `{ $attribute }` ku `<{ $component }>` ya kukuluka kuenje ya yepiwa.
+
+deprecated-attribute-to-child = [deprecation] Attribute `{ $attribute }` ku `<{ $component }>` ya kukuluka; talavaya omõla `<{ $child }>`.
+
+deprecated-attribute-value-renamed = [deprecation] Ocina `{ $value }` ca attribute `{ $attribute }` ku `<{ $component }>` ca kukuluka; talavaya `{ $to }`.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` yi pondola lika oku lingisa Ingelesi valua, kuenje olondaka vyayo vi sialele ndeci wa soneha velivulu lya sonehiwa vu { $locale }. Soneha ocituwa cavalua muẽle, ale ci tumbika la `pluralForm` attribute.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = Ocina `<{ $tag }>` ka ci cina ca Doenet ca kũlĩhĩwa.
+
+schema-element-not-allowed-at-root = Ocina `<{ $tag }>` ka ci ecelelwa kilu lyelivulu.
+
+schema-element-not-allowed-inside = Ocina `<{ $tag }>` ka ci ecelelwa vokati ka `<{ $parent }>`.
+
+schema-attribute-unrecognized = Ocina `<{ $tag }>` ka ci kwete attribute yonduko `{ $attribute }`.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] Attribute `{ $attribute }` yocina `<{ $tag }>` yi sukila oku kala elisitu li kwete ovina vyosi vi kala cimwe pokati ka: { $allowed }
+       *[other] Attribute `{ $attribute }` yocina `<{ $tag }>` yi sukila oku kala cimwe pokati ka: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = Onduko yocituwa ya select ka ya sungulukile.  Onduko yocituwa { $variantName } yi molẽha vu options { $numOptions } pole ocitalatu cokunõla ci kasi { $numToSelect }.
+
+select-variant-name-without-options = Ovituwa vimwe vya tukuiwa ku select pole ka mwa tukuiwile options konduko yocituwa yi tẽliwa: { $variantName }.
+
+select-variant-name-not-possible = Onduko yocituwa { $variantName } ya tukuiwa ku select ka ya nduko yocituwa yi tẽliwa.
+
+select-too-few-options = Ka ci tẽliwa oku nõla ovina { $numToSelect } vu { $numOptions } lika.
+
+select-from-sequence-too-few-values = Ka ci tẽliwa oku nõla ovina { $numToSelect } vosequence yocilamba { $length }.
+
+select-from-sequence-indices-count-mismatch = Ocitalatu cindices vya tukuiwa ku select ci sukila oku likwatisa locitalatu cokunõla
+
+select-from-sequence-indices-not-integers = Indices vyosi vya tukuiwa ku select vi sukila oku kala ovitalatu vyosi
+
+select-from-sequence-index-excluded = Kwa tukuiwa index ya selectfromsequence ya pindiwa
+
+select-from-sequence-indices-excluded-combination = Kwa tukuiwa indices vya selectfromsequence vya kala elikongelo lya pindiwa
+
+select-from-sequence-coprime-not-positive-integers = Ka ci tẽliwa oku nõla alikongelo a coprime momo ka ku nõliwa ovitalatu vyosi vi kasi kilu lya ziro.
+
+select-from-sequence-coprime-common-factor = Ka ci tẽliwa oku nõla ovitalatu vya coprime. Ovina vyosi vi tẽliwa vi kwete ofatoru yimosi. (Ovina vya tukuiwa vya "from" ale "to" vi sukila oku kala coprime la "step".)
+
+select-from-sequence-coprime-single-number = Ka ci tẽliwa oku nõla alikongelo a coprime kocitalatu cimosi ka ci kasi 1.
+
+select-from-sequence-excluded-too-many-combinations = Kwa pindiwa alikongelo a piti 70% vo selectFromSequence
+
+select-from-sequence-coprime-none-found = Ka ci tẽlele oku nõla ovitalatu vya coprime. Ovina vyosi vi tẽliwa vi kwete ofatoru yimosi.
+
+select-from-sequence-too-few-unique-values = Ka ci tẽliwa oku nõla ovina vya litepa { $numToSelect } vosequence yocilamba { $numPossibleValues }
+
+select-prime-numbers-too-few-values = Ka ci tẽliwa oku nõla ovina { $numToSelect } velisitu lyovitalatu vya prime lyocilamba { $numValues }
+
+select-prime-numbers-values-count-mismatch = Ocitalatu covina vya tukuiwa ku select ci sukila oku likwatisa locitalatu cokunõla
+
+select-prime-numbers-values-not-prime = Ovina vyosi vya tukuiwa ku select prime number vi sukila oku kala velisitu lyovitalatu vya prime
+
+select-prime-numbers-values-excluded-combination = Ovina vya tukuiwa vya selectPrimeNumbers vya kala elikongelo lya pindiwa
+
+select-prime-numbers-excluded-too-many-combinations = Kwa pindiwa alikongelo a piti 70% vo selectPrimeNumbers
+
+select-random-combination-fluke = Locina ka ci lavukiwile, ka ci tẽlele oku nõla elikongelo lyovina vyokuyapula
+
+select-random-value-fluke = Locina ka ci lavukiwile, ka ci tẽlele oku nõla ocina cokuyapula

--- a/packages/i18n/locales/umb/diagnostics.ftl
+++ b/packages/i18n/locales/umb/diagnostics.ftl
@@ -49,11 +49,11 @@ vector-dimension-mismatch = numDimensions ka yi likwatisa vovetoru.
 
 ## Attracting and constraining
 
-attract-to-without-nearest-point = Ka ci tẽliwa oku kokela ku `<{ $component }>` momo ka ci kwete nearestPoint.
+attract-to-without-nearest-point = Ka ci tẽliwa oku kokela ku `<{ $component }>` momo ka ci kwete opongoloso nearestPoint.
 
-constrain-to-without-nearest-point = Ka ci tẽliwa oku kutika ku `<{ $component }>` momo ka ci kwete nearestPoint.
+constrain-to-without-nearest-point = Ka ci tẽliwa oku kutika ku `<{ $component }>` momo ka ci kwete opongoloso nearestPoint.
 
-constrain-to-interior-without-nearest-point = Ka ci tẽliwa oku kutika vokati ka `<{ $component }>` momo ka ci kwete nearestPoint.
+constrain-to-interior-without-nearest-point = Ka ci tẽliwa oku kutika vokati ka `<{ $component }>` momo ka ci kwete opongoloso nearestPoint.
 
 ## `<choiceInput>`
 
@@ -161,11 +161,11 @@ circle-change-center-non-numerical = Epongoloko lyokati kocilinganya ci pita pol
 
 function-domain-insufficient-dimensions =
     { $intervals ->
-        [one] Ovinene ka vya sukila kodomain yofunsão. Domain yi kwete otembo { $intervals } pole funsão yi kwete { $inputs ->
+        [one] Ovinene vi tito calua kodomain yofunsão. Domain yi kwete otembo { $intervals } pole funsão yi kwete { $inputs ->
             [one] input { $inputs }
            *[other] input { $inputs }
         }.
-       *[other] Ovinene ka vya sukila kodomain yofunsão. Domain yi kwete olotembo { $intervals } pole funsão yi kwete { $inputs ->
+       *[other] Ovinene vi tito calua kodomain yofunsão. Domain yi kwete olotembo { $intervals } pole funsão yi kwete { $inputs ->
             [one] input { $inputs }
            *[other] input { $inputs }
         }.
@@ -230,7 +230,7 @@ target-state-variable-not-found = Target ya `<{ $source }>` ka ya sungulukile: k
 
 ## `<odeSystem>`
 
-ode-system-variables-match-independent = Olopongoloso vya `<odeSystem>` vi sukila oku litepa lopongoloso yaco muẽle.
+ode-system-variables-match-independent = Olopongoloso vya `<odeSystem>` vi sukila oku litepa lopongoloso ka yi kolela kucikwavo.
 
 ode-system-duplicate-variable-names = Ka ci tẽliwa oku lomboloka ofunsão vya ODE RHS lolonduko vyolopongoloso vya lilwilwa.
 
@@ -264,13 +264,13 @@ eigen-decomposition-failed = Ka ci tẽlele oku sokisa oloeigenvalue vyomatrisi
 
 matches-pattern-parameter-not-in-pattern =
     { $parametersCount ->
-        [one] `<matchesPattern>`: parameter { $parameters } ka yi kasi vocifwa, kuenje yi likwatisa lika lokahandeleko.
-       *[other] `<matchesPattern>`: parameters { $parameters } ka vi kasi vocifwa, kuenje vi likwatisa lika lokahandeleko.
+        [one] `<matchesPattern>`: parameter { $parameters } ka yi kasi vocifwa, kuenje yi likwatisa olonjanja viosi lokahandeleko.
+       *[other] `<matchesPattern>`: parameters { $parameters } ka vi kasi vocifwa, kuenje vi likwatisa olonjanja viosi lokahandeleko.
     }
 
 ## `<graph>`
 
-graph-grid-invalid = `<graph>`: ka ci tẽliwa oku kũlĩhĩsa grid="{ $grid }". Yi sukila oku kala none, medium, dense, ale ovitalatu vivali vinene vya tepiwa locitumãlo, ndeci grid="1 0.5". Ka ku lingiwa grid.
+graph-grid-invalid = `<graph>`: ka ci tẽliwa oku kũlĩhĩsa grid="{ $grid }". Yi sukila oku kala none, medium, dense, ale ovitalatu vivali vi kasi kilu lya ziro vya tepiwa locitumãlo, ndeci grid="1 0.5". Ka ku lingiwa grid.
 
 ## PreFigure renderer
 
@@ -354,7 +354,7 @@ attribute-invalid-values =
 
 attribute-must-be-references = Ocina `{ $value }` ka ca sungulukile ku attribute `{ $attribute }`. Attribute yi sukila oku kala olondaka vi fetika la `$`.
 
-math-input-invalid-function-names = <mathInput>: olonduko vyofunsão ka vya sungulukile vi yepiwa vu { $attribute }: { $names }. Onduko yosi onepa yayo yokulekisa yi sukila ovisonehua vivali ale valua (ovisonehua ale olondimbu); `|<mathspeak alternative>` yi pondola oku kwãma.
+math-input-invalid-function-names = <mathInput>: olonduko vyofunsão ka vya sungulukile vi yepiwa vu { $attribute }: { $names }. Onduko yosi onepa yayo yokulekisa yi sukila ovisonehua vivali ale valua (ovisonehua ale olofeni); `|<mathspeak alternative>` yi pondola oku kwãma.
 
 ## Building components from the source
 
@@ -536,7 +536,7 @@ parser-node-unconvertible = Ka ci tẽliwa oku pongolola node { $node } ku node 
 
 name-attribute-invalid =
     Onduko name='{ $name }' ka ya sungulukile. { $reason ->
-        [characters] Olonduko vi pondola oku kwata lika ovisonehua, ovitalatu, olondimbu vyemehi ale olondimbu.
+        [characters] Olonduko vi pondola oku kwata lika ovisonehua, ovitalatu, olongoli vyemehi ale olofeni.
        *[start] Olonduko vi sukila oku fetika locisonehua.
     }
 

--- a/packages/i18n/locales/umb/editor.ftl
+++ b/packages/i18n/locales/umb/editor.ftl
@@ -1,0 +1,208 @@
+# Umbundu editor and language-server surfaces. Selected by `uiLocale`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+#
+# DoenetML element names, attribute names and `styleNumber` are identifiers of
+# the language and stay in English exactly as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Tiukisa
+       *[update] Pongolola
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] { $word } Ulekisi
+       *[other] { $word } Ulekisi { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Ocituwa
+
+editor-variant-filter = Sanda…
+
+editor-variant-next = Nõla ocituwa cikwãma
+
+editor-variant-previous = Nõla ocituwa cipita
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] Kwa sangiwa elueyo lya WCAG AA kokupitĩla. Yeta oco o { $action ->
+            [close] yike
+           *[open] yulule
+        } elivulu lyokupitĩla.
+        [advisories] Yeta oco o { $action ->
+            [close] yike
+           *[open] yulule
+        } elivulu lyokupitĩla. Ka kwa sangiwile elueyo lya WCAG AA, pole kwa kasi alungulo akwavo okupitĩla.
+       *[clean] Yeta oco o { $action ->
+            [close] yike
+           *[open] yulule
+        } elivulu lyokupitĩla. Ka kwa sangiwile ocitangi cokupitĩla.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] Kwa sangiwa elueyo lya WCAG AA kokupitĩla. Kwa sangiwa { $count ->
+            [one] elueyo { $count } lya WCAG AA
+           *[other] alueyo { $count } a WCAG AA
+        }. Yeta oco o { $action ->
+            [close] yike
+           *[open] yulule
+        } elivulu lyokupitĩla.
+        [advisories] Ka kwa sangiwile elueyo lya WCAG AA. Kwa sangiwa { $count ->
+            [one] elungulo { $count } likwavo lyokupitĩla
+           *[other] alungulo { $count } akwavo okupitĩla
+        }. Yeta oco o { $action ->
+            [close] yike
+           *[open] yulule
+        } elivulu lyokupitĩla.
+       *[clean] Ka kwa sangiwile elueyo lya WCAG AA. Yeta oco o { $action ->
+            [close] yike
+           *[open] yulule
+        } elivulu lyokupitĩla.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = Ocitumbu ca DoenetML { $version }
+
+editor-tab-help = Ekwatiso lyocitumãlo
+editor-tab-help-short = Ocitumãlo
+editor-tab-errors = Oviho
+editor-tab-warnings = Alungulo
+editor-tab-info = Esapulo
+editor-tab-accessibility = Okupitĩla
+editor-tab-responses = Atambululo a tumiwa
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Olonõla vyukwasoneha
+editor-format-as-doenetml = Sokiya ndeci DoenetML
+editor-format-as-xml = Sokiya ndeci XML
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Ongoli #{ $line }
+
+editor-no-errors = Kaku Oviho
+editor-no-warnings = Kaku Alungulo
+editor-no-info = Kaku Esapulo
+
+editor-show-info-annotations = Lekisa esapulo vukwasoneha
+editor-show-accessibility-annotations = Lekisa ovitangi vyokupitĩla vukwasoneha
+
+editor-accessibility-learn-more = Lilongisa ndomo Doenet a tenda okupitĩla
+
+editor-accessibility-violations-heading = Alueyo okupitĩla ({ $standard })
+
+editor-accessibility-other-heading = Ovitangi vikwavo vyokupitĩla
+editor-none-found = Ka kwa sangiwile cimwe
+
+
+## Submitted responses
+
+editor-no-responses = Kwakele omunu wa tuma etambululo
+editor-response-answer-id = Onduko yetambululo
+editor-response-response = Etambululo
+editor-response-credit = Olonoso
+editor-response-submitted = Lya tumiwa
+
+
+## The context-help panel
+
+help-placeholder = Tuma ocilekisilo konduko ya tag, ka attribute, ale ka { $ref } oco o sange elomboloko.
+
+help-unsupported-ref-chain = Ekwatiso kolondaka vyolonepa vyalua ndeci { $example } ka lya kasi handi.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ka kwa sangiwile cimwe ca { $ref }.
+        [multiple] Kwa sangiwa ovina vyalua vya { $ref }.
+       *[indeterminate] Ka ca tẽlele oku kũlĩhĩsa eci { $ref } a lomboloka.
+    }
+
+help-learn-about-references = Lilongisa catiamela kolondaka →
+help-reference-page = Etapa lyelomboloko →
+
+help-suggestions-header =
+    { $location ->
+        [inside] Vokati { $element }
+       *[top] Kilu lyelivulu
+    }{ $allowed ->
+        [none] { " — kaku cimwe ci enda palo." }
+        [text] { " — soneha olondaka palo." }
+        [text-and-components] { " — soneha olondaka palo, ale seteka:" }
+       *[components] { " — ovina o pondola oku seteka:" }
+    }
+
+help-suggestions-footer = Yeta { $shortcut } oco o tale ovina { $total } viosi.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } ondaka yoku tunda ku { $target }.
+       *[other] { $ref } ondaka yoku tunda ku { $target } (ongoli { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] { $owner } wa yi eca ndeci { $role }.
+       *[other] { $owner } wa yi eca kongoli { $line } ndeci { $role }.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } ondaka yoku tunda kocina { $property } ca { $element }.
+       *[other] { $ref } ondaka yoku tunda kocina { $property } ca { $element } (ongoli { $line }).
+    }
+
+help-kind-attribute = attribute
+help-kind-snippet = onepa
+help-kind-array-entry = onepa ya array
+
+help-default = Ci kasi tete:
+help-active-default = Ci kasi tete kuenda ci talavaya:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ovina vya ecelelwa (cimwe kocina cimwe):
+       *[other] Ovina vya ecelelwa:
+    }
+
+help-suggested-values = Ovina vya lekisiwa:
+
+help-inserts = Ci tumbika:
+
+help-coordinates =
+    { $count ->
+        [one] Ocitumãlo:
+       *[other] Ovitumãlo:
+    }
+
+help-type = Ocituwa:
+
+help-resolved-style = Ocituwa ca sangiwa (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Olonduko vyofunsão vya sangiwa:
+help-reset-list = Tiukisa elisitu kokuwo input:
+help-added-on-input = Ca vokiyiwa kokuwo input:
+help-removed-on-input = Ca pindiwa kokuwo input:
+
+help-reset-overrides = { $reset } yi pitisa { $additional } la { $removed }.

--- a/packages/i18n/locales/umb/editor.ftl
+++ b/packages/i18n/locales/umb/editor.ftl
@@ -115,7 +115,7 @@ editor-none-found = Ka kwa sangiwile cimwe
 
 ## Submitted responses
 
-editor-no-responses = Kwakele omunu wa tuma etambululo
+editor-no-responses = Ka kwa tumiwile handi atambululo
 editor-response-answer-id = Onduko yetambululo
 editor-response-response = Etambululo
 editor-response-credit = Olonoso

--- a/packages/i18n/scripts/lint-catalogs.ts
+++ b/packages/i18n/scripts/lint-catalogs.ts
@@ -111,6 +111,19 @@ const englishKeys = collectLocaleKeys(DEFAULT_LOCALE).map((entry) => entry.key);
 const englishKeySet = new Set(englishKeys);
 
 // 3: translations may lag English, but may not invent keys.
+//
+// Keys only — *arguments* are not checked, and a translation naming an
+// argument no call site passes (`{ $bogus }`) still lints clean and renders
+// the literal `{$bogus}` at runtime. The obvious guard, comparing each
+// message's `$name`s against the English message's, cannot be the one: English
+// states most of these messages flat while a translation selects on a class or
+// a gender the caller does pass, so `$gender`, `$role` and `$noun` are absent
+// from English in about 1500 places across the established catalogs and every
+// one of them is correct. The authority for which arguments exist is the call
+// site, not `locales/en`, and reading it would mean matching `t("key", {...})`
+// object literals — worth doing, but a change to `collectCallSites` rather
+// than a line here. See #1687, which confirmed its four new catalogs clean
+// against the argument names the other catalogs use for the same keys.
 for (const locale of locales) {
     if (locale === DEFAULT_LOCALE) {
         continue;

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -38,6 +38,7 @@ export type SupportedLocale =
     | "da"
     | "dag"
     | "de"
+    | "dje"
     | "doi"
     | "dv"
     | "dyu"
@@ -86,6 +87,7 @@ export type SupportedLocale =
     | "ki"
     | "kk"
     | "km"
+    | "kmb"
     | "kn"
     | "ko"
     | "kok"
@@ -104,6 +106,7 @@ export type SupportedLocale =
     | "lv"
     | "mad"
     | "mai"
+    | "men"
     | "mg"
     | "mi"
     | "min"
@@ -182,6 +185,7 @@ export type SupportedLocale =
     | "ty"
     | "ug"
     | "uk"
+    | "umb"
     | "ur"
     | "uz"
     | "ve"
@@ -398,6 +402,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "German",
         endonym: "Deutsch",
         label: "German (Deutsch)",
+    },
+    {
+        locale: "dje",
+        englishName: "Zarma",
+        endonym: "Zarmaciine",
+        label: "Zarma (Zarmaciine)",
     },
     {
         locale: "doi",
@@ -643,6 +653,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Khmer (ខ្មែរ)",
     },
     {
+        locale: "kmb",
+        englishName: "Kimbundu",
+        endonym: "Kimbundu",
+        label: "Kimbundu",
+    },
+    {
         locale: "kn",
         englishName: "Kannada",
         endonym: "ಕನ್ನಡ",
@@ -735,6 +751,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "मैथिली",
         label: "Maithili (मैथिली)",
     },
+    { locale: "men", englishName: "Mende", endonym: "Mende", label: "Mende" },
     {
         locale: "mg",
         englishName: "Malagasy",
@@ -1147,6 +1164,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Ukrainian",
         endonym: "українська",
         label: "Ukrainian (українська)",
+    },
+    {
+        locale: "umb",
+        englishName: "Umbundu",
+        endonym: "Umbundu",
+        label: "Umbundu",
     },
     {
         locale: "ur",

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -261,8 +261,11 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     //
     // `tda` (Tadaksahak) maximizes to `tda-Tfng-NE` — Tifinagh — so a reader
     // most likely arriving in that script is served Latin. That is
-    // `locales/kr`'s asymmetry with `kby` and `locales/ha`'s with Ajami, and
-    // the answer to it is a second catalog rather than a change here.
+    // `locales/kr`'s asymmetry with `kby` in Ajami and `locales/ff`'s in
+    // Adlam — the two other debts CLDR's own maximization creates, rather
+    // than `locales/ha`'s, which CLDR does not: a bare `ha` maximizes to
+    // `ha-Latn-NG`. The answer to it is a second catalog rather than a change
+    // here.
     dje: ["ddn", "hmb", "khq", "ses", "tda", "twq"],
 };
 

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -69,15 +69,20 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * varieties are, which is what makes it checkable and what distinguishes it from
  * the `nn` and `fat` cases in {@link LANGUAGE_ALIASES}: neither of those is a
  * member of `nb` or `ak`, and both are deliberately left to miss. Ten of the
- * twelve keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`, `kg` —
+ * thirteen keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`, `kg` —
  * are ISO 639-3 macrolanguages and list their macrolanguage members; `nah` is an
  * ISO 639-3 **collection** code rather than a macrolanguage, so it lists the
- * individual Nahuan languages ISO 639-5 groups under it; and `mnk` is neither,
- * being a *member* of `man` that this repository happens to name a catalog
- * after. That last is the shape {@link LANGUAGE_ALIASES}'s `man` entry
- * explains, and it is why the members listed under `mnk` exclude `bam` and
- * `dyu`: those two have catalogs of their own, and folding them here would
- * serve a Bambara reader Mandinka.
+ * individual Nahuan languages ISO 639-5 groups under it; and `mnk` and `dje`
+ * are neither, being *members* — of `man` and `son` respectively — that this
+ * repository happens to name catalogs after. Those two are the shape
+ * {@link LANGUAGE_ALIASES}'s `man` entry explains, and it is why the members
+ * listed under `mnk` exclude `bam` and `dyu`: those two have catalogs of their
+ * own, and folding them here would serve a Bambara reader Mandinka.
+ *
+ * The two member cases part company over their macrolanguage, and the reason
+ * is CLDR rather than a preference: `man` is aliased onto `mnk` because
+ * `Intl.Locale#maximize` gives it a region and so decides which member it
+ * means, while `son` is left to miss because it maximizes to nothing.
  *
  * The one member CLDR already folds is included anyway — `quz`, `ojg`, `gug`,
  * `ayr`, `bcl`, `gom`, `dgo`, `fuc`, `knc` — so that each list reads as the
@@ -237,6 +242,28 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // absent for the same reason and is left to miss; answering it with `ktu`
     // would be defensible and is not a membership fact, so it is not done here.
     kg: ["kng", "kwy", "ldi"],
+    // Songhay. `dje` is a *member* rather than the macrolanguage — the shape
+    // {@link LANGUAGE_ALIASES}'s `man` entry explains — so this lists the
+    // sibling members. These six are the whole of `son` apart from Zarma
+    // itself, and ICU folds none of them, so every one of them reaches a
+    // catalog only because this list exists.
+    //
+    // `son` itself is deliberately *not* aliased onto `dje`, and that is the
+    // half worth reading. `man` earns its alias because CLDR decides for
+    // itself which member a bare macrolanguage tag means —
+    // `new Intl.Locale("man").maximize()` is `man-Latn-GM`, Mandinka's
+    // country. `son` maximizes to nothing at all: CLDR adds no region, so it
+    // has no opinion, and picking Zarma because it is the largest would be
+    // exactly the judgement these maps exist to avoid. `negotiate.test.ts`
+    // asserts the absent region rather than merely the absent entry, so a
+    // change in ICU data that gave `son` a region would fail there and invite
+    // someone to reconsider.
+    //
+    // `tda` (Tadaksahak) maximizes to `tda-Tfng-NE` — Tifinagh — so a reader
+    // most likely arriving in that script is served Latin. That is
+    // `locales/kr`'s asymmetry with `kby` and `locales/ha`'s with Ajami, and
+    // the answer to it is a second catalog rather than a change here.
+    dje: ["ddn", "hmb", "khq", "ses", "tda", "twq"],
 };
 
 /** Flattened once at module load rather than searched per request. */

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -794,18 +794,17 @@ describe("negotiateLocales", () => {
         );
 
         /**
-         * The near misses. `kmb` (Kimbundu) and `umb` (Umbundu) are Bantu
-         * neighbours of `lua` and `ktu`; `kbl` (Kanembu) is the language beside
-         * Kanuri that ISO 639-3 keeps *outside* the `kr` macrolanguage; `gur`
-         * (Farefare) and `xsm` (Kasem) are Gur languages beside `mos` and
-         * `dag`; `sus` (Susu) is Mande but not Manding. Every one falls to
-         * English, which is the membership rule working rather than a gap in
-         * it.
+         * The near misses. `kbl` (Kanembu) is the language beside Kanuri that
+         * ISO 639-3 keeps *outside* the `kr` macrolanguage; `gur` (Farefare)
+         * and `xsm` (Kasem) are Gur languages beside `mos` and `dag`; `sus`
+         * (Susu) is Mande but not Manding. Every one falls to English, which is
+         * the membership rule working rather than a gap in it.
+         *
+         * `kmb` (Kimbundu) and `umb` (Umbundu) were here too, as Bantu
+         * neighbours of `lua` and `ktu`, until the Angolan batch below gave
+         * them catalogs of their own — the same removal `men` and `nyn` got,
+         * and the only thing that should ever shorten a negative-control list.
          */
-        // `kmb` and `umb` were on this list until the Angolan batch below gave
-        // Kimbundu and Umbundu catalogs of their own — the same removal `men`
-        // and `nyn` got, and the only thing that should ever shorten a
-        // negative-control list.
         it.each(["kbl", "gur", "xsm", "sus"])(
             "leaves %s on English rather than folding it onto a neighbour",
             (requested) => {
@@ -880,22 +879,24 @@ describe("negotiateLocales", () => {
 
         /**
          * The near misses for this batch. `bin` (Edo) and `efi` (Efik) are
-         * Nigerian neighbours of `pcm` and `tiv`; `men` (Mende) is a Sierra
-         * Leonean neighbour of `kri` and `tem`; `gej` (Gen) is a Gbe language
-         * beside `fon` and `ee`. Every one falls to English rather than being
-         * folded onto a language it is merely near.
+         * Nigerian neighbours of `pcm` and `tiv`; `gej` (Gen) is a Gbe language
+         * beside `fon` and `ee`. Both fall to English rather than being folded
+         * onto a language they are merely near.
+         *
+         * `men` (Mende) was here too, as a Sierra Leonean neighbour of `kri`
+         * and `tem`, until the batch below gave it a catalog of its own — the
+         * only thing that should ever take a code off a negative-control list,
+         * and the same removal `nyn` got a batch earlier.
          *
          * `son` is here for a different reason and is the interesting row: it
-         * is the ISO 639-3 macrolanguage over the Songhay varieties, and this
-         * repository has no catalog for any of them. It is *not* aliased the
-         * way `man` is, because the justification `man`'s entry rests on does
-         * not exist here — `new Intl.Locale("son").maximize()` adds no region,
-         * so CLDR has no opinion about which variety a bare `son` means, and
-         * picking one would be the judgement these maps avoid.
+         * is the ISO 639-3 macrolanguage over the Songhay varieties. It is
+         * *not* aliased the way `man` is, because the justification `man`'s
+         * entry rests on does not exist here — `new Intl.Locale("son").maximize()`
+         * adds no region, so CLDR has no opinion about which variety a bare
+         * `son` means, and picking one would be the judgement these maps avoid.
+         * The batch below gives Songhay a catalog under `dje` without changing
+         * that, and says why.
          */
-        // `men` was on this list until the batch below gave Mende a catalog of
-        // its own, which is the only thing that should ever take a code off a
-        // negative-control list — the same removal `nyn` got a batch earlier.
         it.each(["bin", "efi", "gej", "son"])(
             "leaves %s on English rather than folding it onto a neighbour",
             (requested) => {
@@ -908,9 +909,10 @@ describe("negotiateLocales", () => {
             },
         );
 
-        it("has no CLDR region for `son`, which is why it is not aliased", () => {
-            expect(new Intl.Locale("son").maximize().region).toBeUndefined();
-        });
+        // The guard on `son`'s absent CLDR region used to sit here. It moved
+        // into the batch below, where the same assertion now runs beside
+        // `man`'s present one and beside `son`'s negotiated result, rather than
+        // being made twice.
     });
 
     describe("the Angolan, Sierra Leonean and Songhay batch", () => {

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -996,11 +996,11 @@ describe("negotiateLocales", () => {
         });
 
         /**
-         * The near misses for this batch. `nya` neighbours nothing here; `lol`
-         * (Mongo) and `cjk` (Chokwe) are Bantu neighbours of `kmb` and `umb`;
-         * `kpe` (Kpelle) sits beside `men` in the same two countries without being
-         * a Mande variety of it. Every one falls to
-         * English, which is the membership rule working rather than a gap.
+         * The near misses for this batch. `lol` (Mongo) and `cjk` (Chokwe) are
+         * Bantu neighbours of `kmb` and `umb`; `kpe` (Kpelle) sits beside
+         * `men` in Sierra Leone and is Mande like it without being a variety
+         * of it. Every one falls to English, which is the membership rule
+         * working rather than a gap in it.
          */
         it.each(["lol", "cjk", "kpe"])(
             "leaves %s on English rather than folding it onto a neighbour",

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -802,7 +802,11 @@ describe("negotiateLocales", () => {
          * English, which is the membership rule working rather than a gap in
          * it.
          */
-        it.each(["kmb", "umb", "kbl", "gur", "xsm", "sus"])(
+        // `kmb` and `umb` were on this list until the Angolan batch below gave
+        // Kimbundu and Umbundu catalogs of their own — the same removal `men`
+        // and `nyn` got, and the only thing that should ever shorten a
+        // negative-control list.
+        it.each(["kbl", "gur", "xsm", "sus"])(
             "leaves %s on English rather than folding it onto a neighbour",
             (requested) => {
                 expect(
@@ -889,7 +893,10 @@ describe("negotiateLocales", () => {
          * so CLDR has no opinion about which variety a bare `son` means, and
          * picking one would be the judgement these maps avoid.
          */
-        it.each(["bin", "efi", "men", "gej", "son"])(
+        // `men` was on this list until the batch below gave Mende a catalog of
+        // its own, which is the only thing that should ever take a code off a
+        // negative-control list — the same removal `nyn` got a batch earlier.
+        it.each(["bin", "efi", "gej", "son"])(
             "leaves %s on English rather than folding it onto a neighbour",
             (requested) => {
                 expect(
@@ -904,6 +911,108 @@ describe("negotiateLocales", () => {
         it("has no CLDR region for `son`, which is why it is not aliased", () => {
             expect(new Intl.Locale("son").maximize().region).toBeUndefined();
         });
+    });
+
+    describe("the Angolan, Sierra Leonean and Songhay batch", () => {
+        it.each([
+            // None of the four has a two-letter code, so each arrives under the
+            // tag its directory is named for.
+            ["men", "men"],
+            ["umb", "umb"],
+            ["kmb", "kmb"],
+            ["dje", "dje"],
+            // Region tags, which filter without help.
+            ["men-SL", "men"],
+            ["umb-AO", "umb"],
+            ["kmb-AO", "kmb"],
+            ["dje-NE", "dje"],
+        ])("reaches %s's catalog as %s", (requested, expected) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual([expected, "en"]);
+        });
+
+        /**
+         * Songhay, and the second instance of the shape `mnk` introduced: a
+         * macrolanguage this repository has a *member* catalog for and no
+         * catalog of its own.
+         *
+         * ICU folds none of these six, so each reaches Zarma only because
+         * `MACROLANGUAGE_MEMBERS` lists it. That is the opposite of `kg`'s
+         * entry, where `kng` would arrive anyway through canonicalization —
+         * which is why the `kg` block says so and this one does not have to.
+         */
+        it.each([
+            ["ddn", "dje"],
+            ["hmb", "dje"],
+            ["khq", "dje"],
+            ["ses", "dje"],
+            ["tda", "dje"],
+            ["twq", "dje"],
+        ])(
+            "folds the Songhay member %s onto Zarma as %s",
+            (requested, expected) => {
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual([expected, "en"]);
+            },
+        );
+
+        /**
+         * The decision this batch declines to change, restated now that a
+         * Songhay catalog exists.
+         *
+         * #1686 left `son` unaliased because CLDR has no opinion about which
+         * variety it means. Zarma's arrival makes the alias *possible* and no
+         * more justified: `dje` is the largest Songhay variety, and "largest"
+         * is a judgement rather than a published fact, which is the line these
+         * maps hold everywhere else.
+         *
+         * Asserted on the maximization rather than on the map, so that a change
+         * in ICU data — not a change of mind here — is what fails and reopens
+         * the question.
+         */
+        it("still leaves the Songhay macrolanguage unaliased, CLDR having no opinion", () => {
+            expect(new Intl.Locale("son").maximize().region).toBeUndefined();
+            expect(new Intl.Locale("man").maximize().region).toBe("GM");
+            expect(negotiateLocales([normalizeLocaleTag("son")], available)) //
+                .toEqual(["en"]);
+        });
+
+        /**
+         * `tda` is this batch's script debt, and it is recorded rather than
+         * fixed: Tadaksahak maximizes to `tda-Tfng-NE`, so CLDR's own data says
+         * such a reader most likely arrives in Tifinagh and what they get from
+         * `locales/dje` is Latin. `locales/kr` owes the same debt to `kby` in
+         * Ajami and `locales/ff` owes it in Adlam.
+         */
+        it("serves Tadaksahak Latin although CLDR expects it in Tifinagh", () => {
+            expect(new Intl.Locale("tda").maximize().script).toBe("Tfng");
+            expect(negotiateLocales([normalizeLocaleTag("tda")], available)) //
+                .toEqual(["dje", "en"]);
+        });
+
+        /**
+         * The near misses for this batch. `nya` neighbours nothing here; `lol`
+         * (Mongo) and `cjk` (Chokwe) are Bantu neighbours of `kmb` and `umb`;
+         * `kpe` (Kpelle) sits beside `men` in the same two countries without being
+         * a Mande variety of it. Every one falls to
+         * English, which is the membership rule working rather than a gap.
+         */
+        it.each(["lol", "cjk", "kpe"])(
+            "leaves %s on English rather than folding it onto a neighbour",
+            (requested) => {
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual(["en"]);
+            },
+        );
     });
 });
 

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65088,6 +65088,10 @@
                             "description": "German (Deutsch)"
                         },
                         {
+                            "value": "dje",
+                            "description": "Zarma (Zarmaciine)"
+                        },
+                        {
                             "value": "doi",
                             "description": "Dogri (डोगरी)"
                         },
@@ -65280,6 +65284,10 @@
                             "description": "Khmer (ខ្មែរ)"
                         },
                         {
+                            "value": "kmb",
+                            "description": "Kimbundu"
+                        },
+                        {
                             "value": "kn",
                             "description": "Kannada (ಕನ್ನಡ)"
                         },
@@ -65350,6 +65358,10 @@
                         {
                             "value": "mai",
                             "description": "Maithili (मैथिली)"
+                        },
+                        {
+                            "value": "men",
+                            "description": "Mende"
                         },
                         {
                             "value": "mg",
@@ -65662,6 +65674,10 @@
                         {
                             "value": "uk",
                             "description": "Ukrainian (українська)"
+                        },
+                        {
+                            "value": "umb",
+                            "description": "Umbundu"
                         },
                         {
                             "value": "ur",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3181,7 +3181,7 @@ describe("the Angolan, Sierra Leonean and Songhay batch", () => {
      *
      * The Kimbundu rows are also `locales/kg`'s shape exactly — an agreeing
      * «-a» connective a thousand kilometres away, in a different country — so
-     * these six lines are what makes the header's claim checkable rather than
+     * the rows below are what makes the header's claim checkable rather than
      * asserted: neither family nor geography predicts the shape.
      */
     it("prefixes Umbundu's class onto the stem", () => {
@@ -3221,8 +3221,9 @@ describe("the Angolan, Sierra Leonean and Songhay batch", () => {
      * `men` is the affix-rule case: its describing words follow the noun, so
      * the phrase ends in an argument and Mende's definite suffix — which
      * attaches to whatever word ends the noun phrase — could never be welded
-     * on. The whole catalog is indefinite for that reason, and this row is what
-     * it looks like.
+     * on. Every describing word in the catalog is indefinite for that reason,
+     * so no description ends in the suffix, and this row is what that looks
+     * like.
      */
     it.each([
         ["men", "laing wa kpou kɛ ngeya-ngeya"],

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3194,6 +3194,13 @@ describe("the Angolan, Sierra Leonean and Songhay batch", () => {
         expect(described("umb", "point")).toBe(
             "ondimbu linene likusuka lo olongoli vitito",
         );
+        // «ocinepa» carries an overt `oci-`, so it has to take the `ci-`
+        // concord the other `oci-` nouns take: `noun-gender` listed
+        // `line-segment` under `c10` at first and the head disagreed with the
+        // words beside it, which is the `locales/tiv` defect again.
+        expect(described("umb", "line-segment")).toBe(
+            "ocinepa congoli cinene cikusuka lo olongoli vitito",
+        );
     });
 
     it("moves only Kimbundu's connective, never the stem behind it", () => {

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3149,3 +3149,107 @@ describe("the West and Central African batch, continued", () => {
         ).toBe(expected);
     });
 });
+
+describe("the Angolan, Sierra Leonean and Songhay batch", () => {
+    const forLocale = (locale: string): Translator =>
+        createTranslatorFromLocaleData(
+            { locale, resources: { [locale]: readCatalog(locale, "content") } },
+            locale,
+        );
+
+    const words = {
+        lineWidthWord: "thick",
+        lineStyleWord: "dashed",
+        colorWord: "red",
+    };
+
+    const described = (locale: string, key: NounKey) =>
+        describeStrokedShape(forLocale(locale), words, {
+            noun: { key },
+            withNoun: true,
+        });
+
+    /**
+     * **Two Angolan neighbours putting the same agreement in different
+     * places**, which is the reason this batch has both.
+     *
+     * Umbundu prefixes the class straight onto the stem, so «nene» and
+     * «kusuka» change shape from row to row: `yinene`, `cinene`, `linene`.
+     * Kimbundu leaves the stem alone and moves a connective in front of it:
+     * `ya nene`, `kya nene`. Same family, same class system, same country, and
+     * the two files do not resemble each other.
+     *
+     * The Kimbundu rows are also `locales/kg`'s shape exactly — an agreeing
+     * «-a» connective a thousand kilometres away, in a different country — so
+     * these six lines are what makes the header's claim checkable rather than
+     * asserted: neither family nor geography predicts the shape.
+     */
+    it("prefixes Umbundu's class onto the stem", () => {
+        expect(described("umb", "line")).toBe(
+            "ongoli yinene yikusuka lo olongoli vitito",
+        );
+        expect(described("umb", "circle")).toBe(
+            "ocilinganya cinene cikusuka lo olongoli vitito",
+        );
+        expect(described("umb", "point")).toBe(
+            "ondimbu linene likusuka lo olongoli vitito",
+        );
+    });
+
+    it("moves only Kimbundu's connective, never the stem behind it", () => {
+        expect(described("kmb", "line")).toBe(
+            "nlonji ya nene ya kusuka ya jinlonji jitetuka",
+        );
+        expect(described("kmb", "circle")).toBe(
+            "kizenge kya nene kya kusuka ya jinlonji jitetuka",
+        );
+        expect(described("kmb", "point")).toBe(
+            "kimbanza kya nene kya kusuka ya jinlonji jitetuka",
+        );
+    });
+
+    /**
+     * The two that fork on nothing, one row each.
+     *
+     * `men` is the affix-rule case: its describing words follow the noun, so
+     * the phrase ends in an argument and Mende's definite suffix — which
+     * attaches to whatever word ends the noun phrase — could never be welded
+     * on. The whole catalog is indefinite for that reason, and this row is what
+     * it looks like.
+     */
+    it.each([
+        ["men", "laing wa kpou kɛ ngeya-ngeya"],
+        ["dje", "kar beeri ciray nda dumbu-dumbu"],
+    ])("leaves %s's describing words alone", (locale, expected) => {
+        expect(described(locale, "line")).toBe(expected);
+    });
+
+    /**
+     * All four reach `[noun-tail]`, the side count being a complement in every
+     * one of them.
+     *
+     * The Umbundu row is the one to read, and it is here because probing the
+     * rendered string rather than assuming it caught a real defect: the head
+     * «poligonu» first carried `yi-` while `noun-gender` sends
+     * `regular-polygon` to the `c7` default, so the head and the colour beside
+     * it disagreed. That is the defect #1685 found in `locales/tiv`, and this
+     * row is what would catch it recurring.
+     */
+    it.each([
+        ["men", "pɔligɔn yekpe kpou na kɛ gbua 5"],
+        ["umb", "poligonu cisokisa cikusuka lo olonele 5"],
+        ["kmb", "poligonu ya kusokela ya kusuka ya jimbandu 5"],
+        ["dje", "poligon saawa ciray kaŋ gonda kambu 5"],
+    ])("closes %s's phrase with the side count", (locale, expected) => {
+        expect(
+            describeStrokedShape(
+                forLocale(locale),
+                { colorWord: "red" },
+                {
+                    noun: { key: "regular-polygon", numSides: 5 },
+                    withNoun: true,
+                },
+            ),
+        ).toBe(expected);
+    });
+});


### PR DESCRIPTION
Continues #1685 and #1686 with four more: **Mende (`men`), Umbundu (`umb`),
Kimbundu (`kmb`) and Zarma (`dje`)**.

Every string is machine-generated and **has not been read by a speaker**. Each
catalog says so in its header. The value is that a document declaring one of
these languages stops falling back to English; the cost is that some of it is
wrong, and correcting it needs no permission.

## Scope note, and a pattern worth naming

The ask was 10–15 languages. **This lands four.** #1686 landed six against the
same ask, and I want to name the constraint rather than keep quietly missing it:
each locale is ~1,300 lines of authored Fluent across four namespaces, and a
single session that also has to carry negotiation, tests, docs and five review
cycles reaches four to six of them. Ten is roughly two sessions' work, not one.

I chose to land four complete rather than ten half-wired. If you'd rather have
volume, the way to get it is several PRs — I can run this same shape again
immediately, and the seven candidates below are already scoped.

## Where the last batches asked *where* agreement goes, this one asks what a family predicts

### `umb` beside `kmb` — the answer is "nothing"

Umbundu and Kimbundu are the two largest languages of Angola, both Bantu, both
with the same noun-class system, spoken next door to each other. Umbundu
prefixes the class straight onto the describing stem; Kimbundu leaves the stem
alone and moves an agreeing connective in front of it:

|       | line (c9)         | circle (c7)            | point (c5)             |
| ----- | ----------------- | ---------------------- | ---------------------- |
| `umb` | ongoli **yi**nene | ocilinganya **ci**nene | ondimbu **li**nene     |
| `kmb` | nlonji **ya** nene | kizenge **kya** nene  | kimbanza **kya** nene  |

And Kimbundu's **mechanism is `locales/kg`'s exactly** — an agreeing «-a»
connective a thousand kilometres north, in another country, differing only in
which classes the two catalogs happen to fork on.

So family does not predict the shape of agreement, and neither does geography.
That was #1686's lesson about a creole and its lexifier; this is the same lesson
with the creole taken out, which makes it a fact about Bantu rather than about
creolization. Both halves are pinned in `styleDescriptions.test.ts`.

### `men` — the clearest instance of the affix rule in the tree

Mende's definite marker is a suffix that attaches not to the noun but to
**whichever word ends the noun phrase**. A describing word follows its noun
here, so a style description ends in a placeable — and «{ $color }i» is exactly
what the README's affix rule forbids.

The catalog therefore leaves **every describing word indefinite**, so that no
description ends in the suffix and the suffix is never written against a
placeable: the "choose the words that land there" way out, taken at the level of
a whole file rather than one message. That is defensible on its own terms — a
style description is read out of context, "thick red line" and not "the thick
red line", and the indefinite is what Mende uses there.

It is also the fourth Mande catalog, and like `bm`, `dyu` and `mnk` it forks on
nothing. Four Mande catalogs, four flat `noun-gender` messages — the one family
here that predicts anything.

### `dje` — here for where it sits, not what it does

Every other language across these three batches but one is Niger-Congo or a
creole built on one; the exception is `locales/kr`, the Nilo-Saharan catalog
#1685 seeded. Songhay is neither Niger-Congo nor securely anything else — its
affiliation is genuinely unsettled. It forks
on nothing, and its header says so plainly rather than hunting for an argument:
a batch that only ever added forking catalogs would be selecting its languages
for the argument rather than for the readers.

## Negotiation

`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a *member*
catalog carrying its siblings. ICU folds none of `ddn`, `hmb`, `khq`, `ses`,
`tda`, `twq`, so all six depend on the entry existing.

**`son` is still not aliased.** #1686 recorded the reason when no Songhay
catalog existed; Zarma's arrival makes the alias *possible* and no more
justified. `man` earns its alias because CLDR decides which member it means
(`man-Latn-GM`); `son` maximizes to no region at all, so picking Zarma because
it is the largest is the judgement these maps avoid. The test asserts the absent
region, so ICU data — not a change of mind — is what would reopen it.

`tda` is the script debt: Tadaksahak maximizes to Tifinagh and is served Latin,
the asymmetry `locales/kr` owes `kby` in Ajami.

Three codes came **off** negative-control lists — `men`, `umb` and `kmb` were
all asserted to fall to English until they got catalogs. That is the only thing
that should ever shorten such a list.

## A defect the tests caught

Probing the rendered strings rather than assuming them found a real bug in my
own work: `umb`'s regular-polygon head carried a class-9 prefix while
`noun-gender` sends `regular-polygon` to the `c7` default, so the head disagreed
with the colour beside it. That is precisely the defect #1685's review found in
`locales/tiv`. Fixed, and pinned by a golden row.

Review turned up the **same defect a second time in `umb`**: `noun-gender` sent
`line-segment` to `c10` while the noun «ocinepa» carries an overt `oci-`, so
«ocinepa congoli vinene» put a c10 concord beside a c7 head. `line-segment` now
falls to the `c7` default like every other `oci-` noun, and a golden row pins
it (mutation-checked: restoring the `c10` entry reds it).

## Reading the prose, and the one defect all four shared

A review cycle read all four catalogs' `diagnostics.ftl`, `chrome.ftl` and
`editor.ftl` message by message against `locales/en`. It found **one
mistranslation present in all four at once**, which is the first time that has
happened: `graph-grid-invalid` rendered "two **positive** numbers" as "two
**big** numbers" in Mende, Umbundu, Kimbundu and Zarma alike — and the
message's own example, `grid="1 0.5"`, contradicts it. All four already had
the right idiom a few keys away in
`select-from-sequence-coprime-not-positive-integers`, so every fix reuses that
catalog's own words rather than inventing any.

Also fixed, all with in-catalog vocabulary:

- `attract-to-without-nearest-point` and its two `constrain-to-*` siblings
  dropped "state variable" in all four, leaving a bare identifier.
- `editor-no-responses` invented a person ("nobody has submitted a response")
  in all four where the English states the list is empty; three also dropped
  "yet".
- The orbital spin-arrow buttons were labelled with `umb`'s, `kmb`'s and
  `dje`'s word for *point* — three lines from a real points control.
- `matches-pattern-parameter-not-in-pattern`: "will **always** match a blank"
  became "matches **only** a blank" (`umb`, `kmb`); `dje` lost the blank to a
  broken negative clause.
- `function-domain-insufficient-dimensions` read "dimensions are **not
  required**" (`umb`, `kmb`) — the opposite complaint.
- `ode-system-variables-match-independent` said a variable must differ from
  "its own variable" (`umb`, `kmb`), which is incoherent.
- "letters or dashes" read "letters or **dots**" (`umb`) and "letters or
  **sides**" (`kmb`).
- `men`'s `subset-clear` read "Open all"; `kmb`'s `help-allowed-values` read
  "five values" (`itanu`, the numeral, for `tanwa`, "permitted"); `kmb`'s
  reload prompt told the reader to *change* the page; `kmb`'s
  `prefigure-annotations-not-rendered` left its negation circumfix open on the
  subordinate clause, so "when **not** using PreFigure" could be read as "when
  using" it; `umb` had one class-3 concord error and one off-norm spelling.

**What review deliberately left** is named in the README: each catalog spreads
one word over *variant*, *version*, *type* and *style* — concepts the editor
shows at the same time — three head the feedback panel with their word for
*answer*, and all four use one noun for both *viewer* and *renderer*.
Separating those needs words chosen by a speaker; picking them here would be
the substitution the chemistry tables are omitted to avoid.

### A gap in `lint:i18n`, found by mutation-testing it — and why it is not closed here

The guard was assumed to catch malformed placeables. Mutation-testing it shows
it does **not** flag an argument name that appears in a translation but not in
the English message — `{ $bogus }` passes clean, and renders the literal
`{$bogus}` at runtime.

The obvious fix, comparing each message's `$name`s against the English
message's, was written and run against the whole roster before being
abandoned: it reports **1,526 violations in the 189 established catalogs, every
one of them correct.** English states most of these messages flat while a
translation selects on a class or a gender the caller genuinely passes, so
`$gender`, `$role` and `$noun` are absent from `locales/en` all over the tree.
The authority for which arguments exist is the *call site*, not `locales/en`,
and reading it means matching `t("key", {...})` object literals — a change to
`collectCallSites`, not a line in the lint, and not this PR's business.

So the gap is left, with a precise note at check 3 in `lint-catalogs.ts`
saying what the naive guard costs and what the real one would have to read.
The four new catalogs were confirmed clean under a one-off check against the
argument names the other 189 catalogs use for the same keys: zero unknown
uses.

### One more header claim that did not survive checking

`locales/dje`'s header said Zarma "writes in the official Nigerien Latin
orthography, with «ɲ» and the open vowels". The **only** «ɲ» in the catalog was
the one inside that sentence, and the only «ɛ» and «ɔ» likewise. The header now
says what is true and useful to a reviewer: «ŋ» is the one non-ASCII letter
these files actually use, and no message uses the other three. The replacement
sentence had inherited the same self-refuting shape — it claimed those letters
"happen not to occur anywhere in these four files" while being the one place
they occur — and the final cycle scoped it to messages and said where the three
live.

A later cycle found the same shape in `locales/men`. Its header stated the
definite suffix as "`-i` after a consonant, `-ei` after a vowel" — and then
gave three examples, «pɛlɛ» → «pɛlɛi», «wa» → «wai», «teli» → «telii», every
one of them vowel-final and every one of them taking plain `-i`. The rule
contradicted all three of its own illustrations. It now says what the examples
show: a suffix «-i» that fuses with the final vowel of the word it lands on,
which is still form-dependence and so still the affix rule.

That cycle also closed a cross-reference gap. The README calls `men` "the
clearest instance of the affix rule in the tree", but the affix section itself
named no Mende: its table of what a catalog cannot ask of a placeable listed
`ro` alone under "the definite article on the value", and its list of five ways
out illustrated "choose the words that land there" with Czech only. Both now
carry Mende, so a reader who arrives at the rule finds the catalog that the
batch section sends them there for.

And the last cycle found the third instance of the shape, in the same catalog:
`men`'s header, its `chrome.ftl`, the README and a test docstring all said the
file was "written entirely in the indefinite", while two fixed vocabulary items
in it carry the suffix lexically — «tɔkpɔi» a mark, «laingi ti lɔ va» the
horizontal fill. The rule that is actually held, and that the affix rule cares
about, is narrower: every *describing* word is indefinite, so no description
ends in the suffix and the suffix is never written against a placeable. All four
places now state that, and the header names the two lexical items so a speaker
can rule on them.

## Chemistry: the gap reaches Portuguese

All four omit the element tables. Mende and Zarma are ordinary school-system
cases. **Umbundu and Kimbundu are a third shape**: Angola teaches secondary
science in Portuguese, so the English fallback is neither the language nor the
curriculum — it answers nobody. That argues for filling the keys from
Portuguese, and they are left anyway, because a Portuguese table dressed as an
Umbundu one is the substitution this effort avoids. `locales/umb` records it for
#1521.

## Verification

- `lint:i18n` clean; all four at 432/562, the same coverage as the last batches.
- `@doenet/i18n` 525, `@doenet/utils` styleDescriptions 250, worker-path 30,
  `lsp-tools` autocomplete 129.
- **`build:schema` was run this time.** #1686 shipped without it and CI caught
  it twice; the three-step pipeline is codegen → build i18n → build:schema.
- **Every guard this PR adds was mutation-checked**, not just the negotiation
  ones: dropping `dje`'s member list reds all six Songhay rows plus the `tda`
  script row; sending `umb`'s `line-segment` back to `c10` reds the Umbundu
  stem row; sending `regular-polygon` to `c9` reds the side-count row; moving
  `kmb`'s `circle` off `c7` reds the connective row; and moving `umb`'s
  `border` off `c9` reds the worker-path row, which is what that test's claim
  about a border's own concord rests on.
- One duplicate guard removed: `son`'s absent CLDR region was asserted twice,
  once in the previous batch's block and once in this one. The new assertion
  is a strict superset (it checks `man`'s present region and `son`'s
  negotiated result beside it), so the older standalone test is gone and a
  comment says where it went. That is the `@doenet/i18n` count going 526 → 525.

## If a fourth batch follows

Still scoped and unreached: Ewondo (`ewo`), Efik (`efi`), Jola-Fonyi (`dyo`),
Bini (`bin`), Nupe (`nup`), Susu (`sus`), Baoulé (`bci`). `nup` and `bci` have
no CLDR name and would exercise `LOCALE_NAME_FALLBACKS` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8





