### PR TITLE
fix: make the virtual keyboard usable on phones and tablets

### DIFF
--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -51,13 +51,13 @@ autodetection pins to, or simply a wrapper installed before the viewer it
 loads from the CDN. A viewer from this release **can** be driven by a tray
 from before it: the old tray announces itself by the `accessed` message it
 sends as it takes focus, and its keys are then delivered to the math input the
-same press blurred a moment earlier, with the caret restored after typing.
-Only that input, and only that moment: a key pressed after the reader has left
-a math input of their own accord types nowhere, as before, and a press that
-sends no key at all — the old tray's own close button — leaves no input
-holding the keyboard behind it. This is the pairing that arises the moment a
-new viewer is published under an already-deployed wrapper, so it is the one
-worth keeping working.
+same press blurred a moment earlier, with the caret given back afterwards —
+including when the press carried no key, such as opening the tray while
+already editing an input. Only that input, and only that moment: a press made
+after the reader has left a math input of their own accord types nowhere and
+moves no caret, as before. This is the pairing that arises the moment a new
+viewer is published under an already-deployed wrapper, so it is the one worth
+keeping working.
 
 The opposite pairing cannot be rescued from the viewer's side: a viewer from
 before this release typed only in response to a blur that this tray no longer

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -55,9 +55,14 @@ same press blurred a moment earlier, with the caret given back afterwards —
 including when the press carried no key, such as opening the tray while
 already editing an input. Only that input, and only that moment: a press made
 after the reader has left a math input of their own accord types nowhere and
