### PR TITLE
feat: put implicit attribute value lists into the schema

### DIFF
--- a/.changeset/attribute-value-lists-in-schema.md
+++ b/.changeset/attribute-value-lists-in-schema.md
@@ -1,0 +1,35 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: offer the values of `renderMode`, `marker`, and `grid` in autocomplete and context help.
+
+Each of these attributes accepted a fixed set of words that lived only in the
+renderer's `if`/`else` chain, so the schema surfaced them as free text and an
+author had no way to discover or check what to write.
+
+- `<math renderMode>` now declares `inline` and `display` and matches them
+  case-insensitively; an unrecognized value falls back to `inline` with a
+  diagnostic instead of silently rendering inline. The renderer's other two
+  modes are deliberately not offered on `<math>`: `numbered` needs an equation
+  tag that only `<me>`, `<men>`, and `<odeSystem>` supply, and `align` needs `&`
+  markers that a `<math>` expression cannot carry — use `<md>` for that.
+- `<odeSystem renderMode>` is deprecated and removed. `align` was always its
+  only workable value — the rendered LaTeX carries `&` markers and its own
+  `\tag`, which no other mode's delimiters can hold — so the mode is now fixed
+  by the component. The attribute is dropped during DAST normalization with a
+  deprecation warning, so existing documents keep working and render as before
+  rather than failing on an unknown attribute.
+- `marker` is split per tag, since the two sets do not cross. `<ul>` declares
+  `disc`, `circle`, and `square` and enforces them: they are the complete set,
+  so they now match case-insensitively and an unusable value is reported
+  instead of silently reverting to the level default. `<ol>` offers `1`, `a`,
+  `A`, `i`, and `I` as suggestions only, because the renderer matches on the
+  first character and decorated forms like `1.` or `a)` are legitimate.
+- `<graph grid>` lists its values as suggestions too, since it also accepts
+  two numbers for the spacing, and now offers `1 1` and `2 2` alongside the
+  named spacings so the numeric form stays discoverable.

--- a/.changeset/attribute-value-lists-in-schema.md
+++ b/.changeset/attribute-value-lists-in-schema.md
@@ -35,3 +35,8 @@ author had no way to discover or check what to write.
 - `<graph grid>` lists its values as suggestions too, since it also accepts
   two numbers for the spacing, and now offers `1 1` and `2 2` alongside the
   named spacings so the numeric form stays discoverable.
+
+`<summaryStatistics statisticsToDisplay>` gains the same list, but only as
+runtime validation: the component is experimental and excluded from the schema,
+so the values do not reach autocomplete yet. An unrecognized statistic is now
+dropped with an info diagnostic instead of being ignored in silence.

--- a/.changeset/attribute-value-lists-in-schema.md
+++ b/.changeset/attribute-value-lists-in-schema.md
@@ -23,7 +23,9 @@ author had no way to discover or check what to write.
   `\tag`, which no other mode's delimiters can hold — so the mode is now fixed
   by the component. The attribute is dropped during DAST normalization with a
   deprecation warning, so existing documents keep working and render as before
-  rather than failing on an unknown attribute.
+  rather than failing on an unknown attribute. (Since the mode is no longer an
+  attribute, `$theOdeSystem.renderMode` is no longer available as a public
+  reference.)
 - `marker` is split per tag, since the two sets do not cross. `<ul>` declares
   `disc`, `circle`, and `square` and enforces them: they are the complete set,
   so they now match case-insensitively and an unusable value is reported

--- a/.changeset/attribute-value-lists-in-schema.md
+++ b/.changeset/attribute-value-lists-in-schema.md
@@ -6,7 +6,7 @@
 "doenet-vscode-extension": patch
 ---
 
-Editor: offer the values of `renderMode`, `marker`, and `grid` in autocomplete and context help.
+Offer the values of `renderMode`, `marker`, and `grid` in autocomplete and context help, and check them when a document runs. `<odeSystem renderMode>` is deprecated in the process.
 
 Each of these attributes accepted a fixed set of words that lived only in the
 renderer's `if`/`else` chain, so the schema surfaced them as free text and an

--- a/packages/docs-nextra/pages/reference/ol.mdx
+++ b/packages/docs-nextra/pages/reference/ol.mdx
@@ -136,5 +136,7 @@ change in the counting marker for the inner lists.
 
 
 
-Use the `marker` attribute to indicate a specific counting marker for the list. See 
+Use the `marker` attribute to indicate a specific counting marker for the list: 
+`1`, `a`, `A`, `i`, or `I`. The value is matched on its first character, so a 
+decorated form such as `1.` or `a)` selects the same style. See 
 the `level` example for the default markers at each level.

--- a/packages/docs-nextra/pages/reference/ul.mdx
+++ b/packages/docs-nextra/pages/reference/ul.mdx
@@ -87,7 +87,7 @@ components (list items) as children.
 
 
 
-The `marker` attribute sets the bullet style for the list items. For an unordered list the valid values are `disc`, `circle`, and `square`; any other value is ignored and the level-based default is used instead. If unspecified, the bullet is determined by the list's `level`.
+The `marker` attribute sets the bullet style for the list items. For an unordered list the valid values are `disc`, `circle`, and `square`, in any capitalization; any other value is reported and ignored, and the level-based default is used instead. If unspecified, the bullet is determined by the list's `level`.
 
 
 

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -428,9 +428,40 @@ export default class Graph extends BlockComponent {
             description:
                 "Whether the axis limits are locked (preventing zoom/pan).",
         };
