### PR TITLE
fix: size the virtual keyboard's controls for a fingertip on touch devices

### DIFF
--- a/.changeset/keyboard-touch-target-sizes.md
+++ b/.changeset/keyboard-touch-target-sizes.md
@@ -36,7 +36,9 @@ Where the tray has no room for the whole keyboard — the same phone held
 sideways, or any short window — the keyboard now scrolls inside the tray
 instead of running off the bottom of the screen, so the rows that were cut off,
 the number pad among them, can be reached. Taller keys would have cut off more.
-The tab and the close button stay where they are while it scrolls.
+The tab and the close button stay where they are while it scrolls, and the tray
+opens onto the top of the keyboard however far it was scrolled last time, so
+the layout tabs are always the first thing in it.
 
 Nothing else changes for a reader with a mouse, including on a narrow window:
 the sizing is keyed on the primary pointer being coarse, which is the same test

--- a/.changeset/keyboard-touch-target-sizes.md
+++ b/.changeset/keyboard-touch-target-sizes.md
@@ -24,13 +24,15 @@ rather than 42rem, so a key grows to 48px there instead of staying at 40px in
 the middle of an empty row.
 
 The tray also stops short of the height that would carry its own tab off the
-top of the screen. It hangs the tab exactly its own height above the tray, so a
-taller tab needs a taller gap; on a phone held sideways, where the tray is tall
-enough to reach that limit, the tab was being clipped.
+top of the screen — floor as well as ceiling, so a window shorter than the
+tray's usual 280px no longer pushes the tab out of reach either. It hangs the
+tab exactly its own height above the tray, so a taller tab needs a taller gap;
+on a phone held sideways, where the tray is tall enough to reach that limit,
+the tab was being clipped.
 
-Nothing changes for a reader with a mouse, including on a narrow window: the
-sizing is keyed on the primary pointer being coarse, which is the same test the
-viewer already uses to decide whether to suppress the device's own on-screen
-keyboard.
+Nothing else changes for a reader with a mouse, including on a narrow window:
+the sizing is keyed on the primary pointer being coarse, which is the same test
+the viewer already uses to decide whether to suppress the device's own
+on-screen keyboard.
 
 Closes #449.

--- a/.changeset/keyboard-touch-target-sizes.md
+++ b/.changeset/keyboard-touch-target-sizes.md
@@ -37,8 +37,8 @@ sideways, or any short window — the keyboard now scrolls inside the tray
 instead of running off the bottom of the screen, so the rows that were cut off,
 the number pad among them, can be reached. Taller keys would have cut off more.
 The tab and the close button stay where they are while it scrolls, and the tray
-opens onto the top of the keyboard however far it was scrolled last time, so
-the layout tabs are always the first thing in it.
+opens onto the top of the keyboard however far it was scrolled last time, so the
+layout tabs are in view whenever it opens.
 
 Nothing else changes for a reader with a mouse, including on a narrow window:
 the sizing is keyed on the primary pointer being coarse, which is the same test

--- a/.changeset/keyboard-touch-target-sizes.md
+++ b/.changeset/keyboard-touch-target-sizes.md
@@ -1,0 +1,31 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Viewer: size the virtual keyboard's controls for a fingertip on touch devices.
+
+Every control in the keyboard tray was built for a mouse pointer. On a phone or
+tablet the tab that opens the tray was 48x24, the button that closes it 24x24,
+the layout tabs (`123`, `f(x)`, `ABC`, `αβγ`, `$%∞`) 30x25, and the keys
+themselves 39x40 — all under the 44px minimum a fingertip needs, which is the
+figure in both Apple's HIG and WCAG 2.5.5. The tab that opens the tray was the
+worst of them, since it is the only way in and had to be found before anything
+else could be tapped.
+
+On a device whose primary pointing device is coarse, those controls are now at
+least 44px in the direction that was short: the open tab is 64x44, the close
+button 44x44, and the layout tabs and keys are 44px tall. Key width is left to
+the row layout, which shares the row out evenly — a phone cannot fit twelve
+44px-wide keys across, and forcing it would only cause an overflow. What the
+extra room buys on a tablet is wider keys: the keyboard may now spread to 48rem
+rather than 42rem, so a key grows to 48px there instead of staying at 40px in
+the middle of an empty row.
+
+Nothing changes for a reader with a mouse, including on a narrow window: the
+sizing is keyed on the primary pointer being coarse, which is the same test the
+viewer already uses to decide whether to suppress the device's own on-screen
+keyboard.
+
+Closes #449.

--- a/.changeset/keyboard-touch-target-sizes.md
+++ b/.changeset/keyboard-touch-target-sizes.md
@@ -2,6 +2,8 @@
 "@doenet/doenetml": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
 ---
 
 Viewer: size the virtual keyboard's controls for a fingertip on touch devices.
@@ -30,9 +32,16 @@ tab exactly its own height above the tray, so a taller tab needs a taller gap;
 on a phone held sideways, where the tray is tall enough to reach that limit,
 the tab was being clipped.
 
+Where the tray has no room for the whole keyboard — the same phone held
+sideways, or any short window — the keyboard now scrolls inside the tray
+instead of running off the bottom of the screen, so the rows that were cut off,
+the number pad among them, can be reached. Taller keys would have cut off more.
+The tab and the close button stay where they are while it scrolls.
+
 Nothing else changes for a reader with a mouse, including on a narrow window:
 the sizing is keyed on the primary pointer being coarse, which is the same test
 the viewer already uses to decide whether to suppress the device's own
-on-screen keyboard.
+on-screen keyboard. The scrolling is the exception, and deliberately so — a
+window too short for the keyboard cut it off whatever was pointing at it.
 
 Closes #449.

--- a/.changeset/keyboard-touch-target-sizes.md
+++ b/.changeset/keyboard-touch-target-sizes.md
@@ -23,6 +23,11 @@ extra room buys on a tablet is wider keys: the keyboard may now spread to 48rem
 rather than 42rem, so a key grows to 48px there instead of staying at 40px in
 the middle of an empty row.
 
+The tray also stops short of the height that would carry its own tab off the
+top of the screen. It hangs the tab exactly its own height above the tray, so a
+taller tab needs a taller gap; on a phone held sideways, where the tray is tall
+enough to reach that limit, the tab was being clipped.
+
 Nothing changes for a reader with a mouse, including on a narrow window: the
 sizing is keyed on the primary pointer being coarse, which is the same test the
 viewer already uses to decide whether to suppress the device's own on-screen

--- a/packages/doenetml/dev/main.css
+++ b/packages/doenetml/dev/main.css
@@ -4,11 +4,20 @@
     height: 100%;
 }
 
+/*
+ * Wraps rather than running off the side. These controls are wider than a
+ * phone laid end to end, and a row that cannot wrap makes the whole document
+ * wider than the viewport — at which point Chrome's device toolbar scales the
+ * page down to fit and every mobile check is done against a shrunken render,
+ * with the viewer apparently occupying two thirds of the width and a band of
+ * empty space below it. The viewer itself fits a phone; only this bar did not.
+ */
 .dev-toolbar {
     flex: 0 0 auto;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    gap: 12px;
+    gap: 8px 12px;
     padding: 8px 12px;
     border-bottom: 1px solid #ccc;
     background: #f5f5f5;

--- a/packages/doenetml/dev/main.css
+++ b/packages/doenetml/dev/main.css
@@ -28,6 +28,10 @@
     color: #666;
 }
 