-moves no caret, as before. This is the pairing that arises the moment a new
-viewer is published under an already-deployed wrapper, so it is the one worth
-keeping working.
+moves no caret, as before. Under such a tray the Doenet keyboard is the only
+one on offer on a touch device: the tray does not follow focus, so the reader
+opens it themselves as they always did with it, and closing it does not hand
+the device's own keyboard back, because that tray has no way to report that
+they asked for it. This is the pairing that arises the moment a new viewer is
+published under an already-deployed wrapper, so it is the one worth keeping
+working — without it, a phone reader would meet a math input that raises no
+keyboard at all and a Doenet keyboard that types nothing.
 
 The opposite pairing cannot be rescued from the viewer's side: a viewer from
 before this release typed only in response to a blur that this tray no longer

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -35,14 +35,17 @@ inferred from a 100 ms window between a blur and a tray press. Besides being
 deterministic, that decouples typing from `document.activeElement`, which is
 the prerequisite for operating the keyboard from the keyboard (#747).
 
-Note for embedders who pin `doenetmlVersion` (or serve a `standaloneUrl` for
-a particular release) inside `@doenet/doenetml-iframe`: the wrapper hosts the
-tray while the iframe holds the viewer, and the two must now come from the
-same side of this change. Mixing them either way leaves the virtual keyboard
-unable to type — physical keyboards are unaffected. A viewer from before this
-release typed only in response to the blur a tray press used to cause, which
-the tray no longer causes; and a viewer from this release, under a wrapper
-from before it, reads that blur as the reader leaving the input for good.
-Keeping the wrapper and the viewer on the same release avoids both.
+Note for embedders of `@doenet/doenetml-iframe` whose viewer comes from a
+different release than the wrapper: the wrapper hosts the tray while the
+iframe holds the viewer, and the two must now come from the same side of this
+change. That is a `doenetmlVersion` or `standaloneUrl` naming a particular
+release — and also a document declaring an `xmlns` version, which the
+wrapper's default version autodetection pins to. Mixing them either way leaves
+the virtual keyboard unable to type; physical keyboards are unaffected. A
+viewer from before this release typed only in response to the blur a tray
+press used to cause, which the tray no longer causes; and a viewer from this
+release, under a wrapper from before it, reads that blur as the reader leaving
+the input for good. Keeping the wrapper and the viewer on the same release
+avoids both.
 
 Closes #1692.

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -50,10 +50,12 @@ a document declaring an `xmlns` version that the wrapper's version
 autodetection pins to, or simply a wrapper installed before the viewer it
 loads from the CDN. A viewer from this release **can** be driven by a tray
 from before it: the old tray announces itself by the `accessed` message it
-sends as it takes focus, and the viewer takes its claim on the keyboard back
-when it sees one, then restores the caret after typing. This is the pairing
-that arises the moment a new viewer is published under an already-deployed
-wrapper, so it is the one worth keeping working.
+sends as it takes focus, and the input it has just that moment blurred takes
+its claim on the keyboard back when it sees one, then restores the caret after
+typing. Only that input, and only that moment: a key pressed after the reader
+has left a math input of their own accord types nowhere, as before. This is the
+pairing that arises the moment a new viewer is published under an
+already-deployed wrapper, so it is the one worth keeping working.
 
 The opposite pairing cannot be rescued from the viewer's side: a viewer from
 before this release typed only in response to a blur that this tray no longer

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -36,10 +36,13 @@ deterministic, that decouples typing from `document.activeElement`, which is
 the prerequisite for operating the keyboard from the keyboard (#747).
 
 Note for embedders who pin `doenetmlVersion` (or serve a `standaloneUrl` for
-an older release) inside `@doenet/doenetml-iframe`: the tray no longer blurs
-the input it types into, and viewers from before this release typed only in
-response to that blur. Such a pairing leaves the virtual keyboard unable to
-type — physical keyboards are unaffected. Pinning the viewer and the wrapper
-to the same release avoids this.
+a particular release) inside `@doenet/doenetml-iframe`: the wrapper hosts the
+tray while the iframe holds the viewer, and the two must now come from the
+same side of this change. Mixing them either way leaves the virtual keyboard
+unable to type — physical keyboards are unaffected. A viewer from before this
+release typed only in response to the blur a tray press used to cause, which
+the tray no longer causes; and a viewer from this release, under a wrapper
+from before it, reads that blur as the reader leaving the input for good.
+Keeping the wrapper and the viewer on the same release avoids both.
 
 Closes #1692.

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -43,17 +43,21 @@ record is also taken correctly for a math input focused the instant it
 appears, which used to leave the virtual keyboard typing nowhere until the
 reader left that input and came back to it.
 
-Note for embedders of `@doenet/doenetml-iframe` whose viewer comes from a
-different release than the wrapper: the wrapper hosts the tray while the
-iframe holds the viewer, and the two must now come from the same side of this
-change. That is a `doenetmlVersion` or `standaloneUrl` naming a particular
-release — and also a document declaring an `xmlns` version, which the
-wrapper's default version autodetection pins to. Mixing them either way leaves
-the virtual keyboard unable to type; physical keyboards are unaffected. A
-viewer from before this release typed only in response to the blur a tray
-press used to cause, which the tray no longer causes; and a viewer from this
-release, under a wrapper from before it, reads that blur as the reader leaving
-the input for good. Keeping the wrapper and the viewer on the same release
-avoids both.
+Note for embedders of `@doenet/doenetml-iframe`, where the wrapper hosts the
+tray and the iframe holds the viewer, and the two can come from different
+releases — a `doenetmlVersion` or `standaloneUrl` naming a particular release,
+a document declaring an `xmlns` version that the wrapper's version
+autodetection pins to, or simply a wrapper installed before the viewer it
+loads from the CDN. A viewer from this release **can** be driven by a tray
+from before it: the old tray announces itself by the `accessed` message it
+sends as it takes focus, and the viewer takes its claim on the keyboard back
+when it sees one, then restores the caret after typing. This is the pairing
+that arises the moment a new viewer is published under an already-deployed
+wrapper, so it is the one worth keeping working.
+
+The opposite pairing cannot be rescued from the viewer's side: a viewer from
+before this release typed only in response to a blur that this tray no longer
+causes. An embedder pinning a viewer older than this release should pin the
+wrapper with it. Physical keyboards are unaffected either way.
 
 Closes #1692.

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -1,0 +1,33 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Viewer: make the virtual keyboard usable on phones and tablets.
+
+On a touch device the Doenet keyboard and the device's own on-screen keyboard
+were competing for the same screen. Tapping a math input raised the system
+keyboard, which on iOS covered the Doenet keyboard tray outright; on Android,
+dismissing it was futile, because pressing a Doenet key blurred the input and
+the refocus that followed summoned the system keyboard again.
+
+A math input on a touch device now sets `inputmode="none"` while the Doenet
+tray is open, so the device leaves its own keyboard down — focus, the caret,
+selection, and any physical keyboard still work as before. The tray also
+declines focus when it is pressed, so the input no longer blurs and is no
+longer refocused on every key. Closing the tray hands the device's keyboard
+back; the choice is remembered, so the tray stays shut as the reader moves
+between math inputs until they ask for it again.
+
+The tray now follows focus on touch devices: it opens when a math input takes
+focus and gets out of the way when focus moves to something else, such as a
+text input, whose editing wants the device's own keyboard. On a desktop the
+tray remains under manual control, exactly as before.
+
+Which input the keyboard types into is now recorded explicitly rather than
+inferred from a 100 ms window between a blur and a tray press. Besides being
+deterministic, that decouples typing from `document.activeElement`, which is
+the prerequisite for operating the keyboard from the keyboard (#747).
+
+Closes #1692.

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -50,12 +50,14 @@ a document declaring an `xmlns` version that the wrapper's version
 autodetection pins to, or simply a wrapper installed before the viewer it
 loads from the CDN. A viewer from this release **can** be driven by a tray
 from before it: the old tray announces itself by the `accessed` message it
-sends as it takes focus, and the input it has just that moment blurred takes
-its claim on the keyboard back when it sees one, then restores the caret after
-typing. Only that input, and only that moment: a key pressed after the reader
-has left a math input of their own accord types nowhere, as before. This is the
-pairing that arises the moment a new viewer is published under an
-already-deployed wrapper, so it is the one worth keeping working.
+sends as it takes focus, and its keys are then delivered to the math input the
+same press blurred a moment earlier, with the caret restored after typing.
+Only that input, and only that moment: a key pressed after the reader has left
+a math input of their own accord types nowhere, as before, and a press that
+sends no key at all — the old tray's own close button — leaves no input
+holding the keyboard behind it. This is the pairing that arises the moment a
+new viewer is published under an already-deployed wrapper, so it is the one
+worth keeping working.
 
 The opposite pairing cannot be rescued from the viewer's side: a viewer from
 before this release typed only in response to a blur that this tray no longer

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -19,10 +19,13 @@ not merely once the tray is open, which would be too late to stop the system
 keyboard appearing at the first input the reader taps — so the device leaves
 its own keyboard down. Focus, the caret, selection, and any physical keyboard
 still work as before. The tray also declines focus when it is pressed, so the
-input no longer blurs and is no longer refocused on every key. Closing the
-tray hands the device's keyboard back; the choice is remembered, so the tray
-stays shut, and the system keyboard keeps coming up, as the reader moves
-between math inputs until they ask for the Doenet keyboard again. When the
+input no longer blurs and is no longer refocused on every key. Tabbing into
+the tray does not end the edit either — the keys still go to the input that
+was left, and what was typed is committed once focus leaves the tray for
+somewhere other than that input. Closing the tray hands the device's keyboard
+back; the choice is remembered, so the tray stays shut, and the system
+keyboard keeps coming up, as the reader moves between math inputs until they
+ask for the Doenet keyboard again. When the
 system keyboard is the one in use, it no longer capitalizes or autocorrects
 what is typed into a math input.
 
@@ -35,7 +38,10 @@ On a desktop the tray remains under manual control, exactly as before.
 Which input the keyboard types into is now recorded explicitly rather than
 inferred from a 100 ms window between a blur and a tray press. Besides being
 deterministic, that decouples typing from `document.activeElement`, which is
-the prerequisite for operating the keyboard from the keyboard (#747).
+the prerequisite for operating the keyboard from the keyboard (#747). The
+record is also taken correctly for a math input focused the instant it
+appears, which used to leave the virtual keyboard typing nowhere until the
+reader left that input and came back to it.
 
 Note for embedders of `@doenet/doenetml-iframe` whose viewer comes from a
 different release than the wrapper: the wrapper hosts the tray while the

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -22,7 +22,9 @@ still work as before. The tray also declines focus when it is pressed, so the
 input no longer blurs and is no longer refocused on every key. Closing the
 tray hands the device's keyboard back; the choice is remembered, so the tray
 stays shut, and the system keyboard keeps coming up, as the reader moves
-between math inputs until they ask for the Doenet keyboard again.
+between math inputs until they ask for the Doenet keyboard again. When the
+system keyboard is the one in use, it no longer capitalizes or autocorrects
+what is typed into a math input.
 
 The tray now follows focus on touch devices: it opens when a math input takes
 focus and gets out of the way when focus moves to something else, such as a

--- a/.changeset/virtual-keyboard-on-touch-devices.md
+++ b/.changeset/virtual-keyboard-on-touch-devices.md
@@ -2,6 +2,8 @@
 "@doenet/doenetml": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
 ---
 
 Viewer: make the virtual keyboard usable on phones and tablets.
@@ -12,22 +14,32 @@ keyboard, which on iOS covered the Doenet keyboard tray outright; on Android,
 dismissing it was futile, because pressing a Doenet key blurred the input and
 the refocus that followed summoned the system keyboard again.
 
-A math input on a touch device now sets `inputmode="none"` while the Doenet
-tray is open, so the device leaves its own keyboard down — focus, the caret,
-selection, and any physical keyboard still work as before. The tray also
-declines focus when it is pressed, so the input no longer blurs and is no
-longer refocused on every key. Closing the tray hands the device's keyboard
-back; the choice is remembered, so the tray stays shut as the reader moves
-between math inputs until they ask for it again.
+A math input on a touch device now sets `inputmode="none"` from the outset —
+not merely once the tray is open, which would be too late to stop the system
+keyboard appearing at the first input the reader taps — so the device leaves
+its own keyboard down. Focus, the caret, selection, and any physical keyboard
+still work as before. The tray also declines focus when it is pressed, so the
+input no longer blurs and is no longer refocused on every key. Closing the
+tray hands the device's keyboard back; the choice is remembered, so the tray
+stays shut, and the system keyboard keeps coming up, as the reader moves
+between math inputs until they ask for the Doenet keyboard again.
 
 The tray now follows focus on touch devices: it opens when a math input takes
 focus and gets out of the way when focus moves to something else, such as a
-text input, whose editing wants the device's own keyboard. On a desktop the
-tray remains under manual control, exactly as before.
+text input, whose editing wants the device's own keyboard. Several viewers can
+share a page; the tray stays open while any of them has a math input focused.
+On a desktop the tray remains under manual control, exactly as before.
 
 Which input the keyboard types into is now recorded explicitly rather than
 inferred from a 100 ms window between a blur and a tray press. Besides being
 deterministic, that decouples typing from `document.activeElement`, which is
 the prerequisite for operating the keyboard from the keyboard (#747).
+
+Note for embedders who pin `doenetmlVersion` (or serve a `standaloneUrl` for
+an older release) inside `@doenet/doenetml-iframe`: the tray no longer blurs
+the input it types into, and viewers from before this release typed only in
+response to that blur. Such a pairing leaves the virtual keyboard unable to
+type — physical keyboards are unaffected. Pinning the viewer and the wrapper
+to the same release avoids this.
 
 Closes #1692.

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
@@ -10,6 +10,14 @@ import {
 // bundle; budget more than IFRAME_READY_TIMEOUT for it.
 const CONTENT_TIMEOUT = 30_000;
 
+/**
+ * Comfortably longer than the window in which the viewer will read a tray
+ * press as the cause of a blur, so a press made after it is not taken for one
+ * made during it — and long enough afterwards for a press that should type
+ * nothing to have had its chance to type something.
+ */
+const SETTLE_MS = 500;
+
 const DOENETML = '<p>Type here: <mathInput name="mi" /></p>';
 
 /**
@@ -127,5 +135,43 @@ describe("DoenetViewer (iframe wrapper) — a keyboard tray from before it decli
         viewerBody()
             .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
             .should("contain.text", "xx");
+    });
+
+    it("types nothing once the reader has left the input of their own accord", () => {
+        cy.mount(<Harness />);
+
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("exist")
+            .click();
+
+        cy.get("[data-test=legacy-key-x]").click();
+
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "x");
+
+        // The reader moves on to the surrounding text, which takes no focus of
+        // its own — the same shape of blur the tray causes, and all the viewer
+        // has to tell them apart by is how long ago it happened.
+        viewerBody().find(".para").click("left");
+        cy.get("iframe")
+            .its("0.contentDocument.activeElement")
+            .should("not.match", "textarea");
+
+        // Long enough that the next press cannot be the cause of that blur.
+        cy.wait(SETTLE_MS);
+        cy.get("[data-test=legacy-key-x]").click();
+        cy.wait(SETTLE_MS);
+
+        // The key belonged to no input, so it typed nowhere, and nothing
+        // pulled the caret back into an input the reader had left.
+        viewerBody()
+            .find(".mq-editable-field")
+            .should("contain.text", "x")
+            .should("not.contain.text", "xx");
+        cy.get("iframe")
+            .its("0.contentDocument.activeElement")
+            .should("not.match", "textarea");
     });
 });

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
@@ -70,6 +70,15 @@ function LegacyKeyboardTray({
             >
                 x
             </button>
+            {/*
+             * The old tray's own controls — its open/close button, and the
+             * tray surface between the keys — sent no key at all: they sent
+             * `accessed` from the root's `onMouseDown` and again from its
+             * `onClick`, since only the keys stopped propagation.
+             */}
+            <button data-test="legacy-tray-control" onClick={postAccessed}>
+                tray
+            </button>
         </div>
     );
 }
@@ -170,6 +179,31 @@ describe("DoenetViewer (iframe wrapper) — a keyboard tray from before it decli
             .find(".mq-editable-field")
             .should("contain.text", "x")
             .should("not.contain.text", "xx");
+        cy.get("iframe")
+            .its("0.contentDocument.activeElement")
+            .should("not.match", "textarea");
+    });
+
+    it("does not leave an input holding the keyboard after a tray press that sends no key", () => {
+        cy.mount(<Harness />);
+
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("exist")
+            .click();
+
+        // Pressing the tray somewhere that is not a key blurs the input just
+        // as a key would, and announces itself the same way — but no key ever
+        // follows, so nothing is owed to that input.
+        cy.get("[data-test=legacy-tray-control]").click();
+        cy.wait(SETTLE_MS);
+
+        // Long enough afterwards that this key cannot be the one that press
+        // was reaching for.
+        cy.get("[data-test=legacy-key-x]").click();
+        cy.wait(SETTLE_MS);
+
+        viewerBody().find(".mq-editable-field").should("not.contain.text", "x");
         cy.get("iframe")
             .its("0.contentDocument.activeElement")
             .should("not.match", "textarea");

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
@@ -60,20 +60,22 @@ function LegacyKeyboardTray({
         // No `preventDefault`: this is what the old tray did, and the reason
         // the viewer's input blurs when a key is pressed.
         <div id="legacy-keyboard-tray" onMouseDown={postAccessed}>
+            {/*
+             * A key sent its commands and nothing else: its own `onClick`
+             * called `stopPropagation`, so the root's never ran for it. The
+             * `accessed` that accompanies a key press is the one from the
+             * root's `onMouseDown`, above.
+             */}
             <button
                 data-test="legacy-key-x"
-                onClick={() => {
-                    post([{ type: "type", command: "x" }]);
-                    // The old tray's root `onClick` fired after the key's own.
-                    postAccessed();
-                }}
+                onClick={() => post([{ type: "type", command: "x" }])}
             >
                 x
             </button>
             {/*
-             * The old tray's own controls — its open/close button, and the
-             * tray surface between the keys — sent no key at all: they sent
-             * `accessed` from the root's `onMouseDown` and again from its
+             * The old tray's own controls — its open and close buttons, and
+             * the tray surface between the keys — sent no key at all: they
+             * sent `accessed` from the root's `onMouseDown` and again from its
              * `onClick`, since only the keys stopped propagation.
              */}
             <button data-test="legacy-tray-control" onClick={postAccessed}>
@@ -184,7 +186,7 @@ describe("DoenetViewer (iframe wrapper) — a keyboard tray from before it decli
             .should("not.match", "textarea");
     });
 
-    it("does not leave an input holding the keyboard after a tray press that sends no key", () => {
+    it("gives the caret back after a tray press that sends no key", () => {
         cy.mount(<Harness />);
 
         viewerBody()
@@ -192,20 +194,54 @@ describe("DoenetViewer (iframe wrapper) — a keyboard tray from before it decli
             .should("exist")
             .click();
 
-        // Pressing the tray somewhere that is not a key blurs the input just
-        // as a key would, and announces itself the same way — but no key ever
-        // follows, so nothing is owed to that input.
+        // Opening this tray is a press on it like any other: it takes focus,
+        // and sends no key. This is the ordinary way a reader starts — focus
+        // the input, then reach for the keyboard — so the caret has to come
+        // back, or the first key they press afterwards types nowhere.
         cy.get("[data-test=legacy-tray-control]").click();
-        cy.wait(SETTLE_MS);
-
-        // Long enough afterwards that this key cannot be the one that press
-        // was reaching for.
-        cy.get("[data-test=legacy-key-x]").click();
         cy.wait(SETTLE_MS);
 
         viewerBody().find(".mq-editable-field").should("not.contain.text", "x");
         cy.get("iframe")
             .its("0.contentDocument.activeElement")
+            .should("match", "textarea");
+
+        // Long enough afterwards to be well outside the window in which a key
+        // is matched to a blur: this one types because the input holds the
+        // caret again, not because anything was recorded on its behalf.
+        cy.get("[data-test=legacy-key-x]").click();
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "x");
+    });
+
+    it("does not pull the caret back into an input the reader has left", () => {
+        cy.mount(<Harness />);
+
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("exist")
+            .click();
+
+        // The reader moves on to the surrounding text, which takes no focus of
+        // its own — the same shape of blur a press on this tray causes.
+        viewerBody().find(".para").click("left");
+        cy.get("iframe")
+            .its("0.contentDocument.activeElement")
             .should("not.match", "textarea");
+
+        // Long enough that the next press cannot be the cause of that blur.
+        cy.wait(SETTLE_MS);
+        cy.get("[data-test=legacy-tray-control]").click();
+        cy.wait(SETTLE_MS);
+
+        // The press took no caret from this input, so it has none to give
+        // back, and the input is not left holding the keyboard either.
+        cy.get("iframe")
+            .its("0.contentDocument.activeElement")
+            .should("not.match", "textarea");
+        cy.get("[data-test=legacy-key-x]").click();
+        cy.wait(SETTLE_MS);
+        viewerBody().find(".mq-editable-field").should("not.contain.text", "x");
     });
 });

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.legacyKeyboardTray.cy.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/index";
+import {
+    STANDALONE_BLOB_URL,
+    STANDALONE_CSS_BLOB_URL,
+    IFRAME_READY_TIMEOUT,
+} from "./helpers";
+
+// Rendering a document requires a core-worker boot on top of evaluating the
+// bundle; budget more than IFRAME_READY_TIMEOUT for it.
+const CONTENT_TIMEOUT = 30_000;
+
+const DOENETML = '<p>Type here: <mathInput name="mi" /></p>';
+
+/**
+ * The keyboard tray as `@doenet/doenetml-iframe@0.7.21` shipped it — the
+ * version deployed on doenet.org — reduced to the two behaviors that decide
+ * whether a viewer can be typed into.
+ *
+ * Both are taken from that package's published `index.js`:
+ *
+ *   1. Its tray root carries `onMouseDown` and `onClick` handlers that send
+ *      `{ type: "accessed", command: "", timestamp }`, and **no**
+ *      `preventDefault` anywhere. So pressing a key focuses a real button in
+ *      this document, which pulls focus out of the viewer's iframe.
+ *   2. `ExternalVirtualKeyboard` forwards commands with
+ *      `contentWindow.postMessage({ keyCommands, subject: "keyboard" }, "*")`.
+ *
+ * That pairing is not hypothetical: doenet.org installs the wrapper as
+ * `^0.7.21` but serves the viewer from `@doenet/standalone@latest`, so
+ * publishing a viewer puts a new viewer under this old tray until the site
+ * redeploys.
+ */
+function LegacyKeyboardTray({
+    viewerRef,
+}: {
+    viewerRef: React.RefObject<HTMLDivElement | null>;
+}) {
+    function post(keyCommands: unknown[]) {
+        const iframe = viewerRef.current?.querySelector("iframe");
+        iframe?.contentWindow?.postMessage(
+            { keyCommands, subject: "keyboard" },
+            "*",
+        );
+    }
+
+    function postAccessed() {
+        post([{ type: "accessed", command: "", timestamp: +new Date() }]);
+    }
+
+    return (
+        // No `preventDefault`: this is what the old tray did, and the reason
+        // the viewer's input blurs when a key is pressed.
+        <div id="legacy-keyboard-tray" onMouseDown={postAccessed}>
+            <button
+                data-test="legacy-key-x"
+                onClick={() => {
+                    post([{ type: "type", command: "x" }]);
+                    // The old tray's root `onClick` fired after the key's own.
+                    postAccessed();
+                }}
+            >
+                x
+            </button>
+        </div>
+    );
+}
+
+function Harness() {
+    const viewerRef = React.useRef<HTMLDivElement>(null);
+
+    return (
+        <div>
+            <LegacyKeyboardTray viewerRef={viewerRef} />
+            <div ref={viewerRef}>
+                <DoenetViewer
+                    doenetML={DOENETML}
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                />
+            </div>
+        </div>
+    );
+}
+
+/** The viewer iframe's document body, once the document has rendered. */
+function viewerBody() {
+    return cy
+        .get("iframe", { timeout: IFRAME_READY_TIMEOUT })
+        .its("0.contentDocument.body")
+        .should("not.be.empty")
+        .then(cy.wrap);
+}
+
+describe("DoenetViewer (iframe wrapper) — a keyboard tray from before it declined focus", () => {
+    it("types into the math input, and gives it the caret back", () => {
+        cy.mount(<Harness />);
+
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("exist")
+            .click();
+
+        // The reader is editing the input: it holds focus inside the iframe.
+        cy.get("iframe")
+            .its("0.contentDocument.activeElement")
+            .should("match", "textarea");
+
+        // Pressing a key on this tray focuses a button out here, which blurs
+        // the input in there. The key arrives afterwards by `postMessage`.
+        cy.get("[data-test=legacy-key-x]").click();
+
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "x");
+
+        // And the caret is back in the input, so the reader can keep going —
+        // the old tray left focus on its own button.
+        cy.get("iframe")
+            .its("0.contentDocument.activeElement")
+            .should("match", "textarea");
+
+        // A second key proves the first was not a one-off: the input has to
+        // still be claiming the keyboard after the round trip.
+        cy.get("[data-test=legacy-key-x]").click();
+
+        viewerBody()
+            .find(".mq-editable-field", { timeout: CONTENT_TIMEOUT })
+            .should("contain.text", "xx");
+    });
+});

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.virtualKeyboard.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.virtualKeyboard.cy.tsx
@@ -230,6 +230,28 @@ describe("ExternalVirtualKeyboard — iframe routing", () => {
         cy.get("#virtual-keyboard-tray.open").should("not.exist");
     });
 
+    it("keeps the tray open while another viewer still has a math input focused", () => {
+        cy.mount(<Harness />);
+        stubCoarsePointer();
+
+        postFocusFromIframe(0, true);
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        // Every viewer on the page watches focus, and each reports only about
+        // its own inputs. That none of the second viewer's is focused says
+        // nothing about the first viewer's, and must not shut the tray the
+        // first one just opened.
+        postFocusFromIframe(1, false);
+        // The tray shutting is what would go wrong here, so the message has to
+        // have been delivered — and had its chance to shut it — before the
+        // assertion can mean anything.
+        cy.wait(100);
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        postFocusFromIframe(0, false);
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+    });
+
     it("stays shut at the next math input once the reader closes it", () => {
         cy.mount(<Harness />);
         stubCoarsePointer();
@@ -255,8 +277,11 @@ describe("ExternalVirtualKeyboard — iframe routing", () => {
         cy.mount(<Harness />);
 
         postFocusFromIframe(0, true);
-        // Give the message a chance to be delivered before asserting absence.
-        cy.get("iframe").eq(0).should("exist");
+        // The tray opening is what would go wrong here, so the message has to
+        // have been delivered — and had its chance to open it — before the
+        // assertion can mean anything. A following Cypress command is not
+        // enough of a wait: `postMessage` is delivered later than that.
+        cy.wait(100);
         cy.get("#virtual-keyboard-tray.open").should("not.exist");
     });
 
@@ -340,6 +365,11 @@ describe("VirtualKeyboard — same-window focus tracking", () => {
 
         cy.get("[data-testid=math-input]").focus();
         cy.focused().should("have.attr", "data-testid", "math-input");
+        // The tray opening is what would go wrong here, so the focus watcher
+        // has to have run — and had its chance to open it — before the
+        // assertion can mean anything. It reads focus back on a timeout, which
+        // a following Cypress command does not reliably outlast.
+        cy.wait(100);
         cy.get("#virtual-keyboard-tray.open").should("not.exist");
     });
 });

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.virtualKeyboard.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.virtualKeyboard.cy.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { ExternalVirtualKeyboard } from "../../../../virtual-keyboard/src/virtual-keyboard";
+import {
+    ExternalVirtualKeyboard,
+    VirtualKeyboard,
+} from "../../../../virtual-keyboard/src/virtual-keyboard";
 
 function Harness() {
     const firstRef = React.useRef<HTMLIFrameElement>(null);
@@ -20,7 +23,41 @@ function Harness() {
     );
 }
 
+/**
+ * Command types that are not key presses: bookkeeping the tray sends alongside
+ * (or instead of) typed characters. See `KeyCommand`.
+ */
+const NON_KEY_PRESS_TYPES = ["accessed", "keyboardChoice"];
+
+/** Makes the page look like a phone to `(pointer: coarse)`. */
+function stubCoarsePointer() {
+    cy.window().then((win) => {
+        const realMatchMedia = win.matchMedia.bind(win);
+        cy.stub(win, "matchMedia").callsFake((query: string) =>
+            query === "(pointer: coarse)"
+                ? {
+                      matches: true,
+                      addEventListener() {},
+                      removeEventListener() {},
+                  }
+                : realMatchMedia(query),
+        );
+    });
+}
+
 describe("ExternalVirtualKeyboard — iframe routing", () => {
+    beforeEach(() => {
+        // The tray is torn down asynchronously once the last keyboard on the
+        // page unmounts, which can land in the middle of MathJax typesetting
+        // the keys and reject its promise. That happens as one test ends and
+        // so is reported against the next one, which is nothing to do with
+        // what that test is checking. Only this one rejection is tolerated.
+        cy.on(
+            "uncaught:exception",
+            (error) => !/Typesetting failed/.test(error.message),
+        );
+    });
+
     function expectWriteCallCount(alias: string, count: number) {
         cy.get(alias).should((spy) => {
             const writeCalls = spy
@@ -28,10 +65,24 @@ describe("ExternalVirtualKeyboard — iframe routing", () => {
                 .filter((call) =>
                     call.args[0].keyCommands.some(
                         (command: { type: string }) =>
-                            command.type !== "accessed",
+                            !NON_KEY_PRESS_TYPES.includes(command.type),
                     ),
                 );
             expect(writeCalls).to.have.length(count);
+        });
+    }
+
+    function expectKeyboardChoices(alias: string, choices: string[]) {
+        cy.get(alias).should((spy) => {
+            const reported = spy
+                .getCalls()
+                .flatMap((call) => call.args[0].keyCommands)
+                .filter(
+                    (command: { type: string }) =>
+                        command.type === "keyboardChoice",
+                )
+                .map((command: { command: string }) => command.command);
+            expect(reported).to.deep.equal(choices);
         });
     }
 
@@ -76,6 +127,139 @@ describe("ExternalVirtualKeyboard — iframe routing", () => {
         expectWriteCallCount("@secondPostMessage", 1);
     });
 
+    it("reports the reader's keyboard choice to every owner, not just the focused one", () => {
+        cy.mount(<Harness />);
+
+        cy.get("iframe")
+            .eq(0)
+            .then(($iframe) => {
+                cy.spy(
+                    ($iframe[0] as HTMLIFrameElement).contentWindow!,
+                    "postMessage",
+                ).as("firstPostMessage");
+            });
+        cy.get("iframe")
+            .eq(1)
+            .then(($iframe) => {
+                cy.spy(
+                    ($iframe[0] as HTMLIFrameElement).contentWindow!,
+                    "postMessage",
+                ).as("secondPostMessage");
+            });
+
+        // Nothing is focused: opening the tray is how a reader on a phone
+        // reaches for the Doenet keyboard before touching an input, and both
+        // viewers have to learn of it so they keep the system keyboard down.
+        cy.get(".open-keyboard-button").click({ force: true });
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+        cy.get(".close-keyboard-button").click({ force: true });
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+
+        expectKeyboardChoices("@firstPostMessage", ["virtual", "system"]);
+        expectKeyboardChoices("@secondPostMessage", ["virtual", "system"]);
+    });
+
+    it("declines focus when a key is pressed", () => {
+        cy.mount(<Harness />);
+
+        cy.get(".open-keyboard-button").click({ force: true });
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        // Cancelling the default action of the press is what keeps focus in
+        // the input the reader is typing into. Without it the input blurs on
+        // every key and has to be refocused, which on Android re-summons the
+        // system keyboard on top of this tray (issue #1692).
+        //
+        // Asserted on the events themselves rather than by watching focus:
+        // events dispatched from a test are untrusted and never move focus, so
+        // a focus assertion would pass whether or not the tray declined it.
+        cy.get("#virtual-keyboard-tray .key-y").then(($key) => {
+            for (const press of [
+                new PointerEvent("pointerdown", {
+                    bubbles: true,
+                    cancelable: true,
+                }),
+                new MouseEvent("mousedown", {
+                    bubbles: true,
+                    cancelable: true,
+                }),
+            ]) {
+                $key[0].dispatchEvent(press);
+                expect(
+                    press.defaultPrevented,
+                    `${press.type} default prevented`,
+                ).to.equal(true);
+            }
+        });
+    });
+
+    /**
+     * Reports focus the way the viewer inside the iframe does, since the tray
+     * in this window cannot see which element inside an iframe has focus.
+     */
+    function postFocusFromIframe(index: number, mathInputFocused: boolean) {
+        cy.get("iframe")
+            .eq(index)
+            .then(($iframe) => {
+                const iframeWindow = ($iframe[0] as HTMLIFrameElement)
+                    .contentWindow!;
+                // The message has to be posted by a script belonging to the
+                // iframe, not merely aimed at its parent from out here: the
+                // keyboard identifies its own iframe by `event.source`, and
+                // that is the realm of whoever called `postMessage`.
+                const postFromIframe = new (iframeWindow as any).Function(
+                    "mathInputFocused",
+                    'parent.postMessage({subject: "keyboard-focus", mathInputFocused}, "*")',
+                );
+                postFromIframe(mathInputFocused);
+            });
+    }
+
+    it("follows math input focus on a touch device", () => {
+        cy.mount(<Harness />);
+        stubCoarsePointer();
+
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+
+        postFocusFromIframe(0, true);
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        // Focus moving to something that is not a math input — a text input,
+        // say — gets the tray out of the way of the device's own keyboard.
+        postFocusFromIframe(0, false);
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+    });
+
+    it("stays shut at the next math input once the reader closes it", () => {
+        cy.mount(<Harness />);
+        stubCoarsePointer();
+
+        postFocusFromIframe(0, true);
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        cy.get(".close-keyboard-button").click({ force: true });
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+
+        // The reader asked for the tray to go away; moving between math inputs
+        // must not overrule them.
+        postFocusFromIframe(0, false);
+        postFocusFromIframe(1, true);
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+
+        // Until they ask for it back.
+        cy.get(".open-keyboard-button").click({ force: true });
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+    });
+
+    it("leaves the tray under manual control on a desktop", () => {
+        cy.mount(<Harness />);
+
+        postFocusFromIframe(0, true);
+        // Give the message a chance to be delivered before asserting absence.
+        cy.get("iframe").eq(0).should("exist");
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+    });
+
     it("keeps the last active owner's theme when focus leaves all owners", () => {
         cy.mount(<Harness />);
 
@@ -93,5 +277,69 @@ describe("ExternalVirtualKeyboard — iframe routing", () => {
             "data-theme",
             "dark",
         );
+    });
+});
+
+/**
+ * The keyboard as it runs when the viewer and the tray share a window — the
+ * plain (non-iframe) embedding, where the keyboard watches focus itself
+ * instead of being told about it.
+ */
+function SameWindowHarness() {
+    // Stands in for `mathInput`'s record of the focused math input: the
+    // element of whichever math input has focus, and null when none does.
+    const focusedMathInput = React.useRef<HTMLElement | null>(null);
+    const mathInputRef = React.useRef<HTMLDivElement>(null);
+
+    return (
+        <div>
+            <VirtualKeyboard ownerRef={focusedMathInput} theme="light" />
+            <div
+                ref={mathInputRef}
+                tabIndex={0}
+                data-testid="math-input"
+                onFocus={() => {
+                    focusedMathInput.current = mathInputRef.current;
+                }}
+                onBlur={() => {
+                    focusedMathInput.current = null;
+                }}
+            >
+                math input
+            </div>
+            <input type="text" data-testid="text-input" />
+        </div>
+    );
+}
+
+describe("VirtualKeyboard — same-window focus tracking", () => {
+    beforeEach(() => {
+        cy.on(
+            "uncaught:exception",
+            (error) => !/Typesetting failed/.test(error.message),
+        );
+    });
+
+    it("follows math input focus on a touch device", () => {
+        cy.mount(<SameWindowHarness />);
+        stubCoarsePointer();
+
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+
+        cy.get("[data-testid=math-input]").focus();
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        // A text input wants the device's own keyboard, and all of the screen
+        // the tray is sitting on.
+        cy.get("[data-testid=text-input]").focus();
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+    });
+
+    it("leaves the tray under manual control on a desktop", () => {
+        cy.mount(<SameWindowHarness />);
+
+        cy.get("[data-testid=math-input]").focus();
+        cy.focused().should("have.attr", "data-testid", "math-input");
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
     });
 });

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -15,7 +15,11 @@ import useDoenetRenderer, {
 import { MathField } from "./mathquill/types";
 import { EditableMathField } from "./mathquill/EditableMathField";
 import "./mathquill/mathquill.css";
-import { DEFAULT_MATH_INPUT_FUNCTION_NAMES } from "@doenet/utils";
+import {
+    DEFAULT_MATH_INPUT_FUNCTION_NAMES,
+    hasCoarsePrimaryPointer,
+    subscribeToPrimaryPointerType,
+} from "@doenet/utils";
 import { DescriptionPopover } from "./utils/Description";
 import * as Ariakit from "@ariakit/react";
 
@@ -372,37 +376,52 @@ function MathInputPreviewPopover({
 }
 
 /**
+ * Whether the reader's primary pointing device is coarse, re-evaluated if that
+ * changes (a tablet gaining a trackpad).
+ */
+function useHasCoarsePrimaryPointer(): boolean {
+    return React.useSyncExternalStore(
+        subscribeToPrimaryPointerType,
+        hasCoarsePrimaryPointer,
+        // Server snapshot: assume a conventional pointer device.
+        () => false,
+    );
+}
+
+/**
  * Computes blur-transition context used by `handleBlur`.
  *
- * Determines whether a blur was likely caused by the virtual keyboard handoff
- * and whether focus moved into the preview region, which allows the input blur
- * to be treated as non-final while preview interaction continues.
+ * Determines where focus went, which decides whether the blur is final. Two
+ * destinations are not: the input's own preview popover, and the virtual
+ * keyboard tray, which the reader may have tabbed into in order to type with
+ * it. In both cases the reader is still working on this input.
+ *
+ * Note that clicking or tapping a key does *not* reach here at all — the tray
+ * cancels the default action of the pointer press, so focus never leaves the
+ * input. Only deliberate keyboard navigation into the tray produces a blur
+ * whose `relatedTarget` is inside it.
  */
 function getBlurTransitionContext({
     relatedTarget,
     previewRef,
-    lastBlurTime,
-    lastKeyboardAccessTime,
 }: {
     relatedTarget: EventTarget | null;
     previewRef: React.RefObject<HTMLDivElement | null>;
-    lastBlurTime: number;
-    lastKeyboardAccessTime: number;
 }) {
-    // If the blur was immediately preceded by a keyboard access,
-    // we conclude that the blur was caused by the keyboard access.
-    // If not, we currently indicate the blur was not caused by a keyboard access,
-    // though we'll also check if there is a keyboard access following the blur.
-    const keyboardCausedBlur =
-        Math.abs(lastKeyboardAccessTime - lastBlurTime) < 100;
-
     const focusMovedToPreview =
         relatedTarget instanceof Node &&
         previewRef.current?.contains(relatedTarget);
 
+    const focusMovedToKeyboardTray =
+        relatedTarget instanceof Node &&
+        (document
+            .getElementById("virtual-keyboard-tray")
+            ?.contains(relatedTarget) ??
+            false);
+
     return {
-        keyboardCausedBlur,
         focusMovedToPreview,
+        focusMovedToKeyboardTray,
     };
 }
 
@@ -454,6 +473,9 @@ export default function MathInput(props: UseDoenetRendererProps) {
     const virtualKeyboardEvents = useAppSelector(
         keyboardSlice.selectors.keyboardInput,
     );
+    const systemKeyboardRequested = useAppSelector(
+        keyboardSlice.selectors.systemKeyboardRequested,
+    );
     const focusedMathInput = useContext(FocusedMathInputContext);
     const [mathField, setMathField] = useState<MathField | null>(null);
     // `EditableMathField`'s `handlers.enter` callback can hold stale captures.
@@ -463,9 +485,33 @@ export default function MathInput(props: UseDoenetRendererProps) {
     const [focused, setFocused] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null); // Ref to keep track of the mathInput's disabled state
 
-    const lastKeyboardAccessTime = useRef(0);
-    const lastBlurTime = useRef(0);
-    const keyboardCausedBlur = useRef(false);
+    // On a touch device the Doenet keyboard and the device's own on-screen
+    // keyboard compete for the same screen, so only one of them may be in
+    // play. The Doenet keyboard has it unless the reader closes the tray,
+    // which is how they ask for the device's keyboard back. Deciding this from
+    // the outset, rather than waiting for the tray to open, is what stops the
+    // system keyboard from appearing at the first math input a reader taps.
+    const coarsePointer = useHasCoarsePrimaryPointer();
+    const suppressSystemKeyboard = coarsePointer && !systemKeyboardRequested;
+
+    useEffect(() => {
+        const textarea = textareaRef.current;
+        if (!textarea) {
+            return;
+        }
+        // `inputmode="none"` keeps focus, the caret, selection, and any
+        // physical keyboard working while telling the device not to raise its
+        // on-screen keyboard — the standard way to run a custom math keyboard
+        // on the web (issue #1692). Supported by Chrome/Android 66+, Safari
+        // iOS 12.2+, and Firefox for Android; ignored by desktop browsers,
+        // which is harmless because it is only ever set on touch devices.
+        //
+        // Changing this while the input is focused does not retract a system
+        // keyboard that is already up: reopening it, or dismissing it, needs a
+        // fresh tap on the input, because iOS raises the keyboard only during
+        // a user gesture and this runs after one.
+        textarea.inputMode = suppressSystemKeyboard ? "none" : "text";
+    }, [suppressSystemKeyboard, mathField]);
 
     const rendererValue = useRef(SVs.rawRendererValue);
 
@@ -579,7 +625,10 @@ export default function MathInput(props: UseDoenetRendererProps) {
 
     React.useEffect(() => {
         if (!mathField || focusedMathInput.current !== mathField.el()) {
-            // If we aren't the focused math input, ignore the events
+            // These keys belong to a different input. `focusedMathInput` is
+            // the record of which input the virtual keyboard is typing into;
+            // it deliberately outlives `document.activeElement` moving into
+            // the tray, so that the keyboard can be operated from the keyboard.
             return;
         }
         for (const event of virtualKeyboardEvents) {
@@ -598,50 +647,37 @@ export default function MathInput(props: UseDoenetRendererProps) {
                 }
                 continue;
             }
-            if (event.type === "accessed") {
-                // Record when the virtual keyboard was accessed.
-                lastKeyboardAccessTime.current = event.timestamp || 0;
-
-                // If keyboard access immediately follows blur, treat that blur as
-                // keyboard-caused (handoff), not user intent to leave the field.
-                if (
-                    Math.abs(
-                        lastKeyboardAccessTime.current - lastBlurTime.current,
-                    ) < 100
-                ) {
-                    keyboardCausedBlur.current = true;
-                }
-            }
-            if (keyboardCausedBlur.current) {
-                switch (event.type) {
-                    case "accessed":
-                        // Already handled
-                        break;
-                    case "cmd":
-                        mathField.cmd(event.command);
-                        break;
-                    case "write":
-                        mathField.write(event.command);
-                        break;
-                    case "keystroke":
-                        mathField.keystroke(event.command);
-                        break;
-                    case "type":
-                        mathField.typedText(event.command);
-                        break;
-                    default:
-                        console.warn(
-                            `Unknown event type: ${event.type} in MathInput`,
-                            event,
-                        );
-                        break;
-                }
+            switch (event.type) {
+                case "accessed":
+                case "keyboardChoice":
+                    // Not key presses. Both are handled elsewhere (or, for
+                    // `accessed`, no longer needed at all); see `KeyCommand`.
+                    break;
+                case "cmd":
+                    mathField.cmd(event.command);
+                    break;
+                case "write":
+                    mathField.write(event.command);
+                    break;
+                case "keystroke":
+                    mathField.keystroke(event.command);
+                    break;
+                case "type":
+                    mathField.typedText(event.command);
+                    break;
+                default:
+                    console.warn(
+                        `Unknown event type: ${event.type} in MathInput`,
+                        event,
+                    );
+                    break;
             }
         }
-        if (keyboardCausedBlur.current) {
-            // If the keyboard caused the blur, return focus to the mathField
-            mathField.focus();
-        }
+        // Deliberately no `mathField.focus()` here. The tray declines focus, so
+        // this input still has it; and when the reader has instead tabbed into
+        // the tray, pulling focus back would make the keyboard impossible to
+        // operate by keyboard. Refocusing on every key is also what re-summoned
+        // Android's system keyboard over the tray (issue #1692).
     }, [virtualKeyboardEvents]);
 
     function onFocusChanged(focused: boolean) {
@@ -660,33 +696,36 @@ export default function MathInput(props: UseDoenetRendererProps) {
     };
 
     const handleBlur: FocusEventHandler<HTMLElement> = (e) => {
-        lastBlurTime.current = +new Date();
-
-        const {
-            keyboardCausedBlur: nextKeyboardCausedBlur,
-            focusMovedToPreview,
-        } = getBlurTransitionContext({
-            relatedTarget: e.relatedTarget,
-            previewRef: preview.previewRef,
-            lastBlurTime: lastBlurTime.current,
-            lastKeyboardAccessTime: lastKeyboardAccessTime.current,
-        });
-
-        keyboardCausedBlur.current = nextKeyboardCausedBlur;
-
-        if (!keyboardCausedBlur.current) {
-            // For a genuine blur (not virtual-keyboard handoff), commit and unfocus.
-            callAction({
-                action: actions.updateValue,
-                baseVariableValue: rendererValue.current,
+        const { focusMovedToPreview, focusMovedToKeyboardTray } =
+            getBlurTransitionContext({
+                relatedTarget: e.relatedTarget,
+                previewRef: preview.previewRef,
             });
-            onFocusChanged(false);
 
-            // Keep preview open when keyboard focus tabs from the input into the
-            // preview region.
-            if (focusMovedToPreview) {
-                preview.setInteractingWithPreview(true);
-            }
+        if (focusMovedToKeyboardTray) {
+            // The reader moved focus into the virtual keyboard in order to type
+            // with it, so this input is still the one being edited: stay
+            // registered as the target of its keys, and neither commit the
+            // value nor drop the focused styling.
+            return;
+        }
+
+        // For a genuine blur, stop claiming the virtual keyboard's keys, then
+        // commit and unfocus.
+        if (mathField && focusedMathInput.current === mathField.el()) {
+            focusedMathInput.current = null;
+        }
+
+        callAction({
+            action: actions.updateValue,
+            baseVariableValue: rendererValue.current,
+        });
+        onFocusChanged(false);
+
+        // Keep preview open when keyboard focus tabs from the input into the
+        // preview region.
+        if (focusMovedToPreview) {
+            preview.setInteractingWithPreview(true);
         }
     };
 
@@ -1134,6 +1173,14 @@ export default function MathInput(props: UseDoenetRendererProps) {
                     textareaRef.current = document.createElement("textarea");
                     textareaRef.current.id = inputKey;
                     textareaRef.current.disabled = SVs.disabled;
+                    // MathQuill puts these on the textarea it would have built
+                    // itself, so a substitute has to repeat them. They matter
+                    // most on phones, whose keyboards would otherwise
+                    // capitalize and autocorrect mathematics.
+                    textareaRef.current.setAttribute("autocapitalize", "off");
+                    textareaRef.current.setAttribute("autocomplete", "off");
+                    textareaRef.current.setAttribute("autocorrect", "off");
+                    textareaRef.current.spellcheck = false;
                     textareaRef.current.addEventListener("keydown", (event) => {
                         if (event.key === "Escape") {
                             // Match preview Escape behavior: dismiss the

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -73,24 +73,26 @@ const PARSE_ERROR_PLACEHOLDER_LATEX = "\uff3f";
 const EMPTY_AUTO_OPERATOR_NAMES_SENTINEL = "a-";
 
 /**
- * How soon after a math input gives up its claim on the virtual keyboard a key
- * from a keyboard tray predating this change must arrive for the press that
- * sent it to be read as the cause of that blur — which is what lets such a
- * tray still type (see `KeyCommand`).
+ * How soon after a math input gives up its claim on the virtual keyboard a
+ * press on a keyboard tray predating this change must reach it for that press
+ * to be read as the cause of the blur — which is what lets such a tray still
+ * type into the input, and give it back the caret its press took (see
+ * `KeyCommand`).
  *
  * A bound is needed because nothing else separates that blur from the reader
  * leaving the input of their own accord and reaching for the tray afterwards,
- * and typing in the latter case would put a character into an input the reader
+ * and acting in the latter case would put a character into an input the reader
  * has left and pull the caret back to it. The viewers contemporary with such a
  * tray drew the same line, at 100 ms between the blur and the tray's own
- * timestamp; this measures instead from the blur to the key being handled, so
- * it allows for the `postMessage` hop and the render that follows, while
+ * timestamp; this measures instead from the blur to the message being handled,
+ * so it allows for the `postMessage` hop and the render that follows, while
  * staying well inside the time it takes a reader to leave an input and press a
  * key.
  *
- * A key that misses the window types nothing, which is the same nothing the
- * reader would have got before this accommodation existed — the bound cannot
- * misdirect a key, only decline it.
+ * A press that misses the window does nothing at all, which is the same
+ * nothing the reader would have got before this accommodation existed: the
+ * bound can only decline a press, never send one to an input other than the
+ * one whose blur it is being matched against.
  */
 const LEGACY_TRAY_RECLAIM_WINDOW_MS = 300;
 
@@ -632,10 +634,11 @@ export default function MathInput(props: UseDoenetRendererProps) {
      * having blurred the input as it was pressed, so its keys are matched to
      * the release of the claim that same press caused: this input's, to
      * nothing else in the document, and still fresh. Each key is judged on its
-     * own, and only against the release it can plausibly have caused; the
-     * claim is never reinstated behind the reader's back, so a press that
-     * lands on the tray without producing a key — its close button, the gap
-     * between two keys — leaves nothing behind for a later key to type into.
+     * own, and only against the release it can plausibly have caused, so a key
+     * that arrives long after the reader left an input types nowhere. A press
+     * of such a tray that carried no key is judged the same way: what it owes
+     * the input — the caret it took — is owed to whichever input its keys
+     * would have gone to.
      */
     function claimsVirtualKeyboardKeys(input: HTMLElement) {
         if (focusedMathInput.current === input) {
@@ -656,7 +659,10 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // seeing one settles which tray this page is under for good — and
         // until one is seen, none of the accommodation below applies, which is
         // what keeps it out of current pairings entirely.
-        if (virtualKeyboardEvents.some((event) => event.type === "accessed")) {
+        const trayTookFocus = virtualKeyboardEvents.some(
+            (event) => event.type === "accessed",
+        );
+        if (trayTookFocus) {
             legacyKeyboardTray.current.announced = true;
         }
 
@@ -720,15 +726,29 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // keyboard over the tray (issue #1692).
         //
         // The exception is a tray old enough to have taken focus when it was
-        // pressed: the reader is left with no caret, so put it back, as that
-        // tray's contemporaries did after every key. Recognized by this input
-        // having lost focus to nothing in particular — a reader who moved into
-        // a tray in this document did so deliberately and keeps focus there,
-        // and one typing into an input that still has focus needs nothing.
+        // pressed: whatever the press was reaching for, it left the reader
+        // with no caret, so put it back, as that tray's contemporaries did.
+        // Every press of such a tray says so — that is what `accessed` was
+        // sent for — and not only the ones that carry a key: the reader who
+        // opens the tray while editing an input is still editing it, and would
+        // otherwise find the first key they then press typing nowhere.
+        //
+        // Giving the caret back is a real focus move the reader can see, not a
+        // claim recorded on their behalf: the input holds the keyboard
+        // afterwards because it holds the caret, and gives it up the moment
+        // the reader takes the caret elsewhere. So the worst a misjudged press
+        // can do — the freshness bound in `claimsVirtualKeyboardKeys` is all
+        // that separates the blur such a press causes from the reader leaving
+        // of their own accord — is move the caret in plain sight.
+        //
+        // Where the caret has not in fact been taken, there is nothing to give
+        // back: a reader who moved into a tray in this document did so
+        // deliberately and keeps focus there, and one whose input still has
+        // focus needs nothing.
         const activeElement =
             textareaRef.current?.ownerDocument.activeElement ?? null;
         if (
-            handledAKey &&
+            (handledAKey || trayTookFocus) &&
             activeElement !== textareaRef.current &&
             !isInVirtualKeyboardTray(activeElement)
         ) {

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -32,7 +32,7 @@ import { MathJax } from "better-react-mathjax";
 import "./mathInput.css";
 import {
     FocusedMathInputContext,
-    LastEditedMathInputContext,
+    ReleasedKeyboardClaimContext,
 } from "../../doenetml";
 import { useAppSelector } from "../../state";
 import { keyboardSlice } from "../../state/slices/keyboard";
@@ -71,6 +71,24 @@ const PARSE_ERROR_PLACEHOLDER_LATEX = "\uff3f";
  * smaller `_maxLength` means less work on every keystroke.
  */
 const EMPTY_AUTO_OPERATOR_NAMES_SENTINEL = "a-";
+
+/**
+ * How soon after a math input gives up its claim on the virtual keyboard an
+ * `accessed` message must arrive for the press that sent it to be read as the
+ * cause of that blur — the one thing that lets an input driven by a keyboard
+ * tray from before this change take its claim back (see `KeyCommand`).
+ *
+ * A bound is needed because nothing else separates that blur from the reader
+ * leaving the input of their own accord and reaching for the tray afterwards,
+ * and reclaiming in the latter case would type into an input the reader has
+ * left and pull the caret back to it. The viewers contemporary with such a
+ * tray drew the same line, at 100 ms between the blur and the tray's own
+ * timestamp; this measures instead from the blur to the message being handled,
+ * so it allows for the `postMessage` hop and the render that follows, while
+ * staying well inside the time it takes a reader to leave an input and press a
+ * key.
+ */
+const LEGACY_TRAY_RECLAIM_WINDOW_MS = 300;
 
 /**
  * Encapsulates math input preview popover state and interaction behavior.
@@ -447,7 +465,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         keyboardSlice.selectors.systemKeyboardRequested,
     );
     const focusedMathInput = useContext(FocusedMathInputContext);
-    const lastEditedMathInput = useContext(LastEditedMathInputContext);
+    const releasedKeyboardClaim = useContext(ReleasedKeyboardClaimContext);
     const [mathField, setMathField] = useState<MathField | null>(null);
     // `EditableMathField`'s `handlers.enter` callback can hold stale captures.
     // Keep the latest MathField instance in a ref for enter handling.
@@ -608,11 +626,16 @@ export default function MathInput(props: UseDoenetRendererProps) {
         //
         // The old tray sends this from the pointer press that causes the blur,
         // so it always arrives between the blur and the key. Current trays
-        // never send it, which is what confines this to the old ones.
+        // never send it, which is what confines this to the old ones. The
+        // release it answers has to be this input's, recent, and to nothing
+        // else in this document — otherwise the reader left the input on their
+        // own and a key pressed afterwards is not theirs to take back.
+        const release = releasedKeyboardClaim.current;
         if (
             mathField &&
             focusedMathInput.current === null &&
-            lastEditedMathInput.current === mathField.el() &&
+            release?.input === mathField.el() &&
+            Date.now() - release.releasedAt < LEGACY_TRAY_RECLAIM_WINDOW_MS &&
             virtualKeyboardEvents.some((event) => event.type === "accessed")
         ) {
             focusedMathInput.current = mathField.el();
@@ -645,8 +668,9 @@ export default function MathInput(props: UseDoenetRendererProps) {
             switch (event.type) {
                 case "accessed":
                 case "keyboardChoice":
-                    // Not key presses. Both are handled elsewhere (or, for
-                    // `accessed`, no longer needed at all); see `KeyCommand`.
+                    // Not key presses, and both are dealt with before they get
+                    // here: `accessed` by the reclaim above, `keyboardChoice`
+                    // on its way to the store. See `KeyCommand`.
                     break;
                 case "cmd":
                     mathField.cmd(event.command);
@@ -714,7 +738,6 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // taking it from `mathField` dropped the claim, and the keyboard then
         // typed nowhere until the reader left the input and came back.
         focusedMathInput.current = e.currentTarget;
-        lastEditedMathInput.current = e.currentTarget;
         onFocusChanged(true);
     };
 
@@ -722,13 +745,23 @@ export default function MathInput(props: UseDoenetRendererProps) {
      * Finishes a blur that has taken focus away from this input for good: stop
      * claiming the virtual keyboard's keys, commit the value, and drop the
      * focused styling. `nextFocused` is where focus has gone, if anywhere.
-     *
      */
     function endEditing(nextFocused: EventTarget | null) {
         stopWatchingTrayHandoff.current?.();
 
         if (mathField && focusedMathInput.current === mathField.el()) {
             focusedMathInput.current = null;
+            // A blur with nowhere to hand focus on to is the shape of the one
+            // an old keyboard tray causes, since it takes focus in the
+            // embedding page and `relatedTarget` does not cross that boundary.
+            // Record it so such a tray's press can be recognized as its cause
+            // and the claim taken back; a blur that named where focus went is
+            // the reader moving somewhere in this document, and leaves nothing
+            // to reclaim. See `LEGACY_TRAY_RECLAIM_WINDOW_MS`.
+            releasedKeyboardClaim.current =
+                nextFocused === null
+                    ? { input: mathField.el(), releasedAt: Date.now() }
+                    : null;
         }
 
         callAction({

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -20,7 +20,10 @@ import {
     hasCoarsePrimaryPointer,
     subscribeToPrimaryPointerType,
 } from "@doenet/utils";
-import { isInVirtualKeyboardTray } from "@doenet/virtual-keyboard";
+import {
+    getVirtualKeyboardTrayElement,
+    isInVirtualKeyboardTray,
+} from "@doenet/virtual-keyboard";
 import { DescriptionPopover } from "./utils/Description";
 import * as Ariakit from "@ariakit/react";
 
@@ -477,6 +480,11 @@ export default function MathInput(props: UseDoenetRendererProps) {
         textarea.inputMode = suppressSystemKeyboard ? "none" : "text";
     }, [suppressSystemKeyboard, mathField]);
 
+    // Detaches the watcher that `watchForFocusLeavingTray` installs on the
+    // tray, which lives outside this input's DOM and so outlives it otherwise.
+    const stopWatchingTrayHandoff = useRef<(() => void) | null>(null);
+    useEffect(() => () => stopWatchingTrayHandoff.current?.(), []);
+
     const rendererValue = useRef(SVs.rawRendererValue);
 
     // Keep this in a ref so `handlePressEnter` always sees current state.
@@ -659,28 +667,14 @@ export default function MathInput(props: UseDoenetRendererProps) {
         onFocusChanged(true);
     };
 
-    const handleBlur: FocusEventHandler<HTMLElement> = (e) => {
-        const relatedTarget = e.relatedTarget;
+    /**
+     * Finishes a blur that has taken focus away from this input for good: stop
+     * claiming the virtual keyboard's keys, commit the value, and drop the
+     * focused styling. `nextFocused` is where focus has gone, if anywhere.
+     */
+    function endEditing(nextFocused: EventTarget | null) {
+        stopWatchingTrayHandoff.current?.();
 
-        if (isInVirtualKeyboardTray(relatedTarget)) {
-            // The reader moved focus into the virtual keyboard in order to type
-            // with it, so this input is still the one being edited: stay
-            // registered as the target of its keys, and neither commit the
-            // value nor drop the focused styling. Pressing a key does not reach
-            // here at all — the tray cancels the default action of the pointer
-            // press, so focus never leaves the input; only deliberate keyboard
-            // navigation into the tray produces this blur.
-            //
-            // Nothing releases the input if the reader then tabs out of the
-            // tray to something else: it stays styled as focused, with its
-            // value uncommitted, until they come back to it. Same gap, and the
-            // same reason for leaving it as it is, as the tray's own claim —
-            // see `reportMathInputFocus`.
-            return;
-        }
-
-        // For a genuine blur, stop claiming the virtual keyboard's keys, then
-        // commit and unfocus.
         if (mathField && focusedMathInput.current === mathField.el()) {
             focusedMathInput.current = null;
         }
@@ -694,11 +688,71 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // Keep preview open when keyboard focus tabs from the input into the
         // preview region.
         if (
-            relatedTarget instanceof Node &&
-            preview.previewRef.current?.contains(relatedTarget)
+            nextFocused instanceof Node &&
+            preview.previewRef.current?.contains(nextFocused)
         ) {
             preview.setInteractingWithPreview(true);
         }
+    }
+
+    /**
+     * After focus has been handed from this input to the keyboard tray, waits
+     * for it to leave the tray again and finishes the blur unless it comes back
+     * here.
+     *
+     * The tray is not part of this input's DOM, so focus leaving it raises no
+     * further event on the input: without this the input would stay styled as
+     * focused, with its value uncommitted, until the reader returned to it and
+     * left it properly.
+     */
+    function watchForFocusLeavingTray() {
+        const tray = getVirtualKeyboardTrayElement();
+        if (!tray) {
+            return;
+        }
+
+        function handleTrayFocusOut(event: FocusEvent) {
+            const nextFocused = event.relatedTarget;
+            if (isInVirtualKeyboardTray(nextFocused)) {
+                // Focus is only moving between the tray's own keys.
+                return;
+            }
+            stopWatchingTrayHandoff.current?.();
+            if (
+                nextFocused instanceof Node &&
+                mathField?.el().contains(nextFocused)
+            ) {
+                // Focus came back here; `handleFocus` takes it from there.
+                return;
+            }
+            endEditing(nextFocused);
+        }
+
+        stopWatchingTrayHandoff.current?.();
+        tray.addEventListener("focusout", handleTrayFocusOut);
+        stopWatchingTrayHandoff.current = () => {
+            tray.removeEventListener("focusout", handleTrayFocusOut);
+            stopWatchingTrayHandoff.current = null;
+        };
+    }
+
+    const handleBlur: FocusEventHandler<HTMLElement> = (e) => {
+        const relatedTarget = e.relatedTarget;
+
+        if (isInVirtualKeyboardTray(relatedTarget)) {
+            // The reader moved focus into the virtual keyboard in order to type
+            // with it, so this input is still the one being edited: stay
+            // registered as the target of its keys, and neither commit the
+            // value nor drop the focused styling. Pressing a key does not reach
+            // here at all — the tray cancels the default action of the pointer
+            // press, so focus never leaves the input; only deliberate keyboard
+            // navigation into the tray produces this blur, and the editing
+            // ends when focus leaves the tray for somewhere that is not here.
+            watchForFocusLeavingTray();
+            return;
+        }
+
+        endEditing(relatedTarget);
     };
 
     const onChangeHandler = (text: string) => {

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -660,10 +660,18 @@ export default function MathInput(props: UseDoenetRendererProps) {
         });
     }
 
-    const handleFocus = (e: React.FocusEvent) => {
-        if (mathField) {
-            focusedMathInput.current = mathField.el();
-        }
+    const handleFocus: FocusEventHandler<HTMLElement> = (e) => {
+        // Claim the virtual keyboard's keys for this input.
+        //
+        // `e.currentTarget` rather than `mathField.el()`, even though they are
+        // the same element — MathQuill is built on it, and hands it back from
+        // `el()`. The two are not available at the same time, though: MathQuill
+        // creates the textarea while initializing, so a reader can focus it
+        // before React has committed the `mathField` state that initializing
+        // produced. Reading the element off the event closes that window;
+        // taking it from `mathField` dropped the claim, and the keyboard then
+        // typed nowhere until the reader left the input and came back.
+        focusedMathInput.current = e.currentTarget;
         onFocusChanged(true);
     };
 

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -26,6 +26,7 @@ import * as Ariakit from "@ariakit/react";
 import { MathJax } from "better-react-mathjax";
 
 import "./mathInput.css";
+import { isInVirtualKeyboardTray } from "@doenet/virtual-keyboard";
 import { FocusedMathInputContext } from "../../doenetml";
 import { useAppSelector } from "../../state";
 import { keyboardSlice } from "../../state/slices/keyboard";
@@ -412,12 +413,7 @@ function getBlurTransitionContext({
         relatedTarget instanceof Node &&
         previewRef.current?.contains(relatedTarget);
 
-    const focusMovedToKeyboardTray =
-        relatedTarget instanceof Node &&
-        (document
-            .getElementById("virtual-keyboard-tray")
-            ?.contains(relatedTarget) ??
-            false);
+    const focusMovedToKeyboardTray = isInVirtualKeyboardTray(relatedTarget);
 
     return {
         focusMovedToPreview,

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -659,10 +659,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // seeing one settles which tray this page is under for good — and
         // until one is seen, none of the accommodation below applies, which is
         // what keeps it out of current pairings entirely.
-        const trayTookFocus = virtualKeyboardEvents.some(
-            (event) => event.type === "accessed",
-        );
-        if (trayTookFocus) {
+        if (virtualKeyboardEvents.some((event) => event.type === "accessed")) {
             legacyKeyboardTray.current.announced = true;
         }
 
@@ -670,7 +667,6 @@ export default function MathInput(props: UseDoenetRendererProps) {
             // These keys belong to a different input, or to none.
             return;
         }
-        let handledAKey = false;
         for (const event of virtualKeyboardEvents) {
             if (event.type === "keystroke" && event.command === "Enter") {
                 // The "Enter" key was pressed
@@ -685,7 +681,6 @@ export default function MathInput(props: UseDoenetRendererProps) {
                 ) {
                     submitActionWithPendingRef.current();
                 }
-                handledAKey = true;
                 continue;
             }
             switch (event.type) {
@@ -697,19 +692,15 @@ export default function MathInput(props: UseDoenetRendererProps) {
                     break;
                 case "cmd":
                     mathField.cmd(event.command);
-                    handledAKey = true;
                     break;
                 case "write":
                     mathField.write(event.command);
-                    handledAKey = true;
                     break;
                 case "keystroke":
                     mathField.keystroke(event.command);
-                    handledAKey = true;
                     break;
                 case "type":
                     mathField.typedText(event.command);
-                    handledAKey = true;
                     break;
                 default:
                     console.warn(
@@ -728,10 +719,12 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // The exception is a tray old enough to have taken focus when it was
         // pressed: whatever the press was reaching for, it left the reader
         // with no caret, so put it back, as that tray's contemporaries did.
-        // Every press of such a tray says so — that is what `accessed` was
-        // sent for — and not only the ones that carry a key: the reader who
-        // opens the tray while editing an input is still editing it, and would
-        // otherwise find the first key they then press typing nowhere.
+        // Every press of such a tray took it, and not only the ones that carry
+        // a key: the reader who opens the tray while editing an input is still
+        // editing it, and would otherwise find the first key they then press
+        // typing nowhere. So the condition is which tray sent this batch, not
+        // what the batch contained — and since no current tray announces
+        // itself, no current pairing refocuses at all.
         //
         // Giving the caret back is a real focus move the reader can see, not a
         // claim recorded on their behalf: the input holds the keyboard
@@ -748,7 +741,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         const activeElement =
             textareaRef.current?.ownerDocument.activeElement ?? null;
         if (
-            (handledAKey || trayTookFocus) &&
+            legacyKeyboardTray.current.announced &&
             activeElement !== textareaRef.current &&
             !isInVirtualKeyboardTray(activeElement)
         ) {

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -32,7 +32,7 @@ import { MathJax } from "better-react-mathjax";
 import "./mathInput.css";
 import {
     FocusedMathInputContext,
-    ReleasedKeyboardClaimContext,
+    LegacyKeyboardTrayContext,
 } from "../../doenetml";
 import { useAppSelector } from "../../state";
 import { keyboardSlice } from "../../state/slices/keyboard";
@@ -73,20 +73,24 @@ const PARSE_ERROR_PLACEHOLDER_LATEX = "\uff3f";
 const EMPTY_AUTO_OPERATOR_NAMES_SENTINEL = "a-";
 
 /**
- * How soon after a math input gives up its claim on the virtual keyboard an
- * `accessed` message must arrive for the press that sent it to be read as the
- * cause of that blur — the one thing that lets an input driven by a keyboard
- * tray from before this change take its claim back (see `KeyCommand`).
+ * How soon after a math input gives up its claim on the virtual keyboard a key
+ * from a keyboard tray predating this change must arrive for the press that
+ * sent it to be read as the cause of that blur — which is what lets such a
+ * tray still type (see `KeyCommand`).
  *
  * A bound is needed because nothing else separates that blur from the reader
  * leaving the input of their own accord and reaching for the tray afterwards,
- * and reclaiming in the latter case would type into an input the reader has
- * left and pull the caret back to it. The viewers contemporary with such a
+ * and typing in the latter case would put a character into an input the reader
+ * has left and pull the caret back to it. The viewers contemporary with such a
  * tray drew the same line, at 100 ms between the blur and the tray's own
- * timestamp; this measures instead from the blur to the message being handled,
- * so it allows for the `postMessage` hop and the render that follows, while
+ * timestamp; this measures instead from the blur to the key being handled, so
+ * it allows for the `postMessage` hop and the render that follows, while
  * staying well inside the time it takes a reader to leave an input and press a
  * key.
+ *
+ * A key that misses the window types nothing, which is the same nothing the
+ * reader would have got before this accommodation existed — the bound cannot
+ * misdirect a key, only decline it.
  */
 const LEGACY_TRAY_RECLAIM_WINDOW_MS = 300;
 
@@ -465,7 +469,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         keyboardSlice.selectors.systemKeyboardRequested,
     );
     const focusedMathInput = useContext(FocusedMathInputContext);
-    const releasedKeyboardClaim = useContext(ReleasedKeyboardClaimContext);
+    const legacyKeyboardTray = useContext(LegacyKeyboardTrayContext);
     const [mathField, setMathField] = useState<MathField | null>(null);
     // `EditableMathField`'s `handlers.enter` callback can hold stale captures.
     // Keep the latest MathField instance in a ref for enter handling.
@@ -617,38 +621,50 @@ export default function MathInput(props: UseDoenetRendererProps) {
         }
     }, [callAction]);
 
+    /**
+     * Whether the keys the virtual keyboard has just sent belong to `input`.
+     *
+     * Ordinarily that is simply whether `input` holds the claim — a record
+     * that deliberately outlives `document.activeElement` moving into the
+     * tray, so that the keyboard can be operated from the keyboard.
+     *
+     * A tray from before it learned to decline focus leaves no claim to read,
+     * having blurred the input as it was pressed, so its keys are matched to
+     * the release of the claim that same press caused: this input's, to
+     * nothing else in the document, and still fresh. Each key is judged on its
+     * own, and only against the release it can plausibly have caused; the
+     * claim is never reinstated behind the reader's back, so a press that
+     * lands on the tray without producing a key — its close button, the gap
+     * between two keys — leaves nothing behind for a later key to type into.
+     */
+    function claimsVirtualKeyboardKeys(input: HTMLElement) {
+        if (focusedMathInput.current === input) {
+            return true;
+        }
+        const { announced, release } = legacyKeyboardTray.current;
+        return (
+            announced &&
+            focusedMathInput.current === null &&
+            release?.input === input &&
+            Date.now() - release.releasedAt < LEGACY_TRAY_RECLAIM_WINDOW_MS
+        );
+    }
+
     React.useEffect(() => {
         // An `accessed` message means the tray driving us predates the tray
-        // declining focus (see `KeyCommand`). Such a tray lives in the
-        // embedding page and takes focus when pressed, so this input has
-        // already been blurred and has given up its claim, and the key on its
-        // way over `postMessage` would land nowhere. Take the claim back.
-        //
-        // The old tray sends this from the pointer press that causes the blur,
-        // so it always arrives between the blur and the key. Current trays
-        // never send it, which is what confines this to the old ones. The
-        // release it answers has to be this input's, recent, and to nothing
-        // else in this document — otherwise the reader left the input on their
-        // own and a key pressed afterwards is not theirs to take back.
-        const release = releasedKeyboardClaim.current;
-        if (
-            mathField &&
-            focusedMathInput.current === null &&
-            release?.input === mathField.el() &&
-            Date.now() - release.releasedAt < LEGACY_TRAY_RECLAIM_WINDOW_MS &&
-            virtualKeyboardEvents.some((event) => event.type === "accessed")
-        ) {
-            focusedMathInput.current = mathField.el();
+        // declining focus (see `KeyCommand`). Only such a tray sends it, so
+        // seeing one settles which tray this page is under for good — and
+        // until one is seen, none of the accommodation below applies, which is
+        // what keeps it out of current pairings entirely.
+        if (virtualKeyboardEvents.some((event) => event.type === "accessed")) {
+            legacyKeyboardTray.current.announced = true;
         }
 
-        if (!mathField || focusedMathInput.current !== mathField.el()) {
-            // These keys belong to a different input. `focusedMathInput` is
-            // the record of which input the virtual keyboard is typing into;
-            // it deliberately outlives `document.activeElement` moving into
-            // the tray, so that the keyboard can be operated from the keyboard.
+        if (!mathField || !claimsVirtualKeyboardKeys(mathField.el())) {
+            // These keys belong to a different input, or to none.
             return;
         }
-        let typedSomething = false;
+        let handledAKey = false;
         for (const event of virtualKeyboardEvents) {
             if (event.type === "keystroke" && event.command === "Enter") {
                 // The "Enter" key was pressed
@@ -663,30 +679,31 @@ export default function MathInput(props: UseDoenetRendererProps) {
                 ) {
                     submitActionWithPendingRef.current();
                 }
+                handledAKey = true;
                 continue;
             }
             switch (event.type) {
                 case "accessed":
                 case "keyboardChoice":
                     // Not key presses, and both are dealt with before they get
-                    // here: `accessed` by the reclaim above, `keyboardChoice`
-                    // on its way to the store. See `KeyCommand`.
+                    // here: `accessed` above, `keyboardChoice` on its way to
+                    // the store. See `KeyCommand`.
                     break;
                 case "cmd":
                     mathField.cmd(event.command);
-                    typedSomething = true;
+                    handledAKey = true;
                     break;
                 case "write":
                     mathField.write(event.command);
-                    typedSomething = true;
+                    handledAKey = true;
                     break;
                 case "keystroke":
                     mathField.keystroke(event.command);
-                    typedSomething = true;
+                    handledAKey = true;
                     break;
                 case "type":
                     mathField.typedText(event.command);
-                    typedSomething = true;
+                    handledAKey = true;
                     break;
                 default:
                     console.warn(
@@ -706,11 +723,12 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // pressed: the reader is left with no caret, so put it back, as that
         // tray's contemporaries did after every key. Recognized by this input
         // having lost focus to nothing in particular — a reader who moved into
-        // a tray in this document did so deliberately and keeps focus there.
+        // a tray in this document did so deliberately and keeps focus there,
+        // and one typing into an input that still has focus needs nothing.
         const activeElement =
             textareaRef.current?.ownerDocument.activeElement ?? null;
         if (
-            typedSomething &&
+            handledAKey &&
             activeElement !== textareaRef.current &&
             !isInVirtualKeyboardTray(activeElement)
         ) {
@@ -754,11 +772,12 @@ export default function MathInput(props: UseDoenetRendererProps) {
             // A blur with nowhere to hand focus on to is the shape of the one
             // an old keyboard tray causes, since it takes focus in the
             // embedding page and `relatedTarget` does not cross that boundary.
-            // Record it so such a tray's press can be recognized as its cause
-            // and the claim taken back; a blur that named where focus went is
-            // the reader moving somewhere in this document, and leaves nothing
-            // to reclaim. See `LEGACY_TRAY_RECLAIM_WINDOW_MS`.
-            releasedKeyboardClaim.current =
+            // Record it so a key from such a tray can be recognized as coming
+            // from the press that caused it; a blur that named where focus
+            // went is the reader moving somewhere in this document, and leaves
+            // nothing for a key to come back to. See
+            // `claimsVirtualKeyboardKeys`.
+            legacyKeyboardTray.current.release =
                 nextFocused === null
                     ? { input: mathField.el(), releasedAt: Date.now() }
                     : null;

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -20,13 +20,13 @@ import {
     hasCoarsePrimaryPointer,
     subscribeToPrimaryPointerType,
 } from "@doenet/utils";
+import { isInVirtualKeyboardTray } from "@doenet/virtual-keyboard";
 import { DescriptionPopover } from "./utils/Description";
 import * as Ariakit from "@ariakit/react";
 
 import { MathJax } from "better-react-mathjax";
 
 import "./mathInput.css";
-import { isInVirtualKeyboardTray } from "@doenet/virtual-keyboard";
 import { FocusedMathInputContext } from "../../doenetml";
 import { useAppSelector } from "../../state";
 import { keyboardSlice } from "../../state/slices/keyboard";
@@ -389,38 +389,6 @@ function useHasCoarsePrimaryPointer(): boolean {
     );
 }
 
-/**
- * Computes blur-transition context used by `handleBlur`.
- *
- * Determines where focus went, which decides whether the blur is final. Two
- * destinations are not: the input's own preview popover, and the virtual
- * keyboard tray, which the reader may have tabbed into in order to type with
- * it. In both cases the reader is still working on this input.
- *
- * Note that clicking or tapping a key does *not* reach here at all — the tray
- * cancels the default action of the pointer press, so focus never leaves the
- * input. Only deliberate keyboard navigation into the tray produces a blur
- * whose `relatedTarget` is inside it.
- */
-function getBlurTransitionContext({
-    relatedTarget,
-    previewRef,
-}: {
-    relatedTarget: EventTarget | null;
-    previewRef: React.RefObject<HTMLDivElement | null>;
-}) {
-    const focusMovedToPreview =
-        relatedTarget instanceof Node &&
-        previewRef.current?.contains(relatedTarget);
-
-    const focusMovedToKeyboardTray = isInVirtualKeyboardTray(relatedTarget);
-
-    return {
-        focusMovedToPreview,
-        focusMovedToKeyboardTray,
-    };
-}
-
 interface MathInputSVs {
     [key: string]: any;
     hidden: boolean;
@@ -692,17 +660,22 @@ export default function MathInput(props: UseDoenetRendererProps) {
     };
 
     const handleBlur: FocusEventHandler<HTMLElement> = (e) => {
-        const { focusMovedToPreview, focusMovedToKeyboardTray } =
-            getBlurTransitionContext({
-                relatedTarget: e.relatedTarget,
-                previewRef: preview.previewRef,
-            });
+        const relatedTarget = e.relatedTarget;
 
-        if (focusMovedToKeyboardTray) {
+        if (isInVirtualKeyboardTray(relatedTarget)) {
             // The reader moved focus into the virtual keyboard in order to type
             // with it, so this input is still the one being edited: stay
             // registered as the target of its keys, and neither commit the
-            // value nor drop the focused styling.
+            // value nor drop the focused styling. Pressing a key does not reach
+            // here at all — the tray cancels the default action of the pointer
+            // press, so focus never leaves the input; only deliberate keyboard
+            // navigation into the tray produces this blur.
+            //
+            // Nothing releases the input if the reader then tabs out of the
+            // tray to something else: it stays styled as focused, with its
+            // value uncommitted, until they come back to it. Same gap, and the
+            // same reason for leaving it as it is, as the tray's own claim —
+            // see `reportMathInputFocus`.
             return;
         }
 
@@ -720,7 +693,10 @@ export default function MathInput(props: UseDoenetRendererProps) {
 
         // Keep preview open when keyboard focus tabs from the input into the
         // preview region.
-        if (focusMovedToPreview) {
+        if (
+            relatedTarget instanceof Node &&
+            preview.previewRef.current?.contains(relatedTarget)
+        ) {
             preview.setInteractingWithPreview(true);
         }
     };

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -30,7 +30,10 @@ import * as Ariakit from "@ariakit/react";
 import { MathJax } from "better-react-mathjax";
 
 import "./mathInput.css";
-import { FocusedMathInputContext } from "../../doenetml";
+import {
+    FocusedMathInputContext,
+    LastEditedMathInputContext,
+} from "../../doenetml";
 import { useAppSelector } from "../../state";
 import { keyboardSlice } from "../../state/slices/keyboard";
 import {
@@ -444,6 +447,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         keyboardSlice.selectors.systemKeyboardRequested,
     );
     const focusedMathInput = useContext(FocusedMathInputContext);
+    const lastEditedMathInput = useContext(LastEditedMathInputContext);
     const [mathField, setMathField] = useState<MathField | null>(null);
     // `EditableMathField`'s `handlers.enter` callback can hold stale captures.
     // Keep the latest MathField instance in a ref for enter handling.
@@ -596,6 +600,24 @@ export default function MathInput(props: UseDoenetRendererProps) {
     }, [callAction]);
 
     React.useEffect(() => {
+        // An `accessed` message means the tray driving us predates the tray
+        // declining focus (see `KeyCommand`). Such a tray lives in the
+        // embedding page and takes focus when pressed, so this input has
+        // already been blurred and has given up its claim, and the key on its
+        // way over `postMessage` would land nowhere. Take the claim back.
+        //
+        // The old tray sends this from the pointer press that causes the blur,
+        // so it always arrives between the blur and the key. Current trays
+        // never send it, which is what confines this to the old ones.
+        if (
+            mathField &&
+            focusedMathInput.current === null &&
+            lastEditedMathInput.current === mathField.el() &&
+            virtualKeyboardEvents.some((event) => event.type === "accessed")
+        ) {
+            focusedMathInput.current = mathField.el();
+        }
+
         if (!mathField || focusedMathInput.current !== mathField.el()) {
             // These keys belong to a different input. `focusedMathInput` is
             // the record of which input the virtual keyboard is typing into;
@@ -603,6 +625,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
             // the tray, so that the keyboard can be operated from the keyboard.
             return;
         }
+        let typedSomething = false;
         for (const event of virtualKeyboardEvents) {
             if (event.type === "keystroke" && event.command === "Enter") {
                 // The "Enter" key was pressed
@@ -627,15 +650,19 @@ export default function MathInput(props: UseDoenetRendererProps) {
                     break;
                 case "cmd":
                     mathField.cmd(event.command);
+                    typedSomething = true;
                     break;
                 case "write":
                     mathField.write(event.command);
+                    typedSomething = true;
                     break;
                 case "keystroke":
                     mathField.keystroke(event.command);
+                    typedSomething = true;
                     break;
                 case "type":
                     mathField.typedText(event.command);
+                    typedSomething = true;
                     break;
                 default:
                     console.warn(
@@ -645,11 +672,26 @@ export default function MathInput(props: UseDoenetRendererProps) {
                     break;
             }
         }
-        // Deliberately no `mathField.focus()` here. The tray declines focus, so
-        // this input still has it; and when the reader has instead tabbed into
-        // the tray, pulling focus back would make the keyboard impossible to
-        // operate by keyboard. Refocusing on every key is also what re-summoned
-        // Android's system keyboard over the tray (issue #1692).
+        // Normally no refocusing: the tray declines focus, so this input still
+        // has it, and when the reader has instead tabbed into the tray, pulling
+        // focus back would make the keyboard impossible to operate by keyboard.
+        // Refocusing on every key is also what re-summoned Android's system
+        // keyboard over the tray (issue #1692).
+        //
+        // The exception is a tray old enough to have taken focus when it was
+        // pressed: the reader is left with no caret, so put it back, as that
+        // tray's contemporaries did after every key. Recognized by this input
+        // having lost focus to nothing in particular — a reader who moved into
+        // a tray in this document did so deliberately and keeps focus there.
+        const activeElement =
+            textareaRef.current?.ownerDocument.activeElement ?? null;
+        if (
+            typedSomething &&
+            activeElement !== textareaRef.current &&
+            !isInVirtualKeyboardTray(activeElement)
+        ) {
+            mathField.focus();
+        }
     }, [virtualKeyboardEvents]);
 
     function onFocusChanged(focused: boolean) {
@@ -672,6 +714,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         // taking it from `mathField` dropped the claim, and the keyboard then
         // typed nowhere until the reader left the input and came back.
         focusedMathInput.current = e.currentTarget;
+        lastEditedMathInput.current = e.currentTarget;
         onFocusChanged(true);
     };
 
@@ -679,6 +722,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
      * Finishes a blur that has taken focus away from this input for good: stop
      * claiming the virtual keyboard's keys, commit the value, and drop the
      * focused styling. `nextFocused` is where focus has gone, if anywhere.
+     *
      */
     function endEditing(nextFocused: EventTarget | null) {
         stopWatchingTrayHandoff.current?.();

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -77,30 +77,36 @@ export const FocusedMathInputContext = React.createContext<
 >({ current: null });
 
 /**
- * A math input that has just given up its claim on the virtual keyboard, and
- * when it did so, recorded only when the blur left nothing in this document
- * focused in its place.
+ * Everything a math input needs in order to be driven by a keyboard tray
+ * published before it learned to decline focus.
+ *
+ * Such a tray takes focus when it is pressed, so the input is blurred and has
+ * given up the claim `FocusedMathInputContext` records before the key gets
+ * here. See the `accessed` message in `KeyCommand`, which is what identifies
+ * such a tray, and the handling of it in the math input renderer.
  */
-export type ReleasedKeyboardClaim = {
-    input: HTMLElement;
-    releasedAt: number;
+export type LegacyKeyboardTrayState = {
+    /**
+     * Whether a tray of that vintage has announced itself, by sending an
+     * `accessed` message. Sticky: only those trays ever send it, and the tray
+     * a page is under does not change. Nothing below applies until it is set,
+     * which is what keeps all of this out of current pairings.
+     */
+    announced: boolean;
+    /**
+     * The math input that most recently gave up its claim on the keyboard, and
+     * when — recorded only when the blur left nothing else in this document
+     * focused, which is the shape of the blur such a tray causes. Both halves
+     * are needed to tell that blur from the reader leaving the input of their
+     * own accord.
+     */
+    release: { input: HTMLElement; releasedAt: number } | null;
 };
 
-/**
- * The most recent such release — the counterpart to
- * `FocusedMathInputContext`, which by then holds nothing.
- *
- * Only used to accommodate a keyboard tray published before it learned to
- * decline focus: pressing one of its keys blurs the input before the key
- * arrives, so by the time it does there is no focused input to receive it.
- * See the `accessed` message in `KeyCommand`, which is what identifies such a
- * tray, and the handling of it in the math input renderer, which uses the two
- * halves of this record to tell that blur from the reader leaving the input of
- * their own accord.
- */
-export const ReleasedKeyboardClaimContext = React.createContext<
-    React.RefObject<ReleasedKeyboardClaim | null>
->({ current: null });
+/** Per-viewer {@link LegacyKeyboardTrayState}, shared by its math inputs. */
+export const LegacyKeyboardTrayContext = React.createContext<
+    React.RefObject<LegacyKeyboardTrayState>
+>({ current: { announced: false, release: null } });
 
 /**
  * this is a hack for react-mathqill
@@ -780,7 +786,10 @@ function WrapWithKeyboard({
 }>) {
     const dispatch = useAppDispatch();
     const focusedMathInput = useRef<HTMLElement | null>(null);
-    const releasedKeyboardClaim = useRef<ReleasedKeyboardClaim | null>(null);
+    const legacyKeyboardTray = useRef<LegacyKeyboardTrayState>({
+        announced: false,
+        release: null,
+    });
     const keyboard = addVirtualKeyboard ? (
         <VirtualKeyboard
             externalVirtualKeyboardProvided={externalVirtualKeyboardProvided}
@@ -832,13 +841,11 @@ function WrapWithKeyboard({
 
     return (
         <FocusedMathInputContext.Provider value={focusedMathInput}>
-            <ReleasedKeyboardClaimContext.Provider
-                value={releasedKeyboardClaim}
-            >
+            <LegacyKeyboardTrayContext.Provider value={legacyKeyboardTray}>
                 {children}
                 <div className="before-keyboard" />
                 {keyboard}
-            </ReleasedKeyboardClaimContext.Provider>
+            </LegacyKeyboardTrayContext.Provider>
         </FocusedMathInputContext.Provider>
     );
 }

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -77,17 +77,29 @@ export const FocusedMathInputContext = React.createContext<
 >({ current: null });
 
 /**
- * The math input the reader edited most recently, which — unlike
- * `FocusedMathInputContext` — is not cleared when that input is blurred.
+ * A math input that has just given up its claim on the virtual keyboard, and
+ * when it did so, recorded only when the blur left nothing in this document
+ * focused in its place.
+ */
+export type ReleasedKeyboardClaim = {
+    input: HTMLElement;
+    releasedAt: number;
+};
+
+/**
+ * The most recent such release — the counterpart to
+ * `FocusedMathInputContext`, which by then holds nothing.
  *
  * Only used to accommodate a keyboard tray published before it learned to
  * decline focus: pressing one of its keys blurs the input before the key
  * arrives, so by the time it does there is no focused input to receive it.
  * See the `accessed` message in `KeyCommand`, which is what identifies such a
- * tray, and the handling of it in the math input renderer.
+ * tray, and the handling of it in the math input renderer, which uses the two
+ * halves of this record to tell that blur from the reader leaving the input of
+ * their own accord.
  */
-export const LastEditedMathInputContext = React.createContext<
-    React.RefObject<HTMLElement | null>
+export const ReleasedKeyboardClaimContext = React.createContext<
+    React.RefObject<ReleasedKeyboardClaim | null>
 >({ current: null });
 
 /**
@@ -768,7 +780,7 @@ function WrapWithKeyboard({
 }>) {
     const dispatch = useAppDispatch();
     const focusedMathInput = useRef<HTMLElement | null>(null);
-    const lastEditedMathInput = useRef<HTMLElement | null>(null);
+    const releasedKeyboardClaim = useRef<ReleasedKeyboardClaim | null>(null);
     const keyboard = addVirtualKeyboard ? (
         <VirtualKeyboard
             externalVirtualKeyboardProvided={externalVirtualKeyboardProvided}
@@ -820,11 +832,13 @@ function WrapWithKeyboard({
 
     return (
         <FocusedMathInputContext.Provider value={focusedMathInput}>
-            <LastEditedMathInputContext.Provider value={lastEditedMathInput}>
+            <ReleasedKeyboardClaimContext.Provider
+                value={releasedKeyboardClaim}
+            >
                 {children}
                 <div className="before-keyboard" />
                 {keyboard}
-            </LastEditedMathInputContext.Provider>
+            </ReleasedKeyboardClaimContext.Provider>
         </FocusedMathInputContext.Provider>
     );
 }

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -767,7 +767,29 @@ function WrapWithKeyboard({
             translate={translate}
             direction={direction}
             onClick={(keyCommands) => {
-                dispatch(keyboardSlice.actions.setKeyboardInput(keyCommands));
+                // `keyboardChoice` is a preference, not a key press. It is
+                // routed to the store instead of to the focused input, so that
+                // every math input can decide whether to keep the device's own
+                // on-screen keyboard down. See `KeyCommand`.
+                const lastChoice = keyCommands
+                    .filter((command) => command.type === "keyboardChoice")
+                    .pop();
+                if (lastChoice) {
+                    dispatch(
+                        keyboardSlice.actions.setSystemKeyboardRequested(
+                            lastChoice.command === "system",
+                        ),
+                    );
+                }
+
+                const keyPresses = keyCommands.filter(
+                    (command) => command.type !== "keyboardChoice",
+                );
+                if (keyPresses.length > 0) {
+                    dispatch(
+                        keyboardSlice.actions.setKeyboardInput(keyPresses),
+                    );
+                }
             }}
         />
     ) : null;

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -77,6 +77,20 @@ export const FocusedMathInputContext = React.createContext<
 >({ current: null });
 
 /**
+ * The math input the reader edited most recently, which — unlike
+ * `FocusedMathInputContext` — is not cleared when that input is blurred.
+ *
+ * Only used to accommodate a keyboard tray published before it learned to
+ * decline focus: pressing one of its keys blurs the input before the key
+ * arrives, so by the time it does there is no focused input to receive it.
+ * See the `accessed` message in `KeyCommand`, which is what identifies such a
+ * tray, and the handling of it in the math input renderer.
+ */
+export const LastEditedMathInputContext = React.createContext<
+    React.RefObject<HTMLElement | null>
+>({ current: null });
+
+/**
  * this is a hack for react-mathqill
  * error: global is not defined
  */
@@ -754,6 +768,7 @@ function WrapWithKeyboard({
 }>) {
     const dispatch = useAppDispatch();
     const focusedMathInput = useRef<HTMLElement | null>(null);
+    const lastEditedMathInput = useRef<HTMLElement | null>(null);
     const keyboard = addVirtualKeyboard ? (
         <VirtualKeyboard
             externalVirtualKeyboardProvided={externalVirtualKeyboardProvided}
@@ -805,9 +820,11 @@ function WrapWithKeyboard({
 
     return (
         <FocusedMathInputContext.Provider value={focusedMathInput}>
-            {children}
-            <div className="before-keyboard" />
-            {keyboard}
+            <LastEditedMathInputContext.Provider value={lastEditedMathInput}>
+                {children}
+                <div className="before-keyboard" />
+                {keyboard}
+            </LastEditedMathInputContext.Provider>
         </FocusedMathInputContext.Provider>
     );
 }

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -82,8 +82,9 @@ export const FocusedMathInputContext = React.createContext<
  *
  * Such a tray takes focus when it is pressed, so the input is blurred and has
  * given up the claim `FocusedMathInputContext` records before the key gets
- * here. See the `accessed` message in `KeyCommand`, which is what identifies
- * such a tray, and the handling of it in the math input renderer.
+ * here — and is left without a caret whether or not the press carried a key.
+ * See the `accessed` message in `KeyCommand`, which is what identifies such a
+ * tray, and the handling of it in the math input renderer.
  */
 export type LegacyKeyboardTrayState = {
     /**

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -782,6 +782,15 @@ function WrapWithKeyboard({
                     );
                 }
 
+                // A fresh array every press, and deliberately so: a math input
+                // notices a new batch of keys by the identity of the array in
+                // the store, and the keys of a given tray button are one
+                // constant array reused on every press of it. Storing that
+                // constant would leave the state unchanged, and pressing the
+                // same key twice in a row would type one character. The
+                // bookkeeping events the tray used to send alongside every
+                // press kept the identity moving on their own; nothing does
+                // now, so the dispatch has to.
                 const keyPresses = keyCommands.filter(
                     (command) => command.type !== "keyboardChoice",
                 );

--- a/packages/doenetml/src/state/slices/keyboard.ts
+++ b/packages/doenetml/src/state/slices/keyboard.ts
@@ -19,11 +19,24 @@ export interface KeyboardSlice {
      * Commands sent from the virtual keyboard but not yet processed by a component.
      */
     keyboardInput: KeyCommand[];
+    /**
+     * Whether the reader has asked for the device's own on-screen keyboard in
+     * preference to the Doenet virtual keyboard, by closing the tray.
+     *
+     * Only consulted on touch devices, where the two keyboards compete for the
+     * same screen: there, a math input keeps the system keyboard down
+     * (`inputmode="none"`) unless this is set. Closing the tray sets it and
+     * reopening the tray clears it, so the reader's most recent choice is the
+     * one that sticks. The tray opening and closing as focus moves between
+     * inputs does not count as such a choice and leaves this alone.
+     */
+    systemKeyboardRequested: boolean;
 }
 
 // Define the initial state using that type
 const initialState: KeyboardSlice = {
     keyboardInput: [],
+    systemKeyboardRequested: false,
 };
 
 export const keyboardSlice = createSlice({
@@ -36,8 +49,12 @@ export const keyboardSlice = createSlice({
         clearKeyboardInput: (state) => {
             state.keyboardInput = [];
         },
+        setSystemKeyboardRequested: (state, action: PayloadAction<boolean>) => {
+            state.systemKeyboardRequested = action.payload;
+        },
     },
     selectors: {
         keyboardInput: (state) => state.keyboardInput,
+        systemKeyboardRequested: (state) => state.systemKeyboardRequested,
     },
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
@@ -954,6 +954,43 @@ describe("MathInput Tag Tests", { tags: ["@group2"] }, function () {
         cy.get("#fv").should("have.text", "focused: false");
     });
 
+    it("virtual keyboard types into the focused math input without taking focus from it", () => {
+        // The tray used to blur the input on every press and the input used to
+        // refocus itself afterwards; it now declines focus instead (#1692).
+        // Two things had been riding on that blur-and-refocus: which input the
+        // keys go to, and — because the bookkeeping events the tray sent
+        // alongside every press are gone with it — the fresh array identity by
+        // which a math input notices a new batch of keys. Pressing the same
+        // key twice is what catches a regression in the second.
+        postDoenetML(`
+    <p>a: <mathInput name="a" /></p>
+    <p>a2: <math extend="$a" name="a2" /></p>
+    `);
+
+        cy.get("#a textarea").focus();
+
+        cy.get(".open-keyboard-button").click();
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+        cy.log("Reaching for the tray leaves the input focused");
+        cy.focused().should("match", "#a textarea");
+
+        cy.get("#virtual-keyboard-tray .key-1").click({ force: true });
+        cy.get("#virtual-keyboard-tray .key-1").click({ force: true });
+        cy.get("#a .mq-editable-field").should("contain.text", "11");
+        cy.focused().should("match", "#a textarea");
+
+        // Enter on the virtual keyboard commits, as it does on a physical one.
+        cy.get("#virtual-keyboard-tray .key-enter").click({ force: true });
+        cy.get("#a2").should("contain.text", "11");
+
+        cy.window().then(async (win) => {
+            const stateVariables = await win.returnAllStateVariables1();
+            expect(
+                stateVariables[await win.resolvePath1("a")].stateValues.value,
+            ).eq(11);
+        });
+    });
+
     it("mathInput in a graph renders at its anchor, is editable, and binds its value", () => {
         postDoenetMLWithMathJaxPrimed(`
     <graph name="g">

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
@@ -991,6 +991,49 @@ describe("MathInput Tag Tests", { tags: ["@group2"] }, function () {
         });
     });
 
+    it("commits the value when focus goes on from the tray to somewhere else", () => {
+        // Focus moving into the tray is not the reader leaving the input, so
+        // the input holds on to it. But the tray is not part of the input's
+        // DOM, so focus leaving the tray again raises no further event on the
+        // input: something has to watch the tray, or the value the reader
+        // typed would never be committed.
+        //
+        // Only deliberate keyboard navigation puts focus in the tray — a key
+        // press is declined — so that is what this drives.
+        postDoenetML(`
+    <p>a: <mathInput name="a" /></p>
+    <p>a2: <math extend="$a" name="a2" /></p>
+    <p>b: <mathInput name="b" /></p>
+    `);
+
+        cy.get("#a2").should("contain.text", "＿");
+        cy.get("#a textarea").type("1", { force: true });
+        cy.get("#a .mq-editable-field").should("contain.text", "1");
+        cy.log("Not committed while the input is being edited");
+        cy.get("#a2").should("contain.text", "＿");
+
+        cy.get(".open-keyboard-button").click();
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        cy.log("Move focus into the tray, as a keyboard-only reader does");
+        cy.get("#virtual-keyboard-tray .key-1").focus();
+        cy.focused().should("match", "#virtual-keyboard-tray .key-1");
+        cy.log("Still uncommitted: the reader is operating the keyboard");
+        cy.get("#a2").should("contain.text", "＿");
+
+        // Focus leaves the tray for a different input and never returns to `a`,
+        // so nothing else will ever commit what was typed into it.
+        cy.get("#b textarea").focus();
+        cy.get("#a2").should("contain.text", "1");
+
+        cy.window().then(async (win) => {
+            const stateVariables = await win.returnAllStateVariables1();
+            expect(
+                stateVariables[await win.resolvePath1("a")].stateValues.value,
+            ).eq(1);
+        });
+    });
+
     it("mathInput in a graph renders at its anchor, is editable, and binds its value", () => {
         postDoenetMLWithMathJaxPrimed(`
     <graph name="g">

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
@@ -1021,16 +1021,24 @@ describe("MathInput Tag Tests", { tags: ["@group2"] }, function () {
         cy.log("Still uncommitted: the reader is operating the keyboard");
         cy.get("#a2").should("contain.text", "＿");
 
+        // `a` is still the input the keys go to, even though it no longer holds
+        // `document.activeElement` — which is the whole point of recording the
+        // focused input explicitly.
+        cy.get("#virtual-keyboard-tray .key-2").click({ force: true });
+        cy.get("#a .mq-editable-field").should("contain.text", "12");
+        cy.focused().should("match", "#virtual-keyboard-tray .key-1");
+        cy.get("#a2").should("contain.text", "＿");
+
         // Focus leaves the tray for a different input and never returns to `a`,
         // so nothing else will ever commit what was typed into it.
         cy.get("#b textarea").focus();
-        cy.get("#a2").should("contain.text", "1");
+        cy.get("#a2").should("contain.text", "12");
 
         cy.window().then(async (win) => {
             const stateVariables = await win.returnAllStateVariables1();
             expect(
                 stateVariables[await win.resolvePath1("a")].stateValues.value,
-            ).eq(1);
+            ).eq(12);
         });
     });
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,7 @@ export * from "./ast/logging";
 export * from "./diagnostics/types";
 export * from "./diagnostics/coded";
 export * from "./keyboard/keyboardShortcuts";
+export * from "./keyboard/pointerType";
 export * from "./media/cid";
 export * from "./media/retrieveTextFile";
 export * from "./copy/deepFunctions";

--- a/packages/utils/src/keyboard/pointerType.ts
+++ b/packages/utils/src/keyboard/pointerType.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers for detecting what kind of pointing device the reader is using,
+ * which is what distinguishes a phone or tablet (where the operating system
+ * raises an on-screen keyboard on focus) from a desktop with a physical
+ * keyboard.
+ */
+
+/**
+ * Matches when the reader's *primary* pointing device is coarse — a finger on
+ * a phone or tablet.
+ *
+ * `(pointer: coarse)` rather than `(any-pointer: coarse)`: a touchscreen
+ * laptop matches `any-pointer: coarse` but its primary pointer is the mouse,
+ * and its reader has a physical keyboard. Conversely a tablet with a stylus
+ * matches `any-pointer: fine` while still being a device whose reader has no
+ * physical keyboard, and `(pointer: coarse)` correctly still matches there.
+ */
+export const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
+/**
+ * Accesses `matchMedia` structurally through `globalThis` so this file doesn't
+ * reference the DOM `Window` type, keeping `@doenet/utils` usable in TS
+ * configs that omit the `dom` lib (the same approach `keyboardShortcuts.ts`
+ * takes for `navigator`).
+ */
+type MinimalMediaQueryList = {
+    matches: boolean;
+    addEventListener?: (type: "change", listener: () => void) => void;
+    removeEventListener?: (type: "change", listener: () => void) => void;
+};
+
+function getCoarsePointerQueryList(): MinimalMediaQueryList | null {
+    const matchMedia = (
+        globalThis as {
+            matchMedia?: (query: string) => MinimalMediaQueryList;
+        }
+    ).matchMedia;
+
+    if (typeof matchMedia !== "function") {
+        // Non-browser environment (e.g. SSR, the worker, or a jsdom setup
+        // without `matchMedia`). Treat as a conventional pointer device.
+        return null;
+    }
+
+    return matchMedia(COARSE_POINTER_QUERY);
+}
+
+/**
+ * Whether the reader's primary pointing device is coarse, i.e. whether this is
+ * a touch-first device such as a phone or tablet.
+ *
+ * Returns `false` when the environment cannot answer the question, so callers
+ * default to desktop behavior.
+ */
+export function hasCoarsePrimaryPointer(): boolean {
+    return getCoarsePointerQueryList()?.matches ?? false;
+}
+
+/**
+ * Calls `listener` whenever the answer from {@link hasCoarsePrimaryPointer}
+ * changes — a tablet gaining a trackpad, or a device rotating into a mode the
+ * browser reports differently. Returns an unsubscribe function.
+ */
+export function subscribeToPrimaryPointerType(
+    listener: () => void,
+): () => void {
+    const queryList = getCoarsePointerQueryList();
+
+    if (!queryList?.addEventListener) {
+        return () => {};
+    }
+
+    queryList.addEventListener("change", listener);
+
+    return () => {
+        queryList.removeEventListener?.("change", listener);
+    };
+}

--- a/packages/virtual-keyboard/src/virtual-keyboard/external-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/external-virtual-keyboard.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-import { UniqueKeyboardTray } from "./unique-keyboard-tray";
+import {
+    reportMathInputFocus,
+    UniqueKeyboardTray,
+} from "./unique-keyboard-tray";
 import { KeyCommand } from "./keys";
 
 /**
@@ -9,6 +12,20 @@ import { KeyCommand } from "./keys";
 export type IframeMessage = {
     keyCommands: KeyCommand[];
     subject: "keyboard";
+};
+
+/**
+ * A message sent from the iframe up to the parent window, reporting whether a
+ * math input inside it has focus.
+ *
+ * The tray lives in the parent, whose own focus events see no further than
+ * "the iframe is focused" — they cannot distinguish a math input from a text
+ * input inside it, and the two want opposite things from the tray. So the
+ * iframe, which can tell, says so.
+ */
+export type IframeFocusMessage = {
+    subject: "keyboard-focus";
+    mathInputFocused: boolean;
 };
 
 /**
@@ -21,6 +38,25 @@ export function ExternalVirtualKeyboard({
     theme?: "dark" | "light";
     ownerRef: React.RefObject<HTMLIFrameElement | null>;
 }) {
+    React.useEffect(() => {
+        function listener(event: MessageEvent<IframeFocusMessage | undefined>) {
+            // Only this keyboard's own iframe may move this keyboard's tray.
+            if (
+                event.source !== ownerRef.current?.contentWindow ||
+                event.data?.subject !== "keyboard-focus"
+            ) {
+                return;
+            }
+            reportMathInputFocus(event.data.mathInputFocused);
+        }
+
+        window.addEventListener("message", listener);
+
+        return () => {
+            window.removeEventListener("message", listener);
+        };
+    }, [ownerRef]);
+
     return (
         <UniqueKeyboardTray
             ownerRef={ownerRef}

--- a/packages/virtual-keyboard/src/virtual-keyboard/external-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/external-virtual-keyboard.tsx
@@ -22,6 +22,11 @@ export type IframeMessage = {
  * "the iframe is focused" — they cannot distinguish a math input from a text
  * input inside it, and the two want opposite things from the tray. So the
  * iframe, which can tell, says so.
+ *
+ * Posted with a target origin of `"*"`, for the same reason `IframeMessage`
+ * is: the two documents are routinely on different origins, and neither can
+ * read the other's. Nothing here is sensitive — one bit about focus — and the
+ * parent only acts on messages whose `event.source` is its own iframe.
  */
 export type IframeFocusMessage = {
     subject: "keyboard-focus";
@@ -39,6 +44,8 @@ export function ExternalVirtualKeyboard({
     ownerRef: React.RefObject<HTMLIFrameElement | null>;
 }) {
     React.useEffect(() => {
+        let reportedFocused = false;
+
         function listener(event: MessageEvent<IframeFocusMessage | undefined>) {
             // Only this keyboard's own iframe may move this keyboard's tray.
             if (
@@ -47,13 +54,20 @@ export function ExternalVirtualKeyboard({
             ) {
                 return;
             }
-            reportMathInputFocus(event.data.mathInputFocused);
+            reportedFocused = event.data.mathInputFocused;
+            reportMathInputFocus(ownerRef, reportedFocused);
         }
 
         window.addEventListener("message", listener);
 
         return () => {
             window.removeEventListener("message", listener);
+            if (reportedFocused) {
+                // This keyboard is going away while its iframe still holds the
+                // focused math input. Withdraw the claim, or the tray would
+                // stay open for a viewer that is no longer on the page.
+                reportMathInputFocus(ownerRef, false);
+            }
         };
     }, [ownerRef]);
 

--- a/packages/virtual-keyboard/src/virtual-keyboard/index.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/index.ts
@@ -1,4 +1,5 @@
 export * from "./keyboard";
+export * from "./keyboard-tray";
 export * from "./managed-keyboard";
 export * from "./unique-keyboard-tray";
 export * from "./recoil-virtual-keyboard";

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
@@ -37,11 +37,19 @@ const KeyboardIcon = () => (
  */
 export function KeyboardTray({
     onClick,
+    open,
+    onOpenChange,
     theme,
     translate,
     direction,
 }: {
     onClick: OnClick;
+    /**
+     * Whether the tray is expanded. Controlled by `UniqueKeyboardTray`, which
+     * also opens it when focus lands in a math input on a touch device.
+     */
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
     theme?: "dark" | "light";
     /**
      * Chrome translator for the tray's labels. Passed in rather than read from
@@ -61,7 +69,6 @@ export function KeyboardTray({
      */
     direction?: Direction;
 }) {
-    const [open, setOpen] = React.useState(false);
     const t = translate ?? untranslated;
     const openLabel = t("keyboard-open", undefined, "Open Keyboard");
     const closeLabel = t("keyboard-close", undefined, "Close Keyboard");
@@ -72,26 +79,25 @@ export function KeyboardTray({
             data-theme={theme}
             dir={direction}
             className={classNames({ open })}
-            onMouseDown={() => {
-                // The mousedown event appears to precede a blur event on a mathInput,
-                // so this access event will set the accessed timestamp to be
-                // just before the time of the blur if keyboard is clicked while the mathInput is focused.
-                onClick([
-                    { type: "accessed", command: "", timestamp: +new Date() },
-                ]);
-            }}
-            onClick={() => {
-                // If the keyboard is clicked but a key is not clicked, then we send
-                // this accessed event to make sure the math input is still re-focused after the click.
-                // (The click event appears to occur after the blur event on a mathInput.)
-                onClick([
-                    { type: "accessed", command: "", timestamp: +new Date() },
-                ]);
-            }}
+            // Decline focus for the whole tray, keys included: the events from
+            // the buttons bubble to here, and cancelling the default action of
+            // the pointer press is what stops focus from leaving the input the
+            // reader is typing into. Without this the input blurs on every key
+            // and has to be refocused, which on Android re-summons the system
+            // keyboard on top of this tray (issue #1692), and which made the
+            // keyboard unusable from the keyboard itself (issue #747) because
+            // "which input receives keys" was tied to `document.activeElement`.
+            //
+            // `pointerdown` covers touch and mouse; `mousedown` is the fallback
+            // for browsers that deliver no pointer events. Neither cancels the
+            // subsequent `click`, so the keys themselves still work, and
+            // neither affects moving focus into the tray with the Tab key.
+            onPointerDown={(e) => e.preventDefault()}
+            onMouseDown={(e) => e.preventDefault()}
         >
             <button
                 className="open-keyboard-button"
-                onClick={() => setOpen((old) => !old)}
+                onClick={() => onOpenChange(!open)}
                 title={open ? closeLabel : openLabel}
                 aria-label={open ? closeLabel : openLabel}
             >
@@ -100,7 +106,7 @@ export function KeyboardTray({
             <div className="keyboard-container">
                 <button
                     className="close-keyboard-button"
-                    onClick={() => setOpen(false)}
+                    onClick={() => onOpenChange(false)}
                     title={closeLabel}
                     aria-label={closeLabel}
                 >

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
@@ -16,6 +16,31 @@ import "./keyboard-tray.css";
  */
 const untranslated: Translator = (key, _args, fallback) => fallback ?? key;
 
+/**
+ * The id of the tray's root element. Only one tray exists per page, so an id
+ * identifies it; `keyboard-tray.css` styles it by the same name.
+ */
+export const VIRTUAL_KEYBOARD_TRAY_ID = "virtual-keyboard-tray";
+
+/** The tray's root element, or `null` when no tray is on the page. */
+export function getVirtualKeyboardTrayElement(): HTMLElement | null {
+    return document.getElementById(VIRTUAL_KEYBOARD_TRAY_ID);
+}
+
+/**
+ * Whether `node` is inside the keyboard tray.
+ *
+ * How a math input tells a blur that hands over to the keyboard from one that
+ * leaves the input for good, and how the tray tells that focus is being kept
+ * inside itself rather than moving away from the input it types into.
+ */
+export function isInVirtualKeyboardTray(node: EventTarget | null): boolean {
+    return (
+        node instanceof Node &&
+        (getVirtualKeyboardTrayElement()?.contains(node) ?? false)
+    );
+}
+
 const KeyboardIcon = () => (
     <svg
         stroke="currentColor"
@@ -75,7 +100,7 @@ export function KeyboardTray({
 
     return createPortal(
         <div
-            id="virtual-keyboard-tray"
+            id={VIRTUAL_KEYBOARD_TRAY_ID}
             data-theme={theme}
             dir={direction}
             className={classNames({ open })}

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.tsx
@@ -124,9 +124,9 @@ function Key({
         <button
             className={`key key-${keyInfo.name} ${keyInfo.isMath ? "math" : ""}`}
             onClick={(e) => {
-                // Prevent the click event on the keyboard itself from triggering
-                // so that its "accessed" event doesn't cancel the propagation
-                // of the key click event.
+                // The key's own commands are the whole of what the press
+                // means: don't let it read as a click on the tray around it,
+                // or on the page behind that.
                 e.stopPropagation();
                 onClick(keyInfo.commands);
             }}

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -7,12 +7,25 @@
  *
  * - `"accessed"` — no longer sent. It used to drive a blur/refocus timing
  *   heuristic that the tray no longer needs now that it declines focus
- *   outright. The type stays because the tray and the viewer ship separately
- *   — an embedding page can pin an older bundle inside the iframe — so a
- *   current viewer must still recognize what an older tray sends, and ignore
- *   it rather than warn. (The opposite pairing cannot be rescued: a viewer
- *   old enough to need the heuristic typed only after a blur, and declining
- *   focus is exactly what stops the blur.)
+ *   outright. The type stays so that a current viewer recognizes what an
+ *   older tray sends and ignores it rather than warning about it.
+ *
+ *   Recognizing it does not make the pairing work, though, and neither
+ *   pairing across this change can be rescued. The tray and the viewer ship
+ *   separately — an embedding page can pin an older bundle inside the iframe
+ *   — and typing needs them to agree about the blur:
+ *
+ *   - Older viewer, current tray: the viewer typed only in response to the
+ *     blur a tray press used to cause, and declining focus is exactly what
+ *     removes that blur.
+ *   - Current viewer, older tray: the older tray does cause the blur, and
+ *     across the iframe boundary it arrives with a null `relatedTarget`, so
+ *     the viewer cannot tell it from the reader leaving the input for good
+ *     and stops claiming the keys. `"accessed"` cannot undo that — it is
+ *     delivered by `postMessage`, hence after the blur has been acted on.
+ *
+ *   Embedders should keep the wrapper and the viewer on the same release.
+ *
  * - `"keyboardChoice"` — which keyboard the reader has asked for, with
  *   `command` set to `"virtual"` (they opened the tray) or `"system"` (they
  *   closed it). On a touch device the two keyboards compete for the same

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -5,10 +5,14 @@
  * because it is the only one that already spans the iframe boundary (the tray
  * lives in the embedding page, the inputs live inside the iframe):
  *
- * - `"accessed"` — retained so a tray and a viewer built from different
- *   bundle versions still speak the same protocol. Current viewers ignore it;
- *   it used to drive a blur/refocus timing heuristic that the tray no longer
- *   needs now that it declines focus outright.
+ * - `"accessed"` — no longer sent. It used to drive a blur/refocus timing
+ *   heuristic that the tray no longer needs now that it declines focus
+ *   outright. The type stays because the tray and the viewer ship separately
+ *   — an embedding page can pin an older bundle inside the iframe — so a
+ *   current viewer must still recognize what an older tray sends, and ignore
+ *   it rather than warn. (The opposite pairing cannot be rescued: a viewer
+ *   old enough to need the heuristic typed only after a blur, and declining
+ *   focus is exactly what stops the blur.)
  * - `"keyboardChoice"` — which keyboard the reader has asked for, with
  *   `command` set to `"virtual"` (they opened the tray) or `"system"` (they
  *   closed it). On a touch device the two keyboards compete for the same

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -2,29 +2,8 @@
  * A message sent from the virtual keyboard tray to whichever input is active.
  *
  * Most types are literal key presses. Two are not, and ride this channel
- * because it is the only one that already spans the iframe boundary (the tray
- * lives in the embedding page, the inputs live inside the iframe):
- *
- * - `"accessed"` — no longer sent. It used to drive a blur/refocus timing
- *   heuristic that the tray no longer needs now that it declines focus
- *   outright. The type stays so that a current viewer recognizes what an
- *   older tray sends and ignores it rather than warning about it.
- *
- *   Recognizing it does not make the pairing work, though, and neither
- *   pairing across this change can be rescued. The tray and the viewer ship
- *   separately — an embedding page can pin an older bundle inside the iframe
- *   — and typing needs them to agree about the blur:
- *
- *   - Older viewer, current tray: the viewer typed only in response to the
- *     blur a tray press used to cause, and declining focus is exactly what
- *     removes that blur.
- *   - Current viewer, older tray: the older tray does cause the blur, and
- *     across the iframe boundary it arrives with a null `relatedTarget`, so
- *     the viewer cannot tell it from the reader leaving the input for good
- *     and stops claiming the keys. `"accessed"` cannot undo that — it is
- *     delivered by `postMessage`, hence after the blur has been acted on.
- *
- *   Embedders should keep the wrapper and the viewer on the same release.
+ * because it is the only one that already spans the iframe boundary — the
+ * tray lives in the embedding page, the inputs live inside the iframe:
  *
  * - `"keyboardChoice"` — which keyboard the reader has asked for, with
  *   `command` set to `"virtual"` (they opened the tray) or `"system"` (they
@@ -33,12 +12,22 @@
  *   until told the reader wants it. Sent only when the reader chooses: the
  *   tray also opens and closes by itself as focus moves between inputs, and
  *   that is not a statement about which keyboard they would rather have.
+ *
+ * - `"accessed"` — no longer sent. It drove a blur/refocus timing heuristic
+ *   that the tray no longer needs now that it declines focus outright. The
+ *   type stays so that a current viewer ignores what an older tray sends
+ *   rather than warning about it. That does not make the pairing type,
+ *   though, and no pairing across this change does: an older viewer typed
+ *   only in response to the blur a tray press used to cause, and a current
+ *   viewer reads the blur an older tray still causes — null `relatedTarget`,
+ *   because it crosses the iframe boundary — as the reader leaving the input
+ *   for good. Embedders should keep the wrapper and the viewer on the same
+ *   release; the changelog entry for this change says why.
  */
 export type KeyCommand = {
     type:
         "keystroke" | "type" | "write" | "cmd" | "accessed" | "keyboardChoice";
     command: string;
-    timestamp?: number;
 };
 
 export type KeyDescription = {

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -17,11 +17,13 @@
  *   has no blur to explain. It is still *accepted*, and is the one thing that
  *   identifies a tray from before that change: only those send it, and they
  *   send it from the pointer press that blurs the input, so it arrives
- *   between that blur and the key it precedes. A math input takes its claim
- *   on the keyboard back when it sees one, and puts the caret back after
- *   typing, which is what lets a current viewer be driven by an older tray —
- *   the pairing doenet.org has whenever it serves a newly published viewer
- *   under its installed wrapper.
+ *   between that blur and the key it precedes. A math input that has just
+ *   been blurred that way takes its claim on the keyboard back when it sees
+ *   one, and puts the caret back after typing, which is what lets a current
+ *   viewer be driven by an older tray — the pairing doenet.org has whenever it
+ *   serves a newly published viewer under its installed wrapper. "Just" is
+ *   part of it: a press that arrives long after the reader left an input is
+ *   not the cause of that blur and does not reclaim anything.
  *
  *   The reverse pairing, an older viewer under this tray, cannot be rescued
  *   from this side: that viewer typed only in response to a blur this tray no

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -22,10 +22,10 @@
  *   viewer be driven by an older tray — the pairing doenet.org has whenever it
  *   serves a newly published viewer under its installed wrapper. "A moment
  *   earlier" is part of it: a key that arrives long after the reader left an
- *   input was not caused by that blur and types nowhere. Nor does the
- *   `accessed` message itself hand any input the keyboard, so a press that
- *   produces no key — the tray's close button, the gap between two keys —
- *   leaves nothing behind.
+ *   input was not caused by that blur and types nowhere. The caret goes back
+ *   even when the press carried no key — the tray's open and close buttons,
+ *   the gap between two keys — since that press took it just the same, and a
+ *   reader who opens the tray while editing an input is still editing it.
  *
  *   The reverse pairing, an older viewer under this tray, cannot be rescued
  *   from this side: that viewer typed only in response to a blur this tray no

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -1,5 +1,25 @@
+/**
+ * A message sent from the virtual keyboard tray to whichever input is active.
+ *
+ * Most types are literal key presses. Two are not, and ride this channel
+ * because it is the only one that already spans the iframe boundary (the tray
+ * lives in the embedding page, the inputs live inside the iframe):
+ *
+ * - `"accessed"` — retained so a tray and a viewer built from different
+ *   bundle versions still speak the same protocol. Current viewers ignore it;
+ *   it used to drive a blur/refocus timing heuristic that the tray no longer
+ *   needs now that it declines focus outright.
+ * - `"keyboardChoice"` — which keyboard the reader has asked for, with
+ *   `command` set to `"virtual"` (they opened the tray) or `"system"` (they
+ *   closed it). On a touch device the two keyboards compete for the same
+ *   screen, so a math input keeps the device's own on-screen keyboard down
+ *   until told the reader wants it. Sent only when the reader chooses: the
+ *   tray also opens and closes by itself as focus moves between inputs, and
+ *   that is not a statement about which keyboard they would rather have.
+ */
 export type KeyCommand = {
-    type: "keystroke" | "type" | "write" | "cmd" | "accessed";
+    type:
+        "keystroke" | "type" | "write" | "cmd" | "accessed" | "keyboardChoice";
     command: string;
     timestamp?: number;
 };

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -15,15 +15,17 @@
  *
  * - `"accessed"` — no longer sent by this tray, which declines focus and so
  *   has no blur to explain. It is still *accepted*, and is the one thing that
- *   identifies a tray from before that change: only those send it, and they
- *   send it from the pointer press that blurs the input, so it arrives
- *   between that blur and the key it precedes. A math input that has just
- *   been blurred that way takes its claim on the keyboard back when it sees
- *   one, and puts the caret back after typing, which is what lets a current
+ *   identifies a tray from before that change: only those send it, so the
+ *   first one settles which tray the page is under. A key from such a tray is
+ *   then delivered to the math input its own press blurred a moment earlier,
+ *   and the caret is put back after typing, which is what lets a current
  *   viewer be driven by an older tray — the pairing doenet.org has whenever it
- *   serves a newly published viewer under its installed wrapper. "Just" is
- *   part of it: a press that arrives long after the reader left an input is
- *   not the cause of that blur and does not reclaim anything.
+ *   serves a newly published viewer under its installed wrapper. "A moment
+ *   earlier" is part of it: a key that arrives long after the reader left an
+ *   input was not caused by that blur and types nowhere. Nor does the
+ *   `accessed` message itself hand any input the keyboard, so a press that
+ *   produces no key — the tray's close button, the gap between two keys —
+ *   leaves nothing behind.
  *
  *   The reverse pairing, an older viewer under this tray, cannot be rescued
  *   from this side: that viewer typed only in response to a blur this tray no

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -13,16 +13,20 @@
  *   tray also opens and closes by itself as focus moves between inputs, and
  *   that is not a statement about which keyboard they would rather have.
  *
- * - `"accessed"` — no longer sent. It drove a blur/refocus timing heuristic
- *   that the tray no longer needs now that it declines focus outright. The
- *   type stays so that a current viewer ignores what an older tray sends
- *   rather than warning about it. That does not make the pairing type,
- *   though, and no pairing across this change does: an older viewer typed
- *   only in response to the blur a tray press used to cause, and a current
- *   viewer reads the blur an older tray still causes — null `relatedTarget`,
- *   because it crosses the iframe boundary — as the reader leaving the input
- *   for good. Embedders should keep the wrapper and the viewer on the same
- *   release; the changelog entry for this change says why.
+ * - `"accessed"` — no longer sent by this tray, which declines focus and so
+ *   has no blur to explain. It is still *accepted*, and is the one thing that
+ *   identifies a tray from before that change: only those send it, and they
+ *   send it from the pointer press that blurs the input, so it arrives
+ *   between that blur and the key it precedes. A math input takes its claim
+ *   on the keyboard back when it sees one, and puts the caret back after
+ *   typing, which is what lets a current viewer be driven by an older tray —
+ *   the pairing doenet.org has whenever it serves a newly published viewer
+ *   under its installed wrapper.
+ *
+ *   The reverse pairing, an older viewer under this tray, cannot be rescued
+ *   from this side: that viewer typed only in response to a blur this tray no
+ *   longer causes. Embedders pinning a viewer older than this release should
+ *   pin the wrapper with it.
  */
 export type KeyCommand = {
     type:

--- a/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 
-import { IframeMessage } from "./external-virtual-keyboard";
-import { UniqueKeyboardTray } from "./unique-keyboard-tray";
+import { IframeFocusMessage, IframeMessage } from "./external-virtual-keyboard";
+import {
+    reportMathInputFocus,
+    UniqueKeyboardTray,
+} from "./unique-keyboard-tray";
 import { KeyCommand } from "./keys";
 import type { Direction, Translator } from "@doenet/i18n";
 
@@ -79,6 +82,62 @@ export function ExternalAwareVirtualKeyboard({
             };
         }
     }, [externalVirtualKeyboardProvided, onClick]);
+
+    // Watch focus entering and leaving this viewer's math inputs, so the tray
+    // can follow it on a touch device. `ownerRef` is the element of whichever
+    // math input is currently focused, which makes it the signal: a text input
+    // taking focus leaves it empty, and the tray gets out of the way of the
+    // device's own keyboard.
+    React.useEffect(() => {
+        let lastReported: boolean | null = null;
+        let pending: ReturnType<typeof setTimeout> | undefined;
+
+        function report() {
+            const activeElement = document.activeElement;
+            const owner = ownerRef.current;
+            const mathInputFocused =
+                owner !== null &&
+                activeElement instanceof Node &&
+                owner.contains(activeElement);
+
+            if (mathInputFocused === lastReported) {
+                return;
+            }
+            lastReported = mathInputFocused;
+
+            if (externalVirtualKeyboardProvided) {
+                // The tray lives in the embedding page, which cannot see which
+                // element inside this iframe has focus. See `IframeFocusMessage`
+                // for why the target origin is "*".
+                window.parent.postMessage(
+                    {
+                        subject: "keyboard-focus",
+                        mathInputFocused,
+                    } satisfies IframeFocusMessage,
+                    "*",
+                );
+            } else {
+                reportMathInputFocus(mathInputFocused);
+            }
+        }
+
+        function scheduleReport() {
+            // Focus passes through `<body>` on its way between two elements,
+            // so wait for it to land before reading `document.activeElement`.
+            // This also coalesces the focusout/focusin pair into one report.
+            clearTimeout(pending);
+            pending = setTimeout(report, 0);
+        }
+
+        document.addEventListener("focusin", scheduleReport);
+        document.addEventListener("focusout", scheduleReport);
+
+        return () => {
+            clearTimeout(pending);
+            document.removeEventListener("focusin", scheduleReport);
+            document.removeEventListener("focusout", scheduleReport);
+        };
+    }, [externalVirtualKeyboardProvided, ownerRef]);
 
     // If an external keyboard is not provided,
     // then we add a reference to the keyboard here

--- a/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
@@ -89,8 +89,29 @@ export function ExternalAwareVirtualKeyboard({
     // taking focus leaves it empty, and the tray gets out of the way of the
     // device's own keyboard.
     React.useEffect(() => {
-        let lastReported: boolean | null = null;
+        // Starts at `false` rather than "unknown": a viewer that has never had
+        // a math input focused has nothing to announce, and saying so anyway
+        // would be a report about the other viewers on the page as much as
+        // about this one.
+        let lastReported = false;
         let pending: ReturnType<typeof setTimeout> | undefined;
+
+        function send(mathInputFocused: boolean) {
+            if (externalVirtualKeyboardProvided) {
+                // The tray lives in the embedding page, which cannot see which
+                // element inside this iframe has focus. See `IframeFocusMessage`
+                // for why the target origin is "*".
+                window.parent.postMessage(
+                    {
+                        subject: "keyboard-focus",
+                        mathInputFocused,
+                    } satisfies IframeFocusMessage,
+                    "*",
+                );
+            } else {
+                reportMathInputFocus(ownerRef, mathInputFocused);
+            }
+        }
 
         function report() {
             const activeElement = document.activeElement;
@@ -104,21 +125,7 @@ export function ExternalAwareVirtualKeyboard({
                 return;
             }
             lastReported = mathInputFocused;
-
-            if (externalVirtualKeyboardProvided) {
-                // The tray lives in the embedding page, which cannot see which
-                // element inside this iframe has focus. See `IframeFocusMessage`
-                // for why the target origin is "*".
-                window.parent.postMessage(
-                    {
-                        subject: "keyboard-focus",
-                        mathInputFocused,
-                    } satisfies IframeFocusMessage,
-                    "*",
-                );
-            } else {
-                reportMathInputFocus(mathInputFocused);
-            }
+            send(mathInputFocused);
         }
 
         function scheduleReport() {
@@ -136,6 +143,12 @@ export function ExternalAwareVirtualKeyboard({
             clearTimeout(pending);
             document.removeEventListener("focusin", scheduleReport);
             document.removeEventListener("focusout", scheduleReport);
+            if (lastReported) {
+                // This viewer is unmounting with one of its math inputs
+                // focused. Withdraw the claim, or the tray would stay open for
+                // a viewer that is no longer on the page.
+                send(false);
+            }
         };
     }, [externalVirtualKeyboardProvided, ownerRef]);
 

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -2,12 +2,28 @@ import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { OnClick } from "./keyboard";
 import { KeyboardTray } from "./keyboard-tray";
+import { KeyCommand } from "./keys";
 import { MathJaxContext } from "@doenet/utils/mathjax";
-import { mathjaxConfig } from "@doenet/utils";
+import { hasCoarsePrimaryPointer, mathjaxConfig } from "@doenet/utils";
 import type { Direction, Translator } from "@doenet/i18n";
 
 type VirtualKeyboardState = {
     count: number;
+    /**
+     * Whether the tray is expanded. Held here rather than in the tray
+     * component because focus moving into a math input opens it, and that
+     * happens outside the tray's own React tree — in another window entirely
+     * when the viewer is embedded in an iframe.
+     */
+    open: boolean;
+    /**
+     * Whether the reader closed the tray themselves. Their choice outlasts the
+     * input they made it in: the tray then stays shut as they move between
+     * math inputs, rather than springing back open at each one.
+     */
+    userClosedTray: boolean;
+    /** Subscribers to `open`, so a change re-renders only the tray itself. */
+    openListeners: Set<() => void>;
     keyboardDomNode: HTMLElement | null;
     keyboardReactRoot: Root | null;
     registrations: {
@@ -34,6 +50,9 @@ const globalThis = Function("return this")() || {};
 const virtualKeyboardState: VirtualKeyboardState =
     globalThis?.virtualKeyboardState || {
         count: 0,
+        open: false,
+        userClosedTray: false,
+        openListeners: new Set(),
         keyboardDomNode: null,
         keyboardReactRoot: null,
         registrations: [],
@@ -116,6 +135,99 @@ function getTrayRegistration():
     return registrations[registrations.length - 1];
 }
 
+/**
+ * Tells every viewer on the page which keyboard the reader has just asked for.
+ *
+ * Broadcast rather than sent to the focused viewer alone, because a viewer
+ * needs this to decide whether to keep the device's own on-screen keyboard
+ * down, and that has to be settled before the reader focuses one of its
+ * inputs — reaching for the Doenet keyboard before touching any input is the
+ * ordinary way to start on a phone.
+ */
+function broadcastKeyboardChoice(open: boolean) {
+    const choice: KeyCommand[] = [
+        {
+            type: "keyboardChoice",
+            command: open ? "virtual" : "system",
+            timestamp: +new Date(),
+        },
+    ];
+    for (const registration of virtualKeyboardState.registrations) {
+        registration.onClick(choice);
+    }
+}
+
+function getTrayOpen() {
+    return virtualKeyboardState.open;
+}
+
+function subscribeToTrayOpen(listener: () => void) {
+    virtualKeyboardState.openListeners.add(listener);
+    return () => {
+        virtualKeyboardState.openListeners.delete(listener);
+    };
+}
+
+function setTrayOpen(open: boolean, { byUser }: { byUser: boolean }) {
+    if (byUser) {
+        virtualKeyboardState.userClosedTray = !open;
+        // Only the reader's own choice decides which keyboard they get. The
+        // tray following focus around the page is not them asking for the
+        // device's keyboard back.
+        broadcastKeyboardChoice(open);
+    }
+    if (virtualKeyboardState.open === open) {
+        return;
+    }
+    virtualKeyboardState.open = open;
+    // Notify the tray rather than re-rendering the whole tray root: the root
+    // holds the `MathJaxContext` that typesets the keys, and tearing that down
+    // and rebuilding it on every open and close both wastes the work and can
+    // interrupt a typeset already in flight.
+    for (const listener of virtualKeyboardState.openListeners) {
+        listener();
+    }
+}
+
+/**
+ * Reports that focus has entered or left a math input, so the tray can follow
+ * it on devices that have no physical keyboard.
+ *
+ * Only touch devices get this treatment. On a desktop the tray stays under the
+ * reader's manual control, as it always has: it occupies a fixed strip along
+ * the bottom of the window, and springing that open at every math input would
+ * be an imposition on a reader who has a keyboard in front of them.
+ */
+export function reportMathInputFocus(mathInputFocused: boolean) {
+    if (!hasCoarsePrimaryPointer()) {
+        return;
+    }
+
+    if (mathInputFocused) {
+        if (!virtualKeyboardState.userClosedTray) {
+            setTrayOpen(true, { byUser: false });
+        }
+        return;
+    }
+
+    const activeElement = document.activeElement;
+    if (
+        activeElement instanceof Node &&
+        getTrayElement()?.contains(activeElement)
+    ) {
+        // The reader moved into the keyboard itself to operate it. They are
+        // still editing the input they left; the tray must not fold away
+        // underneath them.
+        return;
+    }
+
+    // Focus has gone somewhere that is not a math input — a text input, say,
+    // whose editing wants the device's own keyboard and all the screen the
+    // tray is occupying. Closing is not the reader's own choice, so it does
+    // not count against reopening at the next math input.
+    setTrayOpen(false, { byUser: false });
+}
+
 function rerenderTray() {
     const registration = getTrayRegistration();
     const theme = registration?.theme;
@@ -143,6 +255,9 @@ function rerenderTray() {
         const currentDirection =
             (trayEl.getAttribute("dir") as Direction | null | undefined) ??
             undefined;
+        // Whether the tray is open is deliberately not part of this
+        // comparison: it does not come from a registration, and it reaches the
+        // tray by subscription rather than by re-rendering this root.
         if (
             currentTheme === theme &&
             currentDirection === direction &&
@@ -157,6 +272,41 @@ function rerenderTray() {
     );
 }
 
+/**
+ * Subscribes the tray to the shared open state, so that opening and closing it
+ * — including when focus moving into a math input opens it — re-renders the
+ * tray alone and leaves the `MathJaxContext` above it untouched.
+ */
+function TrayWithSharedOpenState({
+    theme,
+    translate,
+    direction,
+}: {
+    theme: "dark" | "light" | undefined;
+    translate: Translator | undefined;
+    direction: Direction | undefined;
+}) {
+    const open = React.useSyncExternalStore(
+        subscribeToTrayOpen,
+        getTrayOpen,
+        getTrayOpen,
+    );
+
+    return (
+        <KeyboardTray
+            theme={theme}
+            translate={translate}
+            direction={direction}
+            open={open}
+            onOpenChange={(nextOpen) => setTrayOpen(nextOpen, { byUser: true })}
+            onClick={(e) => {
+                // Route key events only to the active (focused) owner.
+                getActiveRegistration()?.onClick(e);
+            }}
+        />
+    );
+}
+
 function renderTray(
     theme: "dark" | "light" | undefined,
     translate: Translator | undefined,
@@ -164,14 +314,10 @@ function renderTray(
 ) {
     return (
         <MathJaxContext config={mathjaxConfig} version={4}>
-            <KeyboardTray
+            <TrayWithSharedOpenState
                 theme={theme}
                 translate={translate}
                 direction={direction}
-                onClick={(e) => {
-                    // Route key events only to the active (focused) owner.
-                    getActiveRegistration()?.onClick(e);
-                }}
             />
         </MathJaxContext>
     );
@@ -274,6 +420,12 @@ export function UniqueKeyboardTray({
                     );
                     virtualKeyboardState.keyboardDomNode = null;
                 }
+                // The tray itself is gone, so neither is there a tray that is
+                // open nor a reader who has closed one. Leaving these set
+                // would have the next tray built on the page inherit the
+                // disposition of a tray its reader never saw.
+                virtualKeyboardState.open = false;
+                virtualKeyboardState.userClosedTray = false;
             } else {
                 rerenderTray();
             }

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -157,11 +157,7 @@ function getTrayRegistration():
  */
 function broadcastKeyboardChoice(open: boolean) {
     const choice: KeyCommand[] = [
-        {
-            type: "keyboardChoice",
-            command: open ? "virtual" : "system",
-            timestamp: +new Date(),
-        },
+        { type: "keyboardChoice", command: open ? "virtual" : "system" },
     ];
     for (const registration of virtualKeyboardState.registrations) {
         registration.onClick(choice);

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { OnClick } from "./keyboard";
-import { KeyboardTray } from "./keyboard-tray";
+import {
+    getVirtualKeyboardTrayElement,
+    isInVirtualKeyboardTray,
+    KeyboardTray,
+} from "./keyboard-tray";
 import { KeyCommand } from "./keys";
 import { MathJaxContext } from "@doenet/utils/mathjax";
 import { hasCoarsePrimaryPointer, mathjaxConfig } from "@doenet/utils";
@@ -24,6 +28,19 @@ type VirtualKeyboardState = {
     userClosedTray: boolean;
     /** Subscribers to `open`, so a change re-renders only the tray itself. */
     openListeners: Set<() => void>;
+    /**
+     * The viewers that currently have a math input focused, each identified by
+     * the `ownerRef` it registered with.
+     *
+     * A page can hold several viewers, and each watches focus on its own and
+     * reports only about its own inputs. The tray belongs open while *any* of
+     * them has a math input focused, so their reports are collected rather
+     * than allowed to overwrite one another: otherwise a viewer announcing
+     * "none of mine is focused" — which every other viewer on the page does
+     * the moment the reader taps into one of them — would shut the tray that
+     * the tapped viewer just opened.
+     */
+    focusedMathInputSources: Set<object>;
     keyboardDomNode: HTMLElement | null;
     keyboardReactRoot: Root | null;
     registrations: {
@@ -53,6 +70,7 @@ const virtualKeyboardState: VirtualKeyboardState =
         open: false,
         userClosedTray: false,
         openListeners: new Set(),
+        focusedMathInputSources: new Set(),
         keyboardDomNode: null,
         keyboardReactRoot: null,
         registrations: [],
@@ -70,10 +88,6 @@ function getRegistrationById(id: number | null) {
             (registration) => registration.id === id,
         ) ?? null
     );
-}
-
-function getTrayElement() {
-    return document.getElementById("virtual-keyboard-tray");
 }
 
 function getActiveRegistration() {
@@ -97,10 +111,7 @@ function getActiveRegistration() {
         }
     }
 
-    if (
-        activeElement instanceof Node &&
-        getTrayElement()?.contains(activeElement)
-    ) {
+    if (isInVirtualKeyboardTray(activeElement)) {
         return getRegistrationById(
             virtualKeyboardState.lastActiveRegistrationId,
         );
@@ -190,34 +201,48 @@ function setTrayOpen(open: boolean, { byUser }: { byUser: boolean }) {
 }
 
 /**
- * Reports that focus has entered or left a math input, so the tray can follow
- * it on devices that have no physical keyboard.
+ * Reports that focus has entered or left one of `source`'s math inputs, so the
+ * tray can follow it on devices that have no physical keyboard.
+ *
+ * `source` identifies the reporting viewer — any object stable for that
+ * viewer's lifetime; callers pass the `ownerRef` they registered with. Reports
+ * are about that viewer's own inputs only, and are collected across viewers:
+ * see `focusedMathInputSources`.
  *
  * Only touch devices get this treatment. On a desktop the tray stays under the
  * reader's manual control, as it always has: it occupies a fixed strip along
  * the bottom of the window, and springing that open at every math input would
  * be an imposition on a reader who has a keyboard in front of them.
  */
-export function reportMathInputFocus(mathInputFocused: boolean) {
+export function reportMathInputFocus(
+    source: object,
+    mathInputFocused: boolean,
+) {
     if (!hasCoarsePrimaryPointer()) {
         return;
     }
 
+    const focusedSources = virtualKeyboardState.focusedMathInputSources;
+
     if (mathInputFocused) {
+        focusedSources.add(source);
         if (!virtualKeyboardState.userClosedTray) {
             setTrayOpen(true, { byUser: false });
         }
         return;
     }
 
-    const activeElement = document.activeElement;
-    if (
-        activeElement instanceof Node &&
-        getTrayElement()?.contains(activeElement)
-    ) {
+    if (isInVirtualKeyboardTray(document.activeElement)) {
         // The reader moved into the keyboard itself to operate it. They are
-        // still editing the input they left; the tray must not fold away
-        // underneath them.
+        // still editing the input they left, so this viewer keeps its claim on
+        // the tray and the tray must not fold away underneath them.
+        return;
+    }
+
+    focusedSources.delete(source);
+    if (focusedSources.size > 0) {
+        // Another viewer on the page still has a math input focused; this
+        // report is only about focus leaving this one's.
         return;
     }
 
@@ -247,7 +272,7 @@ function rerenderTray() {
     // part of this comparison: moving focus between two viewers whose readers
     // differ only in direction would otherwise leave the tray facing the way
     // the previous one did.
-    const trayEl = getTrayElement();
+    const trayEl = getVirtualKeyboardTrayElement();
     if (trayEl) {
         const currentTheme =
             (trayEl.getAttribute("data-theme") as
@@ -421,11 +446,13 @@ export function UniqueKeyboardTray({
                     virtualKeyboardState.keyboardDomNode = null;
                 }
                 // The tray itself is gone, so neither is there a tray that is
-                // open nor a reader who has closed one. Leaving these set
-                // would have the next tray built on the page inherit the
-                // disposition of a tray its reader never saw.
+                // open nor a reader who has closed one, and no viewer is left
+                // to claim one. Leaving these set would have the next tray
+                // built on the page inherit the disposition of a tray its
+                // reader never saw.
                 virtualKeyboardState.open = false;
                 virtualKeyboardState.userClosedTray = false;
+                virtualKeyboardState.focusedMathInputSources.clear();
             } else {
                 rerenderTray();
             }

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -236,6 +236,15 @@ export function reportMathInputFocus(
         // The reader moved into the keyboard itself to operate it. They are
         // still editing the input they left, so this viewer keeps its claim on
         // the tray and the tray must not fold away underneath them.
+        //
+        // The claim is held rather than queued for release, so if the reader
+        // then leaves the tray for something that is not a math input the tray
+        // stays open: the viewer has already reported "not focused" and has
+        // nothing further to report. Reaching that state needs a hardware
+        // keyboard on a device whose primary pointer is coarse, it rights
+        // itself at the next math input the reader focuses and leaves, and an
+        // open tray is the ordinary state on touch — so it is left alone
+        // rather than answered with a deferred-release queue.
         return;
     }
 


### PR DESCRIPTION
Makes the virtual keyboard usable on phones and tablets, where the Doenet keyboard and the device's own on-screen keyboard were competing for the same screen.

Reported behavior: on Android the system keyboard opened as soon as a `<mathInput>` was tapped, and dismissing it was futile — pressing a single Doenet key brought it straight back, in front of the tray. On iOS the system keyboard covered the tray outright, so the reader never reached it.

## Cause

Two things combined:

1. **The focused element was an ordinary `<textarea>` with no `inputmode`.** MathQuill puts focus in a hidden textarea; the device saw a focused editable field and raised its keyboard.
2. **The tray took focus on press and the input took it back.** Keys handled `onClick` without cancelling the default focus shift, so each press blurred the input; `mathInput.tsx` then called `mathField.focus()` to restore it, gated by a ±100 ms blur/access timestamp heuristic. Invisible on desktop; on Android every one of those `focus()` calls re-opened the system keyboard.

The iOS occlusion was geometry: the tray is `position: fixed; bottom: 0`, and the system keyboard is drawn above all page content, so `z-index` cannot help.

## Changes

- **`inputmode="none"` on MathQuill's textarea** on touch devices, which keeps focus, the caret, selection and any physical keyboard working while telling the device not to raise its own keyboard. This is the standard mechanism for a custom math keyboard on the web (MathLive, Desmos, GeoGebra), supported by Chrome/Android 66+, Safari iOS 12.2+ and Firefox for Android, and ignored by desktop browsers. Set from the outset rather than when the tray opens — otherwise the first math input a reader taps still raises the system keyboard. Also restores the `autocapitalize` / `autocomplete` / `autocorrect` / `spellcheck` attributes that MathQuill puts on the textarea it would have built itself, which the substitute was dropping; they matter most on phones, which would otherwise capitalize and autocorrect mathematics.
- **The tray declines focus**, cancelling the default action of the pointer press at the tray container so keys inherit it. The input never blurs, so it is never refocused.
- **An explicit record of which input the keyboard types into**, replacing the ±100 ms timestamp heuristic. (A bounded remnant of that window survives in exactly one place — the accommodation for old trays described under "Notes for review" — where there is nothing else to go on.) Besides being deterministic — the old window had a real race, where a tray press within 100 ms of leaving a math input typed into an input that no longer had focus — this decouples typing from `document.activeElement`, which is what #747 needs in order to operate the keyboard from the keyboard. The record is taken from the focus event's `currentTarget` rather than from the `mathField` state: they are the same element, but MathQuill creates the textarea while initializing and hands the field back afterwards, so a reader who focuses an input the instant it appears could land in between and lose the claim — after which the keyboard typed nowhere until they left the input and came back. That was reproducible: the new e2e case failed about one run in five before the change and passed twelve for twelve after it.
- **Editing ends when focus goes on from the tray to somewhere else.** Focus moving *into* the tray is not the reader leaving the input, so the input holds on to the keys, its focused styling and its uncommitted value. But the tray is not part of the input's DOM, so focus leaving the tray again raises no further event on the input; without something watching for it, a value typed before tabbing into the tray would never be committed. `handleBlur` therefore watches the tray for a `focusout` that lands outside it, and finishes the blur — commit, unfocus, release the keys — unless focus has come back to this input.
- **The tray follows focus on touch devices**: it opens at a math input and closes when focus moves elsewhere, such as to a `<textInput>`, whose editing wants the device's own keyboard and all the screen the tray occupies. A reader who closes the tray keeps it closed as they move between math inputs, and gets the system keyboard back. On a desktop the tray stays under manual control exactly as before — springing a fixed bottom strip open at every math input would be an imposition on a reader who has a keyboard in front of them.
- **Focus reports are collected per viewer, not overwritten.** The tray is shared by every viewer on the page, and each viewer watches focus on its own and can only speak for its own inputs. The tray stays open while any of them holds a focused math input, so a viewer announcing "none of mine is focused" — which every other viewer on the page does the moment the reader taps into one of them — cannot shut the tray the tapped viewer just opened.
- **A `keyboardChoice` message** carries the reader's choice of keyboard to every viewer on the page. It is broadcast rather than sent to the focused viewer alone, because reaching for the Doenet keyboard before touching any input is the ordinary way to start on a phone. The tray opening and closing as focus moves is deliberately *not* reported as a choice. In the iframe embedding the tray lives in the embedding page, whose focus events see no further than "the iframe is focused", so the viewer posts a `keyboard-focus` message up; the keyboard identifies its own iframe by `event.source`.
- **The tray's element id, and the "is this inside the tray?" test built on it, are exported from `@doenet/virtual-keyboard`** (`VIRTUAL_KEYBOARD_TRAY_ID`, `isInVirtualKeyboardTray`) rather than spelled out at each of the three places that needed it, `mathInput.tsx` included.

## Testing

- `packages/doenetml-iframe` component tests, 10 passing — extended to cover the keyboard-choice broadcast, focus being declined on a key press, auto-open and auto-close, the reader's close being remembered, one viewer's focus report not closing the tray on another's behalf, manual-control-on-desktop, and both the iframe and same-window focus paths.
- A new e2e case in `mathinput.cy.js` covers the thing all of the above is in service of and that nothing exercised end to end before: pressing keys on the tray types into the focused math input, and reaching for the tray does not take focus from it. It presses the same key twice on purpose. The keys of a given tray button are one constant array reused on every press, and a math input notices a new batch of keys by the identity of the array in the store; until now the bookkeeping events the tray sent alongside each press happened to keep that identity moving, and with them gone the dispatch has to build a fresh array itself. Both halves of the case were confirmed to fail when the corresponding change is reverted.
- A second new e2e case in `mathinput.cy.js` covers the end of editing: type into a math input, move focus into the tray as a keyboard-only reader does, press a key from there — it still types into the input that no longer holds `document.activeElement` — then move focus on to a different input, and the first input's value is committed. Confirmed to fail (value never committed) with the tray watcher removed.
- `DoenetViewer.legacyKeyboardTray.cy.tsx`, 4 passing — runs a real, locally built standalone bundle inside a real iframe, driven by a reproduction of the tray published in `@doenet/doenetml-iframe@0.7.21`, the version deployed on doenet.org. One case for the key landing and the caret coming back, one for a key pressed after the reader has left the input landing nowhere, one for a press that carries no key — opening the tray while already editing an input — giving the caret back so the next key still types, and one for such a press not pulling the caret into an input the reader has already left. See the version-skew note below; each was confirmed to fail with the code it covers removed.
- e2e: `mathinput.cy.js` 34/34, `darkModeRendererAccessibility.cy.js` 36/36, `i18n.cy.js` 38/38.

## Notes for review

- **Switching back to the system keyboard costs one extra tap.** Closing the tray restores `inputmode`, but iOS raises its keyboard only during a user gesture and the state arrives just after one, so it appears on the reader's next tap of the input. Suppression is immediate; only the reverse is deferred.
- **A new viewer under an old tray keeps working; the reverse does not.** This is the pairing that actually occurs, and it is not hypothetical: doenet.org installs `@doenet/doenetml-iframe` as `^0.7.21` (`DoenetTools/apps/{web,app}/package.json`) but seeds the default 0.7 version as `fullVersion: "latest"` (`apps/api/prisma/seed.ts`), which `index.tsx` turns into `@doenet/standalone@latest`. Publishing a viewer therefore puts a new viewer under the already-deployed old tray, with no action on the site's part and no window in which the two agree.

  On a phone the stakes are higher than the Doenet keyboard typing nothing. `inputmode="none"` keeps the device's own keyboard down from the first tap, and an old tray has no way to report that the reader has closed it and would like that keyboard back — so without this accommodation a phone reader on doenet.org would meet a math input that raises no keyboard at all *and* a Doenet keyboard whose keys do nothing, for as long as it took the site to redeploy. With it, the Doenet keyboard is simply the one keyboard on offer, opened by hand as it always was under that tray. That is the case for keeping this path rather than reverting it and bumping the wrapper on doenet.org alongside the release: the bump fixes the pairing only once it ships, and this is what the skew looks like until then — for embedders slower to redeploy than doenet.org, considerably longer.

  A version gate cannot address it — gates live in the wrapper and key on the bundle version (`version-gates.ts`), and here the *wrapper* is the old side, which cannot be changed retroactively. So the viewer accommodates the old tray instead. The `accessed` message is the discriminator: only trays from before this change send it, so the first one settles which tray the page is under for good. From then on a key that arrives with no input claiming the keyboard is matched to the release of that claim which the same press caused — this input's, to nothing else in the document, and still fresh — and the caret that press took is given back, as that tray's contemporaries did. The caret comes back after every press of such a tray, not only the ones carrying a key: opening the tray is itself a press, and a reader who reaches for the keyboard while editing an input is still editing it. Without that, the first key they pressed afterwards would type nowhere — and focus the input, then open the keyboard is the ordinary way to start, so the accommodation would fail at the first step.

  Each half of that is load-bearing. Giving the caret back is a real focus move the reader can see, not a claim filed on their behalf: the input holds the keyboard afterwards because it holds the caret, and gives it up the moment the reader takes the caret elsewhere. That is what keeps a keyless press — the old tray's close button, the gap between two keys — from leaving a lingering claim behind it, the shape of which would be a character appearing in an input the reader had left, and the caret dragged back to it out of the text input they had moved to. And every press is judged on its own against a release recent enough to have caused it, because nothing but timing separates the blur the press caused from the reader having left the input of their own accord and reaching for the tray afterwards. The viewers contemporary with that tray drew the same line, at 100 ms between the blur and the tray's own timestamp; the 300 ms bound here measures from the blur to the message being handled, so it allows for the `postMessage` hop and the render that follows. A press that misses it does nothing at all — the bound can only decline a press, never send one to an input other than the one whose blur it is matched against. It applies to nothing else: no current tray sends `accessed`, so no current pairing reaches this code at all.

  Verified against the real thing rather than reasoned about: `DoenetViewer.legacyKeyboardTray.cy.tsx` drives a locally built standalone bundle in a real cross-document iframe from a tray reproducing 0.7.21's published behavior — read out of the published `index.js`, which sends `accessed` on mousedown and has no `preventDefault` anywhere — and checks that the key types, that the caret comes back, and that a second key still lands. It fails without the reclaim. A second case checks the other half: after the reader clicks away onto the surrounding text, a key pressed a moment later types nothing and leaves the caret where they put it — and it fails, typing into the abandoned input, if the reclaim is not bounded. A third presses the tray somewhere that sends no key while the reader is editing — which is what opening the tray does — and then, well outside the matching window, a key: it fails, typing nowhere, if only keys and not the press itself give the caret back. A fourth makes that same keyless press after the reader has moved off the input, and checks that it pulls no caret back and leaves the input holding nothing. Along the way this disproved a plausible-looking first attempt that keyed on `document.hasFocus()`: in that blur the iframe's document still reports having focus, so that discriminator would have silently done nothing.

  The opposite pairing — an older viewer under this tray — cannot be rescued from this side, since that viewer typed only in response to a blur this tray no longer causes. It arises for an embedder pinning an old viewer explicitly, or via a document whose `<document xmlns="…/v0.7.x">` names one (`autodetectVersion` is on by default and overrides the host's choice). Such an embedder should pin the wrapper alongside the viewer; noted in the changeset and `keys.ts`. Physical keyboards are unaffected throughout.

- **A pre-existing MathJax teardown race is now more likely** — filed as #1696. Unmounting the tray while it is typesetting rejects a promise ("Typesetting failed"), which surfaces across test boundaries; that one rejection is filtered in the spec, with a comment, and the filter should go away with the fix. It is harmless to the reader but will happen more often now that the tray opens by itself on phones.
- **Known small gap, left as is.** Tabbing from a math input into the tray and then on to something that is not a math input leaves the *tray's* claim standing, so the tray stays open: the viewer has already reported "not focused" and has nothing further to report. The math input half of this — the value uncommitted — is fixed, since losing what the reader typed is a different order of problem from a tray left open; see the watcher bullet above. What remains needs a hardware keyboard on a device whose primary pointer is coarse (a desktop tray does not follow focus at all), it rights itself at the next math input the reader focuses and leaves, and an open tray is the ordinary state on touch — so it is documented at `reportMathInputFocus` rather than answered with a deferred-release queue.
- **Operating the keyboard from the keyboard: the routing works now, the ergonomics are still #747.** With the blur/refocus coupling gone, a tray that holds focus still types into the math input the reader left, and what it types is committed when focus finally leaves the tray — covered end to end in `mathinput.cy.js`. What #747 still wants is the way *in*: the tray is portaled to the end of `<body>`, so reaching it means tabbing past the rest of the page, its keys are an undifferentiated run of ordinary tab stops with no roving focus, and nothing announces what the reader has arrived at. This also holds only in the same-window embedding: under `@doenet/doenetml-iframe` the viewer cannot see the tray, which lives in the parent, so a blur that leaves the iframe ends the edit — except when the tray identifies itself as an old one, which is what the version-skew note below turns to account.
- #449 (keys too small on iPad/iPhone) is the natural follow-up and interacts with this: the tray's fixed `--keyboard-tray-height: 280px` will need to become dynamic.

Closes #1692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8