+        // `suggestedValues`, not `validValues`: the named spacings are only
+        // part of what this attribute takes — two positive numbers are equally
+        // valid — so the list is offered rather than enforced. (The `grid`
+        // state variable below already matches the names case-insensitively.)
         attributes.grid = {
             createComponentOfType: "text",
             valueForTrue: "medium",
+            suggestedValues: [
+                { value: "none", description: "Draw no grid lines." },
+                {
+                    value: "medium",
+                    description:
+                        "Draw grid lines at the major tick marks. Used when `grid` is given with no value.",
+                },
+                {
+                    value: "dense",
+                    description:
+                        "Draw grid lines at the major and minor tick marks.",
+                },
+                // Two examples of the numeric form, which the named spacings
+                // would otherwise hide: an author scanning a list of three
+                // words has no reason to guess that spacings can be given
+                // explicitly.
+                {
+                    value: "1 1",
+                    description:
+                        "Draw grid lines every 1 unit in x and every 1 unit in y. Any two positive numbers can be given this way.",
+                },
+                {
+                    value: "2 2",
+                    description:
+                        "Draw grid lines every 2 units in x and every 2 units in y.",
+                },
+            ],
             description:
                 'Grid line spacing on the graph: none, medium, dense, or two positive numbers giving the x and y spacing, such as grid="1 0.5".',
         };

--- a/packages/doenetml-worker-javascript/src/components/Lists.js
+++ b/packages/doenetml-worker-javascript/src/components/Lists.js
@@ -12,6 +12,41 @@ import {
     listItemNumberAlignmentForLead,
 } from "../utils/listItemChild";
 