+.dev-label-short {
+    display: none;
+}
+
 .dev-control {
     display: inline-flex;
     align-items: center;
@@ -50,4 +54,42 @@
 .dev-viewer {
     flex: 1 1 auto;
     overflow: hidden;
+}
+
+/*
+ * On a phone the bar is checking the app, not competing with it for the
+ * screen: the labels shorten, the note about local storage goes (the Reset
+ * button's tooltip says the same thing), and the locale fields keep just
+ * enough room for a tag like `en-XB`. Full-width this bar wrapped onto four
+ * rows and took a fifth of an iPhone SE; it now fits on one.
+ *
+ * `40rem` matches Tailwind's `sm` breakpoint, which is where the viewer
+ * beneath already changes its own spacing.
+ */
+@media (max-width: 40rem) {
+    .dev-toolbar {
+        gap: 6px 8px;
+        padding: 6px 8px;
+    }
+
+    .dev-label-full {
+        display: none;
+    }
+
+    .dev-label-short {
+        display: inline;
+    }
+
+    .dev-toolbar-status {
+        display: none;
+    }
+
+    /*
+     * Enough for a tag (`en-XB` is the longest the datalist offers) but not
+     * for the `(document)` placeholder, which truncates. That hint is the
+     * price of the single row; the field's `title` still explains it.
+     */
+    .dev-locale-input {
+        width: 4em;
+    }
 }

--- a/packages/doenetml/dev/main.tsx
+++ b/packages/doenetml/dev/main.tsx
@@ -139,8 +139,9 @@ function useDebounced<T>(value: T, delayMs: number): T {
  * narrow bar. The control carries the full name as its `aria-label` either
  * way, so what is announced does not change with the width.
  *
- * Pass the wording only — the colon and the gap to the control belong to the
- * component, so the two forms cannot end up punctuated differently.
+ * Pass the wording only: the colon belongs here, so the two forms cannot end up
+ * punctuated differently, and the space before the control is `.dev-control`'s
+ * `gap` rather than a literal one written at the call site.
  */
 function DevLabel({ full, short }: { full: string; short?: string }) {
     return (

--- a/packages/doenetml/dev/main.tsx
+++ b/packages/doenetml/dev/main.tsx
@@ -132,6 +132,20 @@ function useDebounced<T>(value: T, delayMs: number): T {
     return debounced;
 }
 
+/**
+ * A toolbar label with a short stand-in for when the bar is narrow. Only one of
+ * the two is ever displayed (see `main.css`); the control carries the full name
+ * as its `aria-label`, so what is announced does not change with the width.
+ */
+function DevLabel({ full, short }: { full: string; short: string }) {
+    return (
+        <>
+            <span className="dev-label-full">{full}: </span>
+            <span className="dev-label-short">{short}</span>
+        </>
+    );
+}
+
 function App() {
     const [initialSource] = React.useState(getInitialSource);
     const [resetKey, setResetKey] = React.useState(0);
@@ -176,16 +190,21 @@ function App() {
         <div className="dev-app">
             <div className="dev-toolbar">
                 <label className="dev-control">
-                    Theme:{" "}
-                    <select value={darkMode} onChange={handleThemeChange}>
+                    <DevLabel full="Theme" short="" />
+                    <select
+                        aria-label="Theme"
+                        value={darkMode}
+                        onChange={handleThemeChange}
+                    >
                         <option value="light">Light</option>
                         <option value="dark">Dark</option>
                         <option value="system">System</option>
                     </select>
                 </label>
                 <label className="dev-control">
-                    Document locale:{" "}
+                    <DevLabel full="Document locale" short="Doc:" />
                     <input
+                        aria-label="Document locale"
                         className="dev-locale-input"
                         list="dev-locale-options"
                         value={documentLocale}
@@ -200,8 +219,9 @@ function App() {
                     />
                 </label>
                 <label className="dev-control">
-                    UI locale:{" "}
+                    <DevLabel full="UI locale" short="UI:" />
                     <input
+                        aria-label="UI locale"
                         className="dev-locale-input"
                         list="dev-locale-options"
                         value={uiLocale}

--- a/packages/doenetml/dev/main.tsx
+++ b/packages/doenetml/dev/main.tsx
@@ -133,15 +133,17 @@ function useDebounced<T>(value: T, delayMs: number): T {
 }
 
 /**
- * A toolbar label with a short stand-in for when the bar is narrow. Only one of
- * the two is ever displayed (see `main.css`); the control carries the full name
- * as its `aria-label`, so what is announced does not change with the width.
+ * A toolbar label, with an optional short stand-in for when the bar is narrow.
+ * At most one of the two is displayed (see `main.css`); omit `short` for a
+ * control that reads well unlabelled, and the label disappears entirely on a
+ * narrow bar. The control carries the full name as its `aria-label` either
+ * way, so what is announced does not change with the width.
  */
-function DevLabel({ full, short }: { full: string; short: string }) {
+function DevLabel({ full, short }: { full: string; short?: string }) {
     return (
         <>
             <span className="dev-label-full">{full}: </span>
-            <span className="dev-label-short">{short}</span>
+            {short ? <span className="dev-label-short">{short}</span> : null}
         </>
     );
 }
@@ -190,7 +192,7 @@ function App() {
         <div className="dev-app">
             <div className="dev-toolbar">
                 <label className="dev-control">
-                    <DevLabel full="Theme" short="" />
+                    <DevLabel full="Theme" />
                     <select
                         aria-label="Theme"
                         value={darkMode}

--- a/packages/doenetml/dev/main.tsx
+++ b/packages/doenetml/dev/main.tsx
@@ -138,12 +138,15 @@ function useDebounced<T>(value: T, delayMs: number): T {
  * control that reads well unlabelled, and the label disappears entirely on a
  * narrow bar. The control carries the full name as its `aria-label` either
  * way, so what is announced does not change with the width.
+ *
+ * Pass the wording only — the colon and the gap to the control belong to the
+ * component, so the two forms cannot end up punctuated differently.
  */
 function DevLabel({ full, short }: { full: string; short?: string }) {
     return (
         <>
-            <span className="dev-label-full">{full}: </span>
-            {short ? <span className="dev-label-short">{short}</span> : null}
+            <span className="dev-label-full">{full}:</span>
+            {short ? <span className="dev-label-short">{short}:</span> : null}
         </>
     );
 }
@@ -204,7 +207,7 @@ function App() {
                     </select>
                 </label>
                 <label className="dev-control">
-                    <DevLabel full="Document locale" short="Doc:" />
+                    <DevLabel full="Document locale" short="Doc" />
                     <input
                         aria-label="Document locale"
                         className="dev-locale-input"
@@ -221,7 +224,7 @@ function App() {
                     />
                 </label>
                 <label className="dev-control">
-                    <DevLabel full="UI locale" short="UI:" />
+                    <DevLabel full="UI locale" short="UI" />
                     <input
                         aria-label="UI locale"
                         className="dev-locale-input"

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -41,17 +41,25 @@
  * tab (showViewer={false} or viewerLocation in {"start","top"} with the
  * keyboard enabled), push the last footer element inward so the icons stay
  * clickable. The reservation must match the keyboard tab's inline-end
- * footprint (`w-12` + `me-4` = 3rem + 1rem) defined in
- * `packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css`. Keep
- * this value in sync if that footprint changes. Very narrow viewports may
- * still let the tab and the icons collide; that's accepted.
+ * footprint (`--keyboard-tab-width` + `me-4`) defined in
+ * `packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css`, which
+ * widens the tab on touch devices to give it a target a fingertip can hit.
+ * Keep both values in sync if that footprint changes. Very narrow viewports
+ * may still let the tab and the icons collide; that's accepted.
  *
  * Logical, and it has to stay paired with the tab's own `end-0`: the tab is
  * portaled to `document.body`, so nothing but this axis agreement keeps the
  * space and the thing it is reserved for on the same side of the screen.
  */
 .editor-panel .editor-footer.reserve-keyboard-button-space {
+    /* 3rem tab + 1rem margin */
     --keyboard-tab-reserve-width: 4rem;
+}
+@media (pointer: coarse) {
+    .editor-panel .editor-footer.reserve-keyboard-button-space {
+        /* 4rem tab + 1rem margin */
+        --keyboard-tab-reserve-width: 5rem;
+    }
 }
 .editor-panel .editor-footer.reserve-keyboard-button-space .footer-menu-button {
     margin-inline-end: var(--keyboard-tab-reserve-width);

--- a/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
@@ -21,6 +21,21 @@ const MIN_TOUCH_TARGET_PX = 44;
 /** What the tab that opens a closed tray measures when a mouse is driving. */
 const DESKTOP_TAB_HEIGHT_PX = 24;
 
+/**
+ * How wide the keyboard is allowed to spread, `max-w-2xl` (42rem) with a mouse
+ * and 48rem with a fingertip. The default viewport is wider than both, so the
+ * keyboard reaches its ceiling either way and these are what it measures. The
+ * extra room is what makes a tablet's keys grow rather than sit small in the
+ * middle of an empty row.
+ */
+const KEYBOARD_MAX_WIDTH_PX = { fine: 672, coarse: 768 };
+
+/**
+ * A phone held sideways — short enough that the tray runs into the ceiling on
+ * its own height, which is the only place that ceiling is observable.
+ */
+const SHORT_VIEWPORT = { width: 568, height: 320 };
+
 function emulateTouchDevice(enabled) {
     return cy
         .wrap(
@@ -129,6 +144,51 @@ describe("Virtual keyboard touch target sizes", { tags: ["@group5"] }, () => {
                 "tray content height fits the viewport",
             ).to.be.at.most(Cypress.config("viewportHeight"));
         });
+
+        // Where there is room, the keyboard spreads further than it does for
+        // a mouse, which is what makes a tablet's keys wider rather than
+        // leaving them small in the middle of an empty row.
+        cy.get("#virtual-keyboard-tray .virtual-keyboard").should(($kb) => {
+            expect(
+                Math.round($kb[0].getBoundingClientRect().width),
+                "keyboard width",
+            ).to.equal(KEYBOARD_MAX_WIDTH_PX.coarse);
+        });
+    });
+
+    it("keeps the open/close tab on screen when the tray fills a short viewport", () => {
+        // The tab hangs its own height above the tray, so the tray's
+        // `max-height` has to leave that much clear. A short viewport is the
+        // only place the ceiling is reached, and widening the tab for a
+        // fingertip without widening the gap clipped it off the top.
+        cy.viewport(SHORT_VIEWPORT.width, SHORT_VIEWPORT.height);
+        emulateTouchDevice(true);
+        loadWithMathInput();
+
+        cy.window().should((win) => {
+            expect(
+                win.matchMedia("(pointer: coarse)").matches,
+                "browser reports a coarse primary pointer",
+            ).to.equal(true);
+        });
+
+        cy.get(".open-keyboard-button").click();
+
+        cy.get("#virtual-keyboard-tray.open").should(($tray) => {
+            // The tray slides up over 300ms, and while it is still below the
+            // fold the tab is trivially on screen — so wait for the tray to
+            // reach the bottom edge before believing anything about the tab.
+            expect(
+                Math.round($tray[0].getBoundingClientRect().bottom),
+                "tray settled against the bottom of the screen",
+            ).to.equal(SHORT_VIEWPORT.height);
+
+            const tab = $tray[0].querySelector(".open-keyboard-button");
+            expect(
+                Math.round(tab.getBoundingClientRect().top),
+                "open/close tab top edge",
+            ).to.be.at.least(0);
+        });
     });
 
     it("leaves the sizes alone when a mouse is driving", () => {
@@ -151,6 +211,16 @@ describe("Virtual keyboard touch target sizes", { tags: ["@group5"] }, () => {
                 Math.round($tab[0].getBoundingClientRect().height),
                 "open-keyboard tab height",
             ).to.equal(DESKTOP_TAB_HEIGHT_PX);
+        });
+
+        cy.get(".open-keyboard-button").click();
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        cy.get("#virtual-keyboard-tray .virtual-keyboard").should(($kb) => {
+            expect(
+                Math.round($kb[0].getBoundingClientRect().width),
+                "keyboard width",
+            ).to.equal(KEYBOARD_MAX_WIDTH_PX.fine);
         });
     });
 });

--- a/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
@@ -22,11 +22,11 @@ const MIN_TOUCH_TARGET_PX = 44;
 const DESKTOP_TAB_HEIGHT_PX = 24;
 
 /**
- * How wide the keyboard is allowed to spread, `max-w-2xl` (42rem) with a mouse
- * and 48rem with a fingertip. The default viewport is wider than both, so the
- * keyboard reaches its ceiling either way and these are what it measures. The
- * extra room is what makes a tablet's keys grow rather than sit small in the
- * middle of an empty row.
+ * How wide the keyboard is allowed to spread — `--keyboard-max-width` in
+ * `keyboard.css`, 42rem with a mouse and 48rem with a fingertip. The default
+ * viewport is wider than both, so the keyboard reaches its ceiling either way
+ * and these are what it measures. The extra room is what makes a tablet's keys
+ * grow rather than sit small in the middle of an empty row.
  */
 const KEYBOARD_MAX_WIDTH_PX = { fine: 672, coarse: 768 };
 

--- a/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
@@ -56,6 +56,61 @@ function emulateTouchDevice(enabled) {
         );
 }
 
+/**
+ * Maps a point in the application's viewport to the coordinates the devtools
+ * protocol works in, which are the browser page's. The application under test
+ * runs in an iframe of the Cypress runner, and Cypress may scale that iframe
+ * to fit the window, so both the offset and the scale have to be undone.
+ */
+function toBrowserCoords(win, x, y) {
+    const iframe = Array.from(
+        window.top.document.querySelectorAll("iframe"),
+    ).find((frame) => frame.contentWindow === win);
+    const rect = iframe.getBoundingClientRect();
+    const scale = rect.width / win.innerWidth;
+    return { x: rect.left + x * scale, y: rect.top + y * scale };
+}
+
+/**
+ * Drags a finger `distance` px up the middle of `element`.
+ *
+ * Real touch input through the browser, not a synthesised `TouchEvent`: an
+ * untrusted event would not reach the compositor, which is what decides
+ * whether a pan scrolls. That decision is the point of the assertions below.
+ */
+function panFingerUp(win, element, distance) {
+    const rect = element.getBoundingClientRect();
+    const start = toBrowserCoords(
+        win,
+        rect.left + rect.width / 2,
+        rect.top + rect.height / 2,
+    );
+    const steps = 12;
+    const touch = (type, y) =>
+        cy.wrap(
+            Cypress.automation("remote:debugger:protocol", {
+                command: "Input.dispatchTouchEvent",
+                params: {
+                    type,
+                    touchPoints:
+                        type === "touchEnd"
+                            ? []
+                            : [{ x: Math.round(start.x), y: Math.round(y) }],
+                },
+            }),
+            { log: false },
+        );
+
+    let chain = touch("touchStart", start.y);
+    for (let step = 1; step <= steps; step++) {
+        const y = start.y - (distance * step) / steps;
+        chain = chain
+            .then(() => touch("touchMove", y))
+            .wait(16, { log: false });
+    }
+    return chain.then(() => touch("touchEnd"));
+}
+
 /** Asserts every element matching `selector` is at least `min` px tall. */
 function expectAllAtLeastTall(selector, min, label) {
     cy.get(selector).should(($elements) => {
@@ -136,15 +191,21 @@ describe("Virtual keyboard touch target sizes", { tags: ["@group5"] }, () => {
             "key",
         );
 
-        // Taller keys must not make the tray's contents outgrow the screen.
-        // The tray is anchored to the bottom edge and does not scroll, so
-        // whatever does not fit runs off the bottom and cannot be tapped —
-        // the way this kind of change usually goes wrong.
+        // Taller keys must not make the tray outgrow the screen. On a viewport
+        // with room for it — this one — nothing should have to be scrolled
+        // into reach before it can be tapped, which is the way this kind of
+        // change usually goes wrong. The short viewport that does run out of
+        // room is a test of its own below.
         cy.get("#virtual-keyboard-tray").should(($tray) => {
             expect(
-                $tray[0].scrollHeight,
-                "tray content height fits the viewport",
+                $tray[0].getBoundingClientRect().height,
+                "tray height fits the viewport",
             ).to.be.at.most(Cypress.config("viewportHeight"));
+            const container = $tray[0].querySelector(".keyboard-container");
+            expect(
+                container.scrollHeight,
+                "keyboard content fits the tray without scrolling",
+            ).to.be.at.most(container.clientHeight);
         });
 
         // Where there is room, the keyboard spreads further than it does for
@@ -190,6 +251,76 @@ describe("Virtual keyboard touch target sizes", { tags: ["@group5"] }, () => {
                 Math.round(tab.getBoundingClientRect().top),
                 "open/close tab top edge",
             ).to.be.at.least(0);
+        });
+    });
+
+    it("lets a finger reach the keys that do not fit a short viewport", () => {
+        // A viewport too short for the keyboard used to cut the bottom rows
+        // off — on the numeric layout, the whole number pad. Taller keys made
+        // that worse, so the keyboard scrolls inside the tray instead.
+        //
+        // Whether a finger can actually pan it is not a foregone conclusion:
+        // the tray cancels the default action of `pointerdown` across its
+        // whole subtree, to keep the key it is typing into from blurring. That
+        // does not suppress a pan — only `touch-action` or a cancelled
+        // `touchstart`/`touchmove` would — and this is what says so.
+        cy.viewport(SHORT_VIEWPORT.width, SHORT_VIEWPORT.height);
+        emulateTouchDevice(true);
+        loadWithMathInput();
+
+        cy.get(".open-keyboard-button").click();
+        cy.get("#virtual-keyboard-tray.open").should(($tray) => {
+            // Wait out the slide-in, as above: measurements of a tray still on
+            // its way up mean nothing.
+            expect(
+                Math.round($tray[0].getBoundingClientRect().bottom),
+                "tray settled against the bottom of the screen",
+            ).to.equal(SHORT_VIEWPORT.height);
+        });
+
+        const container = "#virtual-keyboard-tray .keyboard-container";
+        cy.get(container).should(($container) => {
+            const element = $container[0];
+            expect(
+                element.scrollHeight,
+                "keyboard is taller than the room the tray has for it",
+            ).to.be.greaterThan(element.clientHeight);
+            expect(
+                Math.round(element.getBoundingClientRect().bottom),
+                "keyboard's scroll port ends on screen",
+            ).to.be.at.most(SHORT_VIEWPORT.height);
+        });
+
+        // Far enough to reach the end of the scroll, which is where the last
+        // row is.
+        cy.window().then((win) =>
+            panFingerUp(win, win.document.querySelector(container), 300),
+        );
+
+        cy.get(container).should(($container) => {
+            expect(
+                $container[0].scrollTop,
+                "keyboard scrolled under a finger",
+            ).to.be.greaterThan(0);
+            const keys = $container[0].querySelectorAll(
+                ".virtual-keyboard button",
+            );
+            expect(
+                Math.round(
+                    keys[keys.length - 1].getBoundingClientRect().bottom,
+                ),
+                "last key on screen once scrolled to",
+            ).to.be.at.most(SHORT_VIEWPORT.height);
+        });
+
+        // The close button is inside the scroll port in the markup but
+        // positioned against the tray, so scrolling must not carry it away.
+        cy.get(".close-keyboard-button").should(($close) => {
+            const { top, bottom } = $close[0].getBoundingClientRect();
+            expect(Math.round(top), "close button top").to.be.at.least(0);
+            expect(Math.round(bottom), "close button bottom").to.be.at.most(
+                SHORT_VIEWPORT.height,
+            );
         });
     });
 

--- a/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
@@ -136,8 +136,10 @@ describe("Virtual keyboard touch target sizes", { tags: ["@group5"] }, () => {
             "key",
         );
 
-        // Taller keys must not push the tray past the bottom of the
-        // screen, which is the way this kind of change usually goes wrong.
+        // Taller keys must not make the tray's contents outgrow the screen.
+        // The tray is anchored to the bottom edge and does not scroll, so
+        // whatever does not fit runs off the bottom and cannot be tapped —
+        // the way this kind of change usually goes wrong.
         cy.get("#virtual-keyboard-tray").should(($tray) => {
             expect(
                 $tray[0].scrollHeight,

--- a/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
@@ -1,0 +1,156 @@
+/**
+ * Touch-target sizes for the virtual keyboard (issue #449).
+ *
+ * On a device driven by a fingertip rather than a pointer, every control in
+ * the tray needs a target a fingertip can land on. 44px is the minimum in
+ * Apple's HIG and in WCAG 2.5.5. The tray shipped with a 48x24 tab to open it,
+ * a 24x24 button to close it, layout tabs measuring 30x25 on a phone, and
+ * 39x40 keys.
+ *
+ * Chrome reports a coarse primary pointer when touch emulation is on, which is
+ * what the devtools protocol calls below switch — a media feature cannot be
+ * faked from page scripts. These run in the e2e suite rather than as component
+ * tests because the sizes come from Tailwind `@apply` utilities, which are
+ * only compiled into the package's built stylesheet; a component test mounting
+ * the source measures elements with no sizing applied at all.
+ */
+
+/** The smallest target a fingertip can reliably land on. */
+const MIN_TOUCH_TARGET_PX = 44;
+
+/** What the tab that opens a closed tray measures when a mouse is driving. */
+const DESKTOP_TAB_HEIGHT_PX = 24;
+
+function emulateTouchDevice(enabled) {
+    return cy
+        .wrap(
+            Cypress.automation("remote:debugger:protocol", {
+                command: "Emulation.setTouchEmulationEnabled",
+                params: { enabled, maxTouchPoints: 5 },
+            }),
+            { log: false },
+        )
+        .then(() =>
+            cy.wrap(
+                Cypress.automation("remote:debugger:protocol", {
+                    command: "Emulation.setEmitTouchEventsForMouse",
+                    params: { enabled, configuration: "mobile" },
+                }),
+                { log: false },
+            ),
+        );
+}
+
+/** Asserts every element matching `selector` is at least `min` px tall. */
+function expectAllAtLeastTall(selector, min, label) {
+    cy.get(selector).should(($elements) => {
+        expect($elements.length, `${label}s found`).to.be.greaterThan(0);
+        $elements.each((_, element) => {
+            const name = element.textContent?.trim() || element.className;
+            expect(
+                Math.round(element.getBoundingClientRect().height),
+                `${label} "${name}" height`,
+            ).to.be.at.least(min);
+        });
+    });
+}
+
+describe("Virtual keyboard touch target sizes", { tags: ["@group5"] }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+    });
+
+    afterEach(() => {
+        // Leave the browser as it was found; emulation is per-browser, not
+        // per-test, so a leaked setting would follow the next spec.
+        emulateTouchDevice(false);
+    });
+
+    function loadWithMathInput() {
+        cy.get("#testRunner_toggleControls").should("exist");
+        cy.window().then((win) => {
+            win.postMessage(
+                { doenetML: `<p><mathInput name="mi" /></p>` },
+                "*",
+            );
+        });
+        cy.get("#mi").should("exist");
+    }
+
+    it("gives every control a fingertip-sized target on a touch device", () => {
+        emulateTouchDevice(true);
+        loadWithMathInput();
+
+        cy.window().should((win) => {
+            expect(
+                win.matchMedia("(pointer: coarse)").matches,
+                "browser reports a coarse primary pointer",
+            ).to.equal(true);
+        });
+
+        // The tab that opens a closed tray. It is the only way in, and it
+        // is the control the screenshot in #449 was taken of.
+        cy.get(".open-keyboard-button").should(($tab) => {
+            const { width, height } = $tab[0].getBoundingClientRect();
+            expect(
+                Math.round(height),
+                "open-keyboard tab height",
+            ).to.be.at.least(MIN_TOUCH_TARGET_PX);
+            expect(Math.round(width), "open-keyboard tab width").to.be.at.least(
+                MIN_TOUCH_TARGET_PX,
+            );
+        });
+
+        cy.get(".open-keyboard-button").click();
+        cy.get("#virtual-keyboard-tray.open").should("exist");
+
+        expectAllAtLeastTall(
+            ".close-keyboard-button",
+            MIN_TOUCH_TARGET_PX,
+            "close button",
+        );
+        expectAllAtLeastTall(
+            "#virtual-keyboard-tray .virtual-keyboard-tab-list button",
+            MIN_TOUCH_TARGET_PX,
+            "layout tab",
+        );
+        expectAllAtLeastTall(
+            "#virtual-keyboard-tray .virtual-keyboard button",
+            MIN_TOUCH_TARGET_PX,
+            "key",
+        );
+
+        // Taller keys must not push the tray past the bottom of the
+        // screen, which is the way this kind of change usually goes wrong.
+        cy.get("#virtual-keyboard-tray").should(($tray) => {
+            expect(
+                $tray[0].scrollHeight,
+                "tray content height fits the viewport",
+            ).to.be.at.most(Cypress.config("viewportHeight"));
+        });
+    });
+
+    it("leaves the sizes alone when a mouse is driving", () => {
+        // Not merely the absence of the touch rules: the tray's desktop
+        // proportions are long-standing, and widening the tab in
+        // particular would collide with the space the editor footer
+        // reserves for it. Update this if desktop sizing changes on
+        // purpose.
+        loadWithMathInput();
+
+        cy.window().should((win) => {
+            expect(
+                win.matchMedia("(pointer: coarse)").matches,
+                "browser reports a fine primary pointer",
+            ).to.equal(false);
+        });
+
+        cy.get(".open-keyboard-button").should(($tab) => {
+            expect(
+                Math.round($tab[0].getBoundingClientRect().height),
+                "open-keyboard tab height",
+            ).to.equal(DESKTOP_TAB_HEIGHT_PX);
+        });
+    });
+});

--- a/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js
@@ -322,6 +322,30 @@ describe("Virtual keyboard touch target sizes", { tags: ["@group5"] }, () => {
                 SHORT_VIEWPORT.height,
             );
         });
+
+        // The layout tabs are the first thing in the scroll port, so a tray
+        // that reopened where it was left would be missing them. A closed
+        // tray keeps its scroll position — it is only translated off the
+        // screen — so opening has to put it back.
+        cy.get(".close-keyboard-button").click();
+        cy.get("#virtual-keyboard-tray.open").should("not.exist");
+        cy.get(".open-keyboard-button").click();
+
+        cy.get("#virtual-keyboard-tray.open").should(($tray) => {
+            expect(
+                $tray[0].querySelector(".keyboard-container").scrollTop,
+                "keyboard reopened at the top",
+            ).to.equal(0);
+            const tabs = $tray[0].querySelector(".virtual-keyboard-tab-list");
+            expect(
+                Math.round(tabs.getBoundingClientRect().bottom),
+                "layout tabs back in view",
+            ).to.be.at.most(SHORT_VIEWPORT.height);
+            expect(
+                Math.round(tabs.getBoundingClientRect().top),
+                "layout tabs back in view",
+            ).to.be.at.least(0);
+        });
     });
 
     it("leaves the sizes alone when a mouse is driving", () => {

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -50,6 +50,15 @@ Tailwind base is purposely not included because we want all styles to be prefixe
 
     --keyboard-tray-height: 280px;
 
+    /*
+     * The tab that peeks above a closed tray. Its height and the distance it
+     * is raised by are the same measurement — it sits exactly its own height
+     * above the tray's top edge — so they are one value, not two that have to
+     * be kept equal.
+     */
+    --keyboard-tab-height: 1.5rem;
+    --keyboard-tab-width: 3rem;
+
     border-top: 1px solid var(--kb-tray-border-top);
     @apply fixed bottom-0 w-full pb-2 px-2 overflow-visible;
     @apply transition-transform ease-in-out duration-300 translate-y-[100%];
@@ -65,21 +74,25 @@ Tailwind base is purposely not included because we want all styles to be prefixe
     }
 
     /*
-     * Inline-end footprint of this button (w-12 + me-4 = 4rem) is mirrored
-     * by `--keyboard-tab-reserve-width` in
+     * Inline-end footprint of this button (`--keyboard-tab-width` + me-4) is
+     * mirrored by `--keyboard-tab-reserve-width` in
      * `packages/doenetml/src/EditorViewer/editor-viewer.css` so the editor
      * footer can shift its last element inward to clear it. Keep the two
-     * values in sync — and keep both on the *same* axis. `end-0` here pairs
-     * with `margin-inline-end` there; making one logical and leaving the
-     * other physical would send the tab and the space reserved for it to
-     * opposite edges under `rtl`, which is worse than either alone.
+     * values in sync — including the touch-device widening below — and keep
+     * both on the *same* axis. `end-0` here pairs with `margin-inline-end`
+     * there; making one logical and leaving the other physical would send the
+     * tab and the space reserved for it to opposite edges under `rtl`, which
+     * is worse than either alone.
      */
     .open-keyboard-button {
-        @apply absolute top-[-1.5rem] end-0 rounded-t me-4;
+        @apply absolute end-0 rounded-t me-4;
         @apply border-b-black border-b;
         @apply hover:bg-slate-300 active:bg-slate-400;
-        @apply w-12 h-[1.5rem] flex items-center justify-center;
+        @apply flex items-center justify-center;
         @apply bg-white border;
+        top: calc(-1 * var(--keyboard-tab-height));
+        width: var(--keyboard-tab-width);
+        height: var(--keyboard-tab-height);
     }
 
     .virtual-keyboard-tab-list {
@@ -87,6 +100,35 @@ Tailwind base is purposely not included because we want all styles to be prefixe
     }
     .virtual-keyboard {
         @apply mx-auto;
+    }
+}
+
+/*
+ * Touch devices: everything here is tapped with a fingertip rather than
+ * pointed at, so every control needs a target a fingertip can land on. 44px is
+ * the minimum in Apple's HIG and in WCAG 2.5.5. The tray shipped with a 48x24
+ * tab to open it, a 24x24 button to close it, and layout tabs measuring 30x25
+ * on a phone — issue #449.
+ *
+ * Keyed on the reader's primary pointer being coarse rather than on how wide
+ * the viewport is: a narrow window on a desktop is still driven by a mouse,
+ * and a tablet held in two hands is not, however much room it has. This is the
+ * same test the viewer uses to decide whether to suppress the device's own
+ * on-screen keyboard, so the two stay consistent about what a touch device is.
+ */
+@media (pointer: coarse) {
+    #virtual-keyboard-tray {
+        --keyboard-tab-height: 2.75rem;
+        --keyboard-tab-width: 4rem;
+
+        .open-keyboard-button {
+            /* The icon is drawn at 1em, so it grows with the tab. */
+            @apply text-xl;
+        }
+
+        .close-keyboard-button {
+            @apply w-11 h-11 m-1;
+        }
     }
 }
 

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -84,22 +84,26 @@ Tailwind base is purposely not included because we want all styles to be prefixe
     background-color: var(--kb-tray-bg);
 
     /*
-     * The keyboard, and the only part of the tray that scrolls. A viewport
-     * too short for the keyboard — a phone held sideways, or any short
-     * window — used to cut the bottom rows off, which on the numeric layout
-     * is the number pad; taller keys for a fingertip would have cut off more.
-     * `min-height: 0` is what lets it shrink: a flex item's automatic minimum
-     * is its own content, which would otherwise push the overflow straight
-     * back out to the tray.
+     * The layout tabs and the keyboard under them, and the only part of the
+     * tray that scrolls. A viewport too short for the keyboard — a phone held
+     * sideways, or any short window — used to cut the bottom rows off, which
+     * on the numeric layout is the number pad; taller keys for a fingertip
+     * would have cut off more. `min-height: 0` is what lets it shrink: a flex
+     * item's automatic minimum is its own content, which would otherwise push
+     * the overflow straight back out to the tray.
+     *
+     * The layout tabs scroll with the keys rather than staying pinned, so a
+     * tray reopened at the position it was left at would be missing them.
+     * `keyboard-tray.tsx` scrolls this back to the top as the tray opens.
      *
      * A finger can pan it even though the tray cancels the default action of
      * `pointerdown` across its whole subtree (see `keyboard-tray.tsx`): what
      * suppresses a pan is `touch-action` or a cancelled `touchstart` /
      * `touchmove`, and the tray does neither. Confirmed in Chromium with a
      * real coarse pointer, and asserted in
-     * `cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js`.
-     * `overscroll-behavior` keeps a pan that runs off the end of it from
-     * scrolling the document behind the tray.
+     * `cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js`; iOS
+     * Safari has not been tried. `overscroll-behavior` keeps a pan that runs
+     * off the end of it from scrolling the document behind the tray.
      */
     .keyboard-container {
         min-height: 0;
@@ -111,7 +115,9 @@ Tailwind base is purposely not included because we want all styles to be prefixe
      * Outside `.keyboard-container`'s scroll for positioning purposes even
      * though it is inside it in the markup: its containing block is the tray,
      * so it neither scrolls away nor is clipped, and stays in the corner
-     * where it can be reached.
+     * where it can be reached. That holds only while nothing between the two
+     * is positioned — give `.keyboard-container` a `position` and the button
+     * starts scrolling away with the keys.
      */
     .close-keyboard-button {
         @apply absolute top-0 end-0 m-2 rounded;

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -62,6 +62,8 @@ Tailwind base is purposely not included because we want all styles to be prefixe
     border-top: 1px solid var(--kb-tray-border-top);
     @apply fixed bottom-0 w-full pb-2 px-2 overflow-visible;
     @apply transition-transform ease-in-out duration-300 translate-y-[100%];
+    /* A column, so `.keyboard-container` is bound by the height set below. */
+    @apply flex flex-col;
     /*
      * The tray may never be so tall that it carries its own tab off the top of
      * the screen: the tab hangs exactly `--keyboard-tab-height` above the
@@ -81,6 +83,36 @@ Tailwind base is purposely not included because we want all styles to be prefixe
     z-index: 10000;
     background-color: var(--kb-tray-bg);
 
+    /*
+     * The keyboard, and the only part of the tray that scrolls. A viewport
+     * too short for the keyboard — a phone held sideways, or any short
+     * window — used to cut the bottom rows off, which on the numeric layout
+     * is the number pad; taller keys for a fingertip would have cut off more.
+     * `min-height: 0` is what lets it shrink: a flex item's automatic minimum
+     * is its own content, which would otherwise push the overflow straight
+     * back out to the tray.
+     *
+     * A finger can pan it even though the tray cancels the default action of
+     * `pointerdown` across its whole subtree (see `keyboard-tray.tsx`): what
+     * suppresses a pan is `touch-action` or a cancelled `touchstart` /
+     * `touchmove`, and the tray does neither. Confirmed in Chromium with a
+     * real coarse pointer, and asserted in
+     * `cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js`.
+     * `overscroll-behavior` keeps a pan that runs off the end of it from
+     * scrolling the document behind the tray.
+     */
+    .keyboard-container {
+        min-height: 0;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+    }
+
+    /*
+     * Outside `.keyboard-container`'s scroll for positioning purposes even
+     * though it is inside it in the markup: its containing block is the tray,
+     * so it neither scrolls away nor is clipped, and stays in the corner
+     * where it can be reached.
+     */
     .close-keyboard-button {
         @apply absolute top-0 end-0 m-2 rounded;
         @apply hover:bg-slate-300 active:bg-slate-400;

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -62,8 +62,22 @@ Tailwind base is purposely not included because we want all styles to be prefixe
     border-top: 1px solid var(--kb-tray-border-top);
     @apply fixed bottom-0 w-full pb-2 px-2 overflow-visible;
     @apply transition-transform ease-in-out duration-300 translate-y-[100%];
-    min-height: var(--keyboard-tray-height);
-    max-height: calc(100vh - 1.5rem);
+    /*
+     * The tray may never be so tall that it carries its own tab off the top of
+     * the screen: the tab hangs exactly `--keyboard-tab-height` above the
+     * tray's top edge, so that much has to stay clear. Both bounds are held to
+     * it — the floor as well as the ceiling, because a `min-height` outranks a
+     * `max-height` and would otherwise reinstate the overshoot on a viewport
+     * shorter than the floor. Written against the variable rather than
+     * repeating its value: widening the tab for a fingertip is exactly the
+     * change that a literal here would have missed.
+     */
+    --keyboard-tray-max-height: calc(100vh - var(--keyboard-tab-height));
+    min-height: min(
+        var(--keyboard-tray-height),
+        var(--keyboard-tray-max-height)
+    );
+    max-height: var(--keyboard-tray-max-height);
     z-index: 10000;
     background-color: var(--kb-tray-bg);
 

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
@@ -98,6 +98,26 @@ export function KeyboardTray({
     const openLabel = t("keyboard-open", undefined, "Open Keyboard");
     const closeLabel = t("keyboard-close", undefined, "Close Keyboard");
 
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
+    /*
+     * Open onto the top of the keyboard. The container below is a scroll port
+     * on a screen with no room for the whole keyboard (see
+     * `keyboard-tray.css`), and a closed tray keeps whatever scroll position
+     * it was left at — so without this, a reader who had scrolled down to the
+     * number pad would find the tray reopening onto the middle of it, with the
+     * layout tabs, which are the first thing in the port, out of sight above.
+     *
+     * Before the paint, so the reset is never seen: the tray is still below
+     * the fold at this point, since the slide-in transition has yet to run a
+     * frame.
+     */
+    React.useLayoutEffect(() => {
+        if (open && containerRef.current) {
+            containerRef.current.scrollTop = 0;
+        }
+    }, [open]);
+
     return createPortal(
         <div
             id={VIRTUAL_KEYBOARD_TRAY_ID}
@@ -128,7 +148,7 @@ export function KeyboardTray({
             >
                 <KeyboardIcon />
             </button>
-            <div className="keyboard-container">
+            <div className="keyboard-container" ref={containerRef}>
                 <button
                     className="close-keyboard-button"
                     onClick={() => onOpenChange(false)}

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
@@ -106,6 +106,20 @@
     @apply grid-cols-5;
 }
 
+.virtual-keyboard-tab-list {
+    @apply flex flex-nowrap;
+    button {
+        @apply p-1 sm:p-2 px-1 sm:px-3 pb-1 border-b-2 mb-3;
+        /* Non-selected tabs: slate-200 underline so only the selected tab's
+           blue indicator stands out. Without an explicit color this falls
+           back to currentColor (black), drawing a harsh line under every tab. */
+        @apply border-slate-200;
+    }
+    button[aria-selected="true"] {
+        @apply border-blue-400 text-blue-600;
+    }
+}
+
 /*
  * Touch devices — see the note beside the matching block in
  * `keyboard-tray.css`. A key was 39x40 on a phone and a layout tab 30x25;
@@ -126,11 +140,12 @@
  * partial copy of Tailwind's preflight leaves at the UA font size of
  * 13.33px — so `4em` is 53px and `4.5em` is 60px, not 64 and 72.
  *
- * Each rule sits after the one it raises, since the two have equal specificity
- * and source order is all that separates them. Shift, backspace and space are
- * the exception: their `max-width: none` is set on `.virtual-keyboard .key-*`,
- * two classes, which already outranks the one-class-one-type `button` selector
- * below, so they stay unbounded here without being named again.
+ * Last in the file because every rule here raises one above it and each pair
+ * has equal specificity, so source order is all that separates them — a media
+ * query adds none. Shift, backspace and space are the exception: their
+ * `max-width: none` is set on `.virtual-keyboard .key-*`, two classes, which
+ * already outranks the one-class-one-type `button` selector here, so they
+ * stay unbounded without being named again.
  */
 @media (pointer: coarse) {
     .virtual-keyboard {
@@ -144,27 +159,6 @@
     .virtual-keyboard.numeric .key-backspace {
         @apply max-w-[4.5em];
     }
-}
-
-.virtual-keyboard-tab-list {
-    @apply flex flex-nowrap;
-    button {
-        @apply p-1 sm:p-2 px-1 sm:px-3 pb-1 border-b-2 mb-3;
-        /* Non-selected tabs: slate-200 underline so only the selected tab's
-           blue indicator stands out. Without an explicit color this falls
-           back to currentColor (black), drawing a harsh line under every tab. */
-        @apply border-slate-200;
-    }
-    button[aria-selected="true"] {
-        @apply border-blue-400 text-blue-600;
-    }
-}
-
-/*
- * Touch devices, continued. Placed after the tab strip's own rule above so it
- * wins on source order: both selectors have the same specificity.
- */
-@media (pointer: coarse) {
     .virtual-keyboard-tab-list button {
         min-height: 2.75rem;
         @apply px-3;

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
@@ -97,6 +97,40 @@
     @apply grid-cols-5;
 }
 
+/*
+ * Touch devices — see the note beside the matching block in
+ * `keyboard-tray.css`. A key was 39x40 on a phone and a layout tab 30x25;
+ * both are below the 44px a fingertip needs (issue #449).
+ *
+ * Height is raised outright, since it costs only tray height. Width is left
+ * to the flex layout, which already gives each key an equal share of the row:
+ * a phone cannot fit twelve 44px-wide keys across, and forcing it would push
+ * the row into an overflow or a wrap that helps no one. Raising the ceiling on
+ * how wide a key may grow is what helps the other end — a tablet, where the
+ * row had room to spare and the keys stayed small in the middle of it.
+ */
+@media (pointer: coarse) {
+    .virtual-keyboard {
+        max-width: 48rem;
+
+        button {
+            min-height: 2.75rem;
+            @apply max-w-[4.5em];
+        }
+        .key-shift,
+        .key-backspace,
+        .key-space {
+            @apply max-w-none;
+        }
+    }
+    .virtual-keyboard.numeric .key-backspace {
+        @apply max-w-[4.5em];
+    }
+    .virtual-keyboard .sub-keyboard {
+        max-width: 48rem;
+    }
+}
+
 .virtual-keyboard-tab-list {
     @apply flex flex-nowrap;
     button {
@@ -108,5 +142,16 @@
     }
     button[aria-selected="true"] {
         @apply border-blue-400 text-blue-600;
+    }
+}
+
+/*
+ * Touch devices, continued. Placed after the tab strip's own rule above so it
+ * wins on source order: both selectors have the same specificity.
+ */
+@media (pointer: coarse) {
+    .virtual-keyboard-tab-list button {
+        min-height: 2.75rem;
+        @apply px-3;
     }
 }

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
@@ -108,6 +108,12 @@
  * the row into an overflow or a wrap that helps no one. Raising the ceiling on
  * how wide a key may grow is what helps the other end — a tablet, where the
  * row had room to spare and the keys stayed small in the middle of it.
+ *
+ * Each rule sits after the one it raises, since the two have equal specificity
+ * and source order is all that separates them. Shift, backspace and space are
+ * the exception: their `max-width: none` is set on `.virtual-keyboard .key-*`,
+ * two classes, which already outranks the one-class-one-type `button` selector
+ * below, so they stay unbounded here without being named again.
  */
 @media (pointer: coarse) {
     .virtual-keyboard {
@@ -116,11 +122,6 @@
         button {
             min-height: 2.75rem;
             @apply max-w-[4.5em];
-        }
-        .key-shift,
-        .key-backspace,
-        .key-space {
-            @apply max-w-none;
         }
     }
     .virtual-keyboard.numeric .key-backspace {

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
@@ -30,8 +30,16 @@
 }
 
 .virtual-keyboard {
-    @apply flex gap-y-1 justify-center max-w-2xl sm:gap-y-2 gap-x-3;
+    /*
+     * How wide the keyboard may spread. A variable because the sub-keyboard
+     * has to agree with it, and because the touch-device block below raises
+     * it — two literals that must match are two literals that can drift.
+     */
+    --keyboard-max-width: 42rem;
+
+    @apply flex gap-y-1 justify-center sm:gap-y-2 gap-x-3;
     @apply flex-wrap sm:flex-nowrap;
+    max-width: var(--keyboard-max-width);
     .row {
         @apply flex gap-x-1 basis-full justify-center sm:gap-x-2;
     }
@@ -43,8 +51,9 @@
         }
     }
     .sub-keyboard {
-        @apply flex gap-y-1 flex-wrap justify-center max-w-2xl sm:gap-y-2;
+        @apply flex gap-y-1 flex-wrap justify-center sm:gap-y-2;
         @apply h-full;
+        max-width: var(--keyboard-max-width);
     }
 
     button {
@@ -105,9 +114,17 @@
  * Height is raised outright, since it costs only tray height. Width is left
  * to the flex layout, which already gives each key an equal share of the row:
  * a phone cannot fit twelve 44px-wide keys across, and forcing it would push
- * the row into an overflow or a wrap that helps no one. Raising the ceiling on
- * how wide a key may grow is what helps the other end — a tablet, where the
- * row had room to spare and the keys stayed small in the middle of it.
+ * the row into an overflow or a wrap that helps no one. What helps the other
+ * end — a tablet, where the row had room to spare and the keys stayed small
+ * in the middle of it — is room for the row to grow, so the even share each
+ * key gets is a larger one, and a ceiling raised to match.
+ *
+ * Both halves are needed. `--keyboard-max-width` alone would hand the extra
+ * room to shift, backspace and space, the only keys with no ceiling of their
+ * own; the per-key `max-width` alone has nothing extra to hand out. Note that
+ * the ceiling is in `em`, and a key is a `button`, which this package's
+ * partial copy of Tailwind's preflight leaves at the UA font size of
+ * 13.33px — so `4em` is 53px and `4.5em` is 60px, not 64 and 72.
  *
  * Each rule sits after the one it raises, since the two have equal specificity
  * and source order is all that separates them. Shift, backspace and space are
@@ -117,7 +134,7 @@
  */
 @media (pointer: coarse) {
     .virtual-keyboard {
-        max-width: 48rem;
+        --keyboard-max-width: 48rem;
 
         button {
             min-height: 2.75rem;
@@ -126,9 +143,6 @@
     }
     .virtual-keyboard.numeric .key-backspace {
         @apply max-w-[4.5em];
-    }
-    .virtual-keyboard .sub-keyboard {
-        max-width: 48rem;
     }
 }
 

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard.css
@@ -145,7 +145,10 @@
  * query adds none. Shift, backspace and space are the exception: their
  * `max-width: none` is set on `.virtual-keyboard .key-*`, two classes, which
  * already outranks the one-class-one-type `button` selector here, so they
- * stay unbounded without being named again.
+ * stay unbounded without being named again. Backspace on the numeric layout
+ * is the exception to that exception — a rule above puts its ceiling back at
+ * `4em`, and outranks this block for the same reason — so it is the one key
+ * that has to be raised by name.
  */
 @media (pointer: coarse) {
     .virtual-keyboard {


### PR DESCRIPTION
Sizes the virtual keyboard's controls for a fingertip on touch devices.

## What was wrong

Every control in the tray was built for a mouse pointer. Measured in a real browser at real device widths, before this change:

| control | phone (390) | tablet (834) |
| --- | --- | --- |
| key | 39x40 | 40x40 |
| layout tab (`123`, `f(x)`, `ABC`, `αβγ`, `$%∞`) | **30x25** | 46x33 |
| tab that opens the tray | 48x24 | 48x24 |
| close (×) | 24x24 | 24x24 |

All of them are under 44px, the minimum for a touch target in both Apple's HIG and WCAG 2.5.5.

The screenshot in #449 is of the tab that opens the tray, and it is the worst case of the four: at 48x24 it is the only way into the keyboard and has to be found before anything else can be tapped. In the reported PreTeXt page it sits at the very bottom of the screen as a white tab on a white background with a glyph about 12px across, beside a PreTeXt info icon that is visibly larger.

## What changed

Under `@media (pointer: coarse)`:

- the tab that opens the tray becomes 64x44, the close button 44x44, and the layout tabs and keys 44px tall;
- the keyboard may spread to 48rem rather than 42rem, and a key may grow to 4.5em rather than 4em.

Key *width* on a phone is deliberately left to the row layout, which already shares each row out evenly. Twelve 44px-wide keys do not fit across a 390px screen, and forcing them would push the row into an overflow or a wrap that helps nobody. Raising the ceiling is what helps at the other end — on a tablet the row had room to spare and the keys stayed small in the middle of it. That is where the 40px → 48px comes from.

Four supporting changes:

- The tab's height and the distance it is raised above the tray are the same measurement — it sits exactly its own height above the tray's top edge — so they are now one custom property instead of two values that had to be kept equal by hand.
- The tray's height bounds were a third copy of that measurement, written as a literal `calc(100vh - 1.5rem)`, and so were missed by the widening: on a phone held sideways, where the tray is tall enough to reach its ceiling, a 44px tab hanging above a tray sized for a 24px one was clipped 19px off the top of the screen. Both bounds now read the variable. The floor as well as the ceiling, because a `min-height` outranks a `max-height` and reinstated 3px of the overshoot once only the ceiling was fixed.
- `--keyboard-tab-reserve-width` in the editor footer mirrors the tab's inline-end footprint, so it gains the same breakpoint. Its comment already said to keep the two in sync.
- The keyboard's spread ceiling was likewise two literals that had to agree — `max-w-2xl` on the keyboard and again on the sub-keyboard inside it — so raising it for touch meant writing `48rem` twice. Both now read a `--keyboard-max-width` custom property, and the touch block sets the property instead of restating the rule.

### The keyboard scrolls when the tray has no room for it

A viewport too short for the keyboard cut the bottom rows off — at 568x320 with a coarse pointer, 436px of keyboard in a 276px tray, the number pad below the edge of the screen. That predates this change (a fine pointer gets 385px in a 296px tray at the same size), but taller keys make it worse: 89px clipped becomes 160px. So the tray is now a flex column and the keyboard scrolls inside it, with the tab and the close button staying where they are.

It costs nothing where the keyboard already fits. Measured at 1000x660, 390x844, 834x1112 and 320x568 with each pointer type, every box is identical to before to the pixel; `overflow-y: auto` produces a scroll port only where there was an overflow, which is the two short viewports and nowhere else.

Whether a finger can pan that scroll port was the open question, since the tray cancels the default action of `pointerdown` across its whole subtree to keep the input it types into from blurring (#1692, #747). It can, and this was settled by measurement rather than by reading the spec: with touch emulation on, a real touch drag dispatched through the devtools protocol scrolls the keyboard 85px for a 100px drag, while the `pointerdown` of that same gesture reports `defaultPrevented`. What suppresses a pan is `touch-action`, or cancelling `touchstart`/`touchmove` — neither of which the tray does. The spec asserts it, so a later change that reaches for `touch-action: none` will be caught.

Three details of the arrangement. The close button is inside the scroll port in the markup but positioned against the tray, so it neither scrolls away nor is clipped. `overscroll-behavior: contain` keeps a pan that runs off the end of the keyboard from scrolling the page behind the tray. And the tray scrolls the port back to the top as it opens: the layout tabs are the first thing in the port and do scroll away with the keys, while a closed tray keeps whatever scroll position it was left at — it is only translated off the screen — so without the reset a reader who had panned down to the number pad would find the next tray opening onto the middle of it with no tabs in sight. Measured at 568x320: 169px of scroll survives the close, and the tray reopens at 0. The reset runs in a layout effect, before the paint, and the tray is still below the fold at that point, so it is never seen. Checked by eye too: panned to the end at 568x320, the whole number pad is on screen, its last row included, and the close button is still in its corner.

Keyed on the primary pointer being coarse rather than on viewport width: a narrow window on a desktop is still driven by a mouse, and a tablet held in two hands is not, however much room it has. This is the same test the viewer uses to decide whether to suppress the device's own on-screen keyboard (#1692), so the two agree about what a touch device is.

## After

| control | phone (390) | tablet (834) |
| --- | --- | --- |
| key | 39x**44** | **48x44** |
| layout tab | **46x44** | **46x44** |
| tab that opens the tray | **64x44** | **64x44** |
| close (×) | **44x44** | **44x44** |
| keyboard width | 374 | **768** (was 672) |

## Testing

`cypress/e2e/accessibility/virtualKeyboardTouchTargets.cy.js`, four tests: every control clears 44px and the keyboard takes the wider ceiling with a coarse pointer; on a viewport short enough that the tray hits its ceiling, the tab stays on screen; on that same viewport a finger can pan the keyboard and reach the last row, with the close button still in its corner afterwards and the layout tabs back in view once the tray is closed and reopened; and the tab and the keyboard's width are untouched with a fine pointer. Chrome reports a coarse primary pointer when touch emulation is on, so the spec switches it through the devtools protocol — a media feature cannot be faked from page scripts. Nor can a pan: the drag is dispatched as real browser input, because a synthesised `TouchEvent` never reaches the compositor that decides whether a pan scrolls.

The short-viewport test waits for the tray's slide-in to settle before measuring, since a tray still below the fold puts its tab trivially on screen and would pass for the wrong reason.

It is an e2e spec rather than a component test on purpose: the sizes come from Tailwind `@apply` utilities, which are only compiled into the package's built stylesheet. A component test mounting the source measures elements with no sizing applied at all — I wrote that version first and it reported a 17px close button, which is the height of the bare glyph.

Confirmed non-vacuous: with the new rules disabled and the bundle rebuilt, the coarse case fails on the first assertion (`expected 24 to be at least 44`). The short-viewport test likewise fails on each intermediate state of the height fix — 19px of overshoot with the literal ceiling, 3px with only the ceiling corrected. The pan test fails without the scroll fix too, where the scroll port is the full height of its contents: `expected 436 to be above 436`; and its reopen assertion fails without the layout effect that resets the scroll, which is where the 169 above was measured.

Also checked by observation in a real browser, at exact device widths in iframes, since `position: fixed` resolves against the iframe viewport: 390x844, 844x390, 320x568, 568x320, 834x1112, 1024x1366 and 1366x1024. Desktop measurements after the change are identical to before, down to the pixel. Both writing directions and both themes were measured at the sizes that scroll; `dir="rtl"` moves the tab and the close button to the other end and changes nothing else, and no layout at any of those widths overflows the port horizontally, so the `overflow-x` that comes along with `overflow-y: auto` never produces a scrollbar. Nor does the vertical one, anywhere the keyboard fits — `auto` is a scrollbar only where there is an overflow, so nothing gains a gutter and nothing shifts.

Everything above is Chromium. **iOS Safari has not been tried** — there is no device here — and it is the platform this change is most for, so it is worth saying which parts are taken on trust. The pan itself should hold for the same reason it does in Chromium: what suppresses one is `touch-action` or a cancelled touch event, and the tray sets neither, its `pointerdown`/`mousedown` `preventDefault` notwithstanding. Momentum scrolling inside a `position: fixed` element, and `-webkit-overflow-scrolling`, were an iOS 12-and-earlier problem and have been the default since 13. `overscroll-behavior` needs Safari 16; below that a pan running off the end of the keyboard chains to the page behind the tray, which is what happens today anyway.

One thing measured and left alone, which predates this change and which it does not make worse:

- At 320px wide the 44px close button reaches about 28px into the box of the layout-tab strip, which clears the tray edge by only `mx-5`. Measured, the five tabs end 20px short of where the button starts, so nothing tappable is covered and the button is not sitting on anything; it is the strip's empty trailing space that is overlapped. Wider viewports have more slack still. Left as is.

Regression runs: `darkModeRendererAccessibility.cy.js` 36/36, `i18n.cy.js` 38/38, `mathinput.cy.js` 34/34.

## Also here: the dev harness toolbar

Unrelated to the sizing, and separable if you would rather it were its own PR — but it is what stands between this change and anyone checking it on a phone.

`packages/doenetml/dev/main.css`'s toolbar is a flex row that could not wrap, and its controls are wider than a phone laid end to end. The document therefore came out 608px wide in a 375px viewport, and Chrome's device toolbar answers an over-wide document by scaling the page down to fit — so a mobile check showed a shrunken render, the viewer apparently taking two thirds of the width with a band of empty space beneath it, and the fixed keyboard tab still pinned to the true corner of the frame. Nothing was wrong with the viewer: at 375px it lays out at full width and height once the document stops overflowing. `flex-wrap: wrap` on that one bar takes the document back to exactly 375.

Wrapping alone left it spending four rows and a fifth of an iPhone SE, so below `40rem` it now shortens too: the labels become `Doc:` and `UI:`, the theme select stands on its own, the note about local storage goes (the Reset button's tooltip already says it), and the locale fields keep just enough room for a tag. One 36px row at 375px, 5% of the screen, and the viewer beneath gains 122px. Each control carries the full name as an `aria-label`, so what a screen reader announces does not change with the width. Nothing changes above the breakpoint.

## Not addressed

The tab is white-on-white with a thin border in the reported page, which makes it hard to see quite apart from being hard to hit. Its border colour comes from `currentColor`, so the host page controls it. That is a contrast question rather than a sizing one and wants its own change.

The tray's height bounds are still in `vh`, which on iOS Safari resolves against the viewport with the URL bar retracted — so the ceiling can exceed what is actually visible and put the tab above the top of the screen, exactly the failure the fix above addresses everywhere else. That predates this change (the bound was `calc(100vh - 1.5rem)`) and is not made worse by it. `dvh` is the fix, but it makes the tray resize as the URL bar comes and goes, which wants a device to judge on.

Closes #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8






