### PR TITLE
Seed catalogs for twelve Cyrillic languages of the Russian Federation

### DIFF
--- a/.changeset/seed-russian-federation-cyrillic-catalogs.md
+++ b/.changeset/seed-russian-federation-cyrillic-catalogs.md
@@ -1,0 +1,29 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Seed unreviewed message catalogs for twelve more languages, all written in
+Cyrillic and all spoken in the Russian Federation: Bashkir (`ba`), Chuvash
+(`cv`), Yakut (`sah`), Tuvan (`tyv`), Buryat (`bua`), Kalmyk (`xal`), Udmurt
+(`udm`), Komi (`kv`), Erzya (`myv`), Mari (`chm`), Ossetian (`os`) and Chechen
+(`ce`). A document declaring one of these languages now renders its style
+descriptions, section headings, boolean words, answer buttons, editor chrome
+and diagnostics in it instead of falling back to English. The chemistry element
+tables are deliberately left out of all twelve and still fall back to English.
+
+Three of the twelve are ISO 639-3 macrolanguages, so a reader arriving under a
+member code now reaches the catalog rather than English: Mongolia and China
+Buriat (`bxm`, `bxu`) reach Buryat, Komi-Permyak (`koi`) reaches Komi, and Hill
+Mari (`mrj`) reaches Mari. Each of those catalogs is written in one standard —
+Russia Buriat, Komi-Zyrian, Meadow Mari — and says so in its own header.
+
+Every string is machine-generated and has not been read by a speaker; each
+catalog says so in its header. Two carry an additional confidence caveat:
+`locales/xal` (Kalmyk) is the least certain of the twelve, and `locales/ce`
+(Chechen) is the one catalog that agrees words with a noun class and is honest
+that it could verify the class markers but not the class of every noun it
+needed. Correcting any of this needs no permission.

--- a/.changeset/seed-russian-federation-cyrillic-catalogs.md
+++ b/.changeset/seed-russian-federation-cyrillic-catalogs.md
@@ -22,8 +22,9 @@ Mari (`mrj`) reaches Mari. Each of those catalogs is written in one standard —
 Russia Buriat, Komi-Zyrian, Meadow Mari — and says so in its own header.
 
 Every string is machine-generated and has not been read by a speaker; each
-catalog says so in its header. Two carry an additional confidence caveat:
-`locales/xal` (Kalmyk) is the least certain of the twelve, and `locales/ce`
-(Chechen) is the one catalog that agrees words with a noun class and is honest
-that it could verify the class markers but not the class of every noun it
-needed. Correcting any of this needs no permission.
+catalog says so in its header. Five carry an additional confidence caveat —
+`locales/cv`, `locales/tyv`, `locales/udm`, `locales/xal` and `locales/ce` —
+and two of those are worth naming: `locales/xal` (Kalmyk) is the least certain
+of the twelve, and `locales/ce` (Chechen) is the one catalog that agrees words
+with a noun class and is honest that it could verify the class markers but not
+the class of every noun it needed. Correcting any of this needs no permission.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1278,25 +1278,28 @@ have. The eleven catalogs beside it resolve `one` and `other`. Yakut marks a
 plural perfectly well; what it does not do is keep it after a numeral, so a
 category would have nothing to choose between.
 
-**`locales/cv` is the roster's second `zero` category, and it means the
-opposite of the first.** Latvian's `zero` covers every number ending in 0 and
-the whole of the teens; Chuvash's fires for exactly 0 and `one` for exactly 1,
-so 21 and 101 are `other` where Latvian's are `one`. Two languages, one
-category name, two rules — which is why `locales/cv`'s header spells out where
+**`locales/cv` is the roster's fourth `zero` category, and the interesting
+comparison is with the one it does _not_ match.** `locales/ar`, `locales/cy`
+and `locales/lv` are the other three; Arabic's and Welsh's `zero` fire for
+exactly 0, and so does Chuvash's, with `one` for exactly 1. Latvian's is the
+odd one out — it covers every number ending in 0 and the whole of the teens, so
+21 and 101 are `one` there and `other` in Chuvash. Four languages, one category
+name, three rules — which is why `locales/cv`'s header spells out where
 its `[zero]` branch is genuinely reached (`answer-show-responses`, the two
 accessibility labels) and where the explicit `[0]` branch wins first
 (`attempts-remaining`).
 
-**Six catalogs record the same limit, and it is word order rather than family
+**Five catalogs record the same limit, and it is word order rather than family
 that decides which.** `piecewise-condition-if` is placed by the renderer
 _before_ the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
 Udmurt's «ке», Komi's «кӧ» and Mari's «гын» all close the clause they condition,
-so all five headers record the `locales/dv` shape — a distinction the
-composition messages do not expose, which splitting the key into a prefix and a
-suffix would fix and which no existing catalog needs. Buryat's «хэрбээ»,
-Kalmyk's «кемр», Erzya's «бути», Ossetian's «кæд» and Chechen's «нагахь санна»
-are clause-initial and land correctly. Two Turkic catalogs on opposite sides of
-that line, two Uralic on one side and one on the other: the wall is syntax, not
+so all five files record the `locales/dv` shape beside the key — a distinction
+the composition messages do not expose, which splitting the key into a prefix
+and a suffix would fix and which no existing catalog needs. The other seven are
+clause-initial and land correctly: Bashkir's «әгәр», Chuvash's «енчен»,
+Buryat's «хэрбээ», Kalmyk's «кемр», Erzya's «бути», Ossetian's «кæд» and
+Chechen's «нагахь санна». Two Turkic catalogs on each side of that line, and
+three Uralic on one side against one on the other: the wall is syntax, not
 ancestry.
 
 #### Negotiation

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -84,15 +84,15 @@ English is the source of truth. Every translation — `ace`, `af`, `ak`, `am`,
 `su`, `sus`, `sv`, `sw`, `ta`, `te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`,
 `tk`, `tlh`, `tn`, `to`, `tpi`, `tr`, `ts`, `tt`, `ty`, `tyv`, `udm`, `ug`,
 `uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vi`, `war`, `wo`, `xal`, `xh`, `yi`,
-`yo`, `zgh`, `zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed
-machine-generated seed**, which each file's own header says at the top, and
-which is what #1521's translation platform is for. None has been read by a
-speaker. Correcting one needs no permission and no coordination: a wrong string
-is just wrong, and the English is one key away.
+`yo`, `zgh`, `zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed machine-generated
+seed**, which each file's own header says at the top, and which is what #1521's
+translation platform is for. None has been read by a speaker. Correcting one
+needs no permission and no coordination: a wrong string is just wrong, and the
+English is one key away.
 
-A hundred and forty-one of them are deliberately partial. A hundred and
-forty are partial in the same place — the two chemistry tables — while
-Klingon is partial almost everywhere, for a different reason: see
+A hundred and forty-one of them are deliberately partial. A hundred and forty
+are partial in the same place — the two chemistry tables — while Klingon is
+partial almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The hundred
 and forty are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
@@ -1292,11 +1292,10 @@ and `locales/lv` are the other three; Arabic's and Welsh's `zero` fire for
 exactly 0, and so does Chuvash's, with `one` for exactly 1. Latvian's is the
 odd one out — it covers every number ending in 0 and the whole of the teens, so
 21 and 101 are `one` there and `other` in Chuvash. Four languages, one category
-name, three rules — which is why `locales/cv`'s header spells out where
-its `[zero]` branch is genuinely reached (`answer-show-responses`, and both
-counts inside `editor-accessibility-label`) and where the explicit `[0]` branch
-wins first
-(`attempts-remaining`).
+name, three rules — which is why `locales/cv`'s header spells out where its
+`[zero]` branch is genuinely reached (`answer-show-responses`, and both counts
+inside `editor-accessibility-label`) and where the explicit `[0]` branch wins
+first (`attempts-remaining`).
 
 **Five catalogs record the same limit, and it is word order rather than family
 that decides which.** `piecewise-condition-if` is placed by the renderer

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1285,8 +1285,9 @@ exactly 0, and so does Chuvash's, with `one` for exactly 1. Latvian's is the
 odd one out — it covers every number ending in 0 and the whole of the teens, so
 21 and 101 are `one` there and `other` in Chuvash. Four languages, one category
 name, three rules — which is why `locales/cv`'s header spells out where
-its `[zero]` branch is genuinely reached (`answer-show-responses`, the two
-accessibility labels) and where the explicit `[0]` branch wins first
+its `[zero]` branch is genuinely reached (`answer-show-responses`, and both
+counts inside `editor-accessibility-label`) and where the explicit `[0]` branch
+wins first
 (`attempts-remaining`).
 
 **Five catalogs record the same limit, and it is word order rather than family

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -12,14 +12,14 @@ This package is **never published**. Its `vite.config.ts` has no
 
 ## The two locales
 
-DoenetML separates the language of the _content_ from the language of the
-_chrome_, because they genuinely differ: a Spanish-speaking student may work a
+DoenetML separates the language of the *content* from the language of the
+*chrome*, because they genuinely differ: a Spanish-speaking student may work a
 French physics problem, and a French activity embedded in an English course
 should still say "thick red line" in French.
 
-| Setting          | Selects                                                  | Namespaces                        |
-| ---------------- | -------------------------------------------------------- | --------------------------------- |
-| `documentLocale` | Prose the core computes into the document                | `content`                         |
+| Setting          | Selects                                                 | Namespaces                |
+| ---------------- | ------------------------------------------------------- | ------------------------- |
+| `documentLocale` | Prose the core computes into the document               | `content`                 |
 | `uiLocale`       | Everything addressed to whoever is looking at the screen | `chrome`, `diagnostics`, `editor` |
 
 `<document lang>` wins over the `documentLocale` prop, which falls back to
@@ -66,26 +66,25 @@ locales/<locale>/
   editor.ftl        # editor and LSP surfaces                — uiLocale
 ```
 
-English is the source of truth. Every translation —
-`ace`, `af`, `ak`, `am`, `ar`, `arn`, `as`, `ast`, `ay`, `az`, `ba`, `ban`,
-`bci`, `be`, `bem`, `bg`, `bho`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`,
-`brx`, `bs`, `bua`, `bum`, `ca`, `ce`, `ceb`, `ch`, `chm`, `co`, `cs`, `cv`,
-`cy`, `da`, `dag`, `de`, `dje`, `doi`, `dv`, `dyo`, `dyu`, `dz`, `ee`,
-`efi`, `el`, `es`, `et`, `eu`, `ewo`, `fa`, `ff`, `fi`, `fil`, `fj`, `fo`,
-`fon`, `fr`, `fy`, `ga`, `gaa`, `gd`, `gl`, `gn`, `gu`, `ha`, `haw`, `he`,
-`hi`, `hil`, `hnj`, `hr`, `ht`, `hu`, `hy`, `id`, `ig`, `ilo`, `is`, `it`,
-`ja`, `jv`, `ka`, `kab`, `kbp`, `kg`, `ki`, `kk`, `km`, `kmb`, `kn`, `ko`,
-`kok`, `kpe`, `kr`, `kri`, `ks`, `ktu`, `kv`, `ky`, `lb`, `lg`, `ln`, `lo`,
-`lom`, `lt`, `lua`, `luo`, `lv`, `mad`, `mai`, `men`, `mg`, `mi`, `min`,
-`mk`, `ml`, `mn`, `mni`, `mnk`, `mos`, `mr`, `ms`, `mt`, `my`, `myv`, `nah`,
-`nb`, `nds`, `ne`, `nl`, `nso`, `ny`, `nyn`, `oc`, `oj`, `om`, `or`, `os`,
-`pa`, `pam`, `pcm`, `pl`, `ps`, `pt`, `qu`, `quc`, `rm`, `rn`, `ro`, `ru`,
-`rw`, `sa`, `sah`, `sat`, `sc`, `scn`, `sd`, `se`, `sg`, `shi`, `si`, `sk`,
-`sl`, `sm`, `sn`, `so`, `sq`, `sr`, `ss`, `st`, `su`, `sus`, `sv`, `sw`,
-`ta`, `te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tlh`, `tn`, `to`,
-`tpi`, `tr`, `ts`, `tt`, `ty`, `tyv`, `udm`, `ug`, `uk`, `umb`, `ur`, `urh`,
-`uz`, `ve`, `vi`, `war`, `wo`, `xal`, `xh`, `yi`, `yo`, `zgh`, `zh-Hans`,
-`zh-Hant`, `zu` — is an **unreviewed
+English is the source of truth. Every translation — `ace`, `af`, `ak`, `am`,
+`ar`, `arn`, `as`, `ast`, `ay`, `az`, `ba`, `ban`, `bci`, `be`, `bem`, `bg`,
+`bho`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`, `brx`, `bs`, `bua`, `bum`, `ca`,
+`ce`, `ceb`, `ch`, `chm`, `co`, `cs`, `cv`, `cy`, `da`, `dag`, `de`, `dje`,
+`doi`, `dv`, `dyo`, `dyu`, `dz`, `ee`, `efi`, `el`, `es`, `et`, `eu`, `ewo`,
+`fa`, `ff`, `fi`, `fil`, `fj`, `fo`, `fon`, `fr`, `fy`, `ga`, `gaa`, `gd`,
+`gl`, `gn`, `gu`, `ha`, `haw`, `he`, `hi`, `hil`, `hnj`, `hr`, `ht`, `hu`,
+`hy`, `id`, `ig`, `ilo`, `is`, `it`, `ja`, `jv`, `ka`, `kab`, `kbp`, `kg`,
+`ki`, `kk`, `km`, `kmb`, `kn`, `ko`, `kok`, `kpe`, `kr`, `kri`, `ks`, `ktu`,
+`kv`, `ky`, `lb`, `lg`, `ln`, `lo`, `lom`, `lt`, `lua`, `luo`, `lv`, `mad`,
+`mai`, `men`, `mg`, `mi`, `min`, `mk`, `ml`, `mn`, `mni`, `mnk`, `mos`, `mr`,
+`ms`, `mt`, `my`, `myv`, `nah`, `nb`, `nds`, `ne`, `nl`, `nso`, `ny`, `nyn`,
+`oc`, `oj`, `om`, `or`, `os`, `pa`, `pam`, `pcm`, `pl`, `ps`, `pt`, `qu`,
+`quc`, `rm`, `rn`, `ro`, `ru`, `rw`, `sa`, `sah`, `sat`, `sc`, `scn`, `sd`,
+`se`, `sg`, `shi`, `si`, `sk`, `sl`, `sm`, `sn`, `so`, `sq`, `sr`, `ss`, `st`,
+`su`, `sus`, `sv`, `sw`, `ta`, `te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`,
+`tk`, `tlh`, `tn`, `to`, `tpi`, `tr`, `ts`, `tt`, `ty`, `tyv`, `udm`, `ug`,
+`uk`, `umb`, `ur`, `urh`, `uz`, `ve`, `vi`, `war`, `wo`, `xal`, `xh`, `yi`,
+`yo`, `zgh`, `zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed
 machine-generated seed**, which each file's own header says at the top, and
 which is what #1521's translation platform is for. None has been read by a
 speaker. Correcting one needs no permission and no coordination: a wrong string
@@ -124,7 +123,7 @@ Vietnamese school chemistry has moved from the transliterated names to the
 IUPAC forms, so in each case the fallback is already what the curriculum uses.
 The eight from the first sub-Saharan batch are that same case for a different
 reason: secondary science is taught in English, French or Afrikaans across all
-of them, so the fallback _is_ the curriculum. Afrikaans and Swahili are the two
+of them, so the fallback *is* the curriculum. Afrikaans and Swahili are the two
 of that batch that do have a settled list and supply it.
 
 The eight from the Southeast Asian and Pacific batch split three ways, and the
@@ -133,7 +132,7 @@ the language. Cebuano is the Filipino case again and for the same school
 system, and Malagasy the French-medium case; Samoan and Hawaiian have no
 settled list of all 118 to seed from, and neither does Māori, whose
 kura-taught science coins terms without having reached the whole table.
-Khmer, Lao and Sinhala are the one group where the language _does_ have the
+Khmer, Lao and Sinhala are the one group where the language *does* have the
 names — all three are taught chemistry in their own language, out of textbooks
 that print their own transcriptions — and what is missing is a convention this
 seed could reproduce rather than invent. An unreviewed guess written in a
@@ -154,7 +153,7 @@ Shona, Southern Sotho, Setswana, Tigrinya and Ganda — are partial too, and
 unlike the batches above them they split no ways at all: every one of the ten
 is the school-system case. Secondary science is taught in English across
 Ghana, Zimbabwe, Botswana, Lesotho, Uganda, Eritrea and Tigray, and in French
-across Senegal, Mali and both Congos, so in all ten the fallback _is_ the
+across Senegal, Mali and both Congos, so in all ten the fallback *is* the
 curriculum. That is a fact about ten education ministries rather than about ten
 languages, which is why it reads as one sentence here and takes a sentence of
 its own in each catalog's header.
@@ -166,7 +165,7 @@ textbooks, Asturian out of Spanish, Sardinian and Sicilian out of Italian,
 Western Frisian out of Dutch, Low German and Luxembourgish out of German —
 Luxembourg's upper grades in French as well — and Romansh-medium schooling
 stops below the grades where the periodic table is taught. Northern Sami is the
-one of the eleven where the schooling _is_ in the language and the table still
+one of the eleven where the schooling *is* in the language and the table still
 does not settle: a Sami pupil meets the Norwegian, Swedish or Finnish names
 depending on which side of a border the school is, and those three differ, so
 choosing any of them would report a fact about a border. Yiddish has the
@@ -191,7 +190,7 @@ Mexico, Guatemala, Chile and Argentina — and Haitian Creole out of French ones
 Every one of those seven reaches real classrooms, and Guarani reaches further
 than any other language in the batch, being co-official in Paraguay; but
 bilingual education in all seven is the primary grades and the language
-classroom, and secondary chemistry is not. So in all seven the fallback _is_ the
+classroom, and secondary chemistry is not. So in all seven the fallback *is* the
 curriculum, which is the same sentence the two sub-Saharan batches earned and
 for the same reason.
 
@@ -214,7 +213,7 @@ case — the Philippines from the intermediate grades, Guam and the Northern
 Marianas, Papua New Guinea — which is the `fil` and `ceb` case those two
 catalogs already record. Balinese, Minangkabau, Acehnese and Madurese are the
 Indonesian-medium case, and they differ from `jv` and `su` in an instructive
-way: those two _supply_ the Indonesian names, because their own vocabulary for
+way: those two *supply* the Indonesian names, because their own vocabulary for
 the substances agrees with Indonesian's often enough that the table reads as
 theirs. These four do not, and copying it whole would be neither language —
 Minangkabau says «ameh» where Indonesian says «emas» — so where `jv` and `su`
@@ -236,10 +235,10 @@ every shape the batches above them found, arriving together for the first
 time. Maithili, Bhojpuri, Konkani, Dogri, Manipuri, Kashmiri and Dzongkha are
 the school-system case, in six different school systems: secondary science is
 Hindi-, Nepali-, English-, Marathi- or Urdu-medium depending on the state or
-the country, so in all seven the fallback _is_ the curriculum, and `locales/hi`,
+the country, so in all seven the fallback *is* the curriculum, and `locales/hi`,
 `locales/ne`, `locales/mr` and `locales/ur` are the parallel texts each header
 names. Bodo and Sanskrit are the Samoan case: Bodo-medium schooling in Assam
-_does_ run to the secondary grades, and Sanskrit has words for the metals it
+*does* run to the secondary grades, and Sanskrit has words for the metals it
 knew, but neither has a settled list of all 118 to seed from. Santali is the
 Ojibwe shape — schooling in it stops below the grades where the table is
 taught, and no table waits on the other side — and Dhivehi is `locales/to`'s and
@@ -264,7 +263,7 @@ taught in English or Afrikaans in South Africa, English in Eswatini, Kenya and
 Zambia, Portuguese in Mozambique, French in the Central African Republic and
 across Fula's whole range but Nigeria, and Arabic and French in Morocco and
 Algeria, where Amazigh is taught as a subject rather than used as a medium. So
-in all twelve the fallback _is_ the curriculum. That is a fact about those
+in all twelve the fallback *is* the curriculum. That is a fact about those
 school systems rather than about twelve languages, which is why it reads as one
 paragraph here and takes a sentence of its own in each catalog's header.
 
@@ -487,7 +486,7 @@ itself, CLDR has no Corsican-language data to answer with, and the fallback is
 English — so `endonym` equals `englishName`, the label drops its parenthesis,
 and the roster reads "Corsican" once rather than "Corsican (Corsican)". It is
 not the first to do that: `ak`, `ceb`, `fil`, `hnj`, `mg`, `mi`, `ny` and `sm`
-already read that way, and so do the several whose endonym genuinely _is_ the
+already read that way, and so do the several whose endonym genuinely *is* the
 English word — Afrikaans, Hausa, Igbo, Wolof. Nothing here hand-writes around
 either case, which is why the rule that makes `ny` read "Nyanja" is the rule
 that makes this read "Corsican".
@@ -497,7 +496,7 @@ than one individual language**, and doing so uncovered a real fallback bug rathe
 than merely needing a note.
 
 `qu`, `ay`, `gn` and `oj` are ISO 639-3 macrolanguages and `nah` is an ISO 639-3
-_collection_ code: each covers a family of individual languages with codes of
+*collection* code: each covers a family of individual languages with codes of
 their own. **CLDR's likely-subtags folds exactly one member of a macrolanguage to
 it and leaves the rest unresolvable.** So `quz` reached `qu` on ICU data alone
 and `quh` did not; `ojg` reached `oj` and `ojb` did not; `gug` reached `gn` and
@@ -523,7 +522,7 @@ too.
 
 Serving a related variety is a real compromise, and each of these catalogs says
 in its own header which written standard it is: Southern Quechua in the
-trivocalic orthography, Paraguayan Guarani in the _jopara_ register, Central
+trivocalic orthography, Paraguayan Guarani in the *jopara* register, Central
 Nahuatl in the SEP/INALI orthography, Ojibwe in the Fiero double-vowel
 orthography, Mapudungun in the Alfabeto Mapuche Unificado — which is a choice
 among three live orthographies rather than a neutral default, and its header says
@@ -580,14 +579,14 @@ untouched.
 Twelve languages, and the thing they add to this file is not any one of them
 but the **five Devanagari catalogs that answer the agreement question three
 different ways**. Sanskrit selects on `$gender` and `$role` and inflects for
-gender, number _and_ case; Konkani selects on both with Marathi's three
+gender, number *and* case; Konkani selects on both with Marathi's three
 genders; Dogri selects on `$gender` alone; Maithili and Bhojpuri select on
 neither. Hindi, Marathi and Nepali were already three more answers in the same
 letters. **A script says nothing about the fork**, which is the sharpest
 statement of that this repository has, and `styleDescriptions.test.ts` pins all
 five side by side so it cannot quietly stop being true.
 
-Dogri is the one worth reading closely, because it is _not_ a claim that Dogri
+Dogri is the one worth reading closely, because it is *not* a claim that Dogri
 does not inflect. Its masculine -आ adjectives take an oblique; none of the three
 clause positions reaches it, because the border and background are feminine and
 the text colour is a direct masculine. A `$role` branch would render what the
@@ -607,7 +606,7 @@ Hebrew's eight. **Tibetan and Dzongkha are the opposite extreme**: ICU reports
 exactly one category for each, so no message in either can select on a count and
 every counted message in both is written flat, the way `locales/ja` and
 `locales/th` write theirs. The `[0]` branches that survive are matched by
-_number_ rather than by category — Fluent resolves an explicit number before it
+*number* rather than by category — Fluent resolves an explicit number before it
 consults the plural rules, which is why a wording for none is still reachable.
 
 Three catalogs put their adjectives **after** the noun — Meitei and both
@@ -619,7 +618,7 @@ split is the shape of the complement, not the side the adjectives sit on.
 `bo` and `dz` are two directories rather than one with a script tag, and it is
 the `hr`-against-`sr` case a fifth time: two standard languages, two
 vocabularies, one script. `locales/dz` writes ཧོནམ where `locales/bo` writes
-སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for _opposite_
+སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for *opposite*
 reasons — see the chemistry paragraph above — which is the neatest illustration
 in the roster that the gap is a fact about a school system rather than about a
 script.
@@ -661,7 +660,7 @@ filled in with the real genders anyway, so that a speaker adding the fork has
 the table already and need only write the feminine forms. And `locales/dv` puts
 `piecewise-condition-if` on the wrong side of the mathematics: Dhivehi's
 conditional particle «ނަމަ» is clause-final and the renderer places that key
-_before_ what it introduces, which no wording in the catalog can fix. That is
+*before* what it introduces, which no wording in the catalog can fix. That is
 the `locales/tpi` shape — a distinction the composition messages do not expose
 — and splitting the key into a prefix and a suffix is a change to the worker
 that no existing catalog needs and this one would use.
@@ -680,7 +679,7 @@ any of the ten and get prose in it. (South African Sign Language, official
 since 2023, is the eleventh and has no written form to seed.)
 
 **Six more Bantu catalogs take the noun-class group from ten to sixteen**, and
-the thing they add is how _unevenly_ a class concord lands. `locales/ts` is the
+the thing they add is how *unevenly* a class concord lands. `locales/ts` is the
 case worth reading: Xitsonga has very few true adjectives, and almost
 everything English calls one is a noun joined with a possessive concord — so
 the class fork falls on «-kulu», «-tsongo» and the passive «-tateriwaka» and on
@@ -697,8 +696,8 @@ agrees with its noun's class through a **suffix**: «ɓaleewol» against a `ngol
 noun, «ɓaleere» against a `nde` one. `$gender` is a token set and nothing
 outside a catalog reads its values, so the argument needed no widening to reach
 a suffix any more than it needed widening to reach a noun class — which is the
-cleanest demonstration this file has that the mechanism is about _what a word
-agrees with_ rather than about gender, prefixes, or Bantu.
+cleanest demonstration this file has that the mechanism is about *what a word
+agrees with* rather than about gender, prefixes, or Bantu.
 
 **Luo and Sango select on neither argument, and they sit between catalogs that
 select on three classes each.** Dholuo is Nilotic and Sango Ubangian; neither has
@@ -706,7 +705,7 @@ gender or noun classes, and `locales/ki` and `locales/bem` on either side of
 them fork on `c3`, `c7` and `c9`. A region says as little about agreement
 as a script does. `locales/luo` adds one thing of its own: its relative
 particle «ma-» is written onto the front of the colour, including when the
-colour is a placeable, which makes it the roster's first _prefix_ welded
+colour is a placeable, which makes it the roster's first *prefix* welded
 onto a value the catalog never sees. That is sound for `locales/tlh`'s reason —
 «ma-» has one shape and never assimilates — and its header records the one case
 that would break it.
@@ -869,13 +868,13 @@ Ten of the eleven are the school-system case, in two mediums across eleven
 countries rather than one: English in Ghana, Nigeria and Uganda, French in
 Burundi, Burkina Faso, Côte d'Ivoire and both Congos, and English or French
 depending on the country for Kanuri, which spans four. So in all ten the
-fallback _is_ the curriculum, which is a fact about those education ministries
+fallback *is* the curriculum, which is a fact about those education ministries
 rather than about ten languages.
 
 **Mandinka is the eleventh and the one claim of a different kind.** It is
 spoken across three countries with three different mediums of secondary
 instruction — English in the Gambia, French in Senegal, Portuguese in
-Guinea-Bissau — so there is no one curriculum for a fallback to _be_, and
+Guinea-Bissau — so there is no one curriculum for a fallback to *be*, and
 choosing any of the three would report which side of which border a reader's
 school is on. `locales/se` reached exactly that place between Norway, Sweden
 and Finland; this is the Northern Sami case in West Africa, and it is the first
@@ -884,7 +883,7 @@ time a batch's chemistry paragraph has split since the South Asian one.
 ### The batch continued: a creole beside its lexifier
 
 Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne — six more from the same
-region, and where the eleven above were arranged around _where_ a language puts
+region, and where the eleven above were arranged around *where* a language puts
 its agreement, these six are arranged around a sharper question: **what can you
 learn from two catalogs that you cannot learn from either one alone?**
 
@@ -898,12 +897,12 @@ that «ya» turns out to be Kongo's class-9 row, frozen. The whole of the
 agreement in `locales/kg` is that one syllable, and the describing stem behind
 it never moves:
 
-| class | linker | black      | thick    |
-| ----- | ------ | ---------- | -------- |
-| 5     | dya    | dya ndombe | dya nene |
-| 7     | kya    | kya ndombe | kya nene |
-| 9     | ya     | ya ndombe  | ya nene  |
-| 11    | lwa    | lwa ndombe | lwa nene |
+| class | linker | black         | thick       |
+| ----- | ------ | ------------- | ----------- |
+| 5     | dya    | dya ndombe    | dya nene    |
+| 7     | kya    | kya ndombe    | kya nene    |
+| 9     | ya     | ya ndombe     | ya nene     |
+| 11    | lwa    | lwa ndombe    | lwa nene    |
 
 Putting `color.black` in the two files side by side is the shortest statement of
 what a creole did to its lexifier that this repository can make, and it cost
@@ -933,7 +932,7 @@ in Kabiyè, and as a separate word between the two in Tiv. Three positions, one
 argument, no change to anything outside those files.
 
 **`tem` is the one that can be checked without knowing the language.** Temne's
-concord is _alliterative_: the describing word takes the same prefix the noun
+concord is *alliterative*: the describing word takes the same prefix the noun
 itself carries, so a rendered description reads «kʌlayn kʌbana-bana kʌbana» —
 the same syllable three times. In every other noun-class catalog here the
 concord and the noun's own prefix are different morphs, and `noun-gender` has to
@@ -958,15 +957,15 @@ the map lists them, and `kng` because ICU already folds it.
 
 **`ktu` is deliberately absent from that list**, and it is the one exclusion
 here that is not simply "it has a catalog of its own" — though it does. Kituba
-is a creole _of_ Kikongo rather than a variety of it, ISO 639-3 gives it a code
+is a creole *of* Kikongo rather than a variety of it, ISO 639-3 gives it a code
 outside `kg`, and folding it would serve a Kituba reader a different language.
 `mkw`, Kituba of the Republic of the Congo, is left to miss for the same reason;
 answering it with `ktu` would be defensible and is not a membership fact, so it
-is not done. `negotiate.test.ts` asserts the exclusion on the _un-normalized_
+is not done. `negotiate.test.ts` asserts the exclusion on the *un-normalized*
 tag, which is the only form the mistake would be visible in.
 
 **`son` is the road not taken, and the test says why.** It is the macrolanguage
-over the Songhay varieties, and it is _not_ aliased the way `man` was, because
+over the Songhay varieties, and it is *not* aliased the way `man` was, because
 the justification `man`'s entry rests on does not exist here:
 `new Intl.Locale("son").maximize()` adds no region, so CLDR has no opinion about
 which variety a bare `son` means. Picking one would be the judgement these maps
@@ -984,7 +983,7 @@ again, and it is not an error.
 All six leave `element-name` and `element-anion-name` out. Four are the ordinary
 school-system case — the DRC, Benin and Togo teach secondary science in French,
 Sierra Leone in English — but `pcm` and `kri` are a shape no earlier batch had.
-Their lexifier _is_ English, so the fallback is not merely the curriculum, it is
+Their lexifier *is* English, so the fallback is not merely the curriculum, it is
 very nearly the language: filling those 130 keys in would produce entries
 character-identical to `locales/en` and claim a translation that had not
 happened. Leaving the gap visible is the honest answer, and it is the
@@ -1002,10 +1001,10 @@ class system, spoken next door to one another — and Umbundu prefixes the class
 straight onto the describing stem while Kimbundu leaves the stem alone and moves
 an agreeing connective in front of it:
 
-|       | line (c9)          | circle (c7)            | point (c5)            |
-| ----- | ------------------ | ---------------------- | --------------------- |
-| `umb` | ongoli **yi**nene  | ocilinganya **ci**nene | ondimbu **li**nene    |
-| `kmb` | nlonji **ya** nene | kizenge **kya** nene   | kimbanza **kya** nene |
+| | line (c9) | circle (c7) | point (c5) |
+| --- | --- | --- | --- |
+| `umb` | ongoli **yi**nene | ocilinganya **ci**nene | ondimbu **li**nene |
+| `kmb` | nlonji **ya** nene | kizenge **kya** nene | kimbanza **kya** nene |
 
 And Kimbundu's mechanism is `locales/kg`'s exactly — an agreeing «-a»
 connective a thousand kilometres north, in another country, differing only in
@@ -1017,7 +1016,7 @@ which makes it a fact about Bantu rather than about creolization.
 
 **`men` is the clearest instance of the affix rule in the tree.** Mende's
 definite marker is a suffix that attaches not to the noun but to whichever word
-_ends_ the noun phrase, and a describing word follows its noun here — so a style
+*ends* the noun phrase, and a describing word follows its noun here — so a style
 description ends in a placeable, and «{ $color }i» is exactly what
 [An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
 forbids. The catalog therefore leaves **every describing word indefinite**, so
@@ -1044,14 +1043,14 @@ for the readers.
 
 #### Negotiation: a second member-shaped macrolanguage, and a road still not taken
 
-`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a _member_
+`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a *member*
 catalog carrying its siblings, rather than a macrolanguage carrying its members.
 `ddn`, `hmb`, `khq`, `ses`, `tda` and `twq` reach Zarma, and ICU folds none of
 them on its own, so every one of those six depends on the entry existing.
 
 **`son` is still not aliased**, and that is the half worth reading. #1686
 recorded the reason when no Songhay catalog existed; Zarma's arrival makes the
-alias _possible_ and no more justified. `man` earns its alias because CLDR
+alias *possible* and no more justified. `man` earns its alias because CLDR
 decides for itself which member a bare macrolanguage means —
 `new Intl.Locale("man").maximize()` is `man-Latn-GM`, Mandinka's country.
 `new Intl.Locale("son").maximize()` adds no region at all, so CLDR has no
@@ -1065,7 +1064,7 @@ reader CLDR expects in Tifinagh is served Latin. That is `locales/kr`'s
 asymmetry with `kby` in Ajami and `locales/ff`'s in Adlam, and the answer is a
 second catalog rather than a change here.
 
-Three codes came _off_ negative-control lists this batch — `men`, `umb` and
+Three codes came *off* negative-control lists this batch — `men`, `umb` and
 `kmb` were all asserted to fall to English until they got catalogs of their own.
 That is the only thing that should ever shorten such a list, and `nyn` set the
 precedent two batches ago.
@@ -1102,19 +1101,19 @@ the translation dropped (`attract-to-without-nearest-point` and its two
 that changed which claim it made ("will **always** match a blank" became
 "matches **only** a blank"), a complaint that reversed
 (`function-domain-insufficient-dimensions` read "dimensions are not
-_required_"), and buttons whose word belonged to a different control — the
+*required*"), and buttons whose word belonged to a different control — the
 orbital spin arrows were labelled with `umb`'s, `kmb`'s and `dje`'s word for
-_point_, three lines from a real points control.
+*point*, three lines from a real points control.
 
 **What review deliberately did not fix is the larger finding**, and it is a
 limit of seeding rather than a bug in these four. Each catalog spreads one
-word across several English concepts that the UI shows _at the same time_:
-`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry _variant_,
-_version_, _type_ and _style_ together, and `men`'s «wotela» carries
-_variant_, _version_ and _variable_, so in all four the editor's version
+word across several English concepts that the UI shows *at the same time*:
+`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry *variant*,
+*version*, *type* and *style* together, and `men`'s «wotela» carries
+*variant*, *version* and *variable*, so in all four the editor's version
 footer and its variant picker are labelled identically. Three of the
-four also head the feedback panel with their word for _answer_, and all four
-use one noun for both _viewer_ and _renderer_, so the whole-page failure and
+four also head the feedback panel with their word for *answer*, and all four
+use one noun for both *viewer* and *renderer*, so the whole-page failure and
 the one-component failure read alike. Separating these needs new words chosen
 by someone who speaks the language; picking them here would be the
 substitution the chemistry tables are left out to avoid. They are named here
@@ -1148,7 +1147,7 @@ branches — Central Mande, and two Southwestern Mande sisters) fork on neither
 already made to seven Mande catalogs in a row; `kpe` and `lom` go further
 than `sus` by lacking even a definite or qualifier suffix, so Southwestern
 Mande genuinely marks nothing where Central Mande and Manding each mark one
-thing. `ewo` and `bum` are the pair that shows agreement can be _present_ and
+thing. `ewo` and `bum` are the pair that shows agreement can be *present* and
 still not written down: both are Beti-Pahuin Bantu with a real class-concord
 system, but `bum`'s header commits to two classes (`c1`/`c7`) it found enough
 colour-stem data to write with confidence, while `ewo`'s header explains why
@@ -1226,7 +1225,7 @@ Guinea depending on which is meant (`bci`, `sus`). `lom` is the one worth a
 sentence of its own: Loma is spoken across a border where the two sides teach
 science in different languages entirely — English in Liberia, French in
 Guinea — so, as `locales/mnk` and `locales/se` already established for a
-border of their own, there is no single curriculum for a fallback to _be_, and
+border of their own, there is no single curriculum for a fallback to *be*, and
 leaving both keys out serves each side of the border the same way English
 already partially does for the Liberian half.
 
@@ -1246,12 +1245,21 @@ forks.** Turkic, Mongolic, Uralic and Iranian all answer the agreement question
 with a flat "no": no grammatical gender, no inflected attributive adjective, so
 `noun-gender` returns one token and no message forks on it. `locales/ce` is
 Nakh, and Chechen has a real class system — nouns fall into classes marked by
-в-, й-, б- and д-, and an agreeing word carries the class at the _front_. So
-`locales/ce` writes a class table and forks `style-filled-word` and
-`style-unfilled` on it. One script, twelve catalogs, one fork: a script says as
-little about agreement as a family or a region does, which is the sentence
-`locales/ts` and `locales/ktu` earned inside Bantu and this batch earns across
-five families at once.
+в-, й-, б- and д-, and an agreeing word carries the class at the *front*. So
+`locales/ce` writes a class table and forks `style-filled-word` on it, which
+`styleDescriptions.test.ts` pins across two classes. One script, twelve
+catalogs, one fork: a script says as little about agreement as a family or a
+region does, which is the sentence `locales/ts` and `locales/ktu` earned inside
+Bantu and this batch earns across five families at once.
+
+`style-unfilled` is the other word Chechen would agree, and it is the batch's
+one **unreachable** fork rather than a written one. The message describes a
+fill standing on its own, so `describeFill` renders it with no arguments and no
+noun exists to take a class from; a `$gender` select there could only ever
+render its default branch. So the catalog writes the д-class form flat, as
+every other agreeing catalog in the roster does — `locales/sw`, `locales/zu`
+and `locales/ts` all write theirs as one string for the same reason, which is
+what makes this an argument about the message rather than about Chechen.
 
 **`locales/ce`'s header is honest about which half of its fork it can vouch
 for.** The four class markers and the agreeing participle are what this seed
@@ -1263,7 +1271,7 @@ and waiting, so filling the table in costs a speaker one line per noun.
 
 **Two catalogs record a colour vocabulary that does not split where the style
 pipeline splits, and they are unrelated.** Sakha's «күөх» covers green and
-blue; Ossetian's «цъæх» covers green, blue _and_ grey. The style pipeline needs
+blue; Ossetian's «цъæх» covers green, blue *and* grey. The style pipeline needs
 those as separate words, so both catalogs write the modern compounds that split
 them — «от күөх» and «халлаан күөҕэ» for Sakha, «кæрдæгхуыз» and «æрвхуыз» for
 Ossetian — and both headers say plainly that this is a choice rather than a
@@ -1279,7 +1287,7 @@ plural perfectly well; what it does not do is keep it after a numeral, so a
 category would have nothing to choose between.
 
 **`locales/cv` is the roster's fourth `zero` category, and the interesting
-comparison is with the one it does _not_ match.** `locales/ar`, `locales/cy`
+comparison is with the one it does *not* match.** `locales/ar`, `locales/cy`
 and `locales/lv` are the other three; Arabic's and Welsh's `zero` fire for
 exactly 0, and so does Chuvash's, with `one` for exactly 1. Latvian's is the
 odd one out — it covers every number ending in 0 and the whole of the teens, so
@@ -1292,7 +1300,7 @@ wins first
 
 **Five catalogs record the same limit, and it is word order rather than family
 that decides which.** `piecewise-condition-if` is placed by the renderer
-_before_ the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
+*before* the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
 Udmurt's «ке», Komi's «кӧ» and Mari's «гын» all close the clause they condition,
 so all five files record the `locales/dv` shape beside the key — a distinction
 the composition messages do not expose, which splitting the key into a prefix
@@ -1344,7 +1352,7 @@ pins every one of them.
 All twelve leave `element-name` and `element-anion-name` out, and — like the
 second sub-Saharan batch and the African and Berber one — they split no ways at
 all. Secondary chemistry across the Russian Federation is taught in Russian, so
-in all twelve the fallback _is_ the curriculum. That is a fact about one
+in all twelve the fallback *is* the curriculum. That is a fact about one
 education system rather than about twelve languages, which is why it reads as
 one sentence here and takes a sentence of its own in each catalog's header.
 
@@ -1377,7 +1385,7 @@ an ISO 639-3 code, so it filters like any other individual language, needs no
 entry in `LANGUAGE_ALIASES`, and belongs to no macrolanguage. `Intl` knows the
 English name, so the roster reads **Klingon** — once, not twice, because CLDR
 has no `tlh`-language data to answer the endonym with and the fallback is the
-English name. That is the `co` case, with the twist that Klingon _has_ a
+English name. That is the `co` case, with the twist that Klingon *has* a
 well-known endonym («tlhIngan Hol») and CLDR simply does not carry it.
 
 pIqaD is ISO 15924 `Piqd`, so `tlh-Piqd` is a well-formed tag and reaches the
@@ -1388,7 +1396,7 @@ pIqaD. Quenya (`qya`), Sindarin (`sjn`) and the ISO 639-2 collection code `art`
 all fall to English, which is the membership rule working rather than a gap in
 it — none of them is a member of `tlh`. `negotiate.test.ts` holds all of that.
 
-What _is_ new is the **shape of the gap**. Every other partial catalog leaves
+What *is* new is the **shape of the gap**. Every other partial catalog leaves
 out the chemistry tables because a school system teaches chemistry in another
 language; the language has the words and the seed has no settled list to copy.
 Klingon is the first partial for a lexical reason — its lexicon is closed, since
@@ -1401,7 +1409,7 @@ The line it draws is stated once in `content.ftl` and applied everywhere:
 > description, and is written. A new root is an invention, and is not.
 
 Under it «nagHom» — «nagh» (rock) with the canon diminutive — is a fair way to
-say _dot_, and a word for _parabola_ is not a translation of anything. It is the
+say *dot*, and a word for *parabola* is not a translation of anything. It is the
 argument `locales/oj` already makes about coining 118 element names, generalized
 from one table to a whole catalog.
 
@@ -1412,9 +1420,9 @@ has released a mathematics register over the years, well after TKD, so «mey'»
 (point), «baSta'» (vector) and «chav» (function) all exist and are all used. So
 are «wa'chaw» (table), «wev» and «war» (row and column), «tenwal» (page) and
 «vorgh» (be previous), each of which an earlier draft either coined around or
-left to English. What is genuinely absent is smaller and stranger: _parabola_,
-_polyline_, _curve_ as a noun, and the vocabulary of a document editor —
-_attribute_, _variant_, _matrix_, _snippet_, _accessibility_. **The lesson
+left to English. What is genuinely absent is smaller and stranger: *parabola*,
+*polyline*, *curve* as a noun, and the vocabulary of a document editor —
+*attribute*, *variant*, *matrix*, *snippet*, *accessibility*. **The lesson
 generalizes past Klingon: "this language has no word for X" is a claim about a
 word list, and it needs checking against the word list.**
 
@@ -1426,7 +1434,7 @@ four colour terms are TKD entries. Some are Okrand's own but were released at a
 `qep'a'` or `qepHom'a'` gathering or posted to the old `startrek.klingon`
 newsgroup: «meyrI'», «me'cheD», «baSta'», «chav» in its mathematical sense,
 «vorgh», «wa'chaw», «wev», «war», «tenwal» and «nItlh 'echlet» (keyboard). And
-three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a _single_
+three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a *single*
 relayed answer on the KLI mailing list, one post of 2014.01.27, with no second
 attestation; «ghantoH» (example) and «nompuq» (reference) are the same. All
 three classes are used and none is removed, but the catalogs mark the third
@@ -1437,7 +1445,7 @@ is still his, and what a reader has to go on is one paraphrase. Telling them
 which entries those are is what lets a speaker overrule the right ones.
 
 `.diamond` is the instructive omission, because it is not a lexical gap at all.
-Okrand's note on «chanmon» (the gemstone) says the diamond _shape_ is «meyrI'»,
+Okrand's note on «chanmon» (the gemstone) says the diamond *shape* is «meyrI'»,
 which the catalog already spends on `square`. Writing it would make a square
 marker and a diamond marker report identically — the one distinction a shape
 noun exists to carry — so the key falls back to English instead. That is the
@@ -1496,7 +1504,7 @@ every consumer whether or not anyone reads it, and no single language earns
 that. English is exempt because every fallback chain ends there: it has to be
 present with no network, in every bundling variant.
 
-Note that `content` and `diagnostics` answer to _different_ settings —
+Note that `content` and `diagnostics` answer to *different* settings —
 `documentLocale` and `uiLocale` respectively — which is why `WORKER_NAMESPACES`
 is `content` alone. The worker knows only the content locale, and needs only
 that: it renders `content` itself, but for a diagnostic it emits a code and the
@@ -1533,7 +1541,7 @@ would offer the author English and nothing else.
 
 Neither list is exhaustive from an author's point of view: a deployment can
 hand over catalogs of its own as `localeResources`, which no build-time list
-can know about. So the roster _suggests_ and never _enforces_ — `lang` accepts
+can know about. So the roster *suggests* and never *enforces* — `lang` accepts
 any BCP-47 tag, and an unlisted one draws no diagnostic.
 
 ## Delivery
@@ -1541,7 +1549,7 @@ any BCP-47 tag, and an unlisted one draws no diagnostic.
 A locale that is not inlined still has to reach the browser. `load.ts` does
 that, and the viewer calls it for you: `useLocaleCatalogs` (in
 `@doenet/doenetml`'s `utils/i18n.tsx`) loads the catalogs for whatever tags are
-in play and merges them _under_ the host's `localeResources`, so a deployment
+in play and merges them *under* the host's `localeResources`, so a deployment
 correcting a shipped translation still wins. Adding `locales/pt/` and running
 `npm run codegen` is therefore the whole job — no list of languages to register
 anywhere, and `documentLocale="pt"` and `<document lang="pt">` both work with
@@ -1573,17 +1581,17 @@ catalogs to get one.
 Where the catalogs come from depends on the build, and the difference is real
 rather than cosmetic:
 
-| Build                     | Mechanism                                                                           |
-| ------------------------- | ----------------------------------------------------------------------------------- |
-| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog                               |
-| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle                                   |
-| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`                                        |
+| Build                     | Mechanism                                              |
+| ------------------------- | ------------------------------------------------------ |
+| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog   |
+| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle       |
+| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`           |
 | `@doenet/doenetml-iframe` | Neither: what renders inside its iframe is a standalone bundle, which loads its own |
 
 The glob is what makes adding a language cost a directory. It is also why the
 two single-file builds need a different answer: `inlineDynamicImports` folds
 every dynamic import back into the one output file, so code-splitting cannot
-keep catalogs out of them — and _being reachable is enough_, whether or not
+keep catalogs out of them — and *being reachable is enough*, whether or not
 anything calls it. Both therefore define `__DOENET_CODE_SPLIT_CATALOGS__`
 false, which makes the glob dead code. The standalone build then copies
 `locales/` into `dist/` (`copyLocaleCatalogsPlugin`) and installs
@@ -1695,7 +1703,7 @@ shared by every viewer on the page, which context cannot cross, so it takes a
 Prose the core computes — style descriptions today — is content, so it follows
 `documentLocale` and is built where the core builds everything else. The
 translator arrives as the value of the `translator` dependency, which is a
-_factory_ keyed by locale rather than a translator: the catalogs are fixed for
+*factory* keyed by locale rather than a translator: the catalogs are fixed for
 a core's lifetime but the locale is not, since a nested `<document lang>` can
 differ from the one around it. A definition takes the `locale` of the document
 it sits in — an ordinary ancestor dependency, alongside `theme` — and asks the
@@ -1730,7 +1738,7 @@ that cannot be translated word for word. English writes adjectives before the
 noun and inserts an article before "border"; Spanish writes them after and
 agrees them with the noun's gender. So each description is assembled by a
 message that receives the pieces as arguments plus a `$parts` argument naming
-_which_ pieces are present, and every adjective is handed `$gender`. An absent
+*which* pieces are present, and every adjective is handed `$gender`. An absent
 piece selects a different branch rather than substituting an empty string —
 that is what lets a translation reorder and re-punctuate each combination on
 its own terms.
@@ -1747,7 +1755,7 @@ its fifth is `c12` — «akadomo», the point, is a diminutive there, as it is i
 Ganda. The reachability rule applies to the class tokens exactly as it does to
 `$role`: a catalog writes a branch for a class only if its own `noun-gender`
 can answer that class. That is why Swahili and Nyanja carry `c6` — the plural
-class, which their word for _text_ or _border_ lands in — and the other
+class, which their word for *text* or *border* lands in — and the other
 seventeen do not, and why Venda, Tsonga, Kikuyu and Bemba stop at `c3`, `c7`
 and `c9`: no noun the core names is class 5 in any of the four, so the ḽi-,
 leri-, i- and ili- forms are named in those catalogs' headers rather than
@@ -1757,7 +1765,7 @@ written as branches nothing can select.
 `locales/ff` writes «ɓaleewol» against a `ngol` noun and «ɓaleere» against a
 `nde` one, so the same argument that reaches the front of a Bantu adjective
 reaches the back of a Fula one. Nothing outside the catalog changed to allow
-that, which is the point: what `$gender` names is _what a word agrees with_,
+that, which is the point: what `$gender` names is *what a word agrees with*,
 not where the agreement is spelled.
 
 **The Gur pair spells it the same way from a different family**, which is what
@@ -1769,12 +1777,12 @@ which nouns a catalog happens to name, not about a family, which is what the
 nineteen Bantu catalogs have been saying all along in a script where it is
 easier to miss.
 
-Both write the _juxtaposed_ construction, where the noun keeps its own class
+Both write the *juxtaposed* construction, where the noun keeps its own class
 suffix and each modifier agrees with it, rather than the compound one, where
 the noun drops to its bare stem and the last modifier carries the suffix alone.
 That is the affix rule below: the last element of a description is often a
 placeable, and a suffix cannot be welded to a word the catalog never sees. It
-is _choose the words that land there_ applied to a whole construction rather
+is *choose the words that land there* applied to a whole construction rather
 than to one word.
 
 **Tiv writes it as a word of its own, which is the third place it can go.**
@@ -1808,7 +1816,7 @@ words are rendered in two places each — a border's adjectives, the background
 colour, and the text colour beside it — once standing alone as a state
 variable reports them and once embedded in a clause, and a language that
 inflects for case wants a different form in each. So every adjective is handed
-`$role` as well, naming the _position_ the phrase is going into rather than
+`$role` as well, naming the *position* the phrase is going into rather than
 the case it takes: which case a position governs is the catalog's business,
 exactly as `$gender`'s token set already is. `locales/en/content.ftl` lists the
 positions, and `be`, `bs`, `cs`, `de`, `el`, `et`, `fi`, `fo`, `hi`, `hr`,
@@ -1840,7 +1848,7 @@ The **Celtic four** — `ga`, `gd`, `cy`, `br` — reach that same answer from t
 other end. They mark an adjective heavily, but by mutating the front of it
 rather than by inflecting the end: a feminine singular noun softens whatever
 follows it, so «dearg» is «dhearg» in Irish, «coch» is «goch» in Welsh, and
-«du» is «zu» in Breton. That trigger is the _noun_, and the noun's gender is
+«du» is «zu» in Breton. That trigger is the *noun*, and the noun's gender is
 already a token these messages carry — so all four select on `$gender` alone
 and none of them writes a `$role` branch. Welsh goes one step past the other
 three: a handful of its adjectives have a feminine form of their own before the
@@ -1860,8 +1868,8 @@ width first. Each of those says so above its own `style-stroke`, for the same
 reason.
 
 Basque is the clean case of the opposite: it has a great many cases and selects
-on neither argument, because a Basque case is a suffix on the _last word of the
-whole noun phrase_. What a position asks for lands on a word `locales/eu`
+on neither argument, because a Basque case is a suffix on the *last word of the
+whole noun phrase*. What a position asks for lands on a word `locales/eu`
 writes — «batekin», «planoarekin» — rather than on the adjective, so the
 description reads the same in all four positions.
 
@@ -1902,7 +1910,7 @@ verb, «'ej» between them, and stands the whole clause in front of the noun:
 an attested pattern, since no canon example chains three relative clauses, and
 the catalog's header says so. That puts Klingon on the prenominal
 side with the Philippine catalogs and Tok Pisin, for a reason none of them
-shares, and it is why the catalog needs no `$role` fork — the _position_ is
+shares, and it is why the catalog needs no `$role` fork — the *position* is
 handled by the message that composes the phrase rather than by the word inside
 it, so its tables can hold bare verbs that double as the citation form a state
 variable reports.
@@ -1940,10 +1948,10 @@ the order of the adjectives, and `styleDescriptions.test.ts` pins both halves.
 Two further Fluent constraints shaped it, and both are easy to rediscover the
 hard way:
 
-- **A word that inflects has to be passed in, not referenced.** A _term_
+- **A word that inflects has to be passed in, not referenced.** A *term*
   reference cannot carry a runtime value — `{ -filled(gender: $gender) }` does
   not parse (`E0014 Expected literal`), and `{ -filled }` gets an empty scope
-  and always picks its default variant. A _message_ reference does inherit the
+  and always picks its default variant. A *message* reference does inherit the
   caller's arguments, but references never cross a bundle boundary: a locale
   that translates `style-filled` and not `style-filled-word` would render the
   literal `{style-filled-word}` rather than falling back to English. So the
@@ -1952,9 +1960,9 @@ hard way:
 - **A multiline pattern keeps its newlines.** Continuing a variant onto a
   further line puts a `\n` in the rendered string — including when that line
   opens a nested select. Keep each variant's content on one line; a select
-  nested _within_ that line is fine, and is how a message would sub-divide one
+  nested *within* that line is fine, and is how a message would sub-divide one
   of its variants. The same rule catches a subtler mistake: a `#` line indented
-  _under_ a message is not a comment, it is more of the pattern above it, so a
+  *under* a message is not a comment, it is more of the pattern above it, so a
   note explaining a wording choice has to sit above the message rather than
   beside the attribute it explains. `lint:i18n` fails on any pattern that
   renders a line break, which is what makes both of these findable before a
@@ -1968,30 +1976,30 @@ writing direction — it turned up first in Arabic and Uyghur and then in
 Hungarian, Finnish, Czech, Slovak and Romanian.
 
 A placeable is a value the catalog never sees. So a message may not depend on
-what that value turns out to _be_:
+what that value turns out to *be*:
 
-| The catalog wants                 | The language                       | Why it cannot                                                                              |
-| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------ |
-| a case ending on the value        | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
-| the definite article on the value | `ro`, `men`                        | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai»                           |
-| a preposition before the value    | `cs`, `sk`                         | «v»/«ve» and «s»/«se» vocalize according to what follows                                   |
-| a compound with the value         | `fi`                               | Finnish writes a compound as one word                                                      |
-| a case particle after the value   | `bo`, `dz`                         | the particle has four shapes, picked by the final letter of the syllable before it         |
-| the annexed state on the value    | `kab`, `zgh`, `shi`                | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest»     |
+| The catalog wants | The language | Why it cannot |
+| --- | --- | --- |
+| a case ending on the value | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
+| the definite article on the value | `ro`, `men` | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai» |
+| a preposition before the value | `cs`, `sk` | «v»/«ve» and «s»/«se» vocalize according to what follows |
+| a compound with the value | `fi` | Finnish writes a compound as one word |
+| a case particle after the value | `bo`, `dz` | the particle has four shapes, picked by the final letter of the syllable before it |
+| the annexed state on the value | `kab`, `zgh`, `shi` | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest» |
 
 Adjacency is not the problem. `{ $numSides }-kulmio` is correct Finnish for
 every side count, because `-kulmio` is the same whatever number lands in front
-of it. What cannot be written is _agreement_ with an unknown word.
+of it. What cannot be written is *agreement* with an unknown word.
 
 **Tibetan and Dzongkha are the table's sharpest entry, and the way out they
-take is the fifth one.** A Tibetan case particle is chosen by the _final letter
-of the syllable before it_: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
+take is the fifth one.** A Tibetan case particle is chosen by the *final letter
+of the syllable before it*: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
 genitive གི་, ཀྱི་, གྱི་ or ཡི་. Beside a placeable there is no syllable to
 look at. So `bo/content.ftl` and `dz/content.ftl` — the two files that
-_compose_ a phrase, and so the two that get to choose their particles — use
+*compose* a phrase, and so the two that get to choose their particles — use
 only the ones that have a single shape: དང་ for accompaniment, ལ་ (Dzongkha
-ལུ་) for location, ནང་ for containment. That is _prefer the free allomorph
-over the bound one_ applied to a particle rather than to a prefix, and the
+ལུ་) for location, ནང་ for containment. That is *prefer the free allomorph
+over the bound one* applied to a particle rather than to a prefix, and the
 third family to take that way out, after Kʼicheʼ and the Bisayan catalogs.
 
 **The other three files in each are where the way out runs out**, and it is
@@ -2019,7 +2027,7 @@ this rule and the third way out below to come off. Its adjectives follow the
 noun and the izafat links them, and unlike Persian's — an unwritten vowel after
 a consonant, which is why `locales/fa` lets the space carry it — Tajik's is
 written, as «-и». So `locales/tg` writes `{ $noun }и { $description }`, welding
-an affix onto a value whose _form_ the value decides, which nothing else here
+an affix onto a value whose *form* the value decides, which nothing else here
 does — the hyphenated endings `locales/hy` and `locales/ka` put on an
 identifier are welds too, but each has one shape whatever precedes it, so they
 fall under the paragraph above rather than this one. What makes Tajik's sound is
@@ -2057,13 +2065,13 @@ There are five ways out, and every catalog here takes one of them:
 
 **The three Berber catalogs sharpen the third of those into something new: make
 the position uniform, and one written form is right in all of them.** A Berber
-noun after a preposition goes into the _état d'annexion_, and `$pattern` is a
+noun after a preposition goes into the *état d'annexion*, and `$pattern` is a
 noun these catalogs never see — so no branch can inflect it. What they do
 instead is arrange that every one of the four places a fill pattern is placed
-puts it behind the _same_ preposition «s», including `style-fill`, where
+puts it behind the *same* preposition «s», including `style-fill`, where
 English has no preposition at all. `fill-style` then writes its words already
-annexed and cannot be wrong anywhere. That is _choose the words that land
-there_ with the extra step of choosing how many positions there are to choose
+annexed and cannot be wrong anywhere. That is *choose the words that land
+there* with the extra step of choosing how many positions there are to choose
 for, and `styleDescriptions.test.ts` pins two of the four so that a branch
 dropping the preposition fails rather than quietly producing an unannexed noun.
 
@@ -2071,7 +2079,7 @@ The same three catalogs also settle a question the affix table can otherwise
 make look decided: **an alternation that a clause position triggers is not
 automatically a `$role` fork.** The annexed state is exactly the kind of thing
 `$role` exists for, and all three select on `$gender` alone — because the state
-falls on the _noun_, and every noun a clause position lands on is one the
+falls on the *noun*, and every noun a clause position lands on is one the
 catalog writes out. A `$role` branch would render what the `$gender` branch
 underneath it already renders, which is `locales/gu`'s trap reached from
 Afro-Asiatic.
@@ -2083,7 +2091,7 @@ out right for `locales/tlh`'s reason rather than by luck — «ma-» has one sha
 and assimilates to nothing — and it is written on the colour arguments alone
 (`$color`, and `$background` beside it in `style-text`), because `line-width`
 and `line-style` write their words already marked and would come out doubled;
-so the table above stays a list of languages whose endings _change shape_, and
+so the table above stays a list of languages whose endings *change shape*, and
 gains a language whose beginnings do not.
 
 A select whose variants would land against such an affix carries the affix into
@@ -2100,23 +2108,23 @@ Czech turns up here as a ligature.
 `locales/ceb` and `locales/fil` reached it first and one at a time: Cebuano's
 header calls writing the uncontracted «nga» everywhere "the one place this seed
 is deliberately stiff", and `fil` escapes the ligature outright by selecting on
-the side count, whose two CLDR plural categories _are_ its two linkers. What the
+the side count, whose two CLDR plural categories *are* its two linkers. What the
 Austronesian batch adds is the five Philippine catalogs side by side, which is
 what shows that they do not all resolve it the same way:
 
-|              | The linker    | Decided by             | Resolution                                                   |
-| ------------ | ------------- | ---------------------- | ------------------------------------------------------------ |
+| | The linker | Decided by | Resolution |
+| --- | --- | --- | --- |
 | `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», which is grammatical in both positions |
-| `ilo`        | «a» / «nga»   | the word **after** it  | no invariant form exists; write «a» and name the exception   |
-| `pam`        | «a» / `-ng`   | the word **before** it | no invariant form exists; write «a» and name the exception   |
-| `bik`        | «na» / `-ng`  | the word **before** it | no invariant form exists; write «na» and name the exception  |
+| `ilo` | «a» / «nga» | the word **after** it | no invariant form exists; write «a» and name the exception |
+| `pam` | «a» / `-ng` | the word **before** it | no invariant form exists; write «a» and name the exception |
+| `bik` | «na» / `-ng` | the word **before** it | no invariant form exists; write «na» and name the exception |
 
 Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
 free word in both positions, so writing it out is not a compromise but the form
 that can be written without knowing what stands beside it — the move `locales/ceb`
 already makes, and the same move `locales/quc` makes when it writes the free
 relational «rech» instead of the possessive prefix «u-»/«r-». That is the fifth
-way out listed above — _prefer the free allomorph over the bound one_ — and it
+way out listed above — *prefer the free allomorph over the bound one* — and it
 is stated as a rule here because three families now take it: the Bisayan
 catalogs, Kʼicheʼ, and the two Tibetan-script ones, which reach it for a case
 particle rather than for a linker.
@@ -2254,7 +2262,7 @@ A code is a permanent name — what a bug report cites, what a host reading
 `setDiagnosticsCallback` can filter on, and the anchor a documentation page
 will hang off (#1548). It rides on the record, and on the LSP `code` field for
 a positioned diagnostic — with the arguments alongside it in `data.args`, since
-a code names a message _template_ and it takes both to say which occurrence of
+a code names a message *template* and it takes both to say which occurrence of
 it this is. That pair is how the language server's `dedupeLspDiagnostics`
 recognizes two renderings of one diagnostic without comparing their text.
 Nothing renders the code itself yet, so the codes earn their keep as an
@@ -2266,7 +2274,7 @@ fails if one is renumbered, reused, or dropped from the registry. Retire a code
 in place; never recycle it.
 
 The lock is a committed file, not a service, so it enforces the contract only
-against the registry — deleting a code's line from _both_ files in one change
+against the registry — deleting a code's line from *both* files in one change
 passes the lint, exactly as deleting a `package-lock.json` entry does. That is
 what makes the lock worth reviewing: a diff that removes or edits an existing
 line, rather than only adding one at the end, is the thing to refuse.
@@ -2278,7 +2286,7 @@ severity — the emitting call site chooses the record's `type`.
 Two branches that each claim the next number collide in both the registry and
 the lock, which is the intended outcome: neither file can be auto-merged, so
 the conflict is resolved by hand. Give the later branch the next free number in
-_both_ files — the lock is sorted by code, so its entry moves with it, and the
+*both* files — the lock is sorted by code, so its entry moves with it, and the
 lint passes once the two agree again. Never resolve it by editing a code that
 is already on `main`.
 
@@ -2370,7 +2378,7 @@ npm run lint:i18n -w @doenet/i18n    # CI catalog check (also `npm run lint:i18n
 ```
 
 `lint:i18n` fails on: a catalog that doesn't parse (including entries the Fluent
-_runtime_ would silently drop as junk), an id defined twice within a locale, a
+*runtime* would silently drop as junk), an id defined twice within a locale, a
 catalog naming a `numberingSystem` on a Fluent builtin, a message whose value
 would render a line break, a translated locale
 defining a key English lacks, a stale `messageKeys.ts`, `supportedLocales.ts`,
@@ -2379,7 +2387,7 @@ exactly the inlined locales, a call site referencing a key that doesn't exist,
 an English key no source file references, a malformed diagnostic code, a code
 naming a message English lacks, a code used in source that the registry doesn't
 define, a registered code that nothing raises and that is not listed as
-retired, and any change to a code already issued. Keys _missing_ from a
+retired, and any change to a code already issued. Keys *missing* from a
 translation are reported as coverage, not failure — a partial translation is
 legitimate and falls back.
 
@@ -2439,7 +2447,7 @@ that are not prose: a contrast ratio is written `{ ratio }:1` with the `1` a
 literal in the catalog, a line number is read off a gutter the editor draws
 itself, an author's `styleNumber="3"` is quoted back at them. And mathematics
 is Latin-digit regardless — `MATH_NOTATION_LOCALE`, which #1528 keeps that way
-while it makes the _separator_ configurable. A document whose prose counted in
+while it makes the *separator* configurable. A document whose prose counted in
 one script and whose equations counted in another would be worse than either
 alone.
 
@@ -2476,7 +2484,7 @@ outside it. A nested `<document lang>` needs no state variable of its own —
 `renderedLang` is set exactly when the language changes, so where it is absent
 the direction cannot have changed either.
 
-Chrome drawn _inside_ the document is the reader's language in a box declared to
+Chrome drawn *inside* the document is the reader's language in a box declared to
 be the content's. `useChromeLangDir()` re-declares it — on the in-document error
 box, the feedback heading, the click-to-toggle text on a hint, a solution and a
 collapsible section, a pretzel's answer label, the summary-statistics caption,
@@ -2490,7 +2498,7 @@ drawn by the browser rather than by CSS. `DocViewer`'s error banner is built
 above the provider the hook reads, so it calls the same rule as the plain
 function `chromeLangDir(uiLocale, documentDirection)`.
 
-"The document" there means the _nearest_ one, not the activity: a nested
+"The document" there means the *nearest* one, not the activity: a nested
 `<document lang>` turns its own subtree around, so `section.tsx` re-mounts
 `DocumentDirectionProvider` around whatever it just declared. Otherwise chrome
 inside `<document lang="ar">` would compare itself against a left-to-right
@@ -2514,7 +2522,7 @@ rather than styled. MathJax needs nothing: its CHTML output already pins
 `direction: ltr` on `mjx-math` — but only on the mathematics itself, which is
 why the preview's scroll container still needs its own pin.
 
-A pin on a _block_ needs a width with it: an element as wide as its container
+A pin on a *block* needs a width with it: an element as wide as its container
 aligns its left-to-right contents to the container's left edge, stranding the
 widget at the far side of the page from the prose it belongs to.
 `ltrIslandProps()` in
@@ -2526,7 +2534,7 @@ instead of the column. An inline island, or one whose element already
 shrink-wraps, takes a bare `dir="ltr"`.
 
 The keyboard's keys are pinned in `keyboard.css` rather than by attribute,
-because `Keyboard` returns a different element per style. The tray _around_
+because `Keyboard` returns a different element per style. The tray *around*
 them follows the reader.
 
 Everything else mirrors: the paginator, prose renderers, the feedback and hint
@@ -2548,23 +2556,23 @@ an Arabic sentence and the mathematics beside it count in the same characters.
 almost nothing else, and the catalogs differ from each other far more than they
 differ from `de` or `es`:
 
-|                  | Adjectives       | Gender | Plural categories |
-| ---------------- | ---------------- | ------ | ----------------- |
-| `ar`             | follow the noun  | m/f    | six               |
-| `he`             | follow the noun  | m/f    | three             |
-| `fa`             | follow the noun  | none   | two               |
-| `ur`, `ps`, `sd` | precede the noun | m/f    | two               |
-| `ug`             | precede the noun | none   | two               |
-| `yi`             | precede the noun | m/f/n  | two               |
-| `ks`             | precede the noun | m/f    | two               |
-| `dv`             | precede the noun | none   | two               |
+| | Adjectives | Gender | Plural categories |
+| --- | --- | --- | --- |
+| `ar` | follow the noun | m/f | six |
+| `he` | follow the noun | m/f | three |
+| `fa` | follow the noun | none | two |
+| `ur`, `ps`, `sd` | precede the noun | m/f | two |
+| `ug` | precede the noun | none | two |
+| `yi` | precede the noun | m/f/n | two |
+| `ks` | precede the noun | m/f | two |
+| `dv` | precede the noun | none | two |
 
 `ur` is the outlier worth knowing about: its grammar is `hi`'s, so
 `locales/hi` is the closest thing to a parallel text for it and a correction to
 one is usually a correction to both. `ug` is Turkic and agrees with nothing,
 and `dv` is Indo-Aryan and agrees with nothing either — the two reach the same
 answer from opposite families. `ks` is the one of the ten whose catalog records
-a gap rather than a decision: it _does_ agree an adjective for gender and this
+a gap rather than a decision: it *does* agree an adjective for gender and this
 seed does not, which its header says outright.
 `yi` is Germanic, and it forks on `$role` for a reason none of the other nine
 does: `ur`, `ps` and `sd` fork because an Indo-Aryan or Iranian adjective takes
@@ -2601,7 +2609,7 @@ Three things recur across them, none a property of the direction:
   "are ignored" — most of these cover both with one form, and the select is
   dropped rather than written out twice identically. The count argument then
   goes unused, which is harmless: it stays in the English message for the
-  languages that need it. Where English changes the _noun_ as well, the branch
+  languages that need it. Where English changes the *noun* as well, the branch
   stays — and whether it has to is a fact about the language rather than about
   the script: Persian, Urdu and Uyghur leave a noun singular after a numeral,
   while Arabic, Hebrew, Pashto and Sindhi pluralize it.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -12,14 +12,14 @@ This package is **never published**. Its `vite.config.ts` has no
 
 ## The two locales
 
-DoenetML separates the language of the *content* from the language of the
-*chrome*, because they genuinely differ: a Spanish-speaking student may work a
+DoenetML separates the language of the _content_ from the language of the
+_chrome_, because they genuinely differ: a Spanish-speaking student may work a
 French physics problem, and a French activity embedded in an English course
 should still say "thick red line" in French.
 
-| Setting          | Selects                                                 | Namespaces                |
-| ---------------- | ------------------------------------------------------- | ------------------------- |
-| `documentLocale` | Prose the core computes into the document               | `content`                 |
+| Setting          | Selects                                                  | Namespaces                        |
+| ---------------- | -------------------------------------------------------- | --------------------------------- |
+| `documentLocale` | Prose the core computes into the document                | `content`                         |
 | `uiLocale`       | Everything addressed to whoever is looking at the screen | `chrome`, `diagnostics`, `editor` |
 
 `<document lang>` wins over the `documentLocale` prop, which falls back to
@@ -66,33 +66,36 @@ locales/<locale>/
   editor.ftl        # editor and LSP surfaces                — uiLocale
 ```
 
-English is the source of truth. Every translation — `ace`, `af`, `ak`, `am`,
-`ar`, `arn`, `as`, `ast`, `ay`, `az`, `ban`, `bci`, `be`, `bem`, `bg`, `bho`,
-`bik`, `bin`, `bm`, `bn`, `bo`, `br`, `brx`, `bs`, `bum`, `ca`, `ceb`, `ch`,
-`co`, `cs`, `cy`, `da`, `dag`, `de`, `doi`, `dv`, `dyo`, `dyu`, `dz`, `ee`,
+English is the source of truth. Every translation —
+`ace`, `af`, `ak`, `am`, `ar`, `arn`, `as`, `ast`, `ay`, `az`, `ba`, `ban`,
+`bci`, `be`, `bem`, `bg`, `bho`, `bik`, `bin`, `bm`, `bn`, `bo`, `br`,
+`brx`, `bs`, `bua`, `bum`, `ca`, `ce`, `ceb`, `ch`, `chm`, `co`, `cs`, `cv`,
+`cy`, `da`, `dag`, `de`, `dje`, `doi`, `dv`, `dyo`, `dyu`, `dz`, `ee`,
 `efi`, `el`, `es`, `et`, `eu`, `ewo`, `fa`, `ff`, `fi`, `fil`, `fj`, `fo`,
-`fr`, `fy`, `ga`, `gaa`, `gd`, `gl`, `gn`, `gu`, `ha`, `haw`, `he`, `hi`,
-`hil`, `hnj`, `hr`, `ht`, `hu`, `hy`, `id`, `ig`, `ilo`, `is`, `it`, `ja`,
-`jv`, `ka`, `kab`, `ki`, `kk`, `km`, `kn`, `ko`, `kok`, `kpe`, `kr`, `ks`,
-`ktu`, `ky`, `lb`, `lg`, `ln`, `lo`, `lom`, `lt`, `lua`, `luo`,
-`lv`, `mad`, `mai`, `mg`, `mi`, `min`, `mk`, `ml`, `mn`, `mni`, `mnk`, `mos`,
-`mr`, `ms`, `mt`, `my`, `nah`, `nb`, `nds`, `ne`, `nl`, `nso`, `ny`, `nyn`,
-`oc`, `oj`, `om`, `or`, `pa`, `pam`, `pl`, `ps`, `pt`, `qu`, `quc`, `rm`, `rn`,
-`ro`, `ru`, `rw`, `sa`, `sat`, `sc`, `scn`, `sd`, `se`, `sg`, `shi`, `si`,
-`sk`, `sl`, `sm`, `sn`, `so`, `sq`, `sr`, `ss`, `st`, `su`, `sus`, `sv`, `sw`,
-`ta`, `te`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tlh`, `tn`, `to`, `tpi`,
-`tr`, `ts`, `tt`, `ty`, `ug`, `uk`, `ur`, `urh`, `uz`, `ve`, `vi`, `war`,
-`wo`, `xh`, `yi`, `yo`, `zgh`, `zh-Hans`, `zh-Hant`, `zu` — is an **unreviewed
+`fon`, `fr`, `fy`, `ga`, `gaa`, `gd`, `gl`, `gn`, `gu`, `ha`, `haw`, `he`,
+`hi`, `hil`, `hnj`, `hr`, `ht`, `hu`, `hy`, `id`, `ig`, `ilo`, `is`, `it`,
+`ja`, `jv`, `ka`, `kab`, `kbp`, `kg`, `ki`, `kk`, `km`, `kmb`, `kn`, `ko`,
+`kok`, `kpe`, `kr`, `kri`, `ks`, `ktu`, `kv`, `ky`, `lb`, `lg`, `ln`, `lo`,
+`lom`, `lt`, `lua`, `luo`, `lv`, `mad`, `mai`, `men`, `mg`, `mi`, `min`,
+`mk`, `ml`, `mn`, `mni`, `mnk`, `mos`, `mr`, `ms`, `mt`, `my`, `myv`, `nah`,
+`nb`, `nds`, `ne`, `nl`, `nso`, `ny`, `nyn`, `oc`, `oj`, `om`, `or`, `os`,
+`pa`, `pam`, `pcm`, `pl`, `ps`, `pt`, `qu`, `quc`, `rm`, `rn`, `ro`, `ru`,
+`rw`, `sa`, `sah`, `sat`, `sc`, `scn`, `sd`, `se`, `sg`, `shi`, `si`, `sk`,
+`sl`, `sm`, `sn`, `so`, `sq`, `sr`, `ss`, `st`, `su`, `sus`, `sv`, `sw`,
+`ta`, `te`, `tem`, `tet`, `tg`, `th`, `ti`, `tiv`, `tk`, `tlh`, `tn`, `to`,
+`tpi`, `tr`, `ts`, `tt`, `ty`, `tyv`, `udm`, `ug`, `uk`, `umb`, `ur`, `urh`,
+`uz`, `ve`, `vi`, `war`, `wo`, `xal`, `xh`, `yi`, `yo`, `zgh`, `zh-Hans`,
+`zh-Hant`, `zu` — is an **unreviewed
 machine-generated seed**, which each file's own header says at the top, and
 which is what #1521's translation platform is for. None has been read by a
 speaker. Correcting one needs no permission and no coordination: a wrong string
 is just wrong, and the English is one key away.
 
-A hundred and twenty-nine of them are deliberately partial. A hundred and
-twenty-eight are partial in the same place — the two chemistry tables — while
+A hundred and forty-one of them are deliberately partial. A hundred and
+forty are partial in the same place — the two chemistry tables — while
 Klingon is partial almost everywhere, for a different reason: see
 [A language with no word for it](#a-language-with-no-word-for-it). The hundred
-and twenty-eight are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
+and forty are: Somali, Hmong Njua, Amharic, Assamese, Nepali, Burmese,
 Pashto, Sindhi, Uyghur, Kannada, Punjabi, Filipino, Vietnamese, Zulu, Xhosa,
 Kinyarwanda, Nyanja, Hausa, Yoruba, Igbo, Oromo, Khmer, Lao, Sinhala, Cebuano,
 Malagasy, Māori, Samoan, Hawaiian, Wolof, Bambara, Akan, Ewe, Lingala, Shona,
@@ -107,7 +110,8 @@ Kikuyu, Bemba, Luo, Sango, Fula, Kabyle, Standard Moroccan Tamazight,
 Tachelhit, Rundi, Nyankole, Luba-Lulua, Kituba, Mooré, Dagbani, Dyula,
 Mandinka, Ga, Tiv, Kanuri, Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè, Temne,
 Mende, Umbundu, Kimbundu, Zarma, Baoulé, Bini, Bulu, Jola-Fonyi, Efik, Ewondo,
-Kpelle, Loma, Susu and Urhobo
+Kpelle, Loma, Susu, Urhobo, Bashkir, Chuvash, Yakut, Tuvinian, Buriat,
+Kalmyk, Udmurt, Komi, Erzya, Mari, Ossetic and Chechen
 leave `element-name` and `element-anion-name` out, so those 130 keys fall back
 to English and `lint:i18n` reports the gap. The first nine have no settled
 chemical nomenclature to seed from, and inventing one would be worse than the
@@ -120,7 +124,7 @@ Vietnamese school chemistry has moved from the transliterated names to the
 IUPAC forms, so in each case the fallback is already what the curriculum uses.
 The eight from the first sub-Saharan batch are that same case for a different
 reason: secondary science is taught in English, French or Afrikaans across all
-of them, so the fallback *is* the curriculum. Afrikaans and Swahili are the two
+of them, so the fallback _is_ the curriculum. Afrikaans and Swahili are the two
 of that batch that do have a settled list and supply it.
 
 The eight from the Southeast Asian and Pacific batch split three ways, and the
@@ -129,7 +133,7 @@ the language. Cebuano is the Filipino case again and for the same school
 system, and Malagasy the French-medium case; Samoan and Hawaiian have no
 settled list of all 118 to seed from, and neither does Māori, whose
 kura-taught science coins terms without having reached the whole table.
-Khmer, Lao and Sinhala are the one group where the language *does* have the
+Khmer, Lao and Sinhala are the one group where the language _does_ have the
 names — all three are taught chemistry in their own language, out of textbooks
 that print their own transcriptions — and what is missing is a convention this
 seed could reproduce rather than invent. An unreviewed guess written in a
@@ -150,7 +154,7 @@ Shona, Southern Sotho, Setswana, Tigrinya and Ganda — are partial too, and
 unlike the batches above them they split no ways at all: every one of the ten
 is the school-system case. Secondary science is taught in English across
 Ghana, Zimbabwe, Botswana, Lesotho, Uganda, Eritrea and Tigray, and in French
-across Senegal, Mali and both Congos, so in all ten the fallback *is* the
+across Senegal, Mali and both Congos, so in all ten the fallback _is_ the
 curriculum. That is a fact about ten education ministries rather than about ten
 languages, which is why it reads as one sentence here and takes a sentence of
 its own in each catalog's header.
@@ -162,7 +166,7 @@ textbooks, Asturian out of Spanish, Sardinian and Sicilian out of Italian,
 Western Frisian out of Dutch, Low German and Luxembourgish out of German —
 Luxembourg's upper grades in French as well — and Romansh-medium schooling
 stops below the grades where the periodic table is taught. Northern Sami is the
-one of the eleven where the schooling *is* in the language and the table still
+one of the eleven where the schooling _is_ in the language and the table still
 does not settle: a Sami pupil meets the Norwegian, Swedish or Finnish names
 depending on which side of a border the school is, and those three differ, so
 choosing any of them would report a fact about a border. Yiddish has the
@@ -187,7 +191,7 @@ Mexico, Guatemala, Chile and Argentina — and Haitian Creole out of French ones
 Every one of those seven reaches real classrooms, and Guarani reaches further
 than any other language in the batch, being co-official in Paraguay; but
 bilingual education in all seven is the primary grades and the language
-classroom, and secondary chemistry is not. So in all seven the fallback *is* the
+classroom, and secondary chemistry is not. So in all seven the fallback _is_ the
 curriculum, which is the same sentence the two sub-Saharan batches earned and
 for the same reason.
 
@@ -210,7 +214,7 @@ case — the Philippines from the intermediate grades, Guam and the Northern
 Marianas, Papua New Guinea — which is the `fil` and `ceb` case those two
 catalogs already record. Balinese, Minangkabau, Acehnese and Madurese are the
 Indonesian-medium case, and they differ from `jv` and `su` in an instructive
-way: those two *supply* the Indonesian names, because their own vocabulary for
+way: those two _supply_ the Indonesian names, because their own vocabulary for
 the substances agrees with Indonesian's often enough that the table reads as
 theirs. These four do not, and copying it whole would be neither language —
 Minangkabau says «ameh» where Indonesian says «emas» — so where `jv` and `su`
@@ -232,10 +236,10 @@ every shape the batches above them found, arriving together for the first
 time. Maithili, Bhojpuri, Konkani, Dogri, Manipuri, Kashmiri and Dzongkha are
 the school-system case, in six different school systems: secondary science is
 Hindi-, Nepali-, English-, Marathi- or Urdu-medium depending on the state or
-the country, so in all seven the fallback *is* the curriculum, and `locales/hi`,
+the country, so in all seven the fallback _is_ the curriculum, and `locales/hi`,
 `locales/ne`, `locales/mr` and `locales/ur` are the parallel texts each header
 names. Bodo and Sanskrit are the Samoan case: Bodo-medium schooling in Assam
-*does* run to the secondary grades, and Sanskrit has words for the metals it
+_does_ run to the secondary grades, and Sanskrit has words for the metals it
 knew, but neither has a settled list of all 118 to seed from. Santali is the
 Ojibwe shape — schooling in it stops below the grades where the table is
 taught, and no table waits on the other side — and Dhivehi is `locales/to`'s and
@@ -260,7 +264,7 @@ taught in English or Afrikaans in South Africa, English in Eswatini, Kenya and
 Zambia, Portuguese in Mozambique, French in the Central African Republic and
 across Fula's whole range but Nigeria, and Arabic and French in Morocco and
 Algeria, where Amazigh is taught as a subject rather than used as a medium. So
-in all twelve the fallback *is* the curriculum. That is a fact about those
+in all twelve the fallback _is_ the curriculum. That is a fact about those
 school systems rather than about twelve languages, which is why it reads as one
 paragraph here and takes a sentence of its own in each catalog's header.
 
@@ -483,7 +487,7 @@ itself, CLDR has no Corsican-language data to answer with, and the fallback is
 English — so `endonym` equals `englishName`, the label drops its parenthesis,
 and the roster reads "Corsican" once rather than "Corsican (Corsican)". It is
 not the first to do that: `ak`, `ceb`, `fil`, `hnj`, `mg`, `mi`, `ny` and `sm`
-already read that way, and so do the several whose endonym genuinely *is* the
+already read that way, and so do the several whose endonym genuinely _is_ the
 English word — Afrikaans, Hausa, Igbo, Wolof. Nothing here hand-writes around
 either case, which is why the rule that makes `ny` read "Nyanja" is the rule
 that makes this read "Corsican".
@@ -493,7 +497,7 @@ than one individual language**, and doing so uncovered a real fallback bug rathe
 than merely needing a note.
 
 `qu`, `ay`, `gn` and `oj` are ISO 639-3 macrolanguages and `nah` is an ISO 639-3
-*collection* code: each covers a family of individual languages with codes of
+_collection_ code: each covers a family of individual languages with codes of
 their own. **CLDR's likely-subtags folds exactly one member of a macrolanguage to
 it and leaves the rest unresolvable.** So `quz` reached `qu` on ICU data alone
 and `quh` did not; `ojg` reached `oj` and `ojb` did not; `gug` reached `gn` and
@@ -519,7 +523,7 @@ too.
 
 Serving a related variety is a real compromise, and each of these catalogs says
 in its own header which written standard it is: Southern Quechua in the
-trivocalic orthography, Paraguayan Guarani in the *jopara* register, Central
+trivocalic orthography, Paraguayan Guarani in the _jopara_ register, Central
 Nahuatl in the SEP/INALI orthography, Ojibwe in the Fiero double-vowel
 orthography, Mapudungun in the Alfabeto Mapuche Unificado — which is a choice
 among three live orthographies rather than a neutral default, and its header says
@@ -576,14 +580,14 @@ untouched.
 Twelve languages, and the thing they add to this file is not any one of them
 but the **five Devanagari catalogs that answer the agreement question three
 different ways**. Sanskrit selects on `$gender` and `$role` and inflects for
-gender, number *and* case; Konkani selects on both with Marathi's three
+gender, number _and_ case; Konkani selects on both with Marathi's three
 genders; Dogri selects on `$gender` alone; Maithili and Bhojpuri select on
 neither. Hindi, Marathi and Nepali were already three more answers in the same
 letters. **A script says nothing about the fork**, which is the sharpest
 statement of that this repository has, and `styleDescriptions.test.ts` pins all
 five side by side so it cannot quietly stop being true.
 
-Dogri is the one worth reading closely, because it is *not* a claim that Dogri
+Dogri is the one worth reading closely, because it is _not_ a claim that Dogri
 does not inflect. Its masculine -आ adjectives take an oblique; none of the three
 clause positions reaches it, because the border and background are feminine and
 the text colour is a direct masculine. A `$role` branch would render what the
@@ -603,7 +607,7 @@ Hebrew's eight. **Tibetan and Dzongkha are the opposite extreme**: ICU reports
 exactly one category for each, so no message in either can select on a count and
 every counted message in both is written flat, the way `locales/ja` and
 `locales/th` write theirs. The `[0]` branches that survive are matched by
-*number* rather than by category — Fluent resolves an explicit number before it
+_number_ rather than by category — Fluent resolves an explicit number before it
 consults the plural rules, which is why a wording for none is still reachable.
 
 Three catalogs put their adjectives **after** the noun — Meitei and both
@@ -615,7 +619,7 @@ split is the shape of the complement, not the side the adjectives sit on.
 `bo` and `dz` are two directories rather than one with a script tag, and it is
 the `hr`-against-`sr` case a fifth time: two standard languages, two
 vocabularies, one script. `locales/dz` writes ཧོནམ where `locales/bo` writes
-སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for *opposite*
+སྔོན་པོ, and སྦོམ where it writes མཐུག་པོ. They are also partial for _opposite_
 reasons — see the chemistry paragraph above — which is the neatest illustration
 in the roster that the gap is a fact about a school system rather than about a
 script.
@@ -657,7 +661,7 @@ filled in with the real genders anyway, so that a speaker adding the fork has
 the table already and need only write the feminine forms. And `locales/dv` puts
 `piecewise-condition-if` on the wrong side of the mathematics: Dhivehi's
 conditional particle «ނަމަ» is clause-final and the renderer places that key
-*before* what it introduces, which no wording in the catalog can fix. That is
+_before_ what it introduces, which no wording in the catalog can fix. That is
 the `locales/tpi` shape — a distinction the composition messages do not expose
 — and splitting the key into a prefix and a suffix is a change to the worker
 that no existing catalog needs and this one would use.
@@ -676,7 +680,7 @@ any of the ten and get prose in it. (South African Sign Language, official
 since 2023, is the eleventh and has no written form to seed.)
 
 **Six more Bantu catalogs take the noun-class group from ten to sixteen**, and
-the thing they add is how *unevenly* a class concord lands. `locales/ts` is the
+the thing they add is how _unevenly_ a class concord lands. `locales/ts` is the
 case worth reading: Xitsonga has very few true adjectives, and almost
 everything English calls one is a noun joined with a possessive concord — so
 the class fork falls on «-kulu», «-tsongo» and the passive «-tateriwaka» and on
@@ -693,8 +697,8 @@ agrees with its noun's class through a **suffix**: «ɓaleewol» against a `ngol
 noun, «ɓaleere» against a `nde` one. `$gender` is a token set and nothing
 outside a catalog reads its values, so the argument needed no widening to reach
 a suffix any more than it needed widening to reach a noun class — which is the
-cleanest demonstration this file has that the mechanism is about *what a word
-agrees with* rather than about gender, prefixes, or Bantu.
+cleanest demonstration this file has that the mechanism is about _what a word
+agrees with_ rather than about gender, prefixes, or Bantu.
 
 **Luo and Sango select on neither argument, and they sit between catalogs that
 select on three classes each.** Dholuo is Nilotic and Sango Ubangian; neither has
@@ -702,7 +706,7 @@ gender or noun classes, and `locales/ki` and `locales/bem` on either side of
 them fork on `c3`, `c7` and `c9`. A region says as little about agreement
 as a script does. `locales/luo` adds one thing of its own: its relative
 particle «ma-» is written onto the front of the colour, including when the
-colour is a placeable, which makes it the roster's first *prefix* welded
+colour is a placeable, which makes it the roster's first _prefix_ welded
 onto a value the catalog never sees. That is sound for `locales/tlh`'s reason —
 «ma-» has one shape and never assimilates — and its header records the one case
 that would break it.
@@ -865,13 +869,13 @@ Ten of the eleven are the school-system case, in two mediums across eleven
 countries rather than one: English in Ghana, Nigeria and Uganda, French in
 Burundi, Burkina Faso, Côte d'Ivoire and both Congos, and English or French
 depending on the country for Kanuri, which spans four. So in all ten the
-fallback *is* the curriculum, which is a fact about those education ministries
+fallback _is_ the curriculum, which is a fact about those education ministries
 rather than about ten languages.
 
 **Mandinka is the eleventh and the one claim of a different kind.** It is
 spoken across three countries with three different mediums of secondary
 instruction — English in the Gambia, French in Senegal, Portuguese in
-Guinea-Bissau — so there is no one curriculum for a fallback to *be*, and
+Guinea-Bissau — so there is no one curriculum for a fallback to _be_, and
 choosing any of the three would report which side of which border a reader's
 school is on. `locales/se` reached exactly that place between Norway, Sweden
 and Finland; this is the Northern Sami case in West Africa, and it is the first
@@ -880,7 +884,7 @@ time a batch's chemistry paragraph has split since the South Asian one.
 ### The batch continued: a creole beside its lexifier
 
 Kongo, Fon, Nigerian Pidgin, Krio, Kabiyè and Temne — six more from the same
-region, and where the eleven above were arranged around *where* a language puts
+region, and where the eleven above were arranged around _where_ a language puts
 its agreement, these six are arranged around a sharper question: **what can you
 learn from two catalogs that you cannot learn from either one alone?**
 
@@ -894,12 +898,12 @@ that «ya» turns out to be Kongo's class-9 row, frozen. The whole of the
 agreement in `locales/kg` is that one syllable, and the describing stem behind
 it never moves:
 
-| class | linker | black         | thick       |
-| ----- | ------ | ------------- | ----------- |
-| 5     | dya    | dya ndombe    | dya nene    |
-| 7     | kya    | kya ndombe    | kya nene    |
-| 9     | ya     | ya ndombe     | ya nene     |
-| 11    | lwa    | lwa ndombe    | lwa nene    |
+| class | linker | black      | thick    |
+| ----- | ------ | ---------- | -------- |
+| 5     | dya    | dya ndombe | dya nene |
+| 7     | kya    | kya ndombe | kya nene |
+| 9     | ya     | ya ndombe  | ya nene  |
+| 11    | lwa    | lwa ndombe | lwa nene |
 
 Putting `color.black` in the two files side by side is the shortest statement of
 what a creole did to its lexifier that this repository can make, and it cost
@@ -929,7 +933,7 @@ in Kabiyè, and as a separate word between the two in Tiv. Three positions, one
 argument, no change to anything outside those files.
 
 **`tem` is the one that can be checked without knowing the language.** Temne's
-concord is *alliterative*: the describing word takes the same prefix the noun
+concord is _alliterative_: the describing word takes the same prefix the noun
 itself carries, so a rendered description reads «kʌlayn kʌbana-bana kʌbana» —
 the same syllable three times. In every other noun-class catalog here the
 concord and the noun's own prefix are different morphs, and `noun-gender` has to
@@ -954,15 +958,15 @@ the map lists them, and `kng` because ICU already folds it.
 
 **`ktu` is deliberately absent from that list**, and it is the one exclusion
 here that is not simply "it has a catalog of its own" — though it does. Kituba
-is a creole *of* Kikongo rather than a variety of it, ISO 639-3 gives it a code
+is a creole _of_ Kikongo rather than a variety of it, ISO 639-3 gives it a code
 outside `kg`, and folding it would serve a Kituba reader a different language.
 `mkw`, Kituba of the Republic of the Congo, is left to miss for the same reason;
 answering it with `ktu` would be defensible and is not a membership fact, so it
-is not done. `negotiate.test.ts` asserts the exclusion on the *un-normalized*
+is not done. `negotiate.test.ts` asserts the exclusion on the _un-normalized_
 tag, which is the only form the mistake would be visible in.
 
 **`son` is the road not taken, and the test says why.** It is the macrolanguage
-over the Songhay varieties, and it is *not* aliased the way `man` was, because
+over the Songhay varieties, and it is _not_ aliased the way `man` was, because
 the justification `man`'s entry rests on does not exist here:
 `new Intl.Locale("son").maximize()` adds no region, so CLDR has no opinion about
 which variety a bare `son` means. Picking one would be the judgement these maps
@@ -980,7 +984,7 @@ again, and it is not an error.
 All six leave `element-name` and `element-anion-name` out. Four are the ordinary
 school-system case — the DRC, Benin and Togo teach secondary science in French,
 Sierra Leone in English — but `pcm` and `kri` are a shape no earlier batch had.
-Their lexifier *is* English, so the fallback is not merely the curriculum, it is
+Their lexifier _is_ English, so the fallback is not merely the curriculum, it is
 very nearly the language: filling those 130 keys in would produce entries
 character-identical to `locales/en` and claim a translation that had not
 happened. Leaving the gap visible is the honest answer, and it is the
@@ -998,10 +1002,10 @@ class system, spoken next door to one another — and Umbundu prefixes the class
 straight onto the describing stem while Kimbundu leaves the stem alone and moves
 an agreeing connective in front of it:
 
-| | line (c9) | circle (c7) | point (c5) |
-| --- | --- | --- | --- |
-| `umb` | ongoli **yi**nene | ocilinganya **ci**nene | ondimbu **li**nene |
-| `kmb` | nlonji **ya** nene | kizenge **kya** nene | kimbanza **kya** nene |
+|       | line (c9)          | circle (c7)            | point (c5)            |
+| ----- | ------------------ | ---------------------- | --------------------- |
+| `umb` | ongoli **yi**nene  | ocilinganya **ci**nene | ondimbu **li**nene    |
+| `kmb` | nlonji **ya** nene | kizenge **kya** nene   | kimbanza **kya** nene |
 
 And Kimbundu's mechanism is `locales/kg`'s exactly — an agreeing «-a»
 connective a thousand kilometres north, in another country, differing only in
@@ -1013,7 +1017,7 @@ which makes it a fact about Bantu rather than about creolization.
 
 **`men` is the clearest instance of the affix rule in the tree.** Mende's
 definite marker is a suffix that attaches not to the noun but to whichever word
-*ends* the noun phrase, and a describing word follows its noun here — so a style
+_ends_ the noun phrase, and a describing word follows its noun here — so a style
 description ends in a placeable, and «{ $color }i» is exactly what
 [An affix cannot be welded to a placeable](#an-affix-cannot-be-welded-to-a-placeable)
 forbids. The catalog therefore leaves **every describing word indefinite**, so
@@ -1040,14 +1044,14 @@ for the readers.
 
 #### Negotiation: a second member-shaped macrolanguage, and a road still not taken
 
-`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a *member*
+`dje` joins `MACROLANGUAGE_MEMBERS` in the shape `mnk` introduced — a _member_
 catalog carrying its siblings, rather than a macrolanguage carrying its members.
 `ddn`, `hmb`, `khq`, `ses`, `tda` and `twq` reach Zarma, and ICU folds none of
 them on its own, so every one of those six depends on the entry existing.
 
 **`son` is still not aliased**, and that is the half worth reading. #1686
 recorded the reason when no Songhay catalog existed; Zarma's arrival makes the
-alias *possible* and no more justified. `man` earns its alias because CLDR
+alias _possible_ and no more justified. `man` earns its alias because CLDR
 decides for itself which member a bare macrolanguage means —
 `new Intl.Locale("man").maximize()` is `man-Latn-GM`, Mandinka's country.
 `new Intl.Locale("son").maximize()` adds no region at all, so CLDR has no
@@ -1061,7 +1065,7 @@ reader CLDR expects in Tifinagh is served Latin. That is `locales/kr`'s
 asymmetry with `kby` in Ajami and `locales/ff`'s in Adlam, and the answer is a
 second catalog rather than a change here.
 
-Three codes came *off* negative-control lists this batch — `men`, `umb` and
+Three codes came _off_ negative-control lists this batch — `men`, `umb` and
 `kmb` were all asserted to fall to English until they got catalogs of their own.
 That is the only thing that should ever shorten such a list, and `nyn` set the
 precedent two batches ago.
@@ -1098,19 +1102,19 @@ the translation dropped (`attract-to-without-nearest-point` and its two
 that changed which claim it made ("will **always** match a blank" became
 "matches **only** a blank"), a complaint that reversed
 (`function-domain-insufficient-dimensions` read "dimensions are not
-*required*"), and buttons whose word belonged to a different control — the
+_required_"), and buttons whose word belonged to a different control — the
 orbital spin arrows were labelled with `umb`'s, `kmb`'s and `dje`'s word for
-*point*, three lines from a real points control.
+_point_, three lines from a real points control.
 
 **What review deliberately did not fix is the larger finding**, and it is a
 limit of seeding rather than a bug in these four. Each catalog spreads one
-word across several English concepts that the UI shows *at the same time*:
-`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry *variant*,
-*version*, *type* and *style* together, and `men`'s «wotela» carries
-*variant*, *version* and *variable*, so in all four the editor's version
+word across several English concepts that the UI shows _at the same time_:
+`umb`'s «ocituwa», `kmb`'s «kifwa» and `dje`'s «dumi» each carry _variant_,
+_version_, _type_ and _style_ together, and `men`'s «wotela» carries
+_variant_, _version_ and _variable_, so in all four the editor's version
 footer and its variant picker are labelled identically. Three of the
-four also head the feedback panel with their word for *answer*, and all four
-use one noun for both *viewer* and *renderer*, so the whole-page failure and
+four also head the feedback panel with their word for _answer_, and all four
+use one noun for both _viewer_ and _renderer_, so the whole-page failure and
 the one-component failure read alike. Separating these needs new words chosen
 by someone who speaks the language; picking them here would be the
 substitution the chemistry tables are left out to avoid. They are named here
@@ -1144,7 +1148,7 @@ branches — Central Mande, and two Southwestern Mande sisters) fork on neither
 already made to seven Mande catalogs in a row; `kpe` and `lom` go further
 than `sus` by lacking even a definite or qualifier suffix, so Southwestern
 Mande genuinely marks nothing where Central Mande and Manding each mark one
-thing. `ewo` and `bum` are the pair that shows agreement can be *present* and
+thing. `ewo` and `bum` are the pair that shows agreement can be _present_ and
 still not written down: both are Beti-Pahuin Bantu with a real class-concord
 system, but `bum`'s header commits to two classes (`c1`/`c7`) it found enough
 colour-stem data to write with confidence, while `ewo`'s header explains why
@@ -1222,9 +1226,144 @@ Guinea depending on which is meant (`bci`, `sus`). `lom` is the one worth a
 sentence of its own: Loma is spoken across a border where the two sides teach
 science in different languages entirely — English in Liberia, French in
 Guinea — so, as `locales/mnk` and `locales/se` already established for a
-border of their own, there is no single curriculum for a fallback to *be*, and
+border of their own, there is no single curriculum for a fallback to _be_, and
 leaving both keys out serves each side of the border the same way English
 already partially does for the Liberian half.
+
+### Twelve Cyrillic catalogs, and the one that forks
+
+Bashkir, Chuvash, Yakut, Tuvan, Buryat, Kalmyk, Udmurt, Komi, Erzya, Mari,
+Ossetian and Chechen — twelve catalogs from **five families** (Turkic: `ba`,
+`cv`, `sah`, `tyv`; Mongolic: `bua`, `xal`; Uralic: `udm`, `kv`, `myv`, `chm`;
+Iranian: `os`; Nakh: `ce`), all written in Cyrillic, all spoken inside the
+Russian Federation. It is the roster's first batch whose whole membership
+shares a **script** without sharing a family, and that is what makes it useful:
+every question the earlier batches asked about what a family or a region
+predicts can be asked here about a script, and the answer is the same.
+
+**Eleven of the twelve select on neither `$gender` nor `$role`, and the twelfth
+forks.** Turkic, Mongolic, Uralic and Iranian all answer the agreement question
+with a flat "no": no grammatical gender, no inflected attributive adjective, so
+`noun-gender` returns one token and no message forks on it. `locales/ce` is
+Nakh, and Chechen has a real class system — nouns fall into classes marked by
+в-, й-, б- and д-, and an agreeing word carries the class at the _front_. So
+`locales/ce` writes a class table and forks `style-filled-word` and
+`style-unfilled` on it. One script, twelve catalogs, one fork: a script says as
+little about agreement as a family or a region does, which is the sentence
+`locales/ts` and `locales/ktu` earned inside Bantu and this batch earns across
+five families at once.
+
+**`locales/ce`'s header is honest about which half of its fork it can vouch
+for.** The four class markers and the agreeing participle are what this seed
+could check; the class of every individual geometric noun is what it could not,
+so `noun-gender` lists the entries it is confident of and defaults the rest to
+`d`. That is `locales/ewo`'s judgement — a partial, half-remembered class table
+is worse than an admitted gap — with the difference that the fork is written
+and waiting, so filling the table in costs a speaker one line per noun.
+
+**Two catalogs record a colour vocabulary that does not split where the style
+pipeline splits, and they are unrelated.** Sakha's «күөх» covers green and
+blue; Ossetian's «цъæх» covers green, blue _and_ grey. The style pipeline needs
+those as separate words, so both catalogs write the modern compounds that split
+them — «от күөх» and «халлаан күөҕэ» for Sakha, «кæрдæгхуыз» and «æрвхуыз» for
+Ossetian — and both headers say plainly that this is a choice rather than a
+translation. A Turkic language and an Iranian one, one problem, one shape of
+answer, and neither of them got it from the other.
+
+**`locales/sah` is the roster's first Turkic catalog with a single plural
+category.** `Intl.PluralRules("sah")` reports `other` and nothing else, so no
+message in it can select on a count and every counted message is written flat —
+the shape `locales/ja`, `locales/th`, `locales/bo` and `locales/dz` already
+have. The eleven catalogs beside it resolve `one` and `other`. Yakut marks a
+plural perfectly well; what it does not do is keep it after a numeral, so a
+category would have nothing to choose between.
+
+**`locales/cv` is the roster's second `zero` category, and it means the
+opposite of the first.** Latvian's `zero` covers every number ending in 0 and
+the whole of the teens; Chuvash's fires for exactly 0 and `one` for exactly 1,
+so 21 and 101 are `other` where Latvian's are `one`. Two languages, one
+category name, two rules — which is why `locales/cv`'s header spells out where
+its `[zero]` branch is genuinely reached (`answer-show-responses`, the two
+accessibility labels) and where the explicit `[0]` branch wins first
+(`attempts-remaining`).
+
+**Six catalogs record the same limit, and it is word order rather than family
+that decides which.** `piecewise-condition-if` is placed by the renderer
+_before_ the mathematics it introduces. Sakha's «буоллаҕына», Tuvan's «болза»,
+Udmurt's «ке», Komi's «кӧ» and Mari's «гын» all close the clause they condition,
+so all five headers record the `locales/dv` shape — a distinction the
+composition messages do not expose, which splitting the key into a prefix and a
+suffix would fix and which no existing catalog needs. Buryat's «хэрбээ»,
+Kalmyk's «кемр», Erzya's «бути», Ossetian's «кæд» and Chechen's «нагахь санна»
+are clause-initial and land correctly. Two Turkic catalogs on opposite sides of
+that line, two Uralic on one side and one on the other: the wall is syntax, not
+ancestry.
+
+#### Negotiation
+
+**Three of the twelve are ISO 639-3 macrolanguages, which is the most any one
+batch has added to `MACROLANGUAGE_MEMBERS`.** `bua` stands over Russia (`bxr`),
+Mongolia (`bxm`) and China (`bxu`) Buriat; `kv` over Komi-Zyrian (`kpv`) and
+Komi-Permyak (`koi`); `chm` over Meadow (`mhr`) and Hill (`mrj`) Mari. In each,
+ICU folds exactly one member on its own — `bxr`, `kpv`, `mhr` — and the rest
+reach a catalog only because the map names them, which is the failure that map
+exists to prevent. Each catalog says in its own header which standard it is:
+Russia Buriat, Komi-Zyrian, Meadow Mari.
+
+`bxu` is the batch's **script debt** and is recorded rather than fixed: China
+Buriat maximizes to `bxu-Mong-CN`, so CLDR's own data says such a reader most
+likely arrives in the Mongolian script and what `locales/bua` gives them is
+Cyrillic. That is `locales/dje`'s debt to `tda` in Tifinagh and `locales/kr`'s
+to `kby` in Ajami, and the answer to it is a second catalog rather than a change
+in `negotiate.ts`.
+
+**The other nine filter unaided, so the batch adds no `LANGUAGE_ALIASES` entry
+at all**, and — for the first time in several batches — **no
+`LOCALE_NAME_FALLBACKS` entry either**: CLDR has an English name for every one
+of the twelve. Four of those names will look wrong and are not, the
+`ny`-reads-Nyanja rule again: `sah` renders as **Yakut**, `tyv` as
+**Tuvinian**, `bua` as **Buriat** and `os` as **Ossetic**, and each catalog's
+header says which language it is. `os` is also the one locale here whose
+maximization names a country outside Russia — `os-Cyrl-GE`, Georgia — which is
+CLDR's data rather than an error and costs negotiation nothing.
+
+`mdf` is the near miss worth naming, because it is the other half of a pair
+whose first half now has a catalog. Moksha and Erzya are two languages with two
+ISO 639-3 codes and no macrolanguage over them, so `locales/myv` can do nothing
+for a Moksha reader and must not pretend to — the rule working rather than a
+gap in it, exactly as `fat` and `alq` land. `krc`, `kum`, `nog`, `ady`, `kbd`,
+`av` and `sel` fall to English for the same reason, and `negotiate.test.ts`
+pins every one of them.
+
+#### The chemistry gap
+
+All twelve leave `element-name` and `element-anion-name` out, and — like the
+second sub-Saharan batch and the African and Berber one — they split no ways at
+all. Secondary chemistry across the Russian Federation is taught in Russian, so
+in all twelve the fallback _is_ the curriculum. That is a fact about one
+education system rather than about twelve languages, which is why it reads as
+one sentence here and takes a sentence of its own in each catalog's header.
+
+**`locales/tt` is the counter-example that decides it, and it sits in the same
+country.** Tatar supplies the whole table, because Tatar-medium chemistry
+teaching produced one; Bashkir, its nearest relative and neighbour, does not.
+Nothing about the two languages predicts that, which is `locales/af` against
+`locales/nso` in South Africa and `locales/sw` against `locales/ki` in Kenya,
+restated a third time in a third country. Copying the Russian list into Bashkir
+or Chuvash spelling would produce neither language — the argument `locales/min`
+already makes against copying Indonesian's table — which is the second half of
+why the gap stands.
+
+`locales/xal` gets a sentence of its own for a reason no other catalog in the
+batch has: **it is the least certain catalog here and says so in its own
+header.** Kalmyk is the most endangered language seeded in this batch, its
+written output is small, and its orthography drops unstressed vowels that
+Buryat and Mongolian write — so a word that looks like a typo beside
+`locales/bua` may well be correct and vice versa, which is exactly the class of
+error this seed is least able to check. `locales/lom` set the precedent for
+saying that in a file's own header rather than leaving a reader to discover it,
+and 118 unreviewed element coinages would have been the least defensible thing
+in the file.
 
 ### A language with no word for it
 
@@ -1234,7 +1373,7 @@ an ISO 639-3 code, so it filters like any other individual language, needs no
 entry in `LANGUAGE_ALIASES`, and belongs to no macrolanguage. `Intl` knows the
 English name, so the roster reads **Klingon** — once, not twice, because CLDR
 has no `tlh`-language data to answer the endonym with and the fallback is the
-English name. That is the `co` case, with the twist that Klingon *has* a
+English name. That is the `co` case, with the twist that Klingon _has_ a
 well-known endonym («tlhIngan Hol») and CLDR simply does not carry it.
 
 pIqaD is ISO 15924 `Piqd`, so `tlh-Piqd` is a well-formed tag and reaches the
@@ -1245,7 +1384,7 @@ pIqaD. Quenya (`qya`), Sindarin (`sjn`) and the ISO 639-2 collection code `art`
 all fall to English, which is the membership rule working rather than a gap in
 it — none of them is a member of `tlh`. `negotiate.test.ts` holds all of that.
 
-What *is* new is the **shape of the gap**. Every other partial catalog leaves
+What _is_ new is the **shape of the gap**. Every other partial catalog leaves
 out the chemistry tables because a school system teaches chemistry in another
 language; the language has the words and the seed has no settled list to copy.
 Klingon is the first partial for a lexical reason — its lexicon is closed, since
@@ -1258,7 +1397,7 @@ The line it draws is stated once in `content.ftl` and applied everywhere:
 > description, and is written. A new root is an invention, and is not.
 
 Under it «nagHom» — «nagh» (rock) with the canon diminutive — is a fair way to
-say *dot*, and a word for *parabola* is not a translation of anything. It is the
+say _dot_, and a word for _parabola_ is not a translation of anything. It is the
 argument `locales/oj` already makes about coining 118 element names, generalized
 from one table to a whole catalog.
 
@@ -1269,9 +1408,9 @@ has released a mathematics register over the years, well after TKD, so «mey'»
 (point), «baSta'» (vector) and «chav» (function) all exist and are all used. So
 are «wa'chaw» (table), «wev» and «war» (row and column), «tenwal» (page) and
 «vorgh» (be previous), each of which an earlier draft either coined around or
-left to English. What is genuinely absent is smaller and stranger: *parabola*,
-*polyline*, *curve* as a noun, and the vocabulary of a document editor —
-*attribute*, *variant*, *matrix*, *snippet*, *accessibility*. **The lesson
+left to English. What is genuinely absent is smaller and stranger: _parabola_,
+_polyline_, _curve_ as a noun, and the vocabulary of a document editor —
+_attribute_, _variant_, _matrix_, _snippet_, _accessibility_. **The lesson
 generalizes past Klingon: "this language has no word for X" is a claim about a
 word list, and it needs checking against the word list.**
 
@@ -1283,7 +1422,7 @@ four colour terms are TKD entries. Some are Okrand's own but were released at a
 `qep'a'` or `qepHom'a'` gathering or posted to the old `startrek.klingon`
 newsgroup: «meyrI'», «me'cheD», «baSta'», «chav» in its mathematical sense,
 «vorgh», «wa'chaw», «wev», «war», «tenwal» and «nItlh 'echlet» (keyboard). And
-three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a *single*
+three of the geometry nouns — «mey'», «ra'Duch», «letbaQ» — rest on a _single_
 relayed answer on the KLI mailing list, one post of 2014.01.27, with no second
 attestation; «ghantoH» (example) and «nompuq» (reference) are the same. All
 three classes are used and none is removed, but the catalogs mark the third
@@ -1294,7 +1433,7 @@ is still his, and what a reader has to go on is one paraphrase. Telling them
 which entries those are is what lets a speaker overrule the right ones.
 
 `.diamond` is the instructive omission, because it is not a lexical gap at all.
-Okrand's note on «chanmon» (the gemstone) says the diamond *shape* is «meyrI'»,
+Okrand's note on «chanmon» (the gemstone) says the diamond _shape_ is «meyrI'»,
 which the catalog already spends on `square`. Writing it would make a square
 marker and a diamond marker report identically — the one distinction a shape
 noun exists to carry — so the key falls back to English instead. That is the
@@ -1353,7 +1492,7 @@ every consumer whether or not anyone reads it, and no single language earns
 that. English is exempt because every fallback chain ends there: it has to be
 present with no network, in every bundling variant.
 
-Note that `content` and `diagnostics` answer to *different* settings —
+Note that `content` and `diagnostics` answer to _different_ settings —
 `documentLocale` and `uiLocale` respectively — which is why `WORKER_NAMESPACES`
 is `content` alone. The worker knows only the content locale, and needs only
 that: it renders `content` itself, but for a diagnostic it emits a code and the
@@ -1390,7 +1529,7 @@ would offer the author English and nothing else.
 
 Neither list is exhaustive from an author's point of view: a deployment can
 hand over catalogs of its own as `localeResources`, which no build-time list
-can know about. So the roster *suggests* and never *enforces* — `lang` accepts
+can know about. So the roster _suggests_ and never _enforces_ — `lang` accepts
 any BCP-47 tag, and an unlisted one draws no diagnostic.
 
 ## Delivery
@@ -1398,7 +1537,7 @@ any BCP-47 tag, and an unlisted one draws no diagnostic.
 A locale that is not inlined still has to reach the browser. `load.ts` does
 that, and the viewer calls it for you: `useLocaleCatalogs` (in
 `@doenet/doenetml`'s `utils/i18n.tsx`) loads the catalogs for whatever tags are
-in play and merges them *under* the host's `localeResources`, so a deployment
+in play and merges them _under_ the host's `localeResources`, so a deployment
 correcting a shipped translation still wins. Adding `locales/pt/` and running
 `npm run codegen` is therefore the whole job — no list of languages to register
 anywhere, and `documentLocale="pt"` and `<document lang="pt">` both work with
@@ -1430,17 +1569,17 @@ catalogs to get one.
 Where the catalogs come from depends on the build, and the difference is real
 rather than cosmetic:
 
-| Build                     | Mechanism                                              |
-| ------------------------- | ------------------------------------------------------ |
-| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog   |
-| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle       |
-| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`           |
+| Build                     | Mechanism                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| `@doenet/doenetml`        | `import.meta.glob` — one code-split chunk per catalog                               |
+| `@doenet/standalone`      | `fetch` from `locales/`, served beside the bundle                                   |
+| `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`                                        |
 | `@doenet/doenetml-iframe` | Neither: what renders inside its iframe is a standalone bundle, which loads its own |
 
 The glob is what makes adding a language cost a directory. It is also why the
 two single-file builds need a different answer: `inlineDynamicImports` folds
 every dynamic import back into the one output file, so code-splitting cannot
-keep catalogs out of them — and *being reachable is enough*, whether or not
+keep catalogs out of them — and _being reachable is enough_, whether or not
 anything calls it. Both therefore define `__DOENET_CODE_SPLIT_CATALOGS__`
 false, which makes the glob dead code. The standalone build then copies
 `locales/` into `dist/` (`copyLocaleCatalogsPlugin`) and installs
@@ -1552,7 +1691,7 @@ shared by every viewer on the page, which context cannot cross, so it takes a
 Prose the core computes — style descriptions today — is content, so it follows
 `documentLocale` and is built where the core builds everything else. The
 translator arrives as the value of the `translator` dependency, which is a
-*factory* keyed by locale rather than a translator: the catalogs are fixed for
+_factory_ keyed by locale rather than a translator: the catalogs are fixed for
 a core's lifetime but the locale is not, since a nested `<document lang>` can
 differ from the one around it. A definition takes the `locale` of the document
 it sits in — an ordinary ancestor dependency, alongside `theme` — and asks the
@@ -1587,7 +1726,7 @@ that cannot be translated word for word. English writes adjectives before the
 noun and inserts an article before "border"; Spanish writes them after and
 agrees them with the noun's gender. So each description is assembled by a
 message that receives the pieces as arguments plus a `$parts` argument naming
-*which* pieces are present, and every adjective is handed `$gender`. An absent
+_which_ pieces are present, and every adjective is handed `$gender`. An absent
 piece selects a different branch rather than substituting an empty string —
 that is what lets a translation reorder and re-punctuate each combination on
 its own terms.
@@ -1604,7 +1743,7 @@ its fifth is `c12` — «akadomo», the point, is a diminutive there, as it is i
 Ganda. The reachability rule applies to the class tokens exactly as it does to
 `$role`: a catalog writes a branch for a class only if its own `noun-gender`
 can answer that class. That is why Swahili and Nyanja carry `c6` — the plural
-class, which their word for *text* or *border* lands in — and the other
+class, which their word for _text_ or _border_ lands in — and the other
 seventeen do not, and why Venda, Tsonga, Kikuyu and Bemba stop at `c3`, `c7`
 and `c9`: no noun the core names is class 5 in any of the four, so the ḽi-,
 leri-, i- and ili- forms are named in those catalogs' headers rather than
@@ -1614,7 +1753,7 @@ written as branches nothing can select.
 `locales/ff` writes «ɓaleewol» against a `ngol` noun and «ɓaleere» against a
 `nde` one, so the same argument that reaches the front of a Bantu adjective
 reaches the back of a Fula one. Nothing outside the catalog changed to allow
-that, which is the point: what `$gender` names is *what a word agrees with*,
+that, which is the point: what `$gender` names is _what a word agrees with_,
 not where the agreement is spelled.
 
 **The Gur pair spells it the same way from a different family**, which is what
@@ -1626,12 +1765,12 @@ which nouns a catalog happens to name, not about a family, which is what the
 nineteen Bantu catalogs have been saying all along in a script where it is
 easier to miss.
 
-Both write the *juxtaposed* construction, where the noun keeps its own class
+Both write the _juxtaposed_ construction, where the noun keeps its own class
 suffix and each modifier agrees with it, rather than the compound one, where
 the noun drops to its bare stem and the last modifier carries the suffix alone.
 That is the affix rule below: the last element of a description is often a
 placeable, and a suffix cannot be welded to a word the catalog never sees. It
-is *choose the words that land there* applied to a whole construction rather
+is _choose the words that land there_ applied to a whole construction rather
 than to one word.
 
 **Tiv writes it as a word of its own, which is the third place it can go.**
@@ -1665,7 +1804,7 @@ words are rendered in two places each — a border's adjectives, the background
 colour, and the text colour beside it — once standing alone as a state
 variable reports them and once embedded in a clause, and a language that
 inflects for case wants a different form in each. So every adjective is handed
-`$role` as well, naming the *position* the phrase is going into rather than
+`$role` as well, naming the _position_ the phrase is going into rather than
 the case it takes: which case a position governs is the catalog's business,
 exactly as `$gender`'s token set already is. `locales/en/content.ftl` lists the
 positions, and `be`, `bs`, `cs`, `de`, `el`, `et`, `fi`, `fo`, `hi`, `hr`,
@@ -1697,7 +1836,7 @@ The **Celtic four** — `ga`, `gd`, `cy`, `br` — reach that same answer from t
 other end. They mark an adjective heavily, but by mutating the front of it
 rather than by inflecting the end: a feminine singular noun softens whatever
 follows it, so «dearg» is «dhearg» in Irish, «coch» is «goch» in Welsh, and
-«du» is «zu» in Breton. That trigger is the *noun*, and the noun's gender is
+«du» is «zu» in Breton. That trigger is the _noun_, and the noun's gender is
 already a token these messages carry — so all four select on `$gender` alone
 and none of them writes a `$role` branch. Welsh goes one step past the other
 three: a handful of its adjectives have a feminine form of their own before the
@@ -1717,8 +1856,8 @@ width first. Each of those says so above its own `style-stroke`, for the same
 reason.
 
 Basque is the clean case of the opposite: it has a great many cases and selects
-on neither argument, because a Basque case is a suffix on the *last word of the
-whole noun phrase*. What a position asks for lands on a word `locales/eu`
+on neither argument, because a Basque case is a suffix on the _last word of the
+whole noun phrase_. What a position asks for lands on a word `locales/eu`
 writes — «batekin», «planoarekin» — rather than on the adjective, so the
 description reads the same in all four positions.
 
@@ -1759,7 +1898,7 @@ verb, «'ej» between them, and stands the whole clause in front of the noun:
 an attested pattern, since no canon example chains three relative clauses, and
 the catalog's header says so. That puts Klingon on the prenominal
 side with the Philippine catalogs and Tok Pisin, for a reason none of them
-shares, and it is why the catalog needs no `$role` fork — the *position* is
+shares, and it is why the catalog needs no `$role` fork — the _position_ is
 handled by the message that composes the phrase rather than by the word inside
 it, so its tables can hold bare verbs that double as the citation form a state
 variable reports.
@@ -1797,10 +1936,10 @@ the order of the adjectives, and `styleDescriptions.test.ts` pins both halves.
 Two further Fluent constraints shaped it, and both are easy to rediscover the
 hard way:
 
-- **A word that inflects has to be passed in, not referenced.** A *term*
+- **A word that inflects has to be passed in, not referenced.** A _term_
   reference cannot carry a runtime value — `{ -filled(gender: $gender) }` does
   not parse (`E0014 Expected literal`), and `{ -filled }` gets an empty scope
-  and always picks its default variant. A *message* reference does inherit the
+  and always picks its default variant. A _message_ reference does inherit the
   caller's arguments, but references never cross a bundle boundary: a locale
   that translates `style-filled` and not `style-filled-word` would render the
   literal `{style-filled-word}` rather than falling back to English. So the
@@ -1809,9 +1948,9 @@ hard way:
 - **A multiline pattern keeps its newlines.** Continuing a variant onto a
   further line puts a `\n` in the rendered string — including when that line
   opens a nested select. Keep each variant's content on one line; a select
-  nested *within* that line is fine, and is how a message would sub-divide one
+  nested _within_ that line is fine, and is how a message would sub-divide one
   of its variants. The same rule catches a subtler mistake: a `#` line indented
-  *under* a message is not a comment, it is more of the pattern above it, so a
+  _under_ a message is not a comment, it is more of the pattern above it, so a
   note explaining a wording choice has to sit above the message rather than
   beside the attribute it explains. `lint:i18n` fails on any pattern that
   renders a line break, which is what makes both of these findable before a
@@ -1825,30 +1964,30 @@ writing direction — it turned up first in Arabic and Uyghur and then in
 Hungarian, Finnish, Czech, Slovak and Romanian.
 
 A placeable is a value the catalog never sees. So a message may not depend on
-what that value turns out to *be*:
+what that value turns out to _be_:
 
-| The catalog wants | The language | Why it cannot |
-| --- | --- | --- |
-| a case ending on the value | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
-| the definite article on the value | `ro`, `men` | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai» |
-| a preposition before the value | `cs`, `sk` | «v»/«ve» and «s»/«se» vocalize according to what follows |
-| a compound with the value | `fi` | Finnish writes a compound as one word |
-| a case particle after the value | `bo`, `dz` | the particle has four shapes, picked by the final letter of the syllable before it |
-| the annexed state on the value | `kab`, `zgh`, `shi` | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest» |
+| The catalog wants                 | The language                       | Why it cannot                                                                              |
+| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| a case ending on the value        | `ar`, `ug`, `hu`, `fi`, `ta`, `te` | the ending is welded to the word, and vowel harmony or the final consonant picks its shape |
+| the definite article on the value | `ro`, `men`                        | the article is a suffix — «secțiune» → «secțiunea», «wa» → «wai»                           |
+| a preposition before the value    | `cs`, `sk`                         | «v»/«ve» and «s»/«se» vocalize according to what follows                                   |
+| a compound with the value         | `fi`                               | Finnish writes a compound as one word                                                      |
+| a case particle after the value   | `bo`, `dz`                         | the particle has four shapes, picked by the final letter of the syllable before it         |
+| the annexed state on the value    | `kab`, `zgh`, `shi`                | a Berber noun changes its initial vowel after a preposition — «tawinest» → «n twinest»     |
 
 Adjacency is not the problem. `{ $numSides }-kulmio` is correct Finnish for
 every side count, because `-kulmio` is the same whatever number lands in front
-of it. What cannot be written is *agreement* with an unknown word.
+of it. What cannot be written is _agreement_ with an unknown word.
 
 **Tibetan and Dzongkha are the table's sharpest entry, and the way out they
-take is the fifth one.** A Tibetan case particle is chosen by the *final letter
-of the syllable before it*: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
+take is the fifth one.** A Tibetan case particle is chosen by the _final letter
+of the syllable before it_: the agentive is གིས་, ཀྱིས་, གྱིས་ or ཡིས་ and the
 genitive གི་, ཀྱི་, གྱི་ or ཡི་. Beside a placeable there is no syllable to
 look at. So `bo/content.ftl` and `dz/content.ftl` — the two files that
-*compose* a phrase, and so the two that get to choose their particles — use
+_compose_ a phrase, and so the two that get to choose their particles — use
 only the ones that have a single shape: དང་ for accompaniment, ལ་ (Dzongkha
-ལུ་) for location, ནང་ for containment. That is *prefer the free allomorph
-over the bound one* applied to a particle rather than to a prefix, and the
+ལུ་) for location, ནང་ for containment. That is _prefer the free allomorph
+over the bound one_ applied to a particle rather than to a prefix, and the
 third family to take that way out, after Kʼicheʼ and the Bisayan catalogs.
 
 **The other three files in each are where the way out runs out**, and it is
@@ -1876,7 +2015,7 @@ this rule and the third way out below to come off. Its adjectives follow the
 noun and the izafat links them, and unlike Persian's — an unwritten vowel after
 a consonant, which is why `locales/fa` lets the space carry it — Tajik's is
 written, as «-и». So `locales/tg` writes `{ $noun }и { $description }`, welding
-an affix onto a value whose *form* the value decides, which nothing else here
+an affix onto a value whose _form_ the value decides, which nothing else here
 does — the hyphenated endings `locales/hy` and `locales/ka` put on an
 identifier are welds too, but each has one shape whatever precedes it, so they
 fall under the paragraph above rather than this one. What makes Tajik's sound is
@@ -1914,13 +2053,13 @@ There are five ways out, and every catalog here takes one of them:
 
 **The three Berber catalogs sharpen the third of those into something new: make
 the position uniform, and one written form is right in all of them.** A Berber
-noun after a preposition goes into the *état d'annexion*, and `$pattern` is a
+noun after a preposition goes into the _état d'annexion_, and `$pattern` is a
 noun these catalogs never see — so no branch can inflect it. What they do
 instead is arrange that every one of the four places a fill pattern is placed
-puts it behind the *same* preposition «s», including `style-fill`, where
+puts it behind the _same_ preposition «s», including `style-fill`, where
 English has no preposition at all. `fill-style` then writes its words already
-annexed and cannot be wrong anywhere. That is *choose the words that land
-there* with the extra step of choosing how many positions there are to choose
+annexed and cannot be wrong anywhere. That is _choose the words that land
+there_ with the extra step of choosing how many positions there are to choose
 for, and `styleDescriptions.test.ts` pins two of the four so that a branch
 dropping the preposition fails rather than quietly producing an unannexed noun.
 
@@ -1928,7 +2067,7 @@ The same three catalogs also settle a question the affix table can otherwise
 make look decided: **an alternation that a clause position triggers is not
 automatically a `$role` fork.** The annexed state is exactly the kind of thing
 `$role` exists for, and all three select on `$gender` alone — because the state
-falls on the *noun*, and every noun a clause position lands on is one the
+falls on the _noun_, and every noun a clause position lands on is one the
 catalog writes out. A `$role` branch would render what the `$gender` branch
 underneath it already renders, which is `locales/gu`'s trap reached from
 Afro-Asiatic.
@@ -1940,7 +2079,7 @@ out right for `locales/tlh`'s reason rather than by luck — «ma-» has one sha
 and assimilates to nothing — and it is written on the colour arguments alone
 (`$color`, and `$background` beside it in `style-text`), because `line-width`
 and `line-style` write their words already marked and would come out doubled;
-so the table above stays a list of languages whose endings *change shape*, and
+so the table above stays a list of languages whose endings _change shape_, and
 gains a language whose beginnings do not.
 
 A select whose variants would land against such an affix carries the affix into
@@ -1957,23 +2096,23 @@ Czech turns up here as a ligature.
 `locales/ceb` and `locales/fil` reached it first and one at a time: Cebuano's
 header calls writing the uncontracted «nga» everywhere "the one place this seed
 is deliberately stiff", and `fil` escapes the ligature outright by selecting on
-the side count, whose two CLDR plural categories *are* its two linkers. What the
+the side count, whose two CLDR plural categories _are_ its two linkers. What the
 Austronesian batch adds is the five Philippine catalogs side by side, which is
 what shows that they do not all resolve it the same way:
 
-| | The linker | Decided by | Resolution |
-| --- | --- | --- | --- |
+|              | The linker    | Decided by             | Resolution                                                   |
+| ------------ | ------------- | ---------------------- | ------------------------------------------------------------ |
 | `war`, `hil` | «nga» / `-ng` | the word **before** it | write the free «nga», which is grammatical in both positions |
-| `ilo` | «a» / «nga» | the word **after** it | no invariant form exists; write «a» and name the exception |
-| `pam` | «a» / `-ng` | the word **before** it | no invariant form exists; write «a» and name the exception |
-| `bik` | «na» / `-ng` | the word **before** it | no invariant form exists; write «na» and name the exception |
+| `ilo`        | «a» / «nga»   | the word **after** it  | no invariant form exists; write «a» and name the exception   |
+| `pam`        | «a» / `-ng`   | the word **before** it | no invariant form exists; write «a» and name the exception   |
+| `bik`        | «na» / `-ng`  | the word **before** it | no invariant form exists; write «na» and name the exception  |
 
 Two of the five escape it outright, which is the useful half: Bisayan «nga» is a
 free word in both positions, so writing it out is not a compromise but the form
 that can be written without knowing what stands beside it — the move `locales/ceb`
 already makes, and the same move `locales/quc` makes when it writes the free
 relational «rech» instead of the possessive prefix «u-»/«r-». That is the fifth
-way out listed above — *prefer the free allomorph over the bound one* — and it
+way out listed above — _prefer the free allomorph over the bound one_ — and it
 is stated as a rule here because three families now take it: the Bisayan
 catalogs, Kʼicheʼ, and the two Tibetan-script ones, which reach it for a case
 particle rather than for a linker.
@@ -2111,7 +2250,7 @@ A code is a permanent name — what a bug report cites, what a host reading
 `setDiagnosticsCallback` can filter on, and the anchor a documentation page
 will hang off (#1548). It rides on the record, and on the LSP `code` field for
 a positioned diagnostic — with the arguments alongside it in `data.args`, since
-a code names a message *template* and it takes both to say which occurrence of
+a code names a message _template_ and it takes both to say which occurrence of
 it this is. That pair is how the language server's `dedupeLspDiagnostics`
 recognizes two renderings of one diagnostic without comparing their text.
 Nothing renders the code itself yet, so the codes earn their keep as an
@@ -2123,7 +2262,7 @@ fails if one is renumbered, reused, or dropped from the registry. Retire a code
 in place; never recycle it.
 
 The lock is a committed file, not a service, so it enforces the contract only
-against the registry — deleting a code's line from *both* files in one change
+against the registry — deleting a code's line from _both_ files in one change
 passes the lint, exactly as deleting a `package-lock.json` entry does. That is
 what makes the lock worth reviewing: a diff that removes or edits an existing
 line, rather than only adding one at the end, is the thing to refuse.
@@ -2135,7 +2274,7 @@ severity — the emitting call site chooses the record's `type`.
 Two branches that each claim the next number collide in both the registry and
 the lock, which is the intended outcome: neither file can be auto-merged, so
 the conflict is resolved by hand. Give the later branch the next free number in
-*both* files — the lock is sorted by code, so its entry moves with it, and the
+_both_ files — the lock is sorted by code, so its entry moves with it, and the
 lint passes once the two agree again. Never resolve it by editing a code that
 is already on `main`.
 
@@ -2227,7 +2366,7 @@ npm run lint:i18n -w @doenet/i18n    # CI catalog check (also `npm run lint:i18n
 ```
 
 `lint:i18n` fails on: a catalog that doesn't parse (including entries the Fluent
-*runtime* would silently drop as junk), an id defined twice within a locale, a
+_runtime_ would silently drop as junk), an id defined twice within a locale, a
 catalog naming a `numberingSystem` on a Fluent builtin, a message whose value
 would render a line break, a translated locale
 defining a key English lacks, a stale `messageKeys.ts`, `supportedLocales.ts`,
@@ -2236,7 +2375,7 @@ exactly the inlined locales, a call site referencing a key that doesn't exist,
 an English key no source file references, a malformed diagnostic code, a code
 naming a message English lacks, a code used in source that the registry doesn't
 define, a registered code that nothing raises and that is not listed as
-retired, and any change to a code already issued. Keys *missing* from a
+retired, and any change to a code already issued. Keys _missing_ from a
 translation are reported as coverage, not failure — a partial translation is
 legitimate and falls back.
 
@@ -2296,7 +2435,7 @@ that are not prose: a contrast ratio is written `{ ratio }:1` with the `1` a
 literal in the catalog, a line number is read off a gutter the editor draws
 itself, an author's `styleNumber="3"` is quoted back at them. And mathematics
 is Latin-digit regardless — `MATH_NOTATION_LOCALE`, which #1528 keeps that way
-while it makes the *separator* configurable. A document whose prose counted in
+while it makes the _separator_ configurable. A document whose prose counted in
 one script and whose equations counted in another would be worse than either
 alone.
 
@@ -2333,7 +2472,7 @@ outside it. A nested `<document lang>` needs no state variable of its own —
 `renderedLang` is set exactly when the language changes, so where it is absent
 the direction cannot have changed either.
 
-Chrome drawn *inside* the document is the reader's language in a box declared to
+Chrome drawn _inside_ the document is the reader's language in a box declared to
 be the content's. `useChromeLangDir()` re-declares it — on the in-document error
 box, the feedback heading, the click-to-toggle text on a hint, a solution and a
 collapsible section, a pretzel's answer label, the summary-statistics caption,
@@ -2347,7 +2486,7 @@ drawn by the browser rather than by CSS. `DocViewer`'s error banner is built
 above the provider the hook reads, so it calls the same rule as the plain
 function `chromeLangDir(uiLocale, documentDirection)`.
 
-"The document" there means the *nearest* one, not the activity: a nested
+"The document" there means the _nearest_ one, not the activity: a nested
 `<document lang>` turns its own subtree around, so `section.tsx` re-mounts
 `DocumentDirectionProvider` around whatever it just declared. Otherwise chrome
 inside `<document lang="ar">` would compare itself against a left-to-right
@@ -2371,7 +2510,7 @@ rather than styled. MathJax needs nothing: its CHTML output already pins
 `direction: ltr` on `mjx-math` — but only on the mathematics itself, which is
 why the preview's scroll container still needs its own pin.
 
-A pin on a *block* needs a width with it: an element as wide as its container
+A pin on a _block_ needs a width with it: an element as wide as its container
 aligns its left-to-right contents to the container's left edge, stranding the
 widget at the far side of the page from the prose it belongs to.
 `ltrIslandProps()` in
@@ -2383,7 +2522,7 @@ instead of the column. An inline island, or one whose element already
 shrink-wraps, takes a bare `dir="ltr"`.
 
 The keyboard's keys are pinned in `keyboard.css` rather than by attribute,
-because `Keyboard` returns a different element per style. The tray *around*
+because `Keyboard` returns a different element per style. The tray _around_
 them follows the reader.
 
 Everything else mirrors: the paginator, prose renderers, the feedback and hint
@@ -2405,23 +2544,23 @@ an Arabic sentence and the mathematics beside it count in the same characters.
 almost nothing else, and the catalogs differ from each other far more than they
 differ from `de` or `es`:
 
-| | Adjectives | Gender | Plural categories |
-| --- | --- | --- | --- |
-| `ar` | follow the noun | m/f | six |
-| `he` | follow the noun | m/f | three |
-| `fa` | follow the noun | none | two |
-| `ur`, `ps`, `sd` | precede the noun | m/f | two |
-| `ug` | precede the noun | none | two |
-| `yi` | precede the noun | m/f/n | two |
-| `ks` | precede the noun | m/f | two |
-| `dv` | precede the noun | none | two |
+|                  | Adjectives       | Gender | Plural categories |
+| ---------------- | ---------------- | ------ | ----------------- |
+| `ar`             | follow the noun  | m/f    | six               |
+| `he`             | follow the noun  | m/f    | three             |
+| `fa`             | follow the noun  | none   | two               |
+| `ur`, `ps`, `sd` | precede the noun | m/f    | two               |
+| `ug`             | precede the noun | none   | two               |
+| `yi`             | precede the noun | m/f/n  | two               |
+| `ks`             | precede the noun | m/f    | two               |
+| `dv`             | precede the noun | none   | two               |
 
 `ur` is the outlier worth knowing about: its grammar is `hi`'s, so
 `locales/hi` is the closest thing to a parallel text for it and a correction to
 one is usually a correction to both. `ug` is Turkic and agrees with nothing,
 and `dv` is Indo-Aryan and agrees with nothing either — the two reach the same
 answer from opposite families. `ks` is the one of the ten whose catalog records
-a gap rather than a decision: it *does* agree an adjective for gender and this
+a gap rather than a decision: it _does_ agree an adjective for gender and this
 seed does not, which its header says outright.
 `yi` is Germanic, and it forks on `$role` for a reason none of the other nine
 does: `ur`, `ps` and `sd` fork because an Indo-Aryan or Iranian adjective takes
@@ -2458,7 +2597,7 @@ Three things recur across them, none a property of the direction:
   "are ignored" — most of these cover both with one form, and the select is
   dropped rather than written out twice identically. The count argument then
   goes unused, which is harmless: it stays in the English message for the
-  languages that need it. Where English changes the *noun* as well, the branch
+  languages that need it. Where English changes the _noun_ as well, the branch
   stays — and whether it has to is a fact about the language rather than about
   the script: Persian, Urdu and Uyghur leave a noun singular after a numeral,
   while Arabic, Hebrew, Pashto and Sindhi pluralize it.

--- a/packages/i18n/locales/ba/chrome.ftl
+++ b/packages/i18n/locales/ba/chrome.ftl
@@ -1,0 +1,139 @@
+# Bashkir viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Bashkir counts in two plural categories, `one` and `other`, the same two
+# English has, so every `{ $count -> … }` below keeps the shape it had. A noun
+# after a numeral stays singular — «2 омтылыш», not a plural — so the two
+# branches differ in nothing but the number they print.
+
+
+## Answer submission
+
+answer-checking = Тикшерелә…
+answer-submitting = Ебәрелә…
+
+answer-checking-status = Яуап тикшерелә
+answer-submitting-status = Яуап ебәрелә
+
+answer-correct = Дөрөҫ
+answer-incorrect = Яңылыш
+
+answer-response-saved = Яуап һаҡланды
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% дөрөҫ
+answer-percent-short = { $percent } %
+
+max-credit-available = Мөмкин булған иң юғары балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] омтылыш ҡалманы
+        [one] { $count } омтылыш ҡалды
+       *[other] { $count } омтылыш ҡалды
+    }
+
+validation-correct = (Дөрөҫ)
+validation-incorrect = (Яңылыш)
+validation-partially-correct = (Өлөшләтә дөрөҫ)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } өсөн { $count } яуапты күрһәтеү
+       *[other] { $answerId } өсөн { $count } яуапты күрһәтеү
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Кире бәйләнеш
+
+collapsible-click-to-open = (асыу өсөн баҫығыҙ)
+collapsible-click-to-close = (ябыу өсөн баҫығыҙ)
+
+collapsible-initializing = Әҙерләнә…
+
+footnote-show = Иҫкәрмәне күрһәтеү
+footnote-hide = Иҫкәрмәне йәшереү
+
+description-more-information = өҫтәмә мәғлүмәт
+
+
+## Controls
+
+slider-previous = Алдағы
+slider-next = Киләһе
+
+keyboard-open = Клавиатураны асыу
+keyboard-close = Клавиатураны ябыу
+
+choice-input-remove-choice = { $choice } һайлауын алып ташлау
+
+matrix-remove-row = Юлды алып ташлау
+matrix-add-row = Юл өҫтәү
+matrix-remove-column = Бағананы алып ташлау
+matrix-add-column = Бағана өҫтәү
+
+subset-add-remove-points = Нөктә өҫтәү/алып ташлау
+subset-toggle-points-intervals = Нөктәләр менән аралыҡтарҙы алмаштырыу
+subset-move-points = Нөктәләрҙе күсереү
+subset-clear = Таҙартыу
+
+orbital-add-row = Юл өҫтәү
+orbital-remove-row = Юлды алып ташлау
+orbital-add-box = Күҙәнәк өҫтәү
+orbital-remove-box = Күҙәнәкте алып ташлау
+orbital-add-up-arrow = Өҫкә уҡ өҫтәү
+orbital-add-down-arrow = Аҫҡа уҡ өҫтәү
+orbital-remove-arrow = Уҡты алып ташлау
+
+orbital-row-label = { $row } юлының билдәһе
+
+pretzel-answer = Яуап
+
+summary-statistics-caption = { $column } бағанаһының йомғаҡлау статистикаһы
+
+
+## Math input
+
+math-input-preview-region = математик аңлатманың алдан ҡарашы
+math-input-preview = Алдан ҡараш
+math-input-invalid-expression = Дөрөҫ булмаған аңлатма:
+
+
+## Document status
+
+viewer-initializing = Әҙерләнә…
+
+
+## Errors
+
+error-heading = Хата
+
+error-found-at =
+    { $span ->
+        [line] Табылған юл: { $startLine }.
+       *[lines] Табылған юлдар: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Был документта хаталар бар!
+
+diagnostic-heading-error = Хата
+diagnostic-heading-warning = Иҫкәртеү
+diagnostic-heading-information = Мәғлүмәт
+diagnostic-heading-hint = Кәңәш
+
+accessibility-heading-level-1 = WCAG AA ҡулайлылыҡ боҙоуы
+accessibility-heading-level-2 = Ҡулайлылыҡ хәбәре
+
+something-went-wrong = Ниҙер дөрөҫ булманы.
+
+renderer-load-failed = һүрәтләүсене йөкләп булманы. Битте яңыртығыҙ.
+
+core-start-failed = Документ ҡарағысын эшләтеп ебәреп булманы. Битте яңыртығыҙ.

--- a/packages/i18n/locales/ba/content.ftl
+++ b/packages/i18n/locales/ba/content.ftl
@@ -1,0 +1,252 @@
+# Bashkir content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic, which is the orthography Bashkortostan's schools and
+# publishing use and what CLDR fills a bare `ba` in as. The letters ҙ, ҫ, ғ, ҡ,
+# ң, ө, ү, һ, ә are Bashkir's own and are not Tatar's or Russian's; a catalog
+# that spells «ҡара» as «кара» has quietly become a different language.
+#
+# Bashkir has no grammatical gender and does not inflect an attributive
+# adjective, so both `$gender` and `$role` go unused here exactly as they do in
+# English, Turkish and `locales/tt`. Adjectives precede the noun, so the
+# composition messages keep the English order.
+#
+# The two clauses are marked by a suffix on the *noun* — «ситле», «фонда» — and
+# that noun is one this catalog writes, so nothing is welded to a placeable.
+
+
+## Style vocabulary
+
+color =
+    .black = ҡара
+    .white = аҡ
+    .gray = һоро
+    .red = ҡыҙыл
+    .orange = ҡыҙғылт һары
+    .yellow = һары
+    .green = йәшел
+    .cyan = асыҡ зәңгәр
+    .blue = зәңгәр
+    .purple = шәмәхә
+    .pink = алһыу
+    .brown = көрән
+
+line-width =
+    .thick = ҡалын
+    .thin = нәҙек
+
+line-style =
+    .dashed = өҙөклө
+    .dotted = нөктәле
+
+# Noun phrases: they stand in front of «биҙәкле» and modify nothing.
+fill-style =
+    .horizontal = горизонталь һыҙыҡ
+    .vertical = вертикаль һыҙыҡ
+    .diagonal = диагональ һыҙыҡ
+    .backdiagonal = кире диагональ һыҙыҡ
+    .dots = нөктә
+    .diamonds = ромб
+
+noun =
+    .line = тура һыҙыҡ
+    .line-segment = киҫек
+    .ray = нур
+    .vector = вектор
+    .curve = кәкре һыҙыҡ
+    .function = функция
+    .parabola = парабола
+    .polyline = һынған һыҙыҡ
+    .polygon = күпмөйөш
+    .triangle = өсмөйөш
+    .rectangle = тура мөйөшлөк
+    .circle = әйләнә
+    .region = өлкә
+    .point = нөктә
+    .square = квадрат
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+
+# Bashkir builds the word from the side count in front of the noun, so the
+# whole of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] дөрөҫ { $numSides } мөйөш
+    }
+
+# Bashkir has no grammatical gender, so every noun answers the same and the
+# answer goes unused — as in English, Turkish and Tatar.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = буялған
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } биҙәкле { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } биҙәкле { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } биҙәкле { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «ситле» — "having an edge" — carries the "with a border" sense in its own
+# suffix, so neither a preposition nor an article is wanted, and all four
+# branches read alike except for the connective English needs and Bashkir does
+# not.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } ситле
+        [and] һәм { $border } ситле
+        [and-article] һәм { $border } ситле
+       *[with] { $border } ситле
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } биҙәкле { $color } буяу
+       *[plain] { $color } буяу
+    }
+
+style-unfilled = буялмаған
+
+# «фонда» is the locative of «фон» and says "on the background" by itself, so
+# nothing stands between the two colours.
+style-text =
+    { $parts ->
+        [background] { $background } фонда { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = юҡ
+
+
+## Boolean words
+
+boolean-true = дөрөҫ
+boolean-false = яңылыш
+
+
+## Answer buttons
+
+answer-submit-label = Тикшереү
+answer-submit-label-no-correctness = Яуапты ебәреү
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Эшмәкәрлек
+    .aside = Ситләтмә
+    .cascade = Каскад
+    .definition = Билдәләмә
+    .example = Миҫал
+    .exercise = Күнегеү
+    .exercises = Күнегеүҙәр
+    .given-answer = Яуап
+    .note = Иҫкәрмә
+    .objectives = Маҡсаттар
+    .paragraphs = Абзацтар
+    .part = Өлөш
+    .problem = Мәсьәлә
+    .problems = Мәсьәләләр
+    .proof = Иҫбатлау
+    .question = Һорау
+    .section = Бүлек
+    .solution = Сиселеш
+    .task = Бирем
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Кәңәш
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Рәсем { $enumeration }
+        [numbered-caption] Рәсем { $enumeration }{ ". " }
+        [unnumbered-caption] Рәсем{ ". " }
+       *[unnumbered] Рәсем
+    }
+
+
+## Paginator controls
+
+paginator-previous = Алдағы
+paginator-next = Киләһе
+paginator-page = Бит
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = йәки
+piecewise-condition-if = әгәр
+piecewise-condition-otherwise = юғиһә
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Bashkortostan is
+## taught in Russian, and the element names a Bashkir-speaking pupil meets are
+## the Russian ones out of a Russian-language textbook. Copying that list into
+## Bashkir spelling would produce neither language — the argument
+## `locales/min` already makes against copying Indonesian's table — and
+## `locales/tt` beside this file is the counter-example that decides it: Tatar
+## supplies the whole table because Tatar-medium chemistry teaching produced
+## one, and nothing about the two languages predicts the difference.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Дөрөҫ булмаған химик билдә
+chemistry-invalid-ionic-compound = Дөрөҫ булмаған ион ҡушылмаһы

--- a/packages/i18n/locales/ba/diagnostics.ftl
+++ b/packages/i18n/locales/ba/diagnostics.ftl
@@ -1,0 +1,659 @@
+# Bashkir diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical vocabulary here is largely Russian, which is what written
+# Bashkir itself uses for it: «компонент», «атрибут», «функция», «индекс».
+# What is Bashkir is the grammar around them and the everyday words —
+# «табылманы», «иҫәпкә алынмай», «булырға тейеш».
+#
+# Bashkir counts in the same two categories English does, so every selection
+# below keeps both branches — but a noun after a numeral stays singular, so the
+# two usually differ only in the number they print.
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] ике осло нөктә лә бирелгәндә { $attributes } иҫәпкә алынмай
+       *[other] ике осло нөктә лә бирелгәндә { $attributes } иҫәпкә алынмай
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] осло нөктә лә, урта нөктә лә бирелгәндә { $attributes } иҫәпкә алынмай
+       *[other] осло нөктә лә, урта нөктә лә бирелгәндә { $attributes } иҫәпкә алынмай
+    }
+
+line-segment-midpoint-offset-without-midpoint = урта нөктәһеҙ midpointOffset бер нәмәгә лә тәьҫир итмәй
+
+## `<line>`
+
+line-points-undetermined-dimensions = Үлсәме билдәһеҙ нөктәләр аша үтеүсе тура һыҙыҡ.
+
+line-points-too-few-dimensions = Тура һыҙыҡ кәм тигәндә ике үлсәмле нөктәләр аша үтергә тейеш.
+
+line-points-depend-on-variables = Тура һыҙыҡ үҙгәреүсәндәргә бәйле нөктәләр аша үтә: { $variables }.
+
+line-equation-invalid-format = { $variable1 } һәм { $variable2 } үҙгәреүсәндәрендәге тура һыҙыҡ тигеҙләмәһенең форматы дөрөҫ түгел.
+
+## `<ray>`
+
+ray-overprescribed-through = Нур through, endpoint һәм direction аша бирелгән. Бирелгән through иҫәпкә алынмай.
+
+ray-dimension-mismatch = нурҙа numDimensions тап килмәй.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail һәм displacement аша бирелгән. Бирелгән head иҫәпкә алынмай.
+
+vector-dimension-mismatch = векторҙа numDimensions тап килмәй.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементына тартып булмай, сөнки уның nearestPoint хәл үҙгәреүсәне юҡ.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементы менән сикләп булмай, сөнки уның nearestPoint хәл үҙгәреүсәне юҡ.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементының эсе менән сикләп булмай, сөнки уның nearestPoint хәл үҙгәреүсәне юҡ.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = юл эсендә булмаған choiceInput өсөн labelPosition иҫәпкә алынмай
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput өсөн бирелгән индекстар иҫәпкә алынмай, сөнки уларҙың һаны choice балаларының һанына тап килмәй.
+
+pretzel-indices-count-mismatch = problem өсөн бирелгән индекстар иҫәпкә алынмай, сөнки уларҙың һаны problem балаларының һанына тап килмәй.
+
+shuffle-indices-count-mismatch = shuffle өсөн бирелгән индекстар иҫәпкә алынмай, сөнки уларҙың һаны компоненттар һанына тап килмәй.
+
+indices-ignored-out-of-range = { $component } өсөн бирелгән индекстар иҫәпкә алынмай, сөнки ҡайһы берҙәре сиктәрҙән сыға.
+
+pretzel-indices-repeated = pretzel өсөн бирелгән индекстар иҫәпкә алынмай, сөнки ҡайһы берҙәре ҡабатлана.
+
+pretzel-circuit-first-index = circuit режимында pretzel өсөн бирелгән индекстар иҫәпкә алынмай, сөнки беренсе индекс 1 булырға тейеш.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текст балалары менән эшләһен өсөн `type` атрибуты бирелергә тейеш.
+
+invalid-type-defaulting-to-math = { $component } компоненты өсөн дөрөҫ булмаған төр { $type }. Ул math, text, number йәки boolean булырға тейеш. math ҡулланыла.
+
+string-not-valid-component-to-arrange = «{ $value }» юлы { $component } өсөн яраҡлы компонент түгел. Иҫәпкә алынмай.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Дөрөҫ булмаған төр { $type }, төр number итеп ҡуйыла.
+
+invalid-variable-value = Үҙгәреүсәндең дөрөҫ булмаған ҡиммәте: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = Вариант индексы { $index } һан булырға тейеш
+
+variant-index-must-be-integer = Вариант индексы { $index } бөтөн һан булырға тейеш
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют үлсәмдәр өсөн ғәмәлгә ашырылмаған. Киңлектәр сағыштырмаса була.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют үлсәмдәр өсөн ғәмәлгә ашырылмаған. Ҡыр буйҙары сағыштырмаса була.
+
+side-by-side-no-block-child = Дөрөҫ булмаған `<{ $component }>`: уның кәм тигәндә бер блок балаһы булырға тейеш.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементындағы `for` атрибуты иҫәпкә алынмай.
+
+label-for-must-resolve-to-one = `<label>` элементындағы `for` атрибуты тап бер компонентҡа күрһәтергә тейеш.
+
+label-for-unresolved = `<label>` элементындағы `for` атрибутын компонент менән бәйләп булманы.
+
+label-for-answer-with-authored-inputs = `<label>` элементындағы `for` атрибуты автор яҙған керетеү ҡырҙары булған `<answer>` элементына күрһәтә; ҡырға тураға күрһәтегеҙ.
+
+label-for-answer-without-input = `<label>` элементындағы `for` атрибуты билдәләнәсәк керетеү ҡыры булмаған `<answer>` элементына күрһәтә.
+
+label-for-must-reference-input-or-answer = `<label>` элементындағы `for` атрибуты керетеү ҡырына йәки яуапҡа күрһәтергә тейеш.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ҡулайлылыҡ өсөн `<{ $component }>` йә ҡыҫҡа тасуирламаға эйә булырға, йә биҙәк булараҡ билдәләнергә тейеш.
+
+accessibility-video-short-description = Ҡулайлылыҡ өсөн `<video>` ҡыҫҡа тасуирламаға эйә булырға тейеш.
+
+accessibility-input-short-description-or-label = Ҡулайлылыҡ өсөн `<{ $component }>` ҡыҫҡа тасуирламаға йәки билдәгә эйә булырға тейеш.
+
+accessibility-answer-input-short-description-or-label = Ҡулайлылыҡ өсөн керетеү ҡыры булдырыусы `<answer>` ҡыҫҡа тасуирламаға йәки билдәгә эйә булырға тейеш.
+
+accessibility-short-description-contains-math = Ҡыҫҡа тасуирламаларҙа `<{ $component }>` кеүек математик компоненттар булырға тейеш түгел. Математиканы һүҙҙәр менән яҙығыҙ.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } бүлек башламы тексы өсөн етерлек контраст бирмәй (ҡараңғы тема) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кәм тигәндә { $threshold }:1 кәрәк).
+       *[other] { $colorName } бүлек башламы тексы өсөн етерлек контраст бирмәй ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кәм тигәндә { $threshold }:1 кәрәк).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Нөктәләрҙең һан ҡиммәттәре булмағанда { $count } нөктә аша үтеүсе `<circle>` ғәмәлгә ашырылмаған.
+
+circle-too-many-through-points = 3-тән артыҡ нөктә аша үтеүсе әйләнәне иҫәпләп булмай.
+
+circle-overprescribed-radius-center-points = Бирелгән радиус, үҙәк һәм нөктәләр менән әйләнәне иҫәпләп булмай.
+
+circle-center-with-multiple-points = Бирелгән үҙәк менән 1-ҙән артыҡ нөктә аша үтеүсе әйләнәне иҫәпләп булмай.
+
+circle-radius-too-small = Әйләнәне иҫәпләп булмай: ике нөктә араһындағы алыҫлыҡ { $distance } булғанға, бирелгән радиус { $radius } артыҡ бәләкәй.
+
+circle-radius-with-many-points = Бирелгән радиус менән икенән артыҡ нөктә аша үтеүсе әйләнә төҙөп булмай.
+
+circle-invalid-center-or-through-points = Әйләнәнең үҙәге йәки нөктәләре дөрөҫ түгел.
+
+circle-radius-center-with-multiple-points = Бирелгән үҙәк менән 1-ҙән артыҡ нөктә аша үтеүсе әйләнәнең радиусын иҫәпләп булмай.
+
+circle-change-radius-non-numerical = Һан булмаған нөктәле әйләнәнең радиусын үҙгәртеп булмай
+
+circle-radius-with-points-non-numerical = Һан ҡиммәттәре булмағанда бирелгән радиус менән бертәнән артыҡ нөктә аша үтеүсе әйләнә төҙөп булмай.
+
+circle-change-center-non-numerical = Һан булмаған нөктәләр аша үтеүсе әйләнәнең үҙәген үҙгәртеү ғәмәлгә ашырылмаған.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцияның билдәләнеү өлкәһенең үлсәме етерлек түгел. Өлкәлә { $intervals } аралыҡ бар, ә функцияла { $inputs ->
+            [one] { $inputs } инеш
+           *[other] { $inputs } инеш
+        }.
+       *[other] Функцияның билдәләнеү өлкәһенең үлсәме етерлек түгел. Өлкәлә { $intervals } аралыҡ бар, ә функцияла { $inputs ->
+            [one] { $inputs } инеш
+           *[other] { $inputs } инеш
+        }.
+    }
+
+function-domain-invalid-format = Функцияның билдәләнеү өлкәһенең форматы дөрөҫ түгел.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцияның һан булмаған максимумы иҫәпкә алынмай.
+        [minimum] Функцияның һан булмаған минимумы иҫәпкә алынмай.
+        [extremum] Функцияның һан булмаған экстремумы иҫәпкә алынмай.
+        [point] Функцияның һан булмаған нөктәһе иҫәпкә алынмай.
+        [slope] Функцияның һан булмаған ауышлығы иҫәпкә алынмай.
+       *[other] Функцияның һан булмаған { $type } ҡиммәте иҫәпкә алынмай.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцияның буш максимумы иҫәпкә алынмай.
+        [minimum] Функцияның буш минимумы иҫәпкә алынмай.
+        [extremum] Функцияның буш экстремумы иҫәпкә алынмай.
+        [point] Функцияның буш нөктәһе иҫәпкә алынмай.
+       *[other] Функцияның буш { $type } ҡиммәте иҫәпкә алынмай.
+    }
+
+function-points-too-close = Функцияла бер-береһенә артыҡ яҡын ике нөктә бар. Функцияны билдәләп булмай.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функция итерациялары инештәр һаны сығыштар һанына тигеҙ булғанда ғына мөмкин. Был функцияла { $inputs } инеш һәм { $outputs ->
+            [one] { $outputs } сығыш
+           *[other] { $outputs } сығыш
+        } бар.
+       *[other] Функция итерациялары инештәр һаны сығыштар һанына тигеҙ булғанда ғына мөмкин. Был функцияла { $inputs } инеш һәм { $outputs ->
+            [one] { $outputs } сығыш
+           *[other] { $outputs } сығыш
+        } бар.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Эҙмә-эҙлектең оҙонлоғо дөрөҫ түгел. Ул кире булмаған бөтөн һан булырға тейеш.
+
+sequence-invalid-step = Эҙмә-эҙлектең аҙымы дөрөҫ түгел. { $type } төрөндәге эҙмә-эҙлек өсөн ул һан булырға тейеш.
+
+sequence-invalid-endpoint-number = Һан эҙмә-эҙлегенең «{ $attribute }» ҡиммәте дөрөҫ түгел. Ул һан булырға тейеш.
+
+sequence-invalid-endpoint-letters = Хәреф эҙмә-эҙлегенең «{ $attribute }» ҡиммәте дөрөҫ түгел. Ул хәрефтәр комбинацияһы булырға тейеш.
+
+sequence-invalid-endpoint = Эҙмә-эҙлектең «{ $attribute }» ҡиммәте дөрөҫ түгел.
+
+select-from-sequence-coprime-not-numbers = һандар һайланмағанға coprime иҫәпкә алынмай
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations бирелгәнгә coprime иҫәпкә алынмай
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` өсөн дөрөҫ булмаған target: маҡсат табылманы.
+
+target-state-variable-not-found = `<{ $source }>` өсөн дөрөҫ булмаған target: `<{ $component }>` элементында «{ $property }» исемле хәл үҙгәреүсәне табылманы.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` үҙгәреүсәндәре бойондороҡһоҙ үҙгәреүсәндән айырылырға тейеш.
+
+ode-system-duplicate-variable-names = Бәйле үҙгәреүсәндәрҙең ҡабатланыусы исемдәре менән ДТ уң яҡ функцияларын билдәләп булмай.
+
+ode-system-rhs-function-error = ДТ уң яҡ функцияһын билдәләп булмай. mathjs функцияһын төҙөгәндә хата.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } тура һыҙыҡ араһындағы мөйөштө билдәләп булмай
+
+angle-invalid-through-point = `<angle>` элементының through ҡиммәтендә дөрөҫ булмаған нөктә
+
+parabola-vertex-too-many-points = Бирелгән түбә менән 1-ҙән артыҡ нөктә аша үтеүсе парабола ғәмәлгә ашырылмаған.
+
+parabola-too-many-points = 3-тән артыҡ нөктә аша үтеүсе парабола ғәмәлгә ашырылмаған.
+
+intersection-too-many-items = Икенән артыҡ объекттың киҫешеүе ғәмәлгә ашырылмаған
+
+## Other math components
+
+ionic-compound-not-two-ions = Ике иондан башҡа ион ҡушылмалары ғәмәлгә ашырылмаған.
+
+ionic-compound-needs-cation-and-anion = Ион ҡушылмалары бер катион һәм бер анион өсөн генә ғәмәлгә ашырылған.
+
+solve-equations-cannot-evaluate = Тигеҙләмәне сисеп булмай, сөнки уны иҫәпләп булманы: { $equation }
+
+math-operators-operand-number-required = Математик операндты айырып алыу өсөн operandNumber бирелергә тейеш.
+
+eigen-decomposition-failed = Матрицаның үҙ ҡиммәттәрен иҫәпләп булманы
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметры өлгөлә осрамай, шуға күрә ул һәр ваҡыт бушҡа тап килә.
+       *[other] `<matchesPattern>`: { $parameters } параметрҙары өлгөлә осрамай, шуға күрә улар һәр ваҡыт бушҡа тап килә.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" ҡиммәтен аңлатып булмай. Ул none, medium, dense йәки буш урын менән айырылған ике ыңғай һан булырға тейеш, мәҫәлән grid="1 0.5". Селтәр һыҙылмай.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure һүрәтләүсеһендә xLabelPosition="left" ҡаралмаған; уң урынлашыу тәртибе ҡулланыла.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure һүрәтләүсеһендә yLabelPosition="bottom" ҡаралмаған; өҫкө урынлашыу тәртибе ҡулланыла.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure әйләндереүе өсөн күсәрҙәр сиктәре дөрөҫ түгел; килешеү буйынса bbox (-10,-10,10,10) ҡулланыла.
+
+prefigure-invalid-width = `<graph>`: prefigure әйләндереүе өсөн киңлек дөрөҫ түгел; диаграмманың килешеү буйынса киңлеге 425 ҡулланыла.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure әйләндереүе өсөн aspectRatio дөрөҫ түгел; килешеү буйынса яҡтар нисбәте 1 ҡулланыла.
+
+prefigure-grid-spacing-too-fine = `<graph>`: селтәр аҙымы күсәрҙәр сиктәре өсөн артыҡ ваҡ; prefigure һүрәтләүсеһендә селтәр ҡалдырыла.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure һүрәтләүсеһе ҡулланылмағанда иҫкәрмәләр һыҙылмай.
+
+multiple-annotations-children = `<graph>` эсендә бер нисә `<annotations>` балаһы табылды; һуңғыһынан башҡалары иҫәпкә алынмай.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Танылмаған компонент төрөн киңәйтеп йәки күсереп булмай: { $type }.
+
+copy-prop-not-found = { $component } төрөндәге компонентта { $property } үҙенсәлеге табылманы
+
+collect-no-source = collect өсөн сығанаҡ табылманы.
+
+collect-invalid-component-type = `<{ $component }>` төрөндәге компоненттарҙы йыйып булмай, сөнки был дөрөҫ булмаған компонент төрө.
+
+reference-index-unavailable = `{ $reference }` индексына һылтанма яһап булмай
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентында { $action } саҡырып булмай
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Мәғлүмәттәрҙең формаһы дөрөҫ түгел. Юлдарҙың оҙонлоҡтары төрлө. Табылды componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Мәғлүмәттәрҙә ҡабатланыусы бағана исемдәре бар. Табылды componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Мәғлүмәттәрҙә бағана исеме етмәй. Табылды componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Был яуаптың award ҡиммәте answer тегының үҙ ебәрелгән яуабына нигеҙләнә, был көтөлмәгән тәртипкә килтерә.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` булған контейнер эсендәге `<answer>` элементына `maxNumAttempts` ҡуйыу тәьҫир итмәй, сөнки омтылыштар һанын контейнер билдәләй. `maxNumAttempts` ҡиммәтен контейнерға ҡуйығыҙ.
+
+nested-section-wide-check-work-max-num-attempts = Башҡа `sectionWideCheckWork` контейнеры эсендә торған `sectionWideCheckWork` контейнерына `maxNumAttempts` ҡуйыу тәьҫир итмәй, сөнки омтылыштар һанын тышҡы контейнер билдәләй. `maxNumAttempts` ҡиммәтен тышҡы контейнерға ҡуйығыҙ.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality ҡуйылмаһа, { $attributes } атрибуты тәьҫир итмәйәсәк.
+       *[other] symbolicEquality ҡуйылмаһа, { $attributes } атрибуттары тәьҫир итмәйәсәк.
+    }
+
+answer-invalid-type = answer өсөн дөрөҫ булмаған төр: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентының исеме булмағанға, уны модуль атрибуты итеп ҡулланып булмай
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентын модуль атрибуты итеп ҡулланып булмай, сөнки `<module>` компонент төрөндә «{ $name }» атрибуты инде билдәләнгән.
+
+conditional-content-condition-ignored = case йәки else балалары булған `<conditionalContent>` компонентында `condition` атрибуты иҫәпкә алынмай.
+
+slider-markers-type-mismatch = Маркерҙарҙың төрө шыуҙырғыстың төрөнә тап килмәй.
+
+pretzel-problem-needs-statement-and-answer = Дөрөҫ булмаған pretzel: һәр `<problem>` бер `<statement>` һәм бер `<answer>` эсенә алырға тейеш.
+
+pretzel-circuit-first-problem-distractor = Дөрөҫ булмаған pretzel: mode="circuit" режимында беренсе `<problem>` иғтибарҙы ситкә йүнәлтеүсе була алмай.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибуты өсөн дөрөҫ булмаған ҡиммәт { $values }; иҫәпкә алынмай.
+       *[other] `{ $attribute }` атрибуты өсөн дөрөҫ булмаған ҡиммәттәр { $values }; иҫәпкә алынмай.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибуты өсөн дөрөҫ булмаған ҡиммәт `{ $value }`. Атрибут `$` менән башланыусы һылтанмаларҙан торорға тейеш.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } эсендәге дөрөҫ булмаған функция исемдәре иҫәпкә алынманы: { $names }. Һәр исемдең күрһәтелә торған өлөшө кәм тигәндә 2 билдә булырға тейеш (хәрефтәр йәки һыҙыҡсалар); унан һуң мәжбүри булмаған `|<mathspeak альтернатива>` ҡушымтаһы килеүе мөмкин.
+
+## Building components from the source
+
+component-type-invalid = Дөрөҫ булмаған компонент төрө: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутын ҡабатлап булмай.
+
+attribute-invalid-for-component = `<{ $componentType }>` төрөндәге компонент өсөн дөрөҫ булмаған атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль билдәләмәһендә { $context ->
+        [text-on-background] текст төҫө менән фон төҫө
+        [high-contrast] юғары контраслы төҫ менән һүрәт майҙаны
+        [line] һыҙыҡ төҫө менән һүрәт майҙаны
+        [marker] маркер төҫө менән һүрәт майҙаны
+       *[text-on-canvas] текст төҫө менән һүрәт майҙаны
+    } араһындағы контраст етерлек түгел{ $mode ->
+        [dark] { " (ҡараңғы тема)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кәм тигәндә { $threshold }:1 кәрәк).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль билдәләмәһендә бирелгән төҫтәр яҡты тема өсөн етерлек контраст бирһә лә, улардан алынған ҡараңғы тема төҫтәре текст менән фон араһында етерлек контраст бирмәй ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кәм тигәндә { $threshold }:1 кәрәк). { $suggestion ->
+        [available] Ҡараңғы темала етерлек контраст өсөн йә яҡты темалағы контрасты арттырығыҙ (мәҫәлән { $lightAttribute }="{ $lightColor }"), йә ҡараңғы тема төҫөн алмаштырығыҙ (мәҫәлән { $darkAttribute }="{ $darkColor }").
+       *[none] Ҡараңғы темала етерлек контраст өсөн яҡты темалағы контрасты арттырығыҙ йәки алынған төҫтәрҙе textColorDarkMode һәм/йәки backgroundColorDarkMode менән алмаштырығыҙ.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль билдәләмәһендә бирелгән текст төҫө яҡты тема өсөн етерлек контраст бирһә лә, унан алынған ҡараңғы тема текст төҫө һүрәт майҙаны менән етерлек контраст бирмәй ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кәм тигәндә { $threshold }:1 кәрәк). { $suggestion ->
+        [available] Ҡараңғы темала етерлек контраст өсөн йә яҡты темалағы контрасты арттырығыҙ (мәҫәлән textColor="{ $lightColor }"), йә ҡараңғы тема төҫөн алмаштырығыҙ (мәҫәлән textColorDarkMode="{ $darkColor }").
+       *[none] Ҡараңғы темала етерлек контраст өсөн яҡты темалағы контрасты арттырығыҙ йәки алынған төҫтө textColorDarkMode менән алмаштырығыҙ.
+    }
+
+section-multiple-style-palettes = Бүлек бер генә <stylePalette> һайлай ала; һуңғыһы ҡулланыла.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки numToSelect кире булмаған бөтөн һан түгел.
+
+variant-num-to-select-not-constant-number = { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки numToSelect даими һан түгел.
+
+variant-with-replacement-not-constant-boolean = { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки withReplacement даими логик ҡиммәт түгел.
+
+variant-select-weight-disables-unique = берәй һайлауҙа selectWeight йәки selectForVariants бирелгән булһа, select өсөн ҡабатланмаҫ варианттар һүндерелә
+
+variant-coprime-undetermined = { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки coprime һәр ваҡыт яңылыш икәнен асыҡлап булмай.
+
+variant-attribute-not-constant = { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки { $attribute } даими түгел.
+
+variant-attribute-not-number = { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки { $attribute } һан түгел.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } төрөндәге { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки { $attribute } { $expected ->
+        [letters-combination] хәрефтәр комбинацияһы
+        [math-expression] яраҡлы математик аңлатма
+        [integer] бөтөн һан
+       *[number] һан
+    } түгел.
+
+variant-length-not-integer = { $component } өсөн ҡабатланмаҫ варианттарҙы билдәләп булмай, сөнки length бөтөн һан түгел.
+
+variant-sort-not-implemented = sort булған { $component } өсөн ҡабатланмаҫ варианттар ғәмәлгә ашырылмаған
+
+variant-exclude-combinations-not-implemented = excludeCombinations булған { $component } өсөн ҡабатланмаҫ варианттар ғәмәлгә ашырылмаған
+
+variant-math-exclude-not-implemented = exclude булған math төрөндәге { $component } өсөн ҡабатланмаҫ варианттар ғәмәлгә ашырылмаған
+
+variant-non-constant-exclude-not-implemented = даими булмаған exclude булған { $component } өсөн ҡабатланмаҫ варианттар ғәмәлгә ашырылмаған
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графиктың prefigure һүрәтләүсеһендә ҡаралмаған; вариҫ ҡалдырылды.
+
+prefigure-descendant-invalid-geometry = { $subject }: сикһеҙ йәки тулы булмаған геометрия; вариҫ ҡалдырылды.
+
+prefigure-curve-label-omitted = { $subject }: әйләндерелгән кәкре элементтарында билдәләр ҡаралмаған; билдә ҡалдырылды.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ҡаралмаған кәкре функция билдәләмәһе төрө «{ $definitionType }»; вариҫ ҡалдырылды.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементындағы flipFunctions атрибуты ҡаралмаған; вариҫ ҡалдырылды.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формула менән бирелгән бала функцияларҙы ғына ҡабул итә; вариҫ ҡалдырылды.
+
+prefigure-label-position-unsupported =
+    { $subject }: ҡаралмаған labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] тура һыҙыҡтар ғаиләһе билдәһе өсөн
+       *[point] нөктә билдәһе өсөн
+    }; PreFigure-ҙың килешеү буйынса тигеҙләүе ҡулланыла.
+
+prefigure-fill-style-unsupported = { $subject }: тултырыу стиле «{ $fillStyle }» PreFigure тарафынан ҡаралмаған; бөтөн тултырыуға күселә.
+
+prefigure-line-style-unknown = { $subject }: билдәһеҙ һыҙыҡ стиле «{ $lineStyle }» PreFigure сығышынан алып ташланды.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стиле «{ $markerStyle }» PreFigure «diamond» стиленә тап килтерелде.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стиле «{ $markerStyle }» PreFigure тарафынан ҡаралмаған; килешеү буйынса стиль ҡулланыла.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: дөрөҫ булмаған `ref`; маҡсатты бәйләп булмай. Иҫкәрмә ҡалдырылды.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` бер нисә маҡсат менән бәйләнде; беренсеһе ҡулланыла.
+
+annotation-ref-outside-graph = `<annotation>`: дөрөҫ булмаған `ref`; маҡсат уны эсенә алған графиктан тыш. Иҫкәрмә ҡалдырылды.
+
+annotation-ref-unsupported-target = `<annotation>`: дөрөҫ булмаған `ref`; маҡсат prefigure әйләндереүендә ҡаралған график объект түгел. Иҫкәрмә ҡалдырылды.
+
+annotation-text-missing = `<annotation>`: `text` юҡ йәки буш; буш текст сығарыла.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Циклик бәйлелек асыҡланды.
+       *[other] `<{ $componentType }>` компонентын эсенә алған циклик бәйлелек асыҡланды.
+    }
+
+reference-no-referent = Һылтанма өсөн объект табылманы: `{ $reference }`
+
+reference-multiple-referents = Һылтанма өсөн бер нисә объект табылды: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементының { $attribute } атрибутының форматы дөрөҫ түгел.
+
+children-invalid = `<{ $componentType }>` өсөн дөрөҫ булмаған балалар: дөрөҫ булмаған балалар табылды: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибуты өсөн дөрөҫ булмаған ҡиммәт `{ $value }`; `{ $default }` ҡиммәте ҡулланыла
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версияһы табылманы.
+       *[other] DoenetML { $version } версияһы табылманы. { $fallback } версияһы ҡулланыла
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Дөрөҫ булмаған DoenetML: { $content }
+
+parse-tag-missing-close-tag = Дөрөҫ булмаған DoenetML: `{ $tag }` тегының ябыусы тегы юҡ. Үҙе ябылыусы тег йәки `</{ $tagName }>` тегы көтөлгәйне.
+
+parse-tag-error = Дөрөҫ булмаған DoenetML: `<{ $tagName }>` тегында хата
+
+parse-attribute-missing-value = Дөрөҫ булмаған DoenetML: `{ $attribute }` атрибутында ҡиммәт етмәгән кеүек.
+
+parse-attribute-invalid = Дөрөҫ булмаған DoenetML: дөрөҫ булмаған атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Дөрөҫ булмаған DoenetML: атрибуттың дөрөҫ булмаған ҡиммәте `{ $value }`
+
+parse-attribute-value-quote-mismatch = Дөрөҫ булмаған DoenetML: атрибуттың дөрөҫ булмаған ҡиммәте `{ $value }`. Ҡуштырнаҡтар тап килмәй. `{ $quote }` етмәгән кеүек
+
+parse-open-tag-name-missing = Дөрөҫ булмаған DoenetML: исемһеҙ тег табылды, мәҫәлән `<`
+
+parse-tag-not-closed = Дөрөҫ булмаған DoenetML: `{ $tag }` тегы ябылмаған (`>` етмәгән кеүек).
+
+parse-self-closing-tag-name-missing = Дөрөҫ булмаған DoenetML: исемһеҙ тег табылды `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Дөрөҫ булмаған DoenetML: `{ $tag }` тегы ябылмаған (`/>` етмәгән кеүек).
+
+parse-tag-invalid-attributes = Дөрөҫ булмаған DoenetML: `{ $tag }` тегы яраҡлы түгел. Уның атрибуттары дөрөҫ булмауы мөмкин.
+
+parse-close-tag-name-missing = Дөрөҫ булмаған DoenetML: исемһеҙ ябыусы тег табылды, мәҫәлән `</`
+
+parse-attribute-value-unquoted = Атрибут ҡиммәттәре ҡуштырнаҡ эсендә булырға тейеш: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Дөрөҫ булмаған DoenetML: `{ $tag }` ябыусы тегы табылды, әммә уға тап килеүсе асыусы тег юҡ
+
+parse-close-tag-mismatched = Дөрөҫ булмаған DoenetML: тап килмәүсе ябыусы тег. `</{ $expected }>` көтөлгәйне. `{ $found }` табылды
+
+parser-node-unconvertible = { $node } төйөнөн Dast төйөнөнә әйләндереп булманы.
+
+## Names
+
+name-attribute-invalid =
+    Дөрөҫ булмаған атрибут name='{ $name }'. { $reason ->
+        [characters] Исемдәрҙә хәрефтәр, һандар, аҫҡы һыҙыҡтар йәки һыҙыҡсалар ғына булыуы мөмкин.
+       *[start] Исемдәр хәрефтән башланырға тейеш.
+    }
+
+component-name-invalid-start = Дөрөҫ булмаған компонент исеме «{ $name }». Исемдәр хәрефтән башланырға тейеш.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched төрөндәге answer-ҙың video атрибуты булырға тейеш
+
+answer-video-watched-video-not-reference = videoWatched төрөндәге answer-ҙың video атрибуты һылтанма булырға тейеш
+
+answer-name-not-single-text = answer-ҙың name атрибутында тап бер текст балаһы булырға тейеш
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсия кимәлдәре артыҡ күп булғанға тышҡы DoenetML алып булманы. Циклик һылтанма юҡмы?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресынан DoenetML алып булманы
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресынан дөрөҫ булмаған DoenetML алынды: ул «{ $componentType }» компонент төрөнә тап килмәне
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибуты иҫкергән; уның урынына `{ $to }` ҡулланығыҙ.
+       *[other] [deprecation] `<{ $component }>` элементындағы `{ $from }` атрибуты иҫкергән; уның урынына `{ $to }` ҡулланығыҙ.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибуты иҫкергән һәм иҫәпкә алынмай, сөнки `{ $to }` ҙа бирелгән.
+       *[other] [deprecation] `<{ $component }>` элементындағы `{ $from }` атрибуты иҫкергән һәм иҫәпкә алынмай, сөнки `{ $to }` ҙа бирелгән.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементындағы `{ $attribute }` атрибуты иҫкергән һәм иҫәпкә алынмай.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементындағы `{ $attribute }` атрибуты иҫкергән; уның урынына `<{ $child }>` балаһын ҡулланығыҙ.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементындағы `{ $attribute }` атрибутының `{ $value }` ҡиммәте иҫкергән; уның урынына `{ $to }` ҡулланығыҙ.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` күплек һанды инглиз телендә генә яһай ала, шуға күрә { $locale } телендә яҙылған документта уның тексы үҙгәрешһеҙ ҡала. Күплек формаһын үҙегеҙ яҙығыҙ йәки уны `pluralForm` атрибуты менән бирегеҙ.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элементы танылған Doenet элементы түгел.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементына документтың тамырында рөхсәт ителмәй.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементына `<{ $parent }>` эсендә рөхсәт ителмәй.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементында `{ $attribute }` исемле атрибут юҡ.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементының `{ $attribute }` атрибуты һәр элементы түбәндәгеләрҙең береһе булған исемлек булырға тейеш: { $allowed }
+       *[other] `<{ $tag }>` элементының `{ $attribute }` атрибуты түбәндәгеләрҙең береһе булырға тейеш: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select өсөн дөрөҫ булмаған вариант исеме. { $variantName } вариант исеме { $numOptions } һайлауҙа осрай, ә һайланасаҡ һан { $numToSelect }.
+
+select-variant-name-without-options = select өсөн варианттар бирелгән, әммә мөмкин булған вариант исеме өсөн бер һайлау ҙа юҡ: { $variantName }.
+
+select-variant-name-not-possible = select өсөн бирелгән { $variantName } вариант исеме мөмкин булған вариант исеме түгел.
+
+select-too-few-options = Бары { $numOptions } эсенән { $numToSelect } компонентты һайлап булмай.
+
+select-from-sequence-too-few-values = Оҙонлоғо { $length } эҙмә-эҙлектән { $numToSelect } ҡиммәт һайлап булмай.
+
+select-from-sequence-indices-count-mismatch = select өсөн бирелгән индекстар һаны һайланасаҡ һанға тап килергә тейеш
+
+select-from-sequence-indices-not-integers = select өсөн бирелгән бөтә индекстар бөтөн һан булырға тейеш
+
+select-from-sequence-index-excluded = selectfromsequence өсөн бирелгән индекс сығарылғайны
+
+select-from-sequence-indices-excluded-combination = selectfromsequence өсөн бирелгән индекстар сығарылған комбинация ине
+
+select-from-sequence-coprime-not-positive-integers = Ыңғай бөтөн һандар һайланмағанға үҙ-ара ябай комбинацияларҙы һайлап булмай.
+
+select-from-sequence-coprime-common-factor = Үҙ-ара ябай һандарҙы һайлап булмай. Бөтә мөмкин ҡиммәттәрҙең уртаҡ бүлеүсеһе бар. (Бирелгән "from" йәки "to" ҡиммәттәре "step" менән үҙ-ара ябай булырға тейеш.)
+
+select-from-sequence-coprime-single-number = 1 булмаған берҙән-бер һандан үҙ-ара ябай комбинацияларҙы һайлап булмай.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence эсендә комбинацияларҙың 70%-тан артығы сығарылған
+
+select-from-sequence-coprime-none-found = Үҙ-ара ябай һандарҙы һайлап булманы. Бөтә мөмкин ҡиммәттәрҙең уртаҡ бүлеүсеһе бар.
+
+select-from-sequence-too-few-unique-values = Оҙонлоғо { $numPossibleValues } эҙмә-эҙлектән { $numToSelect } төрлө ҡиммәт һайлап булмай
+
+select-prime-numbers-too-few-values = Оҙонлоғо { $numValues } ябай һандар исемлегенән { $numToSelect } ҡиммәт һайлап булмай
+
+select-prime-numbers-values-count-mismatch = select өсөн бирелгән ҡиммәттәр һаны һайланасаҡ һанға тап килергә тейеш
+
+select-prime-numbers-values-not-prime = select prime number өсөн бирелгән бөтә ҡиммәттәр ябай һандар исемлегендә булырға тейеш
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers өсөн бирелгән ҡиммәттәр сығарылған комбинация ине
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers эсендә комбинацияларҙың 70%-тан артығы сығарылған
+
+select-random-combination-fluke = Бик ихтималһыҙ осраҡлылыҡ арҡаһында осраҡлы ҡиммәттәр комбинацияһын һайлап булманы
+
+select-random-value-fluke = Бик ихтималһыҙ осраҡлылыҡ арҡаһында осраҡлы ҡиммәтте һайлап булманы

--- a/packages/i18n/locales/ba/editor.ftl
+++ b/packages/i18n/locales/ba/editor.ftl
@@ -1,0 +1,215 @@
+# Bashkir editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Bashkir counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Кире ҡайтарыу
+       *[update] Яңыртыу
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Ҡарағысты { $word }
+       *[other] Ҡарағысты { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Һөҙөү…
+editor-variant-next = Киләһе вариантты һайлау
+editor-variant-previous = Алдағы вариантты һайлау
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA ҡулайлылыҡ боҙоуы табылды. Ҡулайлылыҡ хисабын { $action ->
+            [close] ябыу
+           *[open] асыу
+        } өсөн баҫығыҙ.
+        [advisories] Ҡулайлылыҡ хисабын { $action ->
+            [close] ябыу
+           *[open] асыу
+        } өсөн баҫығыҙ. WCAG AA боҙоуҙары табылманы, әммә өҫтәмә ҡулайлылыҡ тәҡдимдәре бар.
+       *[clean] Ҡулайлылыҡ хисабын { $action ->
+            [close] ябыу
+           *[open] асыу
+        } өсөн баҫығыҙ. Ҡулайлылыҡ мәсьәләләре табылманы.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA ҡулайлылыҡ боҙоуы табылды. { $count ->
+            [one] { $count } WCAG AA боҙоуы
+           *[other] { $count } WCAG AA боҙоуы
+        } табылды. Ҡулайлылыҡ хисабын { $action ->
+            [close] ябыу
+           *[open] асыу
+        } өсөн баҫығыҙ.
+        [advisories] WCAG AA боҙоуҙары табылманы. { $count ->
+            [one] { $count } өҫтәмә ҡулайлылыҡ тәҡдиме
+           *[other] { $count } өҫтәмә ҡулайлылыҡ тәҡдиме
+        } табылды. Ҡулайлылыҡ хисабын { $action ->
+            [close] ябыу
+           *[open] асыу
+        } өсөн баҫығыҙ.
+       *[clean] WCAG AA боҙоуҙары табылманы. Ҡулайлылыҡ хисабын { $action ->
+            [close] ябыу
+           *[open] асыу
+        } өсөн баҫығыҙ.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версияһы { $version }
+
+editor-tab-help = Контекст ярҙамы
+editor-tab-help-short = Контекст
+editor-tab-errors = Хаталар
+editor-tab-warnings = Иҫкәртеүҙәр
+editor-tab-info = Мәғлүмәт
+editor-tab-accessibility = Ҡулайлылыҡ
+editor-tab-responses = Ебәрелгән яуаптар
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Мөхәррир көйләүҙәре
+editor-format-as-doenetml = DoenetML булараҡ форматлау
+editor-format-as-xml = XML булараҡ форматлау
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = Юл №{ $line }
+
+editor-no-errors = Хаталар юҡ
+editor-no-warnings = Иҫкәртеүҙәр юҡ
+editor-no-info = Мәғлүмәти хәбәрҙәр юҡ
+
+editor-show-info-annotations = Мәғлүмәти хәбәрҙәрҙе мөхәррирҙә күрһәтеү
+editor-show-accessibility-annotations = Ҡулайлылыҡ хәбәрҙәрен мөхәррирҙә күрһәтеү
+
+editor-accessibility-learn-more = Doenet ҡулайлылыҡҡа нисек ҡарай
+
+editor-accessibility-violations-heading = Ҡулайлылыҡ боҙоуҙары ({ $standard })
+
+editor-accessibility-other-heading = Башҡа ҡулайлылыҡ мәсьәләләре
+editor-none-found = Бер нәмә лә табылманы
+
+
+## Submitted responses
+
+editor-no-responses = Әлегә ебәрелгән яуаптар юҡ
+editor-response-answer-id = Яуаптың Id-ы
+editor-response-response = Яуап
+editor-response-credit = Балл
+editor-response-submitted = Ебәрелде
+
+
+## The context-help panel
+
+help-placeholder = Документацияны күреү өсөн курсорҙы тег исеменә, атрибутҡа йәки { $ref } өҫтөнә ҡуйығыҙ.
+
+help-unsupported-ref-chain = { $example } кеүек күп өлөшлө һылтанмалар өсөн ярҙам әлегә ҡаралмаған.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Һылтанма өсөн объект табылманы: { $ref }.
+        [multiple] Һылтанма өсөн бер нисә объект табылды: { $ref }.
+       *[indeterminate] { $ref } өсөн объектты билдәләп булманы.
+    }
+
+help-learn-about-references = Һылтанмалар тураһында белеү →
+help-reference-page = Белешмә бите →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } эсендә
+       *[top] Юғары кимәлдә
+    }{ $allowed ->
+        [none] { " — бында бер нәмә лә һыймай." }
+        [text] { " — бында текст яҙып була." }
+        [text-and-components] { " — бында текст яҙып була, йәки быларҙы һынап ҡарағыҙ:" }
+       *[components] { " — быларҙы һынап ҡарап була:" }
+    }
+
+help-suggestions-footer = Бөтә { $total } компонентты күреү өсөн { $shortcut } баҫығыҙ.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объектына һылтанма.
+       *[other] { $ref } — { $target } объектына һылтанма (юл { $line }).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Уны { $owner } { $role } булараҡ индергән.
+       *[other] Уны { $owner } { $line } юлында { $role } булараҡ индергән.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементының { $property } үҙенсәлегенә һылтанма.
+       *[other] { $ref } — { $element } элементының { $property } үҙенсәлегенә һылтанма (юл { $line }).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = өҙөк
+help-kind-array-entry = массив элементы
+
+help-default = Килешеү буйынса ҡиммәт:
+help-active-default = Ғәмәлдәге килешеү буйынса ҡиммәт:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Рөхсәт ителгән ҡиммәттәр (һәр элементҡа береһе):
+       *[other] Рөхсәт ителгән ҡиммәттәр:
+    }
+
+help-suggested-values = Тәҡдим ителгән ҡиммәттәр:
+
+help-inserts = Өҫтәй:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координаталар:
+    }
+
+help-type = Төр:
+
+help-resolved-style = Алынған стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Алынған функция исемдәре:
+help-reset-list = Был ҡырҙың кире ҡайтарыу исемлеге:
+help-added-on-input = Был ҡырҙа өҫтәлгәндәр:
+help-removed-on-input = Был ҡырҙан алып ташланғандар:
+
+help-reset-overrides = { $reset } — { $additional } һәм { $removed } өҫтөнән өҫтөнлөклө.

--- a/packages/i18n/locales/bua/chrome.ftl
+++ b/packages/i18n/locales/bua/chrome.ftl
@@ -1,0 +1,138 @@
+# Buryat viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Buryat counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular, so the two branches differ in nothing but the number they print.
+
+
+## Answer submission
+
+answer-checking = Шалгагдажа байна…
+answer-submitting = Эльгээгдэжэ байна…
+
+answer-checking-status = Харюу шалгагдажа байна
+answer-submitting-status = Харюу эльгээгдэжэ байна
+
+answer-correct = Зүб
+answer-incorrect = Буруу
+
+answer-response-saved = Харюу хадагалагдаба
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% зүб
+answer-percent-short = { $percent } %
+
+max-credit-available = Абажа болохо эгээ ехэ балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] оролдолго үлэбэгүй
+        [one] { $count } оролдолго үлэбэ
+       *[other] { $count } оролдолго үлэбэ
+    }
+
+validation-correct = (Зүб)
+validation-incorrect = (Буруу)
+validation-partially-correct = (Хубиингаа зүб)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } дээрэ { $count } харюу харуулха
+       *[other] { $answerId } дээрэ { $count } харюу харуулха
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Хариу дуулгалга
+
+collapsible-click-to-open = (нээхын тулада дарагты)
+collapsible-click-to-close = (хаахын тулада дарагты)
+
+collapsible-initializing = Бэлдэгдэжэ байна…
+
+footnote-show = Тэмдэглэл харуулха
+footnote-hide = Тэмдэглэл нюуха
+
+description-more-information = нэмэлтэ мэдээсэл
+
+
+## Controls
+
+slider-previous = Урдахи
+slider-next = Дараахи
+
+keyboard-open = Хабтагай нээхэ
+keyboard-close = Хабтагай хааха
+
+choice-input-remove-choice = { $choice } шэлэлгые усадхаха
+
+matrix-remove-row = Мүр усадхаха
+matrix-add-row = Мүр нэмэхэ
+matrix-remove-column = Багана усадхаха
+matrix-add-column = Багана нэмэхэ
+
+subset-add-remove-points = Сэг нэмэхэ/усадхаха
+subset-toggle-points-intervals = Сэгүүд ба забһарнуудые һэлгэхэ
+subset-move-points = Сэгүүдые зөөхэ
+subset-clear = Арилгаха
+
+orbital-add-row = Мүр нэмэхэ
+orbital-remove-row = Мүр усадхаха
+orbital-add-box = Нүхэн нэмэхэ
+orbital-remove-box = Нүхэн усадхаха
+orbital-add-up-arrow = Дээшээ һомо нэмэхэ
+orbital-add-down-arrow = Доошоо һомо нэмэхэ
+orbital-remove-arrow = Һомо усадхаха
+
+orbital-row-label = { $row } мүрэй тэмдэг
+
+pretzel-answer = Харюу
+
+summary-statistics-caption = { $column } баганын дүнгэй статистика
+
+
+## Math input
+
+math-input-preview-region = математическа илэрхэйлэлгын урьдшалан харалга
+math-input-preview = Урьдшалан харалга
+math-input-invalid-expression = Буруу илэрхэйлэлгэ:
+
+
+## Document status
+
+viewer-initializing = Бэлдэгдэжэ байна…
+
+
+## Errors
+
+error-heading = Алдуу
+
+error-found-at =
+    { $span ->
+        [line] Олдоһон мүр: { $startLine }.
+       *[lines] Олдоһон мүрнүүд: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Энэ бэшэг соо алдуунууд бии!
+
+diagnostic-heading-error = Алдуу
+diagnostic-heading-warning = Һэргылэмжэ
+diagnostic-heading-information = Мэдээсэл
+diagnostic-heading-hint = Заабари
+
+accessibility-heading-level-1 = WCAG AA хүрэхэ аргын эбдэлгэ
+accessibility-heading-level-2 = Хүрэхэ аргын тухай мэдээсэл
+
+something-went-wrong = Юуншьеб буруу болобо.
+
+renderer-load-failed = зурагшые ашаалжа шадабагүй. Нюур шэнэлэгты.
+
+core-start-failed = Бэшэг харагшые эхилжэ шадабагүй. Нюур шэнэлэгты.

--- a/packages/i18n/locales/bua/content.ftl
+++ b/packages/i18n/locales/bua/content.ftl
@@ -1,0 +1,255 @@
+# Buryat content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Buryat's own ү, ө and һ, which is the orthography
+# Buryatia's schools and publishing use and what CLDR fills a bare `bua` in as.
+# The roster calls this language **Buriat**, because that is what
+# `Intl.DisplayNames` renders `bua` as; Buryat is the more usual English
+# spelling and the two are one language.
+#
+# `bua` is an ISO 639-3 **macrolanguage** over Russia Buriat (`bxr`), China
+# Buriat (`bxu`) and Mongolia Buriat (`bxm`), so it joins
+# `MACROLANGUAGE_MEMBERS` in `negotiate.ts` and all three reach this catalog.
+# What is written here is the Russian Buriat literary standard — the Khori
+# variety Buryatia publishes in — which is a real compromise for a reader of
+# the other two, and the same trade `locales/qu` and `locales/bik` already
+# make. A deployment that wants another supplies it as `localeResources`.
+#
+# Buryat has no grammatical gender and does not inflect an attributive
+# adjective, so `$gender` and `$role` go unused here — the same answer every
+# Turkic catalog in this batch gives, arriving from an unrelated family.
+
+
+## Style vocabulary
+
+color =
+    .black = хара
+    .white = сагаан
+    .gray = саарал
+    .red = улаан
+    .orange = улбар шара
+    .yellow = шара
+    .green = ногоон
+    .cyan = сайбар хүхэ
+    .blue = хүхэ
+    .purple = нил ягаан
+    .pink = ягаан
+    .brown = хүрин
+
+line-width =
+    .thick = бүдүүн
+    .thin = нимгэн
+
+line-style =
+    .dashed = таһаршаһан
+    .dotted = сэгтэй
+
+# Noun phrases: they stand in front of «хээтэй» and modify nothing.
+fill-style =
+    .horizontal = хэбтээ зурлаа
+    .vertical = бодоо зурлаа
+    .diagonal = диагональ зурлаа
+    .backdiagonal = харша диагональ зурлаа
+    .dots = сэг
+    .diamonds = ромб
+
+noun =
+    .line = сэхэ зурлаа
+    .line-segment = хэрчим
+    .ray = сасараг
+    .vector = вектор
+    .curve = муруй зурлаа
+    .function = функци
+    .parabola = парабола
+    .polyline = хухарһан зурлаа
+    .polygon = олон талата
+    .triangle = гурбалжан
+    .rectangle = тэгшэ дүрбэлжэн
+    .circle = тойрог
+    .region = можо
+    .point = сэг
+    .square = дүрбэлжэн
+    .diamond = ромб
+    .cross = хэрээһэн
+    .plus = плюс
+
+# Buryat builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] тэгшэ { $numSides } талата
+    }
+
+# Buryat has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = будагдаһан
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } хээтэй { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } хээтэй { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } хээтэй { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «хизаартай» — "having an edge" — carries the "with a border" sense in its own
+# suffix, so neither a preposition nor an article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } хизаартай
+        [and] ба { $border } хизаартай
+        [and-article] ба { $border } хизаартай
+       *[with] { $border } хизаартай
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } хээтэй { $color } будаг
+       *[plain] { $color } будаг
+    }
+
+style-unfilled = будагдаагүй
+
+# «дээрэ» — "on top of" — is a postposition and follows the background colour,
+# so nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } дэбисхэр дээрэ { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = үгы
+
+
+## Boolean words
+
+boolean-true = үнэн
+boolean-false = худал
+
+
+## Answer buttons
+
+answer-submit-label = Шалгаха
+answer-submit-label-no-correctness = Харюу эльгээхэ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Хүдэлмэри
+    .aside = Хажуугай тэмдэглэл
+    .cascade = Каскад
+    .definition = Тодорхойлолто
+    .example = Жэшээ
+    .exercise = Дасхал
+    .exercises = Дасхалнууд
+    .given-answer = Харюу
+    .note = Тэмдэглэл
+    .objectives = Зорилгонууд
+    .paragraphs = Абзацууд
+    .part = Хуби
+    .problem = Бодолго
+    .problems = Бодолгонууд
+    .proof = Баталга
+    .question = Асуудал
+    .section = Бүлэг
+    .solution = Шиидхэбэри
+    .task = Даабари
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Заабари
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Хүснэгтэ { $enumeration }
+        [numbered-title] Хүснэгтэ { $enumeration }{ ". " }
+        [unnumbered-title] Хүснэгтэ{ ". " }
+       *[unnumbered] Хүснэгтэ
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Зураг { $enumeration }
+        [numbered-caption] Зураг { $enumeration }{ ". " }
+        [unnumbered-caption] Зураг{ ". " }
+       *[unnumbered] Зураг
+    }
+
+
+## Paginator controls
+
+paginator-previous = Урдахи
+paginator-next = Дараахи
+paginator-page = Нюур
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## Buryat's conditional «хэрбээ» is a clause-*initial* particle, unlike the
+## clause-final converbs `locales/sah` and `locales/tyv` record a limit for, so
+## this key lands where the renderer puts it and reads correctly. Two Mongolic
+## and Turkic neighbours, two different answers to the same question.
+
+piecewise-condition-or = али
+piecewise-condition-if = хэрбээ
+piecewise-condition-otherwise = үгы һаа
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Buryatia is taught in
+## Russian, so the element names a Buryat-speaking pupil meets are the Russian
+## ones — the school-system case this batch shares throughout.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Буруу химическэ тэмдэг
+chemistry-invalid-ionic-compound = Буруу ионой холбоо

--- a/packages/i18n/locales/bua/diagnostics.ftl
+++ b/packages/i18n/locales/bua/diagnostics.ftl
@@ -1,0 +1,654 @@
+# Buryat diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Buryat uses
+# for them: «компонент», «атрибут», «функци», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] хоёр үзүүрэй сэг заагдаһан үедэ { $attributes } тоологдоногүй
+       *[other] хоёр үзүүрэй сэг заагдаһан үедэ { $attributes } тоологдоногүй
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] үзүүрэй сэгшье, дунда сэгшье заагдаһан үедэ { $attributes } тоологдоногүй
+       *[other] үзүүрэй сэгшье, дунда сэгшье заагдаһан үедэ { $attributes } тоологдоногүй
+    }
+
+line-segment-midpoint-offset-without-midpoint = дунда сэггүй midpointOffset юуншье дээрэ нүлөөлнэгүй
+
+## `<line>`
+
+line-points-undetermined-dimensions = Хэмжээниинь мэдэгдээгүй сэгүүд соогуур гарадаг сэхэ зурлаа.
+
+line-points-too-few-dimensions = Сэхэ зурлаа хамагай багадаа хоёр хэмжээтэй сэгүүд соогуур гараха ёһотой.
+
+line-points-depend-on-variables = Сэхэ зурлаа хубилдаг хэмжээнүүдһээ дулдыдадаг сэгүүд соогуур гарана: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ба { $variable2 } хубилдаг хэмжээнүүдтэй сэхэ зурлаагай тэгшэдхэлэй формат буруу.
+
+## `<ray>`
+
+ray-overprescribed-through = Сасараг through, endpoint ба direction соогуур үгтэбэ. Үгтэһэн through тоологдоногүй.
+
+ray-dimension-mismatch = сасараг дээрэ numDimensions таарангүй.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail ба displacement соогуур үгтэбэ. Үгтэһэн head тоологдоногүй.
+
+vector-dimension-mismatch = вектор дээрэ numDimensions таарангүй.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элемент руу татажа шадахагүй, юундэб гэхэдэ тэрээндэ nearestPoint байдалай хубилдаг хэмжээн үгы.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементээр хизаарлажа шадахагүй, юундэб гэхэдэ тэрээндэ nearestPoint байдалай хубилдаг хэмжээн үгы.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементын дотоороо хизаарлажа шадахагүй, юундэб гэхэдэ тэрээндэ nearestPoint байдалай хубилдаг хэмжээн үгы.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = мүр соохи бэшэ choiceInput дээрэ labelPosition тоологдоногүй
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput дээрэ үгтэһэн индексүүд тоологдоногүй, юундэб гэхэдэ тэдэнэй тоо choice үхибүүдэй тоодо тааранагүй.
+
+pretzel-indices-count-mismatch = problem дээрэ үгтэһэн индексүүд тоологдоногүй, юундэб гэхэдэ тэдэнэй тоо problem үхибүүдэй тоодо тааранагүй.
+
+shuffle-indices-count-mismatch = shuffle дээрэ үгтэһэн индексүүд тоологдоногүй, юундэб гэхэдэ тэдэнэй тоо компонентнуудай тоодо тааранагүй.
+
+indices-ignored-out-of-range = { $component } дээрэ үгтэһэн индексүүд тоологдоногүй, юундэб гэхэдэ зариманиинь хизаарһаа гарана.
+
+pretzel-indices-repeated = pretzel дээрэ үгтэһэн индексүүд тоологдоногүй, юундэб гэхэдэ зариманиинь дабтагдана.
+
+pretzel-circuit-first-index = circuit горим соо pretzel дээрэ үгтэһэн индексүүд тоологдоногүй, юундэб гэхэдэ түрүүшын индекс 1 байха ёһотой.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текстын үхибүүдтэй хүдэлхын тулада `type` атрибут үгтэхэ ёһотой.
+
+invalid-type-defaulting-to-math = { $component } компонентдо буруу түхэл { $type }. Тэрэ math, text, number али boolean байха ёһотой. math хэрэглэгдэнэ.
+
+string-not-valid-component-to-arrange = «{ $value }» мүр { $component } дээрэ таарамжатай компонент бэшэ. Тоологдоногүй.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Буруу түхэл { $type }, түхэлынь number болгогдоно.
+
+invalid-variable-value = Хубилдаг хэмжээнэй буруу утга: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантын индекс тоо байха ёһотой
+
+variant-index-must-be-integer = { $index } вариантын индекс бүхэли тоо байха ёһотой
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют хэмжээнүүдтэ хэгдээгүй. Үргэнүүдынь харилсуулагдана.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют хэмжээнүүдтэ хэгдээгүй. Хизаарнуудынь харилсуулагдана.
+
+side-by-side-no-block-child = Буруу `<{ $component }>`: тэрээндэ хамагай багадаа нэгэ блог үхибүүн байха ёһотой.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элемент дээрэхи `for` атрибут тоологдоногүй.
+
+label-for-must-resolve-to-one = `<label>` элемент дээрэхи `for` атрибут яг нэгэ компонент дээрэ зааха ёһотой.
+
+label-for-unresolved = `<label>` элемент дээрэхи `for` атрибудые компоненттэй холбожо шадабагүй.
+
+label-for-answer-with-authored-inputs = `<label>` элемент дээрэхи `for` атрибут автор бэшэһэн оруулгын талмайнуудтай `<answer>` дээрэ заана; талмай дээрэ шэглүүлэн заагты.
+
+label-for-answer-without-input = `<label>` элемент дээрэхи `for` атрибут тэмдэглэхэ оруулгын талмайгүй `<answer>` дээрэ заана.
+
+label-for-must-reference-input-or-answer = `<label>` элемент дээрэхи `for` атрибут оруулгын талмай али харюу дээрэ зааха ёһотой.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Хүрэхэ аргын тулада `<{ $component }>` али богони тайлбаритай байха, али шэмэглэл гэжэ тэмдэглэгдэхэ ёһотой.
+
+accessibility-video-short-description = Хүрэхэ аргын тулада `<video>` богони тайлбаритай байха ёһотой.
+
+accessibility-input-short-description-or-label = Хүрэхэ аргын тулада `<{ $component }>` богони тайлбаритай али тэмдэгтэй байха ёһотой.
+
+accessibility-answer-input-short-description-or-label = Хүрэхэ аргын тулада оруулгын талмай бүтээдэг `<answer>` богони тайлбаритай али тэмдэгтэй байха ёһотой.
+
+accessibility-short-description-contains-math = Богони тайлбаринууд соо `<{ $component }>` шэнги математическа компонентнууд байха ёһогүй. Математикые үгөөр бэшэгты.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } бүлэгэй толгойн текстдэ хүрэхэ контраст үгэнэгүй (харанхы түхэл) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; хамагай багадаа { $threshold }:1 хэрэгтэй).
+       *[other] { $colorName } бүлэгэй толгойн текстдэ хүрэхэ контраст үгэнэгүй ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; хамагай багадаа { $threshold }:1 хэрэгтэй).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Сэгүүдэй тоото утга үгы байхада { $count } сэг соогуур гарадаг `<circle>` хэгдээгүй.
+
+circle-too-many-through-points = 3-һаа олон сэг соогуур гарадаг тойрог тооложо шадахагүй.
+
+circle-overprescribed-radius-center-points = Үгтэһэн радиус, түб ба сэгүүдтэй тойрог тооложо шадахагүй.
+
+circle-center-with-multiple-points = Үгтэһэн түбтэй 1-һээ олон сэг соогуур гарадаг тойрог тооложо шадахагүй.
+
+circle-radius-too-small = Тойрог тооложо шадахагүй: хоёр сэгэй хоорондохи зай { $distance } байхада, үгтэһэн радиус { $radius } хэтэрхэй бага.
+
+circle-radius-with-many-points = Үгтэһэн радиустай хоёрһоо олон сэг соогуур гарадаг тойрог бүтээжэ шадахагүй.
+
+circle-invalid-center-or-through-points = Тойрогой түб али сэгүүд буруу.
+
+circle-radius-center-with-multiple-points = Үгтэһэн түбтэй 1-һээ олон сэг соогуур гарадаг тойрогой радиус тооложо шадахагүй.
+
+circle-change-radius-non-numerical = Тоото бэшэ сэгүүдтэй тойрогой радиус хубилгажа шадахагүй
+
+circle-radius-with-points-non-numerical = Тоото утга үгы байхада үгтэһэн радиустай нэгэһээ олон сэг соогуур гарадаг тойрог бүтээжэ шадахагүй.
+
+circle-change-center-non-numerical = Тоото бэшэ сэгүүд соогуур гарадаг тойрогой түб хубилгаха хэгдээгүй.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функциин тодорхойлогдодог можын хэмжээн хүрэнэгүй. Можо соо { $intervals } забһар бии, харин функци соо { $inputs ->
+            [one] { $inputs } оролто
+           *[other] { $inputs } оролто
+        } бии.
+       *[other] Функциин тодорхойлогдодог можын хэмжээн хүрэнэгүй. Можо соо { $intervals } забһар бии, харин функци соо { $inputs ->
+            [one] { $inputs } оролто
+           *[other] { $inputs } оролто
+        } бии.
+    }
+
+function-domain-invalid-format = Функциин тодорхойлогдодог можын формат буруу.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функциин тоото бэшэ максимум тоологдоногүй.
+        [minimum] Функциин тоото бэшэ минимум тоологдоногүй.
+        [extremum] Функциин тоото бэшэ экстремум тоологдоногүй.
+        [point] Функциин тоото бэшэ сэг тоологдоногүй.
+        [slope] Функциин тоото бэшэ хазайлга тоологдоногүй.
+       *[other] Функциин тоото бэшэ { $type } утга тоологдоногүй.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функциин хооһон максимум тоологдоногүй.
+        [minimum] Функциин хооһон минимум тоологдоногүй.
+        [extremum] Функциин хооһон экстремум тоологдоногүй.
+        [point] Функциин хооһон сэг тоологдоногүй.
+       *[other] Функциин хооһон { $type } утга тоологдоногүй.
+    }
+
+function-points-too-close = Функци соо бэе бэедээ хэтэрхэй ойрохон хоёр сэг бии. Функци тодорхойлжо шадахагүй.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функциин итерацинууд оролтын тоо гаралтын тоодо тэнсүү байхада лэ болоно. Энэ функци соо { $inputs } оролто ба { $outputs ->
+            [one] { $outputs } гаралта
+           *[other] { $outputs } гаралта
+        } бии.
+       *[other] Функциин итерацинууд оролтын тоо гаралтын тоодо тэнсүү байхада лэ болоно. Энэ функци соо { $inputs } оролто ба { $outputs ->
+            [one] { $outputs } гаралта
+           *[other] { $outputs } гаралта
+        } бии.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Дараалалай утань буруу. Тэрэ һөрэг бэшэ бүхэли тоо байха ёһотой.
+
+sequence-invalid-step = Дараалалай алхам буруу. { $type } түхэлтэй дараалалда тэрэ тоо байха ёһотой.
+
+sequence-invalid-endpoint-number = Тоото дараалалай «{ $attribute }» утга буруу. Тэрэ тоо байха ёһотой.
+
+sequence-invalid-endpoint-letters = Үзэгэй дараалалай «{ $attribute }» утга буруу. Тэрэ үзэгүүдэй холболто байха ёһотой.
+
+sequence-invalid-endpoint = Дараалалай «{ $attribute }» утга буруу.
+
+select-from-sequence-coprime-not-numbers = тоонууд шэлэгдээгүй тула coprime тоологдоногүй
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations үгтэһэн тула coprime тоологдоногүй
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` дээрэ буруу target: зорилго олдобогүй.
+
+target-state-variable-not-found = `<{ $source }>` дээрэ буруу target: `<{ $component }>` элемент дээрэ «{ $property }» нэрэтэй байдалай хубилдаг хэмжээн олдобогүй.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` хубилдаг хэмжээнүүдынь дулдыдангүй хэмжээнһээ ондоо байха ёһотой.
+
+ode-system-duplicate-variable-names = Дулдыдадаг хэмжээнүүдэй нэрэнүүд дабтагдажа байхада ДТ баруун талын функцинуудые тодорхойлжо шадахагүй.
+
+ode-system-rhs-function-error = ДТ баруун талын функци тодорхойлжо шадахагүй. mathjs функци бүтээхэдэ алдуу.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } сэхэ зурлаагай хоорондохи булан тодорхойлжо шадахагүй
+
+angle-invalid-through-point = `<angle>` элементын through утга соо буруу сэг
+
+parabola-vertex-too-many-points = Үгтэһэн орьёлтой 1-һээ олон сэг соогуур гарадаг парабола хэгдээгүй.
+
+parabola-too-many-points = 3-һаа олон сэг соогуур гарадаг парабола хэгдээгүй.
+
+intersection-too-many-items = Хоёрһоо олон объектын огтолсолго хэгдээгүй
+
+## Other math components
+
+ionic-compound-not-two-ions = Хоёр ионһоо бэшэ ионой холбоо хэгдээгүй.
+
+ionic-compound-needs-cation-and-anion = Ионой холбоо нэгэ катион ба нэгэ анионой тулада лэ хэгдэһэн.
+
+solve-equations-cannot-evaluate = Тэгшэдхэл шиидхэжэ шадахагүй, юундэб гэхэдэ тэрэниие тооложо шадабагүй: { $equation }
+
+math-operators-operand-number-required = Математическа операнд илгаха тулада operandNumber үгтэхэ ёһотой.
+
+eigen-decomposition-failed = Матрицын өөрын утга тооложо шадабагүй
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр загбар соо ушарнагүй, тиимэһээ тэрэ хэзээдэшье хооһондо таарана.
+       *[other] `<matchesPattern>`: { $parameters } параметрнүүд загбар соо ушарнагүй, тиимэһээ тэдэ хэзээдэшье хооһондо таарана.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" утга ойлгожо шадахагүй. Тэрэ none, medium, dense али хооһон зайгаар илгагдаһан хоёр эерэг тоо байха ёһотой, жэшээнь grid="1 0.5". Тор зурагданагүй.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure зурагша дээрэ xLabelPosition="left" хэгдээгүй; баруун талын байрлал хэрэглэгдэнэ.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure зурагша дээрэ yLabelPosition="bottom" хэгдээгүй; дээдэ талын байрлал хэрэглэгдэнэ.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure хубилгалгада тэнхэлэйн хизаарнууд буруу; үндэһэн bbox (-10,-10,10,10) хэрэглэгдэнэ.
+
+prefigure-invalid-width = `<graph>`: prefigure хубилгалгада үргэн буруу; диаграммын үндэһэн үргэн 425 хэрэглэгдэнэ.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure хубилгалгада aspectRatio буруу; үндэһэн талануудай харисаа 1 хэрэглэгдэнэ.
+
+prefigure-grid-spacing-too-fine = `<graph>`: торой алхам тэнхэлэйн хизаарнуудта хэтэрхэй нарин; prefigure зурагша дээрэ тор гаргагданагүй.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure зурагша хэрэглэгдээгүй һаа тэмдэглэлнүүд зурагданагүй.
+
+multiple-annotations-children = `<graph>` соо хэдэн `<annotations>` үхибүүн олдобо; һүүлшынһээ бэшэниинь тоологдоногүй.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Танигдаагүй компонентын түхэл үргэдхэжэ али хуулажа шадахагүй: { $type }.
+
+copy-prop-not-found = { $component } түхэлтэй компонент дээрэ { $property } шанар олдобогүй
+
+collect-no-source = collect дээрэ уг олдобогүй.
+
+collect-invalid-component-type = `<{ $component }>` түхэлтэй компонентнуудые суглуулжа шадахагүй, юундэб гэхэдэ энэ буруу компонентын түхэл.
+
+reference-index-unavailable = `{ $reference }` индекс дээрэ холбоһон хэжэ шадахагүй
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонент дээрэ { $action } дуудажа шадахагүй
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Мэдээсэлэй хэлбэри буруу. Мүрнүүдэй утань ондо ондоо. Олдобо componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Мэдээсэл соо баганын нэрэнүүд дабтагдана. Олдобо componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Мэдээсэл соо баганын нэрэ дуталдана. Олдобо componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Энэ харюугай award утга answer тэгэй өөрын эльгээгдэһэн харюу дээрэ үндэһэлнэ, энэ хүлеэгдээгүй байдалда хүргэнэ.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` бүхы контейнер соохи `<answer>` дээрэ `maxNumAttempts` табихань нүлөөлнэгүй, юундэб гэхэдэ оролдолгын тоо контейнер тодорхойлно. `maxNumAttempts` утга контейнер дээрэ табигты.
+
+nested-section-wide-check-work-max-num-attempts = Ондоо `sectionWideCheckWork` контейнер соо байдаг `sectionWideCheckWork` контейнер дээрэ `maxNumAttempts` табихань нүлөөлнэгүй, юундэб гэхэдэ оролдолгын тоо гадаадахи контейнер тодорхойлно. `maxNumAttempts` утга гадаадахи контейнер дээрэ табигты.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality табигдаагүй һаа { $attributes } атрибут нүлөөлхэгүй.
+       *[other] symbolicEquality табигдаагүй һаа { $attributes } атрибудууд нүлөөлхэгүй.
+    }
+
+answer-invalid-type = answer дээрэ буруу түхэл: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентын нэрэ үгы тула тэрэниие модулиин атрибут болгожо хэрэглэжэ шадахагүй
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонент модулиин атрибут болгожо хэрэглэжэ шадахагүй, юундэб гэхэдэ `<module>` компонентын түхэл дээрэ «{ $name }» атрибут хэдын тодорхойлогдонхой.
+
+conditional-content-condition-ignored = case али else үхибүүдтэй `<conditionalContent>` компонент дээрэ `condition` атрибут тоологдоногүй.
+
+slider-markers-type-mismatch = Маркернуудай түхэл гулгуурай түхэлдэ тааранагүй.
+
+pretzel-problem-needs-statement-and-answer = Буруу pretzel: `<problem>` бүхэн нэгэ `<statement>` ба нэгэ `<answer>` агуулха ёһотой.
+
+pretzel-circuit-first-problem-distractor = Буруу pretzel: mode="circuit" горим соо түрүүшын `<problem>` анхарал буруулагша байжа шадахагүй.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибут дээрэ буруу утга { $values }; тоологдоногүй.
+       *[other] `{ $attribute }` атрибут дээрэ буруу утганууд { $values }; тоологдоногүй.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибут дээрэ буруу утга `{ $value }`. Атрибут `$` тэмдэгһээ эхилдэг холбоһонуудһаа бүридэхэ ёһотой.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } соохи буруу функциин нэрэнүүд тоологдобогүй: { $names }. Нэрэ бүхэнэй харагдадаг хубинь хамагай багадаа 2 тэмдэг байха ёһотой (үзэгүүд али зураанууд); тэрэнэй хойно хэрэгтэй бэшэ `|<mathspeak альтернатива>` нэмэлтэ ерэжэ болохо.
+
+## Building components from the source
+
+component-type-invalid = Буруу компонентын түхэл: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут дабтажа шадахагүй.
+
+attribute-invalid-for-component = `<{ $componentType }>` түхэлтэй компонентдо буруу атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стилиин тодорхойлолто соо { $context ->
+        [text-on-background] текстын үнгэ ба дэбисхэрэй үнгэ
+        [high-contrast] ехэ контрасттай үнгэ ба зурагай талмай
+        [line] зурлаагай үнгэ ба зурагай талмай
+        [marker] маркерай үнгэ ба зурагай талмай
+       *[text-on-canvas] текстын үнгэ ба зурагай талмай
+    } хоорондохи контраст хүрэнэгүй{ $mode ->
+        [dark] { " (харанхы түхэл)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; хамагай багадаа { $threshold }:1 хэрэгтэй).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стилиин тодорхойлолто соо үгтэһэн үнгэнүүд гэрэлтэ түхэлдэ хүрэхэ контраст үгэбэшье, тэдэнһээ гараһан харанхы түхэлэй үнгэнүүд текст ба дэбисхэрэй хоорондо хүрэхэ контраст үгэнэгүй ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; хамагай багадаа { $threshold }:1 хэрэгтэй). { $suggestion ->
+        [available] Харанхы түхэлдэ хүрэхэ контрастын тулада али гэрэлтэ түхэлэй контраст ехэ болгогты (жэшээнь { $lightAttribute }="{ $lightColor }"), али харанхы түхэлэй үнгэ һэлгэгты (жэшээнь { $darkAttribute }="{ $darkColor }").
+       *[none] Харанхы түхэлдэ хүрэхэ контрастын тулада гэрэлтэ түхэлэй контраст ехэ болгогты али гараһан үнгэнүүдые textColorDarkMode ба/али backgroundColorDarkMode-оор һэлгэгты.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стилиин тодорхойлолто соо үгтэһэн текстын үнгэ гэрэлтэ түхэлдэ хүрэхэ контраст үгэбэшье, тэрээнһээ гараһан харанхы түхэлэй текстын үнгэ зурагай талмайтай хүрэхэ контраст үгэнэгүй ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; хамагай багадаа { $threshold }:1 хэрэгтэй). { $suggestion ->
+        [available] Харанхы түхэлдэ хүрэхэ контрастын тулада али гэрэлтэ түхэлэй контраст ехэ болгогты (жэшээнь textColor="{ $lightColor }"), али харанхы түхэлэй үнгэ һэлгэгты (жэшээнь textColorDarkMode="{ $darkColor }").
+       *[none] Харанхы түхэлдэ хүрэхэ контрастын тулада гэрэлтэ түхэлэй контраст ехэ болгогты али гараһан үнгэ textColorDarkMode-оор һэлгэгты.
+    }
+
+section-multiple-style-palettes = Бүлэг ганса <stylePalette> шэлэжэ шадана; һүүлшыниинь хэрэглэгдэнэ.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ numToSelect һөрэг бэшэ бүхэли тоо бэшэ.
+
+variant-num-to-select-not-constant-number = { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ numToSelect тогтоһон тоо бэшэ.
+
+variant-with-replacement-not-constant-boolean = { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ withReplacement тогтоһон логическа утга бэшэ.
+
+variant-select-weight-disables-unique = ямар нэгэн шэлэлгэ дээрэ selectWeight али selectForVariants үгтэһэн һаа, select дээрэ дабтагдашагүй вариантнууд хаагдана
+
+variant-coprime-undetermined = { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ coprime хэзээдэшье худал гү гэжэ тодорхойлжо шадахагүй.
+
+variant-attribute-not-constant = { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ { $attribute } тогтоһон бэшэ.
+
+variant-attribute-not-number = { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ { $attribute } тоо бэшэ.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } түхэлтэй { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ { $attribute } { $expected ->
+        [letters-combination] үзэгүүдэй холболто
+        [math-expression] таарамжатай математическа илэрхэйлэлгэ
+        [integer] бүхэли тоо
+       *[number] тоо
+    } бэшэ.
+
+variant-length-not-integer = { $component } дээрэ дабтагдашагүй вариантнуудые тодорхойлжо шадахагүй, юундэб гэхэдэ length бүхэли тоо бэшэ.
+
+variant-sort-not-implemented = sort бүхы { $component } дээрэ дабтагдашагүй вариантнууд хэгдээгүй
+
+variant-exclude-combinations-not-implemented = excludeCombinations бүхы { $component } дээрэ дабтагдашагүй вариантнууд хэгдээгүй
+
+variant-math-exclude-not-implemented = exclude бүхы math түхэлтэй { $component } дээрэ дабтагдашагүй вариантнууд хэгдээгүй
+
+variant-non-constant-exclude-not-implemented = тогтоһон бэшэ exclude бүхы { $component } дээрэ дабтагдашагүй вариантнууд хэгдээгүй
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графигай prefigure зурагша дээрэ хэгдээгүй; удамынь орхигдобо.
+
+prefigure-descendant-invalid-geometry = { $subject }: түгэсхэлгүй али дүүрэн бэшэ геометри; удамынь орхигдобо.
+
+prefigure-curve-label-omitted = { $subject }: хубилгагдаһан муруй элементнүүд дээрэ тэмдэгүүд хэгдээгүй; тэмдэг орхигдобо.
+
+prefigure-curve-unsupported-definition-type = { $subject }: хэгдээгүй муруй функциин тодорхойлолтын түхэл «{ $definitionType }»; удамынь орхигдобо.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элемент дээрэхи flipFunctions атрибут хэгдээгүй; удамынь орхигдобо.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулаар үгтэһэн үхибүүн функцинуудые лэ абана; удамынь орхигдобо.
+
+prefigure-label-position-unsupported =
+    { $subject }: хэгдээгүй labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] зурлаануудай бүлэгэй тэмдэгтэ
+       *[point] сэгэй тэмдэгтэ
+    }; PreFigure-эй үндэһэн тэгшэлгэ хэрэглэгдэнэ.
+
+prefigure-fill-style-unsupported = { $subject }: дүүргэлгын стиль «{ $fillStyle }» PreFigure дээрэ хэгдээгүй; дүүрэн дүүргэлгэ руу орино.
+
+prefigure-line-style-unknown = { $subject }: мэдэгдээгүй зурлаагай стиль «{ $lineStyle }» PreFigure-эй гаралгаһаа усадхагдаба.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркерай стиль «{ $markerStyle }» PreFigure-эй «diamond» стильтэй тааруулагдаба.
+
+prefigure-marker-style-unsupported = { $subject }: маркерай стиль «{ $markerStyle }» PreFigure дээрэ хэгдээгүй; үндэһэн стиль хэрэглэгдэнэ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: буруу `ref`; зорилго холбожо шадахагүй. Тэмдэглэл усадхагдаба.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` хэдэн зорилготой холбогдобо; түрүүшыниинь хэрэглэгдэнэ.
+
+annotation-ref-outside-graph = `<annotation>`: буруу `ref`; зорилго тэрэниие агуулдаг графигай гадна. Тэмдэглэл усадхагдаба.
+
+annotation-ref-unsupported-target = `<annotation>`: буруу `ref`; зорилго prefigure хубилгалга дээрэ хэгдэһэн график объект бэшэ. Тэмдэглэл усадхагдаба.
+
+annotation-text-missing = `<annotation>`: `text` үгы али хооһон; хооһон текст гаргагдана.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Тойрог дулдыдал элирүүлэгдэбэ.
+       *[other] `<{ $componentType }>` компонент агуулдаг тойрог дулдыдал элирүүлэгдэбэ.
+    }
+
+reference-no-referent = Холбоһондо объект олдобогүй: `{ $reference }`
+
+reference-multiple-referents = Холбоһондо хэдэн объект олдобо: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементын { $attribute } атрибудай формат буруу.
+
+children-invalid = `<{ $componentType }>` дээрэ буруу үхибүүд: буруу үхибүүд олдобо: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибут дээрэ буруу утга `{ $value }`; `{ $default }` утга хэрэглэгдэнэ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } хубилбари олдобогүй.
+       *[other] DoenetML { $version } хубилбари олдобогүй. { $fallback } хубилбари хэрэглэгдэнэ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Буруу DoenetML: { $content }
+
+parse-tag-missing-close-tag = Буруу DoenetML: `{ $tag }` тэгэй хаадаг тэг үгы. Өөрөө хаагдадаг тэг али `</{ $tagName }>` тэг хүлеэгдэһэн.
+
+parse-tag-error = Буруу DoenetML: `<{ $tagName }>` тэг соо алдуу
+
+parse-attribute-missing-value = Буруу DoenetML: `{ $attribute }` атрибут дээрэ утга дуталдажа байна бэшэ гү.
+
+parse-attribute-invalid = Буруу DoenetML: буруу атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Буруу DoenetML: атрибудай буруу утга `{ $value }`
+
+parse-attribute-value-quote-mismatch = Буруу DoenetML: атрибудай буруу утга `{ $value }`. Хашалтанууд тааранагүй. `{ $quote }` дуталдажа байна бэшэ гү
+
+parse-open-tag-name-missing = Буруу DoenetML: нэрэгүй тэг олдобо, жэшээнь `<`
+
+parse-tag-not-closed = Буруу DoenetML: `{ $tag }` тэг хаагдаагүй (`>` дуталдажа байна бэшэ гү).
+
+parse-self-closing-tag-name-missing = Буруу DoenetML: нэрэгүй тэг олдобо `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Буруу DoenetML: `{ $tag }` тэг хаагдаагүй (`/>` дуталдажа байна бэшэ гү).
+
+parse-tag-invalid-attributes = Буруу DoenetML: `{ $tag }` тэг таарамжатай бэшэ. Тэрэнэй атрибудууд буруу байжа болохо.
+
+parse-close-tag-name-missing = Буруу DoenetML: нэрэгүй хаадаг тэг олдобо, жэшээнь `</`
+
+parse-attribute-value-unquoted = Атрибудай утганууд хашалта соо байха ёһотой: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Буруу DoenetML: `{ $tag }` хаадаг тэг олдобо, теэд тэрээндэ таарадаг нээдэг тэг үгы
+
+parse-close-tag-mismatched = Буруу DoenetML: тааранагүй хаадаг тэг. `</{ $expected }>` хүлеэгдэһэн. `{ $found }` олдобо
+
+parser-node-unconvertible = { $node } зангилаае Dast зангилаа болгожо хубилгажа шадабагүй.
+
+## Names
+
+name-attribute-invalid =
+    Буруу атрибут name='{ $name }'. { $reason ->
+        [characters] Нэрэнүүд соо үзэгүүд, тоонууд, доодо зураанууд али зураанууд лэ байжа болохо.
+       *[start] Нэрэнүүд үзэгһөө эхилхэ ёһотой.
+    }
+
+component-name-invalid-start = Буруу компонентын нэрэ «{ $name }». Нэрэнүүд үзэгһөө эхилхэ ёһотой.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched түхэлтэй answer video атрибуттай байха ёһотой
+
+answer-video-watched-video-not-reference = videoWatched түхэлтэй answer-эй video атрибут холбоһон байха ёһотой
+
+answer-name-not-single-text = answer-эй name атрибут яг нэгэ текстын үхибүүтэй байха ёһотой
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсиин шатанууд хэтэрхэй олон тула гадаадахи DoenetML абажа шадабагүй. Тойрог холбоһон үгы гү?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" хаягһаа DoenetML абажа шадабагүй
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" хаягһаа буруу DoenetML абтаба: тэрэ «{ $componentType }» компонентын түхэлдэ тааранагүй
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут хуушарба; тэрэнэй орондо `{ $to }` хэрэглэгты.
+       *[other] [deprecation] `<{ $component }>` элемент дээрэхи `{ $from }` атрибут хуушарба; тэрэнэй орондо `{ $to }` хэрэглэгты.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут хуушарба ба тоологдоногүй, юундэб гэхэдэ `{ $to }` баһа үгтэһэн.
+       *[other] [deprecation] `<{ $component }>` элемент дээрэхи `{ $from }` атрибут хуушарба ба тоологдоногүй, юундэб гэхэдэ `{ $to }` баһа үгтэһэн.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элемент дээрэхи `{ $attribute }` атрибут хуушарба ба тоологдоногүй.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элемент дээрэхи `{ $attribute }` атрибут хуушарба; тэрэнэй орондо `<{ $child }>` үхибүү хэрэглэгты.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элемент дээрэхи `{ $attribute }` атрибудай `{ $value }` утга хуушарба; тэрэнэй орондо `{ $to }` хэрэглэгты.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` олон тоо англи хэлэн дээрэ лэ хэжэ шадана, тиимэһээ { $locale } хэлэн дээрэ бэшэгдэһэн бэшэг соо тэрэнэй текст хубилангүй үлэнэ. Олон тоогой хэлбэри өөрөө бэшэгты али тэрэниие `pluralForm` атрибудаар үгэгты.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент танигдаһан Doenet элемент бэшэ.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементдэ бэшэгэй үндэһэн дээрэ зүбшөөл үгтэнэгүй.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементдэ `<{ $parent }>` соо зүбшөөл үгтэнэгүй.
+
+schema-attribute-unrecognized = `<{ $tag }>` элемент дээрэ `{ $attribute }` нэрэтэй атрибут үгы.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементын `{ $attribute }` атрибут элемент бүхэниинь эдэнэй нэгэн байдаг жагсаалта байха ёһотой: { $allowed }
+       *[other] `<{ $tag }>` элементын `{ $attribute }` атрибут эдэнэй нэгэн байха ёһотой: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select дээрэ буруу вариантын нэрэ. { $variantName } вариантын нэрэ { $numOptions } шэлэлгэ дээрэ ушарна, харин шэлэхэ тоо { $numToSelect }.
+
+select-variant-name-without-options = select дээрэ вариантнууд үгтэһэн, теэд боломжотой вариантын нэрэдэ нэгэшье шэлэлгэ үгы: { $variantName }.
+
+select-variant-name-not-possible = select дээрэ үгтэһэн { $variantName } вариантын нэрэ боломжотой вариантын нэрэ бэшэ.
+
+select-too-few-options = Ниитэ { $numOptions } сооһоо { $numToSelect } компонент шэлэжэ шадахагүй.
+
+select-from-sequence-too-few-values = Утань { $length } дараалалһаа { $numToSelect } утга шэлэжэ шадахагүй.
+
+select-from-sequence-indices-count-mismatch = select дээрэ үгтэһэн индексүүдэй тоо шэлэхэ тоодо таараха ёһотой
+
+select-from-sequence-indices-not-integers = select дээрэ үгтэһэн бүхы индексүүд бүхэли тоо байха ёһотой
+
+select-from-sequence-index-excluded = selectfromsequence дээрэ үгтэһэн индекс усадхагдаһан байгаа
+
+select-from-sequence-indices-excluded-combination = selectfromsequence дээрэ үгтэһэн индексүүд усадхагдаһан холболто байгаа
+
+select-from-sequence-coprime-not-positive-integers = Эерэг бүхэли тоонууд шэлэгдээгүй тула харилсан энгидэрхэй холболтонуудые шэлэжэ шадахагүй.
+
+select-from-sequence-coprime-common-factor = Харилсан энгидэрхэй тоонуудые шэлэжэ шадахагүй. Бүхы боломжотой утганууд ниитэ хубаагшатай. (Үгтэһэн "from" али "to" утганууд "step"-тэй харилсан энгидэрхэй байха ёһотой.)
+
+select-from-sequence-coprime-single-number = 1 бэшэ ганса тооһоо харилсан энгидэрхэй холболтонуудые шэлэжэ шадахагүй.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence соо холболтонуудай 70%-һээ олониинь усадхагдаба
+
+select-from-sequence-coprime-none-found = Харилсан энгидэрхэй тоонуудые шэлэжэ шадабагүй. Бүхы боломжотой утганууд ниитэ хубаагшатай.
+
+select-from-sequence-too-few-unique-values = Утань { $numPossibleValues } дараалалһаа { $numToSelect } ондоо утга шэлэжэ шадахагүй
+
+select-prime-numbers-too-few-values = Утань { $numValues } энгидэрхэй тоонуудай жагсаалтаһаа { $numToSelect } утга шэлэжэ шадахагүй
+
+select-prime-numbers-values-count-mismatch = select дээрэ үгтэһэн утгануудай тоо шэлэхэ тоодо таараха ёһотой
+
+select-prime-numbers-values-not-prime = select prime number дээрэ үгтэһэн бүхы утганууд энгидэрхэй тоонуудай жагсаалта соо байха ёһотой
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers дээрэ үгтэһэн утганууд усадхагдаһан холболто байгаа
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers соо холболтонуудай 70%-һээ олониинь усадхагдаба
+
+select-random-combination-fluke = Тон боломжогүй ушарһаа боложо тохёолдоһон утгануудай холболто шэлэжэ шадабагүй
+
+select-random-value-fluke = Тон боломжогүй ушарһаа боложо тохёолдоһон утга шэлэжэ шадабагүй

--- a/packages/i18n/locales/bua/editor.ftl
+++ b/packages/i18n/locales/bua/editor.ftl
@@ -1,0 +1,215 @@
+# Buryat editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Buryat counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Бусааха
+       *[update] Шэнэлхэ
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Харагшые { $word }
+       *[other] Харагшые { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Шүүлгэ…
+editor-variant-next = Дараахи вариант шэлэхэ
+editor-variant-previous = Урдахи вариант шэлэхэ
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA хүрэхэ аргын эбдэлгэ олдобо. Хүрэхэ аргын тайлан { $action ->
+            [close] хааха
+           *[open] нээхэ
+        } гэжэ дарагты.
+        [advisories] Хүрэхэ аргын тайлан { $action ->
+            [close] хааха
+           *[open] нээхэ
+        } гэжэ дарагты. WCAG AA эбдэлгэнүүд олдобогүй, теэд нэмэлтэ дурадхалнууд бии.
+       *[clean] Хүрэхэ аргын тайлан { $action ->
+            [close] хааха
+           *[open] нээхэ
+        } гэжэ дарагты. Хүрэхэ аргын асуудалнууд олдобогүй.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA хүрэхэ аргын эбдэлгэ олдобо. { $count ->
+            [one] { $count } WCAG AA эбдэлгэ
+           *[other] { $count } WCAG AA эбдэлгэ
+        } олдобо. Хүрэхэ аргын тайлан { $action ->
+            [close] хааха
+           *[open] нээхэ
+        } гэжэ дарагты.
+        [advisories] WCAG AA эбдэлгэнүүд олдобогүй. { $count ->
+            [one] { $count } нэмэлтэ дурадхал
+           *[other] { $count } нэмэлтэ дурадхал
+        } олдобо. Хүрэхэ аргын тайлан { $action ->
+            [close] хааха
+           *[open] нээхэ
+        } гэжэ дарагты.
+       *[clean] WCAG AA эбдэлгэнүүд олдобогүй. Хүрэхэ аргын тайлан { $action ->
+            [close] хааха
+           *[open] нээхэ
+        } гэжэ дарагты.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML-эй хубилбари { $version }
+
+editor-tab-help = Контекстын туһаламжа
+editor-tab-help-short = Контекст
+editor-tab-errors = Алдуунууд
+editor-tab-warnings = Һэргылэмжэнүүд
+editor-tab-info = Мэдээсэл
+editor-tab-accessibility = Хүрэхэ арга
+editor-tab-responses = Эльгээгдэһэн харюунууд
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторай тохироонууд
+editor-format-as-doenetml = DoenetML шэнгеэр форматлаха
+editor-format-as-xml = XML шэнгеэр форматлаха
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-дохи мүр
+
+editor-no-errors = Алдуу үгы
+editor-no-warnings = Һэргылэмжэ үгы
+editor-no-info = Мэдээсэлэй дуулгалга үгы
+
+editor-show-info-annotations = Мэдээсэлэй дуулгалгануудые редактор соо харуулха
+editor-show-accessibility-annotations = Хүрэхэ аргын дуулгалгануудые редактор соо харуулха
+
+editor-accessibility-learn-more = Doenet хүрэхэ аргада яажа хандадаг бэ
+
+editor-accessibility-violations-heading = Хүрэхэ аргын эбдэлгэнүүд ({ $standard })
+
+editor-accessibility-other-heading = Бусад хүрэхэ аргын асуудалнууд
+editor-none-found = Юуншье олдобогүй
+
+
+## Submitted responses
+
+editor-no-responses = Мүнөө болотор эльгээгдэһэн харюу үгы
+editor-response-answer-id = Харюугай Id
+editor-response-response = Харюу
+editor-response-credit = Балл
+editor-response-submitted = Эльгээгдэбэ
+
+
+## The context-help panel
+
+help-placeholder = Баримта бэшэг харахын тулада курсорые тэгэй нэрэ дээрэ, атрибут дээрэ али { $ref } дээрэ табигты.
+
+help-unsupported-ref-chain = { $example } шэнги олон хубитай холбоһондо туһаламжа мүнөө болотор үгы.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Холбоһондо объект олдобогүй: { $ref }.
+        [multiple] Холбоһондо хэдэн объект олдобо: { $ref }.
+       *[indeterminate] { $ref } объектые тодорхойлжо шадабагүй.
+    }
+
+help-learn-about-references = Холбоһон тухай мэдэхэ →
+help-reference-page = Лаблагаанай нюур →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } соо
+       *[top] Дээдэ шатада
+    }{ $allowed ->
+        [none] { " — эндэ юуншье багтахагүй." }
+        [text] { " — эндэ текст бэшэжэ болохо." }
+        [text-and-components] { " — эндэ текст бэшэжэ болохо, али эдэниие туршажа үзэгты:" }
+       *[components] { " — эдэниие туршажа үзэжэ болохо:" }
+    }
+
+help-suggestions-footer = Бүхы { $total } компонент харахын тулада { $shortcut } дарагты.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объект дээрэ холбоһон.
+       *[other] { $ref } — { $target } объект дээрэ холбоһон ({ $line }-дохи мүр).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Үүниие { $owner } { $role } болгожо оруулаа.
+       *[other] Үүниие { $owner } { $line }-дохи мүртэ { $role } болгожо оруулаа.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементын { $property } шанар дээрэ холбоһон.
+       *[other] { $ref } — { $element } элементын { $property } шанар дээрэ холбоһон ({ $line }-дохи мүр).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = хэрчим
+help-kind-array-entry = массивай элемент
+
+help-default = Үндэһэн утга:
+help-active-default = Мүнөөнэй үндэһэн утга:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Зүбшөөгдэһэн утганууд (элемент бүхэндэ нэгэ):
+       *[other] Зүбшөөгдэһэн утганууд:
+    }
+
+help-suggested-values = Дурадхагдаһан утганууд:
+
+help-inserts = Нэмэнэ:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатанууд:
+    }
+
+help-type = Түхэл:
+
+help-resolved-style = Гараһан стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Гараһан функциин нэрэнүүд:
+help-reset-list = Энэ талмайн бусаалгын жагсаалта:
+help-added-on-input = Энэ талмай дээрэ нэмэгдэһэн:
+help-removed-on-input = Энэ талмайһаа усадхагдаһан:
+
+help-reset-overrides = { $reset } — { $additional } ба { $removed } дээрэһээ дабамгайлна.

--- a/packages/i18n/locales/ce/chrome.ftl
+++ b/packages/i18n/locales/ce/chrome.ftl
@@ -1,0 +1,142 @@
+# Chechen viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# The palochka Ӏ is a letter of the alphabet, not a Latin I and not a digit 1.
+#
+# Chechen counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular, so the two branches differ in nothing but the number they print.
+# Nothing in this file agrees with a noun class — see `content.ftl`, which is
+# where the class fork lives.
+
+
+## Answer submission
+
+answer-checking = Талло…
+answer-submitting = ДӀадоьхуьйту…
+
+answer-checking-status = Жоп талло
+answer-submitting-status = Жоп дӀадоьхуьйту
+
+answer-correct = Нийса
+answer-incorrect = Нийса дац
+
+answer-response-saved = Жоп Ӏалашдина
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% нийса
+answer-percent-short = { $percent } %
+
+max-credit-available = Схьаэца тарлун сов баккхий балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] гӀорт йисина яц
+        [one] { $count } гӀорт йисина
+       *[other] { $count } гӀорт йисина
+    }
+
+validation-correct = (Нийса)
+validation-incorrect = (Нийса дац)
+validation-partially-correct = (Дакъош нийса)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } тӀе { $count } жоп гайта
+       *[other] { $answerId } тӀе { $count } жоп гайта
+    }
+
+
+## Disclosure panels
+
+feedback-heading = ЮхаӀаткъам
+
+collapsible-click-to-open = (даста тӀетаӀае)
+collapsible-click-to-close = (дӀакъовла тӀетаӀае)
+
+collapsible-initializing = Кечдо…
+
+footnote-show = Билгалдар гайта
+footnote-hide = Билгалдар къайладаккха
+
+description-more-information = тӀетоьхна хаам
+
+
+## Controls
+
+slider-previous = Хьалха
+slider-next = ТӀаьхьа
+
+keyboard-open = Клавиатура даста
+keyboard-close = Клавиатура дӀакъовла
+
+choice-input-remove-choice = { $choice } харжам дӀабаккха
+
+matrix-remove-row = МогӀа дӀабаккха
+matrix-add-row = МогӀа тӀетоха
+matrix-remove-column = Багана дӀаяккха
+matrix-add-column = Багана тӀетоха
+
+subset-add-remove-points = ТӀадам тӀетоха/дӀабаккха
+subset-toggle-points-intervals = ТӀадамаш а, юкъамаш а хийца
+subset-move-points = ТӀадамаш дӀадаха
+subset-clear = ЦӀандан
+
+orbital-add-row = МогӀа тӀетоха
+orbital-remove-row = МогӀа дӀабаккха
+orbital-add-box = Клетка тӀетоха
+orbital-remove-box = Клетка дӀаяккха
+orbital-add-up-arrow = Лакхарчу тӀам тӀетоха
+orbital-add-down-arrow = Лахарчу тӀам тӀетоха
+orbital-remove-arrow = ТӀам дӀабаккха
+
+orbital-row-label = { $row } могӀанан хьаьрк
+
+pretzel-answer = Жоп
+
+summary-statistics-caption = { $column } баганин жамӀан статистика
+
+
+## Math input
+
+math-input-preview-region = математически билгалдаккхаран хьалхара хьажар
+math-input-preview = Хьалхара хьажар
+math-input-invalid-expression = Нийса доцу билгалдаккхар:
+
+
+## Document status
+
+viewer-initializing = Кечдо…
+
+
+## Errors
+
+error-heading = ГӀалат
+
+error-found-at =
+    { $span ->
+        [line] Каро могӀа: { $startLine }.
+       *[lines] Каро могӀанаш: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = ХӀокху документехь гӀалаташ ду!
+
+diagnostic-heading-error = ГӀалат
+diagnostic-heading-warning = Тергамча
+diagnostic-heading-information = Хаам
+diagnostic-heading-hint = Хьехам
+
+accessibility-heading-level-1 = WCAG AA кхачаран дохор
+accessibility-heading-level-2 = Кхачаран хьокъехь хаам
+
+something-went-wrong = ХӀума нийса ца хилла.
+
+renderer-load-failed = сурт диллархо чуялийта ца делира. АгӀо керлаян.
+
+core-start-failed = Документан хьажархо болийта ца делира. АгӀо керлаян.

--- a/packages/i18n/locales/ce/content.ftl
+++ b/packages/i18n/locales/ce/content.ftl
@@ -1,0 +1,305 @@
+# Chechen content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Ӏ (palochka), which is the orthography Chechnya's
+# schools and publishing use and what CLDR fills a bare `ce` in as. The
+# palochka is a letter, not a Latin capital I and not a digit 1; a catalog that
+# spells «Ӏаьржа» with either has quietly become unreadable.
+#
+# **THIS IS THE ONE CATALOG IN ITS BATCH THAT SELECTS ON `$gender`, AND THAT IS
+# THE FACT WORTH READING.** Every other language seeded beside it — four
+# Turkic, two Mongolic, four Uralic, one Iranian — answers the agreement
+# question with a flat "no". Chechen is Nakh, and it has a real grammatical
+# class system: nouns fall into classes marked by the prefixes в-, й-, б- and
+# д-, and a word agreeing with a noun carries its class at the *front*. So
+# `noun-gender` returns a class here rather than one token, and the words that
+# agree fork on it. Eleven catalogs in one region and one script, and the
+# twelfth forks — which is the sentence `locales/ts`, `locales/luo` and
+# `locales/ktu` already earned inside Bantu, restated in the Caucasus.
+#
+# **What agrees is a much shorter list than in a Bantu catalog, and the header
+# has to be honest about which part of this file is confident.** Chechen's
+# colour and width adjectives — «Ӏаьржа», «дуькъа», «дораха» — are
+# non-agreeing: they take no class prefix and hold still after every noun, so
+# the style vocabulary below forks nowhere. What does agree is the participle
+# «дуьзна», "filled", and its negation, and those two are where `$gender`
+# is used.
+#
+# **`noun-gender`'s table is the least certain thing here and a speaker should
+# check it first.** This seed could verify the four class markers and the
+# agreeing forms of the participle; it could not verify the class of every
+# geometric noun it needed, and a half-remembered class table is worse than an
+# admitted gap — the judgement `locales/ewo` made for Ewondo and `locales/ks`
+# made for Kashmiri's feminine forms. So the table below lists only the nouns
+# whose class this seed is reasonably confident of and defaults everything else
+# to `d`, the largest class. Correcting an entry needs no permission, and the
+# fork it feeds is already written.
+
+
+## Style vocabulary
+##
+## None of these words takes a class prefix, so none of them forks. That is a
+## fact about Chechen adjectives rather than about Chechen agreement.
+
+color =
+    .black = Ӏаьржа
+    .white = кӀайн
+    .gray = сира
+    .red = цӀен
+    .orange = цӀен-можа
+    .yellow = можа
+    .green = баьццара
+    .cyan = сирла сийна
+    .blue = сийна
+    .purple = сийна-цӀен
+    .pink = цӀен-кӀайн
+    .brown = мора
+
+line-width =
+    .thick = дуькъа
+    .thin = дораха
+
+line-style =
+    .dashed = кагйина
+    .dotted = тӀадамашца
+
+# Noun phrases: they stand in front of «сурташца» and modify nothing.
+fill-style =
+    .horizontal = горизонталан сиз
+    .vertical = вертикалан сиз
+    .diagonal = диагоналан сиз
+    .backdiagonal = дуьхьал диагоналан сиз
+    .dots = тӀадам
+    .diamonds = ромб
+
+noun =
+    .line = нийса сиз
+    .line-segment = сизан дакъа
+    .ray = луч
+    .vector = вектор
+    .curve = къевлина сиз
+    .function = функци
+    .parabola = парабола
+    .polyline = кагйина сиз
+    .polygon = дукха сонера
+    .triangle = кхо сонера
+    .rectangle = нийса сонера
+    .circle = гуо
+    .region = меттиг
+    .point = тӀадам
+    .square = квадрат
+    .diamond = ромб
+    .cross = жӀар
+    .plus = плюс
+
+# Chechen builds the word from the side count in front of the noun, so the
+# whole of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] нийса { $numSides } сонера
+    }
+
+# The class of the noun being described, handed to every word that agrees with
+# it. See the note at the top of this file: only the entries this seed could
+# check are written out, and everything else falls to `d`.
+noun-gender =
+    { $noun ->
+        [point] b
+        [square] b
+        [cross] b
+        [circle] d
+        [line] d
+        [line-segment] d
+        [ray] d
+        [border] d
+        [fill] d
+        [text] d
+        [background] d
+       *[other] d
+    }
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+# The one word in this catalog that carries a class prefix, and the reason
+# `$gender` exists here at all.
+style-filled-word =
+    { $gender ->
+        [b] буьзна
+        [j] юьзна
+        [v] вуьзна
+       *[d] дуьзна
+    }
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } сурташца { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } сурташца { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } сурташца { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «йистеца» — "with an edge" — is a case form of a noun this catalog writes, so
+# nothing is welded to a placeable and no article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } йистеца
+        [and] а { $border } йистеца
+        [and-article] а { $border } йистеца
+       *[with] { $border } йистеца
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } сурташца { $color } бос
+       *[plain] { $color } бос
+    }
+
+# The negated participle agrees exactly as the positive one does, so it forks
+# on the same argument and in the same four ways.
+style-unfilled =
+    { $gender ->
+        [b] буьзна боцу
+        [j] юьзна йоцу
+        [v] вуьзна воцу
+       *[d] дуьзна доцу
+    }
+
+# «тӀехь» — "on" — is a postposition and follows the background colour, so
+# nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон тӀехь { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = дац
+
+
+## Boolean words
+
+boolean-true = бакъ
+boolean-false = харц
+
+
+## Answer buttons
+
+answer-submit-label = Таллар
+answer-submit-label-no-correctness = Жоп дӀадахьийта
+
+
+## Sectional blocks
+
+section-name =
+    .activity = ГӀуллакх
+    .aside = АгӀор билгалдар
+    .cascade = Каскад
+    .definition = Билгалдаккхар
+    .example = Масал
+    .exercise = Упражнени
+    .exercises = Упражненеш
+    .given-answer = Жоп
+    .note = Билгалдар
+    .objectives = Ӏалашонаш
+    .paragraphs = Абзацаш
+    .part = Дакъа
+    .problem = Задача
+    .problems = Задачаш
+    .proof = ТӀечӀагӀдар
+    .question = Хаттар
+    .section = Корта
+    .solution = Сацам
+    .task = Дехар
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Хьехам
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Сурт { $enumeration }
+        [numbered-caption] Сурт { $enumeration }{ ". " }
+        [unnumbered-caption] Сурт{ ". " }
+       *[unnumbered] Сурт
+    }
+
+
+## Paginator controls
+
+paginator-previous = Хьалха
+paginator-next = ТӀаьхьа
+paginator-page = АгӀо
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## Chechen's conditional «нагахь санна» is clause-initial, so this key lands
+## where the renderer puts it, as `locales/os`, `locales/bua`, `locales/xal`
+## and `locales/myv` do and unlike the five catalogs of this batch whose
+## conditional closes its clause.
+
+piecewise-condition-or = я
+piecewise-condition-if = нагахь санна
+piecewise-condition-otherwise = кхечу агӀор
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Chechnya is taught in
+## Russian, so the element names a Chechen-speaking pupil meets are the Russian
+## ones — the school-system case this batch shares throughout.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Нийса доцу химин хьаьрк
+chemistry-invalid-ionic-compound = Нийса доцу ионан цхьаьнакхетар

--- a/packages/i18n/locales/ce/content.ftl
+++ b/packages/i18n/locales/ce/content.ftl
@@ -17,8 +17,10 @@
 # д-, and a word agreeing with a noun carries its class at the *front*. So
 # `noun-gender` returns a class here rather than one token, and the words that
 # agree fork on it. Eleven catalogs in one region and one script, and the
-# twelfth forks — which is the sentence `locales/ts`, `locales/luo` and
-# `locales/ktu` already earned inside Bantu, restated in the Caucasus.
+# twelfth forks — which is the sentence `locales/ts` and `locales/ktu` already
+# earned inside Bantu, restated in the Caucasus. (`locales/luo` is the mirror
+# image and not a third example: Dholuo sits between two Bantu catalogs that
+# fork on three classes each and selects on neither argument.)
 #
 # **What agrees is a much shorter list than in a Bantu catalog, and the header
 # has to be honest about which part of this file is confident.** Chechen's

--- a/packages/i18n/locales/ce/content.ftl
+++ b/packages/i18n/locales/ce/content.ftl
@@ -27,8 +27,12 @@
 # colour and width adjectives — «Ӏаьржа», «дуькъа», «дораха» — are
 # non-agreeing: they take no class prefix and hold still after every noun, so
 # the style vocabulary below forks nowhere. What does agree is the participle
-# «дуьзна», "filled", and its negation, and those two are where `$gender`
-# is used.
+# «дуьзна», "filled", and `style-filled-word` is the one message where
+# `$gender` is used. Its negation agrees too, in the language — but
+# `style-unfilled` is rendered with no arguments at all (`describeFill` has no
+# noun to hand it when there is nothing filled), so the catalog cannot select
+# there and writes the д-class form flat, as every other agreeing catalog in
+# the roster does.
 #
 # **`noun-gender`'s table is the least certain thing here and a speaker should
 # check it first.** This seed could verify the four class markers and the
@@ -184,15 +188,12 @@ style-fill =
        *[plain] { $color } бос
     }
 
-# The negated participle agrees exactly as the positive one does, so it forks
-# on the same argument and in the same four ways.
-style-unfilled =
-    { $gender ->
-        [b] буьзна боцу
-        [j] юьзна йоцу
-        [v] вуьзна воцу
-       *[d] дуьзна доцу
-    }
+# The negated participle agrees in the language exactly as the positive one
+# does — «буьзна боцу», «юьзна йоцу», «вуьзна воцу» — but this message
+# describes a fill standing on its own, with no noun and therefore no
+# `$gender` reaching it. So the д-class form is written flat, and a fork here
+# would only ever render its default branch.
+style-unfilled = дуьзна доцу
 
 # «тӀехь» — "on" — is a postposition and follows the background colour, so
 # nothing stands between the two words.

--- a/packages/i18n/locales/ce/diagnostics.ftl
+++ b/packages/i18n/locales/ce/diagnostics.ftl
@@ -1,0 +1,661 @@
+# Chechen diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The palochka Ӏ is a letter, not a Latin I and not a digit 1.
+#
+# Chechen's class agreement does not reach this file: nothing here describes a
+# noun the catalog itself supplies, so no message forks on a class. The fork
+# lives in `content.ftl`, and the reason it lives only there is written out in
+# that file's header.
+#
+# The technical nouns are the Russian ones, which is what written Chechen uses
+# for them: «компонент», «атрибут», «функци», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] шиъ йистан тӀадам билгалбахча { $attributes } хьесапе ца оьцу
+       *[other] шиъ йистан тӀадам билгалбахча { $attributes } хьесапе ца оьцу
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] йистан тӀадам а, юккъера тӀадам а билгалбахча { $attributes } хьесапе ца оьцу
+       *[other] йистан тӀадам а, юккъера тӀадам а билгалбахча { $attributes } хьесапе ца оьцу
+    }
+
+line-segment-midpoint-offset-without-midpoint = юккъера тӀадам боцуш midpointOffset хӀуманна тӀе ца кхочу
+
+## `<line>`
+
+line-points-undetermined-dimensions = Барам ца бевзаш болчу тӀадамашкахула долу нийса сиз.
+
+line-points-too-few-dimensions = Нийса сиз кӀеззиг делахь шиъ барам болчу тӀадамашкахула дала деза.
+
+line-points-depend-on-variables = Нийса сиз хийцалун барамашка хьаьжначу тӀадамашкахула долу: { $variables }.
+
+line-equation-invalid-format = { $variable1 } а, { $variable2 } а хийцалун барамашца долчу нийсачу сизан уравненин формат нийса яц.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint а, direction а тӀехула делла. Делла through хьесапе ца оьцу.
+
+ray-dimension-mismatch = лучехь numDimensions ца богӀу.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail а, displacement а тӀехула делла. Делла head хьесапе ца оьцу.
+
+vector-dimension-mismatch = векторехь numDimensions ца богӀу.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементе таса ца лой, хӀунда аьлча цуьнан nearestPoint хьолан хийцалун барам бац.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементца дозалуш дан ца лой, хӀунда аьлча цуьнан nearestPoint хьолан хийцалун барам бац.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементан чоьхьарчуьнца дозалуш дан ца лой, хӀунда аьлча цуьнан nearestPoint хьолан хийцалун барам бац.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = могӀанан чохь доцчу choiceInput тӀе labelPosition хьесапе ца оьцу
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput тӀе делла индексаш хьесапе ца оьцу, хӀунда аьлча царан дукхалла choice берийн дукхаллина ца тоьи.
+
+pretzel-indices-count-mismatch = problem тӀе делла индексаш хьесапе ца оьцу, хӀунда аьлча царан дукхалла problem берийн дукхаллина ца тоьи.
+
+shuffle-indices-count-mismatch = shuffle тӀе делла индексаш хьесапе ца оьцу, хӀунда аьлча царан дукхалла компоненташан дукхаллина ца тоьи.
+
+indices-ignored-out-of-range = { $component } тӀе делла индексаш хьесапе ца оьцу, хӀунда аьлча цхьаберш доза тӀера аравуьйлу.
+
+pretzel-indices-repeated = pretzel тӀе делла индексаш хьесапе ца оьцу, хӀунда аьлча цхьаберш карладуьйлу.
+
+pretzel-circuit-first-index = circuit режимехь pretzel тӀе делла индексаш хьесапе ца оьцу, хӀунда аьлча хьалхара индекс 1 хила еза.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текстан берашца болх бархьама `type` атрибут яла еза.
+
+invalid-type-defaulting-to-math = { $component } компонентана нийса доцу тайпа { $type }. Иза math, text, number я boolean хила деза. math пайдаэцу.
+
+string-not-valid-component-to-arrange = «{ $value }» могӀа { $component } тӀе тоьшалун компонент бац. Хьесапе ца оьцу.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Нийса доцу тайпа { $type }, тайпа number хуьлу.
+
+invalid-variable-value = Хийцалун барамийн нийса доцу мах: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантан индекс терахь хила деза
+
+variant-index-must-be-integer = { $index } вариантан индекс дийна терахь хила деза
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютни барамашна дина дац. Церан шоралла юстаран хуьлу.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютни барамашна дина дац. Церан йистош юстаран хуьлу.
+
+side-by-side-no-block-child = Нийса доцу `<{ $component }>`: цуьнан кӀеззиг делахь цхьа блок бер хила деза.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементан `for` атрибут хьесапе ца оьцу.
+
+label-for-must-resolve-to-one = `<label>` элементан `for` атрибуто цхьана компонента тӀе бен ца хьожуш хила деза.
+
+label-for-unresolved = `<label>` элементан `for` атрибут компонентца хьаьрчош ца делира.
+
+label-for-answer-with-authored-inputs = `<label>` элементан `for` атрибут авторо яздина чуялоран меттигаш йолчу `<answer>` тӀе хьожу; меттиге нийсса хьажайе.
+
+label-for-answer-without-input = `<label>` элементан `for` атрибут билгалйоран чуялоран меттиг йоцчу `<answer>` тӀе хьожу.
+
+label-for-must-reference-input-or-answer = `<label>` элементан `for` атрибут чуялоран меттиге я жопе хьожуш хила деза.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Кхачарна `<{ $component }>` йоцца цуьнан билгалдаккхарца хила деза, я хазйийриг санна билгалдан деза.
+
+accessibility-video-short-description = Кхачарна `<video>` йоцца билгалдаккхарца хила деза.
+
+accessibility-input-short-description-or-label = Кхачарна `<{ $component }>` йоцца билгалдаккхарца я хьаьркаца хила деза.
+
+accessibility-answer-input-short-description-or-label = Кхачарна чуялоран меттиг кхуллуш болу `<answer>` йоцца билгалдаккхарца я хьаьркаца хила беза.
+
+accessibility-short-description-contains-math = Йоццачу билгалдаккхаршкахь `<{ $component }>` санна математически компоненташ хила ца еза. Математика дешнашца язъе.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } дакъойн коьртан текстана тоьаш контраст ца ло (Ӏаьржа тайпа) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀеззиг делахь { $threshold }:1 оьшу).
+       *[other] { $colorName } дакъойн коьртан текстана тоьаш контраст ца ло ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀеззиг делахь { $threshold }:1 оьшу).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = ТӀадамийн терахьан мехаш ца хилча { $count } тӀадамехула долу `<circle>` дина дац.
+
+circle-too-many-through-points = 3-нал дукха тӀадамехула долу гуо хьесапе дан ца лой.
+
+circle-overprescribed-radius-center-points = Делла радиус, юкъ а, тӀадамаш а болуш гуо хьесапе дан ца лой.
+
+circle-center-with-multiple-points = Делла юкъаца 1-нал дукха тӀадамехула долу гуо хьесапе дан ца лой.
+
+circle-radius-too-small = Гуо хьесапе дан ца лой: шина тӀадаман юкъара гена { $distance } хилча, делла радиус { $radius } тӀех жима бу.
+
+circle-radius-with-many-points = Делла радиусца шиннал дукха тӀадамехула долу гуо кхолла ца лой.
+
+circle-invalid-center-or-through-points = Гуонан юкъ я тӀадамаш нийса дац.
+
+circle-radius-center-with-multiple-points = Делла юкъаца 1-нал дукха тӀадамехула долчу гуонан радиус хьесапе дан ца лой.
+
+circle-change-radius-non-numerical = Терахьан доцчу тӀадамашца долчу гуонан радиус хийца ца лой
+
+circle-radius-with-points-non-numerical = Терахьан мехаш ца хилча делла радиусца цхьаннал дукха тӀадамехула долу гуо кхолла ца лой.
+
+circle-change-center-non-numerical = Терахьан доцчу тӀадамашкахула долчу гуонан юкъ хийцар дина дац.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцин билгалйинчу меттиган барам ца тоьу. Меттигехь { $intervals } юкъ ю, функцехь ткъа { $inputs ->
+            [one] { $inputs } чуялор
+           *[other] { $inputs } чуялор
+        } ю.
+       *[other] Функцин билгалйинчу меттиган барам ца тоьу. Меттигехь { $intervals } юкъ ю, функцехь ткъа { $inputs ->
+            [one] { $inputs } чуялор
+           *[other] { $inputs } чуялор
+        } ю.
+    }
+
+function-domain-invalid-format = Функцин билгалйинчу меттиган формат нийса яц.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцин терахьан доцу максимум хьесапе ца оьцу.
+        [minimum] Функцин терахьан доцу минимум хьесапе ца оьцу.
+        [extremum] Функцин терахьан доцу экстремум хьесапе ца оьцу.
+        [point] Функцин терахьан боцу тӀадам хьесапе ца оьцу.
+        [slope] Функцин терахьан доцу дуьхьалхилар хьесапе ца оьцу.
+       *[other] Функцин терахьан доцу { $type } мах хьесапе ца оьцу.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцин ерриг йоцу максимум хьесапе ца оьцу.
+        [minimum] Функцин ерриг йоцу минимум хьесапе ца оьцу.
+        [extremum] Функцин ерриг йоцу экстремум хьесапе ца оьцу.
+        [point] Функцин баьржина боцу тӀадам хьесапе ца оьцу.
+       *[other] Функцин баьржина доцу { $type } мах хьесапе ца оьцу.
+    }
+
+function-points-too-close = Функцехь вовшашка тӀех гергара шиъ тӀадам бу. Функци билгалъян ца лой.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцин итерацеш хуьлу чуялорийн дукхалла аракхетарийн дукхаллица цхьатерра хилча бен. ХӀокху функцехь { $inputs } чуялор а, { $outputs ->
+            [one] { $outputs } аракхетар
+           *[other] { $outputs } аракхетар
+        } а ю.
+       *[other] Функцин итерацеш хуьлу чуялорийн дукхалла аракхетарийн дукхаллица цхьатерра хилча бен. ХӀокху функцехь { $inputs } чуялор а, { $outputs ->
+            [one] { $outputs } аракхетар
+           *[other] { $outputs } аракхетар
+        } а ю.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Тайпанан дохалла нийса яц. Иза минус йоцу дийна терахь хила деза.
+
+sequence-invalid-step = Тайпанан гӀулч нийса яц. { $type } тайпан тайпанна иза терахь хила деза.
+
+sequence-invalid-endpoint-number = Терахьан тайпанан «{ $attribute }» мах нийса бац. Иза терахь хила деза.
+
+sequence-invalid-endpoint-letters = Элпан тайпанан «{ $attribute }» мах нийса бац. Иза элпийн цхьаьнакхетар хила деза.
+
+sequence-invalid-endpoint = Тайпанан «{ $attribute }» мах нийса бац.
+
+select-from-sequence-coprime-not-numbers = терахьаш ца хаьржина, цундела coprime хьесапе ца оьцу
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations делла, цундела coprime хьесапе ца оьцу
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` тӀе нийса доцу target: Ӏалашо ца карийна.
+
+target-state-variable-not-found = `<{ $source }>` тӀе нийса доцу target: `<{ $component }>` элементехь «{ $property }» цӀе йолу хьолан хийцалун барам ца карийна.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` хийцалун барамаш шаьш-шайн долчу барамах къаьста деза.
+
+ode-system-duplicate-variable-names = Хьаьжначу хийцалун барамийн цӀераш карладийлахь ДУ аьтту агӀон функцеш билгалъян ца лой.
+
+ode-system-rhs-function-error = ДУ аьтту агӀон функци билгалъян ца лой. mathjs функци кхуллуш гӀалат.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } нийсачу сизан юкъара сонера билгалбан ца лой
+
+angle-invalid-through-point = `<angle>` элементан through махехь нийса боцу тӀадам
+
+parabola-vertex-too-many-points = Делла корта болуш 1-нал дукха тӀадамехула йолу парабола йина яц.
+
+parabola-too-many-points = 3-нал дукха тӀадамехула йолу парабола йина яц.
+
+intersection-too-many-items = Шиннал дукха объектийн вовшахкхетар дина дац
+
+## Other math components
+
+ionic-compound-not-two-ions = Шина ионах кхин ионан цхьаьнакхетарш дина дац.
+
+ionic-compound-needs-cation-and-anion = Ионан цхьаьнакхетар цхьана катионна а, цхьана анионна а бен дина дац.
+
+solve-equations-cannot-evaluate = Уравнени ярза ца лой, хӀунда аьлча иза хьесапе ян ца делира: { $equation }
+
+math-operators-operand-number-required = Математически операнд къасторхьама operandNumber яла еза.
+
+eigen-decomposition-failed = Матрицин шен мехаш хьесапе дан ца делира
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр кепехь ца карайо, цундела иза даима а ерриг йоцчуьнца богӀу.
+       *[other] `<matchesPattern>`: { $parameters } параметраш кепехь ца карайо, цундела уьш даима а ерриг йоцчуьнца богӀу.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" мах кхета ца лой. Иза none, medium, dense я ерриг йоцчу меттигаца къаьстина шиъ плюсан терахь хила деза, масала grid="1 0.5". Сеть ца юзу.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure сурт диллархочуьнгахь xLabelPosition="left" дина дац; аьтту агӀон хӀоттам пайдаоьцу.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure сурт диллархочуьнгахь yLabelPosition="bottom" дина дац; лакхара хӀоттам пайдаоьцу.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure дерзорна доза нийса дац; бух болу bbox (-10,-10,10,10) пайдаоьцу.
+
+prefigure-invalid-width = `<graph>`: prefigure дерзорна шоралла нийса яц; диаграммин бух болу шоралла 425 пайдаоьцу.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure дерзорна aspectRatio нийса дац; бух болу агӀонийн барам 1 пайдаоьцу.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сетан гӀулч дозанашна тӀех жима ю; prefigure сурт диллархочуьнгахь сеть ца юьйлайо.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure сурт диллархо ца пайдаоьцуш билгалдарш ца дуьйлайо.
+
+multiple-annotations-children = `<graph>` чохь дукха `<annotations>` бер карийна; тӀаьххьарчух дӀаьнд кхин уьш хьесапе ца оьцу.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Ца бевзаш болу компонентан тайпа шордан я копи ян ца лой: { $type }.
+
+copy-prop-not-found = { $component } тайпанан компонентехь { $property } башхалла ца карийна
+
+collect-no-source = collect тӀе хьост ца карийна.
+
+collect-invalid-component-type = `<{ $component }>` тайпанан компонентеш гулъян ца лой, хӀунда аьлча иза нийса доцу компонентан тайпа ду.
+
+reference-index-unavailable = `{ $reference }` индексе хьажор кхолла ца лой
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентехь { $action } кхайкха ца лой
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Хаамийн кеп нийса яц. МогӀанийн дохалла тайп-тайпана ю. Карийна componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Хаамашкахь баганин цӀераш карладуьйлу. Карийна componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Хаамашкахь баганин цӀе ца тоьу. Карийна componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = ХӀокху жопан award мах answer тегаца шен дӀадахьийтинчу жопе хьоьжу, оцо ца хьоьхучу хьоле дало тарло.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` йолчу контейнеран чуьра `<answer>` тӀе `maxNumAttempts` хӀоттор хӀуманна тӀе ца кхочу, хӀунда аьлча гӀорташан дукхалла контейнеро билгалйо. `maxNumAttempts` мах контейнер тӀе хӀотта.
+
+nested-section-wide-check-work-max-num-attempts = Кхечу `sectionWideCheckWork` контейнеран чохь лаьттачу `sectionWideCheckWork` контейнер тӀе `maxNumAttempts` хӀоттор хӀуманна тӀе ца кхочу, хӀунда аьлча гӀорташан дукхалла арахьарчу контейнеро билгалйо. `maxNumAttempts` мах арахьарчу контейнер тӀе хӀотта.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality хӀоттийна ца хилча { $attributes } атрибут хӀуманна тӀе ца кхочур ду.
+       *[other] symbolicEquality хӀоттийна ца хилча { $attributes } атрибуташ хӀуманна тӀе ца кхочур ду.
+    }
+
+answer-invalid-type = answer тӀе нийса доцу тайпа: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентан цӀе яц, цундела иза модулан атрибут санна пайдаэца ца лой
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонент модулан атрибут санна пайдаэца ца лой, хӀунда аьлча `<module>` компонентан тайпанехь «{ $name }» атрибут хӀинццехь билгалйина.
+
+conditional-content-condition-ignored = case я else бераш долчу `<conditionalContent>` компонентехь `condition` атрибут хьесапе ца оьцу.
+
+slider-markers-type-mismatch = Маркерийн тайпа ползунокан тайпанна ца тоьи.
+
+pretzel-problem-needs-statement-and-answer = Нийса доцу pretzel: хӀор `<problem>` чохь цхьа `<statement>` а, цхьа `<answer>` а хила деза.
+
+pretzel-circuit-first-problem-distractor = Нийса доцу pretzel: mode="circuit" режимехь хьалхара `<problem>` тидам дӀабоккхург хила ца еза.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутана нийса боцу мах { $values }; хьесапе ца оьцу.
+       *[other] `{ $attribute }` атрибутана нийса доцу мехаш { $values }; хьесапе ца оьцу.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутана нийса боцу мах `{ $value }`. Атрибут `$` хьаьркаца долалун хьажорех лаьтташ хила деза.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } чуьра нийса доцу функцийн цӀераш хьесапе ца эцна: { $names }. ХӀор цӀеран гуш йолу дакъа кӀеззиг делахь 2 хьаьрк хила еза (элпаш я сизаш); цул тӀаьхьа оьшуш йоцу `|<mathspeak альтернатива>` тӀетохар кхача тарло.
+
+## Building components from the source
+
+component-type-invalid = Нийса доцу компонентан тайпа: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут карлаяккха ца лой.
+
+attribute-invalid-for-component = `<{ $componentType }>` тайпанан компонентана нийса доцу атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стилан билгалдаккхарехь { $context ->
+        [text-on-background] текстан бос а, фонан бос а
+        [high-contrast] лекха контраст болу бос а, суртан меттиг а
+        [line] сизан бос а, суртан меттиг а
+        [marker] маркеран бос а, суртан меттиг а
+       *[text-on-canvas] текстан бос а, суртан меттиг а
+    } юкъара контраст ца тоьу{ $mode ->
+        [dark] { " (Ӏаьржа тайпа)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀеззиг делахь { $threshold }:1 оьшу).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стилан билгалдаккхарехь делла бесаш сирлачу тайпанна тоьаш контраст делча а, царах даьлла Ӏаьржачу тайпанан бесаш текст а, фон а юкъахь тоьаш контраст ца ло ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀеззиг делахь { $threshold }:1 оьшу). { $suggestion ->
+        [available] Ӏаьржачу тайпанехь тоьаш контраст хилийтархьама я сирлачу тайпанан контраст алсамъяккха (масала { $lightAttribute }="{ $lightColor }"), я Ӏаьржачу тайпанан бос хийца (масала { $darkAttribute }="{ $darkColor }").
+       *[none] Ӏаьржачу тайпанехь тоьаш контраст хилийтархьама сирлачу тайпанан контраст алсамъяккха я даьлла бесаш textColorDarkMode а/я backgroundColorDarkMode а тӀехула хийца.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стилан билгалдаккхарехь делла текстан бос сирлачу тайпанна тоьаш контраст белча а, цунах баьлла Ӏаьржачу тайпанан текстан бос суртан меттигаца тоьаш контраст ца ло ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; кӀеззиг делахь { $threshold }:1 оьшу). { $suggestion ->
+        [available] Ӏаьржачу тайпанехь тоьаш контраст хилийтархьама я сирлачу тайпанан контраст алсамъяккха (масала textColor="{ $lightColor }"), я Ӏаьржачу тайпанан бос хийца (масала textColorDarkMode="{ $darkColor }").
+       *[none] Ӏаьржачу тайпанехь тоьаш контраст хилийтархьама сирлачу тайпанан контраст алсамъяккха я баьлла бос textColorDarkMode тӀехула хийца.
+    }
+
+section-multiple-style-palettes = Корто цхьа <stylePalette> бен харжа ца лой; тӀаьххьарниг пайдаоьцу.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча numToSelect минус йоцу дийна терахь яц.
+
+variant-num-to-select-not-constant-number = { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча numToSelect хийцалуш йоцу терахь яц.
+
+variant-with-replacement-not-constant-boolean = { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча withReplacement хийцалуш боцу логически мах бац.
+
+variant-select-weight-disables-unique = цхьана харжамехь selectWeight я selectForVariants делча, select тӀе карлайовлуш йоцу варианташ дӀаяйо
+
+variant-coprime-undetermined = { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча coprime даима а харц ю я яц, иза билгалдан ца лой.
+
+variant-attribute-not-constant = { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча { $attribute } хийцалуш йоцург яц.
+
+variant-attribute-not-number = { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча { $attribute } терахь яц.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } тайпанан { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча { $attribute } { $expected ->
+        [letters-combination] элпийн цхьаьнакхетар
+        [math-expression] тоьшалун математически билгалдаккхар
+        [integer] дийна терахь
+       *[number] терахь
+    } яц.
+
+variant-length-not-integer = { $component } тӀе карлайовлуш йоцу варианташ билгалъян ца лой, хӀунда аьлча length дийна терахь яц.
+
+variant-sort-not-implemented = sort йолчу { $component } тӀе карлайовлуш йоцу варианташ йина яц
+
+variant-exclude-combinations-not-implemented = excludeCombinations йолчу { $component } тӀе карлайовлуш йоцу варианташ йина яц
+
+variant-math-exclude-not-implemented = exclude йолчу math тайпанан { $component } тӀе карлайовлуш йоцу варианташ йина яц
+
+variant-non-constant-exclude-not-implemented = хийцалуш йоцург йоцу exclude йолчу { $component } тӀе карлайовлуш йоцу варианташ йина яц
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикан prefigure сурт диллархочуьнгахь дина дац; тӀаьхье дӀатесна.
+
+prefigure-descendant-invalid-geometry = { $subject }: чаккхе йоцу я кхачаза геометри; тӀаьхье дӀатесна.
+
+prefigure-curve-label-omitted = { $subject }: дерзийначу къевлинчу элементашкахь хьаьркаш йина яц; хьаьрк дӀатесна.
+
+prefigure-curve-unsupported-definition-type = { $subject }: йина йоцу къевлинчу функцин билгалдаккхаран тайпа «{ $definitionType }»; тӀаьхье дӀатесна.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементан flipFunctions атрибут йина яц; тӀаьхье дӀатесна.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулица делла бераша функцеш бен ца оьцу; тӀаьхье дӀатесна.
+
+prefigure-label-position-unsupported =
+    { $subject }: йина йоцу labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] сизийн доьзалан хьаьркана
+       *[point] тӀадаман хьаьркана
+    }; PreFigure-н бух болу нисдар пайдаоьцу.
+
+prefigure-fill-style-unsupported = { $subject }: дузоран стиль «{ $fillStyle }» PreFigure тӀе йина яц; ерриг дузоре доьрзу.
+
+prefigure-line-style-unknown = { $subject }: ца бевзаш болу сизан стиль «{ $lineStyle }» PreFigure аракхетарера дӀабаьккхина.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркеран стиль «{ $markerStyle }» PreFigure «diamond» стилца нисбина.
+
+prefigure-marker-style-unsupported = { $subject }: маркеран стиль «{ $markerStyle }» PreFigure тӀе йина яц; бух болу стиль пайдаоьцу.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: нийса доцу `ref`; Ӏалашо хьаьрчош ца лой. Билгалдар дӀадаьккхина.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` дукхачу Ӏалашонашца хьаьрчина; хьалхарниг пайдаоьцу.
+
+annotation-ref-outside-graph = `<annotation>`: нийса доцу `ref`; Ӏалашо иза чохь болчу графикех арахьа ю. Билгалдар дӀадаьккхина.
+
+annotation-ref-unsupported-target = `<annotation>`: нийса доцу `ref`; Ӏалашо prefigure дерзорехь йина график объект яц. Билгалдар дӀадаьккхина.
+
+annotation-text-missing = `<annotation>`: `text` яц я ерриг яц; ерриг йоцу текст аракхуьйсу.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Гуонан хьажар карийна.
+       *[other] `<{ $componentType }>` компонент чохь болу гуонан хьажар карийна.
+    }
+
+reference-no-referent = Хьажоранна объект ца карийна: `{ $reference }`
+
+reference-multiple-referents = Хьажоранна дукха объекташ карийна: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементан { $attribute } атрибутан формат нийса яц.
+
+children-invalid = `<{ $componentType }>` тӀе нийса доцу бераш: нийса доцу бераш карийна: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутана нийса боцу мах `{ $value }`; `{ $default }` мах пайдаоьцу
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } верси ца карийна.
+       *[other] DoenetML { $version } верси ца карийна. { $fallback } верси пайдаоьцу
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Нийса доцу DoenetML: { $content }
+
+parse-tag-missing-close-tag = Нийса доцу DoenetML: `{ $tag }` теган дӀакъовлу тег яц. Ша дӀакъовлу тег я `</{ $tagName }>` тег хьоьхуш яра.
+
+parse-tag-error = Нийса доцу DoenetML: `<{ $tagName }>` тегехь гӀалат
+
+parse-attribute-missing-value = Нийса доцу DoenetML: `{ $attribute }` атрибутехь мах ца тоьуш санна бу.
+
+parse-attribute-invalid = Нийса доцу DoenetML: нийса йоцу атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Нийса доцу DoenetML: атрибутан нийса боцу мах `{ $value }`
+
+parse-attribute-value-quote-mismatch = Нийса доцу DoenetML: атрибутан нийса боцу мах `{ $value }`. Кавычкаш ца богӀу. `{ $quote }` ца тоьуш санна ю
+
+parse-open-tag-name-missing = Нийса доцу DoenetML: цӀе йоцу тег карийна, масала `<`
+
+parse-tag-not-closed = Нийса доцу DoenetML: `{ $tag }` тег дӀакъевлина яц (`>` ца тоьуш санна ю).
+
+parse-self-closing-tag-name-missing = Нийса доцу DoenetML: цӀе йоцу тег карийна `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Нийса доцу DoenetML: `{ $tag }` тег дӀакъевлина яц (`/>` ца тоьуш санна ю).
+
+parse-tag-invalid-attributes = Нийса доцу DoenetML: `{ $tag }` тег тоьшалуш яц. Цуьнан атрибуташ нийса ца хила тарло.
+
+parse-close-tag-name-missing = Нийса доцу DoenetML: цӀе йоцу дӀакъовлу тег карийна, масала `</`
+
+parse-attribute-value-unquoted = Атрибутан мехаш кавычкийн чохь хила деза: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Нийса доцу DoenetML: `{ $tag }` дӀакъовлу тег карийна, амма цунна тоьшалу йоллу тег яц
+
+parse-close-tag-mismatched = Нийса доцу DoenetML: ца богӀу дӀакъовлу тег. `</{ $expected }>` хьоьхуш яра. `{ $found }` карийна
+
+parser-node-unconvertible = { $node } узел Dast узеле дерза ца делира.
+
+## Names
+
+name-attribute-invalid =
+    Нийса йоцу атрибут name='{ $name }'. { $reason ->
+        [characters] ЦӀерашкахь элпаш, терахьаш, кӀелхьара сизаш я сизаш бен хила ца тарло.
+       *[start] ЦӀераш элпаца йолалуш хила еза.
+    }
+
+component-name-invalid-start = Нийса йоцу компонентан цӀе «{ $name }». ЦӀераш элпаца йолалуш хила еза.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тайпанан answer video атрибутца хила беза
+
+answer-video-watched-video-not-reference = videoWatched тайпанан answer-н video атрибут хьажор хила еза
+
+answer-name-not-single-text = answer-н name атрибутехь цхьа текстан бер бен хила ца деза
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсин тӀегӀанаш тӀех дукха ду, цундела арахьара DoenetML эца ца делира. Гуонан хьажор яц те?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресера DoenetML эца ца делира
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресера нийса доцу DoenetML эцна: иза «{ $componentType }» компонентан тайпанна ца тоьира
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут йоьхна; цуьнан метта `{ $to }` пайдаэца.
+       *[other] [deprecation] `<{ $component }>` элементан `{ $from }` атрибут йоьхна; цуьнан метта `{ $to }` пайдаэца.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут йоьхна а, хьесапе ца оьцу а, хӀунда аьлча `{ $to }` а елла.
+       *[other] [deprecation] `<{ $component }>` элементан `{ $from }` атрибут йоьхна а, хьесапе ца оьцу а, хӀунда аьлча `{ $to }` а елла.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементан `{ $attribute }` атрибут йоьхна а, хьесапе ца оьцу а.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементан `{ $attribute }` атрибут йоьхна; цуьнан метта `<{ $child }>` бер пайдаэца.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементан `{ $attribute }` атрибутан `{ $value }` мах бухбаьлла; цуьнан метта `{ $to }` пайдаэца.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` дукхаллин терахь ингалсан маттахь бен дан ца лой, цундела { $locale } маттахь язйинчу документехь цуьнан текст ца хийцалуш йисна. Дукхаллин кеп ахьа язъе я иза `pluralForm` атрибутца ло.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент бевзаш болу Doenet элемент бац.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементана документан орамехь бакъо ца ло.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементана `<{ $parent }>` чохь бакъо ца ло.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементехь `{ $attribute }` цӀе йолу атрибут яц.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементан `{ $attribute }` атрибут хӀор элемент хӀокхарех цхьаъ болу список хила еза: { $allowed }
+       *[other] `<{ $tag }>` элементан `{ $attribute }` атрибут хӀокхарех цхьаъ хила еза: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select тӀе нийса йоцу вариантан цӀе. { $variantName } вариантан цӀе { $numOptions } харжамехь карайо, харжа езаш ерг ткъа { $numToSelect } ю.
+
+select-variant-name-without-options = select тӀе варианташ елла, амма хила тарлучу вариантан цӀарна цхьа харжам а бац: { $variantName }.
+
+select-variant-name-not-possible = select тӀе делла { $variantName } вариантан цӀе хила тарлун вариантан цӀе яц.
+
+select-too-few-options = Дерриг { $numOptions } юкъара { $numToSelect } компонент харжа ца лой.
+
+select-from-sequence-too-few-values = Дохалла { $length } йолчу тайпанах { $numToSelect } мах харжа ца лой.
+
+select-from-sequence-indices-count-mismatch = select тӀе делла индексийн дукхалла харжа езачу дукхаллина тоьа еза
+
+select-from-sequence-indices-not-integers = select тӀе делла массо индексаш дийна терахь хила еза
+
+select-from-sequence-index-excluded = selectfromsequence тӀе делла индекс дӀаяьккхина яра
+
+select-from-sequence-indices-excluded-combination = selectfromsequence тӀе делла индексаш дӀаяьккхина цхьаьнакхетар дара
+
+select-from-sequence-coprime-not-positive-integers = Плюсан дийна терахьаш ца хаьржина, цундела вовшашна хьалха доцу цхьаьнакхетарш харжа ца лой.
+
+select-from-sequence-coprime-common-factor = Вовшашна хьалха доцу терахьаш харжа ца лой. Массо хила тарлучу механ цхьаьнан декъархо бу. (Делла "from" я "to" мехаш "step"-ца вовшашна хьалха доцуш хила деза.)
+
+select-from-sequence-coprime-single-number = 1 йоцчу цхьана терахьах вовшашна хьалха доцу цхьаьнакхетарш харжа ца лой.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence чохь цхьаьнакхетарийн 70%-нал дукхачарех дӀадаьхна
+
+select-from-sequence-coprime-none-found = Вовшашна хьалха доцу терахьаш харжа ца делира. Массо хила тарлучу механ цхьаьнан декъархо бу.
+
+select-from-sequence-too-few-unique-values = Дохалла { $numPossibleValues } йолчу тайпанах { $numToSelect } башха мах харжа ца лой
+
+select-prime-numbers-too-few-values = Дохалла { $numValues } йолчу хьалхарчу терахьийн спискех { $numToSelect } мах харжа ца лой
+
+select-prime-numbers-values-count-mismatch = select тӀе делла мехийн дукхалла харжа езачу дукхаллина тоьа еза
+
+select-prime-numbers-values-not-prime = select prime number тӀе делла массо мехаш хьалхарчу терахьийн спискехь хила деза
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers тӀе делла мехаш дӀаяьккхина цхьаьнакхетар дара
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers чохь цхьаьнакхетарийн 70%-нал дукхачарех дӀадаьхна
+
+select-random-combination-fluke = ТӀех хила ца тарлучу хӀуманца ца хууш болчу мехийн цхьаьнакхетар харжа ца делира
+
+select-random-value-fluke = ТӀех хила ца тарлучу хӀуманца ца хууш болу мах харжа ца делира

--- a/packages/i18n/locales/ce/editor.ftl
+++ b/packages/i18n/locales/ce/editor.ftl
@@ -1,0 +1,216 @@
+# Chechen editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Chechen counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike. Nothing here agrees with a noun class: the class fork
+# lives in `content.ftl`, where the noun being described is known.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Юхаяккха
+       *[update] Керлаян
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Хьажархо { $word }
+       *[other] Хьажархо { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Харжар…
+editor-variant-next = ТӀаьхьара вариант харжа
+editor-variant-previous = Хьалхара вариант харжа
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA кхачаран дохор карийна. Кхачаран отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀетаӀае.
+        [advisories] Кхачаран отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀетаӀае. WCAG AA дохораш ца карийна, амма кхин хьехамаш бу.
+       *[clean] Кхачаран отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀетаӀае. Кхачаран хаттарш ца карийна.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA кхачаран дохор карийна. { $count ->
+            [one] { $count } WCAG AA дохор
+           *[other] { $count } WCAG AA дохор
+        } карийна. Кхачаран отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀетаӀае.
+        [advisories] WCAG AA дохораш ца карийна. { $count ->
+            [one] { $count } тӀетоьхна хьехам
+           *[other] { $count } тӀетоьхна хьехам
+        } карийна. Кхачаран отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀетаӀае.
+       *[clean] WCAG AA дохораш ца карийна. Кхачаран отчёт { $action ->
+            [close] дӀакъовла
+           *[open] даста
+        } тӀетаӀае.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML верси { $version }
+
+editor-tab-help = Контекстан гӀо
+editor-tab-help-short = Контекст
+editor-tab-errors = ГӀалаташ
+editor-tab-warnings = Тергамчаш
+editor-tab-info = Хаам
+editor-tab-accessibility = Кхачар
+editor-tab-responses = ДӀадахьийтина жоьпаш
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторан нисдарш
+editor-format-as-doenetml = DoenetML санна форматдан
+editor-format-as-xml = XML санна форматдан
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-гӀа могӀа
+
+editor-no-errors = ГӀалаташ дац
+editor-no-warnings = Тергамчаш яц
+editor-no-info = Хааман хаамаш бац
+
+editor-show-info-annotations = Хааман хаамаш редакторехь гайта
+editor-show-accessibility-annotations = Кхачаран хаамаш редакторехь гайта
+
+editor-accessibility-learn-more = Doenet кхачарна муха хьоьжу
+
+editor-accessibility-violations-heading = Кхачаран дохораш ({ $standard })
+
+editor-accessibility-other-heading = Кхин кхачаран хаттарш
+editor-none-found = ХӀумма ца карийна
+
+
+## Submitted responses
+
+editor-no-responses = ХӀинццалц дӀадахьийтина жоьпаш дац
+editor-response-answer-id = Жопан Id
+editor-response-response = Жоп
+editor-response-credit = Балл
+editor-response-submitted = ДӀадахьийтина
+
+
+## The context-help panel
+
+help-placeholder = Документаци ган курсор теган цӀе тӀе, атрибут тӀе я { $ref } тӀе хӀотта.
+
+help-unsupported-ref-chain = { $example } санна дукха дакъойн хьажораш йолчунна гӀо хӀинца дац.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Хьажоранна объект ца карийна: { $ref }.
+        [multiple] Хьажоранна дукха объекташ карийна: { $ref }.
+       *[indeterminate] { $ref } объект билгалдан ца делира.
+    }
+
+help-learn-about-references = Хьажорийн хьокъехь хаа →
+help-reference-page = Хьесапан агӀо →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } чохь
+       *[top] Лакхарчу тӀегӀанехь
+    }{ $allowed ->
+        [none] { " — кхузахь хӀумма ца тарло." }
+        [text] { " — кхузахь текст яздан мега." }
+        [text-and-components] { " — кхузахь текст яздан мега, я хӀорш зеде:" }
+       *[components] { " — хӀорш зеде мега:" }
+    }
+
+help-suggestions-footer = Массо { $total } компонент ган { $shortcut } тӀетаӀае.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объекте хьажор.
+       *[other] { $ref } — { $target } объекте хьажор ({ $line }-гӀа могӀа).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Иза { $owner } { $role } санна чуялийна.
+       *[other] Иза { $owner } { $line }-чу могӀанехь { $role } санна чуялийна.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементан { $property } лаьцна хьажор.
+       *[other] { $ref } — { $element } элементан { $property } лаьцна хьажор ({ $line }-гӀа могӀа).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = дакъа
+help-kind-array-entry = массиван элемент
+
+help-default = Бух болу мах:
+help-active-default = ХӀинцлера бух болу мах:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Магийна мехаш (хӀор элементана цхьаъ):
+       *[other] Магийна мехаш:
+    }
+
+help-suggested-values = Хьехийна мехаш:
+
+help-inserts = ТӀетуху:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координаташ:
+    }
+
+help-type = Тайпа:
+
+help-resolved-style = Схьаэцна стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Схьаэцна функцийн цӀераш:
+help-reset-list = ХӀокху меттиган юхаяккхаран список:
+help-added-on-input = ХӀокху меттигехь тӀетоьхна:
+help-removed-on-input = ХӀокху меттигера дӀадаьхна:
+
+help-reset-overrides = { $reset } — { $additional } а, { $removed } а тӀехь толу.

--- a/packages/i18n/locales/chm/chrome.ftl
+++ b/packages/i18n/locales/chm/chrome.ftl
@@ -1,0 +1,138 @@
+# Mari viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Mari counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular, so the two branches differ in nothing but the number they print.
+
+
+## Answer submission
+
+answer-checking = Тергалтеш…
+answer-submitting = Колталтеш…
+
+answer-checking-status = Вашмут тергалтеш
+answer-submitting-status = Вашмут колталтеш
+
+answer-correct = Чын
+answer-incorrect = Чын огыл
+
+answer-response-saved = Вашмут аралалте
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% чын
+answer-percent-short = { $percent } %
+
+max-credit-available = Налаш лийше эн кугу балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] тӧчымаш кодын огыл
+        [one] { $count } тӧчымаш кодын
+       *[other] { $count } тӧчымаш кодын
+    }
+
+validation-correct = (Чын)
+validation-incorrect = (Чын огыл)
+validation-partially-correct = (Ужашын чын)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } ӱмбак { $count } вашмутым ончыкташ
+       *[other] { $answerId } ӱмбак { $count } вашмутым ончыкташ
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Мӧҥгеш каласымаш
+
+collapsible-click-to-open = (почаш темдал)
+collapsible-click-to-close = (петыраш темдал)
+
+collapsible-initializing = Ямдылалтеш…
+
+footnote-show = Палемдымашым ончыкташ
+footnote-hide = Палемдымашым шылташ
+
+description-more-information = ешартыш увер
+
+
+## Controls
+
+slider-previous = Ончычсо
+slider-next = Вес
+
+keyboard-open = Клавиатурым почаш
+keyboard-close = Клавиатурым петыраш
+
+choice-input-remove-choice = { $choice } ойырымашым кораҥдаш
+
+matrix-remove-row = Радамым кораҥдаш
+matrix-add-row = Радамым ешараш
+matrix-remove-column = Меҥгым кораҥдаш
+matrix-add-column = Меҥгым ешараш
+
+subset-add-remove-points = Точкым ешараш/кораҥдаш
+subset-toggle-points-intervals = Точко ден кокласым вашталташ
+subset-move-points = Точко-влакым кусараш
+subset-clear = Эрыкташ
+
+orbital-add-row = Радамым ешараш
+orbital-remove-row = Радамым кораҥдаш
+orbital-add-box = Клеткым ешараш
+orbital-remove-box = Клеткым кораҥдаш
+orbital-add-up-arrow = Кӱшкӧ пикшым ешараш
+orbital-add-down-arrow = Ӱлыкӧ пикшым ешараш
+orbital-remove-arrow = Пикшым кораҥдаш
+
+orbital-row-label = { $row } радамын палыже
+
+pretzel-answer = Вашмут
+
+summary-statistics-caption = { $column } меҥгын иктешлыме статистикыже
+
+
+## Math input
+
+math-input-preview-region = математический ойлымашын ончылгоч ончымашыже
+math-input-preview = Ончылгоч ончымаш
+math-input-invalid-expression = Чын огыл ойлымаш:
+
+
+## Document status
+
+viewer-initializing = Ямдылалтеш…
+
+
+## Errors
+
+error-heading = Йоҥылыш
+
+error-found-at =
+    { $span ->
+        [line] Муымо радам: { $startLine }.
+       *[lines] Муымо радам-влак: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Тиде документыште йоҥылыш-влак улыт!
+
+diagnostic-heading-error = Йоҥылыш
+diagnostic-heading-warning = Шижтарымаш
+diagnostic-heading-information = Увер
+diagnostic-heading-hint = Ой
+
+accessibility-heading-level-1 = WCAG AA шуын кертмашын пудыртымашыже
+accessibility-heading-level-2 = Шуын кертмаш нерген увер
+
+something-went-wrong = Ала-мо чын огыл лие.
+
+renderer-load-failed = сӱретызым налаш ыш лий. Лаштыкым уэмде.
+
+core-start-failed = Документым ончышым чӱкташ ыш лий. Лаштыкым уэмде.

--- a/packages/i18n/locales/chm/content.ftl
+++ b/packages/i18n/locales/chm/content.ftl
@@ -1,0 +1,254 @@
+# Mari content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Mari's own ӓ, ӧ, ӱ and ҥ, which is the orthography
+# Mari El's schools and publishing use and what CLDR fills a bare `chm` in as.
+#
+# `chm` is an ISO 639-3 **macrolanguage** over Meadow Mari (`mhr`) and Hill
+# Mari (`mrj`), so it joins `MACROLANGUAGE_MEMBERS` in `negotiate.ts` and both
+# reach this catalog. What is written here is **Meadow Mari**, the larger of
+# the two literary standards and what a bare `chm` is normally taken to mean.
+# Hill Mari is a written standard of its own with its own orthography, so
+# serving it Meadow Mari is a real compromise — the same one `locales/kv` makes
+# for Komi-Permyak, one batch-mate away — and a deployment that wants Hill Mari
+# supplies it as `localeResources`.
+#
+# Mari has no grammatical gender and does not inflect an attributive adjective,
+# so `$gender` and `$role` go unused here, as in the other three Uralic
+# catalogs of this batch.
+
+
+## Style vocabulary
+
+color =
+    .black = шем
+    .white = ош
+    .gray = сур
+    .red = йошкар
+    .orange = оранжевый
+    .yellow = нарынче
+    .green = ужар
+    .cyan = волгыдо канде
+    .blue = канде
+    .purple = фиолетовый
+    .pink = роза тӱсан
+    .brown = кӱрен
+
+line-width =
+    .thick = кӱжгӧ
+    .thin = вичкыж
+
+line-style =
+    .dashed = кӱрылтшӧ
+    .dotted = точкан
+
+# Noun phrases: they stand in front of «сӱретан» and modify nothing.
+fill-style =
+    .horizontal = горизонтальный линий
+    .vertical = вертикальный линий
+    .diagonal = диагональный линий
+    .backdiagonal = ваштареш диагональный линий
+    .dots = точко
+    .diamonds = ромб
+
+noun =
+    .line = вияш линий
+    .line-segment = ужаш
+    .ray = луч
+    .vector = вектор
+    .curve = кадыр линий
+    .function = функций
+    .parabola = парабола
+    .polyline = тодылмо линий
+    .polygon = шуко лукан
+    .triangle = кум лукан
+    .rectangle = вияш лукан
+    .circle = йыргешке
+    .region = кундем
+    .point = точко
+    .square = квадрат
+    .diamond = ромб
+    .cross = вашкыл
+    .plus = плюс
+
+# Mari builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] тӧр { $numSides } лукан
+    }
+
+# Mari has no grammatical gender, so every noun answers the same and the answer
+# goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = чиялтыме
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } сӱретан { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } сӱретан { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } сӱретан { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «тӱран» — "having an edge" — carries the whole of "with a border" in its own
+# suffix, so neither a preposition nor an article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } тӱран
+        [and] да { $border } тӱран
+        [and-article] да { $border } тӱран
+       *[with] { $border } тӱран
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } сӱретан { $color } чия
+       *[plain] { $color } чия
+    }
+
+style-unfilled = чиялтыдыме
+
+# «ӱмбалне» — "on" — is a postposition and follows the background colour, so
+# nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон ӱмбалне { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = уке
+
+
+## Boolean words
+
+boolean-true = чын
+boolean-false = чын огыл
+
+
+## Answer buttons
+
+answer-submit-label = Тергаш
+answer-submit-label-no-correctness = Вашмутым колташ
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Паша
+    .aside = Ӧрдыж палемдымаш
+    .cascade = Каскад
+    .definition = Рашемдымаш
+    .example = Пример
+    .exercise = Упражнений
+    .exercises = Упражнений-влак
+    .given-answer = Вашмут
+    .note = Палемдымаш
+    .objectives = Цель-влак
+    .paragraphs = Абзац-влак
+    .part = Пай
+    .problem = Задаче
+    .problems = Задаче-влак
+    .proof = Пеҥгыдемдымаш
+    .question = Йодыш
+    .section = Ужаш
+    .solution = Решений
+    .task = Пашаж
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Ой
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблице { $enumeration }
+        [numbered-title] Таблице { $enumeration }{ ". " }
+        [unnumbered-title] Таблице{ ". " }
+       *[unnumbered] Таблице
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Сӱрет { $enumeration }
+        [numbered-caption] Сӱрет { $enumeration }{ ". " }
+        [unnumbered-caption] Сӱрет{ ". " }
+       *[unnumbered] Сӱрет
+    }
+
+
+## Paginator controls
+
+paginator-previous = Ончычсо
+paginator-next = Вес
+paginator-page = Лаштык
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## `piecewise-condition-if` is the limit `locales/udm` and `locales/kv` already
+## record, in a third Uralic language: Mari's conditional «гын» closes the
+## clause it conditions, and the renderer places this key before the
+## mathematics. Erzya beside them does not hit it, so the wall is word order
+## rather than family.
+
+piecewise-condition-or = але
+piecewise-condition-if = гын
+piecewise-condition-otherwise = вес семын
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Mari El is taught in
+## Russian, so the element names a Mari-speaking pupil meets are the Russian
+## ones — the school-system case this batch shares throughout.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Чын огыл химический пале
+chemistry-invalid-ionic-compound = Чын огыл ион ушымаш

--- a/packages/i18n/locales/chm/content.ftl
+++ b/packages/i18n/locales/chm/content.ftl
@@ -4,8 +4,10 @@
 # UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
 # Correct anything here freely; nothing in it was written by a translator.
 #
-# Written in Cyrillic with Mari's own ӓ, ӧ, ӱ and ҥ, which is the orthography
-# Mari El's schools and publishing use and what CLDR fills a bare `chm` in as.
+# Written in Cyrillic with Meadow Mari's own ӧ, ӱ and ҥ, which is the
+# orthography Mari El's schools and publishing use and what CLDR fills a bare
+# `chm` in as. Hill Mari's ӓ and ӹ are deliberately absent: they belong to the
+# other standard, and this catalog is not written in it — see below.
 #
 # `chm` is an ISO 639-3 **macrolanguage** over Meadow Mari (`mhr`) and Hill
 # Mari (`mrj`), so it joins `MACROLANGUAGE_MEMBERS` in `negotiate.ts` and both

--- a/packages/i18n/locales/chm/diagnostics.ftl
+++ b/packages/i18n/locales/chm/diagnostics.ftl
@@ -1,0 +1,654 @@
+# Mari diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Mari uses for
+# them: «компонент», «атрибут», «функций», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кок мучаш точко ончыктымо годым { $attributes } шотыш ок нал
+       *[other] кок мучаш точко ончыктымо годым { $attributes } шотыш ок нал
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] мучаш точко ден покшел точко коктынат ончыктымо годым { $attributes } шотыш ок нал
+       *[other] мучаш точко ден покшел точко коктынат ончыктымо годым { $attributes } шотыш ок нал
+    }
+
+line-segment-midpoint-offset-without-midpoint = покшел точко деч посна midpointOffset нимолан ок логал
+
+## `<line>`
+
+line-points-undetermined-dimensions = Виса палыдыме точко-влак гоч эртыше вияш линий.
+
+line-points-too-few-dimensions = Вияш линий эн шагал кок висан точко-влак гоч эртышаш.
+
+line-points-depend-on-variables = Вияш линий вашталтше виса-влак деч зависитлыше точко-влак гоч эрта: { $variables }.
+
+line-equation-invalid-format = { $variable1 } да { $variable2 } вашталтше висан вияш линийын уравненийжын форматше чын огыл.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint да direction гоч пуымо. Пуымо through шотыш ок нал.
+
+ray-dimension-mismatch = лучышто numDimensions ок келше.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail да displacement гоч пуымо. Пуымо head шотыш ок нал.
+
+vector-dimension-mismatch = векторышто numDimensions ок келше.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элемент деке шупшаш ок лий, вет тудын nearestPoint статус вашталтшыже уке.
+
+constrain-to-without-nearest-point = `<{ $component }>` элемент дене чараш ок лий, вет тудын nearestPoint статус вашталтшыже уке.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементын кӧргыж дене чараш ок лий, вет тудын nearestPoint статус вашталтшыже уке.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = радам кӧргыштӧ огыл choiceInput ӱмбак labelPosition шотыш ок нал
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput ӱмбак пуымо индекс-влак шотыш огыт нал, вет нунын чотышт choice икшыве-влакын чотыштлан ок келше.
+
+pretzel-indices-count-mismatch = problem ӱмбак пуымо индекс-влак шотыш огыт нал, вет нунын чотышт problem икшыве-влакын чотыштлан ок келше.
+
+shuffle-indices-count-mismatch = shuffle ӱмбак пуымо индекс-влак шотыш огыт нал, вет нунын чотышт компонент-влакын чотыштлан ок келше.
+
+indices-ignored-out-of-range = { $component } ӱмбак пуымо индекс-влак шотыш огыт нал, вет южыжо чек гыч лектыт.
+
+pretzel-indices-repeated = pretzel ӱмбак пуымо индекс-влак шотыш огыт нал, вет южыжо угыч вашлиялтыт.
+
+pretzel-circuit-first-index = circuit режимыште pretzel ӱмбак пуымо индекс-влак шотыш огыт нал, вет икымше индекс 1 лийшаш.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текст икшыве-влак дене пашам ышташ `type` атрибутым пуаш кӱлеш.
+
+invalid-type-defaulting-to-math = { $component } компонентлан чын огыл тӱс { $type }. Тудо math, text, number але boolean лийшаш. math кучылталтеш.
+
+string-not-valid-component-to-arrange = «{ $value }» радам { $component } ӱмбак келшыше компонент огыл. Шотыш ок нал.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Чын огыл тӱс { $type }, тӱсшӧ number лиеш.
+
+invalid-variable-value = Вашталтшын чын огыл акше: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантын индексше чот лийшаш
+
+variant-index-must-be-integer = { $index } вариантын индексше тичмаш чот лийшаш
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютный виса-влаклан ыштыме огыл. Кумдыкышт таҥастарыме лийыт.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютный виса-влаклан ыштыме огыл. Тӱржӧ таҥастарыме лийыт.
+
+side-by-side-no-block-child = Чын огыл `<{ $component }>`: тудын эн шагал ик блок икшывыже лийшаш.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементын `for` атрибутшо шотыш ок нал.
+
+label-for-must-resolve-to-one = `<label>` элементын `for` атрибутшо лач ик компонент ӱмбак ончыкташ тӱҥалшаш.
+
+label-for-unresolved = `<label>` элементын `for` атрибутшым компонент дене кылдаш ыш лий.
+
+label-for-answer-with-authored-inputs = `<label>` элементын `for` атрибутшо автор возымо пуртымо пасу-влакан `<answer>` ӱмбак ончыкта; пасу ӱмбак вигак ончыкто.
+
+label-for-answer-without-input = `<label>` элементын `for` атрибутшо палемдыме пуртымо пасу деч посна `<answer>` ӱмбак ончыкта.
+
+label-for-must-reference-input-or-answer = `<label>` элементын `for` атрибутшо пуртымо пасу але вашмут ӱмбак ончыкташ тӱҥалшаш.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Шуын кертмашлан `<{ $component }>` але кӱчык умылтарымашан лийшаш, але сӧрастарымаш семын палемдалтшаш.
+
+accessibility-video-short-description = Шуын кертмашлан `<video>` кӱчык умылтарымашан лийшаш.
+
+accessibility-input-short-description-or-label = Шуын кертмашлан `<{ $component }>` кӱчык умылтарымашан але палан лийшаш.
+
+accessibility-answer-input-short-description-or-label = Шуын кертмашлан пуртымо пасум ыштыше `<answer>` кӱчык умылтарымашан але палан лийшаш.
+
+accessibility-short-description-contains-math = Кӱчык умылтарымаш-влакыште `<{ $component }>` гай математический компонент-влак лийшаш огытыл. Математикым мут дене возо.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ужашын вуй текстшылан ситыше контрастым ок пу (пычкемыш тӱс) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн шагал { $threshold }:1 кӱлеш).
+       *[other] { $colorName } ужашын вуй текстшылан ситыше контрастым ок пу ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн шагал { $threshold }:1 кӱлеш).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Точко-влакын чот акышт уке годым { $count } точко гоч эртыше `<circle>` ыштыме огыл.
+
+circle-too-many-through-points = 3 деч шуко точко гоч эртыше йыргешкым шотлаш ок лий.
+
+circle-overprescribed-radius-center-points = Пуымо радиус, покшел да точко-влак дене йыргешкым шотлаш ок лий.
+
+circle-center-with-multiple-points = Пуымо покшел дене 1 деч шуко точко гоч эртыше йыргешкым шотлаш ок лий.
+
+circle-radius-too-small = Йыргешкым шотлаш ок лий: кок точко коклаште кужыт { $distance } улмо годым, пуымо радиус { $radius } пеш изи.
+
+circle-radius-with-many-points = Пуымо радиус дене кок деч шуко точко гоч эртыше йыргешкым ышташ ок лий.
+
+circle-invalid-center-or-through-points = Йыргешкын покшелже але точкыжо чын огытыл.
+
+circle-radius-center-with-multiple-points = Пуымо покшел дене 1 деч шуко точко гоч эртыше йыргешкын радиусшым шотлаш ок лий.
+
+circle-change-radius-non-numerical = Чот огыл точкан йыргешкын радиусшым вашталташ ок лий
+
+circle-radius-with-points-non-numerical = Чот ак-влак уке годым пуымо радиус дене ик деч шуко точко гоч эртыше йыргешкым ышташ ок лий.
+
+circle-change-center-non-numerical = Чот огыл точко-влак гоч эртыше йыргешкын покшелжым вашталтымаш ыштыме огыл.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцийын палемдыме кундемжын висаже ок сите. Кундемыште { $intervals } кокла уло, а функцийыште { $inputs ->
+            [one] { $inputs } пуртымаш
+           *[other] { $inputs } пуртымаш
+        } уло.
+       *[other] Функцийын палемдыме кундемжын висаже ок сите. Кундемыште { $intervals } кокла уло, а функцийыште { $inputs ->
+            [one] { $inputs } пуртымаш
+           *[other] { $inputs } пуртымаш
+        } уло.
+    }
+
+function-domain-invalid-format = Функцийын палемдыме кундемжын форматше чын огыл.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцийын чот огыл максимумжо шотыш ок нал.
+        [minimum] Функцийын чот огыл минимумжо шотыш ок нал.
+        [extremum] Функцийын чот огыл экстремумжо шотыш ок нал.
+        [point] Функцийын чот огыл точкыжо шотыш ок нал.
+        [slope] Функцийын чот огыл важыкшо шотыш ок нал.
+       *[other] Функцийын чот огыл { $type } акше шотыш ок нал.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцийын яра максимумжо шотыш ок нал.
+        [minimum] Функцийын яра минимумжо шотыш ок нал.
+        [extremum] Функцийын яра экстремумжо шотыш ок нал.
+        [point] Функцийын яра точкыжо шотыш ок нал.
+       *[other] Функцийын яра { $type } акше шотыш ок нал.
+    }
+
+function-points-too-close = Функцийыште икте-весылан пеш лишыл кок точко уло. Функцийым палемдаш ок лий.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцийын итерацийже пуртымаш-влакын чотышт лукмаш-влакын чотыштлан икгай улмо годым гына лиеш. Тиде функцийыште { $inputs } пуртымаш да { $outputs ->
+            [one] { $outputs } лукмаш
+           *[other] { $outputs } лукмаш
+        } уло.
+       *[other] Функцийын итерацийже пуртымаш-влакын чотышт лукмаш-влакын чотыштлан икгай улмо годым гына лиеш. Тиде функцийыште { $inputs } пуртымаш да { $outputs ->
+            [one] { $outputs } лукмаш
+           *[other] { $outputs } лукмаш
+        } уло.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Радамын кужытшо чын огыл. Тудо минус огыл тичмаш чот лийшаш.
+
+sequence-invalid-step = Радамын ошкылжо чын огыл. { $type } тӱсан радамлан тудо чот лийшаш.
+
+sequence-invalid-endpoint-number = Чот радамын «{ $attribute }» акше чын огыл. Тудо чот лийшаш.
+
+sequence-invalid-endpoint-letters = Буква радамын «{ $attribute }» акше чын огыл. Тудо буква-влакын ушымашышт лийшаш.
+
+sequence-invalid-endpoint = Радамын «{ $attribute }» акше чын огыл.
+
+select-from-sequence-coprime-not-numbers = чот-влак ойырымо огытыл, сандене coprime шотыш ок нал
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations пуымо, сандене coprime шотыш ок нал
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` ӱмбак чын огыл target: цель муалт огыл.
+
+target-state-variable-not-found = `<{ $source }>` ӱмбак чын огыл target: `<{ $component }>` элементыште «{ $property }» лӱман статус вашталтше муалт огыл.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` вашталтшыже-влак шкешотан вашталтше деч ойыртемалтшаш.
+
+ode-system-duplicate-variable-names = Зависитлыше вашталтше-влакын лӱмышт угыч вашлиялтыт гын, ДТ пурла велын функцийжым палемдаш ок лий.
+
+ode-system-rhs-function-error = ДТ пурла велын функцийжым палемдаш ок лий. mathjs функцийым ыштыме годым йоҥылыш.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } вияш линий коклаште лукым палемдаш ок лий
+
+angle-invalid-through-point = `<angle>` элементын through акыштыже чын огыл точко
+
+parabola-vertex-too-many-points = Пуымо вуй дене 1 деч шуко точко гоч эртыше парабола ыштыме огыл.
+
+parabola-too-many-points = 3 деч шуко точко гоч эртыше парабола ыштыме огыл.
+
+intersection-too-many-items = Кок деч шуко объектын вашпӱчмашыже ыштыме огыл
+
+## Other math components
+
+ionic-compound-not-two-ions = Кок ион деч моло ион ушымаш ыштыме огыл.
+
+ionic-compound-needs-cation-and-anion = Ион ушымаш ик катионлан да ик анионлан гына ыштыме.
+
+solve-equations-cannot-evaluate = Уравненийым ышташ ок лий, вет тудым шотлаш ыш лий: { $equation }
+
+math-operators-operand-number-required = Математический операндым ойыраш operandNumber пуаш кӱлеш.
+
+eigen-decomposition-failed = Матрицын шке акшым шотлаш ыш лий
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр образецыште ок вашлиялт, сандене тудо эре яралан келша.
+       *[other] `<matchesPattern>`: { $parameters } параметр-влак образецыште огыт вашлиялт, сандене нуно эре яралан келшат.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" акым умылаш ок лий. Тудо none, medium, dense але яра вер дене ойырымо кок плюс чот лийшаш, мутлан grid="1 0.5". Сетке ок сӱретлалт.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure сӱретызыште xLabelPosition="left" ыштыме огыл; пурла велын шындымашыже кучылталтеш.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure сӱретызыште yLabelPosition="bottom" ыштыме огыл; кӱшыл велын шындымашыже кучылталтеш.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure вончыктарымашлан ось-влакын чекышт чын огытыл; тӱҥ bbox (-10,-10,10,10) кучылталтеш.
+
+prefigure-invalid-width = `<graph>`: prefigure вончыктарымашлан кумдык чын огыл; диаграммын тӱҥ кумдыкшо 425 кучылталтеш.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure вончыктарымашлан aspectRatio чын огыл; тӱҥ вел-влакын кыл-вашкылышт 1 кучылталтеш.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткын ошкылжо ось-влакын чекыштлан пеш изи; prefigure сӱретызыште сетке ок лук.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure сӱретызе ок кучылталт гын, палемдымаш-влак огыт сӱретлалт.
+
+multiple-annotations-children = `<graph>` кӧргыштӧ шуко `<annotations>` икшыве муалте; пытартышыж деч моло-влак шотыш огыт нал.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Палыдыме компонент тӱсым шараш але копироватлаш ок лий: { $type }.
+
+copy-prop-not-found = { $component } тӱсан компонентыште { $property } свойстве муалт огыл
+
+collect-no-source = collect ӱмбак источник муалт огыл.
+
+collect-invalid-component-type = `<{ $component }>` тӱсан компонент-влакым погаш ок лий, вет тиде чын огыл компонент тӱс.
+
+reference-index-unavailable = `{ $reference }` индекс ӱмбак кылверым ышташ ок лий
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентыште { $action } ӱжаш ок лий
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннӧй-влакын тӱсышт чын огыл. Радам-влакын кужытышт тӱрлӧ. Муалте componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннӧй-влакыште меҥгын лӱмжӧ угыч вашлиялтеш. Муалте componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннӧй-влакыште меҥге лӱм ок сите. Муалте componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Тиде вашмутын award акше answer тегын шке колтымо вашмутшо ӱмбак эҥерта, тиде вучыдымо пашалан конда.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` дене контейнер кӧргысӧ `<answer>` ӱмбак `maxNumAttempts` шындымаш ок логал, вет тӧчымаш-влакын чотыштым контейнер палемда. `maxNumAttempts` акым контейнер ӱмбак шынде.
+
+nested-section-wide-check-work-max-num-attempts = Вес `sectionWideCheckWork` контейнер кӧргыштӧ шогышо `sectionWideCheckWork` контейнер ӱмбак `maxNumAttempts` шындымаш ок логал, вет тӧчымаш-влакын чотыштым тӱжвал контейнер палемда. `maxNumAttempts` акым тӱжвал контейнер ӱмбак шынде.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality шындыме огыл гын, { $attributes } атрибут ок логал.
+       *[other] symbolicEquality шындыме огыл гын, { $attributes } атрибут-влак огыт логал.
+    }
+
+answer-invalid-type = answer ӱмбак чын огыл тӱс: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентын лӱмжӧ уке, сандене тудым модуль атрибут семын кучылташ ок лий
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентым модуль атрибут семын кучылташ ок лий, вет `<module>` компонент тӱсыштӧ «{ $name }» атрибут ынде палемдыме.
+
+conditional-content-condition-ignored = case але else икшыве-влакан `<conditionalContent>` компонентыште `condition` атрибут шотыш ок нал.
+
+slider-markers-type-mismatch = Маркер-влакын тӱсышт ползунокын тӱсышлан ок келше.
+
+pretzel-problem-needs-statement-and-answer = Чын огыл pretzel: кажне `<problem>` ик `<statement>` да ик `<answer>` кӧргыжеш налшаш.
+
+pretzel-circuit-first-problem-distractor = Чын огыл pretzel: mode="circuit" режимыште икымше `<problem>` шонымашым ӧрдыжкӧ наҥгайыше лийшаш огыл.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутлан чын огыл ак { $values }; шотыш ок нал.
+       *[other] `{ $attribute }` атрибутлан чын огыл ак-влак { $values }; шотыш огыт нал.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутлан чын огыл ак `{ $value }`. Атрибут `$` пале дене тӱҥалше кылвер-влак гыч лийшаш.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } кӧргысӧ чын огыл функций лӱм-влак шотыш налме огытыл: { $names }. Кажне лӱмын койшо ужашыже эн шагал 2 пале лийшаш (буква-влак але кыдалаш кыл); тудын почеш кӱлдымӧ `|<mathspeak альтернативе>` ешартыш толын кертеш.
+
+## Building components from the source
+
+component-type-invalid = Чын огыл компонент тӱс: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутым угыч ышташ ок лий.
+
+attribute-invalid-for-component = `<{ $componentType }>` тӱсан компонентлан чын огыл атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль палемдымаште { $context ->
+        [text-on-background] текстын тӱсшӧ да фонын тӱсшӧ
+        [high-contrast] кугу контрастан тӱс да сӱретлыме кундем
+        [line] линийын тӱсшӧ да сӱретлыме кундем
+        [marker] маркерын тӱсшӧ да сӱретлыме кундем
+       *[text-on-canvas] текстын тӱсшӧ да сӱретлыме кундем
+    } коклаште контраст ок сите{ $mode ->
+        [dark] { " (пычкемыш тӱс)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн шагал { $threshold }:1 кӱлеш).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль палемдымаште пуымо тӱс-влак волгыдо тӱслан ситыше контрастым пуышт гынат, нуно гыч лекше пычкемыш тӱсын тӱсшӧ-влак текст ден фон коклаште ситыше контрастым огыт пу ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн шагал { $threshold }:1 кӱлеш). { $suggestion ->
+        [available] Пычкемыш тӱсыштӧ ситыше контрастлан але волгыдо тӱсын контрастшым кугемде (мутлан { $lightAttribute }="{ $lightColor }"), але пычкемыш тӱсын тӱсшым вашталте (мутлан { $darkAttribute }="{ $darkColor }").
+       *[none] Пычкемыш тӱсыштӧ ситыше контрастлан волгыдо тӱсын контрастшым кугемде але лекше тӱс-влакым textColorDarkMode да/але backgroundColorDarkMode гоч вашталте.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль палемдымаште пуымо текст тӱс волгыдо тӱслан ситыше контрастым пуыш гынат, тудын гыч лекше пычкемыш тӱсын текст тӱсшӧ сӱретлыме кундем дене ситыше контрастым ок пу ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эн шагал { $threshold }:1 кӱлеш). { $suggestion ->
+        [available] Пычкемыш тӱсыштӧ ситыше контрастлан але волгыдо тӱсын контрастшым кугемде (мутлан textColor="{ $lightColor }"), але пычкемыш тӱсын тӱсшым вашталте (мутлан textColorDarkMode="{ $darkColor }").
+       *[none] Пычкемыш тӱсыштӧ ситыше контрастлан волгыдо тӱсын контрастшым кугемде але лекше тӱсым textColorDarkMode гоч вашталте.
+    }
+
+section-multiple-style-palettes = Ужаш ик <stylePalette> гына ойырен кертеш; пытартышыже кучылталтеш.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет numToSelect минус огыл тичмаш чот огыл.
+
+variant-num-to-select-not-constant-number = { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет numToSelect вашталтдыме чот огыл.
+
+variant-with-replacement-not-constant-boolean = { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет withReplacement вашталтдыме логический ак огыл.
+
+variant-select-weight-disables-unique = могай-гынат ойырымаште selectWeight але selectForVariants пуымо гын, select ӱмбак угыч лийдыме вариант-влак йӧрат
+
+variant-coprime-undetermined = { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет coprime эре чын огыл мо, тидым палемдаш ок лий.
+
+variant-attribute-not-constant = { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет { $attribute } вашталтдыме огыл.
+
+variant-attribute-not-number = { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет { $attribute } чот огыл.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } тӱсан { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет { $attribute } { $expected ->
+        [letters-combination] буква-влакын ушымашышт
+        [math-expression] келшыше математический ойлымаш
+        [integer] тичмаш чот
+       *[number] чот
+    } огыл.
+
+variant-length-not-integer = { $component } ӱмбак угыч лийдыме вариант-влакым палемдаш ок лий, вет length тичмаш чот огыл.
+
+variant-sort-not-implemented = sort дене { $component } ӱмбак угыч лийдыме вариант-влак ыштыме огытыл
+
+variant-exclude-combinations-not-implemented = excludeCombinations дене { $component } ӱмбак угыч лийдыме вариант-влак ыштыме огытыл
+
+variant-math-exclude-not-implemented = exclude дене math тӱсан { $component } ӱмбак угыч лийдыме вариант-влак ыштыме огытыл
+
+variant-non-constant-exclude-not-implemented = вашталтдыме огыл exclude дене { $component } ӱмбак угыч лийдыме вариант-влак ыштыме огытыл
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикын prefigure сӱретызыштыже ыштыме огыл; тукымжо кодалте.
+
+prefigure-descendant-invalid-geometry = { $subject }: мучашдыме але тичмаш огыл геометрий; тукымжо кодалте.
+
+prefigure-curve-label-omitted = { $subject }: вончыктарыме кадыр элемент-влакыште пале-влак ыштыме огытыл; пале кодалте.
+
+prefigure-curve-unsupported-definition-type = { $subject }: ыштыме огыл кадыр функций палемдымашын тӱсшӧ «{ $definitionType }»; тукымжо кодалте.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементын flipFunctions атрибутшо ыштыме огыл; тукымжо кодалте.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формула дене пуымо икшыве функций-влакым гына налеш; тукымжо кодалте.
+
+prefigure-label-position-unsupported =
+    { $subject }: ыштыме огыл labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] линий тукымын палыжлан
+       *[point] точкын палыжлан
+    }; PreFigure-ын тӱҥ таҥастарымашыже кучылталтеш.
+
+prefigure-fill-style-unsupported = { $subject }: темыме стиль «{ $fillStyle }» PreFigure ӱмбак ыштыме огыл; тичмаш темымашке вонча.
+
+prefigure-line-style-unknown = { $subject }: палыдыме линий стиль «{ $lineStyle }» PreFigure лукмаш гыч кораҥдыме.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стиль «{ $markerStyle }» PreFigure «diamond» стиль дене келыштарыме.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стиль «{ $markerStyle }» PreFigure ӱмбак ыштыме огыл; тӱҥ стиль кучылталтеш.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: чын огыл `ref`; цельым кылдаш ок лий. Палемдымаш кораҥдыме.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` шуко цель дене кылдалте; икымшыже кучылталтеш.
+
+annotation-ref-outside-graph = `<annotation>`: чын огыл `ref`; цель тудым кӧргыжеш налше график деч тӱжвалне. Палемдымаш кораҥдыме.
+
+annotation-ref-unsupported-target = `<annotation>`: чын огыл `ref`; цель prefigure вончыктарымаште ыштыме график объект огыл. Палемдымаш кораҥдыме.
+
+annotation-text-missing = `<annotation>`: `text` уке але яра; яра текст лукталтеш.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Йыр зависимость муалте.
+       *[other] `<{ $componentType }>` компонентым кӧргыжеш налше йыр зависимость муалте.
+    }
+
+reference-no-referent = Кылверлан объект муалт огыл: `{ $reference }`
+
+reference-multiple-referents = Кылверлан шуко объект муалте: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементын { $attribute } атрибутшын форматше чын огыл.
+
+children-invalid = `<{ $componentType }>` ӱмбак чын огыл икшыве-влак: чын огыл икшыве-влак муалтыч: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутлан чын огыл ак `{ $value }`; `{ $default }` ак кучылталтеш
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версий муалт огыл.
+       *[other] DoenetML { $version } версий муалт огыл. { $fallback } версий кучылталтеш
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Чын огыл DoenetML: { $content }
+
+parse-tag-missing-close-tag = Чын огыл DoenetML: `{ $tag }` тегын петырыше тегше уке. Шкенжым петырыше тег але `</{ $tagName }>` тег вучалте.
+
+parse-tag-error = Чын огыл DoenetML: `<{ $tagName }>` тегыште йоҥылыш
+
+parse-attribute-missing-value = Чын огыл DoenetML: `{ $attribute }` атрибутышто ак ок сите гай.
+
+parse-attribute-invalid = Чын огыл DoenetML: чын огыл атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Чын огыл DoenetML: атрибутын чын огыл акше `{ $value }`
+
+parse-attribute-value-quote-mismatch = Чын огыл DoenetML: атрибутын чын огыл акше `{ $value }`. Кавычке-влак огыт келше. `{ $quote }` ок сите гай
+
+parse-open-tag-name-missing = Чын огыл DoenetML: лӱмдымӧ тег муалте, мутлан `<`
+
+parse-tag-not-closed = Чын огыл DoenetML: `{ $tag }` тег петырыме огыл (`>` ок сите гай).
+
+parse-self-closing-tag-name-missing = Чын огыл DoenetML: лӱмдымӧ тег муалте `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Чын огыл DoenetML: `{ $tag }` тег петырыме огыл (`/>` ок сите гай).
+
+parse-tag-invalid-attributes = Чын огыл DoenetML: `{ $tag }` тег келшыше огыл. Тудын атрибутшо-влак чын огыт лий кертыт.
+
+parse-close-tag-name-missing = Чын огыл DoenetML: лӱмдымӧ петырыше тег муалте, мутлан `</`
+
+parse-attribute-value-unquoted = Атрибутын ак-влакше кавычке кӧргыштӧ лийшаш: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Чын огыл DoenetML: `{ $tag }` петырыше тег муалте, но тудлан келшыше почшо тег уке
+
+parse-close-tag-mismatched = Чын огыл DoenetML: келшыдыме петырыше тег. `</{ $expected }>` вучалте. `{ $found }` муалте
+
+parser-node-unconvertible = { $node } узелым Dast узелыш вончыкташ ыш лий.
+
+## Names
+
+name-attribute-invalid =
+    Чын огыл атрибут name='{ $name }'. { $reason ->
+        [characters] Лӱм-влакыште буква-влак, чот-влак, ӱлыл кыл але кыл гына лийын кертыт.
+       *[start] Лӱм-влак буква гыч тӱҥалшаш.
+    }
+
+component-name-invalid-start = Чын огыл компонент лӱм «{ $name }». Лӱм-влак буква гыч тӱҥалшаш.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тӱсан answer-ын video атрибутшо лийшаш
+
+answer-video-watched-video-not-reference = videoWatched тӱсан answer-ын video атрибутшо кылвер лийшаш
+
+answer-name-not-single-text = answer-ын name атрибутыштыже лач ик текст икшыве лийшаш
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсийын кӱкшытшӧ-влак пеш шуко, сандене тӱжвал DoenetML-ым налаш ыш лий. Йыр кылвер уке мо?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адрес гыч DoenetML-ым налаш ыш лий
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адрес гыч чын огыл DoenetML налме: тудо «{ $componentType }» компонент тӱслан ыш келше
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут тошто лийын; тудын олмеш `{ $to }` кучылт.
+       *[other] [deprecation] `<{ $component }>` элементын `{ $from }` атрибутшо тошто лийын; тудын олмеш `{ $to }` кучылт.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут тошто лийын да шотыш ок нал, вет `{ $to }` тоже пуымо.
+       *[other] [deprecation] `<{ $component }>` элементын `{ $from }` атрибутшо тошто лийын да шотыш ок нал, вет `{ $to }` тоже пуымо.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементын `{ $attribute }` атрибутшо тошто лийын да шотыш ок нал.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементын `{ $attribute }` атрибутшо тошто лийын; тудын олмеш `<{ $child }>` икшывым кучылт.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементын `{ $attribute }` атрибутшын `{ $value }` акше тошто лийын; тудын олмеш `{ $to }` кучылт.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` шуко чотым англичан йылме дене гына ыштен кертеш, сандене { $locale } йылме дене возымо документыште тудын текстше вашталтде кодеш. Шуко чот формым шке возо але тудым `pluralForm` атрибут дене пу.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент палыме Doenet элемент огыл.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементлан документын вожыштыжо ок лий.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементлан `<{ $parent }>` кӧргыштӧ ок лий.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементыште `{ $attribute }` лӱман атрибут уке.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементын `{ $attribute }` атрибутшо кажне элементше нунын гыч иктыже лийше лӱмер лийшаш: { $allowed }
+       *[other] `<{ $tag }>` элементын `{ $attribute }` атрибутшо нунын гыч иктыже лийшаш: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select ӱмбак чын огыл вариант лӱм. { $variantName } вариант лӱм { $numOptions } ойырымаште вашлиялтеш, а ойырышаш чот { $numToSelect }.
+
+select-variant-name-without-options = select ӱмбак вариант-влак пуымо, но лийын кертше вариант лӱмлан ик ойырымашат уке: { $variantName }.
+
+select-variant-name-not-possible = select ӱмбак пуымо { $variantName } вариант лӱм лийын кертше вариант лӱм огыл.
+
+select-too-few-options = Чылаже { $numOptions } гыч { $numToSelect } компонентым ойыраш ок лий.
+
+select-from-sequence-too-few-values = Кужытшо { $length } радам гыч { $numToSelect } акым ойыраш ок лий.
+
+select-from-sequence-indices-count-mismatch = select ӱмбак пуымо индекс-влакын чотышт ойырышаш чотлан келшышаш
+
+select-from-sequence-indices-not-integers = select ӱмбак пуымо чыла индекс-влак тичмаш чот лийшаш
+
+select-from-sequence-index-excluded = selectfromsequence ӱмбак пуымо индекс кораҥдыме ыле
+
+select-from-sequence-indices-excluded-combination = selectfromsequence ӱмбак пуымо индекс-влак кораҥдыме ушымаш ыле
+
+select-from-sequence-coprime-not-positive-integers = Плюс тичмаш чот-влак ойырымо огытыл, сандене икте-весылан проста ушымаш-влакым ойыраш ок лий.
+
+select-from-sequence-coprime-common-factor = Икте-весылан проста чот-влакым ойыраш ок лий. Чыла лийын кертше ак-влакын икгай шеледышышт уло. (Пуымо "from" але "to" ак-влак "step" дене икте-весылан проста лийшаш.)
+
+select-from-sequence-coprime-single-number = 1 огыл ик чот гыч икте-весылан проста ушымаш-влакым ойыраш ок лий.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence кӧргыштӧ ушымаш-влакын 70% деч шукыжо кораҥдыме
+
+select-from-sequence-coprime-none-found = Икте-весылан проста чот-влакым ойыраш ыш лий. Чыла лийын кертше ак-влакын икгай шеледышышт уло.
+
+select-from-sequence-too-few-unique-values = Кужытшо { $numPossibleValues } радам гыч { $numToSelect } тӱрлӧ акым ойыраш ок лий
+
+select-prime-numbers-too-few-values = Кужытшо { $numValues } проста чот лӱмер гыч { $numToSelect } акым ойыраш ок лий
+
+select-prime-numbers-values-count-mismatch = select ӱмбак пуымо ак-влакын чотышт ойырышаш чотлан келшышаш
+
+select-prime-numbers-values-not-prime = select prime number ӱмбак пуымо чыла ак-влак проста чот лӱмерыште лийшаш
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers ӱмбак пуымо ак-влак кораҥдыме ушымаш ыле
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers кӧргыштӧ ушымаш-влакын 70% деч шукыжо кораҥдыме
+
+select-random-combination-fluke = Пеш лийын кертдыме паша дене кокла гыч налме ак-влакын ушымашыштым ойыраш ыш лий
+
+select-random-value-fluke = Пеш лийын кертдыме паша дене кокла гыч налме акым ойыраш ыш лий

--- a/packages/i18n/locales/chm/editor.ftl
+++ b/packages/i18n/locales/chm/editor.ftl
@@ -1,0 +1,215 @@
+# Mari editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Mari counts in the same two categories English does, so every selection below
+# keeps both branches — though a noun after a numeral stays singular, so the
+# two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Пӧртылташ
+       *[update] Уэмдаш
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Ончышым { $word }
+       *[other] Ончышым { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Ойырымаш…
+editor-variant-next = Вес вариантым ойыраш
+editor-variant-previous = Ончычсо вариантым ойыраш
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA шуын кертмашын пудыртымашыже муалте. Шуын кертмаш отчётым { $action ->
+            [close] петыраш
+           *[open] почаш
+        } темдал.
+        [advisories] Шуын кертмаш отчётым { $action ->
+            [close] петыраш
+           *[open] почаш
+        } темдал. WCAG AA пудыртымаш-влак муалт огытыл, но ешартыш ой-влак улыт.
+       *[clean] Шуын кертмаш отчётым { $action ->
+            [close] петыраш
+           *[open] почаш
+        } темдал. Шуын кертмаш йодыш-влак муалт огытыл.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA шуын кертмашын пудыртымашыже муалте. { $count ->
+            [one] { $count } WCAG AA пудыртымаш
+           *[other] { $count } WCAG AA пудыртымаш
+        } муалте. Шуын кертмаш отчётым { $action ->
+            [close] петыраш
+           *[open] почаш
+        } темдал.
+        [advisories] WCAG AA пудыртымаш-влак муалт огытыл. { $count ->
+            [one] { $count } ешартыш ой
+           *[other] { $count } ешартыш ой
+        } муалте. Шуын кертмаш отчётым { $action ->
+            [close] петыраш
+           *[open] почаш
+        } темдал.
+       *[clean] WCAG AA пудыртымаш-влак муалт огытыл. Шуын кертмаш отчётым { $action ->
+            [close] петыраш
+           *[open] почаш
+        } темдал.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версий { $version }
+
+editor-tab-help = Контекст полыш
+editor-tab-help-short = Контекст
+editor-tab-errors = Йоҥылыш-влак
+editor-tab-warnings = Шижтарымаш-влак
+editor-tab-info = Увер
+editor-tab-accessibility = Шуын кертмаш
+editor-tab-responses = Колтымо вашмут-влак
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторын келыштарымашыже
+editor-format-as-doenetml = DoenetML семын форматлаш
+editor-format-as-xml = XML семын форматлаш
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-ше радам
+
+editor-no-errors = Йоҥылыш уке
+editor-no-warnings = Шижтарымаш уке
+editor-no-info = Увер увертарымаш уке
+
+editor-show-info-annotations = Увер увертарымаш-влакым редакторышто ончыкташ
+editor-show-accessibility-annotations = Шуын кертмаш увертарымаш-влакым редакторышто ончыкташ
+
+editor-accessibility-learn-more = Doenet шуын кертмашлан кузе онча
+
+editor-accessibility-violations-heading = Шуын кертмашын пудыртымашыже-влак ({ $standard })
+
+editor-accessibility-other-heading = Вес шуын кертмаш йодыш-влак
+editor-none-found = Нимат муалт огыл
+
+
+## Submitted responses
+
+editor-no-responses = Кызытеш колтымо вашмут уке
+editor-response-answer-id = Вашмутын Id-же
+editor-response-response = Вашмут
+editor-response-credit = Балл
+editor-response-submitted = Колтымо
+
+
+## The context-help panel
+
+help-placeholder = Документацийым ужаш курсорым тег лӱм ӱмбак, атрибут ӱмбак але { $ref } ӱмбак шынде.
+
+help-unsupported-ref-chain = { $example } гай шуко ужашан кылверлан полыш эше уке.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Кылверлан объект муалт огыл: { $ref }.
+        [multiple] Кылверлан шуко объект муалте: { $ref }.
+       *[indeterminate] { $ref } объектым палемдаш ыш лий.
+    }
+
+help-learn-about-references = Кылвер-влак нерген пален налаш →
+help-reference-page = Справке лаштык →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } кӧргыштӧ
+       *[top] Эн кӱшыл кӱкшытыштӧ
+    }{ $allowed ->
+        [none] { " — тыште нимо ок пуро." }
+        [text] { " — тыште текстым возаш лиеш." }
+        [text-and-components] { " — тыште текстым возаш лиеш, але нуным терген ончо:" }
+       *[components] { " — нуным терген ончаш лиеш:" }
+    }
+
+help-suggestions-footer = Чыла { $total } компонентым ужаш { $shortcut } темдал.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объект ӱмбак кылвер.
+       *[other] { $ref } — { $target } объект ӱмбак кылвер ({ $line }-ше радам).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Тудым { $owner } { $role } семын пуртен.
+       *[other] Тудым { $owner } { $line }-ше радамыште { $role } семын пуртен.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементын { $property } свойствыж ӱмбак кылвер.
+       *[other] { $ref } — { $element } элементын { $property } свойствыж ӱмбак кылвер ({ $line }-ше радам).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = ужаш
+help-kind-array-entry = массивын элементше
+
+help-default = Тӱҥ ак:
+help-active-default = Кызытсе тӱҥ ак:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Лийше ак-влак (кажне элементлан иктым):
+       *[other] Лийше ак-влак:
+    }
+
+help-suggested-values = Темлыме ак-влак:
+
+help-inserts = Ешара:
+
+help-coordinates =
+    { $count ->
+        [one] Координат:
+       *[other] Координат-влак:
+    }
+
+help-type = Тӱс:
+
+help-resolved-style = Лекше стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Лекше функцийын лӱмжӧ-влак:
+help-reset-list = Тиде пасун пӧртылтымӧ лӱмерже:
+help-added-on-input = Тиде пасуэш ешарыме:
+help-removed-on-input = Тиде пасу гыч кораҥдыме:
+
+help-reset-overrides = { $reset } — { $additional } да { $removed } ӱмбалне сеҥа.

--- a/packages/i18n/locales/cv/chrome.ftl
+++ b/packages/i18n/locales/cv/chrome.ftl
@@ -7,13 +7,13 @@
 # UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
 # Correct anything here freely; nothing in it was written by a translator.
 #
-# Chuvash resolves a CLDR `zero` category, and it is the second catalog here to
-# do so after `locales/lv` — but it means the opposite thing. Latvian's `zero`
-# covers every number ending in 0 and the whole of the teens; Chuvash's fires
-# for exactly 0 and nothing else, and `one` for exactly 1, so 21 and 101 are
-# `other` where Latvian's are `one`. A `zero` category is therefore not a fact
-# about a language family or about a script: it is a rule, and the two rules
-# here happen to share a name.
+# Chuvash resolves a CLDR `zero` category, the fourth catalog here to do so
+# after `locales/ar`, `locales/cy` and `locales/lv`. Arabic's and Welsh's fire
+# for exactly 0, as Chuvash's does; Latvian's is the one that means something
+# else, covering every number ending in 0 and the whole of the teens. Chuvash's
+# `one` is exactly 1, so 21 and 101 are `other` where Latvian's are `one`. A
+# `zero` category is therefore not a fact about a language family or about a
+# script: it is a rule, and the four rules here only share a name.
 #
 # The consequence for this file is small and worth stating so nobody
 # "corrects" it: `attempts-remaining` keeps the explicit `[0]` branch and adds
@@ -24,53 +24,53 @@
 
 ## Answer submission
 
-answer-checking = Тĕрĕслет…
+answer-checking = Тӗрӗслет…
 answer-submitting = Ярать…
 
-answer-checking-status = Хурава тĕрĕслет
+answer-checking-status = Хурава тӗрӗслет
 answer-submitting-status = Хурава ярать
 
-answer-correct = Тĕрĕс
-answer-incorrect = Йăнăш
+answer-correct = Тӗрӗс
+answer-incorrect = Йӑнӑш
 
-answer-response-saved = Хурав упранчĕ
+answer-response-saved = Хурав упранчӗ
 
 answer-percent-credit = { $percent }% балл
-answer-percent-correct = { $percent }% тĕрĕс
+answer-percent-correct = { $percent }% тӗрӗс
 answer-percent-short = { $percent } %
 
-max-credit-available = Пулма пултаракан чи пысăк балл: { $percent }%
+max-credit-available = Пулма пултаракан чи пысӑк балл: { $percent }%
 
 attempts-remaining =
     { $count ->
-        [0] хăтланса пăхмалли юлмарĕ
-        [one] { $count } хут хăтланса пăхма юлчĕ
-       *[other] { $count } хут хăтланса пăхма юлчĕ
+        [0] хӑтланса пӑхмалли юлмарӗ
+        [one] { $count } хут хӑтланса пӑхма юлчӗ
+       *[other] { $count } хут хӑтланса пӑхма юлчӗ
     }
 
-validation-correct = (Тĕрĕс)
-validation-incorrect = (Йăнăш)
-validation-partially-correct = (Пайăн-пайăн тĕрĕс)
+validation-correct = (Тӗрӗс)
+validation-incorrect = (Йӑнӑш)
+validation-partially-correct = (Пайӑн-пайӑн тӗрӗс)
 
 answer-show-responses =
     { $count ->
-        [zero] { $answerId } валли хурав çук
-        [one] { $answerId } валли { $count } хурав кăтартас
-       *[other] { $answerId } валли { $count } хурав кăтартас
+        [zero] { $answerId } валли хурав ҫук
+        [one] { $answerId } валли { $count } хурав кӑтартас
+       *[other] { $answerId } валли { $count } хурав кӑтартас
     }
 
 
 ## Disclosure panels
 
-feedback-heading = Хирĕç калани
+feedback-heading = Хирӗҫ калани
 
-collapsible-click-to-open = (уçма пусăр)
-collapsible-click-to-close = (хупма пусăр)
+collapsible-click-to-open = (уҫма пусӑр)
+collapsible-click-to-close = (хупма пусӑр)
 
-collapsible-initializing = Хатĕрленет…
+collapsible-initializing = Хатӗрленет…
 
-footnote-show = Асăрхаттарăва кăтартас
-footnote-hide = Асăрхаттарăва пытарас
+footnote-show = Асӑрхаттарӑва кӑтартас
+footnote-hide = Асӑрхаттарӑва пытарас
 
 description-more-information = хушма информаци
 
@@ -78,72 +78,72 @@ description-more-information = хушма информаци
 ## Controls
 
 slider-previous = Малтанхи
-slider-next = Тепĕр
+slider-next = Тепӗр
 
-keyboard-open = Клавиатурăна уçас
-keyboard-close = Клавиатурăна хупас
+keyboard-open = Клавиатурӑна уҫас
+keyboard-close = Клавиатурӑна хупас
 
-choice-input-remove-choice = { $choice } суйлавне кăларас
+choice-input-remove-choice = { $choice } суйлавне кӑларас
 
-matrix-remove-row = Йĕркене кăларас
-matrix-add-row = Йĕрке хушас
-matrix-remove-column = Юпана кăларас
+matrix-remove-row = Йӗркене кӑларас
+matrix-add-row = Йӗрке хушас
+matrix-remove-column = Юпана кӑларас
 matrix-add-column = Юпа хушас
 
-subset-add-remove-points = Пăнчă хушас/кăларас
-subset-toggle-points-intervals = Пăнчăсемпе хушăксене улăштарас
-subset-move-points = Пăнчăсене куçарас
+subset-add-remove-points = Пӑнчӑ хушас/кӑларас
+subset-toggle-points-intervals = Пӑнчӑсемпе хушӑксене улӑштарас
+subset-move-points = Пӑнчӑсене куҫарас
 subset-clear = Тасатас
 
-orbital-add-row = Йĕрке хушас
-orbital-remove-row = Йĕркене кăларас
-orbital-add-box = Куçă хушас
-orbital-remove-box = Куçă кăларас
-orbital-add-up-arrow = Çӳлелле йĕппи хушас
-orbital-add-down-arrow = Аялалла йĕппи хушас
-orbital-remove-arrow = Йĕппе кăларас
+orbital-add-row = Йӗрке хушас
+orbital-remove-row = Йӗркене кӑларас
+orbital-add-box = Куҫӑ хушас
+orbital-remove-box = Куҫӑ кӑларас
+orbital-add-up-arrow = Ҫӳлелле йӗппи хушас
+orbital-add-down-arrow = Аялалла йӗппи хушас
+orbital-remove-arrow = Йӗппе кӑларас
 
-orbital-row-label = { $row } йĕркин палли
+orbital-row-label = { $row } йӗркин палли
 
 pretzel-answer = Хурав
 
-summary-statistics-caption = { $column } юпин пĕтĕмлетӳ статистики
+summary-statistics-caption = { $column } юпин пӗтӗмлетӳ статистики
 
 
 ## Math input
 
-math-input-preview-region = математика палăртăвне малтан пăхни
-math-input-preview = Малтан пăхни
-math-input-invalid-expression = Тĕрĕс мар палăрту:
+math-input-preview-region = математика палӑртӑвне малтан пӑхни
+math-input-preview = Малтан пӑхни
+math-input-invalid-expression = Тӗрӗс мар палӑрту:
 
 
 ## Document status
 
-viewer-initializing = Хатĕрленет…
+viewer-initializing = Хатӗрленет…
 
 
 ## Errors
 
-error-heading = Йăнăш
+error-heading = Йӑнӑш
 
 error-found-at =
     { $span ->
-        [line] Тупнă йĕрке: { $startLine }.
-       *[lines] Тупнă йĕркесем: { $startLine }–{ $endLine }.
+        [line] Тупнӑ йӗрке: { $startLine }.
+       *[lines] Тупнӑ йӗркесем: { $startLine }–{ $endLine }.
     }
 
-document-contains-errors = Ку документра йăнăшсем пур!
+document-contains-errors = Ку документра йӑнӑшсем пур!
 
-diagnostic-heading-error = Йăнăш
-diagnostic-heading-warning = Асăрхаттару
+diagnostic-heading-error = Йӑнӑш
+diagnostic-heading-warning = Асӑрхаттару
 diagnostic-heading-information = Информаци
 diagnostic-heading-hint = Канаш
 
-accessibility-heading-level-1 = WCAG AA майлăх пăсăлăвĕ
-accessibility-heading-level-2 = Майлăх пирки хыпар
+accessibility-heading-level-1 = WCAG AA майлӑх пӑсӑлӑвӗ
+accessibility-heading-level-2 = Майлӑх пирки хыпар
 
-something-went-wrong = Темĕн йăнăш пулса тухрĕ.
+something-went-wrong = Темӗн йӑнӑш пулса тухрӗ.
 
-renderer-load-failed = ӳкерекеннине тиеме пулмарĕ. Страницăна çĕнетĕр.
+renderer-load-failed = ӳкерекеннине тиеме пулмарӗ. Страницӑна ҫӗнетӗр.
 
-core-start-failed = Документ пăхмалли хатĕре ĕçлеттерсе яма пулмарĕ. Страницăна çĕнетĕр.
+core-start-failed = Документ пӑхмалли хатӗре ӗҫлеттерсе яма пулмарӗ. Страницӑна ҫӗнетӗр.

--- a/packages/i18n/locales/cv/chrome.ftl
+++ b/packages/i18n/locales/cv/chrome.ftl
@@ -1,0 +1,149 @@
+# Chuvash viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Chuvash resolves a CLDR `zero` category, and it is the second catalog here to
+# do so after `locales/lv` — but it means the opposite thing. Latvian's `zero`
+# covers every number ending in 0 and the whole of the teens; Chuvash's fires
+# for exactly 0 and nothing else, and `one` for exactly 1, so 21 and 101 are
+# `other` where Latvian's are `one`. A `zero` category is therefore not a fact
+# about a language family or about a script: it is a rule, and the two rules
+# here happen to share a name.
+#
+# The consequence for this file is small and worth stating so nobody
+# "corrects" it: `attempts-remaining` keeps the explicit `[0]` branch and adds
+# no `[zero]`, because `[0]` is matched by number and would win over the
+# category anyway. Where English writes no `[0]` — `answer-show-responses` —
+# the `[zero]` branch is written out and is genuinely reached.
+
+
+## Answer submission
+
+answer-checking = Тĕрĕслет…
+answer-submitting = Ярать…
+
+answer-checking-status = Хурава тĕрĕслет
+answer-submitting-status = Хурава ярать
+
+answer-correct = Тĕрĕс
+answer-incorrect = Йăнăш
+
+answer-response-saved = Хурав упранчĕ
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% тĕрĕс
+answer-percent-short = { $percent } %
+
+max-credit-available = Пулма пултаракан чи пысăк балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] хăтланса пăхмалли юлмарĕ
+        [one] { $count } хут хăтланса пăхма юлчĕ
+       *[other] { $count } хут хăтланса пăхма юлчĕ
+    }
+
+validation-correct = (Тĕрĕс)
+validation-incorrect = (Йăнăш)
+validation-partially-correct = (Пайăн-пайăн тĕрĕс)
+
+answer-show-responses =
+    { $count ->
+        [zero] { $answerId } валли хурав çук
+        [one] { $answerId } валли { $count } хурав кăтартас
+       *[other] { $answerId } валли { $count } хурав кăтартас
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Хирĕç калани
+
+collapsible-click-to-open = (уçма пусăр)
+collapsible-click-to-close = (хупма пусăр)
+
+collapsible-initializing = Хатĕрленет…
+
+footnote-show = Асăрхаттарăва кăтартас
+footnote-hide = Асăрхаттарăва пытарас
+
+description-more-information = хушма информаци
+
+
+## Controls
+
+slider-previous = Малтанхи
+slider-next = Тепĕр
+
+keyboard-open = Клавиатурăна уçас
+keyboard-close = Клавиатурăна хупас
+
+choice-input-remove-choice = { $choice } суйлавне кăларас
+
+matrix-remove-row = Йĕркене кăларас
+matrix-add-row = Йĕрке хушас
+matrix-remove-column = Юпана кăларас
+matrix-add-column = Юпа хушас
+
+subset-add-remove-points = Пăнчă хушас/кăларас
+subset-toggle-points-intervals = Пăнчăсемпе хушăксене улăштарас
+subset-move-points = Пăнчăсене куçарас
+subset-clear = Тасатас
+
+orbital-add-row = Йĕрке хушас
+orbital-remove-row = Йĕркене кăларас
+orbital-add-box = Куçă хушас
+orbital-remove-box = Куçă кăларас
+orbital-add-up-arrow = Çӳлелле йĕппи хушас
+orbital-add-down-arrow = Аялалла йĕппи хушас
+orbital-remove-arrow = Йĕппе кăларас
+
+orbital-row-label = { $row } йĕркин палли
+
+pretzel-answer = Хурав
+
+summary-statistics-caption = { $column } юпин пĕтĕмлетӳ статистики
+
+
+## Math input
+
+math-input-preview-region = математика палăртăвне малтан пăхни
+math-input-preview = Малтан пăхни
+math-input-invalid-expression = Тĕрĕс мар палăрту:
+
+
+## Document status
+
+viewer-initializing = Хатĕрленет…
+
+
+## Errors
+
+error-heading = Йăнăш
+
+error-found-at =
+    { $span ->
+        [line] Тупнă йĕрке: { $startLine }.
+       *[lines] Тупнă йĕркесем: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Ку документра йăнăшсем пур!
+
+diagnostic-heading-error = Йăнăш
+diagnostic-heading-warning = Асăрхаттару
+diagnostic-heading-information = Информаци
+diagnostic-heading-hint = Канаш
+
+accessibility-heading-level-1 = WCAG AA майлăх пăсăлăвĕ
+accessibility-heading-level-2 = Майлăх пирки хыпар
+
+something-went-wrong = Темĕн йăнăш пулса тухрĕ.
+
+renderer-load-failed = ӳкерекеннине тиеме пулмарĕ. Страницăна çĕнетĕр.
+
+core-start-failed = Документ пăхмалли хатĕре ĕçлеттерсе яма пулмарĕ. Страницăна çĕнетĕр.

--- a/packages/i18n/locales/cv/chrome.ftl
+++ b/packages/i18n/locales/cv/chrome.ftl
@@ -13,7 +13,8 @@
 # else, covering every number ending in 0 and the whole of the teens. Chuvash's
 # `one` is exactly 1, so 21 and 101 are `other` where Latvian's are `one`. A
 # `zero` category is therefore not a fact about a language family or about a
-# script: it is a rule, and the four rules here only share a name.
+# script: it is a rule, and the four categories here are three rules sharing a
+# name — Arabic's and Welsh's coincide, Latvian's does not.
 #
 # The consequence for this file is small and worth stating so nobody
 # "corrects" it: `attempts-remaining` keeps the explicit `[0]` branch and adds

--- a/packages/i18n/locales/cv/content.ftl
+++ b/packages/i18n/locales/cv/content.ftl
@@ -4,10 +4,16 @@
 # UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
 # Correct anything here freely; nothing in it was written by a translator.
 #
-# Written in Cyrillic with Chuvash's own four extra letters — ă, ĕ, ç, ӳ —
+# Written in Cyrillic with Chuvash's own four extra letters — ӑ, ӗ, ҫ, ӳ —
 # which are what its schools and publishing use and what CLDR fills a bare `cv`
-# in as. Spelling «хура» as «хура» with Russian letters only is a different
+# in as. Spelling «шурӑ» as «шура» with Russian letters only is a different
 # language, so those four are load-bearing rather than decorative.
+#
+# All four are **Cyrillic** codepoints — ӑ U+04D1, ӗ U+04D7, ҫ U+04AB, ӳ U+04F3
+# — and not the Latin lookalikes ă U+0103, ĕ U+0115 and ç U+00E7 that legacy
+# Chuvash typesetting reached for. They look alike and sort, search and
+# case-fold differently, so a correction typed from a Latin keyboard layout
+# would quietly split this catalog across two scripts.
 #
 # CONFIDENCE. Chuvash is the sole surviving Oghur Turkic language and shares
 # far less vocabulary with `locales/tt` and `locales/ba` than their common
@@ -24,53 +30,53 @@
 
 color =
     .black = хура
-    .white = шурă
-    .gray = сăрă
-    .red = хĕрлĕ
-    .orange = хĕрлĕ-сарă
-    .yellow = сарă
-    .green = симĕс
-    .cyan = çутă кăвак
-    .blue = кăвак
-    .purple = хĕрхĕлтĕм
-    .pink = шупка хĕрлĕ
-    .brown = хăмăр
+    .white = шурӑ
+    .gray = сӑрӑ
+    .red = хӗрлӗ
+    .orange = хӗрлӗ-сарӑ
+    .yellow = сарӑ
+    .green = симӗс
+    .cyan = ҫутӑ кӑвак
+    .blue = кӑвак
+    .purple = хӗрхӗлтӗм
+    .pink = шупка хӗрлӗ
+    .brown = хӑмӑр
 
 line-width =
-    .thick = хулăн
-    .thin = çӳхе
+    .thick = хулӑн
+    .thin = ҫӳхе
 
 line-style =
-    .dashed = татăклă
-    .dotted = пăнчăллă
+    .dashed = татӑклӑ
+    .dotted = пӑнчӑллӑ
 
-# Noun phrases: they stand in front of «эрешлĕ» and modify nothing.
+# Noun phrases: they stand in front of «эрешлӗ» and modify nothing.
 fill-style =
-    .horizontal = горизонталь йĕр
-    .vertical = вертикаль йĕр
-    .diagonal = диагональ йĕр
-    .backdiagonal = хирĕç диагональ йĕр
-    .dots = пăнчă
+    .horizontal = горизонталь йӗр
+    .vertical = вертикаль йӗр
+    .diagonal = диагональ йӗр
+    .backdiagonal = хирӗҫ диагональ йӗр
+    .dots = пӑнчӑ
     .diamonds = ромб
 
 noun =
-    .line = тӳрĕ йĕр
-    .line-segment = касăк
-    .ray = пайăрка
+    .line = тӳрӗ йӗр
+    .line-segment = касӑк
+    .ray = пайӑрка
     .vector = вектор
-    .curve = кукăр йĕр
+    .curve = кукӑр йӗр
     .function = функци
     .parabola = парабола
-    .polyline = хуçăлнă йĕр
-    .polygon = нумай кĕтеслĕх
-    .triangle = виçкĕтеслĕх
-    .rectangle = тӳрĕ кĕтеслĕх
-    .circle = çаврашка
-    .region = лаптăк
-    .point = пăнчă
-    .square = тăваткал
+    .polyline = хуҫӑлнӑ йӗр
+    .polygon = нумай кӗтеслӗх
+    .triangle = виҫкӗтеслӗх
+    .rectangle = тӳрӗ кӗтеслӗх
+    .circle = ҫаврашка
+    .region = лаптӑк
+    .point = пӑнчӑ
+    .square = тӑваткал
     .diamond = ромб
-    .cross = хĕрес
+    .cross = хӗрес
     .plus = плюс
 
 # Chuvash builds the word from the side count in front of the noun, so the
@@ -78,7 +84,7 @@ noun =
 noun-regular-polygon =
     { $part ->
         [tail] { "" }
-       *[head] тĕрĕс { $numSides } кĕтеслĕх
+       *[head] тӗрӗс { $numSides } кӗтеслӗх
     }
 
 # Chuvash has no grammatical gender, so every noun answers the same and the
@@ -105,85 +111,85 @@ style-with-noun =
        *[noun] { $description } { $noun }
     }
 
-style-filled-word = сăрланă
+style-filled-word = сӑрланӑ
 
 style-filled =
     { $parts ->
-        [pattern] { $pattern } эрешлĕ { $color } { $filled }
+        [pattern] { $pattern } эрешлӗ { $color } { $filled }
        *[plain] { $color } { $filled }
     }
 
 style-filled-with-noun =
     { $parts ->
-        [pattern] { $pattern } эрешлĕ { $color } { $filled } { $noun }
+        [pattern] { $pattern } эрешлӗ { $color } { $filled } { $noun }
         [plain-tail] { $color } { $filled } { $noun } { $nounTail }
-        [pattern-tail] { $pattern } эрешлĕ { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } эрешлӗ { $color } { $filled } { $noun } { $nounTail }
        *[plain] { $color } { $filled } { $noun }
     }
 
-# «хĕрриллĕ» — "having an edge" — carries the "with a border" sense in its own
+# «хӗрриллӗ» — "having an edge" — carries the "with a border" sense in its own
 # suffix, so neither a preposition nor an article is wanted.
 style-border-clause =
     { $parts ->
-        [with-article] { $border } хĕрриллĕ
-        [and] тата { $border } хĕрриллĕ
-        [and-article] тата { $border } хĕрриллĕ
-       *[with] { $border } хĕрриллĕ
+        [with-article] { $border } хӗрриллӗ
+        [and] тата { $border } хӗрриллӗ
+        [and-article] тата { $border } хӗрриллӗ
+       *[with] { $border } хӗрриллӗ
     }
 
 style-fill =
     { $parts ->
-        [pattern] { $pattern } эрешлĕ { $color } сăр
-       *[plain] { $color } сăр
+        [pattern] { $pattern } эрешлӗ { $color } сӑр
+       *[plain] { $color } сӑр
     }
 
-style-unfilled = сăрламан
+style-unfilled = сӑрламан
 
-# «çинче» — "on" — is a postposition, so it follows the background colour
+# «ҫинче» — "on" — is a postposition, so it follows the background colour
 # rather than standing between the two words the way English's "with a" does.
 style-text =
     { $parts ->
-        [background] { $background } фон çинче { $color }
+        [background] { $background } фон ҫинче { $color }
        *[plain] { $color }
     }
 
-style-background-none = çук
+style-background-none = ҫук
 
 
 ## Boolean words
 
-boolean-true = тĕрĕс
-boolean-false = йăнăш
+boolean-true = тӗрӗс
+boolean-false = йӑнӑш
 
 
 ## Answer buttons
 
-answer-submit-label = Тĕрĕслесе пăхас
+answer-submit-label = Тӗрӗслесе пӑхас
 answer-submit-label-no-correctness = Хурава ярас
 
 
 ## Sectional blocks
 
 section-name =
-    .activity = Ĕç
-    .aside = Асăрхаттару
+    .activity = Ӗҫ
+    .aside = Асӑрхаттару
     .cascade = Каскад
-    .definition = Ăнлантару
-    .example = Тĕслĕх
-    .exercise = Хăнăхтару
-    .exercises = Хăнăхтарусем
+    .definition = Ӑнлантару
+    .example = Тӗслӗх
+    .exercise = Хӑнӑхтару
+    .exercises = Хӑнӑхтарусем
     .given-answer = Хурав
-    .note = Асăрхаттару çырăвĕ
-    .objectives = Тĕллевсем
+    .note = Асӑрхаттару ҫырӑвӗ
+    .objectives = Тӗллевсем
     .paragraphs = Абзацсем
-    .part = Пайĕ
+    .part = Пайӗ
     .problem = Задача
-    .problems = Задачăсем
-    .proof = Кăтартса пани
+    .problems = Задачӑсем
+    .proof = Кӑтартса пани
     .question = Ыйту
     .section = Пай
-    .solution = Татăлăхĕ
-    .task = Ĕç хушни
+    .solution = Татӑлӑхӗ
+    .task = Ӗҫ хушни
     .theorem = Теорема
 
 section-title-prefix =
@@ -211,17 +217,17 @@ table-name =
 
 figure-name =
     { $parts ->
-        [numbered] Ӳкерчĕк { $enumeration }
-        [numbered-caption] Ӳкерчĕк { $enumeration }{ ". " }
-        [unnumbered-caption] Ӳкерчĕк{ ". " }
-       *[unnumbered] Ӳкерчĕк
+        [numbered] Ӳкерчӗк { $enumeration }
+        [numbered-caption] Ӳкерчӗк { $enumeration }{ ". " }
+        [unnumbered-caption] Ӳкерчӗк{ ". " }
+       *[unnumbered] Ӳкерчӗк
     }
 
 
 ## Paginator controls
 
 paginator-previous = Малтанхи
-paginator-next = Тепĕр
+paginator-next = Тепӗр
 paginator-page = Страница
 
 paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
@@ -231,7 +237,7 @@ paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
 
 piecewise-condition-or = е
 piecewise-condition-if = енчен
-piecewise-condition-otherwise = урăх чухне
+piecewise-condition-otherwise = урӑх чухне
 
 
 ## Chemistry
@@ -247,5 +253,5 @@ piecewise-condition-otherwise = урăх чухне
 
 ion-name-oxidation-state = { $name } ({ $numeral })
 
-chemistry-invalid-symbol = Тĕрĕс мар хими палли
-chemistry-invalid-ionic-compound = Тĕрĕс мар ион пĕрлешĕвĕ
+chemistry-invalid-symbol = Тӗрӗс мар хими палли
+chemistry-invalid-ionic-compound = Тӗрӗс мар ион пӗрлешӗвӗ

--- a/packages/i18n/locales/cv/content.ftl
+++ b/packages/i18n/locales/cv/content.ftl
@@ -1,0 +1,251 @@
+# Chuvash content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Chuvash's own four extra letters — ă, ĕ, ç, ӳ —
+# which are what its schools and publishing use and what CLDR fills a bare `cv`
+# in as. Spelling «хура» as «хура» with Russian letters only is a different
+# language, so those four are load-bearing rather than decorative.
+#
+# CONFIDENCE. Chuvash is the sole surviving Oghur Turkic language and shares
+# far less vocabulary with `locales/tt` and `locales/ba` than their common
+# family suggests; this seed had less written Chuvash to draw on than it had
+# Tatar. The colour and shape words below are the part it is most confident of.
+#
+# Chuvash has no grammatical gender and does not inflect an attributive
+# adjective, so both `$gender` and `$role` go unused here, as in English and in
+# every other Turkic catalog in the roster. Adjectives precede the noun, so the
+# composition messages keep the English order.
+
+
+## Style vocabulary
+
+color =
+    .black = хура
+    .white = шурă
+    .gray = сăрă
+    .red = хĕрлĕ
+    .orange = хĕрлĕ-сарă
+    .yellow = сарă
+    .green = симĕс
+    .cyan = çутă кăвак
+    .blue = кăвак
+    .purple = хĕрхĕлтĕм
+    .pink = шупка хĕрлĕ
+    .brown = хăмăр
+
+line-width =
+    .thick = хулăн
+    .thin = çӳхе
+
+line-style =
+    .dashed = татăклă
+    .dotted = пăнчăллă
+
+# Noun phrases: they stand in front of «эрешлĕ» and modify nothing.
+fill-style =
+    .horizontal = горизонталь йĕр
+    .vertical = вертикаль йĕр
+    .diagonal = диагональ йĕр
+    .backdiagonal = хирĕç диагональ йĕр
+    .dots = пăнчă
+    .diamonds = ромб
+
+noun =
+    .line = тӳрĕ йĕр
+    .line-segment = касăк
+    .ray = пайăрка
+    .vector = вектор
+    .curve = кукăр йĕр
+    .function = функци
+    .parabola = парабола
+    .polyline = хуçăлнă йĕр
+    .polygon = нумай кĕтеслĕх
+    .triangle = виçкĕтеслĕх
+    .rectangle = тӳрĕ кĕтеслĕх
+    .circle = çаврашка
+    .region = лаптăк
+    .point = пăнчă
+    .square = тăваткал
+    .diamond = ромб
+    .cross = хĕрес
+    .plus = плюс
+
+# Chuvash builds the word from the side count in front of the noun, so the
+# whole of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] тĕрĕс { $numSides } кĕтеслĕх
+    }
+
+# Chuvash has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = сăрланă
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } эрешлĕ { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } эрешлĕ { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } эрешлĕ { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «хĕрриллĕ» — "having an edge" — carries the "with a border" sense in its own
+# suffix, so neither a preposition nor an article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } хĕрриллĕ
+        [and] тата { $border } хĕрриллĕ
+        [and-article] тата { $border } хĕрриллĕ
+       *[with] { $border } хĕрриллĕ
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } эрешлĕ { $color } сăр
+       *[plain] { $color } сăр
+    }
+
+style-unfilled = сăрламан
+
+# «çинче» — "on" — is a postposition, so it follows the background colour
+# rather than standing between the two words the way English's "with a" does.
+style-text =
+    { $parts ->
+        [background] { $background } фон çинче { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = çук
+
+
+## Boolean words
+
+boolean-true = тĕрĕс
+boolean-false = йăнăш
+
+
+## Answer buttons
+
+answer-submit-label = Тĕрĕслесе пăхас
+answer-submit-label-no-correctness = Хурава ярас
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Ĕç
+    .aside = Асăрхаттару
+    .cascade = Каскад
+    .definition = Ăнлантару
+    .example = Тĕслĕх
+    .exercise = Хăнăхтару
+    .exercises = Хăнăхтарусем
+    .given-answer = Хурав
+    .note = Асăрхаттару çырăвĕ
+    .objectives = Тĕллевсем
+    .paragraphs = Абзацсем
+    .part = Пайĕ
+    .problem = Задача
+    .problems = Задачăсем
+    .proof = Кăтартса пани
+    .question = Ыйту
+    .section = Пай
+    .solution = Татăлăхĕ
+    .task = Ĕç хушни
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Канаш
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ӳкерчĕк { $enumeration }
+        [numbered-caption] Ӳкерчĕк { $enumeration }{ ". " }
+        [unnumbered-caption] Ӳкерчĕк{ ". " }
+       *[unnumbered] Ӳкерчĕк
+    }
+
+
+## Paginator controls
+
+paginator-previous = Малтанхи
+paginator-next = Тепĕр
+paginator-page = Страница
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+
+piecewise-condition-or = е
+piecewise-condition-if = енчен
+piecewise-condition-otherwise = урăх чухне
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Chuvashia is taught in
+## Russian, and the element names a Chuvash-speaking pupil meets are the
+## Russian ones out of a Russian-language textbook. This is the school-system
+## case the sub-Saharan batches already record, arriving in a country where the
+## medium is Russian rather than English or French — and `locales/tt` beside it
+## is the same school system answering differently, which is why the gap is a
+## fact about a curriculum rather than about a language.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Тĕрĕс мар хими палли
+chemistry-invalid-ionic-compound = Тĕрĕс мар ион пĕрлешĕвĕ

--- a/packages/i18n/locales/cv/diagnostics.ftl
+++ b/packages/i18n/locales/cv/diagnostics.ftl
@@ -1,0 +1,658 @@
+# Chuvash diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# CONFIDENCE. This is the file in the Chuvash catalog a speaker should read
+# first. Chuvash has no settled computing vocabulary, so the technical nouns
+# below are the Russian ones written in Chuvash spelling — «компонент»,
+# «атрибут», «функци», «индекс» — which is what written Chuvash does with them
+# in practice, and what a Chuvash-language coinage would have to be checked
+# against rather than replaced by unread.
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] икĕ вĕç пăнчине те кăтартнă чухне { $attributes } шута илмест
+       *[other] икĕ вĕç пăнчине те кăтартнă чухне { $attributes } шута илмест
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] вĕç пăнчипе варри пăнчине те кăтартнă чухне { $attributes } шута илмест
+       *[other] вĕç пăнчипе варри пăнчине те кăтартнă чухне { $attributes } шута илмест
+    }
+
+line-segment-midpoint-offset-without-midpoint = варри пăнчисĕр midpointOffset нимĕне те витĕм кӳмест
+
+## `<line>`
+
+line-points-undetermined-dimensions = Виçи паллă мар пăнчăсем витĕр тухакан тӳрĕ йĕр.
+
+line-points-too-few-dimensions = Тӳрĕ йĕр чи сахалран икĕ виçеллĕ пăнчăсем витĕр тухмалла.
+
+line-points-depend-on-variables = Тӳрĕ йĕр улшăнакансенчен килекен пăнчăсем витĕр тухать: { $variables }.
+
+line-equation-invalid-format = { $variable1 } тата { $variable2 } улшăнаканĕсенчи тӳрĕ йĕр танлăхĕн форматне йышăнмасть.
+
+## `<ray>`
+
+ray-overprescribed-through = Пайăркана through, endpoint тата direction урлă панă. Панă through шута илмест.
+
+ray-dimension-mismatch = пайăркара numDimensions килĕшмест.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектора head, tail тата displacement урлă панă. Панă head шута илмест.
+
+vector-dimension-mismatch = векторта numDimensions килĕшмест.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элемент патне туртма пулмасть, мĕншĕн тесен унăн nearestPoint статус улшăнаканĕ çук.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементпа чарса тăма пулмасть, мĕншĕн тесен унăн nearestPoint статус улшăнаканĕ çук.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементăн шалĕпе чарса тăма пулмасть, мĕншĕн тесен унăн nearestPoint статус улшăнаканĕ çук.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = йĕрке ăшĕнче мар choiceInput валли labelPosition шута илмест
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput валли панă индекссем шута илмеççĕ, мĕншĕн тесен вĕсен йышĕ choice ачисен йышĕпе килĕшмест.
+
+pretzel-indices-count-mismatch = problem валли панă индекссем шута илмеççĕ, мĕншĕн тесен вĕсен йышĕ problem ачисен йышĕпе килĕшмест.
+
+shuffle-indices-count-mismatch = shuffle валли панă индекссем шута илмеççĕ, мĕншĕн тесен вĕсен йышĕ компонентсен йышĕпе килĕшмест.
+
+indices-ignored-out-of-range = { $component } валли панă индекссем шута илмеççĕ, мĕншĕн тесен хăшĕсем чикĕрен тухаççĕ.
+
+pretzel-indices-repeated = pretzel валли панă индекссем шута илмеççĕ, мĕншĕн тесен хăшĕсем тепĕр хут тĕл пулаççĕ.
+
+pretzel-circuit-first-index = circuit режимĕнче pretzel валли панă индекссем шута илмеççĕ, мĕншĕн тесен пĕрремĕш индекс 1 пулмалла.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текст ачисемпе ĕçлетĕр тесен `type` атрибут памалла.
+
+invalid-type-defaulting-to-math = { $component } компонент валли тĕрĕс мар тĕс { $type }. Вăл math, text, number е boolean пулмалла. math усă курать.
+
+string-not-valid-component-to-arrange = «{ $value }» йĕрки { $component } валли юрăхлă компонент мар. Шута илмест.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Тĕрĕс мар тĕс { $type }, тĕсне number тăваççĕ.
+
+invalid-variable-value = Улшăнаканăн тĕрĕс мар хакĕ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариант индексĕ хисеп пулмалла
+
+variant-index-must-be-integer = { $index } вариант индексĕ тулли хисеп пулмалла
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют виçесем валли пурнăçламан. Сарлакăшсене танлаштаруллă тăваççĕ.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют виçесем валли пурнăçламан. Хĕррисене танлаштаруллă тăваççĕ.
+
+side-by-side-no-block-child = Тĕрĕс мар `<{ $component }>`: унăн чи сахалран пĕр блок ачи пулмалла.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементри `for` атрибут шута илмест.
+
+label-for-must-resolve-to-one = `<label>` элементри `for` атрибут шăп пĕр компонент çине кăтартмалла.
+
+label-for-unresolved = `<label>` элементри `for` атрибута компонентпа çыхăнтарма пулмарĕ.
+
+label-for-answer-with-authored-inputs = `<label>` элементри `for` атрибут автор çырнă кĕртӳ хирĕсем пур `<answer>` çине кăтартать; хир çине тӳрремĕн кăтартăр.
+
+label-for-answer-without-input = `<label>` элементри `for` атрибут паллă тумалли кĕртӳ хирĕ çук `<answer>` çине кăтартать.
+
+label-for-must-reference-input-or-answer = `<label>` элементри `for` атрибут кĕртӳ хирĕ е хурав çине кăтартмалла.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Майлăх валли `<{ $component }>` е кĕске ăнлантару пулмалла, е эреш тесе палăртмалла.
+
+accessibility-video-short-description = Майлăх валли `<video>` кĕске ăнлантаруллă пулмалла.
+
+accessibility-input-short-description-or-label = Майлăх валли `<{ $component }>` кĕске ăнлантаруллă е паллăллă пулмалла.
+
+accessibility-answer-input-short-description-or-label = Майлăх валли кĕртӳ хирĕ тăвакан `<answer>` кĕске ăнлантаруллă е паллăллă пулмалла.
+
+accessibility-short-description-contains-math = Кĕске ăнлантарусенче `<{ $component }>` пек математика компоненчĕсем пулмалла мар. Математикăна сăмахпа çырăр.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } пай пуçламăшĕн тексчĕ валли çителĕклĕ контраст памасть (тĕттĕм тĕс) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ).
+       *[other] { $colorName } пай пуçламăшĕн тексчĕ валли çителĕклĕ контраст памасть ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Пăнчăсен хисеп хакĕсем çук чухне { $count } пăнчă витĕр тухакан `<circle>` пурнăçламан.
+
+circle-too-many-through-points = 3-рен ытла пăнчă витĕр тухакан çаврашкана шутлама пулмасть.
+
+circle-overprescribed-radius-center-points = Панă радиуспа, варрипе тата пăнчăсемпе çаврашкана шутлама пулмасть.
+
+circle-center-with-multiple-points = Панă варрипе 1-рен ытла пăнчă витĕр тухакан çаврашкана шутлама пулмасть.
+
+circle-radius-too-small = Çаврашкана шутлама пулмасть: икĕ пăнчă хушши { $distance } пулнипе панă радиус { $radius } ытла пĕчĕк.
+
+circle-radius-with-many-points = Панă радиуспа иккĕрен ытла пăнчă витĕр тухакан çаврашка тума пулмасть.
+
+circle-invalid-center-or-through-points = Çаврашкан варри е пăнчисем тĕрĕс мар.
+
+circle-radius-center-with-multiple-points = Панă варрипе 1-рен ытла пăнчă витĕр тухакан çаврашкан радиусне шутлама пулмасть.
+
+circle-change-radius-non-numerical = Хисеп мар пăнчăллă çаврашкан радиусне улăштарма пулмасть
+
+circle-radius-with-points-non-numerical = Хисеп хакĕсем çук чухне панă радиуспа пĕрререн ытла пăнчă витĕр тухакан çаврашка тума пулмасть.
+
+circle-change-center-non-numerical = Хисеп мар пăнчăсем витĕр тухакан çаврашкан варрине улăштарассине пурнăçламан.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцин палăртнă лаптăкĕн виçи çителĕксĕр. Лаптăкра { $intervals } хушăк пур, функцире вара { $inputs ->
+            [one] { $inputs } кĕрӳ
+           *[other] { $inputs } кĕрӳ
+        }.
+       *[other] Функцин палăртнă лаптăкĕн виçи çителĕксĕр. Лаптăкра { $intervals } хушăк пур, функцире вара { $inputs ->
+            [one] { $inputs } кĕрӳ
+           *[other] { $inputs } кĕрӳ
+        }.
+    }
+
+function-domain-invalid-format = Функцин палăртнă лаптăкĕн форматне йышăнмасть.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцин хисеп мар максимумне шута илмест.
+        [minimum] Функцин хисеп мар минимумне шута илмест.
+        [extremum] Функцин хисеп мар экстремумне шута илмест.
+        [point] Функцин хисеп мар пăнчине шута илмест.
+        [slope] Функцин хисеп мар чалăшлăхне шута илмест.
+       *[other] Функцин хисеп мар { $type } хакне шута илмест.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцин пушă максимумне шута илмест.
+        [minimum] Функцин пушă минимумне шута илмест.
+        [extremum] Функцин пушă экстремумне шута илмест.
+        [point] Функцин пушă пăнчине шута илмест.
+       *[other] Функцин пушă { $type } хакне шута илмест.
+    }
+
+function-points-too-close = Функцире пĕр-пĕрне ытла çывăх икĕ пăнчă пур. Функцие палăртма пулмасть.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функци итерацийĕсем кĕрӳсен йышĕ тухăçсен йышĕпе тан пулсан кăна пулаççĕ. Ку функцире { $inputs } кĕрӳ тата { $outputs ->
+            [one] { $outputs } тухăç
+           *[other] { $outputs } тухăç
+        } пур.
+       *[other] Функци итерацийĕсем кĕрӳсен йышĕ тухăçсен йышĕпе тан пулсан кăна пулаççĕ. Ку функцире { $inputs } кĕрӳ тата { $outputs ->
+            [one] { $outputs } тухăç
+           *[other] { $outputs } тухăç
+        } пур.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Йĕркелĕх вăрăмăшĕ тĕрĕс мар. Вăл негативлă мар тулли хисеп пулмалла.
+
+sequence-invalid-step = Йĕркелĕх утăмĕ тĕрĕс мар. { $type } тĕслĕ йĕркелĕх валли вăл хисеп пулмалла.
+
+sequence-invalid-endpoint-number = Хисеп йĕркелĕхĕн «{ $attribute }» хакĕ тĕрĕс мар. Вăл хисеп пулмалла.
+
+sequence-invalid-endpoint-letters = Сас палли йĕркелĕхĕн «{ $attribute }» хакĕ тĕрĕс мар. Вăл сас паллисен пĕрлешĕвĕ пулмалла.
+
+sequence-invalid-endpoint = Йĕркелĕхĕн «{ $attribute }» хакĕ тĕрĕс мар.
+
+select-from-sequence-coprime-not-numbers = хисепсем суйламаннипе coprime шута илмест
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations панипе coprime шута илмест
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` валли тĕрĕс мар target: тĕллев тупăнмарĕ.
+
+target-state-variable-not-found = `<{ $source }>` валли тĕрĕс мар target: `<{ $component }>` элементра «{ $property }» ятлă статус улшăнаканĕ тупăнмарĕ.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` улшăнаканĕсем ирĕклĕ улшăнаканран уйрăлса тăмалла.
+
+ode-system-duplicate-variable-names = Çыхăнуллă улшăнакансен ячĕсем пĕр пекки чухне ДТ сылтăм енĕн функцийĕсене палăртма пулмасть.
+
+ode-system-rhs-function-error = ДТ сылтăм енĕн функцине палăртма пулмасть. mathjs функцине тунă чухне йăнăш.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } тӳрĕ йĕр хушшинчи кĕтесе палăртма пулмасть
+
+angle-invalid-through-point = `<angle>` элементăн through хакĕнче тĕрĕс мар пăнчă
+
+parabola-vertex-too-many-points = Панă тăрăпа 1-рен ытла пăнчă витĕр тухакан парабола пурнăçламан.
+
+parabola-too-many-points = 3-рен ытла пăнчă витĕр тухакан парабола пурнăçламан.
+
+intersection-too-many-items = Иккĕрен ытла объект хĕресленнине пурнăçламан
+
+## Other math components
+
+ionic-compound-not-two-ions = Икĕ иона пăхмасăр ион пĕрлешĕвĕсене пурнăçламан.
+
+ionic-compound-needs-cation-and-anion = Ион пĕрлешĕвĕсене пĕр катионпа пĕр анион валли кăна пурнăçланă.
+
+solve-equations-cannot-evaluate = Танлăха татса пама пулмасть, мĕншĕн тесен ăна шутлама пулмарĕ: { $equation }
+
+math-operators-operand-number-required = Математика операндне уйăрса илме operandNumber памалла.
+
+eigen-decomposition-failed = Матрицăн хăй хакĕсене шутлама пулмарĕ
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр тĕслĕхре тĕл пулмасть, çавăнпа вăл яланах пушша килĕшет.
+       *[other] `<matchesPattern>`: { $parameters } параметрсем тĕслĕхре тĕл пулмаççĕ, çавăнпа вĕсем яланах пушша килĕшеççĕ.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" хакне ăнланма пулмасть. Вăл none, medium, dense е пушă вырăнпа уйăрнă икĕ позитивлă хисеп пулмалла, тĕслĕхрен grid="1 0.5". Тор ӳкермест.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure ӳкерекенĕнче xLabelPosition="left" пурнăçламан; сылтăм вырнаçу йĕрки усă курать.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure ӳкерекенĕнче yLabelPosition="bottom" пурнăçламан; çӳлти вырнаçу йĕрки усă курать.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure куçарăвĕ валли тĕнĕл чикĕсем тĕрĕс мар; тĕп bbox (-10,-10,10,10) усă курать.
+
+prefigure-invalid-width = `<graph>`: prefigure куçарăвĕ валли сарлакăш тĕрĕс мар; диаграммăн тĕп сарлакăшĕ 425 усă курать.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure куçарăвĕ валли aspectRatio тĕрĕс мар; тĕп енсен танлăхĕ 1 усă курать.
+
+prefigure-grid-spacing-too-fine = `<graph>`: тор утăмĕ тĕнĕл чикĕсем валли ытла вĕтĕ; prefigure ӳкерекенĕнче тора кăлараççĕ.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure ӳкерекенĕпе усă курман чухне асăрхаттарусем ӳкермеççĕ.
+
+multiple-annotations-children = `<graph>` ăшĕнче темиçе `<annotations>` ачи тупăнчĕ; юлашкинчен пуçне ыттисене шута илмеççĕ.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Палламан компонент тĕсне сарма е куçарма пулмасть: { $type }.
+
+copy-prop-not-found = { $component } тĕслĕ компонентра { $property } уйрăмлăхĕ тупăнмарĕ
+
+collect-no-source = collect валли çăлкуç тупăнмарĕ.
+
+collect-invalid-component-type = `<{ $component }>` тĕслĕ компонентсене пуçтарма пулмасть, мĕншĕн тесен ку тĕрĕс мар компонент тĕсĕ.
+
+reference-index-unavailable = `{ $reference }` индекс çине каçă тума пулмасть
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентра { $action } чĕнме пулмасть
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннăйсен формийĕ тĕрĕс мар. Йĕркесен вăрăмăшĕсем тĕрлĕ. Тупăнчĕ componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннăйсенче юпа ячĕсем пĕр пекех. Тупăнчĕ componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннăйсенче юпа ячĕ çитмест. Тупăнчĕ componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ку хуравăн award хакĕ answer тегăн хăйĕн янă хуравĕ çине таянать, ку кĕтмен ĕç-пуçа илсе пырать.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` пур контейнер ăшĕнчи `<answer>` çине `maxNumAttempts` лартни витĕм кӳмест, мĕншĕн тесен хăтланусен йышне контейнер палăртать. `maxNumAttempts` хакне контейнер çине лартăр.
+
+nested-section-wide-check-work-max-num-attempts = Тепĕр `sectionWideCheckWork` контейнерĕ ăшĕнчи `sectionWideCheckWork` контейнерĕ çине `maxNumAttempts` лартни витĕм кӳмест, мĕншĕн тесен хăтланусен йышне тулашри контейнер палăртать. `maxNumAttempts` хакне тулашри контейнер çине лартăр.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality лартмасан { $attributes } атрибут витĕм кӳмĕ.
+       *[other] symbolicEquality лартмасан { $attributes } атрибутсем витĕм кӳмĕç.
+    }
+
+answer-invalid-type = answer валли тĕрĕс мар тĕс: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентăн ячĕ çуккипе ăна модуль атрибучĕ пек усă курма пулмасть
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонента модуль атрибучĕ пек усă курма пулмасть, мĕншĕн тесен `<module>` компонент тĕсĕнче «{ $name }» атрибут ĕнтĕ палăртнă.
+
+conditional-content-condition-ignored = case е else ачисем пур `<conditionalContent>` компонентра `condition` атрибут шута илмест.
+
+slider-markers-type-mismatch = Маркерсен тĕсĕ шуçтармăш тĕсĕпе килĕшмест.
+
+pretzel-problem-needs-statement-and-answer = Тĕрĕс мар pretzel: кашни `<problem>` пĕр `<statement>` тата пĕр `<answer>` тытмалла.
+
+pretzel-circuit-first-problem-distractor = Тĕрĕс мар pretzel: mode="circuit" режимĕнче пĕрремĕш `<problem>` тимлĕхе аяккалла пăракан пулма пултараймасть.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибут валли тĕрĕс мар хак { $values }; шута илмест.
+       *[other] `{ $attribute }` атрибут валли тĕрĕс мар хаксем { $values }; шута илмеççĕ.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибут валли тĕрĕс мар хак `{ $value }`. Атрибут `$` палăртупа пуçланакан каçăсенчен тăмалла.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } ăшĕнчи тĕрĕс мар функци ячĕсене шута илмерĕ: { $names }. Кашни ятăн курăнакан пайĕ чи сахалран 2 палăрту пулмалла (сас паллисем е тире); ун хыççăн кирлĕ мар `|<mathspeak альтернатива>` хушăмĕ пыма пултарать.
+
+## Building components from the source
+
+component-type-invalid = Тĕрĕс мар компонент тĕсĕ: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибута тепĕр хут пама пулмасть.
+
+attribute-invalid-for-component = `<{ $componentType }>` тĕслĕ компонент валли тĕрĕс мар атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль палăртăвĕнче { $context ->
+        [text-on-background] текст тĕсĕпе фон тĕсĕ
+        [high-contrast] пысăк контрастлă тĕспе ӳкерӳ лаптăкĕ
+        [line] йĕр тĕсĕпе ӳкерӳ лаптăкĕ
+        [marker] маркер тĕсĕпе ӳкерӳ лаптăкĕ
+       *[text-on-canvas] текст тĕсĕпе ӳкерӳ лаптăкĕ
+    } хушшинчи контраст çителĕксĕр{ $mode ->
+        [dark] { " (тĕттĕм тĕс)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль палăртăвĕнче панă тĕссем çутă тĕс валли çителĕклĕ контраст парсан та, вĕсенчен тухнă тĕттĕм тĕс тĕсĕсем текстпа фон хушшинче çителĕклĕ контраст памаççĕ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ). { $suggestion ->
+        [available] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен е çутă тĕсри контраста ӳстерĕр (тĕслĕхрен { $lightAttribute }="{ $lightColor }"), е тĕттĕм тĕс тĕсне улăштарăр (тĕслĕхрен { $darkAttribute }="{ $darkColor }").
+       *[none] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен çутă тĕсри контраста ӳстерĕр е тухнă тĕссене textColorDarkMode тата/е backgroundColorDarkMode урлă улăштарăр.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль палăртăвĕнче панă текст тĕсĕ çутă тĕс валли çителĕклĕ контраст парсан та, унран тухнă тĕттĕм тĕс текст тĕсĕ ӳкерӳ лаптăкĕпе çителĕклĕ контраст памасть ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ). { $suggestion ->
+        [available] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен е çутă тĕсри контраста ӳстерĕр (тĕслĕхрен textColor="{ $lightColor }"), е тĕттĕм тĕс тĕсне улăштарăр (тĕслĕхрен textColorDarkMode="{ $darkColor }").
+       *[none] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен çутă тĕсри контраста ӳстерĕр е тухнă тĕсе textColorDarkMode урлă улăштарăр.
+    }
+
+section-multiple-style-palettes = Пай пĕр <stylePalette> кăна суйлама пултарать; юлашкипе усă курать.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен numToSelect негативлă мар тулли хисеп мар.
+
+variant-num-to-select-not-constant-number = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен numToSelect тăтăш хисеп мар.
+
+variant-with-replacement-not-constant-boolean = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен withReplacement тăтăш логика хакĕ мар.
+
+variant-select-weight-disables-unique = хăш те пулин суйлавра selectWeight е selectForVariants панă пулсан, select валли пĕр пек мар вариантсем сӳнеççĕ
+
+variant-coprime-undetermined = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен coprime яланах суя-и, çавна тупма пулмасть.
+
+variant-attribute-not-constant = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен { $attribute } тăтăш мар.
+
+variant-attribute-not-number = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен { $attribute } хисеп мар.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } тĕслĕ { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен { $attribute } { $expected ->
+        [letters-combination] сас паллисен пĕрлешĕвĕ
+        [math-expression] юрăхлă математика палăртăвĕ
+        [integer] тулли хисеп
+       *[number] хисеп
+    } мар.
+
+variant-length-not-integer = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен length тулли хисеп мар.
+
+variant-sort-not-implemented = sort пур { $component } валли пĕр пек мар вариантсене пурнăçламан
+
+variant-exclude-combinations-not-implemented = excludeCombinations пур { $component } валли пĕр пек мар вариантсене пурнăçламан
+
+variant-math-exclude-not-implemented = exclude пур math тĕслĕ { $component } валли пĕр пек мар вариантсене пурнăçламан
+
+variant-non-constant-exclude-not-implemented = тăтăш мар exclude пур { $component } валли пĕр пек мар вариантсене пурнăçламан
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикăн prefigure ӳкерекенĕнче пурнăçламан; тăхăмне сиктерсе хăварнă.
+
+prefigure-descendant-invalid-geometry = { $subject }: вĕçсĕр е тулли мар геометри; тăхăмне сиктерсе хăварнă.
+
+prefigure-curve-label-omitted = { $subject }: куçарнă кукăр элеменчĕсенче паллăсем пурнăçламан; паллăна сиктерсе хăварнă.
+
+prefigure-curve-unsupported-definition-type = { $subject }: пурнăçламан кукăр функци палăртăвĕн тĕсĕ «{ $definitionType }»; тăхăмне сиктерсе хăварнă.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементри flipFunctions атрибут пурнăçламан; тăхăмне сиктерсе хăварнă.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулăпа панă ача функцисене кăна йышăнать; тăхăмне сиктерсе хăварнă.
+
+prefigure-label-position-unsupported =
+    { $subject }: пурнăçламан labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] тӳрĕ йĕрсен йышĕн палли валли
+       *[point] пăнчă палли валли
+    }; PreFigure-ăн тĕп танлаштарăвĕ усă курать.
+
+prefigure-fill-style-unsupported = { $subject }: тултару стилĕ «{ $fillStyle }» PreFigure валли пурнăçламан; тулли тултарăва куçать.
+
+prefigure-line-style-unknown = { $subject }: паллă мар йĕр стилĕ «{ $lineStyle }» PreFigure тухăçĕнчен кăларнă.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стилĕ «{ $markerStyle }» PreFigure «diamond» стилĕпе танлаштарнă.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стилĕ «{ $markerStyle }» PreFigure валли пурнăçламан; тĕп стиль усă курать.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: тĕрĕс мар `ref`; тĕллеве çыхăнтарма пулмасть. Асăрхаттарăва кăларнă.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` темиçе тĕллевпе çыхăнчĕ; пĕрремĕшĕпе усă курать.
+
+annotation-ref-outside-graph = `<annotation>`: тĕрĕс мар `ref`; тĕллев ăна тытакан графикран тулашра. Асăрхаттарăва кăларнă.
+
+annotation-ref-unsupported-target = `<annotation>`: тĕрĕс мар `ref`; тĕллев prefigure куçарăвĕнче пурнăçланă график объект мар. Асăрхаттарăва кăларнă.
+
+annotation-text-missing = `<annotation>`: `text` çук е пушă; пушă текст кăларать.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Çавра çыхăну тупăнчĕ.
+       *[other] `<{ $componentType }>` компонента тытакан çавра çыхăну тупăнчĕ.
+    }
+
+reference-no-referent = Каçă валли объект тупăнмарĕ: `{ $reference }`
+
+reference-multiple-referents = Каçă валли темиçе объект тупăнчĕ: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементăн { $attribute } атрибучĕн форматне йышăнмасть.
+
+children-invalid = `<{ $componentType }>` валли тĕрĕс мар ачасем: тĕрĕс мар ачасем тупăнчĕç: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибут валли тĕрĕс мар хак `{ $value }`; `{ $default }` хакĕ усă курать
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версийĕ тупăнмарĕ.
+       *[other] DoenetML { $version } версийĕ тупăнмарĕ. { $fallback } версийĕ усă курать
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Тĕрĕс мар DoenetML: { $content }
+
+parse-tag-missing-close-tag = Тĕрĕс мар DoenetML: `{ $tag }` тегăн хупакан тегĕ çук. Хăйне хăй хупакан тег е `</{ $tagName }>` тег кĕтнĕччĕ.
+
+parse-tag-error = Тĕрĕс мар DoenetML: `<{ $tagName }>` тегра йăнăш
+
+parse-attribute-missing-value = Тĕрĕс мар DoenetML: `{ $attribute }` атрибутра хак çитмен пек.
+
+parse-attribute-invalid = Тĕрĕс мар DoenetML: тĕрĕс мар атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Тĕрĕс мар DoenetML: атрибутăн тĕрĕс мар хакĕ `{ $value }`
+
+parse-attribute-value-quote-mismatch = Тĕрĕс мар DoenetML: атрибутăн тĕрĕс мар хакĕ `{ $value }`. Чĕрнесем килĕшмеççĕ. `{ $quote }` çитмен пек
+
+parse-open-tag-name-missing = Тĕрĕс мар DoenetML: ятсăр тег тупăнчĕ, тĕслĕхрен `<`
+
+parse-tag-not-closed = Тĕрĕс мар DoenetML: `{ $tag }` тега хупман (`>` çитмен пек).
+
+parse-self-closing-tag-name-missing = Тĕрĕс мар DoenetML: ятсăр тег тупăнчĕ `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Тĕрĕс мар DoenetML: `{ $tag }` тега хупман (`/>` çитмен пек).
+
+parse-tag-invalid-attributes = Тĕрĕс мар DoenetML: `{ $tag }` тег юрăхлă мар. Унăн атрибучĕсем тĕрĕс мар пулма пултараççĕ.
+
+parse-close-tag-name-missing = Тĕрĕс мар DoenetML: ятсăр хупакан тег тупăнчĕ, тĕслĕхрен `</`
+
+parse-attribute-value-unquoted = Атрибут хакĕсем чĕрне ăшĕнче пулмалла: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Тĕрĕс мар DoenetML: `{ $tag }` хупакан тег тупăнчĕ, анчах ăна тивĕçекен уçакан тег çук
+
+parse-close-tag-mismatched = Тĕрĕс мар DoenetML: килĕшмен хупакан тег. `</{ $expected }>` кĕтнĕччĕ. `{ $found }` тупăнчĕ
+
+parser-node-unconvertible = { $node } тĕввине Dast тĕввине куçарма пулмарĕ.
+
+## Names
+
+name-attribute-invalid =
+    Тĕрĕс мар атрибут name='{ $name }'. { $reason ->
+        [characters] Ятсенче сас паллисем, хисепсем, аялти тире е тире кăна пулма пултараççĕ.
+       *[start] Ятсем сас палли-ран пуçланмалла.
+    }
+
+component-name-invalid-start = Тĕрĕс мар компонент ячĕ «{ $name }». Ятсем сас палли-ран пуçланмалла.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched тĕслĕ answer-ăн video атрибучĕ пулмалла
+
+answer-video-watched-video-not-reference = videoWatched тĕслĕ answer-ăн video атрибучĕ каçă пулмалла
+
+answer-name-not-single-text = answer-ăн name атрибучĕн шăп пĕр текст ачи пулмалла
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурси шайĕсем ытла нумай пулнипе тулашри DoenetML-а илме пулмарĕ. Çавра каçă çук-и?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресран DoenetML илме пулмарĕ
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресран тĕрĕс мар DoenetML илнĕ: вăл «{ $componentType }» компонент тĕсĕпе килĕшмерĕ
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут кивелнĕ; ун вырăнне `{ $to }` усă курăр.
+       *[other] [deprecation] `<{ $component }>` элементри `{ $from }` атрибут кивелнĕ; ун вырăнне `{ $to }` усă курăр.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут кивелнĕ тата шута илмест, мĕншĕн тесен `{ $to }` та панă.
+       *[other] [deprecation] `<{ $component }>` элементри `{ $from }` атрибут кивелнĕ тата шута илмест, мĕншĕн тесен `{ $to }` та панă.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибут кивелнĕ тата шута илмест.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибут кивелнĕ; ун вырăнне `<{ $child }>` ачипе усă курăр.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибутăн `{ $value }` хакĕ кивелнĕ; ун вырăнне `{ $to }` усă курăр.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` нумайлă хисепе акăлчанла кăна тăвать, çавăнпа { $locale } чĕлхипе çырнă документра унăн тексчĕ улшăнмасăр юлать. Нумайлă формине хăвăр çырăр е ăна `pluralForm` атрибутпа парăр.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент палланă Doenet элеменчĕ мар.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элемента документăн тымарĕнче ирĕк памаççĕ.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элемента `<{ $parent }>` ăшĕнче ирĕк памаççĕ.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементра `{ $attribute }` ятлă атрибут çук.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементăн `{ $attribute }` атрибучĕ кашни элеменчĕ çаксенчен пĕри пулакан список пулмалла: { $allowed }
+       *[other] `<{ $tag }>` элементăн `{ $attribute }` атрибучĕ çаксенчен пĕри пулмалла: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select валли тĕрĕс мар вариант ячĕ. { $variantName } вариант ячĕ { $numOptions } суйлавра тĕл пулать, суйламалли йышĕ вара { $numToSelect }.
+
+select-variant-name-without-options = select валли вариантсем панă, анчах пулма пултаракан вариант ячĕ валли пĕр суйлав та çук: { $variantName }.
+
+select-variant-name-not-possible = select валли панă { $variantName } вариант ячĕ пулма пултаракан вариант ячĕ мар.
+
+select-too-few-options = Пурĕ { $numOptions } шутĕнчен { $numToSelect } компонент суйлама пулмасть.
+
+select-from-sequence-too-few-values = Вăрăмăшĕ { $length } йĕркелĕхрен { $numToSelect } хак суйлама пулмасть.
+
+select-from-sequence-indices-count-mismatch = select валли панă индекссен йышĕ суйламалли йышпа килĕшмелле
+
+select-from-sequence-indices-not-integers = select валли панă пур индекс та тулли хисеп пулмалла
+
+select-from-sequence-index-excluded = selectfromsequence валли панă индекса кăларнăччĕ
+
+select-from-sequence-indices-excluded-combination = selectfromsequence валли панă индекссем кăларнă пĕрлешӳ пулнă
+
+select-from-sequence-coprime-not-positive-integers = Позитивлă тулли хисепсем суйламаннипе хăйсем хушшинче ансат пĕрлешӳсене суйлама пулмасть.
+
+select-from-sequence-coprime-common-factor = Хăйсем хушшинче ансат хисепсене суйлама пулмасть. Пулма пултаракан пур хакăн та пĕрлехи пайлаканĕ пур. (Панă "from" е "to" хакĕсем "step"-па хăйсем хушшинче ансат пулмалла.)
+
+select-from-sequence-coprime-single-number = 1 мар пĕртен-пĕр хисепрен хăйсем хушшинче ансат пĕрлешӳсене суйлама пулмасть.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ăшĕнче пĕрлешӳсен 70%-ран ытлашшине кăларнă
+
+select-from-sequence-coprime-none-found = Хăйсем хушшинче ансат хисепсене суйлама пулмарĕ. Пулма пултаракан пур хакăн та пĕрлехи пайлаканĕ пур.
+
+select-from-sequence-too-few-unique-values = Вăрăмăшĕ { $numPossibleValues } йĕркелĕхрен { $numToSelect } тĕрлĕ хак суйлама пулмасть
+
+select-prime-numbers-too-few-values = Вăрăмăшĕ { $numValues } ансат хисепсен спискинчен { $numToSelect } хак суйлама пулмасть
+
+select-prime-numbers-values-count-mismatch = select валли панă хаксен йышĕ суйламалли йышпа килĕшмелле
+
+select-prime-numbers-values-not-prime = select prime number валли панă пур хак та ансат хисепсен спискинче пулмалла
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers валли панă хаксем кăларнă пĕрлешӳ пулнă
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ăшĕнче пĕрлешӳсен 70%-ран ытлашшине кăларнă
+
+select-random-combination-fluke = Питĕ пулма пултарайман ăнсăртлăх пирки ăнсăрт хаксен пĕрлешĕвне суйлама пулмарĕ
+
+select-random-value-fluke = Питĕ пулма пултарайман ăнсăртлăх пирки ăнсăрт хака суйлама пулмарĕ

--- a/packages/i18n/locales/cv/diagnostics.ftl
+++ b/packages/i18n/locales/cv/diagnostics.ftl
@@ -23,210 +23,210 @@
 
 line-segment-attributes-ignored-with-endpoints =
     { $attributesCount ->
-        [one] икĕ вĕç пăнчине те кăтартнă чухне { $attributes } шута илмест
-       *[other] икĕ вĕç пăнчине те кăтартнă чухне { $attributes } шута илмест
+        [one] икӗ вӗҫ пӑнчине те кӑтартнӑ чухне { $attributes } шута илмест
+       *[other] икӗ вӗҫ пӑнчине те кӑтартнӑ чухне { $attributes } шута илмест
     }
 
 line-segment-attributes-ignored-with-endpoint-and-midpoint =
     { $attributesCount ->
-        [one] вĕç пăнчипе варри пăнчине те кăтартнă чухне { $attributes } шута илмест
-       *[other] вĕç пăнчипе варри пăнчине те кăтартнă чухне { $attributes } шута илмест
+        [one] вӗҫ пӑнчипе варри пӑнчине те кӑтартнӑ чухне { $attributes } шута илмест
+       *[other] вӗҫ пӑнчипе варри пӑнчине те кӑтартнӑ чухне { $attributes } шута илмест
     }
 
-line-segment-midpoint-offset-without-midpoint = варри пăнчисĕр midpointOffset нимĕне те витĕм кӳмест
+line-segment-midpoint-offset-without-midpoint = варри пӑнчисӗр midpointOffset нимӗне те витӗм кӳмест
 
 ## `<line>`
 
-line-points-undetermined-dimensions = Виçи паллă мар пăнчăсем витĕр тухакан тӳрĕ йĕр.
+line-points-undetermined-dimensions = Виҫи паллӑ мар пӑнчӑсем витӗр тухакан тӳрӗ йӗр.
 
-line-points-too-few-dimensions = Тӳрĕ йĕр чи сахалран икĕ виçеллĕ пăнчăсем витĕр тухмалла.
+line-points-too-few-dimensions = Тӳрӗ йӗр чи сахалран икӗ виҫеллӗ пӑнчӑсем витӗр тухмалла.
 
-line-points-depend-on-variables = Тӳрĕ йĕр улшăнакансенчен килекен пăнчăсем витĕр тухать: { $variables }.
+line-points-depend-on-variables = Тӳрӗ йӗр улшӑнакансенчен килекен пӑнчӑсем витӗр тухать: { $variables }.
 
-line-equation-invalid-format = { $variable1 } тата { $variable2 } улшăнаканĕсенчи тӳрĕ йĕр танлăхĕн форматне йышăнмасть.
+line-equation-invalid-format = { $variable1 } тата { $variable2 } улшӑнаканӗсенчи тӳрӗ йӗр танлӑхӗн форматне йышӑнмасть.
 
 ## `<ray>`
 
-ray-overprescribed-through = Пайăркана through, endpoint тата direction урлă панă. Панă through шута илмест.
+ray-overprescribed-through = Пайӑркана through, endpoint тата direction урлӑ панӑ. Панӑ through шута илмест.
 
-ray-dimension-mismatch = пайăркара numDimensions килĕшмест.
+ray-dimension-mismatch = пайӑркара numDimensions килӗшмест.
 
 ## `<vector>`
 
-vector-overprescribed-head = Вектора head, tail тата displacement урлă панă. Панă head шута илмест.
+vector-overprescribed-head = Вектора head, tail тата displacement урлӑ панӑ. Панӑ head шута илмест.
 
-vector-dimension-mismatch = векторта numDimensions килĕшмест.
+vector-dimension-mismatch = векторта numDimensions килӗшмест.
 
 ## Attracting and constraining
 
-attract-to-without-nearest-point = `<{ $component }>` элемент патне туртма пулмасть, мĕншĕн тесен унăн nearestPoint статус улшăнаканĕ çук.
+attract-to-without-nearest-point = `<{ $component }>` элемент патне туртма пулмасть, мӗншӗн тесен унӑн nearestPoint статус улшӑнаканӗ ҫук.
 
-constrain-to-without-nearest-point = `<{ $component }>` элементпа чарса тăма пулмасть, мĕншĕн тесен унăн nearestPoint статус улшăнаканĕ çук.
+constrain-to-without-nearest-point = `<{ $component }>` элементпа чарса тӑма пулмасть, мӗншӗн тесен унӑн nearestPoint статус улшӑнаканӗ ҫук.
 
-constrain-to-interior-without-nearest-point = `<{ $component }>` элементăн шалĕпе чарса тăма пулмасть, мĕншĕн тесен унăн nearestPoint статус улшăнаканĕ çук.
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементӑн шалӗпе чарса тӑма пулмасть, мӗншӗн тесен унӑн nearestPoint статус улшӑнаканӗ ҫук.
 
 ## `<choiceInput>`
 
-choice-input-label-position-ignored = йĕрке ăшĕнче мар choiceInput валли labelPosition шута илмест
+choice-input-label-position-ignored = йӗрке ӑшӗнче мар choiceInput валли labelPosition шута илмест
 
 ## Ordering children by index
 
-choice-input-indices-count-mismatch = choiceInput валли панă индекссем шута илмеççĕ, мĕншĕн тесен вĕсен йышĕ choice ачисен йышĕпе килĕшмест.
+choice-input-indices-count-mismatch = choiceInput валли панӑ индекссем шута илмеҫҫӗ, мӗншӗн тесен вӗсен йышӗ choice ачисен йышӗпе килӗшмест.
 
-pretzel-indices-count-mismatch = problem валли панă индекссем шута илмеççĕ, мĕншĕн тесен вĕсен йышĕ problem ачисен йышĕпе килĕшмест.
+pretzel-indices-count-mismatch = problem валли панӑ индекссем шута илмеҫҫӗ, мӗншӗн тесен вӗсен йышӗ problem ачисен йышӗпе килӗшмест.
 
-shuffle-indices-count-mismatch = shuffle валли панă индекссем шута илмеççĕ, мĕншĕн тесен вĕсен йышĕ компонентсен йышĕпе килĕшмест.
+shuffle-indices-count-mismatch = shuffle валли панӑ индекссем шута илмеҫҫӗ, мӗншӗн тесен вӗсен йышӗ компонентсен йышӗпе килӗшмест.
 
-indices-ignored-out-of-range = { $component } валли панă индекссем шута илмеççĕ, мĕншĕн тесен хăшĕсем чикĕрен тухаççĕ.
+indices-ignored-out-of-range = { $component } валли панӑ индекссем шута илмеҫҫӗ, мӗншӗн тесен хӑшӗсем чикӗрен тухаҫҫӗ.
 
-pretzel-indices-repeated = pretzel валли панă индекссем шута илмеççĕ, мĕншĕн тесен хăшĕсем тепĕр хут тĕл пулаççĕ.
+pretzel-indices-repeated = pretzel валли панӑ индекссем шута илмеҫҫӗ, мӗншӗн тесен хӑшӗсем тепӗр хут тӗл пулаҫҫӗ.
 
-pretzel-circuit-first-index = circuit режимĕнче pretzel валли панă индекссем шута илмеççĕ, мĕншĕн тесен пĕрремĕш индекс 1 пулмалла.
+pretzel-circuit-first-index = circuit режимӗнче pretzel валли панӑ индекссем шута илмеҫҫӗ, мӗншӗн тесен пӗрремӗш индекс 1 пулмалла.
 
 ## `<shuffle>` and `<sort>`
 
-string-children-need-type = `<{ $component }>` текст ачисемпе ĕçлетĕр тесен `type` атрибут памалла.
+string-children-need-type = `<{ $component }>` текст ачисемпе ӗҫлетӗр тесен `type` атрибут памалла.
 
-invalid-type-defaulting-to-math = { $component } компонент валли тĕрĕс мар тĕс { $type }. Вăл math, text, number е boolean пулмалла. math усă курать.
+invalid-type-defaulting-to-math = { $component } компонент валли тӗрӗс мар тӗс { $type }. Вӑл math, text, number е boolean пулмалла. math усӑ курать.
 
-string-not-valid-component-to-arrange = «{ $value }» йĕрки { $component } валли юрăхлă компонент мар. Шута илмест.
+string-not-valid-component-to-arrange = «{ $value }» йӗрки { $component } валли юрӑхлӑ компонент мар. Шута илмест.
 
 ## Types and variables
 
-invalid-type-defaulting-to-number = Тĕрĕс мар тĕс { $type }, тĕсне number тăваççĕ.
+invalid-type-defaulting-to-number = Тӗрӗс мар тӗс { $type }, тӗсне number тӑваҫҫӗ.
 
-invalid-variable-value = Улшăнаканăн тĕрĕс мар хакĕ: `{ $value }`
+invalid-variable-value = Улшӑнаканӑн тӗрӗс мар хакӗ: `{ $value }`
 
 ## Variants
 
-variant-index-must-be-number = { $index } вариант индексĕ хисеп пулмалла
+variant-index-must-be-number = { $index } вариант индексӗ хисеп пулмалла
 
-variant-index-must-be-integer = { $index } вариант индексĕ тулли хисеп пулмалла
+variant-index-must-be-integer = { $index } вариант индексӗ тулли хисеп пулмалла
 
 ## `<sideBySide>`
 
-side-by-side-absolute-widths = `<{ $component }>` абсолют виçесем валли пурнăçламан. Сарлакăшсене танлаштаруллă тăваççĕ.
+side-by-side-absolute-widths = `<{ $component }>` абсолют виҫесем валли пурнӑҫламан. Сарлакӑшсене танлаштаруллӑ тӑваҫҫӗ.
 
-side-by-side-absolute-margins = `<{ $component }>` абсолют виçесем валли пурнăçламан. Хĕррисене танлаштаруллă тăваççĕ.
+side-by-side-absolute-margins = `<{ $component }>` абсолют виҫесем валли пурнӑҫламан. Хӗррисене танлаштаруллӑ тӑваҫҫӗ.
 
-side-by-side-no-block-child = Тĕрĕс мар `<{ $component }>`: унăн чи сахалран пĕр блок ачи пулмалла.
+side-by-side-no-block-child = Тӗрӗс мар `<{ $component }>`: унӑн чи сахалран пӗр блок ачи пулмалла.
 
 ## `<label>`
 
 label-for-ignored-on-graphical = График `<label>` элементри `for` атрибут шута илмест.
 
-label-for-must-resolve-to-one = `<label>` элементри `for` атрибут шăп пĕр компонент çине кăтартмалла.
+label-for-must-resolve-to-one = `<label>` элементри `for` атрибут шӑп пӗр компонент ҫине кӑтартмалла.
 
-label-for-unresolved = `<label>` элементри `for` атрибута компонентпа çыхăнтарма пулмарĕ.
+label-for-unresolved = `<label>` элементри `for` атрибута компонентпа ҫыхӑнтарма пулмарӗ.
 
-label-for-answer-with-authored-inputs = `<label>` элементри `for` атрибут автор çырнă кĕртӳ хирĕсем пур `<answer>` çине кăтартать; хир çине тӳрремĕн кăтартăр.
+label-for-answer-with-authored-inputs = `<label>` элементри `for` атрибут автор ҫырнӑ кӗртӳ хирӗсем пур `<answer>` ҫине кӑтартать; хир ҫине тӳрремӗн кӑтартӑр.
 
-label-for-answer-without-input = `<label>` элементри `for` атрибут паллă тумалли кĕртӳ хирĕ çук `<answer>` çине кăтартать.
+label-for-answer-without-input = `<label>` элементри `for` атрибут паллӑ тумалли кӗртӳ хирӗ ҫук `<answer>` ҫине кӑтартать.
 
-label-for-must-reference-input-or-answer = `<label>` элементри `for` атрибут кĕртӳ хирĕ е хурав çине кăтартмалла.
+label-for-must-reference-input-or-answer = `<label>` элементри `for` атрибут кӗртӳ хирӗ е хурав ҫине кӑтартмалла.
 
 ## Accessibility
 
-accessibility-short-description-or-decorative = Майлăх валли `<{ $component }>` е кĕске ăнлантару пулмалла, е эреш тесе палăртмалла.
+accessibility-short-description-or-decorative = Майлӑх валли `<{ $component }>` е кӗске ӑнлантару пулмалла, е эреш тесе палӑртмалла.
 
-accessibility-video-short-description = Майлăх валли `<video>` кĕске ăнлантаруллă пулмалла.
+accessibility-video-short-description = Майлӑх валли `<video>` кӗске ӑнлантаруллӑ пулмалла.
 
-accessibility-input-short-description-or-label = Майлăх валли `<{ $component }>` кĕске ăнлантаруллă е паллăллă пулмалла.
+accessibility-input-short-description-or-label = Майлӑх валли `<{ $component }>` кӗске ӑнлантаруллӑ е паллӑллӑ пулмалла.
 
-accessibility-answer-input-short-description-or-label = Майлăх валли кĕртӳ хирĕ тăвакан `<answer>` кĕске ăнлантаруллă е паллăллă пулмалла.
+accessibility-answer-input-short-description-or-label = Майлӑх валли кӗртӳ хирӗ тӑвакан `<answer>` кӗске ӑнлантаруллӑ е паллӑллӑ пулмалла.
 
-accessibility-short-description-contains-math = Кĕске ăнлантарусенче `<{ $component }>` пек математика компоненчĕсем пулмалла мар. Математикăна сăмахпа çырăр.
+accessibility-short-description-contains-math = Кӗске ӑнлантарусенче `<{ $component }>` пек математика компоненчӗсем пулмалла мар. Математикӑна сӑмахпа ҫырӑр.
 
 accessibility-section-title-insufficient-contrast =
     { $mode ->
-        [dark] { $colorName } пай пуçламăшĕн тексчĕ валли çителĕклĕ контраст памасть (тĕттĕм тĕс) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ).
-       *[other] { $colorName } пай пуçламăшĕн тексчĕ валли çителĕклĕ контраст памасть ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ).
+        [dark] { $colorName } пай пуҫламӑшӗн тексчӗ валли ҫителӗклӗ контраст памасть (тӗттӗм тӗс) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлӗ).
+       *[other] { $colorName } пай пуҫламӑшӗн тексчӗ валли ҫителӗклӗ контраст памасть ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлӗ).
     }
 
 ## `<circle>`
 
-circle-through-points-non-numerical = Пăнчăсен хисеп хакĕсем çук чухне { $count } пăнчă витĕр тухакан `<circle>` пурнăçламан.
+circle-through-points-non-numerical = Пӑнчӑсен хисеп хакӗсем ҫук чухне { $count } пӑнчӑ витӗр тухакан `<circle>` пурнӑҫламан.
 
-circle-too-many-through-points = 3-рен ытла пăнчă витĕр тухакан çаврашкана шутлама пулмасть.
+circle-too-many-through-points = 3-рен ытла пӑнчӑ витӗр тухакан ҫаврашкана шутлама пулмасть.
 
-circle-overprescribed-radius-center-points = Панă радиуспа, варрипе тата пăнчăсемпе çаврашкана шутлама пулмасть.
+circle-overprescribed-radius-center-points = Панӑ радиуспа, варрипе тата пӑнчӑсемпе ҫаврашкана шутлама пулмасть.
 
-circle-center-with-multiple-points = Панă варрипе 1-рен ытла пăнчă витĕр тухакан çаврашкана шутлама пулмасть.
+circle-center-with-multiple-points = Панӑ варрипе 1-рен ытла пӑнчӑ витӗр тухакан ҫаврашкана шутлама пулмасть.
 
-circle-radius-too-small = Çаврашкана шутлама пулмасть: икĕ пăнчă хушши { $distance } пулнипе панă радиус { $radius } ытла пĕчĕк.
+circle-radius-too-small = Ҫаврашкана шутлама пулмасть: икӗ пӑнчӑ хушши { $distance } пулнипе панӑ радиус { $radius } ытла пӗчӗк.
 
-circle-radius-with-many-points = Панă радиуспа иккĕрен ытла пăнчă витĕр тухакан çаврашка тума пулмасть.
+circle-radius-with-many-points = Панӑ радиуспа иккӗрен ытла пӑнчӑ витӗр тухакан ҫаврашка тума пулмасть.
 
-circle-invalid-center-or-through-points = Çаврашкан варри е пăнчисем тĕрĕс мар.
+circle-invalid-center-or-through-points = Ҫаврашкан варри е пӑнчисем тӗрӗс мар.
 
-circle-radius-center-with-multiple-points = Панă варрипе 1-рен ытла пăнчă витĕр тухакан çаврашкан радиусне шутлама пулмасть.
+circle-radius-center-with-multiple-points = Панӑ варрипе 1-рен ытла пӑнчӑ витӗр тухакан ҫаврашкан радиусне шутлама пулмасть.
 
-circle-change-radius-non-numerical = Хисеп мар пăнчăллă çаврашкан радиусне улăштарма пулмасть
+circle-change-radius-non-numerical = Хисеп мар пӑнчӑллӑ ҫаврашкан радиусне улӑштарма пулмасть
 
-circle-radius-with-points-non-numerical = Хисеп хакĕсем çук чухне панă радиуспа пĕрререн ытла пăнчă витĕр тухакан çаврашка тума пулмасть.
+circle-radius-with-points-non-numerical = Хисеп хакӗсем ҫук чухне панӑ радиуспа пӗрререн ытла пӑнчӑ витӗр тухакан ҫаврашка тума пулмасть.
 
-circle-change-center-non-numerical = Хисеп мар пăнчăсем витĕр тухакан çаврашкан варрине улăштарассине пурнăçламан.
+circle-change-center-non-numerical = Хисеп мар пӑнчӑсем витӗр тухакан ҫаврашкан варрине улӑштарассине пурнӑҫламан.
 
 ## `<function>`
 
 function-domain-insufficient-dimensions =
     { $intervals ->
-        [one] Функцин палăртнă лаптăкĕн виçи çителĕксĕр. Лаптăкра { $intervals } хушăк пур, функцире вара { $inputs ->
-            [one] { $inputs } кĕрӳ
-           *[other] { $inputs } кĕрӳ
+        [one] Функцин палӑртнӑ лаптӑкӗн виҫи ҫителӗксӗр. Лаптӑкра { $intervals } хушӑк пур, функцире вара { $inputs ->
+            [one] { $inputs } кӗрӳ
+           *[other] { $inputs } кӗрӳ
         }.
-       *[other] Функцин палăртнă лаптăкĕн виçи çителĕксĕр. Лаптăкра { $intervals } хушăк пур, функцире вара { $inputs ->
-            [one] { $inputs } кĕрӳ
-           *[other] { $inputs } кĕрӳ
+       *[other] Функцин палӑртнӑ лаптӑкӗн виҫи ҫителӗксӗр. Лаптӑкра { $intervals } хушӑк пур, функцире вара { $inputs ->
+            [one] { $inputs } кӗрӳ
+           *[other] { $inputs } кӗрӳ
         }.
     }
 
-function-domain-invalid-format = Функцин палăртнă лаптăкĕн форматне йышăнмасть.
+function-domain-invalid-format = Функцин палӑртнӑ лаптӑкӗн форматне йышӑнмасть.
 
 function-ignoring-non-numerical =
     { $type ->
         [maximum] Функцин хисеп мар максимумне шута илмест.
         [minimum] Функцин хисеп мар минимумне шута илмест.
         [extremum] Функцин хисеп мар экстремумне шута илмест.
-        [point] Функцин хисеп мар пăнчине шута илмест.
-        [slope] Функцин хисеп мар чалăшлăхне шута илмест.
+        [point] Функцин хисеп мар пӑнчине шута илмест.
+        [slope] Функцин хисеп мар чалӑшлӑхне шута илмест.
        *[other] Функцин хисеп мар { $type } хакне шута илмест.
     }
 
 function-ignoring-empty =
     { $type ->
-        [maximum] Функцин пушă максимумне шута илмест.
-        [minimum] Функцин пушă минимумне шута илмест.
-        [extremum] Функцин пушă экстремумне шута илмест.
-        [point] Функцин пушă пăнчине шута илмест.
-       *[other] Функцин пушă { $type } хакне шута илмест.
+        [maximum] Функцин пушӑ максимумне шута илмест.
+        [minimum] Функцин пушӑ минимумне шута илмест.
+        [extremum] Функцин пушӑ экстремумне шута илмест.
+        [point] Функцин пушӑ пӑнчине шута илмест.
+       *[other] Функцин пушӑ { $type } хакне шута илмест.
     }
 
-function-points-too-close = Функцире пĕр-пĕрне ытла çывăх икĕ пăнчă пур. Функцие палăртма пулмасть.
+function-points-too-close = Функцире пӗр-пӗрне ытла ҫывӑх икӗ пӑнчӑ пур. Функцие палӑртма пулмасть.
 
 function-iterates-input-output-mismatch =
     { $inputs ->
-        [one] Функци итерацийĕсем кĕрӳсен йышĕ тухăçсен йышĕпе тан пулсан кăна пулаççĕ. Ку функцире { $inputs } кĕрӳ тата { $outputs ->
-            [one] { $outputs } тухăç
-           *[other] { $outputs } тухăç
+        [one] Функци итерацийӗсем кӗрӳсен йышӗ тухӑҫсен йышӗпе тан пулсан кӑна пулаҫҫӗ. Ку функцире { $inputs } кӗрӳ тата { $outputs ->
+            [one] { $outputs } тухӑҫ
+           *[other] { $outputs } тухӑҫ
         } пур.
-       *[other] Функци итерацийĕсем кĕрӳсен йышĕ тухăçсен йышĕпе тан пулсан кăна пулаççĕ. Ку функцире { $inputs } кĕрӳ тата { $outputs ->
-            [one] { $outputs } тухăç
-           *[other] { $outputs } тухăç
+       *[other] Функци итерацийӗсем кӗрӳсен йышӗ тухӑҫсен йышӗпе тан пулсан кӑна пулаҫҫӗ. Ку функцире { $inputs } кӗрӳ тата { $outputs ->
+            [one] { $outputs } тухӑҫ
+           *[other] { $outputs } тухӑҫ
         } пур.
     }
 
 ## `<sequence>`
 
-sequence-invalid-length = Йĕркелĕх вăрăмăшĕ тĕрĕс мар. Вăл негативлă мар тулли хисеп пулмалла.
+sequence-invalid-length = Йӗркелӗх вӑрӑмӑшӗ тӗрӗс мар. Вӑл негативлӑ мар тулли хисеп пулмалла.
 
-sequence-invalid-step = Йĕркелĕх утăмĕ тĕрĕс мар. { $type } тĕслĕ йĕркелĕх валли вăл хисеп пулмалла.
+sequence-invalid-step = Йӗркелӗх утӑмӗ тӗрӗс мар. { $type } тӗслӗ йӗркелӗх валли вӑл хисеп пулмалла.
 
-sequence-invalid-endpoint-number = Хисеп йĕркелĕхĕн «{ $attribute }» хакĕ тĕрĕс мар. Вăл хисеп пулмалла.
+sequence-invalid-endpoint-number = Хисеп йӗркелӗхӗн «{ $attribute }» хакӗ тӗрӗс мар. Вӑл хисеп пулмалла.
 
-sequence-invalid-endpoint-letters = Сас палли йĕркелĕхĕн «{ $attribute }» хакĕ тĕрĕс мар. Вăл сас паллисен пĕрлешĕвĕ пулмалла.
+sequence-invalid-endpoint-letters = Сас палли йӗркелӗхӗн «{ $attribute }» хакӗ тӗрӗс мар. Вӑл сас паллисен пӗрлешӗвӗ пулмалла.
 
-sequence-invalid-endpoint = Йĕркелĕхĕн «{ $attribute }» хакĕ тĕрĕс мар.
+sequence-invalid-endpoint = Йӗркелӗхӗн «{ $attribute }» хакӗ тӗрӗс мар.
 
 select-from-sequence-coprime-not-numbers = хисепсем суйламаннипе coprime шута илмест
 
@@ -234,425 +234,425 @@ select-from-sequence-coprime-with-exclude-combinations = excludeCombinations п�
 
 ## Resolving a `target`
 
-target-not-found = `<{ $source }>` валли тĕрĕс мар target: тĕллев тупăнмарĕ.
+target-not-found = `<{ $source }>` валли тӗрӗс мар target: тӗллев тупӑнмарӗ.
 
-target-state-variable-not-found = `<{ $source }>` валли тĕрĕс мар target: `<{ $component }>` элементра «{ $property }» ятлă статус улшăнаканĕ тупăнмарĕ.
+target-state-variable-not-found = `<{ $source }>` валли тӗрӗс мар target: `<{ $component }>` элементра «{ $property }» ятлӑ статус улшӑнаканӗ тупӑнмарӗ.
 
 ## `<odeSystem>`
 
-ode-system-variables-match-independent = `<odeSystem>` улшăнаканĕсем ирĕклĕ улшăнаканран уйрăлса тăмалла.
+ode-system-variables-match-independent = `<odeSystem>` улшӑнаканӗсем ирӗклӗ улшӑнаканран уйрӑлса тӑмалла.
 
-ode-system-duplicate-variable-names = Çыхăнуллă улшăнакансен ячĕсем пĕр пекки чухне ДТ сылтăм енĕн функцийĕсене палăртма пулмасть.
+ode-system-duplicate-variable-names = Ҫыхӑнуллӑ улшӑнакансен ячӗсем пӗр пекки чухне ДТ сылтӑм енӗн функцийӗсене палӑртма пулмасть.
 
-ode-system-rhs-function-error = ДТ сылтăм енĕн функцине палăртма пулмасть. mathjs функцине тунă чухне йăнăш.
+ode-system-rhs-function-error = ДТ сылтӑм енӗн функцине палӑртма пулмасть. mathjs функцине тунӑ чухне йӑнӑш.
 
 ## `<angle>`, `<parabola>`, and `<intersection>`
 
-angle-too-many-lines = { $count } тӳрĕ йĕр хушшинчи кĕтесе палăртма пулмасть
+angle-too-many-lines = { $count } тӳрӗ йӗр хушшинчи кӗтесе палӑртма пулмасть
 
-angle-invalid-through-point = `<angle>` элементăн through хакĕнче тĕрĕс мар пăнчă
+angle-invalid-through-point = `<angle>` элементӑн through хакӗнче тӗрӗс мар пӑнчӑ
 
-parabola-vertex-too-many-points = Панă тăрăпа 1-рен ытла пăнчă витĕр тухакан парабола пурнăçламан.
+parabola-vertex-too-many-points = Панӑ тӑрӑпа 1-рен ытла пӑнчӑ витӗр тухакан парабола пурнӑҫламан.
 
-parabola-too-many-points = 3-рен ытла пăнчă витĕр тухакан парабола пурнăçламан.
+parabola-too-many-points = 3-рен ытла пӑнчӑ витӗр тухакан парабола пурнӑҫламан.
 
-intersection-too-many-items = Иккĕрен ытла объект хĕресленнине пурнăçламан
+intersection-too-many-items = Иккӗрен ытла объект хӗресленнине пурнӑҫламан
 
 ## Other math components
 
-ionic-compound-not-two-ions = Икĕ иона пăхмасăр ион пĕрлешĕвĕсене пурнăçламан.
+ionic-compound-not-two-ions = Икӗ иона пӑхмасӑр ион пӗрлешӗвӗсене пурнӑҫламан.
 
-ionic-compound-needs-cation-and-anion = Ион пĕрлешĕвĕсене пĕр катионпа пĕр анион валли кăна пурнăçланă.
+ionic-compound-needs-cation-and-anion = Ион пӗрлешӗвӗсене пӗр катионпа пӗр анион валли кӑна пурнӑҫланӑ.
 
-solve-equations-cannot-evaluate = Танлăха татса пама пулмасть, мĕншĕн тесен ăна шутлама пулмарĕ: { $equation }
+solve-equations-cannot-evaluate = Танлӑха татса пама пулмасть, мӗншӗн тесен ӑна шутлама пулмарӗ: { $equation }
 
-math-operators-operand-number-required = Математика операндне уйăрса илме operandNumber памалла.
+math-operators-operand-number-required = Математика операндне уйӑрса илме operandNumber памалла.
 
-eigen-decomposition-failed = Матрицăн хăй хакĕсене шутлама пулмарĕ
+eigen-decomposition-failed = Матрицӑн хӑй хакӗсене шутлама пулмарӗ
 
 ## `<matchesPattern>`
 
 matches-pattern-parameter-not-in-pattern =
     { $parametersCount ->
-        [one] `<matchesPattern>`: { $parameters } параметр тĕслĕхре тĕл пулмасть, çавăнпа вăл яланах пушша килĕшет.
-       *[other] `<matchesPattern>`: { $parameters } параметрсем тĕслĕхре тĕл пулмаççĕ, çавăнпа вĕсем яланах пушша килĕшеççĕ.
+        [one] `<matchesPattern>`: { $parameters } параметр тӗслӗхре тӗл пулмасть, ҫавӑнпа вӑл яланах пушша килӗшет.
+       *[other] `<matchesPattern>`: { $parameters } параметрсем тӗслӗхре тӗл пулмаҫҫӗ, ҫавӑнпа вӗсем яланах пушша килӗшеҫҫӗ.
     }
 
 ## `<graph>`
 
-graph-grid-invalid = `<graph>`: grid="{ $grid }" хакне ăнланма пулмасть. Вăл none, medium, dense е пушă вырăнпа уйăрнă икĕ позитивлă хисеп пулмалла, тĕслĕхрен grid="1 0.5". Тор ӳкермест.
+graph-grid-invalid = `<graph>`: grid="{ $grid }" хакне ӑнланма пулмасть. Вӑл none, medium, dense е пушӑ вырӑнпа уйӑрнӑ икӗ позитивлӑ хисеп пулмалла, тӗслӗхрен grid="1 0.5". Тор ӳкермест.
 
 ## PreFigure renderer
 
-prefigure-x-label-position-unsupported = `<graph>`: prefigure ӳкерекенĕнче xLabelPosition="left" пурнăçламан; сылтăм вырнаçу йĕрки усă курать.
+prefigure-x-label-position-unsupported = `<graph>`: prefigure ӳкерекенӗнче xLabelPosition="left" пурнӑҫламан; сылтӑм вырнаҫу йӗрки усӑ курать.
 
-prefigure-y-label-position-unsupported = `<graph>`: prefigure ӳкерекенĕнче yLabelPosition="bottom" пурнăçламан; çӳлти вырнаçу йĕрки усă курать.
+prefigure-y-label-position-unsupported = `<graph>`: prefigure ӳкерекенӗнче yLabelPosition="bottom" пурнӑҫламан; ҫӳлти вырнаҫу йӗрки усӑ курать.
 
-prefigure-invalid-axis-bounds = `<graph>`: prefigure куçарăвĕ валли тĕнĕл чикĕсем тĕрĕс мар; тĕп bbox (-10,-10,10,10) усă курать.
+prefigure-invalid-axis-bounds = `<graph>`: prefigure куҫарӑвӗ валли тӗнӗл чикӗсем тӗрӗс мар; тӗп bbox (-10,-10,10,10) усӑ курать.
 
-prefigure-invalid-width = `<graph>`: prefigure куçарăвĕ валли сарлакăш тĕрĕс мар; диаграммăн тĕп сарлакăшĕ 425 усă курать.
+prefigure-invalid-width = `<graph>`: prefigure куҫарӑвӗ валли сарлакӑш тӗрӗс мар; диаграммӑн тӗп сарлакӑшӗ 425 усӑ курать.
 
-prefigure-invalid-aspect-ratio = `<graph>`: prefigure куçарăвĕ валли aspectRatio тĕрĕс мар; тĕп енсен танлăхĕ 1 усă курать.
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure куҫарӑвӗ валли aspectRatio тӗрӗс мар; тӗп енсен танлӑхӗ 1 усӑ курать.
 
-prefigure-grid-spacing-too-fine = `<graph>`: тор утăмĕ тĕнĕл чикĕсем валли ытла вĕтĕ; prefigure ӳкерекенĕнче тора кăлараççĕ.
+prefigure-grid-spacing-too-fine = `<graph>`: тор утӑмӗ тӗнӗл чикӗсем валли ытла вӗтӗ; prefigure ӳкерекенӗнче тора кӑлараҫҫӗ.
 
-prefigure-annotations-not-rendered = `<graph>`: PreFigure ӳкерекенĕпе усă курман чухне асăрхаттарусем ӳкермеççĕ.
+prefigure-annotations-not-rendered = `<graph>`: PreFigure ӳкерекенӗпе усӑ курман чухне асӑрхаттарусем ӳкермеҫҫӗ.
 
-multiple-annotations-children = `<graph>` ăшĕнче темиçе `<annotations>` ачи тупăнчĕ; юлашкинчен пуçне ыттисене шута илмеççĕ.
+multiple-annotations-children = `<graph>` ӑшӗнче темиҫе `<annotations>` ачи тупӑнчӗ; юлашкинчен пуҫне ыттисене шута илмеҫҫӗ.
 
 ## Referring to other components
 
-copy-unrecognized-component-type = Палламан компонент тĕсне сарма е куçарма пулмасть: { $type }.
+copy-unrecognized-component-type = Палламан компонент тӗсне сарма е куҫарма пулмасть: { $type }.
 
-copy-prop-not-found = { $component } тĕслĕ компонентра { $property } уйрăмлăхĕ тупăнмарĕ
+copy-prop-not-found = { $component } тӗслӗ компонентра { $property } уйрӑмлӑхӗ тупӑнмарӗ
 
-collect-no-source = collect валли çăлкуç тупăнмарĕ.
+collect-no-source = collect валли ҫӑлкуҫ тупӑнмарӗ.
 
-collect-invalid-component-type = `<{ $component }>` тĕслĕ компонентсене пуçтарма пулмасть, мĕншĕн тесен ку тĕрĕс мар компонент тĕсĕ.
+collect-invalid-component-type = `<{ $component }>` тӗслӗ компонентсене пуҫтарма пулмасть, мӗншӗн тесен ку тӗрӗс мар компонент тӗсӗ.
 
-reference-index-unavailable = `{ $reference }` индекс çине каçă тума пулмасть
+reference-index-unavailable = `{ $reference }` индекс ҫине каҫӑ тума пулмасть
 
 ## `<callAction>`
 
-component-action-unavailable = `{ $reference }` компонентра { $action } чĕнме пулмасть
+component-action-unavailable = `{ $reference }` компонентра { $action } чӗнме пулмасть
 
 ## `<dataFrame>`
 
-data-frame-inconsistent-row-lengths = Даннăйсен формийĕ тĕрĕс мар. Йĕркесен вăрăмăшĕсем тĕрлĕ. Тупăнчĕ componentIdx :{ $componentIdx }
+data-frame-inconsistent-row-lengths = Даннӑйсен формийӗ тӗрӗс мар. Йӗркесен вӑрӑмӑшӗсем тӗрлӗ. Тупӑнчӗ componentIdx :{ $componentIdx }
 
-data-frame-duplicate-column-names = Даннăйсенче юпа ячĕсем пĕр пекех. Тупăнчĕ componentIdx :{ $componentIdx }
+data-frame-duplicate-column-names = Даннӑйсенче юпа ячӗсем пӗр пекех. Тупӑнчӗ componentIdx :{ $componentIdx }
 
-data-frame-missing-column-name = Даннăйсенче юпа ячĕ çитмест. Тупăнчĕ componentIdx :{ $componentIdx }
+data-frame-missing-column-name = Даннӑйсенче юпа ячӗ ҫитмест. Тупӑнчӗ componentIdx :{ $componentIdx }
 
 ## `<answer>` and scoring
 
-answer-award-depends-on-own-response = Ку хуравăн award хакĕ answer тегăн хăйĕн янă хуравĕ çине таянать, ку кĕтмен ĕç-пуçа илсе пырать.
+answer-award-depends-on-own-response = Ку хуравӑн award хакӗ answer тегӑн хӑйӗн янӑ хуравӗ ҫине таянать, ку кӗтмен ӗҫ-пуҫа илсе пырать.
 
-answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` пур контейнер ăшĕнчи `<answer>` çине `maxNumAttempts` лартни витĕм кӳмест, мĕншĕн тесен хăтланусен йышне контейнер палăртать. `maxNumAttempts` хакне контейнер çине лартăр.
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` пур контейнер ӑшӗнчи `<answer>` ҫине `maxNumAttempts` лартни витӗм кӳмест, мӗншӗн тесен хӑтланусен йышне контейнер палӑртать. `maxNumAttempts` хакне контейнер ҫине лартӑр.
 
-nested-section-wide-check-work-max-num-attempts = Тепĕр `sectionWideCheckWork` контейнерĕ ăшĕнчи `sectionWideCheckWork` контейнерĕ çине `maxNumAttempts` лартни витĕм кӳмест, мĕншĕн тесен хăтланусен йышне тулашри контейнер палăртать. `maxNumAttempts` хакне тулашри контейнер çине лартăр.
+nested-section-wide-check-work-max-num-attempts = Тепӗр `sectionWideCheckWork` контейнерӗ ӑшӗнчи `sectionWideCheckWork` контейнерӗ ҫине `maxNumAttempts` лартни витӗм кӳмест, мӗншӗн тесен хӑтланусен йышне тулашри контейнер палӑртать. `maxNumAttempts` хакне тулашри контейнер ҫине лартӑр.
 
 answer-attributes-need-symbolic-equality =
     { $attributesCount ->
-        [one] symbolicEquality лартмасан { $attributes } атрибут витĕм кӳмĕ.
-       *[other] symbolicEquality лартмасан { $attributes } атрибутсем витĕм кӳмĕç.
+        [one] symbolicEquality лартмасан { $attributes } атрибут витӗм кӳмӗ.
+       *[other] symbolicEquality лартмасан { $attributes } атрибутсем витӗм кӳмӗҫ.
     }
 
-answer-invalid-type = answer валли тĕрĕс мар тĕс: { $type }
+answer-invalid-type = answer валли тӗрӗс мар тӗс: { $type }
 
 ## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
 
-module-attribute-child-needs-name = `<{ $component }>` компонентăн ячĕ çуккипе ăна модуль атрибучĕ пек усă курма пулмасть
+module-attribute-child-needs-name = `<{ $component }>` компонентӑн ячӗ ҫуккипе ӑна модуль атрибучӗ пек усӑ курма пулмасть
 
-module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонента модуль атрибучĕ пек усă курма пулмасть, мĕншĕн тесен `<module>` компонент тĕсĕнче «{ $name }» атрибут ĕнтĕ палăртнă.
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонента модуль атрибучӗ пек усӑ курма пулмасть, мӗншӗн тесен `<module>` компонент тӗсӗнче «{ $name }» атрибут ӗнтӗ палӑртнӑ.
 
 conditional-content-condition-ignored = case е else ачисем пур `<conditionalContent>` компонентра `condition` атрибут шута илмест.
 
-slider-markers-type-mismatch = Маркерсен тĕсĕ шуçтармăш тĕсĕпе килĕшмест.
+slider-markers-type-mismatch = Маркерсен тӗсӗ шуҫтармӑш тӗсӗпе килӗшмест.
 
-pretzel-problem-needs-statement-and-answer = Тĕрĕс мар pretzel: кашни `<problem>` пĕр `<statement>` тата пĕр `<answer>` тытмалла.
+pretzel-problem-needs-statement-and-answer = Тӗрӗс мар pretzel: кашни `<problem>` пӗр `<statement>` тата пӗр `<answer>` тытмалла.
 
-pretzel-circuit-first-problem-distractor = Тĕрĕс мар pretzel: mode="circuit" режимĕнче пĕрремĕш `<problem>` тимлĕхе аяккалла пăракан пулма пултараймасть.
+pretzel-circuit-first-problem-distractor = Тӗрӗс мар pretzel: mode="circuit" режимӗнче пӗрремӗш `<problem>` тимлӗхе аяккалла пӑракан пулма пултараймасть.
 
 ## Attribute values
 
 attribute-invalid-values =
     { $valuesCount ->
-        [one] `{ $attribute }` атрибут валли тĕрĕс мар хак { $values }; шута илмест.
-       *[other] `{ $attribute }` атрибут валли тĕрĕс мар хаксем { $values }; шута илмеççĕ.
+        [one] `{ $attribute }` атрибут валли тӗрӗс мар хак { $values }; шута илмест.
+       *[other] `{ $attribute }` атрибут валли тӗрӗс мар хаксем { $values }; шута илмеҫҫӗ.
     }
 
-attribute-must-be-references = `{ $attribute }` атрибут валли тĕрĕс мар хак `{ $value }`. Атрибут `$` палăртупа пуçланакан каçăсенчен тăмалла.
+attribute-must-be-references = `{ $attribute }` атрибут валли тӗрӗс мар хак `{ $value }`. Атрибут `$` палӑртупа пуҫланакан каҫӑсенчен тӑмалла.
 
-math-input-invalid-function-names = <mathInput>: { $attribute } ăшĕнчи тĕрĕс мар функци ячĕсене шута илмерĕ: { $names }. Кашни ятăн курăнакан пайĕ чи сахалран 2 палăрту пулмалла (сас паллисем е тире); ун хыççăн кирлĕ мар `|<mathspeak альтернатива>` хушăмĕ пыма пултарать.
+math-input-invalid-function-names = <mathInput>: { $attribute } ӑшӗнчи тӗрӗс мар функци ячӗсене шута илмерӗ: { $names }. Кашни ятӑн курӑнакан пайӗ чи сахалран 2 палӑрту пулмалла (сас паллисем е тире); ун хыҫҫӑн кирлӗ мар `|<mathspeak альтернатива>` хушӑмӗ пыма пултарать.
 
 ## Building components from the source
 
-component-type-invalid = Тĕрĕс мар компонент тĕсĕ: `<{ $componentType }>`
+component-type-invalid = Тӗрӗс мар компонент тӗсӗ: `<{ $componentType }>`
 
-attribute-repeated = { $attribute } атрибута тепĕр хут пама пулмасть.
+attribute-repeated = { $attribute } атрибута тепӗр хут пама пулмасть.
 
-attribute-invalid-for-component = `<{ $componentType }>` тĕслĕ компонент валли тĕрĕс мар атрибут «{ $attribute }».
+attribute-invalid-for-component = `<{ $componentType }>` тӗслӗ компонент валли тӗрӗс мар атрибут «{ $attribute }».
 
 ## Style definition contrast
 
 style-definition-insufficient-contrast =
-    { $styleNumber } стиль палăртăвĕнче { $context ->
-        [text-on-background] текст тĕсĕпе фон тĕсĕ
-        [high-contrast] пысăк контрастлă тĕспе ӳкерӳ лаптăкĕ
-        [line] йĕр тĕсĕпе ӳкерӳ лаптăкĕ
-        [marker] маркер тĕсĕпе ӳкерӳ лаптăкĕ
-       *[text-on-canvas] текст тĕсĕпе ӳкерӳ лаптăкĕ
-    } хушшинчи контраст çителĕксĕр{ $mode ->
-        [dark] { " (тĕттĕм тĕс)" }
+    { $styleNumber } стиль палӑртӑвӗнче { $context ->
+        [text-on-background] текст тӗсӗпе фон тӗсӗ
+        [high-contrast] пысӑк контрастлӑ тӗспе ӳкерӳ лаптӑкӗ
+        [line] йӗр тӗсӗпе ӳкерӳ лаптӑкӗ
+        [marker] маркер тӗсӗпе ӳкерӳ лаптӑкӗ
+       *[text-on-canvas] текст тӗсӗпе ӳкерӳ лаптӑкӗ
+    } хушшинчи контраст ҫителӗксӗр{ $mode ->
+        [dark] { " (тӗттӗм тӗс)" }
        *[light] { "" }
-    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ).
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлӗ).
 
 style-definition-dark-mode-text-background-contrast =
-    { $styleNumber } стиль палăртăвĕнче панă тĕссем çутă тĕс валли çителĕклĕ контраст парсан та, вĕсенчен тухнă тĕттĕм тĕс тĕсĕсем текстпа фон хушшинче çителĕклĕ контраст памаççĕ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ). { $suggestion ->
-        [available] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен е çутă тĕсри контраста ӳстерĕр (тĕслĕхрен { $lightAttribute }="{ $lightColor }"), е тĕттĕм тĕс тĕсне улăштарăр (тĕслĕхрен { $darkAttribute }="{ $darkColor }").
-       *[none] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен çутă тĕсри контраста ӳстерĕр е тухнă тĕссене textColorDarkMode тата/е backgroundColorDarkMode урлă улăштарăр.
+    { $styleNumber } стиль палӑртӑвӗнче панӑ тӗссем ҫутӑ тӗс валли ҫителӗклӗ контраст парсан та, вӗсенчен тухнӑ тӗттӗм тӗс тӗсӗсем текстпа фон хушшинче ҫителӗклӗ контраст памаҫҫӗ ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлӗ). { $suggestion ->
+        [available] Тӗттӗм тӗсре ҫителӗклӗ контраст тӑвас тесен е ҫутӑ тӗсри контраста ӳстерӗр (тӗслӗхрен { $lightAttribute }="{ $lightColor }"), е тӗттӗм тӗс тӗсне улӑштарӑр (тӗслӗхрен { $darkAttribute }="{ $darkColor }").
+       *[none] Тӗттӗм тӗсре ҫителӗклӗ контраст тӑвас тесен ҫутӑ тӗсри контраста ӳстерӗр е тухнӑ тӗссене textColorDarkMode тата/е backgroundColorDarkMode урлӑ улӑштарӑр.
     }
 
 style-definition-dark-mode-text-canvas-contrast =
-    { $styleNumber } стиль палăртăвĕнче панă текст тĕсĕ çутă тĕс валли çителĕклĕ контраст парсан та, унран тухнă тĕттĕм тĕс текст тĕсĕ ӳкерӳ лаптăкĕпе çителĕклĕ контраст памасть ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлĕ). { $suggestion ->
-        [available] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен е çутă тĕсри контраста ӳстерĕр (тĕслĕхрен textColor="{ $lightColor }"), е тĕттĕм тĕс тĕсне улăштарăр (тĕслĕхрен textColorDarkMode="{ $darkColor }").
-       *[none] Тĕттĕм тĕсре çителĕклĕ контраст тăвас тесен çутă тĕсри контраста ӳстерĕр е тухнă тĕсе textColorDarkMode урлă улăштарăр.
+    { $styleNumber } стиль палӑртӑвӗнче панӑ текст тӗсӗ ҫутӑ тӗс валли ҫителӗклӗ контраст парсан та, унран тухнӑ тӗттӗм тӗс текст тӗсӗ ӳкерӳ лаптӑкӗпе ҫителӗклӗ контраст памасть ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; чи сахалран { $threshold }:1 кирлӗ). { $suggestion ->
+        [available] Тӗттӗм тӗсре ҫителӗклӗ контраст тӑвас тесен е ҫутӑ тӗсри контраста ӳстерӗр (тӗслӗхрен textColor="{ $lightColor }"), е тӗттӗм тӗс тӗсне улӑштарӑр (тӗслӗхрен textColorDarkMode="{ $darkColor }").
+       *[none] Тӗттӗм тӗсре ҫителӗклӗ контраст тӑвас тесен ҫутӑ тӗсри контраста ӳстерӗр е тухнӑ тӗсе textColorDarkMode урлӑ улӑштарӑр.
     }
 
-section-multiple-style-palettes = Пай пĕр <stylePalette> кăна суйлама пултарать; юлашкипе усă курать.
+section-multiple-style-palettes = Пай пӗр <stylePalette> кӑна суйлама пултарать; юлашкипе усӑ курать.
 
 ## Unique variants
 
-variant-num-to-select-not-non-negative-integer = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен numToSelect негативлă мар тулли хисеп мар.
+variant-num-to-select-not-non-negative-integer = { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен numToSelect негативлӑ мар тулли хисеп мар.
 
-variant-num-to-select-not-constant-number = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен numToSelect тăтăш хисеп мар.
+variant-num-to-select-not-constant-number = { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен numToSelect тӑтӑш хисеп мар.
 
-variant-with-replacement-not-constant-boolean = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен withReplacement тăтăш логика хакĕ мар.
+variant-with-replacement-not-constant-boolean = { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен withReplacement тӑтӑш логика хакӗ мар.
 
-variant-select-weight-disables-unique = хăш те пулин суйлавра selectWeight е selectForVariants панă пулсан, select валли пĕр пек мар вариантсем сӳнеççĕ
+variant-select-weight-disables-unique = хӑш те пулин суйлавра selectWeight е selectForVariants панӑ пулсан, select валли пӗр пек мар вариантсем сӳнеҫҫӗ
 
-variant-coprime-undetermined = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен coprime яланах суя-и, çавна тупма пулмасть.
+variant-coprime-undetermined = { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен coprime яланах суя-и, ҫавна тупма пулмасть.
 
-variant-attribute-not-constant = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен { $attribute } тăтăш мар.
+variant-attribute-not-constant = { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен { $attribute } тӑтӑш мар.
 
-variant-attribute-not-number = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен { $attribute } хисеп мар.
+variant-attribute-not-number = { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен { $attribute } хисеп мар.
 
 variant-attribute-wrong-type-for-sequence =
-    { $type } тĕслĕ { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен { $attribute } { $expected ->
-        [letters-combination] сас паллисен пĕрлешĕвĕ
-        [math-expression] юрăхлă математика палăртăвĕ
+    { $type } тӗслӗ { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен { $attribute } { $expected ->
+        [letters-combination] сас паллисен пӗрлешӗвӗ
+        [math-expression] юрӑхлӑ математика палӑртӑвӗ
         [integer] тулли хисеп
        *[number] хисеп
     } мар.
 
-variant-length-not-integer = { $component } валли пĕр пек мар вариантсене палăртма пулмасть, мĕншĕн тесен length тулли хисеп мар.
+variant-length-not-integer = { $component } валли пӗр пек мар вариантсене палӑртма пулмасть, мӗншӗн тесен length тулли хисеп мар.
 
-variant-sort-not-implemented = sort пур { $component } валли пĕр пек мар вариантсене пурнăçламан
+variant-sort-not-implemented = sort пур { $component } валли пӗр пек мар вариантсене пурнӑҫламан
 
-variant-exclude-combinations-not-implemented = excludeCombinations пур { $component } валли пĕр пек мар вариантсене пурнăçламан
+variant-exclude-combinations-not-implemented = excludeCombinations пур { $component } валли пӗр пек мар вариантсене пурнӑҫламан
 
-variant-math-exclude-not-implemented = exclude пур math тĕслĕ { $component } валли пĕр пек мар вариантсене пурнăçламан
+variant-math-exclude-not-implemented = exclude пур math тӗслӗ { $component } валли пӗр пек мар вариантсене пурнӑҫламан
 
-variant-non-constant-exclude-not-implemented = тăтăш мар exclude пур { $component } валли пĕр пек мар вариантсене пурнăçламан
+variant-non-constant-exclude-not-implemented = тӑтӑш мар exclude пур { $component } валли пӗр пек мар вариантсене пурнӑҫламан
 
 ## PreFigure conversion
 
-prefigure-descendant-unsupported = { $subject }: графикăн prefigure ӳкерекенĕнче пурнăçламан; тăхăмне сиктерсе хăварнă.
+prefigure-descendant-unsupported = { $subject }: графикӑн prefigure ӳкерекенӗнче пурнӑҫламан; тӑхӑмне сиктерсе хӑварнӑ.
 
-prefigure-descendant-invalid-geometry = { $subject }: вĕçсĕр е тулли мар геометри; тăхăмне сиктерсе хăварнă.
+prefigure-descendant-invalid-geometry = { $subject }: вӗҫсӗр е тулли мар геометри; тӑхӑмне сиктерсе хӑварнӑ.
 
-prefigure-curve-label-omitted = { $subject }: куçарнă кукăр элеменчĕсенче паллăсем пурнăçламан; паллăна сиктерсе хăварнă.
+prefigure-curve-label-omitted = { $subject }: куҫарнӑ кукӑр элеменчӗсенче паллӑсем пурнӑҫламан; паллӑна сиктерсе хӑварнӑ.
 
-prefigure-curve-unsupported-definition-type = { $subject }: пурнăçламан кукăр функци палăртăвĕн тĕсĕ «{ $definitionType }»; тăхăмне сиктерсе хăварнă.
+prefigure-curve-unsupported-definition-type = { $subject }: пурнӑҫламан кукӑр функци палӑртӑвӗн тӗсӗ «{ $definitionType }»; тӑхӑмне сиктерсе хӑварнӑ.
 
-prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементри flipFunctions атрибут пурнăçламан; тăхăмне сиктерсе хăварнă.
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементри flipFunctions атрибут пурнӑҫламан; тӑхӑмне сиктерсе хӑварнӑ.
 
-prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулăпа панă ача функцисене кăна йышăнать; тăхăмне сиктерсе хăварнă.
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулӑпа панӑ ача функцисене кӑна йышӑнать; тӑхӑмне сиктерсе хӑварнӑ.
 
 prefigure-label-position-unsupported =
-    { $subject }: пурнăçламан labelPosition «{ $labelPosition }» { $labelKind ->
-        [line-family] тӳрĕ йĕрсен йышĕн палли валли
-       *[point] пăнчă палли валли
-    }; PreFigure-ăн тĕп танлаштарăвĕ усă курать.
+    { $subject }: пурнӑҫламан labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] тӳрӗ йӗрсен йышӗн палли валли
+       *[point] пӑнчӑ палли валли
+    }; PreFigure-ӑн тӗп танлаштарӑвӗ усӑ курать.
 
-prefigure-fill-style-unsupported = { $subject }: тултару стилĕ «{ $fillStyle }» PreFigure валли пурнăçламан; тулли тултарăва куçать.
+prefigure-fill-style-unsupported = { $subject }: тултару стилӗ «{ $fillStyle }» PreFigure валли пурнӑҫламан; тулли тултарӑва куҫать.
 
-prefigure-line-style-unknown = { $subject }: паллă мар йĕр стилĕ «{ $lineStyle }» PreFigure тухăçĕнчен кăларнă.
+prefigure-line-style-unknown = { $subject }: паллӑ мар йӗр стилӗ «{ $lineStyle }» PreFigure тухӑҫӗнчен кӑларнӑ.
 
-prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стилĕ «{ $markerStyle }» PreFigure «diamond» стилĕпе танлаштарнă.
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стилӗ «{ $markerStyle }» PreFigure «diamond» стилӗпе танлаштарнӑ.
 
-prefigure-marker-style-unsupported = { $subject }: маркер стилĕ «{ $markerStyle }» PreFigure валли пурнăçламан; тĕп стиль усă курать.
+prefigure-marker-style-unsupported = { $subject }: маркер стилӗ «{ $markerStyle }» PreFigure валли пурнӑҫламан; тӗп стиль усӑ курать.
 
 ## PreFigure annotations
 
-annotation-ref-unresolvable = `<annotation>`: тĕрĕс мар `ref`; тĕллеве çыхăнтарма пулмасть. Асăрхаттарăва кăларнă.
+annotation-ref-unresolvable = `<annotation>`: тӗрӗс мар `ref`; тӗллеве ҫыхӑнтарма пулмасть. Асӑрхаттарӑва кӑларнӑ.
 
-annotation-ref-multiple-targets = `<annotation>`: `ref` темиçе тĕллевпе çыхăнчĕ; пĕрремĕшĕпе усă курать.
+annotation-ref-multiple-targets = `<annotation>`: `ref` темиҫе тӗллевпе ҫыхӑнчӗ; пӗрремӗшӗпе усӑ курать.
 
-annotation-ref-outside-graph = `<annotation>`: тĕрĕс мар `ref`; тĕллев ăна тытакан графикран тулашра. Асăрхаттарăва кăларнă.
+annotation-ref-outside-graph = `<annotation>`: тӗрӗс мар `ref`; тӗллев ӑна тытакан графикран тулашра. Асӑрхаттарӑва кӑларнӑ.
 
-annotation-ref-unsupported-target = `<annotation>`: тĕрĕс мар `ref`; тĕллев prefigure куçарăвĕнче пурнăçланă график объект мар. Асăрхаттарăва кăларнă.
+annotation-ref-unsupported-target = `<annotation>`: тӗрӗс мар `ref`; тӗллев prefigure куҫарӑвӗнче пурнӑҫланӑ график объект мар. Асӑрхаттарӑва кӑларнӑ.
 
-annotation-text-missing = `<annotation>`: `text` çук е пушă; пушă текст кăларать.
+annotation-text-missing = `<annotation>`: `text` ҫук е пушӑ; пушӑ текст кӑларать.
 
 ## Composites and references
 
 composite-circular-dependency =
     { $componentType ->
-        [none] Çавра çыхăну тупăнчĕ.
-       *[other] `<{ $componentType }>` компонента тытакан çавра çыхăну тупăнчĕ.
+        [none] Ҫавра ҫыхӑну тупӑнчӗ.
+       *[other] `<{ $componentType }>` компонента тытакан ҫавра ҫыхӑну тупӑнчӗ.
     }
 
-reference-no-referent = Каçă валли объект тупăнмарĕ: `{ $reference }`
+reference-no-referent = Каҫӑ валли объект тупӑнмарӗ: `{ $reference }`
 
-reference-multiple-referents = Каçă валли темиçе объект тупăнчĕ: `{ $reference }`
+reference-multiple-referents = Каҫӑ валли темиҫе объект тупӑнчӗ: `{ $reference }`
 
 ## Children that do not match
 
-children-invalid-attribute-format = `<{ $componentType }>` элементăн { $attribute } атрибучĕн форматне йышăнмасть.
+children-invalid-attribute-format = `<{ $componentType }>` элементӑн { $attribute } атрибучӗн форматне йышӑнмасть.
 
-children-invalid = `<{ $componentType }>` валли тĕрĕс мар ачасем: тĕрĕс мар ачасем тупăнчĕç: { $children }
+children-invalid = `<{ $componentType }>` валли тӗрӗс мар ачасем: тӗрӗс мар ачасем тупӑнчӗҫ: { $children }
 
 ## Falling back to a default
 
-attribute-value-invalid-using-default = `{ $attribute }` атрибут валли тĕрĕс мар хак `{ $value }`; `{ $default }` хакĕ усă курать
+attribute-value-invalid-using-default = `{ $attribute }` атрибут валли тӗрӗс мар хак `{ $value }`; `{ $default }` хакӗ усӑ курать
 
 ## Loading a DoenetML version
 
 doenetml-version-not-found =
     { $fallback ->
-        [none] DoenetML { $version } версийĕ тупăнмарĕ.
-       *[other] DoenetML { $version } версийĕ тупăнмарĕ. { $fallback } версийĕ усă курать
+        [none] DoenetML { $version } версийӗ тупӑнмарӗ.
+       *[other] DoenetML { $version } версийӗ тупӑнмарӗ. { $fallback } версийӗ усӑ курать
     }
 
 ## Reading the DoenetML
 
-parse-invalid-doenetml = Тĕрĕс мар DoenetML: { $content }
+parse-invalid-doenetml = Тӗрӗс мар DoenetML: { $content }
 
-parse-tag-missing-close-tag = Тĕрĕс мар DoenetML: `{ $tag }` тегăн хупакан тегĕ çук. Хăйне хăй хупакан тег е `</{ $tagName }>` тег кĕтнĕччĕ.
+parse-tag-missing-close-tag = Тӗрӗс мар DoenetML: `{ $tag }` тегӑн хупакан тегӗ ҫук. Хӑйне хӑй хупакан тег е `</{ $tagName }>` тег кӗтнӗччӗ.
 
-parse-tag-error = Тĕрĕс мар DoenetML: `<{ $tagName }>` тегра йăнăш
+parse-tag-error = Тӗрӗс мар DoenetML: `<{ $tagName }>` тегра йӑнӑш
 
-parse-attribute-missing-value = Тĕрĕс мар DoenetML: `{ $attribute }` атрибутра хак çитмен пек.
+parse-attribute-missing-value = Тӗрӗс мар DoenetML: `{ $attribute }` атрибутра хак ҫитмен пек.
 
-parse-attribute-invalid = Тĕрĕс мар DoenetML: тĕрĕс мар атрибут `{ $attribute }`
+parse-attribute-invalid = Тӗрӗс мар DoenetML: тӗрӗс мар атрибут `{ $attribute }`
 
-parse-attribute-value-invalid = Тĕрĕс мар DoenetML: атрибутăн тĕрĕс мар хакĕ `{ $value }`
+parse-attribute-value-invalid = Тӗрӗс мар DoenetML: атрибутӑн тӗрӗс мар хакӗ `{ $value }`
 
-parse-attribute-value-quote-mismatch = Тĕрĕс мар DoenetML: атрибутăн тĕрĕс мар хакĕ `{ $value }`. Чĕрнесем килĕшмеççĕ. `{ $quote }` çитмен пек
+parse-attribute-value-quote-mismatch = Тӗрӗс мар DoenetML: атрибутӑн тӗрӗс мар хакӗ `{ $value }`. Чӗрнесем килӗшмеҫҫӗ. `{ $quote }` ҫитмен пек
 
-parse-open-tag-name-missing = Тĕрĕс мар DoenetML: ятсăр тег тупăнчĕ, тĕслĕхрен `<`
+parse-open-tag-name-missing = Тӗрӗс мар DoenetML: ятсӑр тег тупӑнчӗ, тӗслӗхрен `<`
 
-parse-tag-not-closed = Тĕрĕс мар DoenetML: `{ $tag }` тега хупман (`>` çитмен пек).
+parse-tag-not-closed = Тӗрӗс мар DoenetML: `{ $tag }` тега хупман (`>` ҫитмен пек).
 
-parse-self-closing-tag-name-missing = Тĕрĕс мар DoenetML: ятсăр тег тупăнчĕ `<{ $content }>`
+parse-self-closing-tag-name-missing = Тӗрӗс мар DoenetML: ятсӑр тег тупӑнчӗ `<{ $content }>`
 
-parse-self-closing-tag-not-closed = Тĕрĕс мар DoenetML: `{ $tag }` тега хупман (`/>` çитмен пек).
+parse-self-closing-tag-not-closed = Тӗрӗс мар DoenetML: `{ $tag }` тега хупман (`/>` ҫитмен пек).
 
-parse-tag-invalid-attributes = Тĕрĕс мар DoenetML: `{ $tag }` тег юрăхлă мар. Унăн атрибучĕсем тĕрĕс мар пулма пултараççĕ.
+parse-tag-invalid-attributes = Тӗрӗс мар DoenetML: `{ $tag }` тег юрӑхлӑ мар. Унӑн атрибучӗсем тӗрӗс мар пулма пултараҫҫӗ.
 
-parse-close-tag-name-missing = Тĕрĕс мар DoenetML: ятсăр хупакан тег тупăнчĕ, тĕслĕхрен `</`
+parse-close-tag-name-missing = Тӗрӗс мар DoenetML: ятсӑр хупакан тег тупӑнчӗ, тӗслӗхрен `</`
 
-parse-attribute-value-unquoted = Атрибут хакĕсем чĕрне ăшĕнче пулмалла: `{ $attribute }="{ $value }"`
+parse-attribute-value-unquoted = Атрибут хакӗсем чӗрне ӑшӗнче пулмалла: `{ $attribute }="{ $value }"`
 
-parse-close-tag-without-open-tag = Тĕрĕс мар DoenetML: `{ $tag }` хупакан тег тупăнчĕ, анчах ăна тивĕçекен уçакан тег çук
+parse-close-tag-without-open-tag = Тӗрӗс мар DoenetML: `{ $tag }` хупакан тег тупӑнчӗ, анчах ӑна тивӗҫекен уҫакан тег ҫук
 
-parse-close-tag-mismatched = Тĕрĕс мар DoenetML: килĕшмен хупакан тег. `</{ $expected }>` кĕтнĕччĕ. `{ $found }` тупăнчĕ
+parse-close-tag-mismatched = Тӗрӗс мар DoenetML: килӗшмен хупакан тег. `</{ $expected }>` кӗтнӗччӗ. `{ $found }` тупӑнчӗ
 
-parser-node-unconvertible = { $node } тĕввине Dast тĕввине куçарма пулмарĕ.
+parser-node-unconvertible = { $node } тӗввине Dast тӗввине куҫарма пулмарӗ.
 
 ## Names
 
 name-attribute-invalid =
-    Тĕрĕс мар атрибут name='{ $name }'. { $reason ->
-        [characters] Ятсенче сас паллисем, хисепсем, аялти тире е тире кăна пулма пултараççĕ.
-       *[start] Ятсем сас палли-ран пуçланмалла.
+    Тӗрӗс мар атрибут name='{ $name }'. { $reason ->
+        [characters] Ятсенче сас паллисем, хисепсем, аялти тире е тире кӑна пулма пултараҫҫӗ.
+       *[start] Ятсем сас палли-ран пуҫланмалла.
     }
 
-component-name-invalid-start = Тĕрĕс мар компонент ячĕ «{ $name }». Ятсем сас палли-ран пуçланмалла.
+component-name-invalid-start = Тӗрӗс мар компонент ячӗ «{ $name }». Ятсем сас палли-ран пуҫланмалла.
 
 ## `<answer>` sugar
 
-answer-video-watched-missing-video = videoWatched тĕслĕ answer-ăн video атрибучĕ пулмалла
+answer-video-watched-missing-video = videoWatched тӗслӗ answer-ӑн video атрибучӗ пулмалла
 
-answer-video-watched-video-not-reference = videoWatched тĕслĕ answer-ăн video атрибучĕ каçă пулмалла
+answer-video-watched-video-not-reference = videoWatched тӗслӗ answer-ӑн video атрибучӗ каҫӑ пулмалла
 
-answer-name-not-single-text = answer-ăн name атрибучĕн шăп пĕр текст ачи пулмалла
+answer-name-not-single-text = answer-ӑн name атрибучӗн шӑп пӗр текст ачи пулмалла
 
 ## Referencing another document
 
-external-doenetml-recursion-limit = Рекурси шайĕсем ытла нумай пулнипе тулашри DoenetML-а илме пулмарĕ. Çавра каçă çук-и?
+external-doenetml-recursion-limit = Рекурси шайӗсем ытла нумай пулнипе тулашри DoenetML-а илме пулмарӗ. Ҫавра каҫӑ ҫук-и?
 
-external-doenetml-unavailable = { $attribute }="{ $uri }" адресран DoenetML илме пулмарĕ
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресран DoenetML илме пулмарӗ
 
-external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресран тĕрĕс мар DoenetML илнĕ: вăл «{ $componentType }» компонент тĕсĕпе килĕшмерĕ
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресран тӗрӗс мар DoenetML илнӗ: вӑл «{ $componentType }» компонент тӗсӗпе килӗшмерӗ
 
 ## Deprecated syntax
 
 deprecated-attribute-renamed =
     { $component ->
-        [none] [deprecation] `{ $from }` атрибут кивелнĕ; ун вырăнне `{ $to }` усă курăр.
-       *[other] [deprecation] `<{ $component }>` элементри `{ $from }` атрибут кивелнĕ; ун вырăнне `{ $to }` усă курăр.
+        [none] [deprecation] `{ $from }` атрибут кивелнӗ; ун вырӑнне `{ $to }` усӑ курӑр.
+       *[other] [deprecation] `<{ $component }>` элементри `{ $from }` атрибут кивелнӗ; ун вырӑнне `{ $to }` усӑ курӑр.
     }
 
 deprecated-attribute-renamed-conflict =
     { $component ->
-        [none] [deprecation] `{ $from }` атрибут кивелнĕ тата шута илмест, мĕншĕн тесен `{ $to }` та панă.
-       *[other] [deprecation] `<{ $component }>` элементри `{ $from }` атрибут кивелнĕ тата шута илмест, мĕншĕн тесен `{ $to }` та панă.
+        [none] [deprecation] `{ $from }` атрибут кивелнӗ тата шута илмест, мӗншӗн тесен `{ $to }` та панӑ.
+       *[other] [deprecation] `<{ $component }>` элементри `{ $from }` атрибут кивелнӗ тата шута илмест, мӗншӗн тесен `{ $to }` та панӑ.
     }
 
-deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибут кивелнĕ тата шута илмест.
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибут кивелнӗ тата шута илмест.
 
-deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибут кивелнĕ; ун вырăнне `<{ $child }>` ачипе усă курăр.
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибут кивелнӗ; ун вырӑнне `<{ $child }>` ачипе усӑ курӑр.
 
-deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибутăн `{ $value }` хакĕ кивелнĕ; ун вырăнне `{ $to }` усă курăр.
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементри `{ $attribute }` атрибутӑн `{ $value }` хакӗ кивелнӗ; ун вырӑнне `{ $to }` усӑ курӑр.
 
 
 ## Language coverage
 
-pluralize-english-only = `<pluralize>` нумайлă хисепе акăлчанла кăна тăвать, çавăнпа { $locale } чĕлхипе çырнă документра унăн тексчĕ улшăнмасăр юлать. Нумайлă формине хăвăр çырăр е ăна `pluralForm` атрибутпа парăр.
+pluralize-english-only = `<pluralize>` нумайлӑ хисепе акӑлчанла кӑна тӑвать, ҫавӑнпа { $locale } чӗлхипе ҫырнӑ документра унӑн тексчӗ улшӑнмасӑр юлать. Нумайлӑ формине хӑвӑр ҫырӑр е ӑна `pluralForm` атрибутпа парӑр.
 
 
 ## Checking against the schema
 
-schema-element-unrecognized = `<{ $tag }>` элемент палланă Doenet элеменчĕ мар.
+schema-element-unrecognized = `<{ $tag }>` элемент палланӑ Doenet элеменчӗ мар.
 
-schema-element-not-allowed-at-root = `<{ $tag }>` элемента документăн тымарĕнче ирĕк памаççĕ.
+schema-element-not-allowed-at-root = `<{ $tag }>` элемента документӑн тымарӗнче ирӗк памаҫҫӗ.
 
-schema-element-not-allowed-inside = `<{ $tag }>` элемента `<{ $parent }>` ăшĕнче ирĕк памаççĕ.
+schema-element-not-allowed-inside = `<{ $tag }>` элемента `<{ $parent }>` ӑшӗнче ирӗк памаҫҫӗ.
 
-schema-attribute-unrecognized = `<{ $tag }>` элементра `{ $attribute }` ятлă атрибут çук.
+schema-attribute-unrecognized = `<{ $tag }>` элементра `{ $attribute }` ятлӑ атрибут ҫук.
 
 schema-attribute-value-not-allowed =
     { $isList ->
-        [true] `<{ $tag }>` элементăн `{ $attribute }` атрибучĕ кашни элеменчĕ çаксенчен пĕри пулакан список пулмалла: { $allowed }
-       *[other] `<{ $tag }>` элементăн `{ $attribute }` атрибучĕ çаксенчен пĕри пулмалла: { $allowed }
+        [true] `<{ $tag }>` элементӑн `{ $attribute }` атрибучӗ кашни элеменчӗ ҫаксенчен пӗри пулакан список пулмалла: { $allowed }
+       *[other] `<{ $tag }>` элементӑн `{ $attribute }` атрибучӗ ҫаксенчен пӗри пулмалла: { $allowed }
     }
 
 
 ## The `<select>` family's error boxes
 
-select-variant-name-option-count-mismatch = select валли тĕрĕс мар вариант ячĕ. { $variantName } вариант ячĕ { $numOptions } суйлавра тĕл пулать, суйламалли йышĕ вара { $numToSelect }.
+select-variant-name-option-count-mismatch = select валли тӗрӗс мар вариант ячӗ. { $variantName } вариант ячӗ { $numOptions } суйлавра тӗл пулать, суйламалли йышӗ вара { $numToSelect }.
 
-select-variant-name-without-options = select валли вариантсем панă, анчах пулма пултаракан вариант ячĕ валли пĕр суйлав та çук: { $variantName }.
+select-variant-name-without-options = select валли вариантсем панӑ, анчах пулма пултаракан вариант ячӗ валли пӗр суйлав та ҫук: { $variantName }.
 
-select-variant-name-not-possible = select валли панă { $variantName } вариант ячĕ пулма пултаракан вариант ячĕ мар.
+select-variant-name-not-possible = select валли панӑ { $variantName } вариант ячӗ пулма пултаракан вариант ячӗ мар.
 
-select-too-few-options = Пурĕ { $numOptions } шутĕнчен { $numToSelect } компонент суйлама пулмасть.
+select-too-few-options = Пурӗ { $numOptions } шутӗнчен { $numToSelect } компонент суйлама пулмасть.
 
-select-from-sequence-too-few-values = Вăрăмăшĕ { $length } йĕркелĕхрен { $numToSelect } хак суйлама пулмасть.
+select-from-sequence-too-few-values = Вӑрӑмӑшӗ { $length } йӗркелӗхрен { $numToSelect } хак суйлама пулмасть.
 
-select-from-sequence-indices-count-mismatch = select валли панă индекссен йышĕ суйламалли йышпа килĕшмелле
+select-from-sequence-indices-count-mismatch = select валли панӑ индекссен йышӗ суйламалли йышпа килӗшмелле
 
-select-from-sequence-indices-not-integers = select валли панă пур индекс та тулли хисеп пулмалла
+select-from-sequence-indices-not-integers = select валли панӑ пур индекс та тулли хисеп пулмалла
 
-select-from-sequence-index-excluded = selectfromsequence валли панă индекса кăларнăччĕ
+select-from-sequence-index-excluded = selectfromsequence валли панӑ индекса кӑларнӑччӗ
 
-select-from-sequence-indices-excluded-combination = selectfromsequence валли панă индекссем кăларнă пĕрлешӳ пулнă
+select-from-sequence-indices-excluded-combination = selectfromsequence валли панӑ индекссем кӑларнӑ пӗрлешӳ пулнӑ
 
-select-from-sequence-coprime-not-positive-integers = Позитивлă тулли хисепсем суйламаннипе хăйсем хушшинче ансат пĕрлешӳсене суйлама пулмасть.
+select-from-sequence-coprime-not-positive-integers = Позитивлӑ тулли хисепсем суйламаннипе хӑйсем хушшинче ансат пӗрлешӳсене суйлама пулмасть.
 
-select-from-sequence-coprime-common-factor = Хăйсем хушшинче ансат хисепсене суйлама пулмасть. Пулма пултаракан пур хакăн та пĕрлехи пайлаканĕ пур. (Панă "from" е "to" хакĕсем "step"-па хăйсем хушшинче ансат пулмалла.)
+select-from-sequence-coprime-common-factor = Хӑйсем хушшинче ансат хисепсене суйлама пулмасть. Пулма пултаракан пур хакӑн та пӗрлехи пайлаканӗ пур. (Панӑ "from" е "to" хакӗсем "step"-па хӑйсем хушшинче ансат пулмалла.)
 
-select-from-sequence-coprime-single-number = 1 мар пĕртен-пĕр хисепрен хăйсем хушшинче ансат пĕрлешӳсене суйлама пулмасть.
+select-from-sequence-coprime-single-number = 1 мар пӗртен-пӗр хисепрен хӑйсем хушшинче ансат пӗрлешӳсене суйлама пулмасть.
 
-select-from-sequence-excluded-too-many-combinations = selectFromSequence ăшĕнче пĕрлешӳсен 70%-ран ытлашшине кăларнă
+select-from-sequence-excluded-too-many-combinations = selectFromSequence ӑшӗнче пӗрлешӳсен 70%-ран ытлашшине кӑларнӑ
 
-select-from-sequence-coprime-none-found = Хăйсем хушшинче ансат хисепсене суйлама пулмарĕ. Пулма пултаракан пур хакăн та пĕрлехи пайлаканĕ пур.
+select-from-sequence-coprime-none-found = Хӑйсем хушшинче ансат хисепсене суйлама пулмарӗ. Пулма пултаракан пур хакӑн та пӗрлехи пайлаканӗ пур.
 
-select-from-sequence-too-few-unique-values = Вăрăмăшĕ { $numPossibleValues } йĕркелĕхрен { $numToSelect } тĕрлĕ хак суйлама пулмасть
+select-from-sequence-too-few-unique-values = Вӑрӑмӑшӗ { $numPossibleValues } йӗркелӗхрен { $numToSelect } тӗрлӗ хак суйлама пулмасть
 
-select-prime-numbers-too-few-values = Вăрăмăшĕ { $numValues } ансат хисепсен спискинчен { $numToSelect } хак суйлама пулмасть
+select-prime-numbers-too-few-values = Вӑрӑмӑшӗ { $numValues } ансат хисепсен спискинчен { $numToSelect } хак суйлама пулмасть
 
-select-prime-numbers-values-count-mismatch = select валли панă хаксен йышĕ суйламалли йышпа килĕшмелле
+select-prime-numbers-values-count-mismatch = select валли панӑ хаксен йышӗ суйламалли йышпа килӗшмелле
 
-select-prime-numbers-values-not-prime = select prime number валли панă пур хак та ансат хисепсен спискинче пулмалла
+select-prime-numbers-values-not-prime = select prime number валли панӑ пур хак та ансат хисепсен спискинче пулмалла
 
-select-prime-numbers-values-excluded-combination = selectPrimeNumbers валли панă хаксем кăларнă пĕрлешӳ пулнă
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers валли панӑ хаксем кӑларнӑ пӗрлешӳ пулнӑ
 
-select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ăшĕнче пĕрлешӳсен 70%-ран ытлашшине кăларнă
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers ӑшӗнче пӗрлешӳсен 70%-ран ытлашшине кӑларнӑ
 
-select-random-combination-fluke = Питĕ пулма пултарайман ăнсăртлăх пирки ăнсăрт хаксен пĕрлешĕвне суйлама пулмарĕ
+select-random-combination-fluke = Питӗ пулма пултарайман ӑнсӑртлӑх пирки ӑнсӑрт хаксен пӗрлешӗвне суйлама пулмарӗ
 
-select-random-value-fluke = Питĕ пулма пултарайман ăнсăртлăх пирки ăнсăрт хака суйлама пулмарĕ
+select-random-value-fluke = Питӗ пулма пултарайман ӑнсӑртлӑх пирки ӑнсӑрт хака суйлама пулмарӗ

--- a/packages/i18n/locales/cv/editor.ftl
+++ b/packages/i18n/locales/cv/editor.ftl
@@ -22,13 +22,13 @@
 editor-update-viewer =
     { $action ->
         [reset] Каялла
-       *[update] Çĕнетес
+       *[update] Ҫӗнетес
     }
 
 editor-update-viewer-title =
     { $shortcut ->
-        [none] Пăхмаллине { $word }
-       *[other] Пăхмаллине { $word } { $shortcut }
+        [none] Пӑхмаллине { $word }
+       *[other] Пӑхмаллине { $word } { $shortcut }
     }
 
 
@@ -36,7 +36,7 @@ editor-update-viewer-title =
 
 editor-variant = Вариант
 editor-variant-filter = Суйласа илни…
-editor-variant-next = Тепĕр варианта суйлас
+editor-variant-next = Тепӗр варианта суйлас
 editor-variant-previous = Малтанхи варианта суйлас
 
 
@@ -44,42 +44,42 @@ editor-variant-previous = Малтанхи варианта суйлас
 
 editor-accessibility-title =
     { $status ->
-        [violations] WCAG AA майлăх пăсăлăвĕ тупăнчĕ. Майлăх отчетне { $action ->
+        [violations] WCAG AA майлӑх пӑсӑлӑвӗ тупӑнчӗ. Майлӑх отчетне { $action ->
             [close] хупма
-           *[open] уçма
-        } пусăр.
-        [advisories] Майлăх отчетне { $action ->
+           *[open] уҫма
+        } пусӑр.
+        [advisories] Майлӑх отчетне { $action ->
             [close] хупма
-           *[open] уçма
-        } пусăр. WCAG AA пăсăлăвĕсем тупăнмарĕç, анчах хушма сĕнӳсем пур.
-       *[clean] Майлăх отчетне { $action ->
+           *[open] уҫма
+        } пусӑр. WCAG AA пӑсӑлӑвӗсем тупӑнмарӗҫ, анчах хушма сӗнӳсем пур.
+       *[clean] Майлӑх отчетне { $action ->
             [close] хупма
-           *[open] уçма
-        } пусăр. Майлăх проблемисем тупăнмарĕç.
+           *[open] уҫма
+        } пусӑр. Майлӑх проблемисем тупӑнмарӗҫ.
     }
 
 editor-accessibility-label =
     { $status ->
-        [violations] WCAG AA майлăх пăсăлăвĕ тупăнчĕ. { $count ->
-            [zero] Пĕр WCAG AA пăсăлăвĕ те
-            [one] { $count } WCAG AA пăсăлăвĕ
-           *[other] { $count } WCAG AA пăсăлăвĕ
-        } тупăнчĕ. Майлăх отчетне { $action ->
+        [violations] WCAG AA майлӑх пӑсӑлӑвӗ тупӑнчӗ. { $count ->
+            [zero] Пӗр WCAG AA пӑсӑлӑвӗ те
+            [one] { $count } WCAG AA пӑсӑлӑвӗ
+           *[other] { $count } WCAG AA пӑсӑлӑвӗ
+        } тупӑнчӗ. Майлӑх отчетне { $action ->
             [close] хупма
-           *[open] уçма
-        } пусăр.
-        [advisories] WCAG AA пăсăлăвĕсем тупăнмарĕç. { $count ->
-            [zero] Пĕр хушма сĕнӳ те
-            [one] { $count } хушма сĕнӳ
-           *[other] { $count } хушма сĕнӳ
-        } тупăнчĕ. Майлăх отчетне { $action ->
+           *[open] уҫма
+        } пусӑр.
+        [advisories] WCAG AA пӑсӑлӑвӗсем тупӑнмарӗҫ. { $count ->
+            [zero] Пӗр хушма сӗнӳ те
+            [one] { $count } хушма сӗнӳ
+           *[other] { $count } хушма сӗнӳ
+        } тупӑнчӗ. Майлӑх отчетне { $action ->
             [close] хупма
-           *[open] уçма
-        } пусăр.
-       *[clean] WCAG AA пăсăлăвĕсем тупăнмарĕç. Майлăх отчетне { $action ->
+           *[open] уҫма
+        } пусӑр.
+       *[clean] WCAG AA пӑсӑлӑвӗсем тупӑнмарӗҫ. Майлӑх отчетне { $action ->
             [close] хупма
-           *[open] уçма
-        } пусăр.
+           *[open] уҫма
+        } пусӑр.
     }
 
 editor-accessibility-badge = WCAG
@@ -87,132 +87,132 @@ editor-accessibility-badge = WCAG
 
 ## The footer
 
-editor-version-title = DoenetML версийĕ { $version }
+editor-version-title = DoenetML версийӗ { $version }
 
-editor-tab-help = Контекст пулăшăвĕ
+editor-tab-help = Контекст пулӑшӑвӗ
 editor-tab-help-short = Контекст
-editor-tab-errors = Йăнăшсем
-editor-tab-warnings = Асăрхаттарусем
+editor-tab-errors = Йӑнӑшсем
+editor-tab-warnings = Асӑрхаттарусем
 editor-tab-info = Информаци
-editor-tab-accessibility = Майлăх
-editor-tab-responses = Янă хуравсем
+editor-tab-accessibility = Майлӑх
+editor-tab-responses = Янӑ хуравсем
 
 editor-tab-with-count = { $label }: { $count }
 
-editor-options = Редактор ĕнерлевĕсем
+editor-options = Редактор ӗнерлевӗсем
 editor-format-as-doenetml = DoenetML пек форматлас
 editor-format-as-xml = XML пек форматлас
 
 
 ## The diagnostics panel
 
-editor-diagnostic-line = { $line }-мĕш йĕрке
+editor-diagnostic-line = { $line }-мӗш йӗрке
 
-editor-no-errors = Йăнăшсем çук
-editor-no-warnings = Асăрхаттарусем çук
-editor-no-info = Информаци хыпарĕсем çук
+editor-no-errors = Йӑнӑшсем ҫук
+editor-no-warnings = Асӑрхаттарусем ҫук
+editor-no-info = Информаци хыпарӗсем ҫук
 
-editor-show-info-annotations = Информаци хыпарĕсене редакторта кăтартас
-editor-show-accessibility-annotations = Майлăх хыпарĕсене редакторта кăтартас
+editor-show-info-annotations = Информаци хыпарӗсене редакторта кӑтартас
+editor-show-accessibility-annotations = Майлӑх хыпарӗсене редакторта кӑтартас
 
-editor-accessibility-learn-more = Doenet майлăх çине мĕнле пăхать
+editor-accessibility-learn-more = Doenet майлӑх ҫине мӗнле пӑхать
 
-editor-accessibility-violations-heading = Майлăх пăсăлăвĕсем ({ $standard })
+editor-accessibility-violations-heading = Майлӑх пӑсӑлӑвӗсем ({ $standard })
 
-editor-accessibility-other-heading = Майлăхăн ытти проблемисем
-editor-none-found = Нимĕн те тупăнмарĕ
+editor-accessibility-other-heading = Майлӑхӑн ытти проблемисем
+editor-none-found = Нимӗн те тупӑнмарӗ
 
 
 ## Submitted responses
 
-editor-no-responses = Халĕ таран янă хуравсем çук
-editor-response-answer-id = Хуравăн Id-йĕ
+editor-no-responses = Халӗ таран янӑ хуравсем ҫук
+editor-response-answer-id = Хуравӑн Id-йӗ
 editor-response-response = Хурав
 editor-response-credit = Балл
-editor-response-submitted = Янă
+editor-response-submitted = Янӑ
 
 
 ## The context-help panel
 
-help-placeholder = Документацие курас тесен курсора тег ячĕ, атрибут е { $ref } çине лартăр.
+help-placeholder = Документацие курас тесен курсора тег ячӗ, атрибут е { $ref } ҫине лартӑр.
 
-help-unsupported-ref-chain = { $example } пек нумай пайлă каçăсем валли пулăшу халĕ çук.
+help-unsupported-ref-chain = { $example } пек нумай пайлӑ каҫӑсем валли пулӑшу халӗ ҫук.
 
 help-unresolved-ref =
     { $reason ->
-        [notFound] Каçă валли объект тупăнмарĕ: { $ref }.
-        [multiple] Каçă валли темиçе объект тупăнчĕ: { $ref }.
-       *[indeterminate] { $ref } валли объекта палăртма пулмарĕ.
+        [notFound] Каҫӑ валли объект тупӑнмарӗ: { $ref }.
+        [multiple] Каҫӑ валли темиҫе объект тупӑнчӗ: { $ref }.
+       *[indeterminate] { $ref } валли объекта палӑртма пулмарӗ.
     }
 
-help-learn-about-references = Каçăсем çинчен пĕлес →
+help-learn-about-references = Каҫӑсем ҫинчен пӗлес →
 help-reference-page = Справка страници →
 
 help-suggestions-header =
     { $location ->
-        [inside] { $element } ăшĕнче
-       *[top] Чи çӳлти шайра
+        [inside] { $element } ӑшӗнче
+       *[top] Чи ҫӳлти шайра
     }{ $allowed ->
-        [none] { " — кунта нимĕн те вырнаçмасть." }
-        [text] { " — кунта текст çырма пулать." }
-        [text-and-components] { " — кунта текст çырма пулать, е çаксене сăнаса пăхăр:" }
-       *[components] { " — çаксене сăнаса пăхма пулать:" }
+        [none] { " — кунта нимӗн те вырнаҫмасть." }
+        [text] { " — кунта текст ҫырма пулать." }
+        [text-and-components] { " — кунта текст ҫырма пулать, е ҫаксене сӑнаса пӑхӑр:" }
+       *[components] { " — ҫаксене сӑнаса пӑхма пулать:" }
     }
 
-help-suggestions-footer = Пĕтĕм { $total } компонента курас тесен { $shortcut } пусăр.
+help-suggestions-footer = Пӗтӗм { $total } компонента курас тесен { $shortcut } пусӑр.
 
 help-name-summary = { $name } — { $summary }
 
 help-ref-is-reference =
     { $line ->
-        [none] { $ref } — { $target } объект çине каçă.
-       *[other] { $ref } — { $target } объект çине каçă ({ $line }-мĕш йĕрке).
+        [none] { $ref } — { $target } объект ҫине каҫӑ.
+       *[other] { $ref } — { $target } объект ҫине каҫӑ ({ $line }-мӗш йӗрке).
     }
 
 help-ref-derived-from =
     { $line ->
-        [none] Ăна { $owner } { $role } пек кĕртнĕ.
-       *[other] Ăна { $owner } { $line }-мĕш йĕркере { $role } пек кĕртнĕ.
+        [none] Ӑна { $owner } { $role } пек кӗртнӗ.
+       *[other] Ӑна { $owner } { $line }-мӗш йӗркере { $role } пек кӗртнӗ.
     }
 
 help-property-is-reference =
     { $line ->
-        [none] { $ref } — { $element } элементăн { $property } уйрăмлăхĕ çине каçă.
-       *[other] { $ref } — { $element } элементăн { $property } уйрăмлăхĕ çине каçă ({ $line }-мĕш йĕрке).
+        [none] { $ref } — { $element } элементӑн { $property } уйрӑмлӑхӗ ҫине каҫӑ.
+       *[other] { $ref } — { $element } элементӑн { $property } уйрӑмлӑхӗ ҫине каҫӑ ({ $line }-мӗш йӗрке).
     }
 
 help-kind-attribute = атрибут
-help-kind-snippet = татăк
-help-kind-array-entry = массив элеменчĕ
+help-kind-snippet = татӑк
+help-kind-array-entry = массив элеменчӗ
 
-help-default = Тĕп хак:
-help-active-default = Хальхи тĕп хак:
+help-default = Тӗп хак:
+help-active-default = Хальхи тӗп хак:
 
 help-style-number-annotation = { " " }(styleNumber { $styleNumber })
 
 help-allowed-values =
     { $perItem ->
-        [true] Ирĕк панă хаксем (кашни элемент валли пĕрре):
-       *[other] Ирĕк панă хаксем:
+        [true] Ирӗк панӑ хаксем (кашни элемент валли пӗрре):
+       *[other] Ирӗк панӑ хаксем:
     }
 
-help-suggested-values = Сĕннĕ хаксем:
+help-suggested-values = Сӗннӗ хаксем:
 
 help-inserts = Хушать:
 
 help-coordinates =
     { $count ->
         [one] Координата:
-       *[other] Координатăсем:
+       *[other] Координатӑсем:
     }
 
-help-type = Тĕсĕ:
+help-type = Тӗсӗ:
 
-help-resolved-style = Тухнă стиль (styleNumber { $styleNumber }):
+help-resolved-style = Тухнӑ стиль (styleNumber { $styleNumber }):
 
-help-resolved-function-names = Тухнă функци ячĕсем:
-help-reset-list = Ку хирĕн каялла таврăну списокĕ:
+help-resolved-function-names = Тухнӑ функци ячӗсем:
+help-reset-list = Ку хирӗн каялла таврӑну списокӗ:
 help-added-on-input = Ку хирте хушнисем:
-help-removed-on-input = Ку хиртен кăларнисем:
+help-removed-on-input = Ку хиртен кӑларнисем:
 
-help-reset-overrides = { $reset } — { $additional } тата { $removed } çинчен мала тухать.
+help-reset-overrides = { $reset } — { $additional } тата { $removed } ҫинчен мала тухать.

--- a/packages/i18n/locales/cv/editor.ftl
+++ b/packages/i18n/locales/cv/editor.ftl
@@ -1,0 +1,218 @@
+# Chuvash editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# The two counted messages here write a `[zero]` branch, which Chuvash resolves
+# for exactly 0 — see the note in `chrome.ftl` on how that differs from
+# `locales/lv`'s category of the same name. A `[zero]` here is reached rather
+# than decorative: neither message has an explicit `[0]` branch to win first.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Каялла
+       *[update] Çĕнетес
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Пăхмаллине { $word }
+       *[other] Пăхмаллине { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Суйласа илни…
+editor-variant-next = Тепĕр варианта суйлас
+editor-variant-previous = Малтанхи варианта суйлас
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA майлăх пăсăлăвĕ тупăнчĕ. Майлăх отчетне { $action ->
+            [close] хупма
+           *[open] уçма
+        } пусăр.
+        [advisories] Майлăх отчетне { $action ->
+            [close] хупма
+           *[open] уçма
+        } пусăр. WCAG AA пăсăлăвĕсем тупăнмарĕç, анчах хушма сĕнӳсем пур.
+       *[clean] Майлăх отчетне { $action ->
+            [close] хупма
+           *[open] уçма
+        } пусăр. Майлăх проблемисем тупăнмарĕç.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA майлăх пăсăлăвĕ тупăнчĕ. { $count ->
+            [zero] Пĕр WCAG AA пăсăлăвĕ те
+            [one] { $count } WCAG AA пăсăлăвĕ
+           *[other] { $count } WCAG AA пăсăлăвĕ
+        } тупăнчĕ. Майлăх отчетне { $action ->
+            [close] хупма
+           *[open] уçма
+        } пусăр.
+        [advisories] WCAG AA пăсăлăвĕсем тупăнмарĕç. { $count ->
+            [zero] Пĕр хушма сĕнӳ те
+            [one] { $count } хушма сĕнӳ
+           *[other] { $count } хушма сĕнӳ
+        } тупăнчĕ. Майлăх отчетне { $action ->
+            [close] хупма
+           *[open] уçма
+        } пусăр.
+       *[clean] WCAG AA пăсăлăвĕсем тупăнмарĕç. Майлăх отчетне { $action ->
+            [close] хупма
+           *[open] уçма
+        } пусăр.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версийĕ { $version }
+
+editor-tab-help = Контекст пулăшăвĕ
+editor-tab-help-short = Контекст
+editor-tab-errors = Йăнăшсем
+editor-tab-warnings = Асăрхаттарусем
+editor-tab-info = Информаци
+editor-tab-accessibility = Майлăх
+editor-tab-responses = Янă хуравсем
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редактор ĕнерлевĕсем
+editor-format-as-doenetml = DoenetML пек форматлас
+editor-format-as-xml = XML пек форматлас
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-мĕш йĕрке
+
+editor-no-errors = Йăнăшсем çук
+editor-no-warnings = Асăрхаттарусем çук
+editor-no-info = Информаци хыпарĕсем çук
+
+editor-show-info-annotations = Информаци хыпарĕсене редакторта кăтартас
+editor-show-accessibility-annotations = Майлăх хыпарĕсене редакторта кăтартас
+
+editor-accessibility-learn-more = Doenet майлăх çине мĕнле пăхать
+
+editor-accessibility-violations-heading = Майлăх пăсăлăвĕсем ({ $standard })
+
+editor-accessibility-other-heading = Майлăхăн ытти проблемисем
+editor-none-found = Нимĕн те тупăнмарĕ
+
+
+## Submitted responses
+
+editor-no-responses = Халĕ таран янă хуравсем çук
+editor-response-answer-id = Хуравăн Id-йĕ
+editor-response-response = Хурав
+editor-response-credit = Балл
+editor-response-submitted = Янă
+
+
+## The context-help panel
+
+help-placeholder = Документацие курас тесен курсора тег ячĕ, атрибут е { $ref } çине лартăр.
+
+help-unsupported-ref-chain = { $example } пек нумай пайлă каçăсем валли пулăшу халĕ çук.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Каçă валли объект тупăнмарĕ: { $ref }.
+        [multiple] Каçă валли темиçе объект тупăнчĕ: { $ref }.
+       *[indeterminate] { $ref } валли объекта палăртма пулмарĕ.
+    }
+
+help-learn-about-references = Каçăсем çинчен пĕлес →
+help-reference-page = Справка страници →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } ăшĕнче
+       *[top] Чи çӳлти шайра
+    }{ $allowed ->
+        [none] { " — кунта нимĕн те вырнаçмасть." }
+        [text] { " — кунта текст çырма пулать." }
+        [text-and-components] { " — кунта текст çырма пулать, е çаксене сăнаса пăхăр:" }
+       *[components] { " — çаксене сăнаса пăхма пулать:" }
+    }
+
+help-suggestions-footer = Пĕтĕм { $total } компонента курас тесен { $shortcut } пусăр.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объект çине каçă.
+       *[other] { $ref } — { $target } объект çине каçă ({ $line }-мĕш йĕрке).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ăна { $owner } { $role } пек кĕртнĕ.
+       *[other] Ăна { $owner } { $line }-мĕш йĕркере { $role } пек кĕртнĕ.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементăн { $property } уйрăмлăхĕ çине каçă.
+       *[other] { $ref } — { $element } элементăн { $property } уйрăмлăхĕ çине каçă ({ $line }-мĕш йĕрке).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = татăк
+help-kind-array-entry = массив элеменчĕ
+
+help-default = Тĕп хак:
+help-active-default = Хальхи тĕп хак:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Ирĕк панă хаксем (кашни элемент валли пĕрре):
+       *[other] Ирĕк панă хаксем:
+    }
+
+help-suggested-values = Сĕннĕ хаксем:
+
+help-inserts = Хушать:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатăсем:
+    }
+
+help-type = Тĕсĕ:
+
+help-resolved-style = Тухнă стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Тухнă функци ячĕсем:
+help-reset-list = Ку хирĕн каялла таврăну списокĕ:
+help-added-on-input = Ку хирте хушнисем:
+help-removed-on-input = Ку хиртен кăларнисем:
+
+help-reset-overrides = { $reset } — { $additional } тата { $removed } çинчен мала тухать.

--- a/packages/i18n/locales/cv/editor.ftl
+++ b/packages/i18n/locales/cv/editor.ftl
@@ -11,10 +11,11 @@
 # `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
 # name are identifiers, not prose, and stay as written.
 #
-# The two counted messages here write a `[zero]` branch, which Chuvash resolves
-# for exactly 0 — see the note in `chrome.ftl` on how that differs from
-# `locales/lv`'s category of the same name. A `[zero]` here is reached rather
-# than decorative: neither message has an explicit `[0]` branch to win first.
+# `editor-accessibility-label` counts twice — violations and advisories — and
+# both of its `{ $count -> … }` selectors write a `[zero]` branch, which Chuvash
+# resolves for exactly 0; see the note in `chrome.ftl` on how that differs from
+# `locales/lv`'s category of the same name. Both are reached rather than
+# decorative: neither selector has an explicit `[0]` branch to win first.
 
 
 ## The viewer's controls

--- a/packages/i18n/locales/kv/chrome.ftl
+++ b/packages/i18n/locales/kv/chrome.ftl
@@ -1,0 +1,138 @@
+# Komi viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Komi counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular, so the two branches differ in nothing but the number they print.
+
+
+## Answer submission
+
+answer-checking = Видлалӧ…
+answer-submitting = Мӧдӧдӧ…
+
+answer-checking-status = Вочакыв видлалӧ
+answer-submitting-status = Вочакыв мӧдӧдӧ
+
+answer-correct = Веськыд
+answer-incorrect = Абу веськыд
+
+answer-response-saved = Вочакыв видзӧма
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% веськыд
+answer-percent-short = { $percent } %
+
+max-credit-available = Босьтны позян медся ыджыд балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] видлӧм абу кольӧма
+        [one] { $count } видлӧм кольӧма
+       *[other] { $count } видлӧм кольӧма
+    }
+
+validation-correct = (Веськыд)
+validation-incorrect = (Абу веськыд)
+validation-partially-correct = (Юкӧнӧн веськыд)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } вылӧ { $count } вочакыв петкӧдлыны
+       *[other] { $answerId } вылӧ { $count } вочакыв петкӧдлыны
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Бӧр висьталӧм
+
+collapsible-click-to-open = (восьтны вӧсна ляпкы)
+collapsible-click-to-close = (пӧдлавны вӧсна ляпкы)
+
+collapsible-initializing = Дасьтысьӧ…
+
+footnote-show = Пасйӧд петкӧдлыны
+footnote-hide = Пасйӧд дзебны
+
+description-more-information = содтӧд юӧр
+
+
+## Controls
+
+slider-previous = Бӧрлань
+slider-next = Водзлань
+
+keyboard-open = Клавиатура восьтны
+keyboard-close = Клавиатура пӧдлавны
+
+choice-input-remove-choice = { $choice } бӧрйӧм бӧрйыны
+
+matrix-remove-row = Визь бӧрйыны
+matrix-add-row = Визь содтыны
+matrix-remove-column = Юрбитан бӧрйыны
+matrix-add-column = Юрбитан содтыны
+
+subset-add-remove-points = Пас содтыны/бӧрйыны
+subset-toggle-points-intervals = Пасъяс да коласъяс вежны
+subset-move-points = Пасъяс вуджӧдны
+subset-clear = Сӧстӧммӧдны
+
+orbital-add-row = Визь содтыны
+orbital-remove-row = Визь бӧрйыны
+orbital-add-box = Клетка содтыны
+orbital-remove-box = Клетка бӧрйыны
+orbital-add-up-arrow = Вылӧ ньӧв содтыны
+orbital-add-down-arrow = Улӧ ньӧв содтыны
+orbital-remove-arrow = Ньӧв бӧрйыны
+
+orbital-row-label = { $row } визьлӧн пасыс
+
+pretzel-answer = Вочакыв
+
+summary-statistics-caption = { $column } юрбитанлӧн йитӧд статистикаыс
+
+
+## Math input
+
+math-input-preview-region = математическӧй висьталӧмлӧн водзвыв видзӧдлӧм
+math-input-preview = Водзвыв видзӧдлӧм
+math-input-invalid-expression = Абу веськыд висьталӧм:
+
+
+## Document status
+
+viewer-initializing = Дасьтысьӧ…
+
+
+## Errors
+
+error-heading = Тшыкӧдчӧм
+
+error-found-at =
+    { $span ->
+        [line] Аддзӧм визь: { $startLine }.
+       *[lines] Аддзӧм визьяс: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Тайӧ документын тшыкӧдчӧмъяс эмӧсь!
+
+diagnostic-heading-error = Тшыкӧдчӧм
+diagnostic-heading-warning = Пасйӧм
+diagnostic-heading-information = Юӧр
+diagnostic-heading-hint = Индӧд
+
+accessibility-heading-level-1 = WCAG AA воан позянлун торкӧм
+accessibility-heading-level-2 = Воан позянлун йылысь юӧр
+
+something-went-wrong = Мыйкӧ абу веськыда петіс.
+
+renderer-load-failed = серпасалысьсӧ пыртны эз артмы. Лист бок выльмӧд.
+
+core-start-failed = Документ видзӧдысьсӧ заводитны эз артмы. Лист бок выльмӧд.

--- a/packages/i18n/locales/kv/content.ftl
+++ b/packages/i18n/locales/kv/content.ftl
@@ -1,0 +1,256 @@
+# Komi content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Komi's own ӧ and і, which is the orthography the
+# Komi Republic's schools and publishing use and what CLDR fills a bare `kv`
+# in as.
+#
+# `kv` is an ISO 639-3 **macrolanguage** over Komi-Zyrian (`kpv`) and
+# Komi-Permyak (`koi`), so it joins `MACROLANGUAGE_MEMBERS` in `negotiate.ts`
+# and both reach this catalog. What is written here is **Komi-Zyrian**, the
+# literary standard of the Komi Republic and what CLDR's own data means by a
+# bare `kv`. Serving a Komi-Permyak reader Zyrian is a real compromise — the
+# same one `locales/qu`, `locales/bik` and `locales/bua` already make — and a
+# deployment that wants Permyak supplies it as `localeResources`.
+#
+# Komi has no grammatical gender and does not inflect an attributive adjective,
+# so `$gender` and `$role` go unused here, exactly as in `locales/udm`, its
+# nearest relative in this batch. What both Permic catalogs use instead is the
+# noun's own case suffix in the two clause messages, and in both it falls on a
+# word the catalog writes rather than on a placeable.
+
+
+## Style vocabulary
+
+color =
+    .black = сьӧд
+    .white = еджыд
+    .gray = руд
+    .red = гӧрд
+    .orange = оранжевӧй
+    .yellow = виж
+    .green = турунвиж
+    .cyan = югыд лӧз
+    .blue = лӧз
+    .purple = фиолетовӧй
+    .pink = гӧрдоват
+    .brown = мугӧм
+
+line-width =
+    .thick = кыз
+    .thin = вӧсньыд
+
+line-style =
+    .dashed = вундалӧм
+    .dotted = пасъялӧм
+
+# Noun phrases: they stand in front of «серӧн» and modify nothing.
+fill-style =
+    .horizontal = горизонтальнӧй визь
+    .vertical = вертикальнӧй визь
+    .diagonal = диагональнӧй визь
+    .backdiagonal = паныд диагональнӧй визь
+    .dots = пас
+    .diamonds = ромб
+
+noun =
+    .line = веськыд визь
+    .line-segment = юкӧн
+    .ray = луч
+    .vector = вектор
+    .curve = кусыня визь
+    .function = функция
+    .parabola = парабола
+    .polyline = чегӧм визь
+    .polygon = уна пельӧса
+    .triangle = куим пельӧса
+    .rectangle = веськыд пельӧса
+    .circle = гӧгрӧс
+    .region = ин
+    .point = пас
+    .square = квадрат
+    .diamond = ромб
+    .cross = перекрест
+    .plus = плюс
+
+# Komi builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] веськыд { $numSides } пельӧса
+    }
+
+# Komi has no grammatical gender, so every noun answers the same and the answer
+# goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = мавтӧм
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } серӧн { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } серӧн { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } серӧн { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «дорӧн» is the instrumental of «дор», "edge", and carries the whole of "with
+# a border" in its own suffix, so neither a preposition nor an article is
+# wanted — `locales/udm`'s «дуроен» exactly, in the sister language.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } дорӧн
+        [and] да { $border } дорӧн
+        [and-article] да { $border } дорӧн
+       *[with] { $border } дорӧн
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } серӧн { $color } мавтӧм
+       *[plain] { $color } мавтӧм
+    }
+
+style-unfilled = мавтытӧм
+
+# «вылын» — "on" — is a postposition and follows the background colour, so
+# nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон вылын { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = абу
+
+
+## Boolean words
+
+boolean-true = збыль
+boolean-false = абу збыль
+
+
+## Answer buttons
+
+answer-submit-label = Видлавны
+answer-submit-label-no-correctness = Вочакыв мӧдӧдны
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Уджтор
+    .aside = Бокса пасйӧд
+    .cascade = Каскад
+    .definition = Тӧдмалӧм
+    .example = Пример
+    .exercise = Удж
+    .exercises = Уджъяс
+    .given-answer = Вочакыв
+    .note = Пасйӧд
+    .objectives = Могъяс
+    .paragraphs = Абзацъяс
+    .part = Пай
+    .problem = Задача
+    .problems = Задачаяс
+    .proof = Петкӧдлӧм
+    .question = Юалӧм
+    .section = Юкӧн
+    .solution = Вӧчӧм
+    .task = Уджтас
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Индӧд
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Серпас { $enumeration }
+        [numbered-caption] Серпас { $enumeration }{ ". " }
+        [unnumbered-caption] Серпас{ ". " }
+       *[unnumbered] Серпас
+    }
+
+
+## Paginator controls
+
+paginator-previous = Бӧрлань
+paginator-next = Водзлань
+paginator-page = Лист бок
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## `piecewise-condition-if` is `locales/udm`'s limit in the sister language and
+## for the identical reason: Komi's conditional «кӧ» is a particle that follows
+## the clause it conditions, and the renderer places this key before the
+## mathematics. Two Permic catalogs, one wall.
+
+piecewise-condition-or = либӧ
+piecewise-condition-if = кӧ
+piecewise-condition-otherwise = мӧд ногӧн
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in the Komi Republic is
+## taught in Russian, so the element names a Komi-speaking pupil meets are the
+## Russian ones — the school-system case this batch shares throughout.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Абу веськыд химическӧй пас
+chemistry-invalid-ionic-compound = Абу веськыд ион йитӧд

--- a/packages/i18n/locales/kv/diagnostics.ftl
+++ b/packages/i18n/locales/kv/diagnostics.ftl
@@ -1,0 +1,654 @@
+# Komi diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Komi uses for
+# them: «компонент», «атрибут», «функция», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кык пом пас индӧм дырйи { $attributes } оз лыддьысь
+       *[other] кык пом пас индӧм дырйи { $attributes } оз лыддьысь
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] пом пас да шӧр пас кыкнан индӧм дырйи { $attributes } оз лыддьысь
+       *[other] пом пас да шӧр пас кыкнан индӧм дырйи { $attributes } оз лыддьысь
+    }
+
+line-segment-midpoint-offset-without-midpoint = шӧр пастӧг midpointOffset немтор вылӧ оз вӧч
+
+## `<line>`
+
+line-points-undetermined-dimensions = Мерайтӧмыс тӧдтӧм пасъяс пыр мунысь веськыд визь.
+
+line-points-too-few-dimensions = Веськыд визь этша дырйи кык мерайтӧма пасъяс пыр мунны колӧ.
+
+line-points-depend-on-variables = Веськыд визь вежласяна мерайтӧмъясысь кывтысь пасъяс пыр мунӧ: { $variables }.
+
+line-equation-invalid-format = { $variable1 } да { $variable2 } вежласяна мерайтӧмъяса веськыд визьлӧн уравнениеыслӧн форматыс абу веськыд.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint да direction пыр сетӧма. Сетӧм through оз лыддьысь.
+
+ray-dimension-mismatch = лучын numDimensions оз лӧсяв.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail да displacement пыр сетӧма. Сетӧм head оз лыддьысь.
+
+vector-dimension-mismatch = векторын numDimensions оз лӧсяв.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элемент дорӧ кыскыны оз позь, тайӧс вӧсна мый сылӧн nearestPoint статус вежласяныс абу.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементӧн ӧтувтны оз позь, тайӧс вӧсна мый сылӧн nearestPoint статус вежласяныс абу.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементлӧн пытшкӧсӧн ӧтувтны оз позь, тайӧс вӧсна мый сылӧн nearestPoint статус вежласяныс абу.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = визь пытшкын абу choiceInput вылӧ labelPosition оз лыддьысь
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput вылӧ сетӧм индексъяс оз лыддьысьны, тайӧс вӧсна мый налӧн лыдыс choice челядьлӧн лыдыслы оз лӧсяв.
+
+pretzel-indices-count-mismatch = problem вылӧ сетӧм индексъяс оз лыддьысьны, тайӧс вӧсна мый налӧн лыдыс problem челядьлӧн лыдыслы оз лӧсяв.
+
+shuffle-indices-count-mismatch = shuffle вылӧ сетӧм индексъяс оз лыддьысьны, тайӧс вӧсна мый налӧн лыдыс компонентъяслӧн лыдыслы оз лӧсяв.
+
+indices-ignored-out-of-range = { $component } вылӧ сетӧм индексъяс оз лыддьысьны, тайӧс вӧсна мый кутшӧмкӧяс кывкӧртӧдысь петӧны.
+
+pretzel-indices-repeated = pretzel вылӧ сетӧм индексъяс оз лыддьысьны, тайӧс вӧсна мый кутшӧмкӧяс выльысь лоӧны.
+
+pretzel-circuit-first-index = circuit режимын pretzel вылӧ сетӧм индексъяс оз лыддьысьны, тайӧс вӧсна мый медводдза индексыс 1 лоны колӧ.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текст челядьӧн уджалӧм вӧсна `type` атрибут сетны колӧ.
+
+invalid-type-defaulting-to-math = { $component } компонентлы абу веськыд ног { $type }. Сійӧ math, text, number либӧ boolean лоны колӧ. math вӧдитчӧ.
+
+string-not-valid-component-to-arrange = «{ $value }» визь { $component } вылӧ лӧсялана компонент абу. Оз лыддьысь.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Абу веськыд ног { $type }, ногыс number лоӧ.
+
+invalid-variable-value = Вежласянлӧн абу веськыд донйыс: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариант индекс лыд лоны колӧ
+
+variant-index-must-be-integer = { $index } вариант индекс тыр лыд лоны колӧ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютнӧй мерайтӧмъяслы абу вӧчӧма. Пасьтаясыс ӧтлаӧдана лоӧны.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютнӧй мерайтӧмъяслы абу вӧчӧма. Дорыс ӧтлаӧдана лоӧны.
+
+side-by-side-no-block-child = Абу веськыд `<{ $component }>`: сылӧн этша дырйи ӧти блок челядьыс лоны колӧ.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементысь `for` атрибут оз лыддьысь.
+
+label-for-must-resolve-to-one = `<label>` элементысь `for` атрибут дзик ӧти компонент вылӧ индыны колӧ.
+
+label-for-unresolved = `<label>` элементысь `for` атрибутсӧ компонентӧн йитны эз артмы.
+
+label-for-answer-with-authored-inputs = `<label>` элементысь `for` атрибут автор гижӧм пыртан ин вылӧ `<answer>` вылӧ индӧ; ин вылӧ веськыда индӧй.
+
+label-for-answer-without-input = `<label>` элементысь `for` атрибут пасъялан пыртан интӧг `<answer>` вылӧ индӧ.
+
+label-for-must-reference-input-or-answer = `<label>` элементысь `for` атрибут пыртан ин либӧ вочакыв вылӧ индыны колӧ.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Воан позянлун вӧсна `<{ $component }>` либӧ дженьыд гижӧда лоны колӧ, либӧ серпасалӧм моз пасйыны.
+
+accessibility-video-short-description = Воан позянлун вӧсна `<video>` дженьыд гижӧда лоны колӧ.
+
+accessibility-input-short-description-or-label = Воан позянлун вӧсна `<{ $component }>` дженьыд гижӧда либӧ паса лоны колӧ.
+
+accessibility-answer-input-short-description-or-label = Воан позянлун вӧсна пыртан ин лӧсьӧдысь `<answer>` дженьыд гижӧда либӧ паса лоны колӧ.
+
+accessibility-short-description-contains-math = Дженьыд гижӧдъясын `<{ $component }>` кодь математическӧй компонентъяс лоны оз позь. Математикасӧ кывъясӧн гиж.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } юкӧнлӧн юр текстыслы тырмымӧн контраст оз сет (пемыд ног) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; этша дырйи { $threshold }:1 колӧ).
+       *[other] { $colorName } юкӧнлӧн юр текстыслы тырмымӧн контраст оз сет ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; этша дырйи { $threshold }:1 колӧ).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Пасъяслӧн лыд донъясыс абу кӧ, { $count } пас пыр мунысь `<circle>` абу вӧчӧма.
+
+circle-too-many-through-points = 3-ысь унджык пас пыр мунысь гӧгрӧссӧ лыддьыны оз позь.
+
+circle-overprescribed-radius-center-points = Сетӧм радиусӧн, шӧрӧн да пасъясӧн гӧгрӧссӧ лыддьыны оз позь.
+
+circle-center-with-multiple-points = Сетӧм шӧрӧн 1-ысь унджык пас пыр мунысь гӧгрӧссӧ лыддьыны оз позь.
+
+circle-radius-too-small = Гӧгрӧссӧ лыддьыны оз позь: кык пас костыс { $distance } кӧ, сетӧм радиусыс { $radius } зэв ичӧт.
+
+circle-radius-with-many-points = Сетӧм радиусӧн кыкысь унджык пас пыр мунысь гӧгрӧс вӧчны оз позь.
+
+circle-invalid-center-or-through-points = Гӧгрӧслӧн шӧрыс либӧ пасъясыс абу веськыдӧсь.
+
+circle-radius-center-with-multiple-points = Сетӧм шӧрӧн 1-ысь унджык пас пыр мунысь гӧгрӧслысь радиуссӧ лыддьыны оз позь.
+
+circle-change-radius-non-numerical = Лыд абу пасъяса гӧгрӧслысь радиуссӧ вежны оз позь
+
+circle-radius-with-points-non-numerical = Лыд донъяс абу кӧ, сетӧм радиусӧн ӧтиысь унджык пас пыр мунысь гӧгрӧс вӧчны оз позь.
+
+circle-change-center-non-numerical = Лыд абу пасъяс пыр мунысь гӧгрӧслысь шӧрсӧ вежӧм абу вӧчӧма.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функциялӧн тӧдмалӧм инсьыс мерайтӧмыс оз тырмы. Инын { $intervals } колас эм, а функцияын { $inputs ->
+            [one] { $inputs } пыртӧм
+           *[other] { $inputs } пыртӧм
+        } эм.
+       *[other] Функциялӧн тӧдмалӧм инсьыс мерайтӧмыс оз тырмы. Инын { $intervals } колас эм, а функцияын { $inputs ->
+            [one] { $inputs } пыртӧм
+           *[other] { $inputs } пыртӧм
+        } эм.
+    }
+
+function-domain-invalid-format = Функциялӧн тӧдмалӧм инсьыс форматыс абу веськыд.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функциялӧн лыд абу максимумыс оз лыддьысь.
+        [minimum] Функциялӧн лыд абу минимумыс оз лыддьысь.
+        [extremum] Функциялӧн лыд абу экстремумыс оз лыддьысь.
+        [point] Функциялӧн лыд абу пасыс оз лыддьысь.
+        [slope] Функциялӧн лыд абу мыгӧрыс оз лыддьысь.
+       *[other] Функциялӧн лыд абу { $type } донйыс оз лыддьысь.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функциялӧн тыртӧм максимумыс оз лыддьысь.
+        [minimum] Функциялӧн тыртӧм минимумыс оз лыддьысь.
+        [extremum] Функциялӧн тыртӧм экстремумыс оз лыддьысь.
+        [point] Функциялӧн тыртӧм пасыс оз лыддьысь.
+       *[other] Функциялӧн тыртӧм { $type } донйыс оз лыддьысь.
+    }
+
+function-points-too-close = Функцияын ӧта-мӧдыслы зэв матын кык пас эм. Функциясӧ тӧдмавны оз позь.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функциялӧн итерациясӧ вӧчны позьӧ сӧмын пыртӧмъяслӧн лыдыс петӧмъяслӧн лыдыслы ӧткодь кӧ. Тайӧ функцияын { $inputs } пыртӧм да { $outputs ->
+            [one] { $outputs } петӧм
+           *[other] { $outputs } петӧм
+        } эм.
+       *[other] Функциялӧн итерациясӧ вӧчны позьӧ сӧмын пыртӧмъяслӧн лыдыс петӧмъяслӧн лыдыслы ӧткодь кӧ. Тайӧ функцияын { $inputs } пыртӧм да { $outputs ->
+            [one] { $outputs } петӧм
+           *[other] { $outputs } петӧм
+        } эм.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Радлӧн кузьтаыс абу веськыд. Сійӧ минус абу тыр лыд лоны колӧ.
+
+sequence-invalid-step = Радлӧн воськовыс абу веськыд. { $type } ногӧн радлы сійӧ лыд лоны колӧ.
+
+sequence-invalid-endpoint-number = Лыд радлӧн «{ $attribute }» донйыс абу веськыд. Сійӧ лыд лоны колӧ.
+
+sequence-invalid-endpoint-letters = Шыпас радлӧн «{ $attribute }» донйыс абу веськыд. Сійӧ шыпасъяслӧн ӧтлаӧдӧм лоны колӧ.
+
+sequence-invalid-endpoint = Радлӧн «{ $attribute }» донйыс абу веськыд.
+
+select-from-sequence-coprime-not-numbers = лыдъяс абу бӧрйӧма, сы вӧсна coprime оз лыддьысь
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations сетӧма, сы вӧсна coprime оз лыддьысь
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` вылӧ абу веськыд target: мог эз аддзысь.
+
+target-state-variable-not-found = `<{ $source }>` вылӧ абу веськыд target: `<{ $component }>` элементын «{ $property }» нима статус вежласян эз аддзысь.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` вежласянъясыс аскежса вежласянысь торъявны колӧ.
+
+ode-system-duplicate-variable-names = Кывтысь вежласянъяслӧн нимъясыс выльысь лоӧны кӧ, ДТ веськыд бок функцияяссӧ тӧдмавны оз позь.
+
+ode-system-rhs-function-error = ДТ веськыд бок функциясӧ тӧдмавны оз позь. mathjs функциясӧ лӧсьӧдігӧн тшыкӧдчӧм.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } веськыд визь костса пельӧссӧ тӧдмавны оз позь
+
+angle-invalid-through-point = `<angle>` элементлӧн through донйын абу веськыд пас
+
+parabola-vertex-too-many-points = Сетӧм йывйӧн 1-ысь унджык пас пыр мунысь парабола абу вӧчӧма.
+
+parabola-too-many-points = 3-ысь унджык пас пыр мунысь парабола абу вӧчӧма.
+
+intersection-too-many-items = Кыкысь унджык объектлӧн вомӧнъялӧмыс абу вӧчӧма
+
+## Other math components
+
+ionic-compound-not-two-ions = Кык ионысь мукӧд ион йитӧдъяс абу вӧчӧма.
+
+ionic-compound-needs-cation-and-anion = Ион йитӧд ӧти катионлы да ӧти анионлы сӧмын вӧчӧма.
+
+solve-equations-cannot-evaluate = Уравнениесӧ вӧчны оз позь, тайӧс вӧсна мый сійӧс лыддьыны эз артмы: { $equation }
+
+math-operators-operand-number-required = Математическӧй операндсӧ торйӧдӧм вӧсна operandNumber сетны колӧ.
+
+eigen-decomposition-failed = Матрицалысь ас донъяссӧ лыддьыны эз артмы
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр образецын оз паныдасьлы, сы вӧсна сійӧ пыр тыртӧмлы лӧсялӧ.
+       *[other] `<matchesPattern>`: { $parameters } параметръяс образецын оз паныдасьлыны, сы вӧсна найӧ пыр тыртӧмлы лӧсялӧны.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" донсӧ гӧгӧрвоны оз позь. Сійӧ none, medium, dense либӧ тыртӧм инӧн торйӧдӧм кык плюс лыд лоны колӧ, шуам grid="1 0.5". Сетка оз серпасась.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure серпасалысьын xLabelPosition="left" абу вӧчӧма; веськыд бок пуктӧм вӧдитчӧ.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure серпасалысьын yLabelPosition="bottom" абу вӧчӧма; вылыс бок пуктӧм вӧдитчӧ.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure вуджӧдӧмлы тэльяслӧн помъясыс абу веськыдӧсь; подув bbox (-10,-10,10,10) вӧдитчӧ.
+
+prefigure-invalid-width = `<graph>`: prefigure вуджӧдӧмлы пасьтаыс абу веськыд; диаграммалӧн подув пасьтаыс 425 вӧдитчӧ.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure вуджӧдӧмлы aspectRatio абу веськыд; подув боклӧн йитӧдыс 1 вӧдитчӧ.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткалӧн воськовыс тэльяслӧн помъясыслы зэв ичӧт; prefigure серпасалысьын сетка оз петкӧдчы.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure серпасалысь оз вӧдитчы кӧ, пасйӧдъяс оз серпасасьны.
+
+multiple-annotations-children = `<graph>` пытшкын уна `<annotations>` челядь аддзӧма; медбӧръяысь мукӧдъясыс оз лыддьысьны.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Тӧдтӧм компонент ногсӧ паськӧдны либӧ копируйтны оз позь: { $type }.
+
+copy-prop-not-found = { $component } нога компонентын { $property } свойство эз аддзысь
+
+collect-no-source = collect вылӧ подув эз аддзысь.
+
+collect-invalid-component-type = `<{ $component }>` нога компонентъяссӧ чукӧртны оз позь, тайӧс вӧсна мый тайӧ абу веськыд компонент ног.
+
+reference-index-unavailable = `{ $reference }` индекс вылӧ йитӧд вӧчны оз позь
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентын { $action } корны оз позь
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннӧйяслӧн ногыс абу веськыд. Визьяслӧн кузьтаясыс торъялӧны. Аддзӧма componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннӧйясын юрбитанлӧн нимъясыс выльысь лоӧны. Аддзӧма componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннӧйясын юрбитан ним оз тырмы. Аддзӧма componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Тайӧ вочакывлӧн award донйыс answer тегыслӧн ас мӧдӧдӧм вочакыв вылас пуксьӧ, тайӧ виччысьтӧм могъясӧ воштӧ.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` эма контейнер пытшкса `<answer>` вылӧ `maxNumAttempts` пуктӧм оз вӧч, тайӧс вӧсна мый видлӧмъяслысь лыдсӧ контейнерыс тӧдмалӧ. `maxNumAttempts` донсӧ контейнер вылӧ пукты.
+
+nested-section-wide-check-work-max-num-attempts = Мӧд `sectionWideCheckWork` контейнер пытшкын сулалысь `sectionWideCheckWork` контейнер вылӧ `maxNumAttempts` пуктӧм оз вӧч, тайӧс вӧсна мый видлӧмъяслысь лыдсӧ ортсы контейнерыс тӧдмалӧ. `maxNumAttempts` донсӧ ортсы контейнер вылӧ пукты.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality абу пуктӧма кӧ, { $attributes } атрибут оз вӧч.
+       *[other] symbolicEquality абу пуктӧма кӧ, { $attributes } атрибутъяс оз вӧчны.
+    }
+
+answer-invalid-type = answer вылӧ абу веськыд ног: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентлӧн нимыс абу, сы вӧсна сійӧс модуль атрибут моз вӧдитчыны оз позь
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентсӧ модуль атрибут моз вӧдитчыны оз позь, тайӧс вӧсна мый `<module>` компонент ногын «{ $name }» атрибут нин тӧдмалӧма.
+
+conditional-content-condition-ignored = case либӧ else челядьӧн `<conditionalContent>` компонентын `condition` атрибут оз лыддьысь.
+
+slider-markers-type-mismatch = Маркеръяслӧн ногыс ползунокалӧн ногыслы оз лӧсяв.
+
+pretzel-problem-needs-statement-and-answer = Абу веськыд pretzel: быд `<problem>` ӧти `<statement>` да ӧти `<answer>` пытшкас босьтны колӧ.
+
+pretzel-circuit-first-problem-distractor = Абу веськыд pretzel: mode="circuit" режимын медводдза `<problem>` вниманиесӧ бокӧ нуысь лоны оз вермы.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутлы абу веськыд дон { $values }; оз лыддьысь.
+       *[other] `{ $attribute }` атрибутлы абу веськыд донъяс { $values }; оз лыддьысьны.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутлы абу веськыд дон `{ $value }`. Атрибут `$` пасысь заводитчысь йитӧдъясысь лоны колӧ.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } пытшкса абу веськыд функция нимъяс эз лыддьысьны: { $names }. Быд нимлӧн тыдалана юкӧныс этша дырйи 2 пас лоны колӧ (шыпасъяс либӧ визьясъяс); сы бӧрын колана абу `|<mathspeak альтернатива>` содтӧд воны вермас.
+
+## Building components from the source
+
+component-type-invalid = Абу веськыд компонент ног: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутсӧ выльысь вӧчны оз позь.
+
+attribute-invalid-for-component = `<{ $componentType }>` нога компонентлы абу веськыд атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль тӧдмалӧмын { $context ->
+        [text-on-background] текстлӧн рӧмыс да фонлӧн рӧмыс
+        [high-contrast] ыджыд контраста рӧм да серпасалан ин
+        [line] визьлӧн рӧмыс да серпасалан ин
+        [marker] маркерлӧн рӧмыс да серпасалан ин
+       *[text-on-canvas] текстлӧн рӧмыс да серпасалан ин
+    } кост контрастыс оз тырмы{ $mode ->
+        [dark] { " (пемыд ног)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; этша дырйи { $threshold }:1 колӧ).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль тӧдмалӧмын сетӧм рӧмъяс югыд ноглы тырмымӧн контраст сетісны кӧ, налысь петӧм пемыд ног рӧмъяс текст да фон кост тырмымӧн контраст оз сетны ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; этша дырйи { $threshold }:1 колӧ). { $suggestion ->
+        [available] Пемыд ногын тырмымӧн контраст вӧсна югыд ноглысь контрастсӧ ыдждӧд (шуам { $lightAttribute }="{ $lightColor }"), либӧ пемыд ног рӧмсӧ веж (шуам { $darkAttribute }="{ $darkColor }").
+       *[none] Пемыд ногын тырмымӧн контраст вӧсна югыд ноглысь контрастсӧ ыдждӧд либӧ петӧм рӧмъяссӧ textColorDarkMode да/либӧ backgroundColorDarkMode пыр веж.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль тӧдмалӧмын сетӧм текст рӧм югыд ноглы тырмымӧн контраст сетіс кӧ, сылысь петӧм пемыд ног текст рӧм серпасалан инӧн тырмымӧн контраст оз сет ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; этша дырйи { $threshold }:1 колӧ). { $suggestion ->
+        [available] Пемыд ногын тырмымӧн контраст вӧсна югыд ноглысь контрастсӧ ыдждӧд (шуам textColor="{ $lightColor }"), либӧ пемыд ног рӧмсӧ веж (шуам textColorDarkMode="{ $darkColor }").
+       *[none] Пемыд ногын тырмымӧн контраст вӧсна югыд ноглысь контрастсӧ ыдждӧд либӧ петӧм рӧмсӧ textColorDarkMode пыр веж.
+    }
+
+section-multiple-style-palettes = Юкӧн ӧти сӧмын <stylePalette> бӧрйыны вермас; медбӧръяыс вӧдитчӧ.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый numToSelect минус абу тыр лыд абу.
+
+variant-num-to-select-not-constant-number = { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый numToSelect вежласьтӧм лыд абу.
+
+variant-with-replacement-not-constant-boolean = { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый withReplacement вежласьтӧм логическӧй дон абу.
+
+variant-select-weight-disables-unique = кутшӧмкӧ бӧрйӧмын selectWeight либӧ selectForVariants сетӧма кӧ, select вылӧ выльысь лотӧм вариантъяс кусӧны
+
+variant-coprime-undetermined = { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый coprime пыр абу веськыд-ӧ, сійӧс тӧдмавны оз позь.
+
+variant-attribute-not-constant = { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый { $attribute } вежласьтӧм абу.
+
+variant-attribute-not-number = { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый { $attribute } лыд абу.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } нога { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый { $attribute } { $expected ->
+        [letters-combination] шыпасъяслӧн ӧтлаӧдӧм
+        [math-expression] лӧсялана математическӧй висьталӧм
+        [integer] тыр лыд
+       *[number] лыд
+    } абу.
+
+variant-length-not-integer = { $component } вылӧ выльысь лотӧм вариантъяссӧ тӧдмавны оз позь, тайӧс вӧсна мый length тыр лыд абу.
+
+variant-sort-not-implemented = sort эма { $component } вылӧ выльысь лотӧм вариантъяс абу вӧчӧма
+
+variant-exclude-combinations-not-implemented = excludeCombinations эма { $component } вылӧ выльысь лотӧм вариантъяс абу вӧчӧма
+
+variant-math-exclude-not-implemented = exclude эма math нога { $component } вылӧ выльысь лотӧм вариантъяс абу вӧчӧма
+
+variant-non-constant-exclude-not-implemented = вежласьтӧм абу exclude эма { $component } вылӧ выльысь лотӧм вариантъяс абу вӧчӧма
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графиклӧн prefigure серпасалысьын абу вӧчӧма; выйӧдыс кольӧма.
+
+prefigure-descendant-invalid-geometry = { $subject }: помтӧм либӧ тырмытӧм геометрия; выйӧдыс кольӧма.
+
+prefigure-curve-label-omitted = { $subject }: вуджӧдӧм кусыня элементъясын пасъяс абу вӧчӧма; пас кольӧма.
+
+prefigure-curve-unsupported-definition-type = { $subject }: абу вӧчӧм кусыня функция тӧдмалӧмлӧн ногыс «{ $definitionType }»; выйӧдыс кольӧма.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементысь flipFunctions атрибут абу вӧчӧма; выйӧдыс кольӧма.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулаӧн сетӧм челядь функцияяссӧ сӧмын босьтӧ; выйӧдыс кольӧма.
+
+prefigure-label-position-unsupported =
+    { $subject }: абу вӧчӧм labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] визьяслӧн котырыслӧн пасыслы
+       *[point] паслӧн пасыслы
+    }; PreFigure-лӧн подув ӧтлаӧдӧмыс вӧдитчӧ.
+
+prefigure-fill-style-unsupported = { $subject }: тыртан стиль «{ $fillStyle }» PreFigure вылӧ абу вӧчӧма; тыр тыртӧмӧ вуджӧ.
+
+prefigure-line-style-unknown = { $subject }: тӧдтӧм визь стиль «{ $lineStyle }» PreFigure петӧмысь бӧрйӧма.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стиль «{ $markerStyle }» PreFigure «diamond» стильӧн лӧсьӧдӧма.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стиль «{ $markerStyle }» PreFigure вылӧ абу вӧчӧма; подув стиль вӧдитчӧ.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: абу веськыд `ref`; могсӧ йитны оз позь. Пасйӧд бӧрйӧма.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` уна могӧн йитчис; медводдзаыс вӧдитчӧ.
+
+annotation-ref-outside-graph = `<annotation>`: абу веськыд `ref`; мог сійӧс пытшкас босьтысь графикысь ортсыын. Пасйӧд бӧрйӧма.
+
+annotation-ref-unsupported-target = `<annotation>`: абу веськыд `ref`; мог prefigure вуджӧдӧмын вӧчӧм график объект абу. Пасйӧд бӧрйӧма.
+
+annotation-text-missing = `<annotation>`: `text` абу либӧ тыртӧм; тыртӧм текст петкӧдчӧ.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Гӧгрӧс кывтӧм аддзӧма.
+       *[other] `<{ $componentType }>` компонентсӧ пытшкас босьтысь гӧгрӧс кывтӧм аддзӧма.
+    }
+
+reference-no-referent = Йитӧдлы объект эз аддзысь: `{ $reference }`
+
+reference-multiple-referents = Йитӧдлы уна объект аддзӧма: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементлӧн { $attribute } атрибутыслӧн форматыс абу веськыд.
+
+children-invalid = `<{ $componentType }>` вылӧ абу веськыд челядь: абу веськыд челядь аддзӧма: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутлы абу веськыд дон `{ $value }`; `{ $default }` дон вӧдитчӧ
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версия эз аддзысь.
+       *[other] DoenetML { $version } версия эз аддзысь. { $fallback } версия вӧдитчӧ
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Абу веськыд DoenetML: { $content }
+
+parse-tag-missing-close-tag = Абу веськыд DoenetML: `{ $tag }` теглӧн пӧдлалан тегыс абу. Ас пӧдласьысь тег либӧ `</{ $tagName }>` тег виччысьӧма.
+
+parse-tag-error = Абу веськыд DoenetML: `<{ $tagName }>` тегын тшыкӧдчӧм
+
+parse-attribute-missing-value = Абу веськыд DoenetML: `{ $attribute }` атрибутын дон оз тырмы кодь.
+
+parse-attribute-invalid = Абу веськыд DoenetML: абу веськыд атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Абу веськыд DoenetML: атрибутлӧн абу веськыд донйыс `{ $value }`
+
+parse-attribute-value-quote-mismatch = Абу веськыд DoenetML: атрибутлӧн абу веськыд донйыс `{ $value }`. Кавычкаяс оз лӧсявны. `{ $quote }` оз тырмы кодь
+
+parse-open-tag-name-missing = Абу веськыд DoenetML: нимтӧм тег аддзӧма, шуам `<`
+
+parse-tag-not-closed = Абу веськыд DoenetML: `{ $tag }` тег абу пӧдлалӧма (`>` оз тырмы кодь).
+
+parse-self-closing-tag-name-missing = Абу веськыд DoenetML: нимтӧм тег аддзӧма `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Абу веськыд DoenetML: `{ $tag }` тег абу пӧдлалӧма (`/>` оз тырмы кодь).
+
+parse-tag-invalid-attributes = Абу веськыд DoenetML: `{ $tag }` тег лӧсялана абу. Сылӧн атрибутъясыс абу веськыдӧсь лоны вермасны.
+
+parse-close-tag-name-missing = Абу веськыд DoenetML: нимтӧм пӧдлалан тег аддзӧма, шуам `</`
+
+parse-attribute-value-unquoted = Атрибутлӧн донъясыс кавычка пытшкын лоны колӧ: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Абу веськыд DoenetML: `{ $tag }` пӧдлалан тег аддзӧма, но сылы лӧсялана восьтан тег абу
+
+parse-close-tag-mismatched = Абу веськыд DoenetML: оз лӧсяв пӧдлалан тег. `</{ $expected }>` виччысьӧма. `{ $found }` аддзӧма
+
+parser-node-unconvertible = { $node } узелсӧ Dast узелӧ вуджӧдны эз артмы.
+
+## Names
+
+name-attribute-invalid =
+    Абу веськыд атрибут name='{ $name }'. { $reason ->
+        [characters] Нимъясын шыпасъяс, лыдъяс, улыс визьясъяс либӧ визьясъяс сӧмын лоны вермасны.
+       *[start] Нимъяс шыпасысь заводитчыны колӧ.
+    }
+
+component-name-invalid-start = Абу веськыд компонент ним «{ $name }». Нимъяс шыпасысь заводитчыны колӧ.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched нога answer-лӧн video атрибутыс лоны колӧ
+
+answer-video-watched-video-not-reference = videoWatched нога answer-лӧн video атрибутыс йитӧд лоны колӧ
+
+answer-name-not-single-text = answer-лӧн name атрибутын дзик ӧти текст челядь лоны колӧ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсиялӧн тшупӧдъясыс зэв уна, сы вӧсна ортсы DoenetML босьтны эз артмы. Гӧгрӧс йитӧд абу-ӧ?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресысь DoenetML босьтны эз артмы
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресысь абу веськыд DoenetML босьтӧма: сійӧ «{ $componentType }» компонент ноглы эз лӧсяв
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут важмис; сы пыдди `{ $to }` вӧдитчы.
+       *[other] [deprecation] `<{ $component }>` элементысь `{ $from }` атрибут важмис; сы пыдди `{ $to }` вӧдитчы.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут важмис да оз лыддьысь, тайӧс вӧсна мый `{ $to }` тшӧтш сетӧма.
+       *[other] [deprecation] `<{ $component }>` элементысь `{ $from }` атрибут важмис да оз лыддьысь, тайӧс вӧсна мый `{ $to }` тшӧтш сетӧма.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементысь `{ $attribute }` атрибут важмис да оз лыддьысь.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементысь `{ $attribute }` атрибут важмис; сы пыдди `<{ $child }>` челядьӧн вӧдитчы.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементысь `{ $attribute }` атрибутлӧн `{ $value }` донйыс важмис; сы пыдди `{ $to }` вӧдитчы.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` уна лыдсӧ англия кыв вылын сӧмын вермас вӧчны, сы вӧсна { $locale } кыв вылын гижӧм документын сылӧн текстыс вежсьытӧг колӧ. Уна лыд формасӧ асьыд гиж либӧ сійӧс `pluralForm` атрибутӧн сет.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент тӧдса Doenet элемент абу.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементлы документлӧн вужйын позянлун оз сетсьы.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементлы `<{ $parent }>` пытшкын позянлун оз сетсьы.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементын `{ $attribute }` нима атрибут абу.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементлӧн `{ $attribute }` атрибутыс быд элементыс тайӧясысь ӧти лоан список лоны колӧ: { $allowed }
+       *[other] `<{ $tag }>` элементлӧн `{ $attribute }` атрибутыс тайӧясысь ӧти лоны колӧ: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select вылӧ абу веськыд вариант ним. { $variantName } вариант ним { $numOptions } бӧрйӧмын паныдасьлӧ, а бӧрйан лыдыс { $numToSelect }.
+
+select-variant-name-without-options = select вылӧ вариантъяс сетӧма, но позяна вариант нимлы ӧти бӧрйӧм абу: { $variantName }.
+
+select-variant-name-not-possible = select вылӧ сетӧм { $variantName } вариант ним позяна вариант ним абу.
+
+select-too-few-options = Ставыс { $numOptions } пиысь { $numToSelect } компонент бӧрйыны оз позь.
+
+select-from-sequence-too-few-values = Кузьтаыс { $length } радысь { $numToSelect } дон бӧрйыны оз позь.
+
+select-from-sequence-indices-count-mismatch = select вылӧ сетӧм индексъяслӧн лыдыс бӧрйан лыдлы лӧсявны колӧ
+
+select-from-sequence-indices-not-integers = select вылӧ сетӧм став индексъяс тыр лыд лоны колӧ
+
+select-from-sequence-index-excluded = selectfromsequence вылӧ сетӧм индекс бӧрйӧма вӧлі
+
+select-from-sequence-indices-excluded-combination = selectfromsequence вылӧ сетӧм индексъяс бӧрйӧм ӧтлаӧдӧм вӧлі
+
+select-from-sequence-coprime-not-positive-integers = Плюс тыр лыдъяс абу бӧрйӧма, сы вӧсна ӧта-мӧдлы прӧстӧй ӧтлаӧдӧмъяссӧ бӧрйыны оз позь.
+
+select-from-sequence-coprime-common-factor = Ӧта-мӧдлы прӧстӧй лыдъяссӧ бӧрйыны оз позь. Став позяна донъяслӧн ӧтув юклысьыс эм. (Сетӧм "from" либӧ "to" донъяс "step"-кӧд ӧта-мӧдлы прӧстӧй лоны колӧ.)
+
+select-from-sequence-coprime-single-number = 1 абу ӧти лыдысь ӧта-мӧдлы прӧстӧй ӧтлаӧдӧмъяссӧ бӧрйыны оз позь.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence пытшкын ӧтлаӧдӧмъяслӧн 70%-ысь унджыкыс бӧрйӧма
+
+select-from-sequence-coprime-none-found = Ӧта-мӧдлы прӧстӧй лыдъяссӧ бӧрйыны эз артмы. Став позяна донъяслӧн ӧтув юклысьыс эм.
+
+select-from-sequence-too-few-unique-values = Кузьтаыс { $numPossibleValues } радысь { $numToSelect } торъялана дон бӧрйыны оз позь
+
+select-prime-numbers-too-few-values = Кузьтаыс { $numValues } прӧстӧй лыдъяс списокысь { $numToSelect } дон бӧрйыны оз позь
+
+select-prime-numbers-values-count-mismatch = select вылӧ сетӧм донъяслӧн лыдыс бӧрйан лыдлы лӧсявны колӧ
+
+select-prime-numbers-values-not-prime = select prime number вылӧ сетӧм став донъяс прӧстӧй лыдъяс списокын лоны колӧ
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers вылӧ сетӧм донъяс бӧрйӧм ӧтлаӧдӧм вӧлі
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers пытшкын ӧтлаӧдӧмъяслӧн 70%-ысь унджыкыс бӧрйӧма
+
+select-random-combination-fluke = Зэв позьтӧм лоӧм вӧсна сяма донъяслысь ӧтлаӧдӧмсӧ бӧрйыны эз артмы
+
+select-random-value-fluke = Зэв позьтӧм лоӧм вӧсна сяма донсӧ бӧрйыны эз артмы

--- a/packages/i18n/locales/kv/editor.ftl
+++ b/packages/i18n/locales/kv/editor.ftl
@@ -1,0 +1,215 @@
+# Komi editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Komi counts in the same two categories English does, so every selection below
+# keeps both branches — though a noun after a numeral stays singular, so the
+# two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Бӧр вайны
+       *[update] Выльмӧдны
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Видзӧдысьсӧ { $word }
+       *[other] Видзӧдысьсӧ { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Бӧрйӧм…
+editor-variant-next = Водзӧ вариант бӧрйыны
+editor-variant-previous = Бӧрын вариант бӧрйыны
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA воан позянлун торкӧм аддзӧма. Воан позянлун отчёт { $action ->
+            [close] пӧдлавны
+           *[open] восьтны
+        } вӧсна ляпкы.
+        [advisories] Воан позянлун отчёт { $action ->
+            [close] пӧдлавны
+           *[open] восьтны
+        } вӧсна ляпкы. WCAG AA торкӧмъяс эз аддзысьны, но содтӧд индӧдъяс эмӧсь.
+       *[clean] Воан позянлун отчёт { $action ->
+            [close] пӧдлавны
+           *[open] восьтны
+        } вӧсна ляпкы. Воан позянлун могъяс эз аддзысьны.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA воан позянлун торкӧм аддзӧма. { $count ->
+            [one] { $count } WCAG AA торкӧм
+           *[other] { $count } WCAG AA торкӧм
+        } аддзӧма. Воан позянлун отчёт { $action ->
+            [close] пӧдлавны
+           *[open] восьтны
+        } вӧсна ляпкы.
+        [advisories] WCAG AA торкӧмъяс эз аддзысьны. { $count ->
+            [one] { $count } содтӧд индӧд
+           *[other] { $count } содтӧд индӧд
+        } аддзӧма. Воан позянлун отчёт { $action ->
+            [close] пӧдлавны
+           *[open] восьтны
+        } вӧсна ляпкы.
+       *[clean] WCAG AA торкӧмъяс эз аддзысьны. Воан позянлун отчёт { $action ->
+            [close] пӧдлавны
+           *[open] восьтны
+        } вӧсна ляпкы.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версия { $version }
+
+editor-tab-help = Контекст отсӧг
+editor-tab-help-short = Контекст
+editor-tab-errors = Тшыкӧдчӧмъяс
+editor-tab-warnings = Пасйӧмъяс
+editor-tab-info = Юӧр
+editor-tab-accessibility = Воан позянлун
+editor-tab-responses = Мӧдӧдӧм вочакывъяс
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторлӧн лӧсьӧдӧмъясыс
+editor-format-as-doenetml = DoenetML моз форматируйтны
+editor-format-as-xml = XML моз форматируйтны
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-ӧд визь
+
+editor-no-errors = Тшыкӧдчӧмъяс абуӧсь
+editor-no-warnings = Пасйӧмъяс абуӧсь
+editor-no-info = Юӧр висьталӧмъяс абуӧсь
+
+editor-show-info-annotations = Юӧр висьталӧмъяссӧ редакторын петкӧдлыны
+editor-show-accessibility-annotations = Воан позянлун висьталӧмъяссӧ редакторын петкӧдлыны
+
+editor-accessibility-learn-more = Doenet воан позянлун вылӧ кыдзи видзӧдӧ
+
+editor-accessibility-violations-heading = Воан позянлун торкӧмъяс ({ $standard })
+
+editor-accessibility-other-heading = Мукӧд воан позянлун могъяс
+editor-none-found = Немтор эз аддзысь
+
+
+## Submitted responses
+
+editor-no-responses = Ӧнӧдз мӧдӧдӧм вочакывъяс абуӧсь
+editor-response-answer-id = Вочакывлӧн Id-ыс
+editor-response-response = Вочакыв
+editor-response-credit = Балл
+editor-response-submitted = Мӧдӧдӧма
+
+
+## The context-help panel
+
+help-placeholder = Документация аддзӧм вӧсна курсорсӧ тег ним вылӧ, атрибут вылӧ либӧ { $ref } вылӧ пукты.
+
+help-unsupported-ref-chain = { $example } кодь уна юкӧна йитӧдъяслы отсӧг ӧнӧдз абу.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Йитӧдлы объект эз аддзысь: { $ref }.
+        [multiple] Йитӧдлы уна объект аддзӧма: { $ref }.
+       *[indeterminate] { $ref } объектсӧ тӧдмавны эз артмы.
+    }
+
+help-learn-about-references = Йитӧдъяс йылысь тӧдмавны →
+help-reference-page = Индӧд лист бок →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } пытшкын
+       *[top] Медвылыс тшупӧдын
+    }{ $allowed ->
+        [none] { " — тані немтор оз тӧр." }
+        [text] { " — тані текст гижны позьӧ." }
+        [text-and-components] { " — тані текст гижны позьӧ, либӧ тайӧс видлы:" }
+       *[components] { " — тайӧс видлыны позьӧ:" }
+    }
+
+help-suggestions-footer = Став { $total } компонентсӧ аддзӧм вӧсна { $shortcut } ляпкы.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объект вылӧ йитӧд.
+       *[other] { $ref } — { $target } объект вылӧ йитӧд ({ $line }-ӧд визь).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Сійӧс { $owner } { $role } моз пыртіс.
+       *[other] Сійӧс { $owner } { $line }-ӧд визьын { $role } моз пыртіс.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементлӧн { $property } свойствоыс вылӧ йитӧд.
+       *[other] { $ref } — { $element } элементлӧн { $property } свойствоыс вылӧ йитӧд ({ $line }-ӧд визь).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = юкӧн
+help-kind-array-entry = массивлӧн элементыс
+
+help-default = Подув дон:
+help-active-default = Ӧнія подув дон:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Позьтана донъяс (быд элементлы ӧти):
+       *[other] Позьтана донъяс:
+    }
+
+help-suggested-values = Индӧм донъяс:
+
+help-inserts = Содтӧ:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатаяс:
+    }
+
+help-type = Ногыс:
+
+help-resolved-style = Петӧм стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Петӧм функциялӧн нимъясыс:
+help-reset-list = Тайӧ ин бӧр вайӧм список:
+help-added-on-input = Тайӧ инын содтӧмъяс:
+help-removed-on-input = Тайӧ инысь бӧрйӧмъяс:
+
+help-reset-overrides = { $reset } — { $additional } да { $removed } вылын вермӧ.

--- a/packages/i18n/locales/myv/chrome.ftl
+++ b/packages/i18n/locales/myv/chrome.ftl
@@ -1,0 +1,138 @@
+# Erzya viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Erzya counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular, so the two branches differ in nothing but the number they print.
+
+
+## Answer submission
+
+answer-checking = Ваннови…
+answer-submitting = Кучови…
+
+answer-checking-status = Каршо валось ваннови
+answer-submitting-status = Каршо валось кучови
+
+answer-correct = Виде
+answer-incorrect = А виде
+
+answer-response-saved = Каршо валось ванстозь
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% виде
+answer-percent-short = { $percent } %
+
+max-credit-available = Саемс маштови сехте покш балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] снартнема арась
+        [one] { $count } снартнема кадовсь
+       *[other] { $count } снартнема кадовсь
+    }
+
+validation-correct = (Виде)
+validation-incorrect = (А виде)
+validation-partially-correct = (Пельксэнь коряс виде)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } лангс { $count } каршо вал невтемс
+       *[other] { $answerId } лангс { $count } каршо вал невтемс
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Мекев ёвтамо
+
+collapsible-click-to-open = (панжомга лепштик)
+collapsible-click-to-close = (пекстамга лепштик)
+
+collapsible-initializing = Анокстави…
+
+footnote-show = Тешкстамонть невтемс
+footnote-hide = Тешкстамонть кекшемс
+
+description-more-information = поладкс тевпаро
+
+
+## Controls
+
+slider-previous = Икелень
+slider-next = Сы
+
+keyboard-open = Клавиатуранть панжомс
+keyboard-close = Клавиатуранть пекстамс
+
+choice-input-remove-choice = { $choice } кочкамонть саемс
+
+matrix-remove-row = Рядонть саемс
+matrix-add-row = Ряд поладомс
+matrix-remove-column = Баганонть саемс
+matrix-add-column = Баган поладомс
+
+subset-add-remove-points = Точка поладомс/саемс
+subset-toggle-points-intervals = Точкатнень ды юткотнень полавтомс
+subset-move-points = Точкатнень ютавтомс
+subset-clear = Ванськавтомс
+
+orbital-add-row = Ряд поладомс
+orbital-remove-row = Рядонть саемс
+orbital-add-box = Клетка поладомс
+orbital-remove-box = Клетканть саемс
+orbital-add-up-arrow = Верев нал поладомс
+orbital-add-down-arrow = Алов нал поладомс
+orbital-remove-arrow = Налонть саемс
+
+orbital-row-label = { $row } рядонь тешкс
+
+pretzel-answer = Каршо вал
+
+summary-statistics-caption = { $column } баганонь прядомань статистика
+
+
+## Math input
+
+math-input-preview-region = математикань ёвтамонь икелькс ваномась
+math-input-preview = Икелькс ваномась
+math-input-invalid-expression = А виде ёвтамо:
+
+
+## Document status
+
+viewer-initializing = Анокстави…
+
+
+## Errors
+
+error-heading = Ильведевкс
+
+error-found-at =
+    { $span ->
+        [line] Муезь ряд: { $startLine }.
+       *[lines] Муезь рядт: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Те документсэнть улить ильведевкст!
+
+diagnostic-heading-error = Ильведевкс
+diagnostic-heading-warning = Икелев пелькстамо
+diagnostic-heading-information = Тевпаро
+diagnostic-heading-hint = Невтевкске
+
+accessibility-heading-level-1 = WCAG AA пачкодемань коламо
+accessibility-heading-level-2 = Пачкодемадо тевпаро
+
+something-went-wrong = Мезеяк а виде лиссь.
+
+renderer-load-failed = артыцянть аволь саевсь. Лопанть одкстомтык.
+
+core-start-failed = Документэнь ваныцянть аволь ушодовсь. Лопанть одкстомтык.

--- a/packages/i18n/locales/myv/content.ftl
+++ b/packages/i18n/locales/myv/content.ftl
@@ -1,0 +1,254 @@
+# Erzya content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic, which is the orthography Mordovia's schools and
+# publishing use and what CLDR fills a bare `myv` in as.
+#
+# **Erzya and Moksha are two languages, not two spellings of one.** ISO 639-3
+# gives them `myv` and `mdf` separately, there is no macrolanguage code over
+# them that this repository could name a catalog after, and a Moksha reader
+# arriving under `mdf` therefore reaches English rather than this file. That is
+# the membership rule in `negotiate.ts` working rather than a gap in it — the
+# same place `fat` and `alq` land — and the answer to it is a `locales/mdf`
+# beside this one, not a widening of this one.
+#
+# Erzya has no grammatical gender and does not inflect an attributive
+# adjective, so `$gender` and `$role` go unused — the answer every non-Nakh
+# catalog in this batch gives.
+
+
+## Style vocabulary
+
+color =
+    .black = раужо
+    .white = ашо
+    .gray = серой
+    .red = якстере
+    .orange = тюжа
+    .yellow = ожо
+    .green = пиже
+    .cyan = валдо сэнь
+    .blue = сэнь
+    .purple = фиолетовой
+    .pink = розовой
+    .brown = коричневой
+
+line-width =
+    .thick = эчке
+    .thin = човине
+
+line-style =
+    .dashed = сезнезь
+    .dotted = точкань
+
+# Noun phrases: they stand in front of «мазылгавтомасо» and modify nothing.
+fill-style =
+    .horizontal = горизонтальной линия
+    .vertical = вертикальной линия
+    .diagonal = диагональной линия
+    .backdiagonal = каршо диагональной линия
+    .dots = точка
+    .diamonds = ромб
+
+noun =
+    .line = виде линия
+    .line-segment = пелькске
+    .ray = луч
+    .vector = вектор
+    .curve = кичкере линия
+    .function = функция
+    .parabola = парабола
+    .polyline = синдезь линия
+    .polygon = ламо ужо
+    .triangle = колмо ужо
+    .rectangle = виде ужо
+    .circle = круг
+    .region = тарка
+    .point = точка
+    .square = квадрат
+    .diamond = ромб
+    .cross = крёст
+    .plus = плюс
+
+# Erzya builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] видестэ { $numSides } ужо
+    }
+
+# Erzya has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = артозь
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } мазылгавтомасо { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } мазылгавтомасо { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } мазылгавтомасо { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «чиресэ» is the inessive of «чире», "edge", and carries the whole of "with a
+# border" in its own suffix — the same shape `locales/udm` and `locales/kv`
+# use, arriving from the other end of Uralic.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } чиресэ
+        [and] ды { $border } чиресэ
+        [and-article] ды { $border } чиресэ
+       *[with] { $border } чиресэ
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } мазылгавтомасо { $color } артома
+       *[plain] { $color } артома
+    }
+
+style-unfilled = апак арта
+
+# «лангсо» — "on" — is a postposition and follows the background colour, so
+# nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон лангсо { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = арась
+
+
+## Boolean words
+
+boolean-true = виде
+boolean-false = а виде
+
+
+## Answer buttons
+
+answer-submit-label = Ванномс
+answer-submit-label-no-correctness = Каршо валонть кучомс
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Тев
+    .aside = Ёно тешкстамо
+    .cascade = Каскад
+    .definition = Мерема
+    .example = Невтевкс
+    .exercise = Упражнения
+    .exercises = Упражненият
+    .given-answer = Каршо вал
+    .note = Тешкстамо
+    .objectives = Цельть
+    .paragraphs = Абзацт
+    .part = Пелькс
+    .problem = Задача
+    .problems = Задачат
+    .proof = Кемекстамо
+    .question = Кевкстема
+    .section = Пелькске
+    .solution = Решения
+    .task = Задания
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Невтевкске
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Артовкс { $enumeration }
+        [numbered-caption] Артовкс { $enumeration }{ ". " }
+        [unnumbered-caption] Артовкс{ ". " }
+       *[unnumbered] Артовкс
+    }
+
+
+## Paginator controls
+
+paginator-previous = Икелень
+paginator-next = Сы
+paginator-page = Лопа
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## Erzya's conditional «бути» is clause-initial, as Buryat's and Kalmyk's are,
+## so this key lands where the renderer puts it — unlike the two Permic
+## catalogs beside it, `locales/udm` and `locales/kv`, whose «ке» and «кӧ»
+## follow their clause and record a limit there. Three Uralic catalogs in one
+## batch, and word order rather than family decides.
+
+piecewise-condition-or = эли
+piecewise-condition-if = бути
+piecewise-condition-otherwise = лия таркава
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Mordovia is taught in
+## Russian, so the element names an Erzya-speaking pupil meets are the Russian
+## ones — the school-system case this batch shares throughout.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = А виде химиянь тешкс
+chemistry-invalid-ionic-compound = А виде иононь сюлмавкс

--- a/packages/i18n/locales/myv/content.ftl
+++ b/packages/i18n/locales/myv/content.ftl
@@ -233,8 +233,9 @@ paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
 ## Erzya's conditional «бути» is clause-initial, as Buryat's and Kalmyk's are,
 ## so this key lands where the renderer puts it — unlike the two Permic
 ## catalogs beside it, `locales/udm` and `locales/kv`, whose «ке» and «кӧ»
-## follow their clause and record a limit there. Three Uralic catalogs in one
-## batch, and word order rather than family decides.
+## follow their clause and record a limit there — as `locales/chm`'s «гын»
+## does too. Four Uralic catalogs in one batch, three of them recording the
+## limit and this one not, so word order rather than family decides.
 
 piecewise-condition-or = эли
 piecewise-condition-if = бути

--- a/packages/i18n/locales/myv/diagnostics.ftl
+++ b/packages/i18n/locales/myv/diagnostics.ftl
@@ -1,0 +1,654 @@
+# Erzya diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Erzya uses
+# for them: «компонент», «атрибут», «функция», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кавто пень точкатне невтезь бути, { $attributes } а ловови
+       *[other] кавто пень точкатне невтезь бути, { $attributes } а ловови
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] пень точкась ды куншка точкась кавонест невтезь бути, { $attributes } а ловови
+       *[other] пень точкась ды куншка точкась кавонест невтезь бути, { $attributes } а ловови
+    }
+
+line-segment-midpoint-offset-without-midpoint = куншка точкавтомо midpointOffset мезескак а токши
+
+## `<line>`
+
+line-points-undetermined-dimensions = Онксозо асодавикс точкатнень пачк ютыця виде линия.
+
+line-points-too-few-dimensions = Виде линиясь сехте аламо кавто онкссо точкатнень пачк ютомо эряви.
+
+line-points-depend-on-variables = Виде линиясь полавтовиця онкстнэде лепштявиця точкатнень пачк юты: { $variables }.
+
+line-equation-invalid-format = { $variable1 } ды { $variable2 } полавтовиця онкссо виде линиянь уравнениянть форматозо а виде.
+
+## `<ray>`
+
+ray-overprescribed-through = Лучось through, endpoint ды direction пачк максозь. Максозь through а ловови.
+
+ray-dimension-mismatch = лучсонть numDimensions а вейсэнди.
+
+## `<vector>`
+
+vector-overprescribed-head = Векторось head, tail ды displacement пачк максозь. Максозь head а ловови.
+
+vector-dimension-mismatch = векторсонть numDimensions а вейсэнди.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементэнтень таргамс а маштови, эдь сонзэ nearestPoint статусонь полавтовицязо арась.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементсэ пежедемс а маштови, эдь сонзэ nearestPoint статусонь полавтовицязо арась.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементэнь потмосонзо пежедемс а маштови, эдь сонзэ nearestPoint статусонь полавтовицязо арась.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = ряд потсо аволь choiceInput лангс labelPosition а ловови
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput лангс максозь индекстнэ а ловновить, эдь сынст ламоксчист choice эйкакштнэнь ламоксчинтень а вейсэнди.
+
+pretzel-indices-count-mismatch = problem лангс максозь индекстнэ а ловновить, эдь сынст ламоксчист problem эйкакштнэнь ламоксчинтень а вейсэнди.
+
+shuffle-indices-count-mismatch = shuffle лангс максозь индекстнэ а ловновить, эдь сынст ламоксчист компоненттнэнь ламоксчинтень а вейсэнди.
+
+indices-ignored-out-of-range = { $component } лангс максозь индекстнэ а ловновить, эдь конатнеяк пелькстамодо лисить.
+
+pretzel-indices-repeated = pretzel лангс максозь индекстнэ а ловновить, эдь конатнеяк омбоцеде вастневить.
+
+pretzel-circuit-first-index = circuit режимсэ pretzel лангс максозь индекстнэ а ловновить, эдь васенце индексэсь 1 улемс эряви.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текстэнь эйкакштнэ марто важодемга `type` атрибут максомс эряви.
+
+invalid-type-defaulting-to-math = { $component } компонентэнтень а виде лад { $type }. Сон math, text, number эли boolean улемс эряви. math тевс нолдави.
+
+string-not-valid-component-to-arrange = «{ $value }» рядось { $component } лангс маштовикс компонент арась. А ловови.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = А виде лад { $type }, ладозо number ули.
+
+invalid-variable-value = Полавтовицянь а виде питне: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантонь индексэсь ловома улемс эряви
+
+variant-index-must-be-integer = { $index } вариантонь индексэсь целой ловома улемс эряви
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютной онкстнэнень а теезь. Келест вейсэндявикс улить.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютной онкстнэнень а теезь. Чирест вейсэндявикс улить.
+
+side-by-side-no-block-child = А виде `<{ $component }>`: сонзэ сехте аламо вейке блок эйкакшозо улемс эряви.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементэнь `for` атрибутось а ловови.
+
+label-for-must-resolve-to-one = `<label>` элементэнь `for` атрибутось ансяк вейке компонент лангс невтемс эряви.
+
+label-for-unresolved = `<label>` элементэнь `for` атрибутонть компонент марто сюлмамс эзь маштово.
+
+label-for-answer-with-authored-inputs = `<label>` элементэнь `for` атрибутось авторонь сёрмадозь совавтома таркат марто `<answer>` лангс невти; таркантень видестэ невтик.
+
+label-for-answer-without-input = `<label>` элементэнь `for` атрибутось совавтома таркавтомо `<answer>` лангс невти.
+
+label-for-must-reference-input-or-answer = `<label>` элементэнь `for` атрибутось совавтома тарка эли каршо вал лангс невтемс эряви.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Пачкодемань кисэ `<{ $component }>` эли нурька невтема марто улемс эряви, эли мазылгавтома ладсо тешкстамс.
+
+accessibility-video-short-description = Пачкодемань кисэ `<video>` нурька невтема марто улемс эряви.
+
+accessibility-input-short-description-or-label = Пачкодемань кисэ `<{ $component }>` нурька невтема эли тешкс марто улемс эряви.
+
+accessibility-answer-input-short-description-or-label = Пачкодемань кисэ совавтома тарка теиця `<answer>` нурька невтема эли тешкс марто улемс эряви.
+
+accessibility-short-description-contains-math = Нурька невтематнесэ `<{ $component }>` ладсо математикань компоненттнэ улемс а эрявить. Математиканть валсо сёрмадык.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } пелькскень прявт текстэнтень сатышка контраст а максы (чопода лад) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; сехте аламо { $threshold }:1 эряви).
+       *[other] { $colorName } пелькскень прявт текстэнтень сатышка контраст а максы ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; сехте аламо { $threshold }:1 эряви).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Точкатнень ловома питнест арасть бути, { $count } точкань пачк ютыця `<circle>` а теезь.
+
+circle-too-many-through-points = 3-де ламо точкань пачк ютыця кругонть ловомс а маштови.
+
+circle-overprescribed-radius-center-points = Максозь радиус, куншка ды точкат марто кругонть ловомс а маштови.
+
+circle-center-with-multiple-points = Максозь куншка марто 1-де ламо точкань пачк ютыця кругонть ловомс а маштови.
+
+circle-radius-too-small = Кругонть ловомс а маштови: кавто точкатнень ютксост { $distance } бути, максозь радиусось { $radius } пек вишкине.
+
+circle-radius-with-many-points = Максозь радиус марто кавтодо ламо точкань пачк ютыця круг теемс а маштови.
+
+circle-invalid-center-or-through-points = Кругонь куншказо эли точканзо а видеть.
+
+circle-radius-center-with-multiple-points = Максозь куншка марто 1-де ламо точкань пачк ютыця кругонь радиусонзо ловомс а маштови.
+
+circle-change-radius-non-numerical = Ловома аволь точкат марто кругонь радиусонзо полавтомс а маштови
+
+circle-radius-with-points-non-numerical = Ловома питнеть арасть бути, максозь радиус марто вейкеде ламо точкань пачк ютыця круг теемс а маштови.
+
+circle-change-center-non-numerical = Ловома аволь точкань пачк ютыця кругонь куншканзо полавтомась а теезь.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функциянь содавикс тарканть онксозо а сатни. Таркасонть { $intervals } ютко ули, а функциясонть { $inputs ->
+            [one] { $inputs } совавтома
+           *[other] { $inputs } совавтома
+        } ули.
+       *[other] Функциянь содавикс тарканть онксозо а сатни. Таркасонть { $intervals } ютко ули, а функциясонть { $inputs ->
+            [one] { $inputs } совавтома
+           *[other] { $inputs } совавтома
+        } ули.
+    }
+
+function-domain-invalid-format = Функциянь содавикс тарканть форматозо а виде.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функциянь ловома аволь максимумозо а ловови.
+        [minimum] Функциянь ловома аволь минимумозо а ловови.
+        [extremum] Функциянь ловома аволь экстремумозо а ловови.
+        [point] Функциянь ловома аволь точказо а ловови.
+        [slope] Функциянь ловома аволь чирезэ а ловови.
+       *[other] Функциянь ловома аволь { $type } питнезэ а ловови.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функциянь чаво максимумозо а ловови.
+        [minimum] Функциянь чаво минимумозо а ловови.
+        [extremum] Функциянь чаво экстремумозо а ловови.
+        [point] Функциянь чаво точказо а ловови.
+       *[other] Функциянь чаво { $type } питнезэ а ловови.
+    }
+
+function-points-too-close = Функциясонть вейкест-вейкест пек маласо кавто точкат улить. Функциянть содамс а маштови.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функциянь итерациятне маштовить ансяк совавтоматнень ламоксчист лисематнень ламоксчинтень вейкетть бути. Те функциясонть { $inputs } совавтома ды { $outputs ->
+            [one] { $outputs } лисема
+           *[other] { $outputs } лисема
+        } ули.
+       *[other] Функциянь итерациятне маштовить ансяк совавтоматнень ламоксчист лисематнень ламоксчинтень вейкетть бути. Те функциясонть { $inputs } совавтома ды { $outputs ->
+            [one] { $outputs } лисема
+           *[other] { $outputs } лисема
+        } ули.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Мельга-мельгань кувалмозо а виде. Сон минус аволь целой ловома улемс эряви.
+
+sequence-invalid-step = Мельга-мельгань эскелксэзэ а виде. { $type } ладсо мельга-мельгантень сон ловома улемс эряви.
+
+sequence-invalid-endpoint-number = Ловомань мельга-мельгань «{ $attribute }» питнезэ а виде. Сон ловома улемс эряви.
+
+sequence-invalid-endpoint-letters = Буквань мельга-мельгань «{ $attribute }» питнезэ а виде. Сон буквань вейсэндявкс улемс эряви.
+
+sequence-invalid-endpoint = Мельга-мельгань «{ $attribute }» питнезэ а виде.
+
+select-from-sequence-coprime-not-numbers = ловоматне а кочказь, седе coprime а ловови
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations максозь, седе coprime а ловови
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` лангс а виде target: цель эзь муеве.
+
+target-state-variable-not-found = `<{ $source }>` лангс а виде target: `<{ $component }>` элементсэ «{ $property }» лем марто статусонь полавтовиця эзь муеве.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` полавтовицянзо эсь прянь полавтовицядонть явовомс эрявить.
+
+ode-system-duplicate-variable-names = Лепштявиця полавтовицятнень лемест омбоцеде вастневить бути, ДТ вить пелень функциятнень содамс а маштови.
+
+ode-system-rhs-function-error = ДТ вить пелень функциянть содамс а маштови. mathjs функциянть теемстэ ильведевкс.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } виде линиянь ютксо ужонть содамс а маштови
+
+angle-invalid-through-point = `<angle>` элементэнь through питнесэнть а виде точка
+
+parabola-vertex-too-many-points = Максозь пря марто 1-де ламо точкань пачк ютыця парабола а теезь.
+
+parabola-too-many-points = 3-де ламо точкань пачк ютыця парабола а теезь.
+
+intersection-too-many-items = Кавтодо ламо объектэнь вастневемась а теезь
+
+## Other math components
+
+ionic-compound-not-two-ions = Кавто иондо башка иононь сюлмавкст а теезь.
+
+ionic-compound-needs-cation-and-anion = Иононь сюлмавксось ансяк вейке катионтень ды вейке анионтень теезь.
+
+solve-equations-cannot-evaluate = Уравнениянть теемс а маштови, эдь сонзэ ловомс эзь маштово: { $equation }
+
+math-operators-operand-number-required = Математикань операндонть явовтомга operandNumber максомс эряви.
+
+eigen-decomposition-failed = Матрицань эсь питнензэ ловомс эзь маштово
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметрась образецсэнть а вастневи, седе сон свал чавонтень вейсэнди.
+       *[other] `<matchesPattern>`: { $parameters } параметртне образецсэнть а вастневить, седе сынь свал чавонтень вейсэндить.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" питненть чарькодемс а маштови. Сон none, medium, dense эли чаво таркасо явовтозь кавто плюс ловома улемс эряви, кода grid="1 0.5". Сеткась а артови.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure артыцясонть xLabelPosition="left" а теезь; вить пелень аштема тевс нолдави.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure артыцясонть yLabelPosition="bottom" а теезь; вере пелень аштема тевс нолдави.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure ютавтомантень тенгетнень пест а видеть; основной bbox (-10,-10,10,10) тевс нолдави.
+
+prefigure-invalid-width = `<graph>`: prefigure ютавтомантень келезэ а виде; диаграммань основной келезэ 425 тевс нолдави.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure ютавтомантень aspectRatio а виде; основной пелькстнэнь вейсэндявксост 1 тевс нолдави.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткань эскелксэзэ тенгетнень пестэнзэ пек вишкине; prefigure артыцясонть сеткась а невтеви.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure артыцясь а тевс нолдави бути, тешкстамотне а артовить.
+
+multiple-annotations-children = `<graph>` потсо ламо `<annotations>` эйкакш муезь; меельцеденть башка лиятне а ловновить.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Асодавикс компонентэнь ладонть келейгавтомс эли копировамс а маштови: { $type }.
+
+copy-prop-not-found = { $component } ладсо компонентсэнть { $property } свойства эзь муеве
+
+collect-no-source = collect лангс лисьма эзь муеве.
+
+collect-invalid-component-type = `<{ $component }>` ладсо компоненттнэнь пурнамс а маштови, эдь те а виде компонентэнь лад.
+
+reference-index-unavailable = `{ $reference }` индекс лангс сюлмавкс теемс а маштови
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентсэнть { $action } тердемс а маштови
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннойтнень ладост а виде. Рядтнэнь кувалмост а вейкетть. Муезь componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннойтнесэ баганонь лемтне омбоцеде вастневить. Муезь componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннойтнесэ баганонь лем а сатни. Муезь componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Те каршо валонь award питнезэ answer тегень эсензэ кучозь каршо вал лангс аштевти, те а учовикс тевтненень пачти.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` марто контейнер потсо `<answer>` лангс `maxNumAttempts` путомась а токши, эдь снартнематнень ламоксчист контейнерэсь содасы. `maxNumAttempts` питненть контейнер лангс путык.
+
+nested-section-wide-check-work-max-num-attempts = Лия `sectionWideCheckWork` контейнер потсо аштиця `sectionWideCheckWork` контейнер лангс `maxNumAttempts` путомась а токши, эдь снартнематнень ламоксчист ушо контейнерэсь содасы. `maxNumAttempts` питненть ушо контейнер лангс путык.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality а путозь бути, { $attributes } атрибутось а токши.
+       *[other] symbolicEquality а путозь бути, { $attributes } атрибуттнэ а токшить.
+    }
+
+answer-invalid-type = answer лангс а виде лад: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентэнь лемезэ арась, седе сонзэ модулень атрибут ладсо тевс нолдамс а маштови
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентэнть модулень атрибут ладсо тевс нолдамс а маштови, эдь `<module>` компонентэнь ладсонть «{ $name }» атрибутось уш содазь.
+
+conditional-content-condition-ignored = case эли else эйкакшт марто `<conditionalContent>` компонентсэнть `condition` атрибутось а ловови.
+
+slider-markers-type-mismatch = Маркертнэнь ладост ползунокань ладонтень а вейсэнди.
+
+pretzel-problem-needs-statement-and-answer = А виде pretzel: эрьва `<problem>` вейке `<statement>` ды вейке `<answer>` потмозонзо саемс эряви.
+
+pretzel-circuit-first-problem-distractor = А виде pretzel: mode="circuit" режимсэ васенце `<problem>` мельть ёно ветиця улемс а маштови.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутонтень а виде питне { $values }; а ловови.
+       *[other] `{ $attribute }` атрибутонтень а виде питнеть { $values }; а ловновить.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутонтень а виде питне `{ $value }`. Атрибутось `$` тешкстэ ушодовиця сюлмавкстнэде улемс эряви.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } потсо а виде функциянь лемтне эзть ловново: { $names }. Эрьва лемень неявиця пельксэзэ сехте аламо 2 тешкс улемс эряви (букват эли чирькст); сонзэ мельга а эрявикс `|<mathspeak альтернатива>` поладкс сы маштови.
+
+## Building components from the source
+
+component-type-invalid = А виде компонентэнь лад: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутонть омбоцеде теемс а маштови.
+
+attribute-invalid-for-component = `<{ $componentType }>` ладсо компонентэнтень а виде атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стилень меремасонть { $context ->
+        [text-on-background] текстэнь тюсось ды фононь тюсось
+        [high-contrast] покш контраст марто тюс ды артома тарка
+        [line] линиянь тюсось ды артома тарка
+        [marker] маркерэнь тюсось ды артома тарка
+       *[text-on-canvas] текстэнь тюсось ды артома тарка
+    } ютксо контрастось а сатни{ $mode ->
+        [dark] { " (чопода лад)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; сехте аламо { $threshold }:1 эряви).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стилень меремасонть максозь тюстнэ валдо ладонтень сатышка контраст максть бути, сынст эйстэ лисезь чопода ладонь тюстнэ текстэнь ды фононь ютксо сатышка контраст а максыть ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; сехте аламо { $threshold }:1 эряви). { $suggestion ->
+        [available] Чопода ладсо сатышка контрастонь кисэ валдо ладонь контрастонть покшолгавтык (кода { $lightAttribute }="{ $lightColor }"), эли чопода ладонь тюсонть полавтык (кода { $darkAttribute }="{ $darkColor }").
+       *[none] Чопода ладсо сатышка контрастонь кисэ валдо ладонь контрастонть покшолгавтык эли лисезь тюстнэнь textColorDarkMode ды/эли backgroundColorDarkMode вельде полавтык.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стилень меремасонть максозь текстэнь тюсось валдо ладонтень сатышка контраст максь бути, сонзэ эйстэ лисезь чопода ладонь текстэнь тюсось артома тарка марто сатышка контраст а максы ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; сехте аламо { $threshold }:1 эряви). { $suggestion ->
+        [available] Чопода ладсо сатышка контрастонь кисэ валдо ладонь контрастонть покшолгавтык (кода textColor="{ $lightColor }"), эли чопода ладонь тюсонть полавтык (кода textColorDarkMode="{ $darkColor }").
+       *[none] Чопода ладсо сатышка контрастонь кисэ валдо ладонь контрастонть покшолгавтык эли лисезь тюсонть textColorDarkMode вельде полавтык.
+    }
+
+section-multiple-style-palettes = Пелькскесь ансяк вейке <stylePalette> кочкамс маштови; меельцесь тевс нолдави.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь numToSelect минус аволь целой ловома арась.
+
+variant-num-to-select-not-constant-number = { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь numToSelect а полавтовиця ловома арась.
+
+variant-with-replacement-not-constant-boolean = { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь withReplacement а полавтовиця логикань питне арась.
+
+variant-select-weight-disables-unique = кодамояк кочкамосо selectWeight эли selectForVariants максозь бути, select лангс а вастневиця вариантнэ мадить
+
+variant-coprime-undetermined = { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь coprime свал а виде-арась, сень содамс а маштови.
+
+variant-attribute-not-constant = { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь { $attribute } а полавтовиця арась.
+
+variant-attribute-not-number = { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь { $attribute } ловома арась.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } ладсо { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь { $attribute } { $expected ->
+        [letters-combination] буквань вейсэндявкс
+        [math-expression] маштовикс математикань ёвтамо
+        [integer] целой ловома
+       *[number] ловома
+    } арась.
+
+variant-length-not-integer = { $component } лангс а вастневиця вариантнэнь содамс а маштови, эдь length целой ловома арась.
+
+variant-sort-not-implemented = sort марто { $component } лангс а вастневиця вариантнэ а теезь
+
+variant-exclude-combinations-not-implemented = excludeCombinations марто { $component } лангс а вастневиця вариантнэ а теезь
+
+variant-math-exclude-not-implemented = exclude марто math ладсо { $component } лангс а вастневиця вариантнэ а теезь
+
+variant-non-constant-exclude-not-implemented = а полавтовиця арась exclude марто { $component } лангс а вастневиця вариантнэ а теезь
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикень prefigure артыцясонть а теезь; буезэ кадовсь.
+
+prefigure-descendant-invalid-geometry = { $subject }: пезэ арась эли а сатышка геометрия; буезэ кадовсь.
+
+prefigure-curve-label-omitted = { $subject }: ютавтозь кичкере элементнэсэ тешкстнэ а теезь; тешксэсь кадовсь.
+
+prefigure-curve-unsupported-definition-type = { $subject }: а теезь кичкере функциянь меремань лад «{ $definitionType }»; буезэ кадовсь.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементэнь flipFunctions атрибутось а теезь; буезэ кадовсь.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves ансяк формуласо максозь эйкакш функциятнень саи; буезэ кадовсь.
+
+prefigure-label-position-unsupported =
+    { $subject }: а теезь labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] линиянь кудораськень тешксэнтень
+       *[point] точкань тешксэнтень
+    }; PreFigure-нь основной вейсэндявтомась тевс нолдави.
+
+prefigure-fill-style-unsupported = { $subject }: пештямонь стилесь «{ $fillStyle }» PreFigure лангс а теезь; пешксе пештямос юты.
+
+prefigure-line-style-unknown = { $subject }: асодавикс линиянь стилесь «{ $lineStyle }» PreFigure лисемастонть саезь.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркерэнь стилесь «{ $markerStyle }» PreFigure «diamond» стиль марто вейсэндявтозь.
+
+prefigure-marker-style-unsupported = { $subject }: маркерэнь стилесь «{ $markerStyle }» PreFigure лангс а теезь; основной стиль тевс нолдави.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: а виде `ref`; цельть сюлмамс а маштови. Тешкстамось саезь.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` ламо цель марто сюлмавсь; васенцесь тевс нолдави.
+
+annotation-ref-outside-graph = `<annotation>`: а виде `ref`; целесь сонзэ потмозонзо саиця графикенть ушосо. Тешкстамось саезь.
+
+annotation-ref-unsupported-target = `<annotation>`: а виде `ref`; целесь prefigure ютавтомасонть теезь график объект арась. Тешкстамось саезь.
+
+annotation-text-missing = `<annotation>`: `text` арась эли чаво; чаво текст лиси.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Кружамонь лепштявома муезь.
+       *[other] `<{ $componentType }>` компонентэнть потмозонзо саиця кружамонь лепштявома муезь.
+    }
+
+reference-no-referent = Сюлмавксонтень объект эзь муеве: `{ $reference }`
+
+reference-multiple-referents = Сюлмавксонтень ламо объект муезь: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементэнь { $attribute } атрибутонь форматозо а виде.
+
+children-invalid = `<{ $componentType }>` лангс а виде эйкакшт: а виде эйкакшт муезь: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутонтень а виде питне `{ $value }`; `{ $default }` питнесь тевс нолдави
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версиясь эзь муеве.
+       *[other] DoenetML { $version } версиясь эзь муеве. { $fallback } версиясь тевс нолдави
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = А виде DoenetML: { $content }
+
+parse-tag-missing-close-tag = А виде DoenetML: `{ $tag }` тегень пекстыця тегезэ арась. Эсь прянзо пекстыця тег эли `</{ $tagName }>` тег учовсь.
+
+parse-tag-error = А виде DoenetML: `<{ $tagName }>` тегсэнть ильведевкс
+
+parse-attribute-missing-value = А виде DoenetML: `{ $attribute }` атрибутсонть питне а сатни ладсо.
+
+parse-attribute-invalid = А виде DoenetML: а виде атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = А виде DoenetML: атрибутонь а виде питне `{ $value }`
+
+parse-attribute-value-quote-mismatch = А виде DoenetML: атрибутонь а виде питне `{ $value }`. Кавычкатне а вейсэндить. `{ $quote }` а сатни ладсо
+
+parse-open-tag-name-missing = А виде DoenetML: лемтеме тег муезь, кода `<`
+
+parse-tag-not-closed = А виде DoenetML: `{ $tag }` тегесь а пекстазь (`>` а сатни ладсо).
+
+parse-self-closing-tag-name-missing = А виде DoenetML: лемтеме тег муезь `<{ $content }>`
+
+parse-self-closing-tag-not-closed = А виде DoenetML: `{ $tag }` тегесь а пекстазь (`/>` а сатни ладсо).
+
+parse-tag-invalid-attributes = А виде DoenetML: `{ $tag }` тегесь маштовикс арась. Сонзэ атрибутонзо а видеть улемс маштовить.
+
+parse-close-tag-name-missing = А виде DoenetML: лемтеме пекстыця тег муезь, кода `</`
+
+parse-attribute-value-unquoted = Атрибутонь питнетне кавычка потсо улемс эрявить: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = А виде DoenetML: `{ $tag }` пекстыця тег муезь, ансяк сонензэ вейсэндиця панжиця тег арась
+
+parse-close-tag-mismatched = А виде DoenetML: а вейсэндиця пекстыця тег. `</{ $expected }>` учовсь. `{ $found }` муезь
+
+parser-node-unconvertible = { $node } узелэнть Dast узелс ютавтомс эзь маштово.
+
+## Names
+
+name-attribute-invalid =
+    А виде атрибут name='{ $name }'. { $reason ->
+        [characters] Лемтнесэ ансяк букват, ловомат, ало чирькст эли чирькст улемс маштовить.
+       *[start] Лемтне буквасто ушодовомс эрявить.
+    }
+
+component-name-invalid-start = А виде компонентэнь лем «{ $name }». Лемтне буквасто ушодовомс эрявить.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched ладсо answer-энь video атрибутозо улемс эряви
+
+answer-video-watched-video-not-reference = videoWatched ладсо answer-энь video атрибутозо сюлмавкс улемс эряви
+
+answer-name-not-single-text = answer-энь name атрибутсонзо ансяк вейке текстэнь эйкакш улемс эряви
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсиянь пелькстнэ пек ламот, седе ушо DoenetML саемс эзь маштово. Кружамонь сюлмавкс арась?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адрестэ DoenetML саемс эзь маштово
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адрестэ а виде DoenetML саезь: сон «{ $componentType }» компонентэнь ладонтень эзь вейсэнде
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибутось сыредсь; сонзэ таркас `{ $to }` тевс нолдак.
+       *[other] [deprecation] `<{ $component }>` элементэнь `{ $from }` атрибутось сыредсь; сонзэ таркас `{ $to }` тевс нолдак.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибутось сыредсь ды а ловови, эдь `{ $to }` тожо максозь.
+       *[other] [deprecation] `<{ $component }>` элементэнь `{ $from }` атрибутось сыредсь ды а ловови, эдь `{ $to }` тожо максозь.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементэнь `{ $attribute }` атрибутось сыредсь ды а ловови.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементэнь `{ $attribute }` атрибутось сыредсь; сонзэ таркас `<{ $child }>` эйкакш тевс нолдак.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементэнь `{ $attribute }` атрибутонь `{ $value }` питнезэ сыредсь; сонзэ таркас `{ $to }` тевс нолдак.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` ламоксчинть ансяк англань кельсэ теемс маштови, седе { $locale } кельсэ сёрмадозь документсэнть сонзэ текстэзэ апак полавто кадови. Ламоксчинь форманть эсь прят сёрмадык эли сонзэ `pluralForm` атрибут вельде максык.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элементэсь содавикс Doenet элемент арась.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементэнтень документэнь ундоксонть а мереви.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементэнтень `<{ $parent }>` потсо а мереви.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементсэнть `{ $attribute }` лем марто атрибут арась.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементэнь `{ $attribute }` атрибутось эрьва элементэзэ нетнеде вейке улиця список улемс эряви: { $allowed }
+       *[other] `<{ $tag }>` элементэнь `{ $attribute }` атрибутось нетнеде вейке улемс эряви: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select лангс а виде вариантонь лем. { $variantName } вариантонь лемесь { $numOptions } кочкамосо вастневи, а кочкамс эрявикс ламоксчись { $numToSelect }.
+
+select-variant-name-without-options = select лангс вариантт максозь, ансяк маштовикс вариантонь лемнентень вейкеяк кочкамо арась: { $variantName }.
+
+select-variant-name-not-possible = select лангс максозь { $variantName } вариантонь лемесь маштовикс вариантонь лем арась.
+
+select-too-few-options = Весемезэ { $numOptions } эйстэ { $numToSelect } компонент кочкамс а маштови.
+
+select-from-sequence-too-few-values = Кувалмозо { $length } мельга-мельгастонть { $numToSelect } питне кочкамс а маштови.
+
+select-from-sequence-indices-count-mismatch = select лангс максозь индекстнэнь ламоксчист кочкамс эрявикс ламоксчинтень вейсэндявомс эряви
+
+select-from-sequence-indices-not-integers = select лангс максозь весе индекстнэ целой ловома улемс эрявить
+
+select-from-sequence-index-excluded = selectfromsequence лангс максозь индексэсь саезель
+
+select-from-sequence-indices-excluded-combination = selectfromsequence лангс максозь индекстнэ саезь вейсэндявкс ульнесть
+
+select-from-sequence-coprime-not-positive-integers = Плюс целой ловоматне а кочказь, седе вейкест-вейкест кисэ простой вейсэндявкстнэнь кочкамс а маштови.
+
+select-from-sequence-coprime-common-factor = Вейкест-вейкест кисэ простой ловоматнень кочкамс а маштови. Весе маштовикс питнетнень вейсэнь явицяст ули. (Максозь "from" эли "to" питнетне "step" марто вейкест-вейкест кисэ простой улемс эрявить.)
+
+select-from-sequence-coprime-single-number = 1 арась вейке ловомасто вейкест-вейкест кисэ простой вейсэндявкстнэнь кочкамс а маштови.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence потсо вейсэндявкстнэде 70%-де ламось саезь
+
+select-from-sequence-coprime-none-found = Вейкест-вейкест кисэ простой ловоматнень кочкамс эзь маштово. Весе маштовикс питнетнень вейсэнь явицяст ули.
+
+select-from-sequence-too-few-unique-values = Кувалмозо { $numPossibleValues } мельга-мельгастонть { $numToSelect } явовиця питне кочкамс а маштови
+
+select-prime-numbers-too-few-values = Кувалмозо { $numValues } простой ловомань спискестэ { $numToSelect } питне кочкамс а маштови
+
+select-prime-numbers-values-count-mismatch = select лангс максозь питнетнень ламоксчист кочкамс эрявикс ламоксчинтень вейсэндявомс эряви
+
+select-prime-numbers-values-not-prime = select prime number лангс максозь весе питнетне простой ловомань спискесэ улемс эрявить
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers лангс максозь питнетне саезь вейсэндявкс ульнесть
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers потсо вейсэндявкстнэде 70%-де ламось саезь
+
+select-random-combination-fluke = Пек а маштовикс тевень кувалт эрьва кодамо питнетнень вейсэндявксост кочкамс эзь маштово
+
+select-random-value-fluke = Пек а маштовикс тевень кувалт эрьва кодамо питненть кочкамс эзь маштово

--- a/packages/i18n/locales/myv/editor.ftl
+++ b/packages/i18n/locales/myv/editor.ftl
@@ -1,0 +1,215 @@
+# Erzya editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Erzya counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Мекев велявтомс
+       *[update] Одкстомтомс
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Ваныцянть { $word }
+       *[other] Ваныцянть { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Кочкамо…
+editor-variant-next = Сы вариантонть кочкамс
+editor-variant-previous = Икелень вариантонть кочкамс
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA пачкодемань коламо муезь. Пачкодемань отчётонть { $action ->
+            [close] пекстамга
+           *[open] панжомга
+        } лепштик.
+        [advisories] Пачкодемань отчётонть { $action ->
+            [close] пекстамга
+           *[open] панжомга
+        } лепштик. WCAG AA коламот эзть муеве, ансяк улить поладкс невтевкст.
+       *[clean] Пачкодемань отчётонть { $action ->
+            [close] пекстамга
+           *[open] панжомга
+        } лепштик. Пачкодемань кевкстемат эзть муеве.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA пачкодемань коламо муезь. { $count ->
+            [one] { $count } WCAG AA коламо
+           *[other] { $count } WCAG AA коламо
+        } муезь. Пачкодемань отчётонть { $action ->
+            [close] пекстамга
+           *[open] панжомга
+        } лепштик.
+        [advisories] WCAG AA коламот эзть муеве. { $count ->
+            [one] { $count } поладкс невтевкс
+           *[other] { $count } поладкс невтевкс
+        } муезь. Пачкодемань отчётонть { $action ->
+            [close] пекстамга
+           *[open] панжомга
+        } лепштик.
+       *[clean] WCAG AA коламот эзть муеве. Пачкодемань отчётонть { $action ->
+            [close] пекстамга
+           *[open] панжомга
+        } лепштик.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версия { $version }
+
+editor-tab-help = Контекстэнь лезкс
+editor-tab-help-short = Контекст
+editor-tab-errors = Ильведевкст
+editor-tab-warnings = Икелев пелькстамот
+editor-tab-info = Тевпаро
+editor-tab-accessibility = Пачкодема
+editor-tab-responses = Кучозь каршо валт
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторонь анокстамот
+editor-format-as-doenetml = DoenetML ладсо форматировамс
+editor-format-as-xml = XML ладсо форматировамс
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-це ряд
+
+editor-no-errors = Ильведевкст арасть
+editor-no-warnings = Икелев пелькстамот арасть
+editor-no-info = Тевпаронь ёвтамот арасть
+
+editor-show-info-annotations = Тевпаронь ёвтамотнень редакторсо невтемс
+editor-show-accessibility-annotations = Пачкодемань ёвтамотнень редакторсо невтемс
+
+editor-accessibility-learn-more = Doenet пачкодемантень кода вансты
+
+editor-accessibility-violations-heading = Пачкодемань коламот ({ $standard })
+
+editor-accessibility-other-heading = Лия пачкодемань кевкстемат
+editor-none-found = Мезеяк эзь муеве
+
+
+## Submitted responses
+
+editor-no-responses = Течис кучозь каршо валт арасть
+editor-response-answer-id = Каршо валонь Id
+editor-response-response = Каршо вал
+editor-response-credit = Балл
+editor-response-submitted = Кучозь
+
+
+## The context-help panel
+
+help-placeholder = Документациянть неемга курсоронть путык тег лем лангс, атрибут лангс эли { $ref } лангс.
+
+help-unsupported-ref-chain = { $example } ладсо ламо пельксэнь сюлмавкстнэнень лезкс зярс арась.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Сюлмавксонтень объект эзь муеве: { $ref }.
+        [multiple] Сюлмавксонтень ламо объект муезь: { $ref }.
+       *[indeterminate] { $ref } объектэнть содамс эзь маштово.
+    }
+
+help-learn-about-references = Сюлмавкстнэде содамс →
+help-reference-page = Невтемань лопа →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } потсо
+       *[top] Сехте верде
+    }{ $allowed ->
+        [none] { " — тесэ мезеяк а кельги." }
+        [text] { " — тесэ текст сёрмадомс маштови." }
+        [text-and-components] { " — тесэ текст сёрмадомс маштови, эли неть варчик:" }
+       *[components] { " — неть варчемс маштови:" }
+    }
+
+help-suggestions-footer = Весе { $total } компонентэнть неемга { $shortcut } лепштик.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объект лангс сюлмавкс.
+       *[other] { $ref } — { $target } объект лангс сюлмавкс ({ $line }-це ряд).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Сонзэ { $owner } { $role } ладсо совавтызе.
+       *[other] Сонзэ { $owner } { $line }-це рядсо { $role } ладсо совавтызе.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементэнь { $property } свойстванть лангс сюлмавкс.
+       *[other] { $ref } — { $element } элементэнь { $property } свойстванть лангс сюлмавкс ({ $line }-це ряд).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = пелькске
+help-kind-array-entry = массивень элемент
+
+help-default = Основной питне:
+help-active-default = Неень основной питне:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Мерезь питнеть (эрьва элементэнтень вейке):
+       *[other] Мерезь питнеть:
+    }
+
+help-suggested-values = Невтезь питнеть:
+
+help-inserts = Полады:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатат:
+    }
+
+help-type = Лад:
+
+help-resolved-style = Лисезь стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Лисезь функциянь лемть:
+help-reset-list = Те таркань мекев велявтомань список:
+help-added-on-input = Те таркасо поладозь:
+help-removed-on-input = Те таркасто саезь:
+
+help-reset-overrides = { $reset } — { $additional } ды { $removed } лангсо изни.

--- a/packages/i18n/locales/os/chrome.ftl
+++ b/packages/i18n/locales/os/chrome.ftl
@@ -1,0 +1,138 @@
+# Ossetian viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Ossetian counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular, so the two branches differ in nothing but the number they print.
+
+
+## Answer submission
+
+answer-checking = Бæрæг кæны…
+answer-submitting = Арвиты…
+
+answer-checking-status = Дзуапп бæрæг кæны
+answer-submitting-status = Дзуапп арвиты
+
+answer-correct = Раст
+answer-incorrect = Раст нæу
+
+answer-response-saved = Дзуапп бавæрд
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% раст
+answer-percent-short = { $percent } %
+
+max-credit-available = Райсæн ис фылдæр балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] фæлварæн нал баззад
+        [one] { $count } фæлварæн баззад
+       *[other] { $count } фæлварæн баззад
+    }
+
+validation-correct = (Раст)
+validation-incorrect = (Раст нæу)
+validation-partially-correct = (Хайыл раст)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId }-мæ { $count } дзуапп равдисын
+       *[other] { $answerId }-мæ { $count } дзуапп равдисын
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Фæстæмæ дзуапп
+
+collapsible-click-to-open = (байгом кæнынæн ныххæц)
+collapsible-click-to-close = (æхгæнынæн ныххæц)
+
+collapsible-initializing = Цæттæ кæны…
+
+footnote-show = Фиппаинаг равдисын
+footnote-hide = Фиппаинаг бамбæхсын
+
+description-more-information = фылдæр информаци
+
+
+## Controls
+
+slider-previous = Разæй
+slider-next = Дарддæр
+
+keyboard-open = Клавиатурæ байгом кæнын
+keyboard-close = Клавиатурæ æхгæнын
+
+choice-input-remove-choice = { $choice } æвзарæн аппарын
+
+matrix-remove-row = Рæнхъ аппарын
+matrix-add-row = Рæнхъ бафтауын
+matrix-remove-column = Цæджындз аппарын
+matrix-add-column = Цæджындз бафтауын
+
+subset-add-remove-points = Стъæлф бафтауын/аппарын
+subset-toggle-points-intervals = Стъæлфытæ æмæ интервалтæ ивын
+subset-move-points = Стъæлфытæ аивын
+subset-clear = Ссыгъдæг кæнын
+
+orbital-add-row = Рæнхъ бафтауын
+orbital-remove-row = Рæнхъ аппарын
+orbital-add-box = Клеткæ бафтауын
+orbital-remove-box = Клеткæ аппарын
+orbital-add-up-arrow = Уæлæмæ фат бафтауын
+orbital-add-down-arrow = Дæлæмæ фат бафтауын
+orbital-remove-arrow = Фат аппарын
+
+orbital-row-label = { $row } рæнхъы нысан
+
+pretzel-answer = Дзуапп
+
+summary-statistics-caption = { $column } цæджындзы фæстаг статистикæ
+
+
+## Math input
+
+math-input-preview-region = математикон æвдисæны разæй фенын
+math-input-preview = Разæй фенын
+math-input-invalid-expression = Раст нæу æвдисæн:
+
+
+## Document status
+
+viewer-initializing = Цæттæ кæны…
+
+
+## Errors
+
+error-heading = Рæдыд
+
+error-found-at =
+    { $span ->
+        [line] Ссард рæнхъ: { $startLine }.
+       *[lines] Ссард рæнхъытæ: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Ацы документы рæдыдтытæ ис!
+
+diagnostic-heading-error = Рæдыд
+diagnostic-heading-warning = Фæдзæхст
+diagnostic-heading-information = Информаци
+diagnostic-heading-hint = Амынд
+
+accessibility-heading-level-1 = WCAG AA бахæццæйы халд
+accessibility-heading-level-2 = Бахæццæйы тыххæй хъусынгæнинаг
+
+something-went-wrong = Исты раст нæ рауад.
+
+renderer-load-failed = нывгæнæг æрбавгæрдын нæ бантыст. Фарс ногæй байгом кæн.
+
+core-start-failed = Документы уынæг сыздæхын нæ бантыст. Фарс ногæй байгом кæн.

--- a/packages/i18n/locales/os/content.ftl
+++ b/packages/i18n/locales/os/content.ftl
@@ -1,0 +1,266 @@
+# Ossetian content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Ossetian's own æ, which is the orthography North and
+# South Ossetia's schools and publishing use and what CLDR fills a bare `os` in
+# as. The catalog is **Iron**, the literary standard; Digor is a written
+# variety of its own that ISO 639-3 does not give a separate code, so a Digor
+# reader arriving under `os` reaches Iron.
+#
+# The roster calls this language **Ossetic**, because that is what
+# `Intl.DisplayNames` renders `os` as; Ossetian is the more usual English name
+# and the two are one language. `os` is also the one locale in this batch whose
+# `Intl.Locale("os").maximize()` names a country outside Russia — `os-Cyrl-GE`,
+# Georgia — which is CLDR's data rather than an error, and costs negotiation
+# nothing: no region tag over `os` needs an alias.
+#
+# Ossetian is Iranian and is the only Indo-European language in this batch. It
+# has no grammatical gender and does not inflect an attributive adjective, so
+# `$gender` and `$role` go unused — the same answer the Turkic, Mongolic and
+# Uralic catalogs beside it give, from a fourth family and, this time, from a
+# family whose better-known members (Russian, Persian's neighbours) do inflect.
+#
+# THE COLOUR TABLE IS WORTH READING FIRST, for the reason `locales/sah`'s is.
+# Ossetian's «цъæх» covers green, blue and grey — one word where the style
+# pipeline needs three — so this catalog writes the compounds that split it:
+# «кæрдæгхуыз» (grass-coloured) for green and «æрвхуыз» (sky-coloured) for
+# blue. Two unrelated languages in one batch, one problem, and the same shape
+# of answer.
+
+
+## Style vocabulary
+
+color =
+    .black = сау
+    .white = урс
+    .gray = фæлурс
+    .red = сырх
+    .orange = нарынджы хуыз
+    .yellow = бур
+    .green = кæрдæгхуыз
+    .cyan = рухс æрвхуыз
+    .blue = æрвхуыз
+    .purple = фиолетон
+    .pink = розæхуыз
+    .brown = морæ
+
+line-width =
+    .thick = бæзджын
+    .thin = тæнæг
+
+line-style =
+    .dashed = скъуыдтæ
+    .dotted = стъæлфытимæ
+
+# Noun phrases: they stand in front of «нывимæ» and modify nothing.
+fill-style =
+    .horizontal = горизонталон хахх
+    .vertical = вертикалон хахх
+    .diagonal = диагоналон хахх
+    .backdiagonal = ныхмæ диагоналон хахх
+    .dots = стъæлф
+    .diamonds = ромб
+
+noun =
+    .line = раст хахх
+    .line-segment = хахххай
+    .ray = луч
+    .vector = вектор
+    .curve = къæдз хахх
+    .function = функци
+    .parabola = параболæ
+    .polyline = састхахх
+    .polygon = бирæкъуымон
+    .triangle = æртæкъуымон
+    .rectangle = раст къуымон
+    .circle = тымбыл
+    .region = бынат
+    .point = стъæлф
+    .square = квадрат
+    .diamond = ромб
+    .cross = дзуар
+    .plus = плюс
+
+# Ossetian builds the word from the side count in front of the noun, so the
+# whole of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] раст { $numSides }-къуымон
+    }
+
+# Ossetian has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = ахуырст
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } нывимæ { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } нывимæ { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } нывимæ { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «кæронимæ» — "with an edge" — is written after the colour word this catalog
+# supplies, so the comitative suffix lands on a noun of its own rather than on
+# a placeable, and neither a preposition nor an article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } кæронимæ
+        [and] æмæ { $border } кæронимæ
+        [and-article] æмæ { $border } кæронимæ
+       *[with] { $border } кæронимæ
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } нывимæ { $color } ахорæн
+       *[plain] { $color } ахорæн
+    }
+
+style-unfilled = ахуырст нæу
+
+# «уæлæ» — "on" — is a postposition and follows the background colour, so
+# nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон уæлæ { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = нæй
+
+
+## Boolean words
+
+boolean-true = раст
+boolean-false = раст нæу
+
+
+## Answer buttons
+
+answer-submit-label = Бабæрæг кæнын
+answer-submit-label-no-correctness = Дзуапп арвитын
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Куыст
+    .aside = Фарсмæ фиппаинаг
+    .cascade = Каскад
+    .definition = Бæрæггæнæн
+    .example = Цæвиттон
+    .exercise = Фæлтæрæн
+    .exercises = Фæлтæрæнтæ
+    .given-answer = Дзуапп
+    .note = Фиппаинаг
+    .objectives = Нысæнттæ
+    .paragraphs = Абзацтæ
+    .part = Хай
+    .problem = Хæс
+    .problems = Хæстæ
+    .proof = Бæлвырдгæнæн
+    .question = Фарст
+    .section = Хай
+    .solution = Раиртасæн
+    .task = Хæслæвæрд
+    .theorem = Теоремæ
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Амынд
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблицæ { $enumeration }
+        [numbered-title] Таблицæ { $enumeration }{ ". " }
+        [unnumbered-title] Таблицæ{ ". " }
+       *[unnumbered] Таблицæ
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ныв { $enumeration }
+        [numbered-caption] Ныв { $enumeration }{ ". " }
+        [unnumbered-caption] Ныв{ ". " }
+       *[unnumbered] Ныв
+    }
+
+
+## Paginator controls
+
+paginator-previous = Разæй
+paginator-next = Дарддæр
+paginator-page = Фарс
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## Ossetian's conditional «кæд» is clause-initial, so this key lands where the
+## renderer puts it — unlike `locales/sah`, `locales/tyv`, `locales/udm`,
+## `locales/kv` and `locales/chm`, five catalogs of this batch whose
+## conditional closes its clause and which record a limit there.
+
+piecewise-condition-or = кæнæ
+piecewise-condition-if = кæд
+piecewise-condition-otherwise = æндæр хуызы
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry is taught in Russian in
+## North Ossetia and in Russian in South Ossetia as well, so the element names
+## an Ossetian-speaking pupil meets are the Russian ones — the school-system
+## case this batch shares throughout, arriving here on both sides of a border
+## rather than one.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Раст нæу химион нысан
+chemistry-invalid-ionic-compound = Раст нæу ионон баиу

--- a/packages/i18n/locales/os/diagnostics.ftl
+++ b/packages/i18n/locales/os/diagnostics.ftl
@@ -1,0 +1,654 @@
+# Ossetian diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Ossetian
+# uses for them: «компонент», «атрибут», «функци», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] дыууæ кæроны стъæлф амынд куы уой, уæд { $attributes } нымад нæ цæуы
+       *[other] дыууæ кæроны стъæлф амынд куы уой, уæд { $attributes } нымад нæ цæуы
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] кæроны стъæлф æмæ астæуккаг стъæлф дæр амынд куы уой, уæд { $attributes } нымад нæ цæуы
+       *[other] кæроны стъæлф æмæ астæуккаг стъæлф дæр амынд куы уой, уæд { $attributes } нымад нæ цæуы
+    }
+
+line-segment-midpoint-offset-without-midpoint = астæуккаг стъæлфæй дарддæр midpointOffset ницæуыл ахады
+
+## `<line>`
+
+line-points-undetermined-dimensions = Бæрцæй бæрæг нæ стъæлфтыл цæуæг раст хахх.
+
+line-points-too-few-dimensions = Раст хахх иу æмæ дыууæ бæрцы стъæлфтыл хъуамæ цæуа.
+
+line-points-depend-on-variables = Раст хахх ивгæ бæрцтæй æмбæрст стъæлфтыл цæуы: { $variables }.
+
+line-equation-invalid-format = { $variable1 } æмæ { $variable2 } ивгæ бæрцтимæ раст хаххы æмхуызоны формат раст нæу.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint æмæ direction-æй лæвæрд у. Лæвæрд through нымад нæ цæуы.
+
+ray-dimension-mismatch = лучы numDimensions нæ фидауы.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail æмæ displacement-æй лæвæрд у. Лæвæрд head нымад нæ цæуы.
+
+vector-dimension-mismatch = векторы numDimensions нæ фидауы.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементмæ ласæн нæй, уымæн æмæ йæм nearestPoint уавæры ивгæ бæрц нæй.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементæй æфсæрæн нæй, уымæн æмæ йæм nearestPoint уавæры ивгæ бæрц нæй.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементы мидæгæй æфсæрæн нæй, уымæн æмæ йæм nearestPoint уавæры ивгæ бæрц нæй.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = рæнхъы мидæг нæ чи у, ахæм choiceInput-мæ labelPosition нымад нæ цæуы
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput-мæ лæвæрд индекстæ нымад нæ цæуынц, уымæн æмæ сæ нымæц choice сывæллæтты нымæцимæ нæ фидауы.
+
+pretzel-indices-count-mismatch = problem-мæ лæвæрд индекстæ нымад нæ цæуынц, уымæн æмæ сæ нымæц problem сывæллæтты нымæцимæ нæ фидауы.
+
+shuffle-indices-count-mismatch = shuffle-мæ лæвæрд индекстæ нымад нæ цæуынц, уымæн æмæ сæ нымæц компонентты нымæцимæ нæ фидауы.
+
+indices-ignored-out-of-range = { $component }-мæ лæвæрд индекстæ нымад нæ цæуынц, уымæн æмæ сæ иуæй-иутæ къæйттæй ахизынц.
+
+pretzel-indices-repeated = pretzel-мæ лæвæрд индекстæ нымад нæ цæуынц, уымæн æмæ сæ иуæй-иутæ фæзминаг сты.
+
+pretzel-circuit-first-index = circuit уагы pretzel-мæ лæвæрд индекстæ нымад нæ цæуынц, уымæн æмæ фыццаг индекс хъуамæ 1 уа.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текстон сывæллæттимæ куыст кæнынæн `type` атрибут хъуамæ лæвæрд уа.
+
+invalid-type-defaulting-to-math = { $component } компонентмæ раст нæу хуыз { $type }. Уый хъуамæ уа math, text, number кæнæ boolean. math пайдагонд цæуы.
+
+string-not-valid-component-to-arrange = «{ $value }» рæнхъ { $component }-мæ æмбæлон компонент нæу. Нымад нæ цæуы.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Раст нæу хуыз { $type }, йæ хуыз number сысти.
+
+invalid-variable-value = Ивгæ бæрцы раст нæ аргъ: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } варианты индекс хъуамæ нымæц уа
+
+variant-index-must-be-integer = { $index } варианты индекс хъуамæ æнæхъæн нымæц уа
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолютон бæрцтæм арæзт нæу. Йæ уæрхтæ баргæ сты.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолютон бæрцтæм арæзт нæу. Йæ кæрæттæ баргæ сты.
+
+side-by-side-no-block-child = Раст нæу `<{ $component }>`: йæм хъуамæ иу блок сывæллон уæддæр уа.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементы `for` атрибут нымад нæ цæуы.
+
+label-for-must-resolve-to-one = `<label>` элементы `for` атрибут хъуамæ æрмæст иу компонентмæ амона.
+
+label-for-unresolved = `<label>` элементы `for` атрибут компонентимæ баст кæнын нæ бантыст.
+
+label-for-answer-with-authored-inputs = `<label>` элементы `for` атрибут автор фыст бахæссæн быдыртимæ `<answer>`-мæ амоны; быдырмæ комкоммæ амон.
+
+label-for-answer-without-input = `<label>` элементы `for` атрибут нысангонд бахæссæн быдыр кæмæ нæй, ахæм `<answer>`-мæ амоны.
+
+label-for-must-reference-input-or-answer = `<label>` элементы `for` атрибут хъуамæ бахæссæн быдырмæ кæнæ дзуаппмæ амона.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Бахæццæйы тыххæй `<{ $component }>` хъуамæ цыбыр æрфыстимæ уа, кæнæ фæлыст хуызы нысангонд æрцæуа.
+
+accessibility-video-short-description = Бахæццæйы тыххæй `<video>` хъуамæ цыбыр æрфыстимæ уа.
+
+accessibility-input-short-description-or-label = Бахæццæйы тыххæй `<{ $component }>` хъуамæ цыбыр æрфыстимæ кæнæ нысанимæ уа.
+
+accessibility-answer-input-short-description-or-label = Бахæццæйы тыххæй бахæссæн быдыр аразæг `<answer>` хъуамæ цыбыр æрфыстимæ кæнæ нысанимæ уа.
+
+accessibility-short-description-contains-math = Цыбыр æрфысты `<{ $component }>` хуызæн математикон компоненттæ хъуамæ ма уой. Математикæ дзырдтæй ныффысс.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } хайы сæргонды текстмæ фаг контраст нæ дæтты (тар хуыз) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; уæддæр { $threshold }:1 хъæуы).
+       *[other] { $colorName } хайы сæргонды текстмæ фаг контраст нæ дæтты ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; уæддæр { $threshold }:1 хъæуы).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Стъæлфтæн нымæцон аргъ куы нæ уа, уæд { $count } стъæлфыл цæуæг `<circle>` арæзт нæу.
+
+circle-too-many-through-points = 3-æй фылдæр стъæлфыл цæуæг тымбыл банымайæн нæй.
+
+circle-overprescribed-radius-center-points = Лæвæрд радиус, астæу æмæ стъæлфтимæ тымбыл банымайæн нæй.
+
+circle-center-with-multiple-points = Лæвæрд астæуимæ 1-æй фылдæр стъæлфыл цæуæг тымбыл банымайæн нæй.
+
+circle-radius-too-small = Тымбыл банымайæн нæй: дыууæ стъæлфы астæу { $distance } куы уа, уæд лæвæрд радиус { $radius } тынг гыццыл у.
+
+circle-radius-with-many-points = Лæвæрд радиусимæ дыууæйæ фылдæр стъæлфыл цæуæг тымбыл саразæн нæй.
+
+circle-invalid-center-or-through-points = Тымбылы астæу кæнæ стъæлфтæ раст не сты.
+
+circle-radius-center-with-multiple-points = Лæвæрд астæуимæ 1-æй фылдæр стъæлфыл цæуæг тымбылы радиус банымайæн нæй.
+
+circle-change-radius-non-numerical = Нымæцон нæ стъæлфтимæ тымбылы радиус аивæн нæй
+
+circle-radius-with-points-non-numerical = Нымæцон аргъытæ куы нæ уой, уæд лæвæрд радиусимæ иуæй фылдæр стъæлфыл цæуæг тымбыл саразæн нæй.
+
+circle-change-center-non-numerical = Нымæцон нæ стъæлфтыл цæуæг тымбылы астæу ивын арæзт нæу.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцийы бæрæггонд бынаты бæрц нæ фаг кæны. Бынаты { $intervals } интервал ис, функцийы та { $inputs ->
+            [one] { $inputs } бахæссæн
+           *[other] { $inputs } бахæссæн
+        } ис.
+       *[other] Функцийы бæрæггонд бынаты бæрц нæ фаг кæны. Бынаты { $intervals } интервал ис, функцийы та { $inputs ->
+            [one] { $inputs } бахæссæн
+           *[other] { $inputs } бахæссæн
+        } ис.
+    }
+
+function-domain-invalid-format = Функцийы бæрæггонд бынаты формат раст нæу.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцийы нымæцон нæ максимум нымад нæ цæуы.
+        [minimum] Функцийы нымæцон нæ минимум нымад нæ цæуы.
+        [extremum] Функцийы нымæцон нæ экстремум нымад нæ цæуы.
+        [point] Функцийы нымæцон нæ стъæлф нымад нæ цæуы.
+        [slope] Функцийы нымæцон нæ фæлдæхт нымад нæ цæуы.
+       *[other] Функцийы нымæцон нæ { $type } аргъ нымад нæ цæуы.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцийы афтид максимум нымад нæ цæуы.
+        [minimum] Функцийы афтид минимум нымад нæ цæуы.
+        [extremum] Функцийы афтид экстремум нымад нæ цæуы.
+        [point] Функцийы афтид стъæлф нымад нæ цæуы.
+       *[other] Функцийы афтид { $type } аргъ нымад нæ цæуы.
+    }
+
+function-points-too-close = Функцийы кæрæдзимæ тынг хæстæг дыууæ стъæлфы ис. Функци бæрæг кæнæн нæй.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцийы итерацитæ гæнæн ис æрмæст бахæссæнты нымæц рахæссæнты нымæцимæ æмхуызон куы уа. Ацы функцийы { $inputs } бахæссæн æмæ { $outputs ->
+            [one] { $outputs } рахæссæн
+           *[other] { $outputs } рахæссæн
+        } ис.
+       *[other] Функцийы итерацитæ гæнæн ис æрмæст бахæссæнты нымæц рахæссæнты нымæцимæ æмхуызон куы уа. Ацы функцийы { $inputs } бахæссæн æмæ { $outputs ->
+            [one] { $outputs } рахæссæн
+           *[other] { $outputs } рахæссæн
+        } ис.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Рæнхъæгты даргъдзинад раст нæу. Уый хъуамæ минусон нæ æнæхъæн нымæц уа.
+
+sequence-invalid-step = Рæнхъæгты къахдзæф раст нæу. { $type } хуызы рæнхъæгтæм уый хъуамæ нымæц уа.
+
+sequence-invalid-endpoint-number = Нымæцон рæнхъæгты «{ $attribute }» аргъ раст нæу. Уый хъуамæ нымæц уа.
+
+sequence-invalid-endpoint-letters = Дамгъæйы рæнхъæгты «{ $attribute }» аргъ раст нæу. Уый хъуамæ дамгъæты бастдзинад уа.
+
+sequence-invalid-endpoint = Рæнхъæгты «{ $attribute }» аргъ раст нæу.
+
+select-from-sequence-coprime-not-numbers = нымæцтæ æвзæрст не сты, уымæ гæсгæ coprime нымад нæ цæуы
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations лæвæрд у, уымæ гæсгæ coprime нымад нæ цæуы
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>`-мæ раст нæу target: нысан нæ ссардæуыд.
+
+target-state-variable-not-found = `<{ $source }>`-мæ раст нæу target: `<{ $component }>` элементы «{ $property }» номимæ уавæры ивгæ бæрц нæ ссардæуыд.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>`-ы ивгæ бæрцтæ хъуамæ æнæаходгæ бæрцæй хицæн уой.
+
+ode-system-duplicate-variable-names = Аходгæ бæрцты нæмттæ фæзминаг куы уой, уæд ДУ рахиз фарсы функцитæ бæрæг кæнæн нæй.
+
+ode-system-rhs-function-error = ДУ рахиз фарсы функци бæрæг кæнæн нæй. mathjs функци аразгæйæ рæдыд.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } раст хаххы астæу къуым бæрæг кæнæн нæй
+
+angle-invalid-through-point = `<angle>` элементы through аргъы раст нæу стъæлф
+
+parabola-vertex-too-many-points = Лæвæрд сæримæ 1-æй фылдæр стъæлфыл цæуæг параболæ арæзт нæу.
+
+parabola-too-many-points = 3-æй фылдæр стъæлфыл цæуæг параболæ арæзт нæу.
+
+intersection-too-many-items = Дыууæйæ фылдæр объекты кæрæдзииуварс арæзт нæу
+
+## Other math components
+
+ionic-compound-not-two-ions = Дыууæ ионæй æндæр ионон баиутæ арæзт не сты.
+
+ionic-compound-needs-cation-and-anion = Ионон баиу æрмæст иу катион æмæ иу анионмæ арæзт у.
+
+solve-equations-cannot-evaluate = Æмхуызон аразæн нæй, уымæн æмæ йæ банымайын нæ бантыст: { $equation }
+
+math-operators-operand-number-required = Математикон операнд иртасынæн operandNumber хъуамæ лæвæрд уа.
+
+eigen-decomposition-failed = Матрицæйы йæхи аргъытæ банымайын нæ бантыст
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр фæлгæцы нæ æмбæлы, уымæ гæсгæ уый алы хатт афтидимæ фидауы.
+       *[other] `<matchesPattern>`: { $parameters } параметртæ фæлгæцы нæ æмбæлынц, уымæ гæсгæ уыдон алы хатт афтидимæ фидауынц.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" аргъ бамбарæн нæй. Уый хъуамæ уа none, medium, dense кæнæ афтид бынатæй хицæнгонд дыууæ плюсон нымæц, зæгъæм grid="1 0.5". Сеткæ нæ ныффыссы.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure нывгæнæджы xLabelPosition="left" арæзт нæу; рахизфарсы уаг пайдагонд цæуы.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure нывгæнæджы yLabelPosition="bottom" арæзт нæу; уæллаг уаг пайдагонд цæуы.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure ивдмæ тæгты кæрæттæ раст не сты; бындурон bbox (-10,-10,10,10) пайдагонд цæуы.
+
+prefigure-invalid-width = `<graph>`: prefigure ивдмæ уæрх раст нæу; диаграммæйы бындурон уæрх 425 пайдагонд цæуы.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure ивдмæ aspectRatio раст нæу; бындурон фæрсты бастдзинад 1 пайдагонд цæуы.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткæйы къахдзæф тæгты кæрæттæм тынг гыццыл у; prefigure нывгæнæджы сеткæ нæ рацæуы.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure нывгæнæг куы нæ пайдагонд цæуа, уæд фиппаинæгтæ нæ фыссынц.
+
+multiple-annotations-children = `<graph>` мидæг бирæ `<annotations>` сывæллон ссардæуыд; фæстагæй дарддæр иннæтæ нымад нæ цæуынц.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Æнæзонгæ компоненты хуыз ивазæн кæнæ копи кæнæн нæй: { $type }.
+
+copy-prop-not-found = { $component } хуызы компоненты { $property } миниуæг нæ ссардæуыд
+
+collect-no-source = collect-мæ суадон нæ ссардæуыд.
+
+collect-invalid-component-type = `<{ $component }>` хуызы компоненттæ æмбырд кæнæн нæй, уымæн æмæ уый раст нæу компоненты хуыз.
+
+reference-index-unavailable = `{ $reference }` индексмæ бастдзинад саразæн нæй
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компоненты { $action } сидæн нæй
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Бæрæггæнæнты хуыз раст нæу. Рæнхъыты даргъдзинад хицæн у. Ссардæуыд componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Бæрæггæнæнты цæджындзы нæмттæ фæзминаг сты. Ссардæуыд componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Бæрæггæнæнты цæджындзы ном нæ фаг кæны. Ссардæуыд componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Ацы дзуаппы award аргъ answer тегы йæхи арвыст дзуаппыл æнцой кæны, уый æнæнхъæлæджы уавæрмæ хæццæ кæны.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` кæмæ ис, ахæм контейнеры мидæг `<answer>`-мæ `maxNumAttempts` æвæрын ницы ахады, уымæн æмæ фæлварæнты нымæц контейнер бæрæг кæны. `maxNumAttempts` аргъ контейнермæ сæвæр.
+
+nested-section-wide-check-work-max-num-attempts = Æндæр `sectionWideCheckWork` контейнеры мидæг лæууæг `sectionWideCheckWork` контейнермæ `maxNumAttempts` æвæрын ницы ахады, уымæн æмæ фæлварæнты нымæц æддаг контейнер бæрæг кæны. `maxNumAttempts` аргъ æддаг контейнермæ сæвæр.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality æвæрд куы нæ уа, уæд { $attributes } атрибут ницы бакæндзæн.
+       *[other] symbolicEquality æвæрд куы нæ уа, уæд { $attributes } атрибуттæ ницы бакæндзысты.
+    }
+
+answer-invalid-type = answer-мæ раст нæу хуыз: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентмæ ном нæй, уымæ гæсгæ йæ модулы атрибут хуызы пайда кæнæн нæй
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентæй модулы атрибут хуызы пайда кæнæн нæй, уымæн æмæ `<module>` компоненты хуызы «{ $name }» атрибут раджы бæрæггонд æрцыд.
+
+conditional-content-condition-ignored = case кæнæ else сывæллæттимæ `<conditionalContent>` компоненты `condition` атрибут нымад нæ цæуы.
+
+slider-markers-type-mismatch = Маркерты хуыз ползунокы хуызимæ нæ фидауы.
+
+pretzel-problem-needs-statement-and-answer = Раст нæу pretzel: алы `<problem>` хъуамæ иу `<statement>` æмæ иу `<answer>` йæхимæ иса.
+
+pretzel-circuit-first-problem-distractor = Раст нæу pretzel: mode="circuit" уаджы фыццаг `<problem>` хъуамæ хъус иуварсмæ ласæг ма уа.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутмæ раст нæу аргъ { $values }; нымад нæ цæуы.
+       *[other] `{ $attribute }` атрибутмæ раст нæу аргъытæ { $values }; нымад нæ цæуынц.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутмæ раст нæу аргъ `{ $value }`. Атрибут хъуамæ `$` нысанæй райдайæг бастдзинæдтæй арæзт уа.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } мидæг раст нæу функцийы нæмттæ нымад не ’рцыдысты: { $names }. Алы номы зынгæ хай хъуамæ уæддæр 2 нысаны уа (дамгъæтæ кæнæ хæххытæ); йæ фæстæ хъæугæ нæу `|<mathspeak альтернативæ>` бафтауæн æрцæуа.
+
+## Building components from the source
+
+component-type-invalid = Раст нæу компоненты хуыз: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут фæзминаг кæнæн нæй.
+
+attribute-invalid-for-component = `<{ $componentType }>` хуызы компонентмæ раст нæу атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стилы бæрæггæнæны { $context ->
+        [text-on-background] тексты хуыз æмæ фоны хуыз
+        [high-contrast] бæрзонд контрастимæ хуыз æмæ нывы бынат
+        [line] хаххы хуыз æмæ нывы бынат
+        [marker] маркеры хуыз æмæ нывы бынат
+       *[text-on-canvas] тексты хуыз æмæ нывы бынат
+    } æхсæн контраст нæ фаг кæны{ $mode ->
+        [dark] { " (тар хуыз)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; уæддæр { $threshold }:1 хъæуы).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стилы бæрæггæнæны лæвæрд хуызтæ рухс хуызмæ фаг контраст куыд радтой, афтæ уыдонæй рацыд тар хуызы хуызтæ текст æмæ фоны æхсæн фаг контраст нæ дæттынц ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; уæддæр { $threshold }:1 хъæуы). { $suggestion ->
+        [available] Тар хуызы фаг контрастмæ кæнæ рухс хуызы контраст фæфылдæр кæн (зæгъæм { $lightAttribute }="{ $lightColor }"), кæнæ тар хуызы хуыз аив (зæгъæм { $darkAttribute }="{ $darkColor }").
+       *[none] Тар хуызы фаг контрастмæ рухс хуызы контраст фæфылдæр кæн кæнæ рацыд хуызтæ textColorDarkMode æмæ/кæнæ backgroundColorDarkMode-æй аив.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стилы бæрæггæнæны лæвæрд тексты хуыз рухс хуызмæ фаг контраст куыд радта, афтæ дзы рацыд тар хуызы тексты хуыз нывы бынатимæ фаг контраст нæ дæтты ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; уæддæр { $threshold }:1 хъæуы). { $suggestion ->
+        [available] Тар хуызы фаг контрастмæ кæнæ рухс хуызы контраст фæфылдæр кæн (зæгъæм textColor="{ $lightColor }"), кæнæ тар хуызы хуыз аив (зæгъæм textColorDarkMode="{ $darkColor }").
+       *[none] Тар хуызы фаг контрастмæ рухс хуызы контраст фæфылдæр кæн кæнæ рацыд хуыз textColorDarkMode-æй аив.
+    }
+
+section-multiple-style-palettes = Хай æрмæст иу <stylePalette> равзарын йæ бон у; фæстаг пайдагонд цæуы.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ numToSelect минусон нæ æнæхъæн нымæц нæу.
+
+variant-num-to-select-not-constant-number = { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ numToSelect æнæивгæ нымæц нæу.
+
+variant-with-replacement-not-constant-boolean = { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ withReplacement æнæивгæ логикон аргъ нæу.
+
+variant-select-weight-disables-unique = искæцы æвзарæны selectWeight кæнæ selectForVariants лæвæрд куы уа, уæд select-мæ фæзминаг нæ варианттæ ахгæд цæуынц
+
+variant-coprime-undetermined = { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ coprime алы хатт мæнг у æви нæ, уый бæрæг кæнæн нæй.
+
+variant-attribute-not-constant = { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ { $attribute } æнæивгæ нæу.
+
+variant-attribute-not-number = { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ { $attribute } нымæц нæу.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } хуызы { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ { $attribute } { $expected ->
+        [letters-combination] дамгъæты бастдзинад
+        [math-expression] æмбæлон математикон æвдисæн
+        [integer] æнæхъæн нымæц
+       *[number] нымæц
+    } нæу.
+
+variant-length-not-integer = { $component }-мæ фæзминаг нæ варианттæ бæрæг кæнæн нæй, уымæн æмæ length æнæхъæн нымæц нæу.
+
+variant-sort-not-implemented = sort кæмæ ис, ахæм { $component }-мæ фæзминаг нæ варианттæ арæзт не сты
+
+variant-exclude-combinations-not-implemented = excludeCombinations кæмæ ис, ахæм { $component }-мæ фæзминаг нæ варианттæ арæзт не сты
+
+variant-math-exclude-not-implemented = exclude кæмæ ис, ахæм math хуызы { $component }-мæ фæзминаг нæ варианттæ арæзт не сты
+
+variant-non-constant-exclude-not-implemented = æнæивгæ нæ exclude кæмæ ис, ахæм { $component }-мæ фæзминаг нæ варианттæ арæзт не сты
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикы prefigure нывгæнæджы арæзт нæу; йæ байзæддаг ныууагътам.
+
+prefigure-descendant-invalid-geometry = { $subject }: æнæкæрон кæнæ æнæххæст геометри; йæ байзæддаг ныууагътам.
+
+prefigure-curve-label-omitted = { $subject }: ивд къæдз элементты нысæнттæ арæзт не сты; нысан ныууагътам.
+
+prefigure-curve-unsupported-definition-type = { $subject }: арæзт нæ къæдз функцийы бæрæггæнæны хуыз «{ $definitionType }»; йæ байзæддаг ныууагътам.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементы flipFunctions атрибут арæзт нæу; йæ байзæддаг ныууагътам.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves æрмæст формулæйæ лæвæрд сывæллон функцитæ исы; йæ байзæддаг ныууагътам.
+
+prefigure-label-position-unsupported =
+    { $subject }: арæзт нæ labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] хæххыты бинонты нысанмæ
+       *[point] стъæлфы нысанмæ
+    }; PreFigure-йы бындурон бартæ пайдагонд цæуынц.
+
+prefigure-fill-style-unsupported = { $subject }: байдзаг кæныны стиль «{ $fillStyle }» PreFigure-мæ арæзт нæу; æххæст байдзаг кæнынмæ ахизы.
+
+prefigure-line-style-unknown = { $subject }: æнæзонгæ хаххы стиль «{ $lineStyle }» PreFigure-йы рахæссæнæй аппæрст æрцыд.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркеры стиль «{ $markerStyle }» PreFigure-йы «diamond» стилимæ баст æрцыд.
+
+prefigure-marker-style-unsupported = { $subject }: маркеры стиль «{ $markerStyle }» PreFigure-мæ арæзт нæу; бындурон стиль пайдагонд цæуы.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: раст нæу `ref`; нысан баст кæнæн нæй. Фиппаинаг аппæрст æрцыд.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` бирæ нысæнттимæ баст æрцыд; фыццаг пайдагонд цæуы.
+
+annotation-ref-outside-graph = `<annotation>`: раст нæу `ref`; нысан æй кæцы график хæссы, уымæй æддæмæ у. Фиппаинаг аппæрст æрцыд.
+
+annotation-ref-unsupported-target = `<annotation>`: раст нæу `ref`; нысан prefigure ивды арæзт график объект нæу. Фиппаинаг аппæрст æрцыд.
+
+annotation-text-missing = `<annotation>`: `text` нæй кæнæ афтид у; афтид текст рацæуы.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Тымбыл бастдзинад ссардæуыд.
+       *[other] `<{ $componentType }>` компонент хæссæг тымбыл бастдзинад ссардæуыд.
+    }
+
+reference-no-referent = Бастдзинадæн объект нæ ссардæуыд: `{ $reference }`
+
+reference-multiple-referents = Бастдзинадæн бирæ объекттæ ссардæуыд: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементы { $attribute } атрибуты формат раст нæу.
+
+children-invalid = `<{ $componentType }>`-мæ раст нæ сывæллæттæ: раст нæ сывæллæттæ ссардæуыд: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутмæ раст нæу аргъ `{ $value }`; `{ $default }` аргъ пайдагонд цæуы
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } верси нæ ссардæуыд.
+       *[other] DoenetML { $version } верси нæ ссардæуыд. { $fallback } верси пайдагонд цæуы
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Раст нæу DoenetML: { $content }
+
+parse-tag-missing-close-tag = Раст нæу DoenetML: `{ $tag }` тегмæ æхгæнæг тег нæй. Йæхи æхгæнæг тег кæнæ `</{ $tagName }>` тег æнхъæлмæ каст.
+
+parse-tag-error = Раст нæу DoenetML: `<{ $tagName }>` тегы рæдыд
+
+parse-attribute-missing-value = Раст нæу DoenetML: `{ $attribute }` атрибутмæ аргъ нæ фаг кæны, афтæ зыны.
+
+parse-attribute-invalid = Раст нæу DoenetML: раст нæу атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Раст нæу DoenetML: атрибуты раст нæ аргъ `{ $value }`
+
+parse-attribute-value-quote-mismatch = Раст нæу DoenetML: атрибуты раст нæ аргъ `{ $value }`. Дæндæгтæ нæ фидауынц. `{ $quote }` нæ фаг кæны, афтæ зыны
+
+parse-open-tag-name-missing = Раст нæу DoenetML: æнæном тег ссардæуыд, зæгъæм `<`
+
+parse-tag-not-closed = Раст нæу DoenetML: `{ $tag }` тег æхгæд нæу (`>` нæ фаг кæны, афтæ зыны).
+
+parse-self-closing-tag-name-missing = Раст нæу DoenetML: æнæном тег ссардæуыд `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Раст нæу DoenetML: `{ $tag }` тег æхгæд нæу (`/>` нæ фаг кæны, афтæ зыны).
+
+parse-tag-invalid-attributes = Раст нæу DoenetML: `{ $tag }` тег æмбæлон нæу. Йæ атрибуттæ раст нæ уой, гæнæн ис.
+
+parse-close-tag-name-missing = Раст нæу DoenetML: æнæном æхгæнæг тег ссардæуыд, зæгъæм `</`
+
+parse-attribute-value-unquoted = Атрибуты аргъытæ хъуамæ дæндæгты мидæг уой: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Раст нæу DoenetML: `{ $tag }` æхгæнæг тег ссардæуыд, фæлæ йæм æмбæлон гом кæнæг тег нæй
+
+parse-close-tag-mismatched = Раст нæу DoenetML: нæ фидауæг æхгæнæг тег. `</{ $expected }>` æнхъæлмæ каст. `{ $found }` ссардæуыд
+
+parser-node-unconvertible = { $node } узел Dast узелмæ ивын нæ бантыст.
+
+## Names
+
+name-attribute-invalid =
+    Раст нæу атрибут name='{ $name }'. { $reason ->
+        [characters] Нæмтты æрмæст дамгъæтæ, нымæцтæ, дæллаг хæххытæ кæнæ хæххытæ уæвæн ис.
+       *[start] Нæмттæ хъуамæ дамгъæйæ райдайой.
+    }
+
+component-name-invalid-start = Раст нæу компоненты ном «{ $name }». Нæмттæ хъуамæ дамгъæйæ райдайой.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched хуызы answer-мæ хъуамæ video атрибут уа
+
+answer-video-watched-video-not-reference = videoWatched хуызы answer-ы video атрибут хъуамæ бастдзинад уа
+
+answer-name-not-single-text = answer-ы name атрибутмæ хъуамæ æрмæст иу текстон сывæллон уа
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсийы уæлæнгæйтты нымæц тынг бирæ у, уымæ гæсгæ æддагон DoenetML райсын нæ бантыст. Тымбыл бастдзинад нæй?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адисæй DoenetML райсын нæ бантыст
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адисæй раст нæу DoenetML райстæуыд: уый «{ $componentType }» компоненты хуызимæ нæ бафидыдта
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут зæронд сси; йæ бæсты `{ $to }` пайда кæн.
+       *[other] [deprecation] `<{ $component }>` элементы `{ $from }` атрибут зæронд сси; йæ бæсты `{ $to }` пайда кæн.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут зæронд сси æмæ нымад нæ цæуы, уымæн æмæ `{ $to }` дæр лæвæрд у.
+       *[other] [deprecation] `<{ $component }>` элементы `{ $from }` атрибут зæронд сси æмæ нымад нæ цæуы, уымæн æмæ `{ $to }` дæр лæвæрд у.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементы `{ $attribute }` атрибут зæронд сси æмæ нымад нæ цæуы.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементы `{ $attribute }` атрибут зæронд сси; йæ бæсты `<{ $child }>` сывæллонæй пайда кæн.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементы `{ $attribute }` атрибуты `{ $value }` аргъ зæронд сси; йæ бæсты `{ $to }` пайда кæн.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` бирæон нымæц æрмæст англисаг æвзагыл аразын йæ бон у, уымæ гæсгæ { $locale } æвзагыл фыст документы йæ текст æнæивгæ баззайы. Бирæон формæ дæхæдæг ныффысс кæнæ йæ `pluralForm` атрибутæй радт.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент зонгæ Doenet элемент нæу.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементæн документы уидагыл бар нæ дæттынц.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементæн `<{ $parent }>` мидæг бар нæ дæттынц.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементмæ `{ $attribute }` номимæ атрибут нæй.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементы `{ $attribute }` атрибут хъуамæ ахæм номхыгъд уа, кæцы алы элемент дæр уыдонæй иу уа: { $allowed }
+       *[other] `<{ $tag }>` элементы `{ $attribute }` атрибут хъуамæ уыдонæй иу уа: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select-мæ раст нæу варианты ном. { $variantName } варианты ном { $numOptions } æвзарæны æмбæлы, æвзарæн нымæц та { $numToSelect }.
+
+select-variant-name-without-options = select-мæ варианттæ лæвæрд сты, фæлæ гæнæн варианты номмæ иу æвзарæн дæр нæй: { $variantName }.
+
+select-variant-name-not-possible = select-мæ лæвæрд { $variantName } варианты ном гæнæн варианты ном нæу.
+
+select-too-few-options = Æппæт { $numOptions }-æй { $numToSelect } компонент равзарæн нæй.
+
+select-from-sequence-too-few-values = Даргъдзинад { $length } рæнхъæгтæй { $numToSelect } аргъ равзарæн нæй.
+
+select-from-sequence-indices-count-mismatch = select-мæ лæвæрд индексты нымæц хъуамæ æвзарæн нымæцимæ фидауа
+
+select-from-sequence-indices-not-integers = select-мæ лæвæрд æппæт индекстæ хъуамæ æнæхъæн нымæц уой
+
+select-from-sequence-index-excluded = selectfromsequence-мæ лæвæрд индекс аппæрст уыд
+
+select-from-sequence-indices-excluded-combination = selectfromsequence-мæ лæвæрд индекстæ аппæрст бастдзинад уыдысты
+
+select-from-sequence-coprime-not-positive-integers = Плюсон æнæхъæн нымæцтæ æвзæрст не сты, уымæ гæсгæ кæрæдзимæ хуымæтæг бастдзинæдтæ равзарæн нæй.
+
+select-from-sequence-coprime-common-factor = Кæрæдзимæ хуымæтæг нымæцтæ равзарæн нæй. Æппæт гæнæн аргъытæн иумæйаг дихгæнæг ис. (Лæвæрд "from" кæнæ "to" аргъытæ хъуамæ "step"-имæ кæрæдзимæ хуымæтæг уой.)
+
+select-from-sequence-coprime-single-number = 1 нæ чи у, ахæм иунæг нымæцæй кæрæдзимæ хуымæтæг бастдзинæдтæ равзарæн нæй.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence мидæг бастдзинæдты 70%-æй фылдæр аппæрст æрцыд
+
+select-from-sequence-coprime-none-found = Кæрæдзимæ хуымæтæг нымæцтæ равзарын нæ бантыст. Æппæт гæнæн аргъытæн иумæйаг дихгæнæг ис.
+
+select-from-sequence-too-few-unique-values = Даргъдзинад { $numPossibleValues } рæнхъæгтæй { $numToSelect } хицæн аргъ равзарæн нæй
+
+select-prime-numbers-too-few-values = Даргъдзинад { $numValues } хуымæтæг нымæцты номхыгъдæй { $numToSelect } аргъ равзарæн нæй
+
+select-prime-numbers-values-count-mismatch = select-мæ лæвæрд аргъыты нымæц хъуамæ æвзарæн нымæцимæ фидауа
+
+select-prime-numbers-values-not-prime = select prime number-мæ лæвæрд æппæт аргъытæ хъуамæ хуымæтæг нымæцты номхыгъды уой
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers-мæ лæвæрд аргъытæ аппæрст бастдзинад уыдысты
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers мидæг бастдзинæдты 70%-æй фылдæр аппæрст æрцыд
+
+select-random-combination-fluke = Тынг æнæгæнæн хабары фæрцы æнæбæрæг аргъыты бастдзинад равзарын нæ бантыст
+
+select-random-value-fluke = Тынг æнæгæнæн хабары фæрцы æнæбæрæг аргъ равзарын нæ бантыст

--- a/packages/i18n/locales/os/editor.ftl
+++ b/packages/i18n/locales/os/editor.ftl
@@ -1,0 +1,215 @@
+# Ossetian editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Ossetian counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Раздæхын
+       *[update] Ногæй кæнын
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Уынæг { $word }
+       *[other] Уынæг { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Æвзарæн…
+editor-variant-next = Дарддæры вариант равзарын
+editor-variant-previous = Разæйы вариант равзарын
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA бахæццæйы халд ссардæуыд. Бахæццæйы отчёт { $action ->
+            [close] æхгæнынæн
+           *[open] байгом кæнынæн
+        } ныххæц.
+        [advisories] Бахæццæйы отчёт { $action ->
+            [close] æхгæнынæн
+           *[open] байгом кæнынæн
+        } ныххæц. WCAG AA халдтытæ нæ ссардæуыд, фæлæ ис æндæр амындтытæ.
+       *[clean] Бахæццæйы отчёт { $action ->
+            [close] æхгæнынæн
+           *[open] байгом кæнынæн
+        } ныххæц. Бахæццæйы фарстытæ нæ ссардæуыд.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA бахæццæйы халд ссардæуыд. { $count ->
+            [one] { $count } WCAG AA халд
+           *[other] { $count } WCAG AA халд
+        } ссардæуыд. Бахæццæйы отчёт { $action ->
+            [close] æхгæнынæн
+           *[open] байгом кæнынæн
+        } ныххæц.
+        [advisories] WCAG AA халдтытæ нæ ссардæуыд. { $count ->
+            [one] { $count } æндæр амынд
+           *[other] { $count } æндæр амынд
+        } ссардæуыд. Бахæццæйы отчёт { $action ->
+            [close] æхгæнынæн
+           *[open] байгом кæнынæн
+        } ныххæц.
+       *[clean] WCAG AA халдтытæ нæ ссардæуыд. Бахæццæйы отчёт { $action ->
+            [close] æхгæнынæн
+           *[open] байгом кæнынæн
+        } ныххæц.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML верси { $version }
+
+editor-tab-help = Контексты æххуыс
+editor-tab-help-short = Контекст
+editor-tab-errors = Рæдыдтытæ
+editor-tab-warnings = Фæдзæхстытæ
+editor-tab-info = Информаци
+editor-tab-accessibility = Бахæццæ
+editor-tab-responses = Арвыст дзуæппытæ
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторы уагæвæрдтæ
+editor-format-as-doenetml = DoenetML хуызы формат кæнын
+editor-format-as-xml = XML хуызы формат кæнын
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-æм рæнхъ
+
+editor-no-errors = Рæдыдтытæ нæй
+editor-no-warnings = Фæдзæхстытæ нæй
+editor-no-info = Информацион хъусынгæнинæгтæ нæй
+
+editor-show-info-annotations = Информацион хъусынгæнинæгтæ редакторы равдисын
+editor-show-accessibility-annotations = Бахæццæйы хъусынгæнинæгтæ редакторы равдисын
+
+editor-accessibility-learn-more = Doenet бахæццæмæ куыд кæсы
+
+editor-accessibility-violations-heading = Бахæццæйы халдтытæ ({ $standard })
+
+editor-accessibility-other-heading = Æндæр бахæццæйы фарстытæ
+editor-none-found = Ницы ссардæуыд
+
+
+## Submitted responses
+
+editor-no-responses = Ныртæккæмæ арвыст дзуæппытæ нæй
+editor-response-answer-id = Дзуаппы Id
+editor-response-response = Дзуапп
+editor-response-credit = Балл
+editor-response-submitted = Арвыст
+
+
+## The context-help panel
+
+help-placeholder = Документаци фенынæн курсор сæвæр тегы номыл, атрибутыл кæнæ { $ref }-ыл.
+
+help-unsupported-ref-chain = { $example } хуызæн бирæхаййон бастдзинæдтæн æххуыс нырма нæй.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Бастдзинадæн объект нæ ссардæуыд: { $ref }.
+        [multiple] Бастдзинадæн бирæ объекттæ ссардæуыд: { $ref }.
+       *[indeterminate] { $ref } объект бæрæг кæнын нæ бантыст.
+    }
+
+help-learn-about-references = Бастдзинæдты тыххæй базонын →
+help-reference-page = Æрмæджы фарс →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } мидæг
+       *[top] Уæллаг уæлæнгайы
+    }{ $allowed ->
+        [none] { " — ам ницы бацæуы." }
+        [text] { " — ам текст фыссæн ис." }
+        [text-and-components] { " — ам текст фыссæн ис, кæнæ ацытæ бафæлвар:" }
+       *[components] { " — ацытæ бафæлварæн ис:" }
+    }
+
+help-suggestions-footer = Æппæт { $total } компонент фенынæн { $shortcut } ныххæц.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объектмæ бастдзинад.
+       *[other] { $ref } — { $target } объектмæ бастдзинад ({ $line }-æм рæнхъ).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Уый { $owner } { $role } хуызы бахаста.
+       *[other] Уый { $owner } { $line }-æм рæнхъы { $role } хуызы бахаста.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементы { $property } миниуæгмæ бастдзинад.
+       *[other] { $ref } — { $element } элементы { $property } миниуæгмæ бастдзинад ({ $line }-æм рæнхъ).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = хай
+help-kind-array-entry = массивы элемент
+
+help-default = Бындурон аргъ:
+help-active-default = Ныртæккæйы бындурон аргъ:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Уадзгæ аргъытæ (алы элементмæ иу):
+       *[other] Уадзгæ аргъытæ:
+    }
+
+help-suggested-values = Амынд аргъытæ:
+
+help-inserts = Бафтауы:
+
+help-coordinates =
+    { $count ->
+        [one] Координатæ:
+       *[other] Координатæтæ:
+    }
+
+help-type = Хуыз:
+
+help-resolved-style = Рацыд стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Рацыд функцийы нæмттæ:
+help-reset-list = Ацы быдыры раздæхыны номхыгъд:
+help-added-on-input = Ацы быдыры бафтыд:
+help-removed-on-input = Ацы быдырæй аппæрст:
+
+help-reset-overrides = { $reset } — { $additional } æмæ { $removed } сæрты фæуæлахиз вæййы.

--- a/packages/i18n/locales/sah/chrome.ftl
+++ b/packages/i18n/locales/sah/chrome.ftl
@@ -1,0 +1,142 @@
+# Sakha (Yakut) viewer chrome. Translated from `locales/en/chrome.ftl`, which
+# is the source of truth: `lint:i18n` rejects a key that does not exist there,
+# and reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# SAKHA RESOLVES EXACTLY ONE PLURAL CATEGORY. `Intl.PluralRules("sah")` reports
+# `other` and nothing else, so no message in this catalog can select on a
+# count and every counted message below is written flat — the shape
+# `locales/ja`, `locales/th`, `locales/bo` and `locales/dz` already have, and
+# the first time a Turkic language in this roster has it. It is not a claim
+# that Sakha has no plural: it marks one with -лар and its family, but a noun
+# after a numeral stays in the singular, so the number carries the counting on
+# its own and a category would have nothing to choose between.
+#
+# The `[0]` branches that survive are matched by *number* rather than by
+# category — Fluent resolves an explicit number before it consults the plural
+# rules — which is why a separate wording for none is still reachable here.
+
+
+## Answer submission
+
+answer-checking = Бэрэбиэркэлэнэр…
+answer-submitting = Ыытыллар…
+
+answer-checking-status = Хоруй бэрэбиэркэлэнэр
+answer-submitting-status = Хоруй ыытыллар
+
+answer-correct = Сөп
+answer-incorrect = Сыыһа
+
+answer-response-saved = Хоруй хараллыбыта
+
+answer-percent-credit = { $percent }% баал
+answer-percent-correct = { $percent }% сөп
+answer-percent-short = { $percent } %
+
+max-credit-available = Ылыахха сөптөөх үрдүк баал: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] боруобалыыр кыах хаалбата
+       *[other] { $count } боруобалыыр кыах хаалла
+    }
+
+validation-correct = (Сөп)
+validation-incorrect = (Сыыһа)
+validation-partially-correct = (Аҥаардастыы сөп)
+
+answer-show-responses = { $answerId } диэҥҥэ { $count } хоруйу көрдөр
+
+
+## Disclosure panels
+
+feedback-heading = Хардары этии
+
+collapsible-click-to-open = (аһар туһугар баттаа)
+collapsible-click-to-close = (сабар туһугар баттаа)
+
+collapsible-initializing = Бэлэмнэнэр…
+
+footnote-show = Бэлиэтээһини көрдөр
+footnote-hide = Бэлиэтээһини кистээ
+
+description-more-information = эбии информация
+
+
+## Controls
+
+slider-previous = Иннинээҕи
+slider-next = Аныгыскы
+
+keyboard-open = Клавиатураны аһар
+keyboard-close = Клавиатураны сабар
+
+choice-input-remove-choice = { $choice } талыытын сот
+
+matrix-remove-row = Строканы сот
+matrix-add-row = Строка эп
+matrix-remove-column = Колонканы сот
+matrix-add-column = Колонка эп
+
+subset-add-remove-points = Туочука эбии/сотуу
+subset-toggle-points-intervals = Туочукалары уонна кэрчиктэри уларыт
+subset-move-points = Туочукалары көһөр
+subset-clear = Ыраастаа
+
+orbital-add-row = Строка эп
+orbital-remove-row = Строканы сот
+orbital-add-box = Кыаһы эп
+orbital-remove-box = Кыаһы сот
+orbital-add-up-arrow = Үөһэ ох эп
+orbital-add-down-arrow = Аллара ох эп
+orbital-remove-arrow = Оҕу сот
+
+orbital-row-label = { $row } строка бэлиэтэ
+
+pretzel-answer = Хоруй
+
+summary-statistics-caption = { $column } колонка түмүк статистиката
+
+
+## Math input
+
+math-input-preview-region = математика этиитин иннинэ көрүү
+math-input-preview = Иннинэ көрүү
+math-input-invalid-expression = Сыыһа этии:
+
+
+## Document status
+
+viewer-initializing = Бэлэмнэнэр…
+
+
+## Errors
+
+error-heading = Алҕас
+
+error-found-at =
+    { $span ->
+        [line] Булуллубут строка: { $startLine }.
+       *[lines] Булуллубут строкалар: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Бу дьокумуоҥҥа алҕастар бааллар!
+
+diagnostic-heading-error = Алҕас
+diagnostic-heading-warning = Сэрэтии
+diagnostic-heading-information = Информация
+diagnostic-heading-hint = Сүбэ
+
+accessibility-heading-level-1 = WCAG AA туттуллар кыаҕын кэһиитэ
+accessibility-heading-level-2 = Туттуллар кыаҕын туһунан биллэрии
+
+something-went-wrong = Туох эрэ сыыһа тахсыбыт.
+
+renderer-load-failed = ойуулааччыны хачайдыы иликпит. Сирэйи саҥалыы хачайдаа.
+
+core-start-failed = Дьокумуон көрөр тэрилин саҕалыыр кыах суох. Сирэйи саҥалыы хачайдаа.

--- a/packages/i18n/locales/sah/content.ftl
+++ b/packages/i18n/locales/sah/content.ftl
@@ -1,0 +1,266 @@
+# Sakha (Yakut) content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Sakha's own extra letters — ҕ, ҥ, һ, ө, ү, and the
+# digraphs дь and нь — which its schools and publishing use and which CLDR
+# fills a bare `sah` in as. The roster calls this language **Yakut**, because
+# that is what `Intl.DisplayNames` renders `sah` as; Sakha is what its speakers
+# call it, and the two names are one language.
+#
+# Sakha has no grammatical gender and does not inflect an attributive
+# adjective, so `$gender` and `$role` go unused, as in every Turkic catalog
+# here.
+#
+# THE COLOUR TABLE IS THE PART OF THIS FILE TO READ FIRST. Sakha's «күөх»
+# covers both green and blue — one word where the style pipeline needs two —
+# so this catalog writes the two modern compounds that split it: «от күөх»
+# (grass-green) for green and «халлаан күөҕэ» (sky-colour) for blue. That is a
+# real choice rather than a translation, it is what written Sakha does when it
+# has to distinguish them, and a speaker may well prefer other words. `cyan` is
+# the hardest of the three and is written as a lightened sky-colour.
+# «оранжевай» and «розовай» are Russian, which is what Sakha uses for those
+# two; nothing here invents a native coinage to avoid an honest loanword.
+
+
+## Style vocabulary
+
+color =
+    .black = хара
+    .white = үрүҥ
+    .gray = боруон
+    .red = кыһыл
+    .orange = оранжевай
+    .yellow = араҕас
+    .green = от күөх
+    .cyan = сырдык халлаан күөҕэ
+    .blue = халлаан күөҕэ
+    .purple = фиолетовай
+    .pink = розовай
+    .brown = кугас
+
+line-width =
+    .thick = халыҥ
+    .thin = синньигэс
+
+line-style =
+    .dashed = быстах-быстах
+    .dotted = туочукалаах
+
+# Noun phrases: they stand in front of «оҥоһуулаах» and modify nothing.
+fill-style =
+    .horizontal = горизонтальнай сурааһын
+    .vertical = вертикальнай сурааһын
+    .diagonal = диагональ сурааһын
+    .backdiagonal = утары диагональ сурааһын
+    .dots = туочука
+    .diamonds = ромб
+
+noun =
+    .line = көнө сурааһын
+    .line-segment = кэрчик
+    .ray = сардаҥа
+    .vector = вектор
+    .curve = токур сурааһын
+    .function = функция
+    .parabola = парабола
+    .polyline = тосторуу сурааһын
+    .polygon = элбэх муннуктаах
+    .triangle = үс муннуктаах
+    .rectangle = көнө муннуктаах
+    .circle = түгэрик
+    .region = сир
+    .point = туочука
+    .square = квадрат
+    .diamond = ромб
+    .cross = кириэс
+    .plus = плюс
+
+# Sakha builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] тэҥ { $numSides } муннуктаах
+    }
+
+# Sakha has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = кырааскалаах
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } оҥоһуулаах { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } оҥоһуулаах { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } оҥоһуулаах { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «кыраныыстаах» — "having an edge" — carries the "with a border" sense in its
+# own suffix, so neither a preposition nor an article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } кыраныыстаах
+        [and] уонна { $border } кыраныыстаах
+        [and-article] уонна { $border } кыраныыстаах
+       *[with] { $border } кыраныыстаах
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } оҥоһуулаах { $color } кырааска
+       *[plain] { $color } кырааска
+    }
+
+style-unfilled = кырааската суох
+
+# «үрдүгэр» — "on top of" — is a postposition and follows the background
+# colour, so nothing stands between the two words the way English's "with a"
+# does.
+style-text =
+    { $parts ->
+        [background] { $background } фон үрдүгэр { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = суох
+
+
+## Boolean words
+
+boolean-true = сөп
+boolean-false = сыыһа
+
+
+## Answer buttons
+
+answer-submit-label = Бэрэбиэркэлээ
+answer-submit-label-no-correctness = Хоруйу ыыт
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Дьарык
+    .aside = Аһары этии
+    .cascade = Каскад
+    .definition = Өйдөбүл
+    .example = Холобур
+    .exercise = Үөрэтии
+    .exercises = Үөрэтиилэр
+    .given-answer = Хоруй
+    .note = Бэлиэтээһин
+    .objectives = Сыаллар
+    .paragraphs = Абзацтар
+    .part = Чааһа
+    .problem = Сорудах
+    .problems = Сорудахтар
+    .proof = Дакаастааһын
+    .question = Ыйытык
+    .section = Салаа
+    .solution = Быһаарыы
+    .task = Үлэ
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Сүбэ
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Ойуу { $enumeration }
+        [numbered-caption] Ойуу { $enumeration }{ ". " }
+        [unnumbered-caption] Ойуу{ ". " }
+       *[unnumbered] Ойуу
+    }
+
+
+## Paginator controls
+
+paginator-previous = Иннинээҕи
+paginator-next = Аныгыскы
+paginator-page = Сирэй
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## `piecewise-condition-if` records a limit rather than a choice, and it is
+## `locales/dv`'s case in a different family. Sakha marks a condition with a
+## converb suffix on the verb at the *end* of its clause — «буоллаҕына» — and
+## the renderer places this key *before* the mathematics it introduces, which
+## no wording here can fix. The word is written in its citation form so that
+## the sentence is at least readable; splitting the key into a prefix and a
+## suffix is a change to the worker that no existing catalog needs and this one
+## would use.
+
+piecewise-condition-or = эбэтэр
+piecewise-condition-if = буоллаҕына
+piecewise-condition-otherwise = атын түгэннэргэ
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Sakha is taught in
+## Russian, and the element names a Sakha-speaking pupil meets are the Russian
+## ones out of a Russian-language textbook — the school-system case, arriving
+## in a country whose medium is Russian. Sakha-medium schooling is real and
+## reaches further up the grades than most of this batch's languages, which is
+## exactly why the gap is worth stating plainly rather than leaving to be
+## inferred: what is missing is a settled list of all 118, not the schooling.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Сыыһа хиимийэ бэлиэтэ
+chemistry-invalid-ionic-compound = Сыыһа ион холбоһуга

--- a/packages/i18n/locales/sah/diagnostics.ftl
+++ b/packages/i18n/locales/sah/diagnostics.ftl
@@ -1,0 +1,618 @@
+# Sakha (Yakut) diagnostics. Translated from `locales/en/diagnostics.ftl`,
+# which is the source of truth: `lint:i18n` rejects a key that does not exist
+# there, and reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# Sakha resolves exactly one plural category, so every counted message here is
+# written flat and the selections English uses for `one`/`other` collapse to a
+# single branch — see the note at the top of `chrome.ftl`.
+#
+# The technical nouns are Russian written in Sakha spelling, which is what
+# written Sakha does with them: «компонент», «атрибут», «функция», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints = икки төбө туочуката ыйыллыбытына { $attributes } аахсыллыбат
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint = төбө туочуката уонна ортоку туочука иккиэн ыйыллыбыттарына { $attributes } аахсыллыбат
+
+line-segment-midpoint-offset-without-midpoint = ортоку туочуката суох midpointOffset туохха да дьайбат
+
+## `<line>`
+
+line-points-undetermined-dimensions = Кээмэйэ биллибэт туочукалар нөҥүө ааһар көнө сурааһын.
+
+line-points-too-few-dimensions = Көнө сурааһын аҕыйаҕа икки кээмэйдээх туочукалар нөҥүө ааһыахтаах.
+
+line-points-depend-on-variables = Көнө сурааһын уларыйар кээмэйдэртэн тутулуктаах туочукалар нөҥүө ааһар: { $variables }.
+
+line-equation-invalid-format = { $variable1 } уонна { $variable2 } уларыйар кээмэйдээх көнө сурааһын тэҥэ сыыһа форматтаах.
+
+## `<ray>`
+
+ray-overprescribed-through = Сардаҥа through, endpoint уонна direction нөҥүө ыйыллыбыт. Ыйыллыбыт through аахсыллыбат.
+
+ray-dimension-mismatch = сардаҥаҕа numDimensions сөп түбэспэт.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail уонна displacement нөҥүө ыйыллыбыт. Ыйыллыбыт head аахсыллыбат.
+
+vector-dimension-mismatch = векторга numDimensions сөп түбэспэт.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элеменҥэ тардар кыах суох, тоҕо диэтэххэ кини nearestPoint турук кээмэйэ суох.
+
+constrain-to-without-nearest-point = `<{ $component }>` элеменинэн хааччахтыыр кыах суох, тоҕо диэтэххэ кини nearestPoint турук кээмэйэ суох.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элемен иһинэн хааччахтыыр кыах суох, тоҕо диэтэххэ кини nearestPoint турук кээмэйэ суох.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = строка иһигэр суох choiceInput туһугар labelPosition аахсыллыбат
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput туһугар ыйыллыбыт индекстэр аахсыллыбаттар, тоҕо диэтэххэ ахсааннара choice оҕолорун ахсаанын кытта сөп түбэспэт.
+
+pretzel-indices-count-mismatch = problem туһугар ыйыллыбыт индекстэр аахсыллыбаттар, тоҕо диэтэххэ ахсааннара problem оҕолорун ахсаанын кытта сөп түбэспэт.
+
+shuffle-indices-count-mismatch = shuffle туһугар ыйыллыбыт индекстэр аахсыллыбаттар, тоҕо диэтэххэ ахсааннара компонент ахсаанын кытта сөп түбэспэт.
+
+indices-ignored-out-of-range = { $component } туһугар ыйыллыбыт индекстэр аахсыллыбаттар, тоҕо диэтэххэ сорохторо кээмэйтэн тахсаллар.
+
+pretzel-indices-repeated = pretzel туһугар ыйыллыбыт индекстэр аахсыллыбаттар, тоҕо диэтэххэ сорохторо хатыланаллар.
+
+pretzel-circuit-first-index = circuit режимҥэ pretzel туһугар ыйыллыбыт индекстэр аахсыллыбаттар, тоҕо диэтэххэ бастакы индекс 1 буолуохтаах.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` тиэкис оҕолорун кытта үлэлиир туһугар `type` атрибут ыйыллыахтаах.
+
+invalid-type-defaulting-to-math = { $component } компонеҥҥа сыыһа көрүҥ { $type }. Кини math, text, number эбэтэр boolean буолуохтаах. math туттуллар.
+
+string-not-valid-component-to-arrange = «{ $value }» строка { $component } туһугар сөптөөх компонент буолбатах. Аахсыллыбат.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Сыыһа көрүҥ { $type }, көрүҥэ number буолар.
+
+invalid-variable-value = Уларыйар кээмэй сыыһа суолтата: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } барыйаан индексэ ахсаан буолуохтаах
+
+variant-index-must-be-integer = { $index } барыйаан индексэ бүтүн ахсаан буолуохтаах
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют кээмэйдэргэ оҥоһуллубатах. Кэтиттэрэ тэҥнээх буолаллар.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют кээмэйдэргэ оҥоһуллубатах. Кыраныыстара тэҥнээх буолаллар.
+
+side-by-side-no-block-child = Сыыһа `<{ $component }>`: кини аҕыйаҕа биир блок оҕолоох буолуохтаах.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элеменин `for` атрибута аахсыллыбат.
+
+label-for-must-resolve-to-one = `<label>` элемен `for` атрибута биир эрэ компоненҥа ыйыахтаах.
+
+label-for-unresolved = `<label>` элемен `for` атрибутун компонеҥҥа сибээстиир кыах суох.
+
+label-for-answer-with-authored-inputs = `<label>` элемен `for` атрибута ааптар суруйбут киллэрии хонуулаах `<answer>` диэки ыйар; хонууну быһаччы ыйыҥ.
+
+label-for-answer-without-input = `<label>` элемен `for` атрибута бэлиэтиир киллэрии хонуута суох `<answer>` диэки ыйар.
+
+label-for-must-reference-input-or-answer = `<label>` элемен `for` атрибута киллэрии хонуутугар эбэтэр хоруйга ыйыахтаах.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Туттуллар кыах туһугар `<{ $component }>` кылгас быһаарыылаах буолуохтаах эбэтэр оҥоһуу быһыытынан бэлиэтэниэхтээх.
+
+accessibility-video-short-description = Туттуллар кыах туһугар `<video>` кылгас быһаарыылаах буолуохтаах.
+
+accessibility-input-short-description-or-label = Туттуллар кыах туһугар `<{ $component }>` кылгас быһаарыылаах эбэтэр бэлиэлээх буолуохтаах.
+
+accessibility-answer-input-short-description-or-label = Туттуллар кыах туһугар киллэрии хонуутун оҥорор `<answer>` кылгас быһаарыылаах эбэтэр бэлиэлээх буолуохтаах.
+
+accessibility-short-description-contains-math = Кылгас быһаарыыларга `<{ $component }>` курдук математика компонена буолуо суохтаах. Математиканы тылынан суруй.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } салаа баһын тиэкиһигэр тиийэр контраһы биэрбэт (хараҥа көрүҥ) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; аҕыйаҕа { $threshold }:1 наада).
+       *[other] { $colorName } салаа баһын тиэкиһигэр тиийэр контраһы биэрбэт ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; аҕыйаҕа { $threshold }:1 наада).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Туочукалар ахсаан суолталара суох буоллахтарына { $count } туочука нөҥүө ааһар `<circle>` оҥоһуллубатах.
+
+circle-too-many-through-points = 3-тэн ордук туочука нөҥүө ааһар түгэриги ааҕар кыах суох.
+
+circle-overprescribed-radius-center-points = Ыйыллыбыт радиус, киин уонна туочукалар кытта түгэриги ааҕар кыах суох.
+
+circle-center-with-multiple-points = Ыйыллыбыт кииннээх 1-тэн ордук туочука нөҥүө ааһар түгэриги ааҕар кыах суох.
+
+circle-radius-too-small = Түгэриги ааҕар кыах суох: икки туочука икки ардыгар ыраах { $distance } буолан, ыйыллыбыт радиус { $radius } наһаа кыра.
+
+circle-radius-with-many-points = Ыйыллыбыт радиустаах иккиттэн ордук туочука нөҥүө ааһар түгэриги оҥорор кыах суох.
+
+circle-invalid-center-or-through-points = Түгэрик киинэ эбэтэр туочукалара сыыһалар.
+
+circle-radius-center-with-multiple-points = Ыйыллыбыт кииннээх 1-тэн ордук туочука нөҥүө ааһар түгэрик радиуһун ааҕар кыах суох.
+
+circle-change-radius-non-numerical = Ахсаана суох туочукалаах түгэрик радиуһун уларытар кыах суох
+
+circle-radius-with-points-non-numerical = Ахсаан суолталара суох буоллахтарына ыйыллыбыт радиустаах биирдэн ордук туочука нөҥүө ааһар түгэриги оҥорор кыах суох.
+
+circle-change-center-non-numerical = Ахсаана суох туочукалар нөҥүө ааһар түгэрик киинин уларытыы оҥоһуллубатах.
+
+## `<function>`
+
+function-domain-insufficient-dimensions = Функция быһаарыллар сирин кээмэйэ тиийбэт. Сиргэ { $intervals } кэрчик баар, функцияҕа { $inputs } киллэрии баар.
+
+function-domain-invalid-format = Функция быһаарыллар сирэ сыыһа форматтаах.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функция ахсаана суох максимума аахсыллыбат.
+        [minimum] Функция ахсаана суох минимума аахсыллыбат.
+        [extremum] Функция ахсаана суох экстремума аахсыллыбат.
+        [point] Функция ахсаана суох туочуката аахсыллыбат.
+        [slope] Функция ахсаана суох таҥнарыыта аахсыллыбат.
+       *[other] Функция ахсаана суох { $type } суолтата аахсыллыбат.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функция кураанах максимума аахсыллыбат.
+        [minimum] Функция кураанах минимума аахсыллыбат.
+        [extremum] Функция кураанах экстремума аахсыллыбат.
+        [point] Функция кураанах туочуката аахсыллыбат.
+       *[other] Функция кураанах { $type } суолтата аахсыллыбат.
+    }
+
+function-points-too-close = Функцияҕа биир биирдэригэр наһаа чугас икки туочука баар. Функцияны быһаарар кыах суох.
+
+function-iterates-input-output-mismatch = Функция итерациялара киллэрии ахсаана таһаарыы ахсаанын кытта тэҥнэһэр эрэ түгэнигэр кыаллаллар. Бу функцияҕа { $inputs } киллэрии уонна { $outputs } таһаарыы баар.
+
+## `<sequence>`
+
+sequence-invalid-length = Кэккэ уһуна сыыһа. Кини минуһа суох бүтүн ахсаан буолуохтаах.
+
+sequence-invalid-step = Кэккэ хаамыыта сыыһа. { $type } көрүҥнээх кэккэҕэ кини ахсаан буолуохтаах.
+
+sequence-invalid-endpoint-number = Ахсаан кэккэтин «{ $attribute }» суолтата сыыһа. Кини ахсаан буолуохтаах.
+
+sequence-invalid-endpoint-letters = Буукуба кэккэтин «{ $attribute }» суолтата сыыһа. Кини буукубалар холбоһуктара буолуохтаах.
+
+sequence-invalid-endpoint = Кэккэ «{ $attribute }» суолтата сыыһа.
+
+select-from-sequence-coprime-not-numbers = ахсааннар талыллыбатахтарынан coprime аахсыллыбат
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations ыйыллыбытынан coprime аахсыллыбат
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` туһугар сыыһа target: сыал булуллубата.
+
+target-state-variable-not-found = `<{ $source }>` туһугар сыыһа target: `<{ $component }>` элеменҥэ «{ $property }» диэн ааттаах турук кээмэйэ булуллубата.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` уларыйар кээмэйдэрэ тутулуга суох кээмэйтэн уратылаах буолуохтаахтар.
+
+ode-system-duplicate-variable-names = Тутулуктаах кээмэйдэр ааттара хатыланар буоллахтарына ДТ уҥа өттүн функцияларын быһаарар кыах суох.
+
+ode-system-rhs-function-error = ДТ уҥа өттүн функциятын быһаарар кыах суох. mathjs функциятын оҥорорго алҕас.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } көнө сурааһын икки ардыгар муннугу быһаарар кыах суох
+
+angle-invalid-through-point = `<angle>` элемен through суолтатыгар сыыһа туочука
+
+parabola-vertex-too-many-points = Ыйыллыбыт төбөлөөх 1-тэн ордук туочука нөҥүө ааһар парабола оҥоһуллубатах.
+
+parabola-too-many-points = 3-тэн ордук туочука нөҥүө ааһар парабола оҥоһуллубатах.
+
+intersection-too-many-items = Иккиттэн ордук объект кирилиэһэ оҥоһуллубатах
+
+## Other math components
+
+ionic-compound-not-two-ions = Икки иоҥҥа эрэ ион холбоһуга оҥоһуллубут.
+
+ionic-compound-needs-cation-and-anion = Ион холбоһуга биир катиоҥҥа уонна биир аниоҥҥа эрэ оҥоһуллубут.
+
+solve-equations-cannot-evaluate = Тэҥи быһаарар кыах суох, тоҕо диэтэххэ кинини ааҕар кыах суох этэ: { $equation }
+
+math-operators-operand-number-required = Математика операнын араарарга operandNumber ыйыллыахтаах.
+
+eigen-decomposition-failed = Матрица бэйэтин суолталарын ааҕар кыах суоҕа
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern = `<matchesPattern>`: { $parameters } параметр холобурга көстүбэт, онон кини куруук кураанаҕы кытта сөп түбэһэр.
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" суолтатын өйдүүр кыах суох. Кини none, medium, dense эбэтэр кураанах миэстэнэн арахсыбыт икки плюстаах ахсаан буолуохтаах, холобур grid="1 0.5". Сиэккэ оҥоһуллубат.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure ойуулааччытыгар xLabelPosition="left" оҥоһуллубатах; уҥа туруу туттуллар.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure ойуулааччытыгар yLabelPosition="bottom" оҥоһуллубатах; үөһэ туруу туттуллар.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure көһөрүүтүгэр өҥүөс кыраныыстара сыыһалар; сүрүн bbox (-10,-10,10,10) туттуллар.
+
+prefigure-invalid-width = `<graph>`: prefigure көһөрүүтүгэр кэтит сыыһа; диаграмма сүрүн кэтитэ 425 туттуллар.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure көһөрүүтүгэр aspectRatio сыыһа; сүрүн өттүлэр сыһыаннара 1 туттуллар.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сиэккэ хаамыыта өҥүөс кыраныыстарыгар наһаа кыра; prefigure ойуулааччытыгар сиэккэ таһаарыллыбат.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure ойуулааччыта туттуллубатаҕына бэлиэтээһиннэр оҥоһуллубаттар.
+
+multiple-annotations-children = `<graph>` иһигэр хас да `<annotations>` оҕото булулунна; бүтэһигиттэн ураты бары аахсыллыбаттар.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Биллибэт компонент көрүҥүн кэҥэтэр эбэтэр көһөрөр кыах суох: { $type }.
+
+copy-prop-not-found = { $component } көрүҥнээх компонеҥҥа { $property } бэлиэтэ булуллубата
+
+collect-no-source = collect туһугар төрүт булуллубата.
+
+collect-invalid-component-type = `<{ $component }>` көрүҥнээх компоненнары хомуйар кыах суох, тоҕо диэтэххэ бу сыыһа компонент көрүҥэ.
+
+reference-index-unavailable = `{ $reference }` индекскэ ыйыы оҥорор кыах суох
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонеҥҥа { $action } ыҥырар кыах суох
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннайдар форматтара сыыһа. Строкалар уһуннара атын-атын. Булулунна componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннайдарга колонка ааттара хатыланаллар. Булулунна componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннайдарга колонка аата тиийбэт. Булулунна componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Бу хоруй award суолтата answer тиэг бэйэтин ыытыллыбыт хоруйугар олоҕурар, бу күүппэтэх түмүккэ тиэрдэр.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` баар контейнер иһинээҕи `<answer>` диэки `maxNumAttempts` туруоруу дьайбат, тоҕо диэтэххэ боруобалыыр ахсааны контейнер быһаарар. `maxNumAttempts` суолтатын контейнерга туруор.
+
+nested-section-wide-check-work-max-num-attempts = Атын `sectionWideCheckWork` контейнер иһинээҕи `sectionWideCheckWork` контейнерга `maxNumAttempts` туруоруу дьайбат, тоҕо диэтэххэ боруобалыыр ахсааны таһынааҕы контейнер быһаарар. `maxNumAttempts` суолтатын таһынааҕы контейнерга туруор.
+
+answer-attributes-need-symbolic-equality = symbolicEquality туруорулла илигинэ { $attributes } атрибут туохха да дьайыа суоҕа.
+
+answer-invalid-type = answer туһугар сыыһа көрүҥ: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонент аата суоҕунан кинини модуль атрибутун быһыытынан туттар кыах суох
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонену модуль атрибутун быһыытынан туттар кыах суох, тоҕо диэтэххэ `<module>` компонент көрүҥэр «{ $name }» атрибут быһаарыллыбыт.
+
+conditional-content-condition-ignored = case эбэтэр else оҕолордоох `<conditionalContent>` компонеҥҥа `condition` атрибут аахсыллыбат.
+
+slider-markers-type-mismatch = Маркердар көрүҥнэрэ ползунок көрүҥүн кытта сөп түбэспэт.
+
+pretzel-problem-needs-statement-and-answer = Сыыһа pretzel: хас `<problem>` барыта биир `<statement>` уонна биир `<answer>` иһиниэхтээх.
+
+pretzel-circuit-first-problem-distractor = Сыыһа pretzel: mode="circuit" режимҥэ бастакы `<problem>` дистрактор буолуо суохтаах.
+
+## Attribute values
+
+attribute-invalid-values = `{ $attribute }` атрибукка сыыһа суолта { $values }; аахсыллыбат.
+
+attribute-must-be-references = `{ $attribute }` атрибукка сыыһа суолта `{ $value }`. Атрибут `$` бэлиэттэн саҕаланар ыйыылартан турар буолуохтаах.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } иһинээҕи сыыһа функция ааттара аахсыллыбатылар: { $names }. Хас ааттан көстөр чааһа аҕыйаҕа 2 бэлиэ буолуохтаах (буукубалар эбэтэр тиирэ); кэнниттэн наадата суох `|<mathspeak альтернатива>` эбии кэлиэн сөп.
+
+## Building components from the source
+
+component-type-invalid = Сыыһа компонент көрүҥэ: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибуту хатылыыр кыах суох.
+
+attribute-invalid-for-component = `<{ $componentType }>` көрүҥнээх компоненҥа сыыһа атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } истиил быһаарыытыгар { $context ->
+        [text-on-background] тиэкис өҥө уонна фон өҥө
+        [high-contrast] үрдүк контрастаах өҥ уонна ойуу сирэ
+        [line] сурааһын өҥө уонна ойуу сирэ
+        [marker] маркер өҥө уонна ойуу сирэ
+       *[text-on-canvas] тиэкис өҥө уонна ойуу сирэ
+    } икки ардыгар контрас тиийбэт{ $mode ->
+        [dark] { " (хараҥа көрүҥ)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; аҕыйаҕа { $threshold }:1 наада).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } истиил быһаарыытыгар ыйыллыбыт өҥнөр сырдык көрүҥҥэ тиийэр контраһы биэрбиттэрин үрдүнэн, кинилэртэн тахсыбыт хараҥа көрүҥ өҥнөрө тиэкис уонна фон икки ардыгар тиийэр контраһы биэрбэттэр ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; аҕыйаҕа { $threshold }:1 наада). { $suggestion ->
+        [available] Хараҥа көрүҥҥэ тиийэр контраһы оҥорорго сырдык көрүҥ контраһын улаат (холобур { $lightAttribute }="{ $lightColor }") эбэтэр хараҥа көрүҥ өҥүн уларыт (холобур { $darkAttribute }="{ $darkColor }").
+       *[none] Хараҥа көрүҥҥэ тиийэр контраһы оҥорорго сырдык көрүҥ контраһын улаат эбэтэр тахсыбыт өҥнөрү textColorDarkMode уонна/эбэтэр backgroundColorDarkMode нөҥүө уларыт.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } истиил быһаарыытыгар ыйыллыбыт тиэкис өҥө сырдык көрүҥҥэ тиийэр контраһы биэрбитин үрдүнэн, кинитээҕэр тахсыбыт хараҥа көрүҥ тиэкис өҥө ойуу сирин кытта тиийэр контраһы биэрбэт ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; аҕыйаҕа { $threshold }:1 наада). { $suggestion ->
+        [available] Хараҥа көрүҥҥэ тиийэр контраһы оҥорорго сырдык көрүҥ контраһын улаат (холобур textColor="{ $lightColor }") эбэтэр хараҥа көрүҥ өҥүн уларыт (холобур textColorDarkMode="{ $darkColor }").
+       *[none] Хараҥа көрүҥҥэ тиийэр контраһы оҥорорго сырдык көрүҥ контраһын улаат эбэтэр тахсыбыт өҥү textColorDarkMode нөҥүө уларыт.
+    }
+
+section-multiple-style-palettes = Салаа биир эрэ <stylePalette> талыан сөп; бүтэһигэ туттуллар.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ numToSelect минуһа суох бүтүн ахсаан буолбатах.
+
+variant-num-to-select-not-constant-number = { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ numToSelect уларыйбат ахсаан буолбатах.
+
+variant-with-replacement-not-constant-boolean = { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ withReplacement уларыйбат логика суолтата буолбатах.
+
+variant-select-weight-disables-unique = ханнык эмэ талыыга selectWeight эбэтэр selectForVariants ыйыллыбыт буоллаҕына, select туһугар хатыламмат барыйааннар араарыллаллар
+
+variant-coprime-undetermined = { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ coprime куруук сыыһа дуо диэни быһаарар кыах суох.
+
+variant-attribute-not-constant = { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ { $attribute } уларыйбат буолбатах.
+
+variant-attribute-not-number = { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ { $attribute } ахсаан буолбатах.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } көрүҥнээх { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ { $attribute } { $expected ->
+        [letters-combination] буукубалар холбоһуктара
+        [math-expression] сөптөөх математика этиитэ
+        [integer] бүтүн ахсаан
+       *[number] ахсаан
+    } буолбатах.
+
+variant-length-not-integer = { $component } туһугар хатыламмат барыйааннары быһаарар кыах суох, тоҕо диэтэххэ length бүтүн ахсаан буолбатах.
+
+variant-sort-not-implemented = sort баар { $component } туһугар хатыламмат барыйааннар оҥоһуллубатахтар
+
+variant-exclude-combinations-not-implemented = excludeCombinations баар { $component } туһугар хатыламмат барыйааннар оҥоһуллубатахтар
+
+variant-math-exclude-not-implemented = exclude баар math көрүҥнээх { $component } туһугар хатыламмат барыйааннар оҥоһуллубатахтар
+
+variant-non-constant-exclude-not-implemented = уларыйар exclude баар { $component } туһугар хатыламмат барыйааннар оҥоһуллубатахтар
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: график prefigure ойуулааччытыгар оҥоһуллубатах; утума хаалларылынна.
+
+prefigure-descendant-invalid-geometry = { $subject }: бүппэт эбэтэр толору буолбатах геометрия; утума хаалларылынна.
+
+prefigure-curve-label-omitted = { $subject }: көһөрүллүбүт токур элеменнэргэ бэлиэлэр оҥоһуллубатахтар; бэлиэ хаалларылынна.
+
+prefigure-curve-unsupported-definition-type = { $subject }: оҥоһуллубатах токур функция быһаарыытын көрүҥэ «{ $definitionType }»; утума хаалларылынна.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элеменин flipFunctions атрибута оҥоһуллубатах; утума хаалларылынна.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулалаах оҕо функциялары эрэ ылынар; утума хаалларылынна.
+
+prefigure-label-position-unsupported =
+    { $subject }: оҥоһуллубатах labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] сурааһыннар ыаллара бэлиэлэригэр
+       *[point] туочука бэлиэтигэр
+    }; PreFigure сүрүн тэҥнээһинэ туттуллар.
+
+prefigure-fill-style-unsupported = { $subject }: толоруу истиилэ «{ $fillStyle }» PreFigure-га оҥоһуллубатах; толору толорууга көһөр.
+
+prefigure-line-style-unknown = { $subject }: биллибэт сурааһын истиилэ «{ $lineStyle }» PreFigure таһаарыытыттан соруллунна.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер истиилэ «{ $markerStyle }» PreFigure «diamond» истиилигэр сөп түбэһиннэрилиннэ.
+
+prefigure-marker-style-unsupported = { $subject }: маркер истиилэ «{ $markerStyle }» PreFigure-га оҥоһуллубатах; сүрүн истиил туттуллар.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: сыыһа `ref`; сыалы сибээстиир кыах суох. Бэлиэтээһин соруллунна.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` хас да сыалы кытта сибээстэстэ; бастакыта туттуллар.
+
+annotation-ref-outside-graph = `<annotation>`: сыыһа `ref`; сыал кинини иһитиннэрэр графиктан тас өттүгэр. Бэлиэтээһин соруллунна.
+
+annotation-ref-unsupported-target = `<annotation>`: сыыһа `ref`; сыал prefigure көһөрүүтүгэр оҥоһуллубут график объект буолбатах. Бэлиэтээһин соруллунна.
+
+annotation-text-missing = `<annotation>`: `text` суох эбэтэр кураанах; кураанах тиэкис таһаарыллар.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Түгэрик тутулук булулунна.
+       *[other] `<{ $componentType }>` компонену иһитиннэрэр түгэрик тутулук булулунна.
+    }
+
+reference-no-referent = Ыйыыга объект булуллубата: `{ $reference }`
+
+reference-multiple-referents = Ыйыыга хас да объект булулунна: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элемен { $attribute } атрибута сыыһа форматтаах.
+
+children-invalid = `<{ $componentType }>` туһугар сыыһа оҕолор: сыыһа оҕолор булуллулар: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибукка сыыһа суолта `{ $value }`; `{ $default }` суолта туттуллар
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } барыла булуллубата.
+       *[other] DoenetML { $version } барыла булуллубата. { $fallback } барыла туттуллар
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Сыыһа DoenetML: { $content }
+
+parse-tag-missing-close-tag = Сыыһа DoenetML: `{ $tag }` тиэг сабар тиэгэ суох. Бэйэтэ сабыллар тиэг эбэтэр `</{ $tagName }>` тиэг күүтүллүбүтэ.
+
+parse-tag-error = Сыыһа DoenetML: `<{ $tagName }>` тиэккэ алҕас
+
+parse-attribute-missing-value = Сыыһа DoenetML: `{ $attribute }` атрибукка суолта тиийбэтэҕэ буолуо.
+
+parse-attribute-invalid = Сыыһа DoenetML: сыыһа атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Сыыһа DoenetML: атрибут сыыһа суолтата `{ $value }`
+
+parse-attribute-value-quote-mismatch = Сыыһа DoenetML: атрибут сыыһа суолтата `{ $value }`. Тырнахтар сөп түбэспэттэр. `{ $quote }` тиийбэтэҕэ буолуо
+
+parse-open-tag-name-missing = Сыыһа DoenetML: аата суох тиэг булулунна, холобур `<`
+
+parse-tag-not-closed = Сыыһа DoenetML: `{ $tag }` тиэг сабыллыбатах (`>` тиийбэтэҕэ буолуо).
+
+parse-self-closing-tag-name-missing = Сыыһа DoenetML: аата суох тиэг булулунна `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Сыыһа DoenetML: `{ $tag }` тиэг сабыллыбатах (`/>` тиийбэтэҕэ буолуо).
+
+parse-tag-invalid-attributes = Сыыһа DoenetML: `{ $tag }` тиэг сөптөөх буолбатах. Атрибуттара сыыһа буолуохтарын сөп.
+
+parse-close-tag-name-missing = Сыыһа DoenetML: аата суох сабар тиэг булулунна, холобур `</`
+
+parse-attribute-value-unquoted = Атрибут суолталара тырнах иһигэр буолуохтаахтар: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Сыыһа DoenetML: `{ $tag }` сабар тиэг булулунна, ол эрээри кинини сөп түбэһэр аһар тиэг суох
+
+parse-close-tag-mismatched = Сыыһа DoenetML: сөп түбэспэт сабар тиэг. `</{ $expected }>` күүтүллүбүтэ. `{ $found }` булулунна
+
+parser-node-unconvertible = { $node } түмүгү Dast түмүгэр көһөрөр кыах суоҕа.
+
+## Names
+
+name-attribute-invalid =
+    Сыыһа атрибут name='{ $name }'. { $reason ->
+        [characters] Ааттарга буукубалар, ахсааннар, аллараа тиирэ эбэтэр тиирэ эрэ буолуохтарын сөп.
+       *[start] Ааттар буукубаттан саҕаланыахтаахтар.
+    }
+
+component-name-invalid-start = Сыыһа компонент аата «{ $name }». Ааттар буукубаттан саҕаланыахтаахтар.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched көрүҥнээх answer video атрибуттаах буолуохтаах
+
+answer-video-watched-video-not-reference = videoWatched көрүҥнээх answer video атрибута ыйыы буолуохтаах
+
+answer-name-not-single-text = answer name атрибута биир эрэ тиэкис оҕолоох буолуохтаах
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсия таһымнара наһаа элбэхтэринэн тас DoenetML-ы ылар кыах суоҕа. Түгэрик ыйыы суох дуо?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" аадырыстан DoenetML ылар кыах суоҕа
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" аадырыстан сыыһа DoenetML ылылынна: кини «{ $componentType }» компонент көрүҥүн кытта сөп түбэспэтэ
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эргэрбит; оннугар `{ $to }` тут.
+       *[other] [deprecation] `<{ $component }>` элеменнээҕи `{ $from }` атрибут эргэрбит; оннугар `{ $to }` тут.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эргэрбит уонна аахсыллыбат, тоҕо диэтэххэ `{ $to }` эмиэ ыйыллыбыт.
+       *[other] [deprecation] `<{ $component }>` элеменнээҕи `{ $from }` атрибут эргэрбит уонна аахсыллыбат, тоҕо диэтэххэ `{ $to }` эмиэ ыйыллыбыт.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элеменнээҕи `{ $attribute }` атрибут эргэрбит уонна аахсыллыбат.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элеменнээҕи `{ $attribute }` атрибут эргэрбит; оннугар `<{ $child }>` оҕотун тут.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элеменнээҕи `{ $attribute }` атрибут `{ $value }` суолтата эргэрбит; оннугар `{ $to }` тут.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` элбэх ахсааны английскай тылга эрэ оҥорор, онон { $locale } тылынан суруллубут дьокумуоҥҥа кини тиэкиһэ уларыйбакка хаалар. Элбэх ахсаан формата бэйэҥ суруй эбэтэр кинини `pluralForm` атрибутунан ыйан биэр.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемен биллэр Doenet элемена буолбатах.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элеменҥэ дьокумуон силигэр көҥүл биэриллибэт.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элеменҥэ `<{ $parent }>` иһигэр көҥүл биэриллибэт.
+
+schema-attribute-unrecognized = `<{ $tag }>` элеменҥэ `{ $attribute }` диэн ааттаах атрибут суох.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элемен `{ $attribute }` атрибута хас элемена барыта маннык буолар испииһэк буолуохтаах: { $allowed }
+       *[other] `<{ $tag }>` элемен `{ $attribute }` атрибута маннык буолуохтаах: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select туһугар сыыһа барыйаан аата. { $variantName } барыйаан аата { $numOptions } талыыга көстөр, талыллыахтаах ахсаан эбэтэр { $numToSelect }.
+
+select-variant-name-without-options = select туһугар барыйааннар ыйыллыбыттар, ол эрээри кыаллар барыйаан аатыгар биир да талыы суох: { $variantName }.
+
+select-variant-name-not-possible = select туһугар ыйыллыбыт { $variantName } барыйаан аата кыаллар барыйаан аата буолбатах.
+
+select-too-few-options = Барыта { $numOptions } иһиттэн { $numToSelect } компонену талар кыах суох.
+
+select-from-sequence-too-few-values = Уһуна { $length } кэккэттэн { $numToSelect } суолтаны талар кыах суох.
+
+select-from-sequence-indices-count-mismatch = select туһугар ыйыллыбыт индекстэр ахсааннара талыллыахтаах ахсааны кытта сөп түбэһиэхтээхтэр
+
+select-from-sequence-indices-not-integers = select туһугар ыйыллыбыт бары индекстэр бүтүн ахсаан буолуохтаахтар
+
+select-from-sequence-index-excluded = selectfromsequence туһугар ыйыллыбыт индекс соруллубута
+
+select-from-sequence-indices-excluded-combination = selectfromsequence туһугар ыйыллыбыт индекстэр соруллубут холбоһук этилэр
+
+select-from-sequence-coprime-not-positive-integers = Плюстаах бүтүн ахсааннар талыллыбатахтарынан бэйэ-бэйэлэригэр судургу холбоһуктары талар кыах суох.
+
+select-from-sequence-coprime-common-factor = Бэйэ-бэйэлэригэр судургу ахсааннары талар кыах суох. Кыаллар бары суолталар биир үллэстээччилээхтэр. (Ыйыллыбыт "from" эбэтэр "to" суолталара "step" кытта бэйэ-бэйэлэригэр судургу буолуохтаахтар.)
+
+select-from-sequence-coprime-single-number = 1 буолбатах биир эрэ ахсаантан бэйэ-бэйэлэригэр судургу холбоһуктары талар кыах суох.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence иһигэр холбоһуктар 70%-тан ордуга соруллубут
+
+select-from-sequence-coprime-none-found = Бэйэ-бэйэлэригэр судургу ахсааннары талар кыах суоҕа. Кыаллар бары суолталар биир үллэстээччилээхтэр.
+
+select-from-sequence-too-few-unique-values = Уһуна { $numPossibleValues } кэккэттэн { $numToSelect } атын-атын суолтаны талар кыах суох
+
+select-prime-numbers-too-few-values = Уһуна { $numValues } судургу ахсааннар испииһэктэриттэн { $numToSelect } суолтаны талар кыах суох
+
+select-prime-numbers-values-count-mismatch = select туһугар ыйыллыбыт суолталар ахсааннара талыллыахтаах ахсааны кытта сөп түбэһиэхтээхтэр
+
+select-prime-numbers-values-not-prime = select prime number туһугар ыйыллыбыт бары суолталар судургу ахсааннар испииһэктэригэр буолуохтаахтар
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers туһугар ыйыллыбыт суолталар соруллубут холбоһук этилэр
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers иһигэр холбоһуктар 70%-тан ордуга соруллубут
+
+select-random-combination-fluke = Олус кыаллыбат түбэлтэ түмүгэр түбэлтэлээх суолталар холбоһуктарын талар кыах суоҕа
+
+select-random-value-fluke = Олус кыаллыбат түбэлтэ түмүгэр түбэлтэлээх суолтаны талар кыах суоҕа

--- a/packages/i18n/locales/sah/editor.ftl
+++ b/packages/i18n/locales/sah/editor.ftl
@@ -1,0 +1,205 @@
+# Sakha (Yakut) editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Sakha resolves exactly one plural category, so every counted message here is
+# written flat — see the note at the top of `chrome.ftl`. `help-coordinates`
+# and the two accessibility labels are where that shows.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Төннөр
+       *[update] Саҥырт
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Көрөөччүнү { $word }
+       *[other] Көрөөччүнү { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Барыйаан
+editor-variant-filter = Талан ыл…
+editor-variant-next = Аныгыскы барыйааны тал
+editor-variant-previous = Иннинээҕи барыйааны тал
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA туттуллар кыаҕын кэһиитэ булулунна. Туттуллар кыах отчуотун { $action ->
+            [close] сабар
+           *[open] аһар
+        } туһугар баттаа.
+        [advisories] Туттуллар кыах отчуотун { $action ->
+            [close] сабар
+           *[open] аһар
+        } туһугар баттаа. WCAG AA кэһиитэ булулунна суох, ол эрээри эбии сүбэлэр бааллар.
+       *[clean] Туттуллар кыах отчуотун { $action ->
+            [close] сабар
+           *[open] аһар
+        } туһугар баттаа. Туттуллар кыах кыһалҕалара булуллубата.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA туттуллар кыаҕын кэһиитэ булулунна. { $count } WCAG AA кэһиитэ булулунна. Туттуллар кыах отчуотун { $action ->
+            [close] сабар
+           *[open] аһар
+        } туһугар баттаа.
+        [advisories] WCAG AA кэһиитэ булуллубата. { $count } эбии сүбэ булулунна. Туттуллар кыах отчуотун { $action ->
+            [close] сабар
+           *[open] аһар
+        } туһугар баттаа.
+       *[clean] WCAG AA кэһиитэ булуллубата. Туттуллар кыах отчуотун { $action ->
+            [close] сабар
+           *[open] аһар
+        } туһугар баттаа.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML барыла { $version }
+
+editor-tab-help = Контекс көмөтө
+editor-tab-help-short = Контекс
+editor-tab-errors = Алҕастар
+editor-tab-warnings = Сэрэтиилэр
+editor-tab-info = Информация
+editor-tab-accessibility = Туттуллар кыах
+editor-tab-responses = Ыытыллыбыт хоруйдар
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редактор туруоруулара
+editor-format-as-doenetml = DoenetML курдук формалаа
+editor-format-as-xml = XML курдук формалаа
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line } строка
+
+editor-no-errors = Алҕас суох
+editor-no-warnings = Сэрэтии суох
+editor-no-info = Информация биллэриитэ суох
+
+editor-show-info-annotations = Информация биллэриилэрин редактордаах көрдөр
+editor-show-accessibility-annotations = Туттуллар кыах биллэриилэрин редактордаах көрдөр
+
+editor-accessibility-learn-more = Doenet туттуллар кыахха хайдах сыһыаннааҕый
+
+editor-accessibility-violations-heading = Туттуллар кыах кэһиилэрэ ({ $standard })
+
+editor-accessibility-other-heading = Атын туттуллар кыах кыһалҕалара
+editor-none-found = Туох да булуллубата
+
+
+## Submitted responses
+
+editor-no-responses = Билиҥҥэ ыытыллыбыт хоруй суох
+editor-response-answer-id = Хоруй Id-та
+editor-response-response = Хоруй
+editor-response-credit = Баал
+editor-response-submitted = Ыытыллыбыта
+
+
+## The context-help panel
+
+help-placeholder = Дьокумуонтаассыйаны көрөр туһугар курсору тиэг аатыгар, атрибукка эбэтэр { $ref } үрдүгэр туруор.
+
+help-unsupported-ref-chain = { $example } курдук элбэх чаастаах ыйыылар көмөлөрө өссө суох.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Ыйыыга объект булуллубата: { $ref }.
+        [multiple] Ыйыыга хас да объект булулунна: { $ref }.
+       *[indeterminate] { $ref } объегын быһаарар кыах суох.
+    }
+
+help-learn-about-references = Ыйыылар туһунан бил →
+help-reference-page = Ыйынньык сирэйэ →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } иһигэр
+       *[top] Үрдүкү таһымҥа
+    }{ $allowed ->
+        [none] { " — манна туох да батпат." }
+        [text] { " — манна тиэкис суруйуохха сөп." }
+        [text-and-components] { " — манна тиэкис суруйуохха сөп, эбэтэр буларын боруобалаа:" }
+       *[components] { " — буларын боруобалыахха сөп:" }
+    }
+
+help-suggestions-footer = Бүтүн { $total } компонены көрөр туһугар { $shortcut } баттаа.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объекка ыйыы.
+       *[other] { $ref } — { $target } объекка ыйыы ({ $line } строка).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Маны { $owner } { $role } быһыытынан киллэрбит.
+       *[other] Маны { $owner } { $line } строкаҕа { $role } быһыытынан киллэрбит.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элеменнэ { $property } бэлиэтигэр ыйыы.
+       *[other] { $ref } — { $element } элеменнэ { $property } бэлиэтигэр ыйыы ({ $line } строка).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = кэрчик
+help-kind-array-entry = массив элемена
+
+help-default = Сүрүн суолтата:
+help-active-default = Билиҥҥи сүрүн суолтата:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Көҥүллэммит суолталар (биир элеменҥэ биир):
+       *[other] Көҥүллэммит суолталар:
+    }
+
+help-suggested-values = Сүбэлэммит суолталар:
+
+help-inserts = Эбэр:
+
+help-coordinates = Координаталар:
+
+help-type = Көрүҥэ:
+
+help-resolved-style = Тахсыбыт истиил (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Тахсыбыт функция ааттара:
+help-reset-list = Бу хонуу төннөрөр испииһэгэ:
+help-added-on-input = Бу хонууга эбиллибиттэр:
+help-removed-on-input = Бу хонууттан соруллубуттар:
+
+help-reset-overrides = { $reset } — { $additional } уонна { $removed } үрдүнэн туттуллар.

--- a/packages/i18n/locales/tyv/chrome.ftl
+++ b/packages/i18n/locales/tyv/chrome.ftl
@@ -1,0 +1,141 @@
+# Tuvan viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Tuvan counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had — and, as in Bashkir and
+# Tatar, a noun after a numeral stays singular, so the two branches differ in
+# nothing but the number they print. `locales/sah` beside it is the Turkic
+# catalog where ICU reports only one category at all, which is worth knowing
+# before anyone assumes the family decides this.
+
+
+## Answer submission
+
+answer-checking = Хынап турар…
+answer-submitting = Чорудуп турар…
+
+answer-checking-status = Харыыны хынап турар
+answer-submitting-status = Харыыны чорудуп турар
+
+answer-correct = Шын
+answer-incorrect = Меге
+
+answer-response-saved = Харыы шыгжаттынган
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% шын
+answer-percent-short = { $percent } %
+
+max-credit-available = Ап болур эң улуг балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] оралдажыышкын арталбаан
+        [one] { $count } оралдажыышкын арткан
+       *[other] { $count } оралдажыышкын арткан
+    }
+
+validation-correct = (Шын)
+validation-incorrect = (Меге)
+validation-partially-correct = (Кезии-биле шын)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } дээш { $count } харыыны көргүзер
+       *[other] { $answerId } дээш { $count } харыыны көргүзер
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Дедир харыы
+
+collapsible-click-to-open = (ажарда базыңар)
+collapsible-click-to-close = (хаарда базыңар)
+
+collapsible-initializing = Белеткенип турар…
+
+footnote-show = Демдеглелди көргүзер
+footnote-hide = Демдеглелди чажырар
+
+description-more-information = немелде медээ
+
+
+## Controls
+
+slider-previous = Мурнунда
+slider-next = Дараазында
+
+keyboard-open = Клавиатураны ажар
+keyboard-close = Клавиатураны хаар
+
+choice-input-remove-choice = { $choice } шилилгезин ужулдурар
+
+matrix-remove-row = Одуругну ужулдурар
+matrix-add-row = Одуруг немээр
+matrix-remove-column = Баганны ужулдурар
+matrix-add-column = Баган немээр
+
+subset-add-remove-points = Точка немээр/ужулдурар
+subset-toggle-points-intervals = Точкалар биле аразын солуштурар
+subset-move-points = Точкаларны шимчедир
+subset-clear = Арыглаар
+
+orbital-add-row = Одуруг немээр
+orbital-remove-row = Одуругну ужулдурар
+orbital-add-box = Куду немээр
+orbital-remove-box = Кудуну ужулдурар
+orbital-add-up-arrow = Өрү согун немээр
+orbital-add-down-arrow = Куду согун немээр
+orbital-remove-arrow = Согунну ужулдурар
+
+orbital-row-label = { $row } одуругнуң демдээ
+
+pretzel-answer = Харыы
+
+summary-statistics-caption = { $column } баганның түңнел статистиказы
+
+
+## Math input
+
+math-input-preview-region = математиктиг илередиишкинниң мурнунда көрүүшкүнү
+math-input-preview = Мурнунда көрүүшкүн
+math-input-invalid-expression = Шын эвес илередиишкин:
+
+
+## Document status
+
+viewer-initializing = Белеткенип турар…
+
+
+## Errors
+
+error-heading = Частырыг
+
+error-found-at =
+    { $span ->
+        [line] Тывылган одуруг: { $startLine }.
+       *[lines] Тывылган одуруглар: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Бо документиде частырыглар бар!
+
+diagnostic-heading-error = Частырыг
+diagnostic-heading-warning = Сагындырыг
+diagnostic-heading-information = Медээ
+diagnostic-heading-hint = Сүме
+
+accessibility-heading-level-1 = WCAG AA ажыглаар аргазының үрелиишкини
+accessibility-heading-level-2 = Ажыглаар арга дугайында медээ
+
+something-went-wrong = Бир-ле чүве шын эвес болган.
+
+renderer-load-failed = чуруктаарны чүдүрүп шыдаваан. Арынны катап ажыдыңар.
+
+core-start-failed = Документ көрүкчүзүн эгелеп шыдаваан. Арынны катап ажыдыңар.

--- a/packages/i18n/locales/tyv/content.ftl
+++ b/packages/i18n/locales/tyv/content.ftl
@@ -1,0 +1,252 @@
+# Tuvan content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with ң, ө and ү, which is the orthography Tuva's schools
+# and publishing use and what CLDR fills a bare `tyv` in as. The roster calls
+# this language **Tuvinian**, because that is what `Intl.DisplayNames` renders
+# `tyv` as; Tuvan is the usual English name and the two are one language.
+#
+# Tuvan has no grammatical gender and does not inflect an attributive
+# adjective, so `$gender` and `$role` go unused, as in every other Turkic
+# catalog here.
+#
+# CONFIDENCE. Tuvan's colour vocabulary below leans on Russian for the three
+# words its own palette does not name separately — «фиолет», «розовый» — and a
+# speaker may well have native words this seed did not find. It does *not*
+# have `locales/sah`'s green/blue problem: «ногаан» and «көк» are two words for
+# two colours.
+
+
+## Style vocabulary
+
+color =
+    .black = кара
+    .white = ак
+    .gray = бора
+    .red = кызыл
+    .orange = кызыл-сарыг
+    .yellow = сарыг
+    .green = ногаан
+    .cyan = чырык көк
+    .blue = көк
+    .purple = фиолет
+    .pink = розовый
+    .brown = хүрең
+
+line-width =
+    .thick = кылын
+    .thin = чуга
+
+line-style =
+    .dashed = үзүктелген
+    .dotted = точкалыг
+
+# Noun phrases: they stand in front of «чурумалдыг» and modify nothing.
+fill-style =
+    .horizontal = горизонталь шугум
+    .vertical = вертикаль шугум
+    .diagonal = диагональ шугум
+    .backdiagonal = удурланышкак диагональ шугум
+    .dots = точка
+    .diamonds = ромб
+
+noun =
+    .line = дорт шугум
+    .line-segment = кезек
+    .ray = луч
+    .vector = вектор
+    .curve = кыйыг шугум
+    .function = функция
+    .parabola = парабола
+    .polyline = сынган шугум
+    .polygon = хөй булуңнуг
+    .triangle = үш булуңнуг
+    .rectangle = дорт булуңнуг
+    .circle = тегерик
+    .region = шөл
+    .point = точка
+    .square = дөрбелчин
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+
+# Tuvan builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] дең { $numSides } булуңнуг
+    }
+
+# Tuvan has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = будаан
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } чурумалдыг { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } чурумалдыг { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } чурумалдыг { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «кыдыглыг» — "having an edge" — carries the "with a border" sense in its own
+# suffix, so neither a preposition nor an article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } кыдыглыг
+        [and] база { $border } кыдыглыг
+        [and-article] база { $border } кыдыглыг
+       *[with] { $border } кыдыглыг
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } чурумалдыг { $color } будуг
+       *[plain] { $color } будуг
+    }
+
+style-unfilled = будаваан
+
+# «кырында» — "on top of" — is a postposition and follows the background
+# colour, so nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон кырында { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = чок
+
+
+## Boolean words
+
+boolean-true = шын
+boolean-false = меге
+
+
+## Answer buttons
+
+answer-submit-label = Хынаар
+answer-submit-label-no-correctness = Харыыны чорудар
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Ажыл
+    .aside = Кыдыг демдеглел
+    .cascade = Каскад
+    .definition = Тодарадылга
+    .example = Чижек
+    .exercise = Мергежилге
+    .exercises = Мергежилгелер
+    .given-answer = Харыы
+    .note = Демдеглел
+    .objectives = Сорулгалар
+    .paragraphs = Абзацтар
+    .part = Кезээ
+    .problem = Бодалга
+    .problems = Бодалгалар
+    .proof = Бадыткал
+    .question = Айтырыг
+    .section = Эге
+    .solution = Шиитпир
+    .task = Онаалга
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Сүме
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Чурук { $enumeration }
+        [numbered-caption] Чурук { $enumeration }{ ". " }
+        [unnumbered-caption] Чурук{ ". " }
+       *[unnumbered] Чурук
+    }
+
+
+## Paginator controls
+
+paginator-previous = Мурнунда
+paginator-next = Дараазында
+paginator-page = Арын
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## `piecewise-condition-if` is `locales/sah`'s limit again and for the same
+## reason: Tuvan marks a condition at the end of its clause — «болза» — and the
+## renderer places this key before the mathematics it introduces. The word is
+## written in its citation form so the sentence is at least readable.
+
+piecewise-condition-or = азы
+piecewise-condition-if = болза
+piecewise-condition-otherwise = өске таварылгада
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Tuva is taught in
+## Russian and the element names a Tuvan-speaking pupil meets are the Russian
+## ones — the school-system case this whole batch shares.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Шын эвес химиктиг демдек
+chemistry-invalid-ionic-compound = Шын эвес ион каттыжыышкыны

--- a/packages/i18n/locales/tyv/content.ftl
+++ b/packages/i18n/locales/tyv/content.ftl
@@ -13,7 +13,7 @@
 # adjective, so `$gender` and `$role` go unused, as in every other Turkic
 # catalog here.
 #
-# CONFIDENCE. Tuvan's colour vocabulary below leans on Russian for the three
+# CONFIDENCE. Tuvan's colour vocabulary below leans on Russian for the two
 # words its own palette does not name separately — «фиолет», «розовый» — and a
 # speaker may well have native words this seed did not find. It does *not*
 # have `locales/sah`'s green/blue problem: «ногаан» and «көк» are two words for

--- a/packages/i18n/locales/tyv/diagnostics.ftl
+++ b/packages/i18n/locales/tyv/diagnostics.ftl
@@ -1,0 +1,654 @@
+# Tuvan diagnostics. Translated from `locales/en/diagnostics.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Tuvan uses
+# for them: «компонент», «атрибут», «функция», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] ийи ужу точказы-даа айыттынган болза { $attributes } санашпас
+       *[other] ийи ужу точказы-даа айыттынган болза { $attributes } санашпас
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] ужу точказы-даа, ортузу точказы-даа айыттынган болза { $attributes } санашпас
+       *[other] ужу точказы-даа, ортузу точказы-даа айыттынган болза { $attributes } санашпас
+    }
+
+line-segment-midpoint-offset-without-midpoint = ортузу точказы чок midpointOffset чүүге-даа салдар чедирбес
+
+## `<line>`
+
+line-points-undetermined-dimensions = Хемчээ билдинмес точкалар дамчыштыр эртер дорт шугум.
+
+line-points-too-few-dimensions = Дорт шугум эң эвээш ийи хемчээлдиг точкалар дамчыштыр эртер ужурлуг.
+
+line-points-depend-on-variables = Дорт шугум өскерлир хемчээлдерден хамааржыр точкалар дамчыштыр эртер: { $variables }.
+
+line-equation-invalid-format = { $variable1 } биле { $variable2 } өскерлир хемчээлдерлиг дорт шугум деңнелгезиниң форматы шын эвес.
+
+## `<ray>`
+
+ray-overprescribed-through = Лучту through, endpoint база direction дамчыштыр берген. Берген through санашпас.
+
+ray-dimension-mismatch = лучта numDimensions дүүшпес.
+
+## `<vector>`
+
+vector-overprescribed-head = Векторну head, tail база displacement дамчыштыр берген. Берген head санашпас.
+
+vector-dimension-mismatch = векторда numDimensions дүүшпес.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элементиже тыртып шыдавас, чүге дизе ооң nearestPoint байдал хемчээли чок.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементи-биле кызыгаарлап шыдавас, чүге дизе ооң nearestPoint байдал хемчээли чок.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементиниң иштии-биле кызыгаарлап шыдавас, чүге дизе ооң nearestPoint байдал хемчээли чок.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = одуруг иштинде эвес choiceInput дээш labelPosition санашпас
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput дээш берген индекстер санашпас, чүге дизе оларның саны choice уругларының санынга дүүшпес.
+
+pretzel-indices-count-mismatch = problem дээш берген индекстер санашпас, чүге дизе оларның саны problem уругларының санынга дүүшпес.
+
+shuffle-indices-count-mismatch = shuffle дээш берген индекстер санашпас, чүге дизе оларның саны компонентилер санынга дүүшпес.
+
+indices-ignored-out-of-range = { $component } дээш берген индекстер санашпас, чүге дизе чамдыызы кызыгаардан үнүп турар.
+
+pretzel-indices-repeated = pretzel дээш берген индекстер санашпас, чүге дизе чамдыызы катаптаттынып турар.
+
+pretzel-circuit-first-index = circuit чурумунда pretzel дээш берген индекстер санашпас, чүге дизе баштайгы индекс 1 болур ужурлуг.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текст уруглары-биле ажылдаары-биле `type` атрибут бээр ужурлуг.
+
+invalid-type-defaulting-to-math = { $component } компонентиге шын эвес хевир { $type }. Ол math, text, number азы boolean болур ужурлуг. math ажыглаттынар.
+
+string-not-valid-component-to-arrange = «{ $value }» одуруг { $component } дээш таарымчалыг компонент эвес. Санашпас.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Шын эвес хевир { $type }, хевири number кылдыр салдынар.
+
+invalid-variable-value = Өскерлир хемчээлдиң шын эвес утказы: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариант индекизи сан болур ужурлуг
+
+variant-index-must-be-integer = { $index } вариант индекизи бүдүн сан болур ужурлуг
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют хемчээлдерге кылдынмаан. Делгемнери деңнештирилге кылдыр салдынар.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют хемчээлдерге кылдынмаан. Кыдыглары деңнештирилге кылдыр салдынар.
+
+side-by-side-no-block-child = Шын эвес `<{ $component }>`: ооң эң эвээш бир блок уруу турар ужурлуг.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементиниң `for` атрибуду санашпас.
+
+label-for-must-resolve-to-one = `<label>` элементиниң `for` атрибуду чаңгыс компонентиже айтыр ужурлуг.
+
+label-for-unresolved = `<label>` элементиниң `for` атрибудун компонент-биле холбап шыдаваан.
+
+label-for-answer-with-authored-inputs = `<label>` элементиниң `for` атрибуду автор бижээн киирилде шөлдерлиг `<answer>` иже айтып турар; шөлче дорт айтыңар.
+
+label-for-answer-without-input = `<label>` элементиниң `for` атрибуду демдеглээр киирилде шөлү чок `<answer>` иже айтып турар.
+
+label-for-must-reference-input-or-answer = `<label>` элементиниң `for` атрибуду киирилде шөлүнче азы харыыже айтыр ужурлуг.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Ажыглаар арга дээш `<{ $component }>` кыска тайылбырлыг болур азы чурумал кылдыр демдеглеттинер ужурлуг.
+
+accessibility-video-short-description = Ажыглаар арга дээш `<video>` кыска тайылбырлыг болур ужурлуг.
+
+accessibility-input-short-description-or-label = Ажыглаар арга дээш `<{ $component }>` кыска тайылбырлыг азы демдектиг болур ужурлуг.
+
+accessibility-answer-input-short-description-or-label = Ажыглаар арга дээш киирилде шөлүн тургузар `<answer>` кыска тайылбырлыг азы демдектиг болур ужурлуг.
+
+accessibility-short-description-contains-math = Кыска тайылбырларда `<{ $component }>` дег математиктиг компонентилер турбас ужурлуг. Математиканы сөс-биле бижиңер.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } эге баштыңының тексти дээш четчир контраст бербейн турар (караңгы хевир) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эң эвээш { $threshold }:1 негеттинер).
+       *[other] { $colorName } эге баштыңының тексти дээш четчир контраст бербейн турар ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эң эвээш { $threshold }:1 негеттинер).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Точкаларның сан утказы чок болганда { $count } точка дамчыштыр эртер `<circle>` кылдынмаан.
+
+circle-too-many-through-points = 3-тен хөй точка дамчыштыр эртер тегерикти санап шыдавас.
+
+circle-overprescribed-radius-center-points = Берген радиус, төп база точкалар-биле тегерикти санап шыдавас.
+
+circle-center-with-multiple-points = Берген төп-биле 1-ден хөй точка дамчыштыр эртер тегерикти санап шыдавас.
+
+circle-radius-too-small = Тегерикти санап шыдавас: ийи точка аразының ырааны { $distance } болганда, берген радиус { $radius } дыка биче.
+
+circle-radius-with-many-points = Берген радиус-биле ийиден хөй точка дамчыштыр эртер тегерик тургузуп шыдавас.
+
+circle-invalid-center-or-through-points = Тегериктиң төвү азы точкалары шын эвес.
+
+circle-radius-center-with-multiple-points = Берген төп-биле 1-ден хөй точка дамчыштыр эртер тегериктиң радиузун санап шыдавас.
+
+circle-change-radius-non-numerical = Сан эвес точкалыг тегериктиң радиузун өскертип шыдавас
+
+circle-radius-with-points-non-numerical = Сан утказы чок болганда берген радиус-биле бирден хөй точка дамчыштыр эртер тегерик тургузуп шыдавас.
+
+circle-change-center-non-numerical = Сан эвес точкалар дамчыштыр эртер тегериктиң төвүн өскертири кылдынмаан.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцияның тодараттынар шөлүнүң хемчээли четчир эвес. Шөлде { $intervals } аразы бар, а функцияда { $inputs ->
+            [one] { $inputs } киирилде
+           *[other] { $inputs } киирилде
+        }.
+       *[other] Функцияның тодараттынар шөлүнүң хемчээли четчир эвес. Шөлде { $intervals } аразы бар, а функцияда { $inputs ->
+            [one] { $inputs } киирилде
+           *[other] { $inputs } киирилде
+        }.
+    }
+
+function-domain-invalid-format = Функцияның тодараттынар шөлүнүң форматы шын эвес.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцияның сан эвес максимуму санашпас.
+        [minimum] Функцияның сан эвес минимуму санашпас.
+        [extremum] Функцияның сан эвес экстремуму санашпас.
+        [point] Функцияның сан эвес точказы санашпас.
+        [slope] Функцияның сан эвес чарлыы санашпас.
+       *[other] Функцияның сан эвес { $type } утказы санашпас.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцияның куруг максимуму санашпас.
+        [minimum] Функцияның куруг минимуму санашпас.
+        [extremum] Функцияның куруг экстремуму санашпас.
+        [point] Функцияның куруг точказы санашпас.
+       *[other] Функцияның куруг { $type } утказы санашпас.
+    }
+
+function-points-too-close = Функцияда бот-боттарынга дыка чоок ийи точка бар. Функцияны тодарадып шыдавас.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функция итерациялары киирилделер саны үндүрүлгелер санынга дең турда чүгле болур. Бо функцияда { $inputs } киирилде база { $outputs ->
+            [one] { $outputs } үндүрүлге
+           *[other] { $outputs } үндүрүлге
+        } бар.
+       *[other] Функция итерациялары киирилделер саны үндүрүлгелер санынга дең турда чүгле болур. Бо функцияда { $inputs } киирилде база { $outputs ->
+            [one] { $outputs } үндүрүлге
+           *[other] { $outputs } үндүрүлге
+        } бар.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Дараалашкактың узуну шын эвес. Ол минус эвес бүдүн сан болур ужурлуг.
+
+sequence-invalid-step = Дараалашкактың базымы шын эвес. { $type } хевирлиг дараалашкакка ол сан болур ужурлуг.
+
+sequence-invalid-endpoint-number = Сан дараалашкааның «{ $attribute }» утказы шын эвес. Ол сан болур ужурлуг.
+
+sequence-invalid-endpoint-letters = Ужук дараалашкааның «{ $attribute }» утказы шын эвес. Ол ужуктар каттыжыышкыны болур ужурлуг.
+
+sequence-invalid-endpoint = Дараалашкактың «{ $attribute }» утказы шын эвес.
+
+select-from-sequence-coprime-not-numbers = саннар шилиттинмээн болганда coprime санашпас
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations берген болганда coprime санашпас
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` дээш шын эвес target: сорулга тывылбаан.
+
+target-state-variable-not-found = `<{ $source }>` дээш шын эвес target: `<{ $component }>` элементиде «{ $property }» деп аттыг байдал хемчээли тывылбаан.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` өскерлир хемчээлдери хамаарышпас хемчээлден ылгалыр ужурлуг.
+
+ode-system-duplicate-variable-names = Хамааржыр хемчээлдерниң аттары катаптаттынып турда ДТ оң талазының функцияларын тодарадып шыдавас.
+
+ode-system-rhs-function-error = ДТ оң талазының функциязын тодарадып шыдавас. mathjs функциязын тургузарда частырыг.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } дорт шугум аразында булуңну тодарадып шыдавас
+
+angle-invalid-through-point = `<angle>` элементиниң through утказында шын эвес точка
+
+parabola-vertex-too-many-points = Берген бажы-биле 1-ден хөй точка дамчыштыр эртер парабола кылдынмаан.
+
+parabola-too-many-points = 3-тен хөй точка дамчыштыр эртер парабола кылдынмаан.
+
+intersection-too-many-items = Ийиден хөй объектиниң кежилгези кылдынмаан
+
+## Other math components
+
+ionic-compound-not-two-ions = Ийи иондан өске ион каттыжыышкыны кылдынмаан.
+
+ionic-compound-needs-cation-and-anion = Ион каттыжыышкыны чаңгыс катион биле чаңгыс анион дээш чүгле кылдынган.
+
+solve-equations-cannot-evaluate = Деңнелгени шиитпирлеп шыдавас, чүге дизе ону санап шыдаваан: { $equation }
+
+math-operators-operand-number-required = Математиктиг операндыны аңгылаары-биле operandNumber бээр ужурлуг.
+
+eigen-decomposition-failed = Матрицаның бодунуң утказын санап шыдаваан
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр үлегерде таварышпайн турар, ынчангаш ол кезээде куругга дүгжүр.
+       *[other] `<matchesPattern>`: { $parameters } параметрлер үлегерде таварышпайн турар, ынчангаш олар кезээде куругга дүгжүр.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" утказын билип шыдавас. Ол none, medium, dense азы куруг чер-биле аңгыланган ийи плюстуг сан болур ужурлуг, чижээ grid="1 0.5". Сеткил чуруттунмас.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure чуруктаарында xLabelPosition="left" кылдынмаан; оң талага салыр чуруму ажыглаттынар.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure чуруктаарында yLabelPosition="bottom" кылдынмаан; кырынга салыр чуруму ажыглаттынар.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure шилчидиишкининге тенгиш кызыгаарлары шын эвес; кол bbox (-10,-10,10,10) ажыглаттынар.
+
+prefigure-invalid-width = `<graph>`: prefigure шилчидиишкининге делгеми шын эвес; диаграмманың кол делгеми 425 ажыглаттынар.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure шилчидиишкининге aspectRatio шын эвес; кол таларның хамаарылгазы 1 ажыглаттынар.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткил базымы тенгиш кызыгаарларынга дыка бичии; prefigure чуруктаарында сеткил үндүрүлбес.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure чуруктаары ажыглаттынмас болза демдеглелдер чуруттунмас.
+
+multiple-annotations-children = `<graph>` иштинде хөй `<annotations>` уруу тывылган; сөөлгүзүнден өскелери санашпас.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Билдинмес компонент хевирин делгедип азы хоолгалап шыдавас: { $type }.
+
+copy-prop-not-found = { $component } хевирлиг компонентиде { $property } шынары тывылбаан
+
+collect-no-source = collect дээш үнер чер тывылбаан.
+
+collect-invalid-component-type = `<{ $component }>` хевирлиг компонентилерни чыып шыдавас, чүге дизе бо шын эвес компонент хевири.
+
+reference-index-unavailable = `{ $reference }` индексче шилчилге кылып шыдавас
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентиде { $action } кыйгырып шыдавас
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Медээлерниң хевири шын эвес. Одуругларның узуну аңгы-аңгы. Тывылган componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Медээлерде баган аттары катаптаттынып турар. Тывылган componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Медээлерде баган ады чедишпейн турар. Тывылган componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Бо харыының award утказы answer тегтиң бодунуң чорудупкан харыызынга үндезилеттинген, бо манавааны байдалче чедирер.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` бар контейнер иштинде `<answer>` иже `maxNumAttempts` салыры салдар чедирбес, чүге дизе оралдажыышкыннар санын контейнер тодарадыр. `maxNumAttempts` утказын контейнерже салыңар.
+
+nested-section-wide-check-work-max-num-attempts = Өске `sectionWideCheckWork` контейнер иштинде турар `sectionWideCheckWork` контейнерже `maxNumAttempts` салыры салдар чедирбес, чүге дизе оралдажыышкыннар санын даштыкы контейнер тодарадыр. `maxNumAttempts` утказын даштыкы контейнерже салыңар.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality салдынмаан болза { $attributes } атрибут салдар чедирбес.
+       *[other] symbolicEquality салдынмаан болза { $attributes } атрибуттар салдар чедирбес.
+    }
+
+answer-invalid-type = answer дээш шын эвес хевир: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентиниң ады чок болганда ону модуль атрибуду кылдыр ажыглап шыдавас
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентини модуль атрибуду кылдыр ажыглап шыдавас, чүге дизе `<module>` компонент хевиринде «{ $name }» атрибут ам-даа тодараттынган.
+
+conditional-content-condition-ignored = case азы else уруглары бар `<conditionalContent>` компонентиде `condition` атрибут санашпас.
+
+slider-markers-type-mismatch = Маркерлерниң хевири шимчедикчиниң хевиринге дүүшпес.
+
+pretzel-problem-needs-statement-and-answer = Шын эвес pretzel: `<problem>` бүрүзү чаңгыс `<statement>` база чаңгыс `<answer>` иштинде турар ужурлуг.
+
+pretzel-circuit-first-problem-distractor = Шын эвес pretzel: mode="circuit" чурумунда баштайгы `<problem>` кичээнгейни оскунар кылдыр турбас ужурлуг.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутка шын эвес утка { $values }; санашпас.
+       *[other] `{ $attribute }` атрибутка шын эвес утказы { $values }; санашпас.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутка шын эвес утка `{ $value }`. Атрибут `$` демдектен эгелээр шилчилгелерден тургустунган болур ужурлуг.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } иштинде шын эвес функция аттары санашпаан: { $names }. Ат бүрүзүнүң көстүр кезээ эң эвээш 2 демдек болур ужурлуг (ужуктар азы шыйыглар); ооң соонда негеттинмес `|<mathspeak альтернатива>` немелдези кээп болур.
+
+## Building components from the source
+
+component-type-invalid = Шын эвес компонент хевири: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутту катаптап шыдавас.
+
+attribute-invalid-for-component = `<{ $componentType }>` хевирлиг компонентиге шын эвес атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль тодарадылгазында { $context ->
+        [text-on-background] текст өңү биле фон өңү
+        [high-contrast] бедик контрастылыг өң биле чурук шөлү
+        [line] шугум өңү биле чурук шөлү
+        [marker] маркер өңү биле чурук шөлү
+       *[text-on-canvas] текст өңү биле чурук шөлү
+    } аразында контраст четчир эвес{ $mode ->
+        [dark] { " (караңгы хевир)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эң эвээш { $threshold }:1 негеттинер).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль тодарадылгазында берген өңнер чырык хевирге четчир контраст берген-даа болза, олардан үнген караңгы хевир өңнери текст биле фон аразынга четчир контраст бербейн турар ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эң эвээш { $threshold }:1 негеттинер). { $suggestion ->
+        [available] Караңгы хевирге четчир контраст дээш чырык хевирниң контразын улгаттырыңар (чижээ { $lightAttribute }="{ $lightColor }") азы караңгы хевир өңүн солуңар (чижээ { $darkAttribute }="{ $darkColor }").
+       *[none] Караңгы хевирге четчир контраст дээш чырык хевирниң контразын улгаттырыңар азы үнген өңнерни textColorDarkMode база/азы backgroundColorDarkMode-биле солуңар.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль тодарадылгазында берген текст өңү чырык хевирге четчир контраст берген-даа болза, ооң-биле үнген караңгы хевир текст өңү чурук шөлү-биле четчир контраст бербейн турар ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; эң эвээш { $threshold }:1 негеттинер). { $suggestion ->
+        [available] Караңгы хевирге четчир контраст дээш чырык хевирниң контразын улгаттырыңар (чижээ textColor="{ $lightColor }") азы караңгы хевир өңүн солуңар (чижээ textColorDarkMode="{ $darkColor }").
+       *[none] Караңгы хевирге четчир контраст дээш чырык хевирниң контразын улгаттырыңар азы үнген өңнү textColorDarkMode-биле солуңар.
+    }
+
+section-multiple-style-palettes = Эге чаңгыс <stylePalette> шилип болур; сөөлгүзү ажыглаттынар.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе numToSelect минус эвес бүдүн сан эвес.
+
+variant-num-to-select-not-constant-number = { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе numToSelect турум сан эвес.
+
+variant-with-replacement-not-constant-boolean = { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе withReplacement турум логиктиг утка эвес.
+
+variant-select-weight-disables-unique = кандыг-бир шилилгеде selectWeight азы selectForVariants берген болза, select дээш катаптаттынмас варианттар өжүрлүр
+
+variant-coprime-undetermined = { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе coprime кезээде меге бе дээрзин тодарадып шыдавас.
+
+variant-attribute-not-constant = { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе { $attribute } турум эвес.
+
+variant-attribute-not-number = { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе { $attribute } сан эвес.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } хевирлиг { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе { $attribute } { $expected ->
+        [letters-combination] ужуктар каттыжыышкыны
+        [math-expression] таарымчалыг математиктиг илередиишкин
+        [integer] бүдүн сан
+       *[number] сан
+    } эвес.
+
+variant-length-not-integer = { $component } дээш катаптаттынмас варианттарны тодарадып шыдавас, чүге дизе length бүдүн сан эвес.
+
+variant-sort-not-implemented = sort бар { $component } дээш катаптаттынмас варианттар кылдынмаан
+
+variant-exclude-combinations-not-implemented = excludeCombinations бар { $component } дээш катаптаттынмас варианттар кылдынмаан
+
+variant-math-exclude-not-implemented = exclude бар math хевирлиг { $component } дээш катаптаттынмас варианттар кылдынмаан
+
+variant-non-constant-exclude-not-implemented = турум эвес exclude бар { $component } дээш катаптаттынмас варианттар кылдынмаан
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графиктиң prefigure чуруктаарында кылдынмаан; салгакчызы кагдынган.
+
+prefigure-descendant-invalid-geometry = { $subject }: төнчү чок азы долу эвес геометрия; салгакчызы кагдынган.
+
+prefigure-curve-label-omitted = { $subject }: шилчиткен кыйыг элементилерге демдектер кылдынмаан; демдек кагдынган.
+
+prefigure-curve-unsupported-definition-type = { $subject }: кылдынмаан кыйыг функция тодарадылгазының хевири «{ $definitionType }»; салгакчызы кагдынган.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементиниң flipFunctions атрибуду кылдынмаан; салгакчызы кагдынган.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формула-биле берген уруг функцияларны чүгле хүлээп алыр; салгакчызы кагдынган.
+
+prefigure-label-position-unsupported =
+    { $subject }: кылдынмаан labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] шугумнар өг-бүлезиниң демдээ дээш
+       *[point] точка демдээ дээш
+    }; PreFigure-ниң кол деңнештирилгези ажыглаттынар.
+
+prefigure-fill-style-unsupported = { $subject }: долдурар стиль «{ $fillStyle }» PreFigure-ге кылдынмаан; долу долдурарынче шилчиир.
+
+prefigure-line-style-unknown = { $subject }: билдинмес шугум стили «{ $lineStyle }» PreFigure үндүрүлгезинден ужулдурган.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стили «{ $markerStyle }» PreFigure «diamond» стилинге дүүштүрген.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стили «{ $markerStyle }» PreFigure-ге кылдынмаан; кол стиль ажыглаттынар.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: шын эвес `ref`; сорулганы холбап шыдавас. Демдеглел ужулдурган.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` хөй сорулга-биле холбашкан; баштайгызы ажыглаттынар.
+
+annotation-ref-outside-graph = `<annotation>`: шын эвес `ref`; сорулга ону иштинде тудуп турар графиктиң дашты. Демдеглел ужулдурган.
+
+annotation-ref-unsupported-target = `<annotation>`: шын эвес `ref`; сорулга prefigure шилчидиишкининде кылдынган график объект эвес. Демдеглел ужулдурган.
+
+annotation-text-missing = `<annotation>`: `text` чок азы куруг; куруг текст үндүрүлүр.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Долгандыр хамаарылга тывылган.
+       *[other] `<{ $componentType }>` компонентини иштинде тудуп турар долгандыр хамаарылга тывылган.
+    }
+
+reference-no-referent = Шилчилгеге объект тывылбаан: `{ $reference }`
+
+reference-multiple-referents = Шилчилгеге хөй объект тывылган: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементиниң { $attribute } атрибудунуң форматы шын эвес.
+
+children-invalid = `<{ $componentType }>` дээш шын эвес уруглар: шын эвес уруглар тывылган: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутка шын эвес утка `{ $value }`; `{ $default }` утказы ажыглаттынар
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } хевири тывылбаан.
+       *[other] DoenetML { $version } хевири тывылбаан. { $fallback } хевири ажыглаттынар
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Шын эвес DoenetML: { $content }
+
+parse-tag-missing-close-tag = Шын эвес DoenetML: `{ $tag }` тегтиң хаар тегги чок. Бодун хаар тег азы `</{ $tagName }>` тег манаттынган.
+
+parse-tag-error = Шын эвес DoenetML: `<{ $tagName }>` тегде частырыг
+
+parse-attribute-missing-value = Шын эвес DoenetML: `{ $attribute }` атрибутта утка чедишпейн турар хире.
+
+parse-attribute-invalid = Шын эвес DoenetML: шын эвес атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Шын эвес DoenetML: атрибуттуң шын эвес утказы `{ $value }`
+
+parse-attribute-value-quote-mismatch = Шын эвес DoenetML: атрибуттуң шын эвес утказы `{ $value }`. Дырбактар дүүшпейн турар. `{ $quote }` чедишпейн турар хире
+
+parse-open-tag-name-missing = Шын эвес DoenetML: ат чок тег тывылган, чижээ `<`
+
+parse-tag-not-closed = Шын эвес DoenetML: `{ $tag }` тег хагдынмаан (`>` чедишпейн турар хире).
+
+parse-self-closing-tag-name-missing = Шын эвес DoenetML: ат чок тег тывылган `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Шын эвес DoenetML: `{ $tag }` тег хагдынмаан (`/>` чедишпейн турар хире).
+
+parse-tag-invalid-attributes = Шын эвес DoenetML: `{ $tag }` тег таарымчалыг эвес. Ооң атрибуттары шын эвес болуп болур.
+
+parse-close-tag-name-missing = Шын эвес DoenetML: ат чок хаар тег тывылган, чижээ `</`
+
+parse-attribute-value-unquoted = Атрибут утказы дырбак иштинде турар ужурлуг: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Шын эвес DoenetML: `{ $tag }` хаар тег тывылган, ынчалза-даа аңаа дүгжүр ажыдар тег чок
+
+parse-close-tag-mismatched = Шын эвес DoenetML: дүүшпес хаар тег. `</{ $expected }>` манаттынган. `{ $found }` тывылган
+
+parser-node-unconvertible = { $node } түңнелди Dast түңнелинче шилчидип шыдаваан.
+
+## Names
+
+name-attribute-invalid =
+    Шын эвес атрибут name='{ $name }'. { $reason ->
+        [characters] Аттарда ужуктар, саннар, адаккы шыйыглар азы шыйыглар чүгле турар ужурлуг.
+       *[start] Аттар ужуктан эгелээр ужурлуг.
+    }
+
+component-name-invalid-start = Шын эвес компонент ады «{ $name }». Аттар ужуктан эгелээр ужурлуг.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched хевирлиг answer video атрибуттуг болур ужурлуг
+
+answer-video-watched-video-not-reference = videoWatched хевирлиг answer video атрибуду шилчилге болур ужурлуг
+
+answer-name-not-single-text = answer name атрибуду чаңгыс текст уруглуг болур ужурлуг
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсия деңнелдери дыка хөй болганда даштыкы DoenetML ап шыдаваан. Долгандыр шилчилге чок бе?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адрестен DoenetML ап шыдаваан
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адрестен шын эвес DoenetML алдынган: ол «{ $componentType }» компонент хевиринге дүүшпээн
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эргижирээн; ооң орнунга `{ $to }` ажыглаңар.
+       *[other] [deprecation] `<{ $component }>` элементиниң `{ $from }` атрибуду эргижирээн; ооң орнунга `{ $to }` ажыглаңар.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут эргижирээн база санашпас, чүге дизе `{ $to }` база берген.
+       *[other] [deprecation] `<{ $component }>` элементиниң `{ $from }` атрибуду эргижирээн база санашпас, чүге дизе `{ $to }` база берген.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементиниң `{ $attribute }` атрибуду эргижирээн база санашпас.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементиниң `{ $attribute }` атрибуду эргижирээн; ооң орнунга `<{ $child }>` уруун ажыглаңар.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементиниң `{ $attribute }` атрибудунуң `{ $value }` утказы эргижирээн; ооң орнунга `{ $to }` ажыглаңар.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` хөй санны чүгле англи дылга кылып шыдаар, ынчангаш { $locale } дылга бижиттинген документиде ооң тексти өскерилбейн артар. Хөй сан хевирин боттарыңар бижиңер азы ону `pluralForm` атрибут-биле бериңер.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент билдингир Doenet элементизи эвес.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементиге документиниң дазылында чөпшээрел бербес.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементиге `<{ $parent }>` иштинде чөпшээрел бербес.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементиде `{ $attribute }` деп аттыг атрибут чок.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементиниң `{ $attribute }` атрибуду элемент бүрүзү мындыгларның бирээзи болур даңзы болур ужурлуг: { $allowed }
+       *[other] `<{ $tag }>` элементиниң `{ $attribute }` атрибуду мындыгларның бирээзи болур ужурлуг: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select дээш шын эвес вариант ады. { $variantName } вариант ады { $numOptions } шилилгеде таваржып турар, а шилиир саны { $numToSelect }.
+
+select-variant-name-without-options = select дээш варианттар берген, ынчалза-даа болур вариант адынга чаңгыс-даа шилилге чок: { $variantName }.
+
+select-variant-name-not-possible = select дээш берген { $variantName } вариант ады болур вариант ады эвес.
+
+select-too-few-options = Шупту { $numOptions } иштинден { $numToSelect } компонентини шилип шыдавас.
+
+select-from-sequence-too-few-values = Узуну { $length } дараалашкактан { $numToSelect } утканы шилип шыдавас.
+
+select-from-sequence-indices-count-mismatch = select дээш берген индекстер саны шилиир санынга дүүшкен турар ужурлуг
+
+select-from-sequence-indices-not-integers = select дээш берген бүгү индекстер бүдүн сан болур ужурлуг
+
+select-from-sequence-index-excluded = selectfromsequence дээш берген индекс үндүрүлген турган
+
+select-from-sequence-indices-excluded-combination = selectfromsequence дээш берген индекстер үндүрген каттыжыышкын турган
+
+select-from-sequence-coprime-not-positive-integers = Плюстуг бүдүн саннар шилиттинмээн болганда бот-боттарынга барымдаалыг каттыжыышкыннарны шилип шыдавас.
+
+select-from-sequence-coprime-common-factor = Бот-боттарынга барымдаалыг саннарны шилип шыдавас. Болур бүгү утка ниити үлекчилиг. (Берген "from" азы "to" утказы "step"-биле бот-боттарынга барымдаалыг болур ужурлуг.)
+
+select-from-sequence-coprime-single-number = 1 эвес чаңгыс сандан бот-боттарынга барымдаалыг каттыжыышкыннарны шилип шыдавас.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence иштинде каттыжыышкыннарның 70%-тен хөйү үндүрүлген
+
+select-from-sequence-coprime-none-found = Бот-боттарынга барымдаалыг саннарны шилип шыдаваан. Болур бүгү утка ниити үлекчилиг.
+
+select-from-sequence-too-few-unique-values = Узуну { $numPossibleValues } дараалашкактан { $numToSelect } аңгы-аңгы утканы шилип шыдавас
+
+select-prime-numbers-too-few-values = Узуну { $numValues } барымдаалыг саннар даңзызындан { $numToSelect } утканы шилип шыдавас
+
+select-prime-numbers-values-count-mismatch = select дээш берген утка саны шилиир санынга дүүшкен турар ужурлуг
+
+select-prime-numbers-values-not-prime = select prime number дээш берген бүгү утка барымдаалыг саннар даңзызында турар ужурлуг
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers дээш берген утка үндүрген каттыжыышкын турган
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers иштинде каттыжыышкыннарның 70%-тен хөйү үндүрүлген
+
+select-random-combination-fluke = Дыка болдунмас таварылга-биле таварылгалыг утка каттыжыышкынын шилип шыдаваан
+
+select-random-value-fluke = Дыка болдунмас таварылга-биле таварылгалыг утканы шилип шыдаваан

--- a/packages/i18n/locales/tyv/editor.ftl
+++ b/packages/i18n/locales/tyv/editor.ftl
@@ -1,0 +1,215 @@
+# Tuvan editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Tuvan counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Дедир эгидер
+       *[update] Чаартыр
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Көрүкчүнү { $word }
+       *[other] Көрүкчүнү { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Шүүрээр…
+editor-variant-next = Дараазында вариантыны шилиир
+editor-variant-previous = Мурнунда вариантыны шилиир
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA ажыглаар аргазының үрелиишкини тывылган. Ажыглаар арга дугайында отчетту { $action ->
+            [close] хаар
+           *[open] ажар
+        } дээш базыңар.
+        [advisories] Ажыглаар арга дугайында отчетту { $action ->
+            [close] хаар
+           *[open] ажар
+        } дээш базыңар. WCAG AA үрелиишкиннери тывылбаан, ынчалза-даа немелде сүмелер бар.
+       *[clean] Ажыглаар арга дугайында отчетту { $action ->
+            [close] хаар
+           *[open] ажар
+        } дээш базыңар. Ажыглаар арга айтырыглары тывылбаан.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA ажыглаар аргазының үрелиишкини тывылган. { $count ->
+            [one] { $count } WCAG AA үрелиишкини
+           *[other] { $count } WCAG AA үрелиишкини
+        } тывылган. Ажыглаар арга дугайында отчетту { $action ->
+            [close] хаар
+           *[open] ажар
+        } дээш базыңар.
+        [advisories] WCAG AA үрелиишкиннери тывылбаан. { $count ->
+            [one] { $count } немелде сүме
+           *[other] { $count } немелде сүме
+        } тывылган. Ажыглаар арга дугайында отчетту { $action ->
+            [close] хаар
+           *[open] ажар
+        } дээш базыңар.
+       *[clean] WCAG AA үрелиишкиннери тывылбаан. Ажыглаар арга дугайында отчетту { $action ->
+            [close] хаар
+           *[open] ажар
+        } дээш базыңар.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML хевири { $version }
+
+editor-tab-help = Контекст дузазы
+editor-tab-help-short = Контекст
+editor-tab-errors = Частырыглар
+editor-tab-warnings = Сагындырыглар
+editor-tab-info = Медээ
+editor-tab-accessibility = Ажыглаар арга
+editor-tab-responses = Чорудупкан харыылар
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редактор тааржылгалары
+editor-format-as-doenetml = DoenetML кылдыр форматтаар
+editor-format-as-xml = XML кылдыр форматтаар
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line } дугаар одуруг
+
+editor-no-errors = Частырыг чок
+editor-no-warnings = Сагындырыг чок
+editor-no-info = Медээ дыңнадыы чок
+
+editor-show-info-annotations = Медээ дыңнадыгларын редакторда көргүзер
+editor-show-accessibility-annotations = Ажыглаар арга дыңнадыгларын редакторда көргүзер
+
+editor-accessibility-learn-more = Doenet ажыглаар аргага канчаар хамаарылгалыгыл
+
+editor-accessibility-violations-heading = Ажыглаар арга үрелиишкиннери ({ $standard })
+
+editor-accessibility-other-heading = Өске ажыглаар арга айтырыглары
+editor-none-found = Чүү-даа тывылбаан
+
+
+## Submitted responses
+
+editor-no-responses = Ам дээрезинде чорудупкан харыы чок
+editor-response-answer-id = Харыының Id-зи
+editor-response-response = Харыы
+editor-response-credit = Балл
+editor-response-submitted = Чорудупкан
+
+
+## The context-help panel
+
+help-placeholder = Документацияны көөр дизе курсорну тег адынга, атрибутка азы { $ref } кырынга салыңар.
+
+help-unsupported-ref-chain = { $example } дег хөй кезектиг шилчилгелерге дуза ам-даа чок.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Шилчилгеге объект тывылбаан: { $ref }.
+        [multiple] Шилчилгеге хөй объект тывылган: { $ref }.
+       *[indeterminate] { $ref } объектизин тодарадып шыдаваан.
+    }
+
+help-learn-about-references = Шилчилгелер дугайында билип алыр →
+help-reference-page = Айтыкчы арын →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } иштинде
+       *[top] Дээди деңнелде
+    }{ $allowed ->
+        [none] { " — мында чүү-даа таарышпас." }
+        [text] { " — мында текст бижип болур." }
+        [text-and-components] { " — мында текст бижип болур, азы боларны оралдажып көрүңер:" }
+       *[components] { " — боларны оралдажып көрүп болур:" }
+    }
+
+help-suggestions-footer = Шупту { $total } компонентини көөр дизе { $shortcut } базыңар.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объектиже шилчилге.
+       *[other] { $ref } — { $target } объектиже шилчилге ({ $line } дугаар одуруг).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Ону { $owner } { $role } кылдыр киирген.
+       *[other] Ону { $owner } { $line } дугаар одуругда { $role } кылдыр киирген.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементиниң { $property } шынарынче шилчилге.
+       *[other] { $ref } — { $element } элементиниң { $property } шынарынче шилчилге ({ $line } дугаар одуруг).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = кезек
+help-kind-array-entry = массив элементизи
+
+help-default = Кол утказы:
+help-active-default = Амгы кол утказы:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Чөпшээрээн утказы (кажан-даа элемент бүрүзүнге бирээ):
+       *[other] Чөпшээрээн утказы:
+    }
+
+help-suggested-values = Сүмелээн утказы:
+
+help-inserts = Немээр:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координаталар:
+    }
+
+help-type = Хевири:
+
+help-resolved-style = Үнген стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Үнген функция аттары:
+help-reset-list = Бо шөлдүң дедир эгидер даңзызы:
+help-added-on-input = Бо шөлге немешкени:
+help-removed-on-input = Бо шөлден ужулдурганы:
+
+help-reset-overrides = { $reset } — { $additional } биле { $removed } кырындан ажыглаттынар.

--- a/packages/i18n/locales/udm/chrome.ftl
+++ b/packages/i18n/locales/udm/chrome.ftl
@@ -1,0 +1,139 @@
+# Udmurt viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Udmurt counts in two plural categories, `one` and `other`, so every
+# `{ $count -> … }` below keeps the shape it had. A noun after a numeral stays
+# singular — «2 выремлык», not a plural — so the two branches differ in nothing
+# but the number they print.
+
+
+## Answer submission
+
+answer-checking = Эскериське…
+answer-submitting = Ыстӥське…
+
+answer-checking-status = Ответ эскериське
+answer-submitting-status = Ответ ыстӥське
+
+answer-correct = Шонер
+answer-incorrect = Янгыш
+
+answer-response-saved = Ответ утемын
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% шонер
+answer-percent-short = { $percent } %
+
+max-credit-available = Басьтыны луонлыко бадӟым балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] выремлык кылемын ӧвӧл
+        [one] { $count } выремлык кылемын
+       *[other] { $count } выремлык кылемын
+    }
+
+validation-correct = (Шонер)
+validation-incorrect = (Янгыш)
+validation-partially-correct = (Люкетэн шонер)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } понна { $count } ответэз возьматыны
+       *[other] { $answerId } понна { $count } ответэз возьматыны
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Берыктэт
+
+collapsible-click-to-open = (усьтон понна зӥбе)
+collapsible-click-to-close = (ворсан понна зӥбе)
+
+collapsible-initializing = Дасяське…
+
+footnote-show = Пусъёнэз возьматыны
+footnote-hide = Пусъёнэз ватыны
+
+description-more-information = ватсаса ивортэт
+
+
+## Controls
+
+slider-previous = Азьло
+slider-next = Собере
+
+keyboard-open = Клавиатураез усьтыны
+keyboard-close = Клавиатураез ворсаны
+
+choice-input-remove-choice = { $choice } быръёнэз палэнтыны
+
+matrix-remove-row = Чурез палэнтыны
+matrix-add-row = Чур ватсаны
+matrix-remove-column = Юбоез палэнтыны
+matrix-add-column = Юбо ватсаны
+
+subset-add-remove-points = Пус ватсаны/палэнтыны
+subset-toggle-points-intervals = Пусъёсты но кусыпъёсты воштыны
+subset-move-points = Пусъёсты выретыны
+subset-clear = Сузяны
+
+orbital-add-row = Чур ватсаны
+orbital-remove-row = Чурез палэнтыны
+orbital-add-box = Клетка ватсаны
+orbital-remove-box = Клеткаез палэнтыны
+orbital-add-up-arrow = Вылӥе ньӧл ватсаны
+orbital-add-down-arrow = Улӥе ньӧл ватсаны
+orbital-remove-arrow = Ньӧлэз палэнтыны
+
+orbital-row-label = { $row } чурлэн пусэз
+
+pretzel-answer = Ответ
+
+summary-statistics-caption = { $column } юболэн йылпумъян статистикаез
+
+
+## Math input
+
+math-input-preview-region = математической валэктонлэн азьло учконэз
+math-input-preview = Азьло учкон
+math-input-invalid-expression = Янгыш валэктон:
+
+
+## Document status
+
+viewer-initializing = Дасяське…
+
+
+## Errors
+
+error-heading = Янгыш
+
+error-found-at =
+    { $span ->
+        [line] Шедьтэм чур: { $startLine }.
+       *[lines] Шедьтэм чуръёс: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Та документын янгышъёс вань!
+
+diagnostic-heading-error = Янгыш
+diagnostic-heading-warning = Сак кариськон
+diagnostic-heading-information = Ивортэт
+diagnostic-heading-hint = Юрттэт
+
+accessibility-heading-level-1 = WCAG AA вуонлык тӥян
+accessibility-heading-level-2 = Вуонлык сярысь ивортэт
+
+something-went-wrong = Мар ке янгыш потӥз.
+
+renderer-load-failed = суредасез пыртыны ӧз луы. Бамез выльдэ.
+
+core-start-failed = Документэз учконэз кутскытыны ӧз луы. Бамез выльдэ.

--- a/packages/i18n/locales/udm/content.ftl
+++ b/packages/i18n/locales/udm/content.ftl
@@ -1,0 +1,258 @@
+# Udmurt content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Udmurt's own ӝ, ӟ, ӥ, ӧ and ӵ, which is the
+# orthography Udmurtia's schools and publishing use and what CLDR fills a bare
+# `udm` in as. Those five letters are load-bearing: «сьӧд» spelled «сьод» is
+# not Udmurt.
+#
+# Udmurt is the roster's first Permic language and its first Uralic one from
+# inside Russia. It has no grammatical gender and does not inflect an
+# attributive adjective, so `$gender` and `$role` go unused — the same answer
+# the Turkic and Mongolic catalogs beside it give, from a third family. What
+# Udmurt has instead is a rich case system on the *noun*, and the two clause
+# messages below use it: the case suffix falls on a word this catalog writes,
+# never on a placeable, which is what keeps it inside the affix rule.
+#
+# CONFIDENCE. The colour and shape vocabulary is the part this seed is most
+# sure of. The newer technical nouns are Russian, which is what written Udmurt
+# uses for them.
+
+
+## Style vocabulary
+
+color =
+    .black = сьӧд
+    .white = тӧдьы
+    .gray = пурысь
+    .red = горд
+    .orange = оранжевой
+    .yellow = чуж
+    .green = вож
+    .cyan = югыт лыз
+    .blue = лыз
+    .purple = фиолетовой
+    .pink = лемлет
+    .brown = коричневой
+
+line-width =
+    .thick = зӧк
+    .thin = векчи
+
+line-style =
+    .dashed = чигем
+    .dotted = пусъем
+
+# Noun phrases: they stand in front of «чеберъямен» and modify nothing.
+fill-style =
+    .horizontal = горизонтальной чур
+    .vertical = вертикальной чур
+    .diagonal = диагональной чур
+    .backdiagonal = пумит диагональной чур
+    .dots = пус
+    .diamonds = ромб
+
+noun =
+    .line = шонер чур
+    .line-segment = висъет
+    .ray = луч
+    .vector = вектор
+    .curve = кожась чур
+    .function = функция
+    .parabola = парабола
+    .polyline = чигем чур
+    .polygon = трос сэрего
+    .triangle = куинь сэрего
+    .rectangle = шонер сэрего
+    .circle = котырес
+    .region = инты
+    .point = пус
+    .square = квадрат
+    .diamond = ромб
+    .cross = перекрест
+    .plus = плюс
+
+# Udmurt builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] шонер { $numSides } сэрего
+    }
+
+# Udmurt has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = буям
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } чеберъямен { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } чеберъямен { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } чеберъямен { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «дуроен» is the instrumental of «дур», "edge", and carries the whole of "with
+# a border" in its own suffix — so neither a preposition nor an article is
+# wanted, and the suffix sits on a noun this catalog writes rather than on a
+# placeable.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } дуроен
+        [and] но { $border } дуроен
+        [and-article] но { $border } дуроен
+       *[with] { $border } дуроен
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } чеберъямен { $color } буям
+       *[plain] { $color } буям
+    }
+
+style-unfilled = буямтэ
+
+# «вылын» — "on" — is a postposition and follows the background colour, so
+# nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } фон вылын { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = ӧвӧл
+
+
+## Boolean words
+
+boolean-true = зэм
+boolean-false = зэм ӧвӧл
+
+
+## Answer buttons
+
+answer-submit-label = Эскерыны
+answer-submit-label-no-correctness = Ответэз ыстыны
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Ужрад
+    .aside = Пал пусъён
+    .cascade = Каскад
+    .definition = Валэктон
+    .example = Пример
+    .exercise = Дышетскон уж
+    .exercises = Дышетскон ужъёс
+    .given-answer = Ответ
+    .note = Пусъён
+    .objectives = Ужпумъёс
+    .paragraphs = Абзацъёс
+    .part = Люкет
+    .problem = Задача
+    .problems = Задачаос
+    .proof = Юнматон
+    .question = Юан
+    .section = Ёзэт
+    .solution = Шедьтон
+    .task = Уж
+    .theorem = Теорема
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Юрттэт
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Таблица { $enumeration }
+        [numbered-title] Таблица { $enumeration }{ ". " }
+        [unnumbered-title] Таблица{ ". " }
+       *[unnumbered] Таблица
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Суред { $enumeration }
+        [numbered-caption] Суред { $enumeration }{ ". " }
+        [unnumbered-caption] Суред{ ". " }
+       *[unnumbered] Суред
+    }
+
+
+## Paginator controls
+
+paginator-previous = Азьло
+paginator-next = Собере
+paginator-page = Бам
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## `piecewise-condition-if` is `locales/sah`'s and `locales/tyv`'s limit a
+## third time, arriving from a third family: Udmurt's conditional «ке» is a
+## particle that *follows* the clause it conditions, and the renderer places
+## this key before the mathematics it introduces. Three catalogs in this batch
+## hit the same wall and two — `locales/bua` and `locales/xal` — do not, which
+## is what makes it a fact about word order rather than about the region.
+
+piecewise-condition-or = яке
+piecewise-condition-if = ке
+piecewise-condition-otherwise = мукет учыре
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Udmurtia is taught in
+## Russian, so the element names an Udmurt-speaking pupil meets are the Russian
+## ones — the school-system case this batch shares throughout.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Янгыш химической пус
+chemistry-invalid-ionic-compound = Янгыш ион герӟет

--- a/packages/i18n/locales/udm/content.ftl
+++ b/packages/i18n/locales/udm/content.ftl
@@ -236,9 +236,11 @@ paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
 ## `piecewise-condition-if` is `locales/sah`'s and `locales/tyv`'s limit a
 ## third time, arriving from a third family: Udmurt's conditional «ке» is a
 ## particle that *follows* the clause it conditions, and the renderer places
-## this key before the mathematics it introduces. Three catalogs in this batch
-## hit the same wall and two — `locales/bua` and `locales/xal` — do not, which
-## is what makes it a fact about word order rather than about the region.
+## this key before the mathematics it introduces. Five catalogs in this batch
+## hit the same wall — `locales/sah`, `locales/tyv`, this one, `locales/kv` and
+## `locales/chm` — and the other seven, among them `locales/bua` and
+## `locales/xal`, do not, which is what makes it a fact about word order rather
+## than about the region.
 
 piecewise-condition-or = яке
 piecewise-condition-if = ке

--- a/packages/i18n/locales/udm/diagnostics.ftl
+++ b/packages/i18n/locales/udm/diagnostics.ftl
@@ -1,0 +1,654 @@
+# Udmurt diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Udmurt uses
+# for them: «компонент», «атрибут», «функция», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] кык пум пус возьматэмын ке, { $attributes } лыдэ уг басьтӥськы
+       *[other] кык пум пус возьматэмын ке, { $attributes } лыдэ уг басьтӥськы
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] пум пус но шор пус кыксы возьматэмын ке, { $attributes } лыдэ уг басьтӥськы
+       *[other] пум пус но шор пус кыксы возьматэмын ке, { $attributes } лыдэ уг басьтӥськы
+    }
+
+line-segment-midpoint-offset-without-midpoint = шор пустэк midpointOffset номырлы уг йӧты
+
+## `<line>`
+
+line-points-undetermined-dimensions = Мертанэз тодмотэм пусъёс пыр ортчись шонер чур.
+
+line-points-too-few-dimensions = Шонер чур ичиез ке кык мертанэн пусъёс пыр ортчоно.
+
+line-points-depend-on-variables = Шонер чур воштӥськись мертанъёслэсь дуно пусъёс пыр ортче: { $variables }.
+
+line-equation-invalid-format = { $variable1 } но { $variable2 } воштӥськись мертанъёсын шонер чурлэн уравнениезлэн форматэз янгыш.
+
+## `<ray>`
+
+ray-overprescribed-through = Луч through, endpoint но direction пыр сётэмын. Сётэм through лыдэ уг басьтӥськы.
+
+ray-dimension-mismatch = лучын numDimensions уг тупа.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail но displacement пыр сётэмын. Сётэм head лыдэ уг басьтӥськы.
+
+vector-dimension-mismatch = векторын numDimensions уг тупа.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элемент доры кыскыны уг луы, малы ке шуоно солэн nearestPoint статус воштӥськисез ӧвӧл.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементэн ӵектыны уг луы, малы ке шуоно солэн nearestPoint статус воштӥськисез ӧвӧл.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементлэн пушкыныз ӵектыны уг луы, малы ке шуоно солэн nearestPoint статус воштӥськисез ӧвӧл.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = чур пушкын ӧвӧл choiceInput понна labelPosition лыдэ уг басьтӥськы
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput понна сётэм индексъёс лыдэ уг басьтӥсько, малы ке шуоно соослэн лыдзы choice нылпиослэн лыдзылы уг тупа.
+
+pretzel-indices-count-mismatch = problem понна сётэм индексъёс лыдэ уг басьтӥсько, малы ке шуоно соослэн лыдзы problem нылпиослэн лыдзылы уг тупа.
+
+shuffle-indices-count-mismatch = shuffle понна сётэм индексъёс лыдэ уг басьтӥсько, малы ке шуоно соослэн лыдзы компонентъёслэн лыдзылы уг тупа.
+
+indices-ignored-out-of-range = { $component } понна сётэм индексъёс лыдэ уг басьтӥсько, малы ке шуоно кудъёсыз пумысь потэмын.
+
+pretzel-indices-repeated = pretzel понна сётэм индексъёс лыдэ уг басьтӥсько, малы ке шуоно кудъёсыз берыктӥсько.
+
+pretzel-circuit-first-index = circuit режимын pretzel понна сётэм индексъёс лыдэ уг басьтӥсько, малы ке шуоно нырысетӥ индекс 1 луыны кулэ.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текст нылпиосын ужаны понна `type` атрибут сётоно.
+
+invalid-type-defaulting-to-math = { $component } компонентлы янгыш пӧртэмлык { $type }. Со math, text, number яке boolean луыны кулэ. math кутӥське.
+
+string-not-valid-component-to-arrange = «{ $value }» чур { $component } понна тупась компонент ӧвӧл. Лыдэ уг басьтӥськы.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Янгыш пӧртэмлык { $type }, пӧртэмлыкез number луэ.
+
+invalid-variable-value = Воштӥськисьлэн янгыш дунэз: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариант индекс лыд луыны кулэ
+
+variant-index-must-be-integer = { $index } вариант индекс тыр лыд луыны кулэ
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют мертанъёслы лэсьтымтэ. Пасьталаосыз ӵошатон луо.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют мертанъёслы лэсьтымтэ. Дуръёсыз ӵошатон луо.
+
+side-by-side-no-block-child = Янгыш `<{ $component }>`: солэн ичиез ке одӥг блок нылпиез луыны кулэ.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элементысь `for` атрибут лыдэ уг басьтӥськы.
+
+label-for-must-resolve-to-one = `<label>` элементысь `for` атрибут тупак одӥг компонент вылэ возьматоно.
+
+label-for-unresolved = `<label>` элементысь `for` атрибутэз компонентэн герӟаны ӧз луы.
+
+label-for-answer-with-authored-inputs = `<label>` элементысь `for` атрибут автор гожтэм пыртон бусыосын `<answer>` вылэ возьматэ; бусы вылэ шонерак возьматэ.
+
+label-for-answer-without-input = `<label>` элементысь `for` атрибут пусъяно пыртон бусытэк `<answer>` вылэ возьматэ.
+
+label-for-must-reference-input-or-answer = `<label>` элементысь `for` атрибут пыртон бусы яке ответ вылэ возьматоно.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Вуонлык понна `<{ $component }>` яке вакчи валэктонэн луыны кулэ, яке чеберъян сямен пусъяно.
+
+accessibility-video-short-description = Вуонлык понна `<video>` вакчи валэктонэн луыны кулэ.
+
+accessibility-input-short-description-or-label = Вуонлык понна `<{ $component }>` вакчи валэктонэн яке пусэн луыны кулэ.
+
+accessibility-answer-input-short-description-or-label = Вуонлык понна пыртон бусы кылдытӥсь `<answer>` вакчи валэктонэн яке пусэн луыны кулэ.
+
+accessibility-short-description-contains-math = Вакчи валэктонъёсын `<{ $component }>` кадь математической компонентъёс луыны уг яра. Математикаез кылъёсын гожтэ.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } ёзэтлэн йырозэзлэн текстэзлы тырмыт контраст уг сёты (пеймыт бамал) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ичиез ке { $threshold }:1 кулэ).
+       *[other] { $colorName } ёзэтлэн йырозэзлэн текстэзлы тырмыт контраст уг сёты ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ичиез ке { $threshold }:1 кулэ).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Пусъёслэн лыд дунъёссы ӧвӧл ке, { $count } пус пыр ортчись `<circle>` лэсьтымтэ.
+
+circle-too-many-through-points = 3-лэсь трос пус пыр ортчись котыресэз лыдъяны уг луы.
+
+circle-overprescribed-radius-center-points = Сётэм радиусэн, шорен но пусъёсын котыресэз лыдъяны уг луы.
+
+circle-center-with-multiple-points = Сётэм шорен 1-лэсь трос пус пыр ортчись котыресэз лыдъяны уг луы.
+
+circle-radius-too-small = Котыресэз лыдъяны уг луы: кык пус куспын кузьда { $distance } луэ, сётэм радиус { $radius } туж покчи.
+
+circle-radius-with-many-points = Сётэм радиусэн кыклэсь трос пус пыр ортчись котырес лэсьтыны уг луы.
+
+circle-invalid-center-or-through-points = Котыреслэн шорез яке пусъёсыз янгыш.
+
+circle-radius-center-with-multiple-points = Сётэм шорен 1-лэсь трос пус пыр ортчись котыреслэсь радиуссэ лыдъяны уг луы.
+
+circle-change-radius-non-numerical = Лыд ӧвӧл пусъёсын котыреслэсь радиуссэ воштыны уг луы
+
+circle-radius-with-points-non-numerical = Лыд дунъёс ӧвӧл ке, сётэм радиусэн одӥглэсь трос пус пыр ортчись котырес лэсьтыны уг луы.
+
+circle-change-center-non-numerical = Лыд ӧвӧл пусъёс пыр ортчись котыреслэсь шорзэ воштон лэсьтымтэ.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцилэн тодмам интыезлэн мертанэз тырмыт ӧвӧл. Интыын { $intervals } кусып вань, нош функциын { $inputs ->
+            [one] { $inputs } пыртон
+           *[other] { $inputs } пыртон
+        } вань.
+       *[other] Функцилэн тодмам интыезлэн мертанэз тырмыт ӧвӧл. Интыын { $intervals } кусып вань, нош функциын { $inputs ->
+            [one] { $inputs } пыртон
+           *[other] { $inputs } пыртон
+        } вань.
+    }
+
+function-domain-invalid-format = Функцилэн тодмам интыезлэн форматэз янгыш.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцилэн лыд ӧвӧл максимумез лыдэ уг басьтӥськы.
+        [minimum] Функцилэн лыд ӧвӧл минимумез лыдэ уг басьтӥськы.
+        [extremum] Функцилэн лыд ӧвӧл экстремумез лыдэ уг басьтӥськы.
+        [point] Функцилэн лыд ӧвӧл пусэз лыдэ уг басьтӥськы.
+        [slope] Функцилэн лыд ӧвӧл мыкыртэмез лыдэ уг басьтӥськы.
+       *[other] Функцилэн лыд ӧвӧл { $type } дунэз лыдэ уг басьтӥськы.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцилэн буш максимумез лыдэ уг басьтӥськы.
+        [minimum] Функцилэн буш минимумез лыдэ уг басьтӥськы.
+        [extremum] Функцилэн буш экстремумез лыдэ уг басьтӥськы.
+        [point] Функцилэн буш пусэз лыдэ уг басьтӥськы.
+       *[other] Функцилэн буш { $type } дунэз лыдэ уг басьтӥськы.
+    }
+
+function-points-too-close = Функциын огзылы огзы туж матын кык пус вань. Функциез тодманы уг луы.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцилэн итерациосыз пыртонъёслэн лыдзы потонъёслэн лыдзылы тупа ке гинэ луо. Та функциын { $inputs } пыртон но { $outputs ->
+            [one] { $outputs } потон
+           *[other] { $outputs } потон
+        } вань.
+       *[other] Функцилэн итерациосыз пыртонъёслэн лыдзы потонъёслэн лыдзылы тупа ке гинэ луо. Та функциын { $inputs } пыртон но { $outputs ->
+            [one] { $outputs } потон
+           *[other] { $outputs } потон
+        } вань.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Радъетлэн кузьдалаез янгыш. Со минус ӧвӧл тыр лыд луыны кулэ.
+
+sequence-invalid-step = Радъетлэн вамышез янгыш. { $type } пӧртэмлыко радъетлы со лыд луыны кулэ.
+
+sequence-invalid-endpoint-number = Лыд радъетлэн «{ $attribute }» дунэз янгыш. Со лыд луыны кулэ.
+
+sequence-invalid-endpoint-letters = Букваос радъетлэн «{ $attribute }» дунэз янгыш. Со буквалэн герӟетэз луыны кулэ.
+
+sequence-invalid-endpoint = Радъетлэн «{ $attribute }» дунэз янгыш.
+
+select-from-sequence-coprime-not-numbers = лыдъёс быръемын ӧвӧл, соин coprime лыдэ уг басьтӥськы
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations сётэмын, соин coprime лыдэ уг басьтӥськы
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` понна янгыш target: ужпум ӧз шедьтӥськы.
+
+target-state-variable-not-found = `<{ $source }>` понна янгыш target: `<{ $component }>` элементын «{ $property }» нимо статус воштӥськись ӧз шедьтӥськы.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` воштӥськисьёсыз асэсьтэм воштӥськисьлэсь пӧртэм луыны кулэ.
+
+ode-system-duplicate-variable-names = Дуно воштӥськисьёслэн нимъёссы берыктӥсько ке, ДТ бур палысь функциосты тодманы уг луы.
+
+ode-system-rhs-function-error = ДТ бур палысь функциез тодманы уг луы. mathjs функциез кылдытыкы янгыш.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } шонер чур куспын сэрегез тодманы уг луы
+
+angle-invalid-through-point = `<angle>` элементлэн through дуназ янгыш пус
+
+parabola-vertex-too-many-points = Сётэм йылын 1-лэсь трос пус пыр ортчись парабола лэсьтымтэ.
+
+parabola-too-many-points = 3-лэсь трос пус пыр ортчись парабола лэсьтымтэ.
+
+intersection-too-many-items = Кыклэсь трос объектлэн вамен потэмез лэсьтымтэ
+
+## Other math components
+
+ionic-compound-not-two-ions = Кык ионлэсь мукет ион герӟетъёс лэсьтымтэ.
+
+ionic-compound-needs-cation-and-anion = Ион герӟет одӥг катионлы но одӥг анионлы гинэ лэсьтэмын.
+
+solve-equations-cannot-evaluate = Уравнениез быдэстыны уг луы, малы ке шуоно сое лыдъяны ӧз луы: { $equation }
+
+math-operators-operand-number-required = Математической операндэз висъян понна operandNumber сётоно.
+
+eigen-decomposition-failed = Матрицалэсь ас дунъёссэ лыдъяны ӧз луы
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр образецын уг пумиськы, соин со котьку бушлы тупа.
+       *[other] `<matchesPattern>`: { $parameters } параметръёс образецын уг пумисько, соин соос котьку бушлы тупало.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" дунэз валаны уг луы. Со none, medium, dense яке буш интыен висъям кык плюс лыд луыны кулэ, кылсярысь grid="1 0.5". Сетка уг суредаськы.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure суредасьын xLabelPosition="left" лэсьтымтэ; бур пала пуктон кутӥське.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure суредасьын yLabelPosition="bottom" лэсьтымтэ; вылӥ пала пуктон кутӥське.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure выжтонлы тэльёслэн пумъёссы янгыш; инъет bbox (-10,-10,10,10) кутӥське.
+
+prefigure-invalid-width = `<graph>`: prefigure выжтонлы пасьтала янгыш; диаграммалэн инъет пасьталаез 425 кутӥське.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure выжтонлы aspectRatio янгыш; инъет палъёслэн герӟетсы 1 кутӥське.
+
+prefigure-grid-spacing-too-fine = `<graph>`: сеткалэн вамышез тэльёслэн пумъёссылы туж вакчи; prefigure суредасьын сетка уг поттӥськы.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure суредась уг кутӥськы ке, пусъёнъёс уг суредасько.
+
+multiple-annotations-children = `<graph>` пушкын трос `<annotations>` нылпи шедьтэмын; берпуметӥезлэсь мукетъёсыз лыдэ уг басьтӥсько.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Тодмотэм компонент пӧртэмлыкез паськытатыны яке копировать карыны уг луы: { $type }.
+
+copy-prop-not-found = { $component } пӧртэмлыко компонентын { $property } тодмет ӧз шедьтӥськы
+
+collect-no-source = collect понна инъет ӧз шедьтӥськы.
+
+collect-invalid-component-type = `<{ $component }>` пӧртэмлыко компонентъёсты люканы уг луы, малы ке шуоно та янгыш компонент пӧртэмлык.
+
+reference-index-unavailable = `{ $reference }` индекс вылэ герӟет лэсьтыны уг луы
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонентын { $action } ӧтьыны уг луы
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Даннойёслэн тусзы янгыш. Чуръёслэн кузьдалазы пӧртэм. Шедьтэмын componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Даннойёсын юболэн нимъёсыз берыктӥсько. Шедьтэмын componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Даннойёсын юбо ним уг тырмы. Шедьтэмын componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Та ответлэн award дунэз answer тегъяслэн ас ыстэм ответсы вылэ пыкиське, со витёнтэм ужпумъёсы вуттэ.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` вань контейнер пушкысь `<answer>` вылэ `maxNumAttempts` пуктон уг йӧты, малы ке шуоно выремлыкъёслэсь лыдзэс контейнер тодма. `maxNumAttempts` дунэз контейнер вылэ пукты.
+
+nested-section-wide-check-work-max-num-attempts = Мукет `sectionWideCheckWork` контейнер пушкын сылӥсь `sectionWideCheckWork` контейнер вылэ `maxNumAttempts` пуктон уг йӧты, малы ке шуоно выремлыкъёслэсь лыдзэс кузя контейнер тодма. `maxNumAttempts` дунэз кузя контейнер вылэ пукты.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality пуктымтэ ке, { $attributes } атрибут уз йӧты.
+       *[other] symbolicEquality пуктымтэ ке, { $attributes } атрибутъёс уз йӧто.
+    }
+
+answer-invalid-type = answer понна янгыш пӧртэмлык: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентлэн нимыз ӧвӧл, соин сое модуль атрибут сямен кутыны уг луы
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонентэз модуль атрибут сямен кутыны уг луы, малы ке шуоно `<module>` компонент пӧртэмлыкын «{ $name }» атрибут ини тодмамын.
+
+conditional-content-condition-ignored = case яке else нылпиосын `<conditionalContent>` компонентын `condition` атрибут лыдэ уг басьтӥськы.
+
+slider-markers-type-mismatch = Маркеръёслэн пӧртэмлыксы ползунокалэн пӧртэмлыкезлы уг тупа.
+
+pretzel-problem-needs-statement-and-answer = Янгыш pretzel: котькуд `<problem>` одӥг `<statement>` но одӥг `<answer>` пушказ басьтоно.
+
+pretzel-circuit-first-problem-distractor = Янгыш pretzel: mode="circuit" режимын нырысетӥ `<problem>` саклыкез палэнтӥсь луыны уг быгаты.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибутлы янгыш дун { $values }; лыдэ уг басьтӥськы.
+       *[other] `{ $attribute }` атрибутлы янгыш дунъёс { $values }; лыдэ уг басьтӥсько.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибутлы янгыш дун `{ $value }`. Атрибут `$` пусэн кутскись герӟетъёслэсь луыны кулэ.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } пушкысь янгыш функци нимъёс лыдэ ӧз басьтӥськы: { $names }. Котькуд нимлэн адӟиськись люкетэз ичиез ке 2 пус луыны кулэ (буквалъёс яке черточкаос); со бере кулэтэм `|<mathspeak альтернатива>` ватсэт лыктыны быгатэ.
+
+## Building components from the source
+
+component-type-invalid = Янгыш компонент пӧртэмлык: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибутэз берыктыны уг луы.
+
+attribute-invalid-for-component = `<{ $componentType }>` пӧртэмлыко компонентлы янгыш атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стиль валэктонын { $context ->
+        [text-on-background] текстлэн буёлэз но фонлэн буёлэз
+        [high-contrast] бадӟым контрастэн буёл но суредан инты
+        [line] чурлэн буёлэз но суредан инты
+        [marker] маркерлэн буёлэз но суредан инты
+       *[text-on-canvas] текстлэн буёлэз но суредан инты
+    } куспын контраст тырмыт ӧвӧл{ $mode ->
+        [dark] { " (пеймыт бамал)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ичиез ке { $threshold }:1 кулэ).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стиль валэктонын сётэм буёлъёс югыт бамаллы тырмыт контраст сётӥзы ке но, соослэсь потэм пеймыт бамал буёлъёс текст но фон куспын тырмыт контраст уг сёто ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ичиез ке { $threshold }:1 кулэ). { $suggestion ->
+        [available] Пеймыт бамалын тырмыт контраст понна яке югыт бамаллэсь контрастсэ будэтэ (кылсярысь { $lightAttribute }="{ $lightColor }"), яке пеймыт бамал буёлэз воштэ (кылсярысь { $darkAttribute }="{ $darkColor }").
+       *[none] Пеймыт бамалын тырмыт контраст понна югыт бамаллэсь контрастсэ будэтэ яке потэм буёлъёсты textColorDarkMode но/яке backgroundColorDarkMode пыр воштэ.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стиль валэктонын сётэм текст буёл югыт бамаллы тырмыт контраст сётӥз ке но, солэсь потэм пеймыт бамал текст буёл суредан интыен тырмыт контраст уг сёты ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; ичиез ке { $threshold }:1 кулэ). { $suggestion ->
+        [available] Пеймыт бамалын тырмыт контраст понна яке югыт бамаллэсь контрастсэ будэтэ (кылсярысь textColor="{ $lightColor }"), яке пеймыт бамал буёлэз воштэ (кылсярысь textColorDarkMode="{ $darkColor }").
+       *[none] Пеймыт бамалын тырмыт контраст понна югыт бамаллэсь контрастсэ будэтэ яке потэм буёлэз textColorDarkMode пыр воштэ.
+    }
+
+section-multiple-style-palettes = Ёзэт одӥг гинэ <stylePalette> быръыны быгатэ; берпуметӥез кутӥське.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно numToSelect минус ӧвӧл тыр лыд ӧвӧл.
+
+variant-num-to-select-not-constant-number = { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно numToSelect воштӥськисьтэм лыд ӧвӧл.
+
+variant-with-replacement-not-constant-boolean = { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно withReplacement воштӥськисьтэм логической дун ӧвӧл.
+
+variant-select-weight-disables-unique = кыӵе ке быръёнын selectWeight яке selectForVariants сётэмын ке, select понна берыктымтэ вариантъёс кысо
+
+variant-coprime-undetermined = { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно coprime котьку янгыш-а, сое тодманы уг луы.
+
+variant-attribute-not-constant = { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно { $attribute } воштӥськисьтэм ӧвӧл.
+
+variant-attribute-not-number = { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно { $attribute } лыд ӧвӧл.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } пӧртэмлыко { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно { $attribute } { $expected ->
+        [letters-combination] буквалъёслэн герӟетсы
+        [math-expression] тупась математической валэктон
+        [integer] тыр лыд
+       *[number] лыд
+    } ӧвӧл.
+
+variant-length-not-integer = { $component } понна берыктымтэ вариантъёсты тодманы уг луы, малы ке шуоно length тыр лыд ӧвӧл.
+
+variant-sort-not-implemented = sort вань { $component } понна берыктымтэ вариантъёс лэсьтымтэ
+
+variant-exclude-combinations-not-implemented = excludeCombinations вань { $component } понна берыктымтэ вариантъёс лэсьтымтэ
+
+variant-math-exclude-not-implemented = exclude вань math пӧртэмлыко { $component } понна берыктымтэ вариантъёс лэсьтымтэ
+
+variant-non-constant-exclude-not-implemented = воштӥськисьтэм ӧвӧл exclude вань { $component } понна берыктымтэ вариантъёс лэсьтымтэ
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графиклэн prefigure суредасяз лэсьтымтэ; выжыез кельтэмын.
+
+prefigure-descendant-invalid-geometry = { $subject }: пумтэм яке тырмымтэ геометрия; выжыез кельтэмын.
+
+prefigure-curve-label-omitted = { $subject }: выжтэм кожась элементъёсын пусъёс лэсьтымтэ; пус кельтэмын.
+
+prefigure-curve-unsupported-definition-type = { $subject }: лэсьтымтэ кожась функци валэктонлэн пӧртэмлыкез «{ $definitionType }»; выжыез кельтэмын.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элементысь flipFunctions атрибут лэсьтымтэ; выжыез кельтэмын.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулаен сётэм нылпи функциосты гинэ басьтэ; выжыез кельтэмын.
+
+prefigure-label-position-unsupported =
+    { $subject }: лэсьтымтэ labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] чуръёслэн семьязылэн пусэзлы
+       *[point] пуслэн пусэзлы
+    }; PreFigure-лэн инъет ӵошатэмез кутӥське.
+
+prefigure-fill-style-unsupported = { $subject }: тырон стиль «{ $fillStyle }» PreFigure понна лэсьтымтэ; тыр тыронэ выже.
+
+prefigure-line-style-unknown = { $subject }: тодмотэм чур стиль «{ $lineStyle }» PreFigure потонысь палэнтэмын.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркер стиль «{ $markerStyle }» PreFigure «diamond» стилен тупатэмын.
+
+prefigure-marker-style-unsupported = { $subject }: маркер стиль «{ $markerStyle }» PreFigure понна лэсьтымтэ; инъет стиль кутӥське.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: янгыш `ref`; ужпумез герӟаны уг луы. Пусъён палэнтэмын.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` трос ужпумен герӟаськиз; нырысетӥез кутӥське.
+
+annotation-ref-outside-graph = `<annotation>`: янгыш `ref`; ужпум сое пушказ басьтӥсь графиклэсь палэнын. Пусъён палэнтэмын.
+
+annotation-ref-unsupported-target = `<annotation>`: янгыш `ref`; ужпум prefigure выжтонын лэсьтэм график объект ӧвӧл. Пусъён палэнтэмын.
+
+annotation-text-missing = `<annotation>`: `text` ӧвӧл яке буш; буш текст поттӥське.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Котыртэм герӟаськон шедьтэмын.
+       *[other] `<{ $componentType }>` компонентэз пушказ басьтӥсь котыртэм герӟаськон шедьтэмын.
+    }
+
+reference-no-referent = Герӟетлы объект ӧз шедьтӥськы: `{ $reference }`
+
+reference-multiple-referents = Герӟетлы трос объект шедьтэмын: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементлэн { $attribute } атрибутэзлэн форматэз янгыш.
+
+children-invalid = `<{ $componentType }>` понна янгыш нылпиос: янгыш нылпиос шедьтэмын: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибутлы янгыш дун `{ $value }`; `{ $default }` дун кутӥське
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } версия ӧз шедьтӥськы.
+       *[other] DoenetML { $version } версия ӧз шедьтӥськы. { $fallback } версия кутӥське
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Янгыш DoenetML: { $content }
+
+parse-tag-missing-close-tag = Янгыш DoenetML: `{ $tag }` теглэн ворсась тегез ӧвӧл. Ачиз ворсаськись тег яке `</{ $tagName }>` тег витиськиз.
+
+parse-tag-error = Янгыш DoenetML: `<{ $tagName }>` тегын янгыш
+
+parse-attribute-missing-value = Янгыш DoenetML: `{ $attribute }` атрибутын дун уг тырмы кадь.
+
+parse-attribute-invalid = Янгыш DoenetML: янгыш атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Янгыш DoenetML: атрибутлэн янгыш дунэз `{ $value }`
+
+parse-attribute-value-quote-mismatch = Янгыш DoenetML: атрибутлэн янгыш дунэз `{ $value }`. Кавычкаос уг тупало. `{ $quote }` уг тырмы кадь
+
+parse-open-tag-name-missing = Янгыш DoenetML: нимтэк тег шедьтэмын, кылсярысь `<`
+
+parse-tag-not-closed = Янгыш DoenetML: `{ $tag }` тег ворсамтэ (`>` уг тырмы кадь).
+
+parse-self-closing-tag-name-missing = Янгыш DoenetML: нимтэк тег шедьтэмын `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Янгыш DoenetML: `{ $tag }` тег ворсамтэ (`/>` уг тырмы кадь).
+
+parse-tag-invalid-attributes = Янгыш DoenetML: `{ $tag }` тег тупась ӧвӧл. Солэн атрибутъёсыз янгыш луыны быгато.
+
+parse-close-tag-name-missing = Янгыш DoenetML: нимтэк ворсась тег шедьтэмын, кылсярысь `</`
+
+parse-attribute-value-unquoted = Атрибутлэн дунъёсыз кавычка пушкын луыны кулэ: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Янгыш DoenetML: `{ $tag }` ворсась тег шедьтэмын, нош солы тупась усьтӥсь тег ӧвӧл
+
+parse-close-tag-mismatched = Янгыш DoenetML: тупамтэ ворсась тег. `</{ $expected }>` витиськиз. `{ $found }` шедьтэмын
+
+parser-node-unconvertible = { $node } узелэз Dast узеле выжтыны ӧз луы.
+
+## Names
+
+name-attribute-invalid =
+    Янгыш атрибут name='{ $name }'. { $reason ->
+        [characters] Нимъёсын буквалъёс, лыдъёс, улӥ черточкаос яке черточкаос гинэ луыны быгато.
+       *[start] Нимъёс буквалэсь кутсконо.
+    }
+
+component-name-invalid-start = Янгыш компонент ним «{ $name }». Нимъёс буквалэсь кутсконо.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched пӧртэмлыко answer-лэн video атрибутэз луыны кулэ
+
+answer-video-watched-video-not-reference = videoWatched пӧртэмлыко answer-лэн video атрибутэз герӟет луыны кулэ
+
+answer-name-not-single-text = answer-лэн name атрибутаз тупак одӥг текст нылпи луыны кулэ
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсилэн ёзъёсыз туж трос, соин палэнысь DoenetML басьтыны ӧз луы. Котыртэм герӟет ӧвӧл-а?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресысь DoenetML басьтыны ӧз луы
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресысь янгыш DoenetML басьтэмын: со «{ $componentType }» компонент пӧртэмлыклы ӧз тупа
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут вужмиз; со интые `{ $to }` куты.
+       *[other] [deprecation] `<{ $component }>` элементысь `{ $from }` атрибут вужмиз; со интые `{ $to }` куты.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут вужмиз но лыдэ уг басьтӥськы, малы ке шуоно `{ $to }` но сётэмын.
+       *[other] [deprecation] `<{ $component }>` элементысь `{ $from }` атрибут вужмиз но лыдэ уг басьтӥськы, малы ке шуоно `{ $to }` но сётэмын.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элементысь `{ $attribute }` атрибут вужмиз но лыдэ уг басьтӥськы.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элементысь `{ $attribute }` атрибут вужмиз; со интые `<{ $child }>` нылпиез куты.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элементысь `{ $attribute }` атрибутлэн `{ $value }` дунэз вужмиз; со интые `{ $to }` куты.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` трослыко лыдэз англи кылын гинэ лэсьтыны быгатэ, соин { $locale } кылын гожтэм документын солэн текстэз воштӥськытэк кыле. Трослыко формазэ ачид гожты яке сое `pluralForm` атрибутэн сёт.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент тодмо Doenet элемент ӧвӧл.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементлы документлэн выжыяз лэзьымтэ.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементлы `<{ $parent }>` пушкын лэзьымтэ.
+
+schema-attribute-unrecognized = `<{ $tag }>` элементын `{ $attribute }` нимо атрибут ӧвӧл.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементлэн `{ $attribute }` атрибутэз котькуд элементэз таослэн огез луись список луыны кулэ: { $allowed }
+       *[other] `<{ $tag }>` элементлэн `{ $attribute }` атрибутэз таослэн огез луыны кулэ: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select понна янгыш вариант ним. { $variantName } вариант ним { $numOptions } быръёнын пумиське, нош быръёно лыд { $numToSelect }.
+
+select-variant-name-without-options = select понна вариантъёс сётэмын, нош луонлыко вариант нимлы одӥг быръён но ӧвӧл: { $variantName }.
+
+select-variant-name-not-possible = select понна сётэм { $variantName } вариант ним луонлыко вариант ним ӧвӧл.
+
+select-too-few-options = Ваньмыз { $numOptions } пӧлысь { $numToSelect } компонентэз быръыны уг луы.
+
+select-from-sequence-too-few-values = Кузьдалаез { $length } радъетысь { $numToSelect } дунэз быръыны уг луы.
+
+select-from-sequence-indices-count-mismatch = select понна сётэм индексъёслэн лыдзы быръёно лыдлы тупано
+
+select-from-sequence-indices-not-integers = select понна сётэм ваньмыз индексъёс тыр лыд луыны кулэ
+
+select-from-sequence-index-excluded = selectfromsequence понна сётэм индекс палэнтэмын вал
+
+select-from-sequence-indices-excluded-combination = selectfromsequence понна сётэм индексъёс палэнтэм герӟет вал
+
+select-from-sequence-coprime-not-positive-integers = Плюс тыр лыдъёс быръемын ӧвӧл, соин ог-огзылы простой герӟетъёсты быръыны уг луы.
+
+select-from-sequence-coprime-common-factor = Ог-огзылы простой лыдъёсты быръыны уг луы. Ваньмыз луонлыко дунъёслэн огъя люкисьсы вань. (Сётэм "from" яке "to" дунъёс "step"-эн ог-огзылы простой луыны кулэ.)
+
+select-from-sequence-coprime-single-number = 1 ӧвӧл одӥг лыдысь ог-огзылы простой герӟетъёсты быръыны уг луы.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence пушкын герӟетъёслэн 70%-лэсь тросэз палэнтэмын
+
+select-from-sequence-coprime-none-found = Ог-огзылы простой лыдъёсты быръыны ӧз луы. Ваньмыз луонлыко дунъёслэн огъя люкисьсы вань.
+
+select-from-sequence-too-few-unique-values = Кузьдалаез { $numPossibleValues } радъетысь { $numToSelect } пӧртэм дунэз быръыны уг луы
+
+select-prime-numbers-too-few-values = Кузьдалаез { $numValues } простой лыдъёслэн списокысьтызы { $numToSelect } дунэз быръыны уг луы
+
+select-prime-numbers-values-count-mismatch = select понна сётэм дунъёслэн лыдзы быръёно лыдлы тупано
+
+select-prime-numbers-values-not-prime = select prime number понна сётэм ваньмыз дунъёс простой лыдъёслэн списказы луыны кулэ
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers понна сётэм дунъёс палэнтэм герӟет вал
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers пушкын герӟетъёслэн 70%-лэсь тросэз палэнтэмын
+
+select-random-combination-fluke = Туж луонтэм учыр сэрен шаплы дунъёслэсь герӟетсэс быръыны ӧз луы
+
+select-random-value-fluke = Туж луонтэм учыр сэрен шаплы дунэз быръыны ӧз луы

--- a/packages/i18n/locales/udm/editor.ftl
+++ b/packages/i18n/locales/udm/editor.ftl
@@ -1,0 +1,215 @@
+# Udmurt editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+#
+# Udmurt counts in the same two categories English does, so every selection
+# below keeps both branches — though a noun after a numeral stays singular, so
+# the two read alike.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Берыктыны
+       *[update] Выльдыны
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Учконэз { $word }
+       *[other] Учконэз { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Бӧрысь…
+editor-variant-next = Собере вариантэз быръёно
+editor-variant-previous = Азьло вариантэз быръёно
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA вуонлык тӥян шедьтэмын. Вуонлык отчётэз { $action ->
+            [close] ворсан
+           *[open] усьтон
+        } понна зӥбе.
+        [advisories] Вуонлык отчётэз { $action ->
+            [close] ворсан
+           *[open] усьтон
+        } понна зӥбе. WCAG AA тӥянъёс ӧз шедьтӥськы, нош ватсам ӵектонъёс вань.
+       *[clean] Вуонлык отчётэз { $action ->
+            [close] ворсан
+           *[open] усьтон
+        } понна зӥбе. Вуонлык ужпумъёс ӧз шедьтӥськы.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA вуонлык тӥян шедьтэмын. { $count ->
+            [one] { $count } WCAG AA тӥян
+           *[other] { $count } WCAG AA тӥян
+        } шедьтэмын. Вуонлык отчётэз { $action ->
+            [close] ворсан
+           *[open] усьтон
+        } понна зӥбе.
+        [advisories] WCAG AA тӥянъёс ӧз шедьтӥськы. { $count ->
+            [one] { $count } ватсам ӵектон
+           *[other] { $count } ватсам ӵектон
+        } шедьтэмын. Вуонлык отчётэз { $action ->
+            [close] ворсан
+           *[open] усьтон
+        } понна зӥбе.
+       *[clean] WCAG AA тӥянъёс ӧз шедьтӥськы. Вуонлык отчётэз { $action ->
+            [close] ворсан
+           *[open] усьтон
+        } понна зӥбе.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML версия { $version }
+
+editor-tab-help = Контекст юрттэт
+editor-tab-help-short = Контекст
+editor-tab-errors = Янгышъёс
+editor-tab-warnings = Сак кариськонъёс
+editor-tab-info = Ивортэт
+editor-tab-accessibility = Вуонлык
+editor-tab-responses = Ыстэм ответъёс
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторлэн тупатонъёсыз
+editor-format-as-doenetml = DoenetML кадь форматировать карыны
+editor-format-as-xml = XML кадь форматировать карыны
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-тӥ чур
+
+editor-no-errors = Янгышъёс ӧвӧл
+editor-no-warnings = Сак кариськонъёс ӧвӧл
+editor-no-info = Ивортэт юрттэтъёс ӧвӧл
+
+editor-show-info-annotations = Ивортэт юрттэтъёсты редакторын возьматыны
+editor-show-accessibility-annotations = Вуонлык юрттэтъёсты редакторын возьматыны
+
+editor-accessibility-learn-more = Doenet вуонлыклы кызьы учке
+
+editor-accessibility-violations-heading = Вуонлык тӥянъёс ({ $standard })
+
+editor-accessibility-other-heading = Мукет вуонлык ужпумъёс
+editor-none-found = Номыр ӧз шедьтӥськы
+
+
+## Submitted responses
+
+editor-no-responses = Али ке но ыстэм ответъёс ӧвӧл
+editor-response-answer-id = Ответлэн Id-ез
+editor-response-response = Ответ
+editor-response-credit = Балл
+editor-response-submitted = Ыстэмын
+
+
+## The context-help panel
+
+help-placeholder = Документациез адӟон понна курсорез тег нимын, атрибут яке { $ref } вылэ пукты.
+
+help-unsupported-ref-chain = { $example } кадь трос люкетъем герӟетъёслы юрттэт али ӧвӧл.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Герӟетлы объект ӧз шедьтӥськы: { $ref }.
+        [multiple] Герӟетлы трос объект шедьтэмын: { $ref }.
+       *[indeterminate] { $ref } объектэз тодманы ӧз луы.
+    }
+
+help-learn-about-references = Герӟетъёс сярысь тодыны →
+help-reference-page = Справка бам →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } пушкын
+       *[top] Вылӥ ёзын
+    }{ $allowed ->
+        [none] { " — татын номыр уг тэры." }
+        [text] { " — татын текст гожтыны луэ." }
+        [text-and-components] { " — татын текст гожтыны луэ, яке таосты эскере:" }
+       *[components] { " — таосты эскерыны луэ:" }
+    }
+
+help-suggestions-footer = Вань { $total } компонентэз адӟон понна { $shortcut } зӥбе.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объект вылэ герӟет.
+       *[other] { $ref } — { $target } объект вылэ герӟет ({ $line }-тӥ чур).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Сое { $owner } { $role } сямен пыртӥз.
+       *[other] Сое { $owner } { $line }-тӥ чурын { $role } сямен пыртӥз.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементлэн { $property } тодметэз вылэ герӟет.
+       *[other] { $ref } — { $element } элементлэн { $property } тодметэз вылэ герӟет ({ $line }-тӥ чур).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = висъет
+help-kind-array-entry = массивлэн элементэз
+
+help-default = Инъет дун:
+help-active-default = Али инъет дун:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Лэзем дунъёс (котькуд элементлы огез):
+       *[other] Лэзем дунъёс:
+    }
+
+help-suggested-values = Ӵектэм дунъёс:
+
+help-inserts = Ватса:
+
+help-coordinates =
+    { $count ->
+        [one] Координата:
+       *[other] Координатаос:
+    }
+
+help-type = Пӧртэмлык:
+
+help-resolved-style = Потэм стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Потэм функциослэн нимъёссы:
+help-reset-list = Та бусылэн берыктон списокез:
+help-added-on-input = Та бусыын ватсамъёс:
+help-removed-on-input = Та бусыысь палэнтэмъёс:
+
+help-reset-overrides = { $reset } — { $additional } но { $removed } вылтӥ вормись.

--- a/packages/i18n/locales/xal/chrome.ftl
+++ b/packages/i18n/locales/xal/chrome.ftl
@@ -1,0 +1,141 @@
+# Kalmyk viewer chrome. Translated from `locales/en/chrome.ftl`, which is the
+# source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Read the confidence note at the top of `content.ftl` before this file: this
+# is the least certain catalog in its batch and says so in its own header.
+#
+# Kalmyk counts in two plural categories, `one` and `other`, and a noun after a
+# numeral stays singular, so the two branches of every `{ $count -> … }` below
+# differ in nothing but the number they print.
+
+
+## Answer submission
+
+answer-checking = Шинҗлгдҗәнә…
+answer-submitting = Илгәгдҗәнә…
+
+answer-checking-status = Хәрү шинҗлгдҗәнә
+answer-submitting-status = Хәрү илгәгдҗәнә
+
+answer-correct = Зөв
+answer-incorrect = Буру
+
+answer-response-saved = Хәрү хадһлгдв
+
+answer-percent-credit = { $percent }% балл
+answer-percent-correct = { $percent }% зөв
+answer-percent-short = { $percent } %
+
+max-credit-available = Авч болх хамгин ик балл: { $percent }%
+
+attempts-remaining =
+    { $count ->
+        [0] эрлһн үлдсн уга
+        [one] { $count } эрлһн үлдв
+       *[other] { $count } эрлһн үлдв
+    }
+
+validation-correct = (Зөв)
+validation-incorrect = (Буру)
+validation-partially-correct = (Хүвәр зөв)
+
+answer-show-responses =
+    { $count ->
+        [one] { $answerId } деер { $count } хәрү үзүлх
+       *[other] { $answerId } деер { $count } хәрү үзүлх
+    }
+
+
+## Disclosure panels
+
+feedback-heading = Хәрү медәллт
+
+collapsible-click-to-open = (секхин төлә даргтн)
+collapsible-click-to-close = (хаахин төлә даргтн)
+
+collapsible-initializing = Белдгдҗәнә…
+
+footnote-show = Темдг үзүлх
+footnote-hide = Темдг нүүх
+
+description-more-information = немр медәлл
+
+
+## Controls
+
+slider-previous = Өмнк
+slider-next = Дару
+
+keyboard-open = Клавиатур секх
+keyboard-close = Клавиатур хаах
+
+choice-input-remove-choice = { $choice } суңһврыг уга кех
+
+matrix-remove-row = Мөр уга кех
+matrix-add-row = Мөр немх
+matrix-remove-column = Багана уга кех
+matrix-add-column = Багана немх
+
+subset-add-remove-points = Цег немх/уга кех
+subset-toggle-points-intervals = Цегүд болн зәәс сольх
+subset-move-points = Цегүдиг нүүлһх
+subset-clear = Цеврлх
+
+orbital-add-row = Мөр немх
+orbital-remove-row = Мөр уга кех
+orbital-add-box = Нүкн немх
+orbital-remove-box = Нүкн уга кех
+orbital-add-up-arrow = Өөдән сумн немх
+orbital-add-down-arrow = Дор сумн немх
+orbital-remove-arrow = Сумн уга кех
+
+orbital-row-label = { $row } мөрин темдг
+
+pretzel-answer = Хәрү
+
+summary-statistics-caption = { $column } баганан дүңцүлгч статистик
+
+
+## Math input
+
+math-input-preview-region = математическ илдкврин урдаснь үзлт
+math-input-preview = Урдаснь үзлт
+math-input-invalid-expression = Буру илдквр:
+
+
+## Document status
+
+viewer-initializing = Белдгдҗәнә…
+
+
+## Errors
+
+error-heading = Эндү
+
+error-found-at =
+    { $span ->
+        [line] Олгдсн мөр: { $startLine }.
+       *[lines] Олгдсн мөрмүд: { $startLine }–{ $endLine }.
+    }
+
+document-contains-errors = Эн бичгт эндүс бәәнә!
+
+diagnostic-heading-error = Эндү
+diagnostic-heading-warning = Селвг
+diagnostic-heading-information = Медәлл
+diagnostic-heading-hint = Зәәсн
+
+accessibility-heading-level-1 = WCAG AA күрх аргин эвдлт
+accessibility-heading-level-2 = Күрх аргин тускар медәлл
+
+something-went-wrong = Юмн буру болв.
+
+renderer-load-failed = зурачиг ачлҗ чадсн уга. Халхциг шинрүлтн.
+
+core-start-failed = Бичг үзгчиг эклҗ чадсн уга. Халхциг шинрүлтн.

--- a/packages/i18n/locales/xal/content.ftl
+++ b/packages/i18n/locales/xal/content.ftl
@@ -1,0 +1,260 @@
+# Kalmyk content catalog: the prose the core computes into the document.
+# Selected by `documentLocale` — the language the activity was written in.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Written in Cyrillic with Kalmyk's own ә, ө, ү, җ, ң and һ, which is the
+# orthography Kalmykia's schools and publishing use and what CLDR fills a bare
+# `xal` in as. Todo bichig — the Clear Script — is Kalmyk's historic
+# orthography and is still written; if it is ever seeded it is an `xal-Mong`
+# catalog beside this one rather than a rename of it, which is the answer
+# `locales/sr` and `locales/az` already give to a script asymmetry.
+#
+# THIS IS THE LEAST CERTAIN CATALOG IN ITS BATCH, and a speaker should read it
+# before the other eleven. Kalmyk is the most endangered language seeded here —
+# UNESCO lists it as definitely endangered, its written output is small, and
+# this seed had markedly less of it to draw on than it had Buryat, its nearest
+# relative in this batch. Kalmyk orthography also drops unstressed vowels that
+# Buryat and Mongolian write, so a word that looks like a typo beside
+# `locales/bua` may well be correct here and vice versa — that is exactly the
+# class of error this seed is least able to check. `locales/lom` set the
+# precedent for saying so in a file's own header rather than leaving a reader
+# to discover it.
+#
+# Kalmyk has no grammatical gender and does not inflect an attributive
+# adjective, so `$gender` and `$role` go unused, as everywhere else in this
+# batch but `locales/ce`.
+
+
+## Style vocabulary
+
+color =
+    .black = хар
+    .white = цаһан
+    .gray = бор
+    .red = улан
+    .orange = улашар
+    .yellow = шар
+    .green = ноһан
+    .cyan = цегән көк
+    .blue = көк
+    .purple = ниил яһан
+    .pink = яһан
+    .brown = хүрң
+
+line-width =
+    .thick = зузан
+    .thin = нимгн
+
+line-style =
+    .dashed = тасрха
+    .dotted = цегтә
+
+# Noun phrases: they stand in front of «кеермжтә» and modify nothing.
+fill-style =
+    .horizontal = хөндлң зурас
+    .vertical = босх зурас
+    .diagonal = диагональ зурас
+    .backdiagonal = өөрхә диагональ зурас
+    .dots = цег
+    .diamonds = ромб
+
+noun =
+    .line = шулун зурас
+    .line-segment = хәәрцг
+    .ray = сарул
+    .vector = вектор
+    .curve = мурул зурас
+    .function = функц
+    .parabola = парабол
+    .polyline = хуһрсн зурас
+    .polygon = олн талта
+    .triangle = һурвлҗн
+    .rectangle = шулун дөрвлҗн
+    .circle = төөрг
+    .region = һазр
+    .point = цег
+    .square = дөрвлҗн
+    .diamond = ромб
+    .cross = крест
+    .plus = плюс
+
+# Kalmyk builds the word from the side count in front of the noun, so the whole
+# of it is one head and there is no tail.
+noun-regular-polygon =
+    { $part ->
+        [tail] { "" }
+       *[head] дүңцү { $numSides } талта
+    }
+
+# Kalmyk has no grammatical gender, so every noun answers the same and the
+# answer goes unused.
+noun-gender = neuter
+
+
+## Style composition
+
+style-stroke =
+    { $parts ->
+        [width-style-color] { $width } { $lineStyle } { $color }
+        [width-color] { $width } { $color }
+        [style-color] { $lineStyle } { $color }
+        [width-style] { $width } { $lineStyle }
+        [width] { $width }
+        [style] { $lineStyle }
+       *[color] { $color }
+    }
+
+style-with-noun =
+    { $parts ->
+        [noun-tail] { $description } { $noun } { $nounTail }
+       *[noun] { $description } { $noun }
+    }
+
+style-filled-word = буддгсн
+
+style-filled =
+    { $parts ->
+        [pattern] { $pattern } кеермжтә { $color } { $filled }
+       *[plain] { $color } { $filled }
+    }
+
+style-filled-with-noun =
+    { $parts ->
+        [pattern] { $pattern } кеермжтә { $color } { $filled } { $noun }
+        [plain-tail] { $color } { $filled } { $noun } { $nounTail }
+        [pattern-tail] { $pattern } кеермжтә { $color } { $filled } { $noun } { $nounTail }
+       *[plain] { $color } { $filled } { $noun }
+    }
+
+# «кеҗгтә» — "having an edge" — carries the "with a border" sense in its own
+# suffix, so neither a preposition nor an article is wanted.
+style-border-clause =
+    { $parts ->
+        [with-article] { $border } кеҗгтә
+        [and] болн { $border } кеҗгтә
+        [and-article] болн { $border } кеҗгтә
+       *[with] { $border } кеҗгтә
+    }
+
+style-fill =
+    { $parts ->
+        [pattern] { $pattern } кеермжтә { $color } буд
+       *[plain] { $color } буд
+    }
+
+style-unfilled = буддго
+
+# «деер» — "on top of" — is a postposition and follows the background colour,
+# so nothing stands between the two words.
+style-text =
+    { $parts ->
+        [background] { $background } ора деер { $color }
+       *[plain] { $color }
+    }
+
+style-background-none = уга
+
+
+## Boolean words
+
+boolean-true = үнн
+boolean-false = худл
+
+
+## Answer buttons
+
+answer-submit-label = Шинҗлх
+answer-submit-label-no-correctness = Хәрүг илгәх
+
+
+## Sectional blocks
+
+section-name =
+    .activity = Күцәмҗ
+    .aside = Хаҗу темдг
+    .cascade = Каскад
+    .definition = Тодрхлт
+    .example = Үзмҗ
+    .exercise = Дасхлт
+    .exercises = Дасхлтс
+    .given-answer = Хәрү
+    .note = Темдг
+    .objectives = Күслс
+    .paragraphs = Абзацс
+    .part = Хүв
+    .problem = Бодлһн
+    .problems = Бодлһнс
+    .proof = Батлвр
+    .question = Сурвр
+    .section = Бөлг
+    .solution = Шиидвр
+    .task = Даалһвр
+    .theorem = Теорем
+
+section-title-prefix =
+    { $parts ->
+        [name] { $sectionName }
+        [number] { $sectionNumber }
+        [name-title] { $sectionName }{ ". " }
+        [number-title] { $sectionNumber }{ ". " }
+        [name-number-title] { $sectionName } { $sectionNumber }{ ". " }
+       *[name-number] { $sectionName } { $sectionNumber }
+    }
+
+hint-title = Зәәсн
+
+
+## Tables and figures
+
+table-name =
+    { $parts ->
+        [numbered] Хүсңт { $enumeration }
+        [numbered-title] Хүсңт { $enumeration }{ ". " }
+        [unnumbered-title] Хүсңт{ ". " }
+       *[unnumbered] Хүсңт
+    }
+
+figure-name =
+    { $parts ->
+        [numbered] Зург { $enumeration }
+        [numbered-caption] Зург { $enumeration }{ ". " }
+        [unnumbered-caption] Зург{ ". " }
+       *[unnumbered] Зург
+    }
+
+
+## Paginator controls
+
+paginator-previous = Өмнк
+paginator-next = Дару
+paginator-page = Халхц
+
+paginator-page-status = { $pageLabel } { $currentPage } / { $numPages }
+
+
+## Piecewise functions
+##
+## Kalmyk's conditional «кемр» is clause-initial, as Buryat's «хэрбээ» is, so
+## this key lands where the renderer puts it — unlike `locales/sah` and
+## `locales/tyv`, which record a limit here.
+
+piecewise-condition-or = эсвл
+piecewise-condition-if = кемр
+piecewise-condition-otherwise = нань бәәдлд
+
+
+## Chemistry
+##
+## `element-name` and `element-anion-name` are deliberately left out, so their
+## 130 keys fall back to English. Secondary chemistry in Kalmykia is taught in
+## Russian, so the element names a Kalmyk-speaking pupil meets are the Russian
+## ones — the school-system case this batch shares throughout, and here with an
+## extra reason on top of it: this catalog's own header explains why 118
+## unreviewed coinages would be the least defensible thing in it.
+
+ion-name-oxidation-state = { $name } ({ $numeral })
+
+chemistry-invalid-symbol = Буру химическ темдг
+chemistry-invalid-ionic-compound = Буру ионы ниилвр

--- a/packages/i18n/locales/xal/diagnostics.ftl
+++ b/packages/i18n/locales/xal/diagnostics.ftl
@@ -1,0 +1,657 @@
+# Kalmyk diagnostics. Translated from `locales/en/diagnostics.ftl`, which is
+# the source of truth: `lint:i18n` rejects a key that does not exist there, and
+# reports a key that exists there but not here as missing coverage.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Read the confidence note at the top of `content.ftl` before this file: this
+# is the least certain catalog in its batch, and this is its longest file.
+#
+# Attribute names, element names and every other DoenetML identifier —
+# `through`, `endpoint`, `midpointOffset`, `numDimensions`, `<answer>`,
+# `selectFromSequence` — are part of the language, not prose, and stay in
+# English exactly as written. So does anything quoted back from the author's
+# own source.
+#
+# The technical nouns are the Russian ones, which is what written Kalmyk uses
+# for them: «компонент», «атрибут», «функц», «индекс».
+
+
+## `<lineSegment>`
+
+line-segment-attributes-ignored-with-endpoints =
+    { $attributesCount ->
+        [one] хойр үзүрин цег зааврлгдсн цагт { $attributes } тооллго уга
+       *[other] хойр үзүрин цег зааврлгдсн цагт { $attributes } тооллго уга
+    }
+
+line-segment-attributes-ignored-with-endpoint-and-midpoint =
+    { $attributesCount ->
+        [one] үзүрин цег болн дунд цег хойрулн зааврлгдсн цагт { $attributes } тооллго уга
+       *[other] үзүрин цег болн дунд цег хойрулн зааврлгдсн цагт { $attributes } тооллго уга
+    }
+
+line-segment-midpoint-offset-without-midpoint = дунд цег уга midpointOffset юмнд нөлөлхш
+
+## `<line>`
+
+line-points-undetermined-dimensions = Кемҗән медгддго цегүдәр һардг шулун зурас.
+
+line-points-too-few-dimensions = Шулун зурас яһад чигн хойр кемҗәтә цегүдәр һарх зөвтә.
+
+line-points-depend-on-variables = Шулун зурас хүврдг кемҗәс дүңгәдг цегүдәр һарна: { $variables }.
+
+line-equation-invalid-format = { $variable1 } болн { $variable2 } хүврдг кемҗәстә шулун зурасин әдллтин формат буру.
+
+## `<ray>`
+
+ray-overprescribed-through = Сарул through, endpoint болн direction деегүр өггдв. Өггдсн through тооллго уга.
+
+ray-dimension-mismatch = сарул деер numDimensions таарлго уга.
+
+## `<vector>`
+
+vector-overprescribed-head = Вектор head, tail болн displacement деегүр өггдв. Өггдсн head тооллго уга.
+
+vector-dimension-mismatch = вектор деер numDimensions таарлго уга.
+
+## Attracting and constraining
+
+attract-to-without-nearest-point = `<{ $component }>` элемент тал татҗ чадшго, юңгад гихлә түүнд nearestPoint бәәдлин хүврдг кемҗән уга.
+
+constrain-to-without-nearest-point = `<{ $component }>` элементәр хәәкрлҗ чадшго, юңгад гихлә түүнд nearestPoint бәәдлин хүврдг кемҗән уга.
+
+constrain-to-interior-without-nearest-point = `<{ $component }>` элементин дотркарнь хәәкрлҗ чадшго, юңгад гихлә түүнд nearestPoint бәәдлин хүврдг кемҗән уга.
+
+## `<choiceInput>`
+
+choice-input-label-position-ignored = мөр дотрк биш choiceInput деер labelPosition тооллго уга
+
+## Ordering children by index
+
+choice-input-indices-count-mismatch = choiceInput деер өггдсн индексүд тооллго уга, юңгад гихлә теднә то choice үрдин тод таарлго уга.
+
+pretzel-indices-count-mismatch = problem деер өггдсн индексүд тооллго уга, юңгад гихлә теднә то problem үрдин тод таарлго уга.
+
+shuffle-indices-count-mismatch = shuffle деер өггдсн индексүд тооллго уга, юңгад гихлә теднә то компонентмүдин тод таарлго уга.
+
+indices-ignored-out-of-range = { $component } деер өггдсн индексүд тооллго уга, юңгад гихлә зәрмнь кемҗәһәс һарна.
+
+pretzel-indices-repeated = pretzel деер өггдсн индексүд тооллго уга, юңгад гихлә зәрмнь давтгдна.
+
+pretzel-circuit-first-index = circuit бәәдлд pretzel деер өггдсн индексүд тооллго уга, юңгад гихлә түрүн индекс 1 болх зөвтә.
+
+## `<shuffle>` and `<sort>`
+
+string-children-need-type = `<{ $component }>` текстин үрдтә көдлхин төлә `type` атрибут өггдх зөвтә.
+
+invalid-type-defaulting-to-math = { $component } компонентд буру зүсн { $type }. Тер math, text, number эсвл boolean болх зөвтә. math олзлгдна.
+
+string-not-valid-component-to-arrange = «{ $value }» мөр { $component } деер таармҗта компонент биш. Тооллго уга.
+
+## Types and variables
+
+invalid-type-defaulting-to-number = Буру зүсн { $type }, зүснь number болһгдна.
+
+invalid-variable-value = Хүврдг кемҗәнә буру утх: `{ $value }`
+
+## Variants
+
+variant-index-must-be-number = { $index } вариантин индекс то болх зөвтә
+
+variant-index-must-be-integer = { $index } вариантин индекс бүклә то болх зөвтә
+
+## `<sideBySide>`
+
+side-by-side-absolute-widths = `<{ $component }>` абсолют кемҗәст кегдсн уга. Өргнднь дүңцүлгч болна.
+
+side-by-side-absolute-margins = `<{ $component }>` абсолют кемҗәст кегдсн уга. Кеҗгүднь дүңцүлгч болна.
+
+side-by-side-no-block-child = Буру `<{ $component }>`: түүнд яһад чигн негн блок үрн бәәх зөвтә.
+
+## `<label>`
+
+label-for-ignored-on-graphical = График `<label>` элемент деерк `for` атрибут тооллго уга.
+
+label-for-must-resolve-to-one = `<label>` элемент деерк `for` атрибут яһ негн компонент деер заах зөвтә.
+
+label-for-unresolved = `<label>` элемент деерк `for` атрибутиг компоненттә залһҗ чадсн уга.
+
+label-for-answer-with-authored-inputs = `<label>` элемент деерк `for` атрибут автор бичсн орулһна һазрмудта `<answer>` деер заана; һазр деер шуд заатн.
+
+label-for-answer-without-input = `<label>` элемент деерк `for` атрибут темдглх орулһна һазр уга `<answer>` деер заана.
+
+label-for-must-reference-input-or-answer = `<label>` элемент деерк `for` атрибут орулһна һазр эсвл хәрү деер заах зөвтә.
+
+## Accessibility
+
+accessibility-short-description-or-decorative = Күрх аргин төлә `<{ $component }>` эсвл ахр тәәлвртә болх, эсвл кеермҗ гиҗ темдглгдх зөвтә.
+
+accessibility-video-short-description = Күрх аргин төлә `<video>` ахр тәәлвртә болх зөвтә.
+
+accessibility-input-short-description-or-label = Күрх аргин төлә `<{ $component }>` ахр тәәлвртә эсвл темдгтә болх зөвтә.
+
+accessibility-answer-input-short-description-or-label = Күрх аргин төлә орулһна һазр кедг `<answer>` ахр тәәлвртә эсвл темдгтә болх зөвтә.
+
+accessibility-short-description-contains-math = Ахр тәәлврмүдт `<{ $component }>` мет математическ компонентмүд бәәх зөв уга. Математикиг үгәр бичтн.
+
+accessibility-section-title-insufficient-contrast =
+    { $mode ->
+        [dark] { $colorName } бөлгин толһан текстд күрх контраст өгчәхш (харңһу зүсн) ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яһад чигн { $threshold }:1 кергтә).
+       *[other] { $colorName } бөлгин толһан текстд күрх контраст өгчәхш ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яһад чигн { $threshold }:1 кергтә).
+    }
+
+## `<circle>`
+
+circle-through-points-non-numerical = Цегүдин тоота утх уга цагт { $count } цегәр һардг `<circle>` кегдсн уга.
+
+circle-too-many-through-points = 3-ас олн цегәр һардг төөрг тоолҗ чадшго.
+
+circle-overprescribed-radius-center-points = Өггдсн радиус, төв болн цегүдтә төөрг тоолҗ чадшго.
+
+circle-center-with-multiple-points = Өггдсн төвтә 1-әс олн цегәр һардг төөрг тоолҗ чадшго.
+
+circle-radius-too-small = Төөрг тоолҗ чадшго: хойр цегин хоорнд зәә { $distance } болхла, өггдсн радиус { $radius } үлү бичкн.
+
+circle-radius-with-many-points = Өггдсн радиустта хойрас олн цегәр һардг төөрг кеҗ чадшго.
+
+circle-invalid-center-or-through-points = Төөргин төв эсвл цегүднь буру.
+
+circle-radius-center-with-multiple-points = Өггдсн төвтә 1-әс олн цегәр һардг төөргин радиус тоолҗ чадшго.
+
+circle-change-radius-non-numerical = Тоота биш цегүдтә төөргин радиус хүврүлҗ чадшго
+
+circle-radius-with-points-non-numerical = Тоота утх уга цагт өггдсн радиустта негәс олн цегәр һардг төөрг кеҗ чадшго.
+
+circle-change-center-non-numerical = Тоота биш цегүдәр һардг төөргин төв хүврүлх кегдсн уга.
+
+## `<function>`
+
+function-domain-insufficient-dimensions =
+    { $intervals ->
+        [one] Функцин тодрхлгддг һазрин кемҗән күрчәхш. Һазрт { $intervals } зәә бәәнә, харм функцд { $inputs ->
+            [one] { $inputs } орулт
+           *[other] { $inputs } орулт
+        } бәәнә.
+       *[other] Функцин тодрхлгддг һазрин кемҗән күрчәхш. Һазрт { $intervals } зәә бәәнә, харм функцд { $inputs ->
+            [one] { $inputs } орулт
+           *[other] { $inputs } орулт
+        } бәәнә.
+    }
+
+function-domain-invalid-format = Функцин тодрхлгддг һазрин формат буру.
+
+function-ignoring-non-numerical =
+    { $type ->
+        [maximum] Функцин тоота биш максимум тооллго уга.
+        [minimum] Функцин тоота биш минимум тооллго уга.
+        [extremum] Функцин тоота биш экстремум тооллго уга.
+        [point] Функцин тоота биш цег тооллго уга.
+        [slope] Функцин тоота биш хәләц тооллго уга.
+       *[other] Функцин тоота биш { $type } утх тооллго уга.
+    }
+
+function-ignoring-empty =
+    { $type ->
+        [maximum] Функцин хоосн максимум тооллго уга.
+        [minimum] Функцин хоосн минимум тооллго уга.
+        [extremum] Функцин хоосн экстремум тооллго уга.
+        [point] Функцин хоосн цег тооллго уга.
+       *[other] Функцин хоосн { $type } утх тооллго уга.
+    }
+
+function-points-too-close = Функцд эн-теркәһән үлү өөрхн хойр цег бәәнә. Функц тодрхлҗ чадшго.
+
+function-iterates-input-output-mismatch =
+    { $inputs ->
+        [one] Функцин итерацс орултын то һарлтын тод әдл болхла болна. Эн функцд { $inputs } орулт болн { $outputs ->
+            [one] { $outputs } һарлт
+           *[other] { $outputs } һарлт
+        } бәәнә.
+       *[other] Функцин итерацс орултын то һарлтын тод әдл болхла болна. Эн функцд { $inputs } орулт болн { $outputs ->
+            [one] { $outputs } һарлт
+           *[other] { $outputs } һарлт
+        } бәәнә.
+    }
+
+## `<sequence>`
+
+sequence-invalid-length = Дарандын ут буру. Тер сөрг биш бүклә то болх зөвтә.
+
+sequence-invalid-step = Дарандын ишк буру. { $type } зүстә дарандд тер то болх зөвтә.
+
+sequence-invalid-endpoint-number = Тоота дарандын «{ $attribute }» утх буру. Тер то болх зөвтә.
+
+sequence-invalid-endpoint-letters = Үзгин дарандын «{ $attribute }» утх буру. Тер үзгүдин ниилвр болх зөвтә.
+
+sequence-invalid-endpoint = Дарандын «{ $attribute }» утх буру.
+
+select-from-sequence-coprime-not-numbers = тос суңһгдсн угаһар coprime тооллго уга
+
+select-from-sequence-coprime-with-exclude-combinations = excludeCombinations өггдсн учрар coprime тооллго уга
+
+## Resolving a `target`
+
+target-not-found = `<{ $source }>` деер буру target: күсл олгдсн уга.
+
+target-state-variable-not-found = `<{ $source }>` деер буру target: `<{ $component }>` элемент деер «{ $property }» нертә бәәдлин хүврдг кемҗән олгдсн уга.
+
+## `<odeSystem>`
+
+ode-system-variables-match-independent = `<odeSystem>` хүврдг кемҗәснь дүңгәлго кемҗәһәс талдан болх зөвтә.
+
+ode-system-duplicate-variable-names = Дүңгәдг кемҗәсин нерд давтгдсн цагт ДТ барун талын функцс тодрхлҗ чадшго.
+
+ode-system-rhs-function-error = ДТ барун талын функц тодрхлҗ чадшго. mathjs функц кехд эндү.
+
+## `<angle>`, `<parabola>`, and `<intersection>`
+
+angle-too-many-lines = { $count } шулун зурасин хоорнд булң тодрхлҗ чадшго
+
+angle-invalid-through-point = `<angle>` элементин through утхд буру цег
+
+parabola-vertex-too-many-points = Өггдсн орьятта 1-әс олн цегәр һардг парабол кегдсн уга.
+
+parabola-too-many-points = 3-ас олн цегәр һардг парабол кегдсн уга.
+
+intersection-too-many-items = Хойрас олн объектин хәрлцлһн кегдсн уга
+
+## Other math components
+
+ionic-compound-not-two-ions = Хойр ионас талдан ионы ниилвр кегдсн уга.
+
+ionic-compound-needs-cation-and-anion = Ионы ниилвр негн катион болн негн анионд л кегдсн.
+
+solve-equations-cannot-evaluate = Әдллт шиидҗ чадшго, юңгад гихлә түүг тоолҗ чадсн уга: { $equation }
+
+math-operators-operand-number-required = Математическ операнд салһхин төлә operandNumber өггдх зөвтә.
+
+eigen-decomposition-failed = Матрицин эврә утх тоолҗ чадсн уга
+
+## `<matchesPattern>`
+
+matches-pattern-parameter-not-in-pattern =
+    { $parametersCount ->
+        [one] `<matchesPattern>`: { $parameters } параметр үлгүрт таарлго уга, тиигәд тер даңгин хоосн деер таарна.
+       *[other] `<matchesPattern>`: { $parameters } параметрмүд үлгүрт таарлго уга, тиигәд тедн даңгин хоосн деер таарна.
+    }
+
+## `<graph>`
+
+graph-grid-invalid = `<graph>`: grid="{ $grid }" утх медҗ чадшго. Тер none, medium, dense эсвл хоосн зәәһәр салһгдсн хойр эерг то болх зөвтә, чиг grid="1 0.5". Тор зурлго уга.
+
+## PreFigure renderer
+
+prefigure-x-label-position-unsupported = `<graph>`: prefigure зурач деер xLabelPosition="left" кегдсн уга; барун талын бәәрллт олзлгдна.
+
+prefigure-y-label-position-unsupported = `<graph>`: prefigure зурач деер yLabelPosition="bottom" кегдсн уга; деед талын бәәрллт олзлгдна.
+
+prefigure-invalid-axis-bounds = `<graph>`: prefigure хүврлтд тэңгин кеҗгүд буру; ул bbox (-10,-10,10,10) олзлгдна.
+
+prefigure-invalid-width = `<graph>`: prefigure хүврлтд өргн буру; диаграмин ул өргн 425 олзлгдна.
+
+prefigure-invalid-aspect-ratio = `<graph>`: prefigure хүврлтд aspectRatio буру; ул талсин харһлт 1 олзлгдна.
+
+prefigure-grid-spacing-too-fine = `<graph>`: торин ишк тэңгин кеҗгүдт үлү нәрхн; prefigure зурач деер тор һарһгдхш.
+
+prefigure-annotations-not-rendered = `<graph>`: PreFigure зурач олзлгдсн угаһар темдгүд зурлго уга.
+
+multiple-annotations-children = `<graph>` дотр кесг `<annotations>` үрн олгдв; хөөтхәс талданнь тооллго уга.
+
+## Referring to other components
+
+copy-unrecognized-component-type = Таньгдсн уга компонентин зүсн өргҗүлҗ эсвл көчүлҗ чадшго: { $type }.
+
+copy-prop-not-found = { $component } зүстә компонент деер { $property } чинр олгдсн уга
+
+collect-no-source = collect деер уңг олгдсн уга.
+
+collect-invalid-component-type = `<{ $component }>` зүстә компонентмүд цуглулҗ чадшго, юңгад гихлә эн буру компонентин зүсн.
+
+reference-index-unavailable = `{ $reference }` индекс деер заавр кеҗ чадшго
+
+## `<callAction>`
+
+component-action-unavailable = `{ $reference }` компонент деер { $action } дуудҗ чадшго
+
+## `<dataFrame>`
+
+data-frame-inconsistent-row-lengths = Медәлин хевнь буру. Мөрмүдин утнь ниг биш. Олгдв componentIdx :{ $componentIdx }
+
+data-frame-duplicate-column-names = Медәлд баганан нерд давтгдна. Олгдв componentIdx :{ $componentIdx }
+
+data-frame-missing-column-name = Медәлд баганан нерн дутна. Олгдв componentIdx :{ $componentIdx }
+
+## `<answer>` and scoring
+
+answer-award-depends-on-own-response = Эн хәрүһин award утх answer тегин эврә илгәгдсн хәрү деер тулна, эн күләгдсн уга бәәдлд күргнә.
+
+answer-max-num-attempts-in-section-wide-check-work = `sectionWideCheckWork` бәәх контейнер дотрк `<answer>` деер `maxNumAttempts` тәвлһн нөлөлхш, юңгад гихлә эрлһнә то контейнер тодрхлна. `maxNumAttempts` утх контейнер деер тәвтн.
+
+nested-section-wide-check-work-max-num-attempts = Талдан `sectionWideCheckWork` контейнер дотр бәәх `sectionWideCheckWork` контейнер деер `maxNumAttempts` тәвлһн нөлөлхш, юңгад гихлә эрлһнә то һаза контейнер тодрхлна. `maxNumAttempts` утх һаза контейнер деер тәвтн.
+
+answer-attributes-need-symbolic-equality =
+    { $attributesCount ->
+        [one] symbolicEquality тәвгдсн угаһар { $attributes } атрибут нөлөлшго.
+       *[other] symbolicEquality тәвгдсн угаһар { $attributes } атрибутмуд нөлөлшго.
+    }
+
+answer-invalid-type = answer деер буру зүсн: { $type }
+
+## `<module>`, `<conditionalContent>`, `<slider>`, `<pretzel>`
+
+module-attribute-child-needs-name = `<{ $component }>` компонентин нерн угаһар түүг модулин атрибут болһҗ олзлҗ чадшго
+
+module-attribute-name-already-defined = `<{ $component } name="{ $name }">` компонент модулин атрибут болһҗ олзлҗ чадшго, юңгад гихлә `<module>` компонентин зүснд «{ $name }» атрибут эрт тодрхлгдсн.
+
+conditional-content-condition-ignored = case эсвл else үрдтә `<conditionalContent>` компонент деер `condition` атрибут тооллго уга.
+
+slider-markers-type-mismatch = Маркермүдин зүсн гүлгүрин зүснд таарлго уга.
+
+pretzel-problem-needs-statement-and-answer = Буру pretzel: `<problem>` болһн негн `<statement>` болн негн `<answer>` багтах зөвтә.
+
+pretzel-circuit-first-problem-distractor = Буру pretzel: mode="circuit" бәәдлд түрүн `<problem>` оньгиг хаҗулгч болҗ чадшго.
+
+## Attribute values
+
+attribute-invalid-values =
+    { $valuesCount ->
+        [one] `{ $attribute }` атрибут деер буру утх { $values }; тооллго уга.
+       *[other] `{ $attribute }` атрибут деер буру утхс { $values }; тооллго уга.
+    }
+
+attribute-must-be-references = `{ $attribute }` атрибут деер буру утх `{ $value }`. Атрибут `$` темдгәс эклдг зааврас тогтх зөвтә.
+
+math-input-invalid-function-names = <mathInput>: { $attribute } дотрк буру функцин нерд тооллго уга: { $names }. Нерн болһна үзгддг хүвнь яһад чигн 2 темдг болх зөвтә (үзгүд эсвл зурас); терүнә хөөн кергтә биш `|<mathspeak альтернатив>` немлт ирҗ чадна.
+
+## Building components from the source
+
+component-type-invalid = Буру компонентин зүсн: `<{ $componentType }>`
+
+attribute-repeated = { $attribute } атрибут давтҗ чадшго.
+
+attribute-invalid-for-component = `<{ $componentType }>` зүстә компонентд буру атрибут «{ $attribute }».
+
+## Style definition contrast
+
+style-definition-insufficient-contrast =
+    { $styleNumber } стилин тодрхлтд { $context ->
+        [text-on-background] текстин өңг болн ора өңг
+        [high-contrast] ик контрасттта өңг болн зургин һазр
+        [line] зурасин өңг болн зургин һазр
+        [marker] маркерин өңг болн зургин һазр
+       *[text-on-canvas] текстин өңг болн зургин һазр
+    } хоорндк контраст күрчәхш{ $mode ->
+        [dark] { " (харңһу зүсн)" }
+       *[light] { "" }
+    } ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яһад чигн { $threshold }:1 кергтә).
+
+style-definition-dark-mode-text-background-contrast =
+    { $styleNumber } стилин тодрхлтд өггдсн өңгүд герлтә зүснд күрх контраст өгсн бийнь, теднәс һарсн харңһу зүснә өңгүд текст болн ора хоорнд күрх контраст өгчәхш ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яһад чигн { $threshold }:1 кергтә). { $suggestion ->
+        [available] Харңһу зүснд күрх контрастын төлә эсвл герлтә зүснә контраст икдүлтн (чиг { $lightAttribute }="{ $lightColor }"), эсвл харңһу зүснә өңг сольтн (чиг { $darkAttribute }="{ $darkColor }").
+       *[none] Харңһу зүснд күрх контрастын төлә герлтә зүснә контраст икдүлтн эсвл һарсн өңгүдиг textColorDarkMode болн/эсвл backgroundColorDarkMode-ар сольтн.
+    }
+
+style-definition-dark-mode-text-canvas-contrast =
+    { $styleNumber } стилин тодрхлтд өггдсн текстин өңг герлтә зүснд күрх контраст өгсн бийнь, түүнәс һарсн харңһу зүснә текстин өңг зургин һазрта күрх контраст өгчәхш ({ NUMBER($ratio, minimumFractionDigits: 2, maximumFractionDigits: 2) }:1; яһад чигн { $threshold }:1 кергтә). { $suggestion ->
+        [available] Харңһу зүснд күрх контрастын төлә эсвл герлтә зүснә контраст икдүлтн (чиг textColor="{ $lightColor }"), эсвл харңһу зүснә өңг сольтн (чиг textColorDarkMode="{ $darkColor }").
+       *[none] Харңһу зүснд күрх контрастын төлә герлтә зүснә контраст икдүлтн эсвл һарсн өңг textColorDarkMode-ар сольтн.
+    }
+
+section-multiple-style-palettes = Бөлг негн л <stylePalette> суңһҗ чадна; хөөтнь олзлгдна.
+
+## Unique variants
+
+variant-num-to-select-not-non-negative-integer = { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә numToSelect сөрг биш бүклә то биш.
+
+variant-num-to-select-not-constant-number = { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә numToSelect тогтмл то биш.
+
+variant-with-replacement-not-constant-boolean = { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә withReplacement тогтмл логическ утх биш.
+
+variant-select-weight-disables-unique = ямаран нег суңһврт selectWeight эсвл selectForVariants өггдсн болхла, select деер давтгдшго вариантс хаагдна
+
+variant-coprime-undetermined = { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә coprime даңгин худл болҗахинь тодрхлҗ чадшго.
+
+variant-attribute-not-constant = { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә { $attribute } тогтмл биш.
+
+variant-attribute-not-number = { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә { $attribute } то биш.
+
+variant-attribute-wrong-type-for-sequence =
+    { $type } зүстә { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә { $attribute } { $expected ->
+        [letters-combination] үзгүдин ниилвр
+        [math-expression] таармҗта математическ илдквр
+        [integer] бүклә то
+       *[number] то
+    } биш.
+
+variant-length-not-integer = { $component } деер давтгдшго вариантс тодрхлҗ чадшго, юңгад гихлә length бүклә то биш.
+
+variant-sort-not-implemented = sort бәәх { $component } деер давтгдшго вариантс кегдсн уга
+
+variant-exclude-combinations-not-implemented = excludeCombinations бәәх { $component } деер давтгдшго вариантс кегдсн уга
+
+variant-math-exclude-not-implemented = exclude бәәх math зүстә { $component } деер давтгдшго вариантс кегдсн уга
+
+variant-non-constant-exclude-not-implemented = тогтмл биш exclude бәәх { $component } деер давтгдшго вариантс кегдсн уга
+
+## PreFigure conversion
+
+prefigure-descendant-unsupported = { $subject }: графикин prefigure зурач деер кегдсн уга; үлдл хайгдв.
+
+prefigure-descendant-invalid-geometry = { $subject }: төгсшго эсвл дүүрң биш геометр; үлдл хайгдв.
+
+prefigure-curve-label-omitted = { $subject }: хүврүлгдсн мурул элементмүд деер темдгүд кегдсн уга; темдг хайгдв.
+
+prefigure-curve-unsupported-definition-type = { $subject }: кегдсн уга мурул функцин тодрхлтын зүсн «{ $definitionType }»; үлдл хайгдв.
+
+prefigure-region-flip-functions-unsupported = { $subject }: regionBetweenCurves элемент деерк flipFunctions атрибут кегдсн уга; үлдл хайгдв.
+
+prefigure-region-non-formula-child = { $subject }: regionBetweenCurves формулар өггдсн үрн функцс л авна; үлдл хайгдв.
+
+prefigure-label-position-unsupported =
+    { $subject }: кегдсн уга labelPosition «{ $labelPosition }» { $labelKind ->
+        [line-family] зурасин өрк-бүлин темдгт
+       *[point] цегин темдгт
+    }; PreFigure-ин ул әдллһн олзлгдна.
+
+prefigure-fill-style-unsupported = { $subject }: дүүргһнә стиль «{ $fillStyle }» PreFigure деер кегдсн уга; дүүрң дүүргһн тал орна.
+
+prefigure-line-style-unknown = { $subject }: медгддго зурасин стиль «{ $lineStyle }» PreFigure-ин һарлтас уга кегдв.
+
+prefigure-marker-style-mapped-to-diamond = { $subject }: маркерин стиль «{ $markerStyle }» PreFigure-ин «diamond» стильд таарулгдв.
+
+prefigure-marker-style-unsupported = { $subject }: маркерин стиль «{ $markerStyle }» PreFigure деер кегдсн уга; ул стиль олзлгдна.
+
+## PreFigure annotations
+
+annotation-ref-unresolvable = `<annotation>`: буру `ref`; күсл залһҗ чадшго. Темдг уга кегдв.
+
+annotation-ref-multiple-targets = `<annotation>`: `ref` кесг күслтә залһгдв; түрүннь олзлгдна.
+
+annotation-ref-outside-graph = `<annotation>`: буру `ref`; күсл түүг багтадг графикас һаза. Темдг уга кегдв.
+
+annotation-ref-unsupported-target = `<annotation>`: буру `ref`; күсл prefigure хүврлтд кегдсн график объект биш. Темдг уга кегдв.
+
+annotation-text-missing = `<annotation>`: `text` уга эсвл хоосн; хоосн текст һарһгдна.
+
+## Composites and references
+
+composite-circular-dependency =
+    { $componentType ->
+        [none] Төөргтә дүңгәлт олгдв.
+       *[other] `<{ $componentType }>` компонент багтадг төөргтә дүңгәлт олгдв.
+    }
+
+reference-no-referent = Заавр деер объект олгдсн уга: `{ $reference }`
+
+reference-multiple-referents = Заавр деер кесг объект олгдв: `{ $reference }`
+
+## Children that do not match
+
+children-invalid-attribute-format = `<{ $componentType }>` элементин { $attribute } атрибутын формат буру.
+
+children-invalid = `<{ $componentType }>` деер буру үрд: буру үрд олгдв: { $children }
+
+## Falling back to a default
+
+attribute-value-invalid-using-default = `{ $attribute }` атрибут деер буру утх `{ $value }`; `{ $default }` утх олзлгдна
+
+## Loading a DoenetML version
+
+doenetml-version-not-found =
+    { $fallback ->
+        [none] DoenetML { $version } хүврлт олгдсн уга.
+       *[other] DoenetML { $version } хүврлт олгдсн уга. { $fallback } хүврлт олзлгдна
+    }
+
+## Reading the DoenetML
+
+parse-invalid-doenetml = Буру DoenetML: { $content }
+
+parse-tag-missing-close-tag = Буру DoenetML: `{ $tag }` тегин хаадг тег уга. Эврән хаагддг тег эсвл `</{ $tagName }>` тег күләгдсн.
+
+parse-tag-error = Буру DoenetML: `<{ $tagName }>` тегт эндү
+
+parse-attribute-missing-value = Буру DoenetML: `{ $attribute }` атрибут деер утх дутҗахла әдл.
+
+parse-attribute-invalid = Буру DoenetML: буру атрибут `{ $attribute }`
+
+parse-attribute-value-invalid = Буру DoenetML: атрибутын буру утх `{ $value }`
+
+parse-attribute-value-quote-mismatch = Буру DoenetML: атрибутын буру утх `{ $value }`. Хашлтс таарлго уга. `{ $quote }` дутҗахла әдл
+
+parse-open-tag-name-missing = Буру DoenetML: нерн уга тег олгдв, чиг `<`
+
+parse-tag-not-closed = Буру DoenetML: `{ $tag }` тег хаагдсн уга (`>` дутҗахла әдл).
+
+parse-self-closing-tag-name-missing = Буру DoenetML: нерн уга тег олгдв `<{ $content }>`
+
+parse-self-closing-tag-not-closed = Буру DoenetML: `{ $tag }` тег хаагдсн уга (`/>` дутҗахла әдл).
+
+parse-tag-invalid-attributes = Буру DoenetML: `{ $tag }` тег таармҗта биш. Түүнә атрибутмуд буру болҗ чадна.
+
+parse-close-tag-name-missing = Буру DoenetML: нерн уга хаадг тег олгдв, чиг `</`
+
+parse-attribute-value-unquoted = Атрибутын утхс хашлт дотр болх зөвтә: `{ $attribute }="{ $value }"`
+
+parse-close-tag-without-open-tag = Буру DoenetML: `{ $tag }` хаадг тег олгдв, болв түүнд таарх секдг тег уга
+
+parse-close-tag-mismatched = Буру DoenetML: таарлго уга хаадг тег. `</{ $expected }>` күләгдсн. `{ $found }` олгдв
+
+parser-node-unconvertible = { $node } зангилаг Dast зангила болһҗ хүврүлҗ чадсн уга.
+
+## Names
+
+name-attribute-invalid =
+    Буру атрибут name='{ $name }'. { $reason ->
+        [characters] Нерднд үзгүд, тос, дор зурас эсвл зурас л бәәҗ чадна.
+       *[start] Нерд үзгәс эклх зөвтә.
+    }
+
+component-name-invalid-start = Буру компонентин нерн «{ $name }». Нерд үзгәс эклх зөвтә.
+
+## `<answer>` sugar
+
+answer-video-watched-missing-video = videoWatched зүстә answer video атрибуттта болх зөвтә
+
+answer-video-watched-video-not-reference = videoWatched зүстә answer-ин video атрибут заавр болх зөвтә
+
+answer-name-not-single-text = answer-ин name атрибут яһ негн текстин үртә болх зөвтә
+
+## Referencing another document
+
+external-doenetml-recursion-limit = Рекурсин кемҗәс үлү олн болад һаза DoenetML авч чадсн уга. Төөргтә заавр угай?
+
+external-doenetml-unavailable = { $attribute }="{ $uri }" адресәс DoenetML авч чадсн уга
+
+external-doenetml-type-mismatch = { $attribute }="{ $uri }" адресәс буру DoenetML авгдв: тер «{ $componentType }» компонентин зүснд таарсн уга
+
+## Deprecated syntax
+
+deprecated-attribute-renamed =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут хуучрв; түүнә ормд `{ $to }` олзлтн.
+       *[other] [deprecation] `<{ $component }>` элемент деерк `{ $from }` атрибут хуучрв; түүнә ормд `{ $to }` олзлтн.
+    }
+
+deprecated-attribute-renamed-conflict =
+    { $component ->
+        [none] [deprecation] `{ $from }` атрибут хуучрв болн тооллго уга, юңгад гихлә `{ $to }` чигн өггдсн.
+       *[other] [deprecation] `<{ $component }>` элемент деерк `{ $from }` атрибут хуучрв болн тооллго уга, юңгад гихлә `{ $to }` чигн өггдсн.
+    }
+
+deprecated-attribute-ignored = [deprecation] `<{ $component }>` элемент деерк `{ $attribute }` атрибут хуучрв болн тооллго уга.
+
+deprecated-attribute-to-child = [deprecation] `<{ $component }>` элемент деерк `{ $attribute }` атрибут хуучрв; түүнә ормд `<{ $child }>` үрн олзлтн.
+
+deprecated-attribute-value-renamed = [deprecation] `<{ $component }>` элемент деерк `{ $attribute }` атрибутын `{ $value }` утх хуучрв; түүнә ормд `{ $to }` олзлтн.
+
+
+## Language coverage
+
+pluralize-english-only = `<pluralize>` олн то англь келн деер л кеҗ чадна, тиигәд { $locale } келн деер бичгдсн бичгт түүнә текст хүврлго үлднә. Олн тон хевиг эврән бичтн эсвл түүг `pluralForm` атрибутар өгтн.
+
+
+## Checking against the schema
+
+schema-element-unrecognized = `<{ $tag }>` элемент таньгдсн Doenet элемент биш.
+
+schema-element-not-allowed-at-root = `<{ $tag }>` элементд бичгин уңгд зөвшәрл өггдхш.
+
+schema-element-not-allowed-inside = `<{ $tag }>` элементд `<{ $parent }>` дотр зөвшәрл өггдхш.
+
+schema-attribute-unrecognized = `<{ $tag }>` элемент деер `{ $attribute }` нертә атрибут уга.
+
+schema-attribute-value-not-allowed =
+    { $isList ->
+        [true] `<{ $tag }>` элементин `{ $attribute }` атрибут элемент болһннь эднә негнь болдг списк болх зөвтә: { $allowed }
+       *[other] `<{ $tag }>` элементин `{ $attribute }` атрибут эднә негнь болх зөвтә: { $allowed }
+    }
+
+
+## The `<select>` family's error boxes
+
+select-variant-name-option-count-mismatch = select деер буру вариантин нерн. { $variantName } вариантин нерн { $numOptions } суңһврт таарна, харм суңһх то { $numToSelect }.
+
+select-variant-name-without-options = select деер вариантс өггдсн, болв болх вариантин нернд негн чигн суңһвр уга: { $variantName }.
+
+select-variant-name-not-possible = select деер өггдсн { $variantName } вариантин нерн болх вариантин нерн биш.
+
+select-too-few-options = Цугтан { $numOptions } дотрас { $numToSelect } компонент суңһҗ чадшго.
+
+select-from-sequence-too-few-values = Утнь { $length } дарандас { $numToSelect } утх суңһҗ чадшго.
+
+select-from-sequence-indices-count-mismatch = select деер өггдсн индексүдин то суңһх тод таарх зөвтә
+
+select-from-sequence-indices-not-integers = select деер өггдсн цуг индексүд бүклә то болх зөвтә
+
+select-from-sequence-index-excluded = selectfromsequence деер өггдсн индекс уга кегдсн бәәҗ
+
+select-from-sequence-indices-excluded-combination = selectfromsequence деер өггдсн индексүд уга кегдсн ниилвр бәәҗ
+
+select-from-sequence-coprime-not-positive-integers = Эерг бүклә тос суңһгдсн угаһар хоорндан әңгрхн ниилврмүд суңһҗ чадшго.
+
+select-from-sequence-coprime-common-factor = Хоорндан әңгрхн тос суңһҗ чадшго. Цуг болх утхс негн әңглгчтә. (Өггдсн "from" эсвл "to" утхс "step"-тә хоорндан әңгрхн болх зөвтә.)
+
+select-from-sequence-coprime-single-number = 1 биш негн л тоһас хоорндан әңгрхн ниилврмүд суңһҗ чадшго.
+
+select-from-sequence-excluded-too-many-combinations = selectFromSequence дотр ниилврмүдин 70%-ас олнь уга кегдв
+
+select-from-sequence-coprime-none-found = Хоорндан әңгрхн тос суңһҗ чадсн уга. Цуг болх утхс негн әңглгчтә.
+
+select-from-sequence-too-few-unique-values = Утнь { $numPossibleValues } дарандас { $numToSelect } талдан утх суңһҗ чадшго
+
+select-prime-numbers-too-few-values = Утнь { $numValues } әңгрхн тосин спискәс { $numToSelect } утх суңһҗ чадшго
+
+select-prime-numbers-values-count-mismatch = select деер өггдсн утхсин то суңһх тод таарх зөвтә
+
+select-prime-numbers-values-not-prime = select prime number деер өггдсн цуг утхс әңгрхн тосин списк дотр болх зөвтә
+
+select-prime-numbers-values-excluded-combination = selectPrimeNumbers деер өггдсн утхс уга кегдсн ниилвр бәәҗ
+
+select-prime-numbers-excluded-too-many-combinations = selectPrimeNumbers дотр ниилврмүдин 70%-ас олнь уга кегдв
+
+select-random-combination-fluke = Ик болшго учрар таварлта утхсин ниилвр суңһҗ чадсн уга
+
+select-random-value-fluke = Ик болшго учрар таварлта утх суңһҗ чадсн уга

--- a/packages/i18n/locales/xal/editor.ftl
+++ b/packages/i18n/locales/xal/editor.ftl
@@ -1,0 +1,213 @@
+# Kalmyk editor and language-server surfaces. Translated from
+# `locales/en/editor.ftl`, which is the source of truth: `lint:i18n` rejects a
+# key that does not exist there, and reports a key that exists there but not
+# here as missing coverage.
+#
+# Message ids are never translated — only the text to the right of `=`.
+#
+# UNREVIEWED SEED. Machine-generated, pending review by a speaker (#1521).
+# Correct anything here freely; nothing in it was written by a translator.
+#
+# Read the confidence note at the top of `content.ftl` before this file.
+#
+# `WCAG AA`, `DoenetML`, `XML`, `styleNumber` and every attribute or element
+# name are identifiers, not prose, and stay as written.
+
+
+## The viewer's controls
+
+editor-update-viewer =
+    { $action ->
+        [reset] Хәрүлх
+       *[update] Шинрүлх
+    }
+
+editor-update-viewer-title =
+    { $shortcut ->
+        [none] Үзгчиг { $word }
+       *[other] Үзгчиг { $word } { $shortcut }
+    }
+
+
+## The variant picker
+
+editor-variant = Вариант
+editor-variant-filter = Шүүвр…
+editor-variant-next = Дару вариант суңһх
+editor-variant-previous = Өмнк вариант суңһх
+
+
+## The accessibility status button
+
+editor-accessibility-title =
+    { $status ->
+        [violations] WCAG AA күрх аргин эвдлт олгдв. Күрх аргин элгц { $action ->
+            [close] хаах
+           *[open] секх
+        } гиҗ даргтн.
+        [advisories] Күрх аргин элгц { $action ->
+            [close] хаах
+           *[open] секх
+        } гиҗ даргтн. WCAG AA эвдлтс олгдсн уга, болв немр селвгүд бәәнә.
+       *[clean] Күрх аргин элгц { $action ->
+            [close] хаах
+           *[open] секх
+        } гиҗ даргтн. Күрх аргин сурврмуд олгдсн уга.
+    }
+
+editor-accessibility-label =
+    { $status ->
+        [violations] WCAG AA күрх аргин эвдлт олгдв. { $count ->
+            [one] { $count } WCAG AA эвдлт
+           *[other] { $count } WCAG AA эвдлт
+        } олгдв. Күрх аргин элгц { $action ->
+            [close] хаах
+           *[open] секх
+        } гиҗ даргтн.
+        [advisories] WCAG AA эвдлтс олгдсн уга. { $count ->
+            [one] { $count } немр селвг
+           *[other] { $count } немр селвг
+        } олгдв. Күрх аргин элгц { $action ->
+            [close] хаах
+           *[open] секх
+        } гиҗ даргтн.
+       *[clean] WCAG AA эвдлтс олгдсн уга. Күрх аргин элгц { $action ->
+            [close] хаах
+           *[open] секх
+        } гиҗ даргтн.
+    }
+
+editor-accessibility-badge = WCAG
+
+
+## The footer
+
+editor-version-title = DoenetML-ин хүврлт { $version }
+
+editor-tab-help = Контекстин дөң
+editor-tab-help-short = Контекст
+editor-tab-errors = Эндүс
+editor-tab-warnings = Селвгүд
+editor-tab-info = Медәлл
+editor-tab-accessibility = Күрх арг
+editor-tab-responses = Илгәгдсн хәрүс
+
+editor-tab-with-count = { $label }: { $count }
+
+editor-options = Редакторин таарулһс
+editor-format-as-doenetml = DoenetML болҗ форматлх
+editor-format-as-xml = XML болҗ форматлх
+
+
+## The diagnostics panel
+
+editor-diagnostic-line = { $line }-ч мөр
+
+editor-no-errors = Эндү уга
+editor-no-warnings = Селвг уга
+editor-no-info = Медәллин зәңг уга
+
+editor-show-info-annotations = Медәллин зәңгүдиг редактор деер үзүлх
+editor-show-accessibility-annotations = Күрх аргин зәңгүдиг редактор деер үзүлх
+
+editor-accessibility-learn-more = Doenet күрх аргд яһҗ хандна
+
+editor-accessibility-violations-heading = Күрх аргин эвдлтс ({ $standard })
+
+editor-accessibility-other-heading = Талдан күрх аргин сурврмуд
+editor-none-found = Юмн олгдсн уга
+
+
+## Submitted responses
+
+editor-no-responses = Оддг цаг илгәгдсн хәрү уга
+editor-response-answer-id = Хәрүһин Id
+editor-response-response = Хәрү
+editor-response-credit = Балл
+editor-response-submitted = Илгәгдв
+
+
+## The context-help panel
+
+help-placeholder = Документац үзхин төлә курсориг тег нердән, атрибут деер эсвл { $ref } деер тәвтн.
+
+help-unsupported-ref-chain = { $example } мет олн хүвтә заавр деер дөң оддг цаг уга.
+
+help-unresolved-ref =
+    { $reason ->
+        [notFound] Заавр деер объект олгдсн уга: { $ref }.
+        [multiple] Заавр деер кесг объект олгдв: { $ref }.
+       *[indeterminate] { $ref } объектиг тодрхлҗ чадсн уга.
+    }
+
+help-learn-about-references = Заавриг тускар медх →
+help-reference-page = Лавлврин халхц →
+
+help-suggestions-header =
+    { $location ->
+        [inside] { $element } дотр
+       *[top] Деед кемҗәнд
+    }{ $allowed ->
+        [none] { " — эндр юмн багтхш." }
+        [text] { " — эндр текст бичҗ болхмн." }
+        [text-and-components] { " — эндр текст бичҗ болхмн, эсвл эднг эрлһҗ үзтн:" }
+       *[components] { " — эднг эрлһҗ үзҗ болхмн:" }
+    }
+
+help-suggestions-footer = Цуг { $total } компонент үзхин төлә { $shortcut } даргтн.
+
+help-name-summary = { $name } — { $summary }
+
+help-ref-is-reference =
+    { $line ->
+        [none] { $ref } — { $target } объект деер заавр.
+       *[other] { $ref } — { $target } объект деер заавр ({ $line }-ч мөр).
+    }
+
+help-ref-derived-from =
+    { $line ->
+        [none] Үүг { $owner } { $role } болһҗ орулв.
+       *[other] Үүг { $owner } { $line }-ч мөрт { $role } болһҗ орулв.
+    }
+
+help-property-is-reference =
+    { $line ->
+        [none] { $ref } — { $element } элементин { $property } чинр деер заавр.
+       *[other] { $ref } — { $element } элементин { $property } чинр деер заавр ({ $line }-ч мөр).
+    }
+
+help-kind-attribute = атрибут
+help-kind-snippet = хәәрцг
+help-kind-array-entry = массивин элемент
+
+help-default = Ул утх:
+help-active-default = Оддг ул утх:
+
+help-style-number-annotation = { " " }(styleNumber { $styleNumber })
+
+help-allowed-values =
+    { $perItem ->
+        [true] Зөвшәргдсн утхс (элемент болһнд негн):
+       *[other] Зөвшәргдсн утхс:
+    }
+
+help-suggested-values = Селвгләгдсн утхс:
+
+help-inserts = Немнә:
+
+help-coordinates =
+    { $count ->
+        [one] Координат:
+       *[other] Координатс:
+    }
+
+help-type = Зүсн:
+
+help-resolved-style = Һарсн стиль (styleNumber { $styleNumber }):
+
+help-resolved-function-names = Һарсн функцин нерд:
+help-reset-list = Эн һазрин хәрүлһнә списк:
+help-added-on-input = Эн һазрт немгдсн:
+help-removed-on-input = Эн һазрас уга кегдсн:
+
+help-reset-overrides = { $reset } — { $additional } болн { $removed } деерәс дәәвлнә.

--- a/packages/i18n/src/generated/supportedLocales.ts
+++ b/packages/i18n/src/generated/supportedLocales.ts
@@ -17,6 +17,7 @@ export type SupportedLocale =
     | "ast"
     | "ay"
     | "az"
+    | "ba"
     | "ban"
     | "bci"
     | "be"
@@ -31,12 +32,16 @@ export type SupportedLocale =
     | "br"
     | "brx"
     | "bs"
+    | "bua"
     | "bum"
     | "ca"
+    | "ce"
     | "ceb"
     | "ch"
+    | "chm"
     | "co"
     | "cs"
+    | "cv"
     | "cy"
     | "da"
     | "dag"
@@ -102,6 +107,7 @@ export type SupportedLocale =
     | "kri"
     | "ks"
     | "ktu"
+    | "kv"
     | "ky"
     | "lb"
     | "lg"
@@ -128,6 +134,7 @@ export type SupportedLocale =
     | "ms"
     | "mt"
     | "my"
+    | "myv"
     | "nah"
     | "nb"
     | "nds"
@@ -140,6 +147,7 @@ export type SupportedLocale =
     | "oj"
     | "om"
     | "or"
+    | "os"
     | "pa"
     | "pam"
     | "pcm"
@@ -154,6 +162,7 @@ export type SupportedLocale =
     | "ru"
     | "rw"
     | "sa"
+    | "sah"
     | "sat"
     | "sc"
     | "scn"
@@ -192,6 +201,8 @@ export type SupportedLocale =
     | "ts"
     | "tt"
     | "ty"
+    | "tyv"
+    | "udm"
     | "ug"
     | "uk"
     | "umb"
@@ -202,6 +213,7 @@ export type SupportedLocale =
     | "vi"
     | "war"
     | "wo"
+    | "xal"
     | "xh"
     | "yi"
     | "yo"
@@ -298,6 +310,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Azerbaijani (azərbaycan)",
     },
     {
+        locale: "ba",
+        englishName: "Bashkir",
+        endonym: "башҡорт",
+        label: "Bashkir (башҡорт)",
+    },
+    {
         locale: "ban",
         englishName: "Balinese",
         endonym: "Balinese",
@@ -366,12 +384,24 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "bosanski",
         label: "Bosnian (bosanski)",
     },
+    {
+        locale: "bua",
+        englishName: "Buriat",
+        endonym: "буряад",
+        label: "Buriat (буряад)",
+    },
     { locale: "bum", englishName: "Bulu", endonym: "Bulu", label: "Bulu" },
     {
         locale: "ca",
         englishName: "Catalan",
         endonym: "català",
         label: "Catalan (català)",
+    },
+    {
+        locale: "ce",
+        englishName: "Chechen",
+        endonym: "нохчийн",
+        label: "Chechen (нохчийн)",
     },
     {
         locale: "ceb",
@@ -385,6 +415,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Chamorro",
         label: "Chamorro",
     },
+    { locale: "chm", englishName: "Mari", endonym: "Mari", label: "Mari" },
     {
         locale: "co",
         englishName: "Corsican",
@@ -396,6 +427,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Czech",
         endonym: "čeština",
         label: "Czech (čeština)",
+    },
+    {
+        locale: "cv",
+        englishName: "Chuvash",
+        endonym: "чӑваш чӗлхи",
+        label: "Chuvash (чӑваш чӗлхи)",
     },
     {
         locale: "cy",
@@ -727,6 +764,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "Kikongo ya leta",
         label: "Kituba (Kikongo ya leta)",
     },
+    { locale: "kv", englishName: "Komi", endonym: "Komi", label: "Komi" },
     {
         locale: "ky",
         englishName: "Kyrgyz",
@@ -858,6 +896,7 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         endonym: "မြန်မာ",
         label: "Burmese (မြန်မာ)",
     },
+    { locale: "myv", englishName: "Erzya", endonym: "Erzya", label: "Erzya" },
     {
         locale: "nah",
         englishName: "Nahuatl",
@@ -919,6 +958,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Odia",
         endonym: "ଓଡ଼ିଆ",
         label: "Odia (ଓଡ଼ିଆ)",
+    },
+    {
+        locale: "os",
+        englishName: "Ossetic",
+        endonym: "ирон",
+        label: "Ossetic (ирон)",
     },
     {
         locale: "pa",
@@ -1003,6 +1048,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         englishName: "Sanskrit",
         endonym: "संस्कृत भाषा",
         label: "Sanskrit (संस्कृत भाषा)",
+    },
+    {
+        locale: "sah",
+        englishName: "Yakut",
+        endonym: "саха тыла",
+        label: "Yakut (саха тыла)",
     },
     {
         locale: "sat",
@@ -1193,6 +1244,18 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
         label: "Tahitian",
     },
     {
+        locale: "tyv",
+        englishName: "Tuvinian",
+        endonym: "Тыва",
+        label: "Tuvinian (Тыва)",
+    },
+    {
+        locale: "udm",
+        englishName: "Udmurt",
+        endonym: "Udmurt",
+        label: "Udmurt",
+    },
+    {
         locale: "ug",
         englishName: "Uyghur",
         endonym: "ئۇيغۇرچە",
@@ -1237,6 +1300,12 @@ export const SUPPORTED_LOCALES: readonly SupportedLocaleInfo[] = [
     },
     { locale: "war", englishName: "Waray", endonym: "Waray", label: "Waray" },
     { locale: "wo", englishName: "Wolof", endonym: "Wolof", label: "Wolof" },
+    {
+        locale: "xal",
+        englishName: "Kalmyk",
+        endonym: "Kalmyk",
+        label: "Kalmyk",
+    },
     {
         locale: "xh",
         englishName: "Xhosa",

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -68,8 +68,9 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * The rule is published membership rather than a judgement about how close two
  * varieties are, which is what makes it checkable and what distinguishes it from
  * the `nn` and `fat` cases in {@link LANGUAGE_ALIASES}: neither of those is a
- * member of `nb` or `ak`, and both are deliberately left to miss. Ten of the
- * thirteen keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`, `kg` —
+ * member of `nb` or `ak`, and both are deliberately left to miss. Thirteen of
+ * the sixteen keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`,
+ * `kg`, `bua`, `kv`, `chm` —
  * are ISO 639-3 macrolanguages and list their macrolanguage members; `nah` is an
  * ISO 639-3 **collection** code rather than a macrolanguage, so it lists the
  * individual Nahuan languages ISO 639-5 groups under it; and `mnk` and `dje`
@@ -267,6 +268,25 @@ const MACROLANGUAGE_MEMBERS: Record<string, readonly string[]> = {
     // `ha-Latn-NG`. The answer to it is a second catalog rather than a change
     // here.
     dje: ["ddn", "hmb", "khq", "ses", "tda", "twq"],
+    // Buryat. The catalog is the Russia Buriat literary standard, which is what
+    // ICU already folds `bxr` onto; `bxm` (Mongolia) and `bxu` (China) are the
+    // members it does not, and they reach `locales/bua` only through this list.
+    // `bxu` maximizes to `bxu-Mong-CN` — the Mongolian script — so a China
+    // Buriat reader most likely arriving in that script is served Cyrillic.
+    // That is `locales/kr`'s asymmetry with `kby` and `locales/dje`'s with
+    // `tda`, and the answer to it is a second catalog rather than a change
+    // here.
+    bua: ["bxm", "bxr", "bxu"],
+    // Komi. The catalog is Komi-Zyrian, which is what ICU folds `kpv` onto;
+    // `koi` (Komi-Permyak) is the member it does not, and it is a written
+    // standard of its own, so serving it Zyrian is the compromise every entry
+    // in this map makes and `locales/kv`'s header records.
+    kv: ["koi", "kpv"],
+    // Mari. The catalog is Meadow Mari, which is what ICU folds `mhr` onto;
+    // `mrj` (Hill Mari) is the member it does not, and, like `koi` above, it is
+    // a written standard with an orthography of its own rather than a spelling
+    // of this one.
+    chm: ["mhr", "mrj"],
 };
 
 /** Flattened once at module load rather than searched per request. */

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -71,14 +71,14 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * member of `nb` or `ak`, and both are deliberately left to miss. Thirteen of
  * the sixteen keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`,
  * `kg`, `bua`, `kv`, `chm` — are ISO 639-3 macrolanguages and list their
- * macrolanguage members; `nah` is an
- * ISO 639-3 **collection** code rather than a macrolanguage, so it lists the
- * individual Nahuan languages ISO 639-5 groups under it; and `mnk` and `dje`
- * are neither, being *members* — of `man` and `son` respectively — that this
- * repository happens to name catalogs after. Those two are the shape
- * {@link LANGUAGE_ALIASES}'s `man` entry explains, and it is why the members
- * listed under `mnk` exclude `bam` and `dyu`: those two have catalogs of their
- * own, and folding them here would serve a Bambara reader Mandinka.
+ * macrolanguage members; `nah` is an ISO 639-3 **collection** code rather than a
+ * macrolanguage, so it lists the individual Nahuan languages ISO 639-5 groups
+ * under it; and `mnk` and `dje` are neither, being *members* — of `man` and
+ * `son` respectively — that this repository happens to name catalogs after.
+ * Those two are the shape {@link LANGUAGE_ALIASES}'s `man` entry explains, and
+ * it is why the members listed under `mnk` exclude `bam` and `dyu`: those two
+ * have catalogs of their own, and folding them here would serve a Bambara
+ * reader Mandinka.
  *
  * The two member cases part company over their macrolanguage, and the reason
  * is CLDR rather than a preference: `man` is aliased onto `mnk` because
@@ -87,11 +87,10 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  *
  * The one member CLDR already folds is included anyway — `quz`, `ojg`, `gug`,
  * `ayr`, `bcl`, `gom`, `dgo`, `fuc`, `knc`, `bxr`, `kpv`, `mhr` — so that each
- * list reads as the
- * whole of a group rather than as the leftovers of one, and so that a change in
- * ICU data cannot silently drop a code out of coverage. `mnk`'s list carries
- * `emk` for the same reason, though what ICU folds `emk` to is `man` rather
- * than `mnk`.
+ * list reads as the whole of a group rather than as the leftovers of one, and
+ * so that a change in ICU data cannot silently drop a code out of coverage.
+ * `mnk`'s list carries `emk` for the same reason, though what ICU folds `emk`
+ * to is `man` rather than `mnk`.
  *
  * Serving a related variety is a real compromise, and each of these catalogs
  * says in its own header which written standard it is — Southern Quechua,

--- a/packages/i18n/src/negotiate.ts
+++ b/packages/i18n/src/negotiate.ts
@@ -70,8 +70,8 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * the `nn` and `fat` cases in {@link LANGUAGE_ALIASES}: neither of those is a
  * member of `nb` or `ak`, and both are deliberately left to miss. Thirteen of
  * the sixteen keys — `qu`, `ay`, `gn`, `oj`, `bik`, `kok`, `doi`, `ff`, `kr`,
- * `kg`, `bua`, `kv`, `chm` —
- * are ISO 639-3 macrolanguages and list their macrolanguage members; `nah` is an
+ * `kg`, `bua`, `kv`, `chm` — are ISO 639-3 macrolanguages and list their
+ * macrolanguage members; `nah` is an
  * ISO 639-3 **collection** code rather than a macrolanguage, so it lists the
  * individual Nahuan languages ISO 639-5 groups under it; and `mnk` and `dje`
  * are neither, being *members* — of `man` and `son` respectively — that this
@@ -86,7 +86,8 @@ const LANGUAGE_ALIASES: Record<string, string> = {
  * means, while `son` is left to miss because it maximizes to nothing.
  *
  * The one member CLDR already folds is included anyway — `quz`, `ojg`, `gug`,
- * `ayr`, `bcl`, `gom`, `dgo`, `fuc`, `knc` — so that each list reads as the
+ * `ayr`, `bcl`, `gom`, `dgo`, `fuc`, `knc`, `bxr`, `kpv`, `mhr` — so that each
+ * list reads as the
  * whole of a group rather than as the leftovers of one, and so that a change in
  * ICU data cannot silently drop a code out of coverage. `mnk`'s list carries
  * `emk` for the same reason, though what ICU folds `emk` to is `man` rather

--- a/packages/i18n/test/negotiate.test.ts
+++ b/packages/i18n/test/negotiate.test.ts
@@ -1021,6 +1021,114 @@ describe("negotiateLocales", () => {
             },
         );
     });
+
+    /**
+     * The Cyrillic-script languages of the Russian Federation. Twelve
+     * catalogs, and the batch is the first whose *whole* membership shares a
+     * script without sharing a family: four Turkic, two Mongolic, four Uralic,
+     * one Iranian and one Nakh.
+     *
+     * Three of the twelve are ISO 639-3 macrolanguages and go in
+     * `MACROLANGUAGE_MEMBERS` — `bua`, `kv` and `chm` — which is the largest
+     * number any one batch has added. The other nine are individual languages
+     * that filter unaided, so the batch adds no `LANGUAGE_ALIASES` entry at
+     * all.
+     */
+    describe("the Russian Federation batch", () => {
+        it.each([
+            // The three macrolanguages. In each, the first member listed is the
+            // one `Intl.getCanonicalLocales` folds on its own and the rest
+            // reach the catalog only because `MACROLANGUAGE_MEMBERS` names
+            // them.
+            ["bxr", "bua"],
+            ["bxm", "bua"],
+            ["bxu", "bua"],
+            ["kpv", "kv"],
+            ["koi", "kv"],
+            ["mhr", "chm"],
+            ["mrj", "chm"],
+            // The ISO 639-3 codes ICU canonicalizes to a 639-1 code on its own.
+            ["bak", "ba"],
+            ["chv", "cv"],
+            ["udm", "udm"],
+            ["kom", "kv"],
+            ["oss", "os"],
+            ["che", "ce"],
+            // `sah`, `tyv`, `myv` and `xal` have no 639-1 code of their own, so
+            // they arrive under the same tag the directory is named for.
+            ["sah", "sah"],
+            ["tyv", "tyv"],
+            ["myv", "myv"],
+            ["xal", "xal"],
+            // Region tags, which filter without help — including `os`, whose
+            // maximization names Georgia rather than Russia and which costs
+            // negotiation nothing either way.
+            ["ba-RU", "ba"],
+            ["cv-RU", "cv"],
+            ["sah-RU", "sah"],
+            ["tyv-RU", "tyv"],
+            ["bua-RU", "bua"],
+            ["xal-RU", "xal"],
+            ["udm-RU", "udm"],
+            ["kv-RU", "kv"],
+            ["myv-RU", "myv"],
+            ["chm-RU", "chm"],
+            ["os-RU", "os"],
+            ["os-GE", "os"],
+            ["ce-RU", "ce"],
+            // Script asymmetries. Every catalog here is Cyrillic, so a reader
+            // arriving under a Latin tag gets Cyrillic — the answer `locales/sr`
+            // and `locales/kk` already give.
+            ["ba-Latn", "ba"],
+            ["cv-Latn", "cv"],
+            ["ce-Latn", "ce"],
+            ["xal-Mong", "xal"],
+        ])("reaches %s's catalog as %s", (requested, expected) => {
+            expect(
+                negotiateLocales([normalizeLocaleTag(requested)], available),
+            ).toEqual([expected, "en"]);
+        });
+
+        /**
+         * `bxu` is this batch's script debt, and it is recorded rather than
+         * fixed: China Buriat maximizes to `bxu-Mong-CN`, so CLDR's own data
+         * says such a reader most likely arrives in the Mongolian script and
+         * what `locales/bua` gives them is Cyrillic. `locales/dje` owes the
+         * same debt to `tda` in Tifinagh and `locales/kr` to `kby` in Ajami.
+         */
+        it("serves China Buriat Cyrillic although CLDR expects it in Mongolian script", () => {
+            expect(new Intl.Locale("bxu").maximize().script).toBe("Mong");
+            expect(negotiateLocales([normalizeLocaleTag("bxu")], available)) //
+                .toEqual(["bua", "en"]);
+        });
+
+        /**
+         * The near misses, and this batch's are unusually sharp because two of
+         * them are the *other half* of a pair whose first half now has a
+         * catalog. `mdf` is Moksha, Erzya's sister: ISO 639-3 gives the two
+         * separate codes and no macrolanguage over them, so `locales/myv` can
+         * do nothing for a Moksha reader and must not pretend to. `krc`, `kum`
+         * and `nog` are Turkic neighbours of `ba` in the Caucasus and the
+         * Volga; `ady`, `kbd` and `av` are Caucasian neighbours of `ce` in
+         * three different families; `sel` is Uralic beside `udm` and `kv`
+         * without belonging to either.
+         *
+         * Every one falls to English, which is the membership rule working
+         * rather than a gap in it — Moksha is not Erzya, however close a map
+         * makes them look, and Kabardian is not Chechen at all.
+         */
+        it.each(["mdf", "krc", "kum", "nog", "ady", "kbd", "av", "sel"])(
+            "leaves %s on English rather than folding it onto a neighbour",
+            (requested) => {
+                expect(
+                    negotiateLocales(
+                        [normalizeLocaleTag(requested)],
+                        available,
+                    ),
+                ).toEqual(["en"]);
+            },
+        );
+    });
 });
 
 describe("resolveDocumentLocale", () => {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65004,6 +65004,10 @@
                             "description": "Azerbaijani (azərbaycan)"
                         },
                         {
+                            "value": "ba",
+                            "description": "Bashkir (башҡорт)"
+                        },
+                        {
                             "value": "ban",
                             "description": "Balinese"
                         },
@@ -65060,12 +65064,20 @@
                             "description": "Bosnian (bosanski)"
                         },
                         {
+                            "value": "bua",
+                            "description": "Buriat (буряад)"
+                        },
+                        {
                             "value": "bum",
                             "description": "Bulu"
                         },
                         {
                             "value": "ca",
                             "description": "Catalan (català)"
+                        },
+                        {
+                            "value": "ce",
+                            "description": "Chechen (нохчийн)"
                         },
                         {
                             "value": "ceb",
@@ -65076,12 +65088,20 @@
                             "description": "Chamorro"
                         },
                         {
+                            "value": "chm",
+                            "description": "Mari"
+                        },
+                        {
                             "value": "co",
                             "description": "Corsican"
                         },
                         {
                             "value": "cs",
                             "description": "Czech (čeština)"
+                        },
+                        {
+                            "value": "cv",
+                            "description": "Chuvash (чӑваш чӗлхи)"
                         },
                         {
                             "value": "cy",
@@ -65344,6 +65364,10 @@
                             "description": "Kituba (Kikongo ya leta)"
                         },
                         {
+                            "value": "kv",
+                            "description": "Komi"
+                        },
+                        {
                             "value": "ky",
                             "description": "Kyrgyz (кыргызча)"
                         },
@@ -65448,6 +65472,10 @@
                             "description": "Burmese (မြန်မာ)"
                         },
                         {
+                            "value": "myv",
+                            "description": "Erzya"
+                        },
+                        {
                             "value": "nah",
                             "description": "Nahuatl (Nāhuatl)"
                         },
@@ -65494,6 +65522,10 @@
                         {
                             "value": "or",
                             "description": "Odia (ଓଡ଼ିଆ)"
+                        },
+                        {
+                            "value": "os",
+                            "description": "Ossetic (ирон)"
                         },
                         {
                             "value": "pa",
@@ -65550,6 +65582,10 @@
                         {
                             "value": "sa",
                             "description": "Sanskrit (संस्कृत भाषा)"
+                        },
+                        {
+                            "value": "sah",
+                            "description": "Yakut (саха тыла)"
                         },
                         {
                             "value": "sat",
@@ -65704,6 +65740,14 @@
                             "description": "Tahitian"
                         },
                         {
+                            "value": "tyv",
+                            "description": "Tuvinian (Тыва)"
+                        },
+                        {
+                            "value": "udm",
+                            "description": "Udmurt"
+                        },
+                        {
                             "value": "ug",
                             "description": "Uyghur (ئۇيغۇرچە)"
                         },
@@ -65742,6 +65786,10 @@
                         {
                             "value": "wo",
                             "description": "Wolof"
+                        },
+                        {
+                            "value": "xal",
+                            "description": "Kalmyk"
                         },
                         {
                             "value": "xh",

--- a/packages/utils/test/styleDescriptions.test.ts
+++ b/packages/utils/test/styleDescriptions.test.ts
@@ -3261,3 +3261,148 @@ describe("the Angolan, Sierra Leonean and Songhay batch", () => {
         ).toBe(expected);
     });
 });
+
+describe("the Russian Federation's Cyrillic batch", () => {
+    const forLocale = (locale: string): Translator =>
+        createTranslatorFromLocaleData(
+            { locale, resources: { [locale]: readCatalog(locale, "content") } },
+            locale,
+        );
+
+    const words = {
+        lineWidthWord: "thick",
+        lineStyleWord: "dashed",
+        colorWord: "red",
+    };
+
+    /**
+     * Twelve catalogs from five families — Turkic, Mongolic, Uralic, Iranian
+     * and Nakh — sharing nothing but a script, and the useful thing to pin is
+     * that the script predicts nothing while the twelve agree anyway: all of
+     * them put their adjectives **in front of** the noun and fold a regular
+     * polygon's side count into the head, so `noun-regular-polygon`'s `[tail]`
+     * branch renders empty in every one.
+     *
+     * Asserted as an identity rather than as a difference, the way the
+     * Americas batch's rows are: what this catches is someone "correcting" one
+     * of these catalogs by moving its adjectives behind the noun.
+     */
+    const prenominal: [string, string, string][] = [
+        ["ba", "ҡалын өҙөклө ҡыҙыл тура һыҙыҡ", "ҡалын өҙөклө ҡыҙыл"],
+        ["cv", "хулӑн татӑклӑ хӗрлӗ тӳрӗ йӗр", "хулӑн татӑклӑ хӗрлӗ"],
+        [
+            "sah",
+            "халыҥ быстах-быстах кыһыл көнө сурааһын",
+            "халыҥ быстах-быстах кыһыл",
+        ],
+        ["tyv", "кылын үзүктелген кызыл дорт шугум", "кылын үзүктелген кызыл"],
+        [
+            "bua",
+            "бүдүүн таһаршаһан улаан сэхэ зурлаа",
+            "бүдүүн таһаршаһан улаан",
+        ],
+        ["xal", "зузан тасрха улан шулун зурас", "зузан тасрха улан"],
+        ["udm", "зӧк чигем горд шонер чур", "зӧк чигем горд"],
+        ["kv", "кыз вундалӧм гӧрд веськыд визь", "кыз вундалӧм гӧрд"],
+        ["myv", "эчке сезнезь якстере виде линия", "эчке сезнезь якстере"],
+        ["chm", "кӱжгӧ кӱрылтшӧ йошкар вияш линий", "кӱжгӧ кӱрылтшӧ йошкар"],
+        ["os", "бæзджын скъуыдтæ сырх раст хахх", "бæзджын скъуыдтæ сырх"],
+        ["ce", "дуькъа кагйина цӀен нийса сиз", "дуькъа кагйина цӀен"],
+    ];
+
+    for (const [locale, withNoun, adjectivesOnly] of prenominal) {
+        it(`puts ${locale}'s adjectives in front of the noun`, () => {
+            const t = forLocale(locale);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: true,
+                }),
+            ).toBe(withNoun);
+            // The noun is appended to the adjectives rather than woven into
+            // them, which is what makes this English's shape and not merely
+            // English's sequence.
+            expect(withNoun.startsWith(adjectivesOnly)).toBe(true);
+            expect(
+                describeStrokedShape(t, words, {
+                    noun: { key: "line" },
+                    withNoun: false,
+                }),
+            ).toBe(adjectivesOnly);
+        });
+    }
+
+    it("keeps the side count in the head for all twelve, leaving no tail", () => {
+        for (const [locale] of prenominal) {
+            const description = describeStrokedShape(forLocale(locale), words, {
+                noun: { key: "regular-polygon", numSides: 5 },
+                withNoun: true,
+            });
+            // The count is present, and it is inside the noun rather than
+            // trailing after the adjectives.
+            expect(description).toContain("5");
+            expect(description.trimEnd()).toBe(description);
+            expect(description).not.toContain("  ");
+        }
+    });
+});
+
+/**
+ * `$gender` carrying a Northeast Caucasian noun class, which is the fifth
+ * mechanism the argument has been asked to hold after a European gender, a
+ * Bantu noun class, Ojibwe's animacy and Fula's suffixed concord.
+ *
+ * Chechen marks its classes with в-, й-, б- and д- at the *front* of an
+ * agreeing word, and almost nothing in a style description agrees: the colour
+ * and width adjectives take no prefix at all. The single word that does is the
+ * participle «дуьзна», "filled", so unlike Swahili's this catalog's fork is
+ * one message wide — and these rows are the only thing standing between it and
+ * being quietly flattened by someone who reads the rest of the file and
+ * concludes that Chechen agrees nothing.
+ */
+describe("Chechen noun classes", () => {
+    const ce: Translator = createTranslatorFromLocaleData(
+        { locale: "ce", resources: { ce: readCatalog("ce", "content") } },
+        "ce",
+    );
+
+    const blueFill = { fillColorWord: "blue", fillStyleWord: "" };
+
+    // «гуо» is `d` and «тӀадам» is `b`, so one word of the two moves and the
+    // colour beside it does not. The `withNoun: false` half is the one that
+    // could not pass by accident: with the noun withheld, the prefix is all
+    // that is left to tell the two classes apart.
+    it.each([
+        ["circle", "сийна дуьзна гуо", "сийна дуьзна"],
+        ["point", "сийна буьзна тӀадам", "сийна буьзна"],
+    ])("agrees the filled participle with «%s»", (key, withNoun, alone) => {
+        expect(
+            describeClosedShape(ce, blueFill, {
+                filled: true,
+                noun: { key: key as NounKey },
+                withNoun: true,
+            }),
+        ).toBe(withNoun);
+        expect(
+            describeClosedShape(ce, blueFill, {
+                filled: true,
+                noun: { key: key as NounKey },
+                withNoun: false,
+            }),
+        ).toBe(alone);
+    });
+
+    /**
+     * The other half of the same fact, and the reason `style-unfilled` is
+     * written flat here rather than forked the way `style-filled-word` is:
+     * `describeFill` renders it with no arguments, because a fill described on
+     * its own has no noun to take a class from. A `$gender` select in that
+     * message could only ever reach its default branch, which is why no
+     * agreeing catalog in the roster writes one.
+     */
+    it("says unfilled without agreeing with anything", () => {
+        expect(
+            describeFill(ce, { fillColorWord: "blue" }, { filled: false }),
+        ).toBe("дуьзна доцу");
+    });
+});


### PR DESCRIPTION
Continues #1685, #1686, #1687 and #1688 with a batch from a region the roster
had no coverage of at all: **Bashkir (`ba`), Chuvash (`cv`), Yakut (`sah`),
Tuvan (`tyv`), Buryat (`bua`), Kalmyk (`xal`), Udmurt (`udm`), Komi (`kv`),
Erzya (`myv`), Mari (`chm`), Ossetian (`os`) and Chechen (`ce`)** — twelve
catalogs across five families (Turkic, Mongolic, Uralic, Iranian, Nakh), all
written in Cyrillic, all spoken inside the Russian Federation.

Every string is machine-generated and **has not been read by a speaker**. Each
catalog says so in its header. The value is that a document declaring one of
these languages stops falling back to English; the cost is that some of it is
wrong, and correcting it needs no permission.

## Eleven catalogs say no, and the twelfth forks

This is the first batch whose whole membership shares a **script** without
sharing a family, which makes it a clean test of what a script predicts:
nothing. Turkic, Mongolic, Uralic and Iranian all answer the agreement question
flat — no grammatical gender, no inflected attributive adjective, so
`noun-gender` returns one token and nothing forks on it.

`locales/ce` is the exception and the most interesting file here. Chechen is
Nakh and has a real class system: nouns fall into classes marked by в-, й-, б-
and д-, and an agreeing word carries the class at the *front*. So it writes a
class table and forks `style-filled-word` on `$gender`, which
`styleDescriptions.test.ts` now pins across two classes.
One script, twelve catalogs, one fork — the sentence `locales/ts` and
`locales/ktu` earned inside Bantu, restated across five families at once.

Its header is honest about which half of the fork it can vouch for: the four
class markers and the agreeing participle are what this seed could check, the
class of every geometric noun is what it could not, so the table lists the
entries it is confident of and defaults the rest to `d`. That is
`locales/ewo`'s judgement with the fork already written and waiting.

## Two unrelated catalogs, one colour problem

Sakha's «күөх» covers green and blue; Ossetian's «цъæх» covers green, blue
*and* grey. The style pipeline needs those separately, so both write the modern
compounds that split them — «от күөх»/«халлаан күөҕэ» and
«кæрдæгхуыз»/«æрвхуыз» — and both headers say plainly that this is a choice
rather than a translation. A Turkic language and an Iranian one, one problem,
one shape of answer, neither borrowed from the other.

## Plural categories, and a `zero` that means the opposite

- **`locales/sah` is the roster's first Turkic catalog with a single plural
  category.** ICU reports `other` and nothing else, so every counted message is
  written flat — `locales/ja`'s and `locales/bo`'s shape. The eleven beside it
  resolve `one`/`other`.
- **`locales/cv` is the roster's fourth `zero` category, and the comparison
  worth making is with the one it does *not* match.** `ar`, `cy` and `lv` are
  the other three: Arabic's and Welsh's `zero` fire for exactly 0, and so does
  Chuvash's, while Latvian's covers every number ending in 0 and the whole
  teens — so 21 and 101 are `one` in Latvian and `other` in Chuvash. Four
  languages, one category name, three rules. `locales/cv`'s header spells out
  where the `[zero]` branch is genuinely reached and where the explicit `[0]`
  branch wins first.

## Five catalogs hit the same wall, and syntax decides which

`piecewise-condition-if` is placed *before* the mathematics. Sakha, Tuvan,
Udmurt, Komi and Mari all mark a condition at the *end* of the clause, so all
five record the `locales/dv` shape beside the key — a distinction the
composition messages do not expose. The other seven are clause-initial and land
correctly: Bashkir, Chuvash, Buryat, Kalmyk, Erzya, Ossetian and Chechen. Two
Turkic catalogs on each side of that line and three Uralic on one side with one
on the other: the wall is word order, not ancestry.

## Negotiation

**Three of the twelve are ISO 639-3 macrolanguages — the most any batch has
added to `MACROLANGUAGE_MEMBERS`.** `bua` over `bxr`/`bxm`/`bxu`, `kv` over
`kpv`/`koi`, `chm` over `mhr`/`mrj`. ICU folds exactly one member of each on its
own and leaves the rest unresolvable, which is the failure that map exists to
prevent. Each catalog names its standard in its header: Russia Buriat,
Komi-Zyrian, Meadow Mari.

`bxu` is the batch's **script debt**, recorded rather than fixed: China Buriat
maximizes to `bxu-Mong-CN`, so such a reader most likely arrives in the
Mongolian script and gets Cyrillic — `locales/dje`'s debt to `tda` and
`locales/kr`'s to `kby`, with the same answer (a second catalog, not a change
here).

The other nine filter unaided, so **`LANGUAGE_ALIASES` gains nothing**, and —
for the first time in several batches — **`LOCALE_NAME_FALLBACKS` gains nothing
either**: CLDR names all twelve. Four of those names look wrong and are not,
the `ny`-reads-Nyanja rule again: `sah` is **Yakut**, `tyv` **Tuvinian**, `bua`
**Buriat**, `os` **Ossetic**. `os` also maximizes to Georgia rather than
Russia, which is CLDR's data and costs negotiation nothing.

`mdf` (Moksha) is the near miss worth naming: it is Erzya's sister, the two have
separate codes and no macrolanguage over them, so `locales/myv` can do nothing
for a Moksha reader and must not pretend to. `krc`, `kum`, `nog`, `ady`, `kbd`,
`av` and `sel` fall to English for the same reason. `negotiate.test.ts` pins
every one.

## Chemistry

All twelve leave `element-name` and `element-anion-name` out, and they split no
ways at all: secondary chemistry across the Federation is taught in Russian, so
the fallback *is* the curriculum. **`locales/tt` is the counter-example, and it
sits in the same country** — Tatar supplies the whole table and Bashkir, its
nearest relative, does not. That is `af`/`nso` in South Africa and `sw`/`ki` in
Kenya a third time. Copying the Russian list into Bashkir or Chuvash spelling
would be neither language, which is `locales/min`'s argument and the second
half of why the gap stands.

`locales/xal` gets a sentence of its own: it is **the least certain catalog in
the batch and says so in its own header.** Kalmyk is the most endangered
language seeded here, its written output is small, and its orthography drops
unstressed vowels that Buryat and Mongolian write — so a word that looks like a
typo beside `locales/bua` may well be correct, which is exactly the error class
this seed cannot check. `locales/lom` set that precedent.

## Chuvash is written in Cyrillic codepoints, not Latin lookalikes

Review caught `locales/cv` spelling its four extra letters with the Latin
lookalikes legacy Chuvash typesetting reaches for — `ă` U+0103, `ĕ` U+0115 and
`ç` U+00E7 — beside a correctly Cyrillic `ӳ` U+04F3, so the catalog was split
across two scripts in 2,010 places. All of them are now `ӑ` U+04D1, `ӗ` U+04D7
and `ҫ` U+04AB, and `content.ftl`'s header names the codepoints so a correction
typed from a Latin keyboard layout does not reintroduce them. The letters look
alike and sort, search and case-fold differently, which is why this is a bug
rather than a spelling preference.

## Verification

- `npm run codegen -w @doenet/i18n` — regenerated `messageKeys.ts`,
  `supportedLocales.ts` (215 locales now) and `diagnostic-codes.lock.json`.
- `npm run lint:i18n -w @doenet/i18n` — clean; the twelve new locales report
  432/562 keys translated (130 fall back to English, the chemistry gap),
  matching every other partial catalog in the roster.
- `npm run test -w @doenet/i18n` — green (564 tests) with the new
  `negotiate.test.ts` block covering the three macrolanguages, the `bxu` script
  debt and eight negative controls.
- `npm run build:schema -w @doenet/static-assets` — run, per #1687's note that
  skipping it once let CI catch the gap twice.

The README's roster list also picks up ten codes that were missing from it
before this batch (`dje`, `fon`, `kbp`, `kg`, `kmb`, `kri`, `men`, `pcm`,
`tem`, `umb`). Nothing generates that list — it is prose — so it was checked
against `locales/` entry by entry instead, and it now matches all 214
directories exactly.

## Review cycle 2: five false claims, and a clean sweep of the scripts

The mixed-script bug cycle 1 caught in `locales/cv` was checked for across the
other eleven and is not there. Every non-ASCII codepoint in all twelve catalogs
sits in the Cyrillic block and in the alphabet its header claims — Bashkir's
ҙ/ҫ/ғ/ҡ/һ/ә, Sakha's ҕ/ҥ/һ/ө/ү, Tuvan's ң/ө/ү, Buryat's and Kalmyk's
ү/ө/һ/җ/ң/ә, Udmurt's ӝ/ӟ/ӥ/ӧ/ӵ, Komi's ӧ/і, Mari's ӧ/ӱ/ҥ, Chechen's palochka
Ӏ U+04C0 — with two deliberate exceptions: Ossetian's æ **is** Latin U+00E6,
which is what Ossetian orthography uses, and `locales/cv`'s header names the
three Latin lookalikes as counter-examples. Also checked and clean: every
locale's plural branches match `Intl.PluralRules` for that exact tag; no
placeable name in any of the twelve differs from `locales/en`'s for the same
key (`locales/ce`'s `$noun`/`$gender` follow `locales/ts`, and `locales/sah`'s
dropped count selectors follow `locales/ja`); and the macrolanguage
memberships, CLDR names, maximizations and the README's roster and
partial-catalog counts all hold against the data.

What did not hold, and is fixed:

- **`locales/chm` claimed Meadow Mari is written with ӓ.** It is not — ӓ is
  Hill Mari's letter, the standard the same header says nine lines later this
  catalog is *not* written in, and it occurs nowhere in the file's strings.
- **`locales/ce` credited `locales/luo` with the class-fork sentence.** Dholuo
  is Nilotic, has no noun classes, and selects on neither argument; it is the
  mirror image of that sentence rather than a third instance of it. (The
  README's version of the sentence was already correct.)
- **`locales/udm` miscounted its own paragraph**: three catalogs hit the
  clause-final conditional wall and two do not, it said. It is five and seven.
- **`locales/myv` said three Uralic catalogs in the batch**; there are four.
- **`locales/tyv` said three Russian colour loans and listed two.**
- **`locales/cv/editor.ftl` said two counted messages write `[zero]`.** It is
  one message, `editor-accessibility-label`, counting twice; the README said
  the same thing loosely and now names the message.
- **`locales/cv/chrome.ftl` called four `zero` rules distinct** where its own
  preceding sentence groups Arabic's with Welsh's — three rules across four
  categories, which is what the README already said.
- **The changeset said two headers carry a confidence caveat**; five do
  (`cv`, `tyv`, `udm`, `xal`, `ce`).

`lint:i18n`, `vitest --root packages/i18n` (564 tests) and prettier are all
green after the change; no catalog string moved, so `codegen` output is
unchanged.

## Review cycle 3: an unreachable fork, a missing pin, and 100 lines of unrelated diff

Cycles 1 and 2 checked claims. This one checked the twelve against each other
and against the rest of `locales/`, and found the structure sound — all 48
files carry the repo's section banners in the repo's order, every namespace's
message ids and their order match `locales/en` exactly, and all twelve omit the
same two chemistry keys and nothing else. Three things did not hold:

- **`locales/ce`'s `style-unfilled` fork could never fire.** It selected on
  `$gender` in four branches, but `describeFill` renders that message with *no
  arguments at all* — a fill described on its own has no noun to take a class
  from — so only the default branch was ever reachable, and it is the only
  catalog in the roster that forks there. `locales/sw`, `locales/zu` and
  `locales/ts` all agree far more than Chechen does and all write theirs flat,
  which is what says this is a fact about the message rather than about
  Chechen. The message is now the д-class form written flat, with the reason
  beside it, and the catalog header, the README and this description no longer
  claim two forks where there is one.
- **The batch had no case in `styleDescriptions.test.ts`**, which every batch
  since the Indigenous Americas one has added and which is exactly where a
  class fork is pinned (`locales/sw`, `locales/oj`, `locales/ts`,
  `locales/ktu` all have blocks there). Added: the twelve prenominal rows with
  their adjectives-only halves, the side-count-in-the-head check for all
  twelve, and **Chechen noun classes** — «гуо» is `d` and «тӀадам» is `b`, so
  «сийна дуьзна» against «сийна буьзна» with the noun withheld is the
  assertion that could not pass by accident. `packages/utils` is green (266
  tests).
- **The README diff carried ~100 lines of unrelated reformatting** — emphasis
  rewritten from `*x*` to `_x_` throughout a 2,400-line file, plus three
  tables realigned, one of them *into* misalignment. `**/*.md` is in
  `.prettierignore`, so none of it was required. All of it is reverted, the
  new section now matches the file's `*x*` convention, and the roster list is
  rewrapped as one paragraph instead of a ragged block. The README diff is now
  the roster list, the two partial-catalog counts and the new section, and
  nothing else.

`lint:i18n`, `vitest --root packages/i18n` (564), `vitest --root
packages/utils` (784, of which `styleDescriptions.test.ts` is 266), prettier
and `codegen` are all green; codegen and `build:schema` produce no change,
since no locale was added or removed.

## Review cycle 4: the class fork is reachable, and nothing else moved

This cycle re-derived the claims rather than trusting the previous summaries,
and the substantive ones all hold:

- **`locales/ce`'s remaining `$gender` fork on `style-filled-word` *is*
  reachable**, checked at the call site the way cycle 3 checked `style-unfilled`:
  `describeClosedShape` looks the word up with `{ gender: genderOf(t,
  noun.key), role: "standalone" }`, and `noun-gender` returns `b` for «тӀадам»
  against `d` for «гуо», so two branches fire from real input. The class-fork
  claim in the header, the README and this description stands. A sweep of all
  twelve catalogs for selectors on arguments `locales/en` does not select on
  found exactly two — `ce`'s `noun-gender` and `style-filled-word` — so there
  is no other dead branch in the batch.
- **Cycle 3's test additions assert what the catalogs actually produce.** Run
  and read: the twelve prenominal rows and the two Chechen class rows are exact
  Cyrillic string equalities, not fallbacks, and the block mirrors the existing
  batches' shape line for line.
- **The twelve are internally consistent with the worker.** Every one folds the
  side count into `noun-regular-polygon`'s `*[head]` and writes `[tail]` empty;
  `style-with-noun`, `style-filled`, `style-filled-with-noun`,
  `style-border-clause`, `style-fill`, `style-text` and `style-stroke` carry
  exactly `locales/en`'s variant keys, which are the ones `styleDescriptions.ts`
  passes.
- **The README's new section does not overclaim.** Re-derived against the data:
  16 `MACROLANGUAGE_MEMBERS` keys of which 13 are macrolanguages; `sah` alone
  resolving `other`; `cv` the fourth `zero` and Latvian the odd rule out (21 and
  101 are `one` in `lv`, `other` in `cv`); `bxu` maximizing to `bxu-Mong-CN`;
  `os` to `os-Cyrl-GE`; CLDR naming all twelve (Yakut, Tuvinian, Buriat,
  Ossetic); 141 partial catalogs, 140 of them chemistry-only, and the list of
  140 names counted; the roster list matching all 214 directories.

Changed: the verification count above (the 266 is one file, not the package),
and hard-wrapping in `negotiate.ts`'s `MACROLANGUAGE_MEMBERS` doc comment and
three README paragraphs that this PR's edits had left ragged. No string, key or
generated file moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8