+/**
+ * The marker styles a numbered list (`<ol>`) can use.
+ *
+ * Kept beside the unnumbered set below so the two stay recognizable as the two
+ * halves of one renderer decision: `list.tsx` reads `numbered` to pick which
+ * of them applies, and neither half does anything on the other kind of list.
+ */
+function returnNumberedMarkerValues() {
+    return [
+        { value: "1", description: "Arabic numerals: 1, 2, 3, …" },
+        { value: "a", description: "Lowercase letters: a, b, c, …" },
+        { value: "A", description: "Uppercase letters: A, B, C, …" },
+        {
+            value: "i",
+            description: "Lowercase roman numerals: i, ii, iii, …",
+        },
+        {
+            value: "I",
+            description: "Uppercase roman numerals: I, II, III, …",
+        },
+    ];
+}
+
+/**
+ * The marker styles an unnumbered list (`<ul>`) can use — the complete set,
+ * unlike the numbered ones above, which is why `<ul>` enforces these.
+ */
+function returnUnnumberedMarkerValues() {
+    return [
+        { value: "disc", description: "A filled circle." },
+        { value: "circle", description: "A hollow circle." },
+        { value: "square", description: "A filled square." },
+    ];
+}
+
 export class Ol extends BlockComponent {
     constructor(args) {
         super(args);
@@ -49,13 +84,24 @@ export class Ol extends BlockComponent {
             description: "Nesting level of this list (1-based).",
         };
 
+        // The numbered markers, since `<ol>` fixes `numbered` to true. `<ul>`
+        // overrides this whole declaration with the bullet markers — the two
+        // sets do not cross, so a list offering both would offer each tag
+        // values that do nothing there.
+        //
+        // `suggestedValues`, not `validValues`: the markers are distinguished
+        // by *case* (`a` vs `A`), so the value cannot be lower-cased, and the
+        // renderer matches on the first character only, so decorated forms
+        // like `1.` or `a)` work too. Offering the list without enforcing it
+        // keeps both of those intact.
         attributes.marker = {
             createComponentOfType: "text",
             createStateVariable: "marker",
             defaultValue: null,
             forRenderer: true,
+            suggestedValues: returnNumberedMarkerValues(),
             description:
-                "Marker style for list items (e.g. 'disc', 'circle', '1', 'a').",
+                "Marker style for the list items: `1`, `a`, `A`, `i`, or `I`. The value is matched on its first character, so a decorated form such as `1.` or `a)` selects the same style. Defaults to a style chosen by the list's nesting level.",
         };
 
         let scoredSectionAttributes = returnScoredSectionAttributes();
@@ -175,6 +221,31 @@ export class Ul extends Ol {
         summary: "An unordered list",
     };
     static rendererType = "list";
+
+    static createAttributesObject() {
+        let attributes = super.createAttributesObject();
+
+        // Replace `<ol>`'s numbered markers with the bullet ones. These are
+        // `validValues` where `<ol>`'s are only suggestions, because here the
+        // list really is the permitted set: the renderer lower-cases the value
+        // and drops anything outside these three, so `none` and the rest of
+        // the CSS `list-style-type` vocabulary do nothing. Enforcing turns
+        // that into an author-facing diagnostic instead of a marker that
+        // silently reverts to the level default. `suggestedValues` has to go
+        // with it — the spread inherits `<ol>`'s, and declaring both is a
+        // build error.
+        const { suggestedValues: _numberedMarkers, ...inheritedMarker } =
+            attributes.marker;
+        attributes.marker = {
+            ...inheritedMarker,
+            toLowerCase: true,
+            validValues: returnUnnumberedMarkerValues(),
+            description:
+                "Marker style for the list items: `disc`, `circle`, or `square`. Defaults to a style chosen by the list's nesting level.",
+        };
+
+        return attributes;
+    }
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();

--- a/packages/doenetml-worker-javascript/src/components/Lists.js
+++ b/packages/doenetml-worker-javascript/src/components/Lists.js
@@ -19,33 +19,29 @@ import {
  * halves of one renderer decision: `list.tsx` reads `numbered` to pick which
  * of them applies, and neither half does anything on the other kind of list.
  */
-function returnNumberedMarkerValues() {
-    return [
-        { value: "1", description: "Arabic numerals: 1, 2, 3, …" },
-        { value: "a", description: "Lowercase letters: a, b, c, …" },
-        { value: "A", description: "Uppercase letters: A, B, C, …" },
-        {
-            value: "i",
-            description: "Lowercase roman numerals: i, ii, iii, …",
-        },
-        {
-            value: "I",
-            description: "Uppercase roman numerals: I, II, III, …",
-        },
-    ];
-}
+const NUMBERED_MARKER_VALUES = [
+    { value: "1", description: "Arabic numerals: 1, 2, 3, …" },
+    { value: "a", description: "Lowercase letters: a, b, c, …" },
+    { value: "A", description: "Uppercase letters: A, B, C, …" },
+    {
+        value: "i",
+        description: "Lowercase roman numerals: i, ii, iii, …",
+    },
+    {
+        value: "I",
+        description: "Uppercase roman numerals: I, II, III, …",
+    },
+];
 
 /**
  * The marker styles an unnumbered list (`<ul>`) can use — the complete set,
  * unlike the numbered ones above, which is why `<ul>` enforces these.
  */
-function returnUnnumberedMarkerValues() {
-    return [
-        { value: "disc", description: "A filled circle." },
-        { value: "circle", description: "A hollow circle." },
-        { value: "square", description: "A filled square." },
-    ];
-}
+const UNNUMBERED_MARKER_VALUES = [
+    { value: "disc", description: "A filled circle." },
+    { value: "circle", description: "A hollow circle." },
+    { value: "square", description: "A filled square." },
+];
 
 export class Ol extends BlockComponent {
     constructor(args) {
@@ -99,7 +95,7 @@ export class Ol extends BlockComponent {
             createStateVariable: "marker",
             defaultValue: null,
             forRenderer: true,
-            suggestedValues: returnNumberedMarkerValues(),
+            suggestedValues: NUMBERED_MARKER_VALUES,
             description:
                 "Marker style for the list items: `1`, `a`, `A`, `i`, or `I`. The value is matched on its first character, so a decorated form such as `1.` or `a)` selects the same style. Defaults to a style chosen by the list's nesting level.",
         };
@@ -239,7 +235,7 @@ export class Ul extends Ol {
         attributes.marker = {
             ...inheritedMarker,
             toLowerCase: true,
-            validValues: returnUnnumberedMarkerValues(),
+            validValues: UNNUMBERED_MARKER_VALUES,
             description:
                 "Marker style for the list items: `disc`, `circle`, or `square`. Defaults to a style chosen by the list's nesting level.",
         };

--- a/packages/doenetml-worker-javascript/src/components/Math.js
+++ b/packages/doenetml-worker-javascript/src/components/Math.js
@@ -136,10 +136,29 @@ export default class MathComponent extends InlineComponent {
         attributes.displayDigits.highlighted = true;
 
         attributes.renderMode = {
-            description: 'How the math is rendered (e.g. "inline", "display").',
+            description: "How the math is rendered.",
             createComponentOfType: "text",
             createStateVariable: "renderMode",
             defaultValue: "inline",
+            toLowerCase: true,
+            // The math renderer understands two further modes, neither of
+            // which `<math>` can reach. `numbered` needs an `equationTag` state
+            // variable to fill its `\tag{}`, and only the equation components
+            // (`<me>`, `<men>`, `<odeSystem>`) define one. `align` needs `&`
+            // alignment markers in the LaTeX, which the math-expressions
+            // expression underlying `<math>` cannot carry — that mode is
+            // reached through components like `<md>` instead.
+            validValues: [
+                {
+                    value: "inline",
+                    description: "Render inline with the surrounding text.",
+                },
+                {
+                    value: "display",
+                    description:
+                        "Render as a centered equation on its own line.",
+                },
+            ],
             public: true,
             forRenderer: true,
         };

--- a/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
+++ b/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
@@ -46,6 +46,33 @@ export default class SummaryStatistics extends BlockComponent {
             createComponentOfType: "textList",
             createStateVariable: "statisticsToDisplayPrelim",
             defaultValue: ["default"],
+            toLowerCase: true,
+            validValues: [
+                {
+                    value: "default",
+                    description:
+                        "The default selection: mean, stdev, count, minimum, quartile1, median, quartile3, and maximum.",
+                },
+                { value: "all", description: "Every statistic listed here." },
+                { value: "mean", description: "The arithmetic mean." },
+                { value: "stdev", description: "The standard deviation." },
+                { value: "variance", description: "The variance." },
+                { value: "stderr", description: "The standard error." },
+                {
+                    value: "count",
+                    description: "The number of non-missing values.",
+                },
+                { value: "minimum", description: "The smallest value." },
+                { value: "quartile1", description: "The first quartile." },
+                { value: "median", description: "The median." },
+                { value: "quartile3", description: "The third quartile." },
+                { value: "maximum", description: "The largest value." },
+                {
+                    value: "range",
+                    description: "The maximum minus the minimum.",
+                },
+                { value: "sum", description: "The sum of the values." },
+            ],
             description:
                 'Which summary statistics to display (or "default" / "all").',
         };
@@ -103,10 +130,9 @@ export default class SummaryStatistics extends BlockComponent {
 
                 let statisticsToDisplay = [];
 
-                let desiredStats =
-                    dependencyValues.statisticsToDisplayPrelim.map((x) =>
-                        x.toLowerCase(),
-                    );
+                // Already lower-cased and filtered to `validValues` by the
+                // attribute machinery.
+                let desiredStats = dependencyValues.statisticsToDisplayPrelim;
 
                 if (desiredStats.includes("default")) {
                     statisticsToDisplay = [

--- a/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
+++ b/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
@@ -8,6 +8,47 @@ import {
     returnNumberDisplayStateVariableDefinitions,
 } from "../utils/numberDisplay";
 
+/**
+ * The individual statistics `statisticsToDisplay` can name, in the order they
+ * are displayed.
+ *
+ * This single list drives both the attribute's `validValues` and the
+ * `statisticsToDisplay` state variable's selection, so the set an author may
+ * write and the set that can be displayed cannot drift apart.
+ */
+const STATISTIC_VALUES = [
+    { value: "mean", description: "The arithmetic mean." },
+    { value: "stdev", description: "The standard deviation." },
+    { value: "variance", description: "The variance." },
+    { value: "stderr", description: "The standard error." },
+    {
+        value: "count",
+        description: "The number of non-missing values.",
+    },
+    { value: "minimum", description: "The smallest value." },
+    { value: "quartile1", description: "The first quartile." },
+    { value: "median", description: "The median." },
+    { value: "quartile3", description: "The third quartile." },
+    { value: "maximum", description: "The largest value." },
+    {
+        value: "range",
+        description: "The maximum minus the minimum.",
+    },
+    { value: "sum", description: "The sum of the values." },
+];
+
+/** The subset of `STATISTIC_VALUES` that `statisticsToDisplay="default"` selects. */
+const DEFAULT_STATISTICS = [
+    "mean",
+    "stdev",
+    "count",
+    "minimum",
+    "quartile1",
+    "median",
+    "quartile3",
+    "maximum",
+];
+
 export default class SummaryStatistics extends BlockComponent {
     constructor(args) {
         super(args);
@@ -47,31 +88,22 @@ export default class SummaryStatistics extends BlockComponent {
             createStateVariable: "statisticsToDisplayPrelim",
             defaultValue: ["default"],
             toLowerCase: true,
+            // `default` and `all` are selections over the statistics rather
+            // than statistics of their own, so they are listed here rather
+            // than in `STATISTIC_VALUES`.
+            //
+            // The component sets `excludeFromSchema`, so these values do not
+            // yet reach autocomplete or the reference docs; what they buy
+            // today is the runtime validation — an unrecognized statistic is
+            // dropped with an info diagnostic instead of being ignored in
+            // silence.
             validValues: [
                 {
                     value: "default",
-                    description:
-                        "The default selection: mean, stdev, count, minimum, quartile1, median, quartile3, and maximum.",
+                    description: `The default selection: ${DEFAULT_STATISTICS.join(", ")}.`,
                 },
                 { value: "all", description: "Every statistic listed here." },
-                { value: "mean", description: "The arithmetic mean." },
-                { value: "stdev", description: "The standard deviation." },
-                { value: "variance", description: "The variance." },
-                { value: "stderr", description: "The standard error." },
-                {
-                    value: "count",
-                    description: "The number of non-missing values.",
-                },
-                { value: "minimum", description: "The smallest value." },
-                { value: "quartile1", description: "The first quartile." },
-                { value: "median", description: "The median." },
-                { value: "quartile3", description: "The third quartile." },
-                { value: "maximum", description: "The largest value." },
-                {
-                    value: "range",
-                    description: "The maximum minus the minimum.",
-                },
-                { value: "sum", description: "The sum of the values." },
+                ...STATISTIC_VALUES,
             ],
             description:
                 'Which summary statistics to display (or "default" / "all").',
@@ -113,20 +145,7 @@ export default class SummaryStatistics extends BlockComponent {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let options = [
-                    "mean",
-                    "stdev",
-                    "variance",
-                    "stderr",
-                    "count",
-                    "minimum",
-                    "quartile1",
-                    "median",
-                    "quartile3",
-                    "maximum",
-                    "range",
-                    "sum",
-                ];
+                const options = STATISTIC_VALUES.map((entry) => entry.value);
 
                 let statisticsToDisplay = [];
 
@@ -135,16 +154,7 @@ export default class SummaryStatistics extends BlockComponent {
                 let desiredStats = dependencyValues.statisticsToDisplayPrelim;
 
                 if (desiredStats.includes("default")) {
-                    statisticsToDisplay = [
-                        "mean",
-                        "stdev",
-                        "count",
-                        "minimum",
-                        "quartile1",
-                        "median",
-                        "quartile3",
-                        "maximum",
-                    ];
+                    statisticsToDisplay = [...DEFAULT_STATISTICS];
                 } else if (desiredStats.includes("all")) {
                     statisticsToDisplay = [...options];
                 } else {

--- a/packages/doenetml-worker-javascript/src/components/dynamicalSystems/ODESystem.js
+++ b/packages/doenetml-worker-javascript/src/components/dynamicalSystems/ODESystem.js
@@ -45,16 +45,6 @@ export default class ODESystem extends InlineComponent {
 
         Object.assign(attributes, returnNumberDisplayAttributes());
 
-        attributes.renderMode = {
-            createComponentOfType: "text",
-            createStateVariable: "renderMode",
-            defaultValue: "align",
-            public: true,
-            forRenderer: true,
-            description:
-                'How to format the rendered system of equations (e.g. "align").',
-        };
-
         attributes.chunkSize = {
             createComponentOfType: "number",
             createStateVariable: "chunkSize",
@@ -416,6 +406,17 @@ export default class ODESystem extends InlineComponent {
             targetVariableName: "initialCondition1",
             description:
                 "The initial value of the first dependent variable at the initial independent-variable value.",
+        };
+
+        // Fixed, not author-settable: the `latex` state variable below always
+        // builds an aligned environment, so this is the only mode that renders
+        // it correctly. There used to be a `renderMode` attribute, now
+        // deprecated and dropped during DAST normalization — see
+        // `attributeRemovals` in `parser/src/dast-normalize/deprecations.ts`.
+        stateVariableDefinitions.renderMode = {
+            forRenderer: true,
+            returnDependencies: () => ({}),
+            definition: () => ({ setValue: { renderMode: "align" } }),
         };
 
         stateVariableDefinitions.equationTag = {

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
@@ -49,6 +49,37 @@ describe("Warning Tests @group4", async () => {
         ).eq(true);
     });
 
+    it("Deprecated odeSystem renderMode attribute", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<odeSystem name="ode" renderMode="display">
+    <rightHandSide>-x</rightHandSide>
+</odeSystem>
+            `,
+        });
+
+        const diagnosticsByType = getDiagnosticsByType(core);
+
+        // The deprecation pass drops the attribute before the component sees
+        // it, so it is a warning rather than an "invalid attribute" error.
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(diagnosticsByType.warnings.length).eq(1);
+        expect(
+            diagnosticsByType.warnings.some((warning) =>
+                warning.message.includes(
+                    "Attribute `renderMode` on `<odeSystem>` is deprecated and ignored.",
+                ),
+            ),
+        ).eq(true);
+
+        // The system still renders as an aligned environment.
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("ode")].stateValues
+                .renderMode,
+        ).eq("align");
+    });
+
     it("Deprecated selectFromSequence sortResults attribute", async () => {
         const { core } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/lists.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/lists.test.ts
@@ -1,12 +1,72 @@
 import { describe, expect, it, vi } from "vitest";
 import { createTestCore } from "../utils/test-core";
 import { updateBooleanInputValue } from "../utils/actions";
+import { getDiagnosticsByType } from "../utils/diagnostics";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
 vi.mock("hyperformula");
 
 describe("List tag tests @group4", async () => {
+    it("marker reaches the renderer on both kinds of list", async () => {
+        // `<ul>` overrides the `marker` attribute to swap in its own value
+        // list, so check that the override kept the rest of the declaration
+        // — the state variable and the renderer flag — intact on both classes.
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<ol name="o" marker="a"><li>x</li></ol>
+<ul name="u" marker="square"><li>y</li></ul>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("o")].stateValues.marker,
+        ).eq("a");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("o")].stateValues
+                .numbered,
+        ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("u")].stateValues.marker,
+        ).eq("square");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("u")].stateValues
+                .numbered,
+        ).eq(false);
+    });
+
+    it("ul enforces its marker values, ol does not", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<ul name="u1" marker="SQUARE"><li>a</li></ul>
+<ul name="u2" marker="lower-greek"><li>b</li></ul>
+<ol name="o1" marker="a)"><li>c</li></ol>`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        // `<ul>`'s three markers are the complete set, so they are enforced:
+        // matched case-insensitively, and an unusable value is reported and
+        // reverts to the level-based default rather than failing silently.
+        expect(
+            stateVariables[await resolvePathToNodeIdx("u1")].stateValues.marker,
+        ).eq("square");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("u2")].stateValues.marker,
+        ).eq(null);
+
+        const infos = getDiagnosticsByType(core).infos;
+        expect(infos.length).eq(1);
+        expect(infos[0].message).contain("lower-greek");
+
+        // `<ol>` only suggests its markers, so a decorated form is left alone
+        // for the renderer to match on its first character.
+        expect(
+            stateVariables[await resolvePathToNodeIdx("o1")].stateValues.marker,
+        ).eq("a)");
+    });
+
     it("li publishes its first visible child for list-item alignment", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
@@ -13518,4 +13518,31 @@ describe("Math tag tests @group3", async () => {
             ),
         ).eq("7\\cdot10^{-12}x^{2}");
     });
+
+    it("renderMode is matched case-insensitively and falls back when unrecognized", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <math name="m1" renderMode="Display">x</math>
+    <math name="m2" renderMode=" INLINE ">x</math>
+    <math name="m3" renderMode="bananas">x</math>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m1")].stateValues
+                .renderMode,
+        ).eq("display");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m2")].stateValues
+                .renderMode,
+        ).eq("inline");
+        // An unrecognized mode falls back to the default rather than reaching
+        // the renderer, which would have quietly treated it as inline.
+        expect(
+            stateVariables[await resolvePathToNodeIdx("m3")].stateValues
+                .renderMode,
+        ).eq("inline");
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/utils/attributes.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/attributes.test.ts
@@ -56,6 +56,25 @@ describe("preprocessAttributesObject @group4", () => {
         ]);
     });
 
+    it("lower-cases an array defaultValue item-wise, keeping it an array", () => {
+        // A list-valued attribute's default is a list; stringifying it would
+        // hand every consumer a comma-joined string instead.
+        const attrs: Record<string, AttributeDefinition<unknown>> = {
+            stats: {
+                toLowerCase: true,
+                defaultValue: ["Default", "MEAN"],
+                validValues: [
+                    { value: "Default", description: "The default set." },
+                    { value: "MEAN", description: "The mean." },
+                ],
+            },
+        };
+
+        const result = preprocessAttributesObject(attrs);
+
+        expect(result.stats.defaultValue).toEqual(["default", "mean"]);
+    });
+
     it("leaves validValues casing intact when toLowerCase is not set", () => {
         const attrs: Record<string, AttributeDefinition<unknown>> = {
             mode: {

--- a/packages/doenetml-worker-javascript/src/utils/attributes.ts
+++ b/packages/doenetml-worker-javascript/src/utils/attributes.ts
@@ -9,8 +9,9 @@ export type AttributesObject = Record<string, AttributeDefinition<unknown>>;
  * Preprocess an attributes object created by componentClass.createAttributesObject().
  *
  * When `toLowerCase` is `true`, `defaultValue`, each `validValues[].value`,
- * `valueForTrue`, and `valueForFalse` are lower-cased. Descriptions are
- * left untouched.
+ * `valueForTrue`, and `valueForFalse` are lower-cased. An array
+ * `defaultValue` — what a list-valued attribute declares — is lower-cased
+ * item-wise and stays an array. Descriptions are left untouched.
  *
  * @param attributesObject - The result of componentClass.createAttributesObject()
  * @returns The preprocessed attributes object

--- a/packages/doenetml-worker-javascript/src/utils/attributes.ts
+++ b/packages/doenetml-worker-javascript/src/utils/attributes.ts
@@ -54,9 +54,19 @@ export function preprocessAttributesObject<T extends AttributesObject>(
                 attrSpec.defaultValue !== undefined &&
                 attrSpec.defaultValue !== null
             ) {
-                attrSpec.defaultValue = String(
-                    attrSpec.defaultValue,
-                ).toLowerCase();
+                // A list-valued attribute (e.g. `createComponentOfType:
+                // "textList"`) has an array default, and `validValues`
+                // constrains each item, so lower-case item-wise. Stringifying
+                // the array instead would replace the default with a comma-
+                // joined string, which every consumer expecting a list would
+                // then have to cope with.
+                attrSpec.defaultValue = Array.isArray(attrSpec.defaultValue)
+                    ? attrSpec.defaultValue.map((entry) =>
+                          typeof entry === "string"
+                              ? entry.toLowerCase()
+                              : entry,
+                      )
+                    : String(attrSpec.defaultValue).toLowerCase();
             }
 
             if (Array.isArray(attrSpec.validValues)) {

--- a/packages/parser/src/dast-normalize/deprecations.ts
+++ b/packages/parser/src/dast-normalize/deprecations.ts
@@ -329,6 +329,12 @@ const DEPRECATION_REGISTRY: DeprecationRegistry = {
             "anchor",
             "positionFromAnchor",
         ]),
+        // `align` was the only mode an ODE system could ever be rendered in:
+        // its LaTeX carries `&` alignment markers and its own `\tag`/`\notag`
+        // (equation numbering is controlled by `number`), none of which are
+        // legal in the delimiters the other modes of the math renderer supply.
+        // The mode is now fixed by the component, so the attribute is dropped.
+        odeSystem: ignoredAttributes("odeSystem", ["renderMode"]),
     },
     attributeValueRenames: {
         // The label sits beside the input in DOM order, which mirrors with the

--- a/packages/parser/test/normalize-dast.test.ts
+++ b/packages/parser/test/normalize-dast.test.ts
@@ -440,6 +440,24 @@ describe("Normalize dast", async () => {
         ]);
     });
 
+    it("drops the deprecated odeSystem renderMode attribute", () => {
+        const source = `<odeSystem renderMode="display">x</odeSystem>`;
+        const dast = lezerToDast(source);
+        const normalized = normalizeDocumentDast(dast);
+
+        expect(toXml(normalized)).toEqual(
+            "<document><odeSystem>x</odeSystem></document>",
+        );
+
+        const warnings = extractDastErrors(normalized).filter(
+            (error) => error.error_type === "warning",
+        );
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toContain(
+            "[deprecation] Attribute `renderMode` on `<odeSystem>` is deprecated and ignored.",
+        );
+    });
+
     it("keeps non-deprecated attributes when dropping deprecated ones", () => {
         const source = `<description name="d" aggregateScores>hello</description>`;
         const dast = lezerToDast(source);

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -919,7 +919,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -1303,7 +1304,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -14751,7 +14752,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -15149,7 +15151,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -15614,7 +15616,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -16012,7 +16015,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -16477,7 +16480,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -16873,7 +16877,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -17338,7 +17342,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -17734,7 +17739,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -18199,7 +18204,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -18595,7 +18601,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -19060,7 +19066,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -19450,7 +19457,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -19908,7 +19915,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "createVectors": {
@@ -20285,7 +20293,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -20730,7 +20738,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -21114,7 +21123,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -21565,7 +21574,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -21949,7 +21959,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -22400,7 +22410,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -22784,7 +22795,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -23235,7 +23246,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -23619,7 +23631,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -24070,7 +24082,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -24468,7 +24481,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -24933,7 +24946,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -25331,7 +25345,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -25796,7 +25810,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -26201,7 +26216,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -26673,7 +26688,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -27078,7 +27094,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -27550,7 +27566,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -27948,7 +27965,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -28413,7 +28430,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -28811,7 +28829,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -29276,7 +29294,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -29674,7 +29693,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -30139,7 +30158,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -30537,7 +30557,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -31002,7 +31022,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -31400,7 +31421,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -31865,7 +31886,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -32263,7 +32285,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -32728,7 +32750,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -33134,7 +33157,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -65866,7 +65889,9 @@
                 "marker": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "disc",
+                        "circle",
+                        "square"
                     ]
                 },
                 "aggregateScores": {
@@ -67145,12 +67170,6 @@
                         "false"
                     ]
                 },
-                "renderMode": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "chunkSize": {
                     "optional": true,
                     "type": [
@@ -67239,13 +67258,6 @@
                     "type": "math",
                     "isArray": false,
                     "description": "The value of the independent variable at which the initial conditions are specified.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How to format the rendered system of equations (e.g. \"align\").",
                     "fromAttribute": true
                 },
                 {
@@ -71471,7 +71483,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -71855,7 +71868,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -85282,7 +85295,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -85666,7 +85680,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -89127,7 +89141,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -89504,7 +89519,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -109233,7 +109248,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -109610,7 +109626,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -122245,7 +122261,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -122417,7 +122434,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -124672,7 +124689,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -124854,7 +124872,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -139063,7 +139081,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -139460,7 +139479,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -146076,7 +146095,8 @@
                 "renderMode": {
                     "optional": true,
                     "type": [
-                        "string"
+                        "inline",
+                        "display"
                     ]
                 },
                 "unordered": {
@@ -146250,7 +146270,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -573,9 +573,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -793,7 +807,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -11231,9 +11245,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -11471,7 +11499,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -12096,9 +12124,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -12336,7 +12378,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -12961,9 +13003,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -13193,7 +13249,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -13818,9 +13874,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -14050,7 +14120,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -14675,9 +14745,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -14907,7 +14991,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -15532,9 +15616,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -15758,7 +15856,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -16376,9 +16474,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "createVectors",
@@ -16586,7 +16698,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -17191,9 +17303,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -17411,7 +17537,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -18022,9 +18148,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -18242,7 +18382,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -18853,9 +18993,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -19073,7 +19227,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -19684,9 +19838,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -19904,7 +20072,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -20515,9 +20683,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -20755,7 +20937,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -21380,9 +21562,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -21620,7 +21816,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -22245,9 +22441,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -22495,7 +22705,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -23127,9 +23337,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -23377,7 +23601,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -24009,9 +24233,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -24249,7 +24487,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -24874,9 +25112,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -25114,7 +25366,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -25739,9 +25991,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -25979,7 +26245,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -26604,9 +26870,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -26844,7 +27124,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -27469,9 +27749,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -27709,7 +28003,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -28334,9 +28628,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -28574,7 +28882,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -29199,9 +29507,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -29466,7 +29788,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -51976,8 +52298,31 @@
                 },
                 {
                     "name": "marker",
-                    "description": "Marker style for list items (e.g. 'disc', 'circle', '1', 'a').",
+                    "description": "Marker style for the list items: `1`, `a`, `A`, `i`, or `I`. The value is matched on its first character, so a decorated form such as `1.` or `a)` selects the same style. Defaults to a style chosen by the list's nesting level.",
                     "defaultValue": null,
+                    "autocompleteValues": [
+                        {
+                            "value": "1",
+                            "description": "Arabic numerals: 1, 2, 3, …"
+                        },
+                        {
+                            "value": "a",
+                            "description": "Lowercase letters: a, b, c, …"
+                        },
+                        {
+                            "value": "A",
+                            "description": "Uppercase letters: A, B, C, …"
+                        },
+                        {
+                            "value": "i",
+                            "description": "Lowercase roman numerals: i, ii, iii, …"
+                        },
+                        {
+                            "value": "I",
+                            "description": "Uppercase roman numerals: I, II, III, …"
+                        }
+                    ],
+                    "suggestedValuesOnly": true,
                     "type": "text"
                 },
                 {
@@ -52307,9 +52652,28 @@
                 },
                 {
                     "name": "marker",
-                    "description": "Marker style for list items (e.g. 'disc', 'circle', '1', 'a').",
+                    "description": "Marker style for the list items: `disc`, `circle`, or `square`. Defaults to a style chosen by the list's nesting level.",
                     "defaultValue": null,
-                    "type": "text"
+                    "values": [
+                        "disc",
+                        "circle",
+                        "square"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "disc",
+                            "description": "A filled circle."
+                        },
+                        {
+                            "value": "circle",
+                            "description": "A hollow circle."
+                        },
+                        {
+                            "value": "square",
+                            "description": "A filled square."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "aggregateScores",
@@ -53244,12 +53608,6 @@
                     "type": "boolean"
                 },
                 {
-                    "name": "renderMode",
-                    "description": "How to format the rendered system of equations (e.g. \"align\").",
-                    "defaultValue": "align",
-                    "type": "text"
-                },
-                {
                     "name": "chunkSize",
                     "description": "Step-size chunk used when numerically integrating the system.",
                     "defaultValue": 10,
@@ -53332,13 +53690,6 @@
                     "type": "math",
                     "isArray": false,
                     "description": "The value of the independent variable at which the initial conditions are specified.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "renderMode",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "How to format the rendered system of equations (e.g. \"align\").",
                     "fromAttribute": true
                 },
                 {
@@ -57748,9 +58099,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -57968,7 +58333,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -68084,9 +68449,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -68304,7 +68683,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -71043,9 +71422,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -71253,7 +71646,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -87765,6 +88158,29 @@
                 {
                     "name": "grid",
                     "description": "Grid line spacing on the graph: none, medium, dense, or two positive numbers giving the x and y spacing, such as grid=\"1 0.5\".",
+                    "autocompleteValues": [
+                        {
+                            "value": "none",
+                            "description": "Draw no grid lines."
+                        },
+                        {
+                            "value": "medium",
+                            "description": "Draw grid lines at the major tick marks. Used when `grid` is given with no value."
+                        },
+                        {
+                            "value": "dense",
+                            "description": "Draw grid lines at the major and minor tick marks."
+                        },
+                        {
+                            "value": "1 1",
+                            "description": "Draw grid lines every 1 unit in x and every 1 unit in y. Any two positive numbers can be given this way."
+                        },
+                        {
+                            "value": "2 2",
+                            "description": "Draw grid lines every 2 units in x and every 2 units in y."
+                        }
+                    ],
+                    "suggestedValuesOnly": true,
                     "type": "text"
                 },
                 {
@@ -90523,9 +90939,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -90733,7 +91163,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -99951,9 +100381,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -100201,7 +100645,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -102290,9 +102734,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -102545,7 +103003,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -112156,9 +112614,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -112405,7 +112877,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {
@@ -118013,9 +118485,23 @@
                 },
                 {
                     "name": "renderMode",
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "defaultValue": "inline",
-                    "type": "text"
+                    "values": [
+                        "inline",
+                        "display"
+                    ],
+                    "autocompleteValues": [
+                        {
+                            "value": "inline",
+                            "description": "Render inline with the surrounding text."
+                        },
+                        {
+                            "value": "display",
+                            "description": "Render as a centered equation on its own line."
+                        }
+                    ],
+                    "type": "keyword"
                 },
                 {
                     "name": "unordered",
@@ -118251,7 +118737,7 @@
                     "name": "renderMode",
                     "type": "text",
                     "isArray": false,
-                    "description": "How the math is rendered (e.g. \"inline\", \"display\").",
+                    "description": "How the math is rendered.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/test/get-schema-top-level.test.ts
+++ b/packages/static-assets/test/get-schema-top-level.test.ts
@@ -104,6 +104,42 @@ describe("generated schema top-level elements", () => {
         expect(
             gridAttribute.autocompleteValues?.map((entry) => entry.value),
         ).toEqual(["none", "medium", "dense", "1 1", "2 2"]);
+        // The flag that keeps author-facing surfaces honest: the help panel
+        // says "Suggested values" and autocomplete stays free-text.
+        expect(gridAttribute.suggestedValuesOnly).toBe(true);
+    });
+
+    it("ol and ul offer their own marker values, and only ul enforces them", () => {
+        const schema = getSchema();
+        const elementsByName = Object.fromEntries(
+            schema.elements.map((element) => [element.name, element]),
+        );
+
+        const markerOf = (elementName: string) => {
+            const attribute = elementsByName[elementName]?.attributes.find(
+                (attribute) => attribute.name === "marker",
+            );
+            if (!attribute) {
+                throw new Error(`Expected ${elementName}.marker attribute`);
+            }
+            return attribute;
+        };
+
+        // `<ul>` overrides `<ol>`'s declaration, so the two must not leak into
+        // each other: a bullet style does nothing on a numbered list and vice
+        // versa.
+        const olMarker = markerOf("ol");
+        expect(
+            olMarker.autocompleteValues?.map((entry) => entry.value),
+        ).toEqual(["1", "a", "A", "i", "I"]);
+        // Suggestions only: the renderer matches on the first character, so
+        // decorated forms like `1.` are legitimate and must not be flagged.
+        expect(olMarker.values).toBeUndefined();
+        expect(olMarker.suggestedValuesOnly).toBe(true);
+
+        const ulMarker = markerOf("ul");
+        expect(ulMarker.values).toEqual(["disc", "circle", "square"]);
+        expect(ulMarker.suggestedValuesOnly).toBeUndefined();
     });
 
     describe("aliased elements carry children for context-aware LSP validation (#1174)", () => {

--- a/packages/static-assets/test/get-schema-top-level.test.ts
+++ b/packages/static-assets/test/get-schema-top-level.test.ts
@@ -95,8 +95,15 @@ describe("generated schema top-level elements", () => {
         if (!gridAttribute) {
             throw new Error("Expected graph.grid attribute");
         }
+        // `grid` declares `suggestedValues`, so it carries the named spacings
+        // in `autocompleteValues` while `values` stays absent — the attribute
+        // also takes two numbers, so nothing is enforced. What must not appear
+        // either way is a `false` alias: `grid` sets `valueForTrue` and no
+        // `valueForFalse`, and only a two-sided pair contributes aliases.
         expect(gridAttribute.values).toBeUndefined();
-        expect(gridAttribute.autocompleteValues).toBeUndefined();
+        expect(
+            gridAttribute.autocompleteValues?.map((entry) => entry.value),
+        ).toEqual(["none", "medium", "dense", "1 1", "2 2"]);
     });
 
     describe("aliased elements carry children for context-aware LSP validation (#1174)", () => {


### PR DESCRIPTION
## Problem

Several attributes accept a fixed set of words, but that set lived only in a renderer's `if`/`else` chain. The schema surfaced them as plain text, so autocomplete and context-sensitive help offered nothing, and an unrecognized value failed silently.

`renderMode` was the case that prompted this: there was no normalization mechanism at all. `<math renderMode="Display">` rendered inline, because `math.tsx` only ever compared against exact lowercase strings and ended with `// treat as inline if have unrecognized renderMode`.

## Approach

I scanned every attribute declaration in `doenetml-worker-javascript/src/components` for `text`/`textList`/primitive-string attributes lacking `validValues`, then cross-checked the generated schema for any remaining free-text attribute whose description hinted at an enumeration. Each case below is either enforced (`validValues`, with `toLowerCase` so authors can write any casing) or offered (`suggestedValues`) where the list is genuinely incomplete.

## Changes

**`<math renderMode>`** — declares `inline` and `display`, matched case-insensitively; an unrecognized value falls back to the default with a diagnostic. The renderer's other two modes are deliberately excluded: `numbered` needs an `equationTag` state variable only `<me>`, `<men>`, and `<odeSystem>` define, and `align` needs `&` alignment markers a math-expressions expression cannot carry — that mode is reached through `<md>`.

**`<odeSystem renderMode>`** — deprecated and removed. `align` was always its only workable value: the component's `latex` always emits `&` markers and its own `\tag`/`\notag` (numbering is controlled by `number`), none of which are legal in the delimiters the other modes supply. The mode is now fixed by a state variable, and the attribute is dropped during DAST normalization via the existing `attributeRemovals` registry, so existing documents get a deprecation warning and render exactly as before rather than failing on an unknown attribute. The replacement state variable is not `public`, so `$theOdeSystem.renderMode` is no longer a usable reference — noted in the changeset.

**`marker`** — split per tag, since the two halves of the list never cross (`<ol>` fixes `numbered` true, `<ul>` fixes it false). `<ul>` **enforces** `disc`/`circle`/`square`: those are the complete set, so they now match case-insensitively and an unusable value like `lower-greek` is reported instead of silently reverting to the level-based default. `<ol>` **suggests** `1`/`a`/`A`/`i`/`I`, because the renderer matches on the first character only, making decorated forms like `1.` and `a)` legitimate values no enum could list.

**`<graph grid>`** — suggests `none`/`medium`/`dense` plus `1 1` and `2 2`. It also accepts two positive numbers, so nothing is enforced; the two numeric examples keep that form discoverable next to the named spacings.

**`<summaryStatistics statisticsToDisplay>`** — declares its fourteen statistics. Runtime validation only, since the component is `excludeFromSchema`. The twelve individual statistics now live in one module-level `STATISTIC_VALUES` list that feeds both `validValues` and the `statisticsToDisplay` state variable, so the set an author may write and the set that can be displayed cannot drift apart; the `default` selection is likewise a single `DEFAULT_STATISTICS` constant, referenced from the `default` entry's description.

**`preprocessAttributesObject`** — `toLowerCase` lower-cased `defaultValue` with `String(...)`, which turned a *list*-valued attribute's array default into a comma-joined string. `statisticsToDisplay` is the first attribute to pair `toLowerCase` with an array default (`["default"]`), so it hit this; the helper now lower-cases array defaults item-wise and leaves them arrays. Covered by a new case in `utils/attributes.test.ts`.

## Deliberately left alone

- **`<dataFrame columnTypes>`** is positional (entry *n* types column *n*), and `validValues` drops invalid list items — which would shift every later column's type.
- **`<ref textType>`** looks like an enum but nothing in the repo reads it.

## Documentation

- `reference/ul.mdx` — the marker values are now matched in any capitalization, and an unusable one is reported rather than silently ignored.
- `reference/ol.mdx` — names the five marker values and the first-character matching that makes `1.` and `a)` work.

## Testing

- `math.test.ts` — `renderMode` case/trim normalization and fallback.
- `lists.test.ts` — `marker` reaches the state variable on both tags after the `<ul>` override; `<ul>` enforces and normalizes while `<ol>` leaves `a)` alone.
- `normalize-dast.test.ts` and `warningsInfos.test.ts` — the `odeSystem` deprecation warns, drops the attribute rather than erroring, and still renders aligned.
- `utils/attributes.test.ts` — an array `defaultValue` is lower-cased item-wise and stays an array.
- `get-schema-top-level.test.ts` — updated one assertion (it asserted `graph.grid` had no `autocompleteValues`; its real contract is that a one-sided `valueForTrue` must not invent a `false` alias, which it now checks directly, alongside `suggestedValuesOnly`), and added a case pinning the `<ol>`/`<ul>` marker split in the generated schema: `<ol>` carries only `autocompleteValues` with `suggestedValuesOnly`, `<ul>` carries the enforced `values`, and neither leaks the other's markers.

Worker, parser, static-assets, and lsp-tools suites pass; schema regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8



