### PR TITLE
fix: make a codeEditor inside a dark-mode document use the dark theme

### DIFF
--- a/.changeset/code-editor-inherits-dark-mode.md
+++ b/.changeset/code-editor-inherits-dark-mode.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Make a `<codeEditor>` inside a dark-mode document use the dark editor theme.
+
+The `<codeEditor>` renderer mounts the same `EditorViewer` the authoring editor
+does, but never told it which theme to use, so it fell back to the light-mode
+default. Inside a dark-mode document that left light syntax colors — chosen for
+contrast on a white canvas — painted on the dark canvas, and plain text content
+in particular came out nearly invisible. The renderer now reads the document's
+resolved theme from context and passes it down, so the embedded editor's
+canvas, gutters, and syntax highlighting follow the surrounding document.

--- a/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
+++ b/TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md
@@ -21,6 +21,8 @@ Do not assume an existing preview server or an earlier build is still valid.
 
 If you skip the rebuild, you may be testing stale assets and get false pass/fail results.
 
+A root `npm run build` does **not** cover this: it does not build `@doenet/test-cypress`, and reports the package as skipped rather than as an error. Run `npm run build -w @doenet/test-cypress` explicitly (step 1 below), even if a root build just succeeded.
+
 ## Prefigure Unit Tests (Non-Interactive)
 
 Run targeted Vitest tests with `--run`:

--- a/packages/doenetml/src/Viewer/renderers/codeEditor.tsx
+++ b/packages/doenetml/src/Viewer/renderers/codeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useContext } from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
@@ -7,6 +7,7 @@ import { sizeToCSS } from "./utils/css";
 import { useInView } from "framer-motion";
 import { EditorViewer } from "../../EditorViewer/EditorViewer";
 import type { DiagnosticsTabId } from "../../EditorViewer/DiagnosticsResponseTabs";
+import { DocContext } from "../DocViewer";
 
 interface CodeEditorSVs {
     [key: string]: any;
@@ -27,6 +28,10 @@ export default React.memo(function CodeEditor(props: UseDoenetRendererProps) {
 
     // @ts-ignore
     CodeEditor.baseStateVariable = "immediateValue";
+
+    // Inherit the document's resolved theme so the embedded editor doesn't
+    // fall back to its light-mode default inside a dark-mode document.
+    const { darkMode } = useContext(DocContext) || {};
 
     const [currentValue, setCurrentValue] = useState(SVs.immediateValue);
     const currentValueRef = useRef(currentValue);
@@ -115,6 +120,7 @@ export default React.memo(function CodeEditor(props: UseDoenetRendererProps) {
                 showResponses={SVs.showResults}
                 showFormatter={SVs.showFormatter}
                 readOnly={SVs.readOnly}
+                darkMode={darkMode}
                 initialOpenTab={initialOpenTab}
                 immediateDoenetmlChangeCallback={
                     immediateDoenetmlChangeCallback

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
@@ -1,0 +1,149 @@
+import { expectNoColorContrastViolations } from "../../support/colorContrast";
+
+/**
+ * Accessibility coverage for the `<codeEditor>` renderer — the editor embedded
+ * *inside a document*, as opposed to the authoring editor covered by
+ * `darkModeEditorAccessibility.cy.js`.
+ *
+ * The two reach the same `EditorViewer`/CodeMirror component by different
+ * routes, so a theme that is correct for the authoring editor is not evidence
+ * that the embedded one is: `<codeEditor>` has to pick the resolved theme up
+ * from `DocContext` itself. A regression there leaves light-mode syntax colors
+ * painted on the dark canvas, which is exactly what axe's `color-contrast`
+ * rule catches.
+ *
+ * Each case loads a document containing a `<codeEditor>` whose contents
+ * exercise a particular corner of the highlight palette (see
+ * `packages/codemirror/src/extensions/syntax-highlighting.ts`), then scans the
+ * embedded editor in both dark and light mode.
+ */
+describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+        cy.injectAxe();
+    });
+
+    /**
+     * Load `doenetML` in the viewer under `theme`, wait for the theme
+     * attribute and for the embedded CodeMirror to render.
+     */
+    function loadCodeEditor(doenetML, theme) {
+        cy.window().then((win) => {
+            win.postMessage({ doenetML, darkMode: theme }, "*");
+        });
+        cy.get(`[data-theme="${theme}"]`).should("exist");
+        cy.get(".doenet-viewer .cm-editor").should("exist");
+        // Let CodeMirror finish its first highlight pass.
+        cy.wait(200);
+    }
+
+    /**
+     * Each case names a slice of the syntax-highlight palette and the
+     * markup that provokes it. The `content` string is what goes *inside*
+     * the `<codeEditor>`, i.e. the text CodeMirror highlights.
+     */
+    const syntaxCases = [
+        {
+            name: "plain text content",
+            // The reported case: bare text, styled with the `content` tag.
+            content: `Nice. This is invisible.`,
+        },
+        {
+            name: "tag names and angle brackets",
+            content: `<p>Hello</p>
+<math />`,
+        },
+        {
+            name: "attribute names, the `=` operator, and attribute values",
+            content: `<point name="P" labelIsName styleNumber="2" />`,
+        },
+        {
+            name: "macros",
+            content: `<p>The point is at $P.x, and $$f(3) too.</p>`,
+        },
+        {
+            name: "comments",
+            content: `<!-- a block comment explaining the markup -->
+<p>after the comment</p>`,
+        },
+        {
+            name: "invalid markup (mismatched close tag)",
+            content: `<p>mismatched</div>`,
+        },
+        {
+            name: "character and entity references",
+            content: `<p>less than &lt; and &#60; too</p>`,
+        },
+        {
+            name: "mixed markup exercising the whole palette",
+            content: `<!-- everything at once -->
+<graph name="g" size="small">
+  <point name="P">(3, 4)</point>
+</graph>
+<p>P is at $P.coords &amp; nothing else.</p>`,
+        },
+    ];
+
+    for (const { name, content } of syntaxCases) {
+        it(`dark mode: ${name}`, () => {
+            loadCodeEditor(
+                `<codeEditor name="ce" showResults>\n${content}\n</codeEditor>`,
+                "dark",
+            );
+            expectNoColorContrastViolations(".doenet-viewer .editor-panel");
+        });
+    }
+
+    it("light mode: mixed markup exercising the whole palette", () => {
+        // Guards against a fix that trades one theme's contrast for the
+        // other's.
+        const { content } = syntaxCases[syntaxCases.length - 1];
+        loadCodeEditor(
+            `<codeEditor name="ce" showResults>\n${content}\n</codeEditor>`,
+            "light",
+        );
+        expectNoColorContrastViolations(".doenet-viewer .editor-panel");
+    });
+
+    it("dark mode: read-only codeEditor", () => {
+        // Read-only mode swaps in `readOnlyColorTheme`, a separate palette
+        // from the editable one.
+        loadCodeEditor(
+            `<codeEditor name="ce" readOnly showResults>\n<p>read-only $x</p>\n</codeEditor>`,
+            "dark",
+        );
+        expectNoColorContrastViolations(".doenet-viewer .editor-panel");
+    });
+
+    it("dark mode: codeEditor chrome (footer tabs and viewer controls)", () => {
+        loadCodeEditor(
+            `<codeEditor name="ce" showResults>\n<p>some text</p>\n</codeEditor>`,
+            "dark",
+        );
+        cy.get(".doenet-viewer .editor-footer").should("exist");
+        expectNoColorContrastViolations([
+            ".doenet-viewer .editor-footer",
+            ".doenet-viewer .viewer-controls",
+        ]);
+    });
+
+    it("dark mode: the embedded editor uses the dark canvas", () => {
+        // A direct check on the mechanism the axe scans depend on: if the
+        // renderer stops inheriting the document theme, the canvas stays
+        // white and every case above fails at once with a less obvious
+        // message than this one.
+        loadCodeEditor(
+            `<codeEditor name="ce" showResults>\n<p>text</p>\n</codeEditor>`,
+            "dark",
+        );
+        // CodeMirror's generated class names carry no theme information, so
+        // check the canvas color the dark theme actually paints (`#121212`,
+        // from `canvasBackground()` in the codemirror package).
+        cy.get(".doenet-viewer .cm-editor").should(
+            "have.css",
+            "background-color",
+            "rgb(18, 18, 18)",
+        );
+    });
+});

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
@@ -25,10 +25,16 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
     });
 
     /**
-     * Load `doenetML` in the viewer under `theme`, wait for the theme
-     * attribute and for the embedded CodeMirror to render.
+     * Load a document whose only content is a `<codeEditor>` holding
+     * `content`, under `theme`, then wait for the theme attribute and for the
+     * embedded CodeMirror to render.
+     *
+     * @param {string} content Markup to place inside the `<codeEditor>`.
+     * @param {"dark"|"light"} theme Theme to render the document in.
+     * @param {string} [extraAttributes] Extra attributes for the `<codeEditor>`.
      */
-    function loadCodeEditor(doenetML, theme) {
+    function loadCodeEditor(content, theme, extraAttributes = "") {
+        const doenetML = `<codeEditor name="ce" showResults ${extraAttributes}>\n${content}\n</codeEditor>`;
         cy.window().then((win) => {
             win.postMessage({ doenetML, darkMode: theme }, "*");
         });
@@ -87,10 +93,7 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
 
     for (const { name, content } of syntaxCases) {
         it(`dark mode: ${name}`, () => {
-            loadCodeEditor(
-                `<codeEditor name="ce" showResults>\n${content}\n</codeEditor>`,
-                "dark",
-            );
+            loadCodeEditor(content, "dark");
             expectNoColorContrastViolations(".doenet-viewer .editor-panel");
         });
     }
@@ -98,29 +101,19 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
     it("light mode: mixed markup exercising the whole palette", () => {
         // Guards against a fix that trades one theme's contrast for the
         // other's.
-        const { content } = syntaxCases[syntaxCases.length - 1];
-        loadCodeEditor(
-            `<codeEditor name="ce" showResults>\n${content}\n</codeEditor>`,
-            "light",
-        );
+        loadCodeEditor(syntaxCases.at(-1).content, "light");
         expectNoColorContrastViolations(".doenet-viewer .editor-panel");
     });
 
     it("dark mode: read-only codeEditor", () => {
         // Read-only mode swaps in `readOnlyColorTheme`, a separate palette
         // from the editable one.
-        loadCodeEditor(
-            `<codeEditor name="ce" readOnly showResults>\n<p>read-only $x</p>\n</codeEditor>`,
-            "dark",
-        );
+        loadCodeEditor(`<p>read-only $x</p>`, "dark", "readOnly");
         expectNoColorContrastViolations(".doenet-viewer .editor-panel");
     });
 
     it("dark mode: codeEditor chrome (footer tabs and viewer controls)", () => {
-        loadCodeEditor(
-            `<codeEditor name="ce" showResults>\n<p>some text</p>\n</codeEditor>`,
-            "dark",
-        );
+        loadCodeEditor(`<p>some text</p>`, "dark");
         cy.get(".doenet-viewer .editor-footer").should("exist");
         expectNoColorContrastViolations([
             ".doenet-viewer .editor-footer",
@@ -133,10 +126,7 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
         // renderer stops inheriting the document theme, the canvas stays
         // white and every case above fails at once with a less obvious
         // message than this one.
-        loadCodeEditor(
-            `<codeEditor name="ce" showResults>\n<p>text</p>\n</codeEditor>`,
-            "dark",
-        );
+        loadCodeEditor(`<p>text</p>`, "dark");
         // CodeMirror's generated class names carry no theme information, so
         // check the canvas color the dark theme actually paints (`#121212`,
         // from `canvasBackground()` in the codemirror package).

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
@@ -12,11 +12,13 @@ import { expectNoColorContrastViolations } from "../../support/colorContrast";
  * painted on the dark canvas, which is exactly what axe's `color-contrast`
  * rule catches.
  *
- * Each case loads a document containing a `<codeEditor>` whose contents
+ * Most cases load a document containing a `<codeEditor>` whose contents
  * exercise a particular corner of the highlight palette (see
- * `packages/codemirror/src/extensions/syntax-highlighting.ts`) and scans the
- * embedded editor in dark mode; one case repeats in light mode so a fix
- * cannot trade one theme's contrast for the other's.
+ * `packages/codemirror/src/extensions/syntax-highlighting.ts`) and scan the
+ * embedded editor in dark mode. The rest cover what those cases leave out:
+ * read-only mode (a palette of its own), the editor's chrome, one repeat in
+ * light mode so a fix cannot trade one theme's contrast for the other's, and
+ * a direct check that the dark canvas is painted at all.
  */
 describe("codeEditor dark-mode accessibility", { tags: ["@group5"] }, () => {
     beforeEach(() => {
@@ -132,8 +134,10 @@ describe("codeEditor dark-mode accessibility", { tags: ["@group5"] }, () => {
         // message than this one.
         loadCodeEditor(`<p>text</p>`, "dark");
         // CodeMirror's generated class names carry no theme information, so
-        // check the canvas color the dark theme actually paints (`#121212`,
-        // from `canvasBackground()` in the codemirror package).
+        // check the canvas color the dark theme actually paints. That is
+        // `canvasBackground()` in the codemirror package, `var(--canvas,
+        // #121212)`, and `--canvas` is `#121212` under `[data-theme="dark"]`
+        // in `packages/doenetml/src/DoenetML.css`.
         cy.get(".doenet-viewer .cm-editor").should(
             "have.css",
             "background-color",

--- a/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js
@@ -14,10 +14,11 @@ import { expectNoColorContrastViolations } from "../../support/colorContrast";
  *
  * Each case loads a document containing a `<codeEditor>` whose contents
  * exercise a particular corner of the highlight palette (see
- * `packages/codemirror/src/extensions/syntax-highlighting.ts`), then scans the
- * embedded editor in both dark and light mode.
+ * `packages/codemirror/src/extensions/syntax-highlighting.ts`) and scans the
+ * embedded editor in dark mode; one case repeats in light mode so a fix
+ * cannot trade one theme's contrast for the other's.
  */
-describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
+describe("codeEditor dark-mode accessibility", { tags: ["@group5"] }, () => {
     beforeEach(() => {
         cy.clearIndexedDB();
         cy.visit("/");
@@ -34,7 +35,7 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
      * @param {string} [extraAttributes] Extra attributes for the `<codeEditor>`.
      */
     function loadCodeEditor(content, theme, extraAttributes = "") {
-        const doenetML = `<codeEditor name="ce" showResults ${extraAttributes}>\n${content}\n</codeEditor>`;
+        const doenetML = `<codeEditor showResults ${extraAttributes}>\n${content}\n</codeEditor>`;
         cy.window().then((win) => {
             win.postMessage({ doenetML, darkMode: theme }, "*");
         });
@@ -43,6 +44,13 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
         // Let CodeMirror finish its first highlight pass.
         cy.wait(200);
     }
+
+    // Exercises the whole palette at once; reused for the light-mode case.
+    const mixedMarkup = `<!-- everything at once -->
+<graph name="g" size="small">
+  <point name="P">(3, 4)</point>
+</graph>
+<p>P is at $P.coords &amp; nothing else.</p>`;
 
     /**
      * Each case names a slice of the syntax-highlight palette and the
@@ -83,11 +91,7 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
         },
         {
             name: "mixed markup exercising the whole palette",
-            content: `<!-- everything at once -->
-<graph name="g" size="small">
-  <point name="P">(3, 4)</point>
-</graph>
-<p>P is at $P.coords &amp; nothing else.</p>`,
+            content: mixedMarkup,
         },
     ];
 
@@ -101,7 +105,7 @@ describe("codeEditor accessibility checks", { tags: ["@group5"] }, () => {
     it("light mode: mixed markup exercising the whole palette", () => {
         // Guards against a fix that trades one theme's contrast for the
         // other's.
-        loadCodeEditor(syntaxCases.at(-1).content, "light");
+        loadCodeEditor(mixedMarkup, "light");
         expectNoColorContrastViolations(".doenet-viewer .editor-panel");
     });
 


### PR DESCRIPTION
### The bug

```
<codeEditor showResults>
  Nice. This is invisible.
</codeEditor>
```

In dark mode, that text is very nearly invisible.

`packages/doenetml/src/Viewer/renderers/codeEditor.tsx` mounts the same `EditorViewer` the authoring editor does, but never passed it a `darkMode` prop. `EditorViewer` defaults to `"light"`, as does the `CodeMirror` component below it, so an embedded `<codeEditor>` rendered a light canvas and the light syntax palette no matter what theme the surrounding document was in. The plain-text color is `#24292f` — 14.65:1 on the white canvas it was chosen for, but roughly 1.2:1 on the dark `#121212` canvas it was actually being painted on.

The theme was already available to the renderer: `DocContext` carries the document's resolved theme, and other renderers (`angle.tsx`, `choiceInput.tsx`) read it. `codeEditor.tsx` did not import it at all.

### The fix

Read `darkMode` from `DocContext` and pass it to `EditorViewer`. That one prop carries the theme through to the canvas, gutters, syntax highlighting, and the read-only palette.

### Test coverage

There was a gap here worth naming. `darkModeEditorAccessibility.cy.js` covers the **authoring** editor in dark mode, and the `@doenet/codemirror` component specs cover both modes — but nothing covered the **embedded** `<codeEditor>`. The two reach the same component by different routes, so the existing specs could not have caught this.

New spec `packages/test-cypress/cypress/e2e/accessibility/darkModeCodeEditorAccessibility.cy.js` (12 tests, `@group5`) runs axe's `color-contrast` rule over the embedded editor for each slice of the highlight palette:

- plain text content (the reported case)
- tag names and angle brackets
- attribute names, the `=` operator, and attribute values
- macros
- comments
- invalid markup (mismatched close tag)
- character and entity references
- mixed markup exercising the whole palette

plus read-only mode (which swaps in a separate palette), the footer/viewer chrome, a light-mode case so a fix cannot trade one theme's contrast for the other's, and a direct check that the embedded editor paints the dark canvas.

### Verification

- 9 of the 12 new tests fail on `main`; all 12 pass with the fix.
- The whole `cypress/e2e/accessibility/` directory plus `EditorViewer/editorViewerAccessibilityReport.cy.js` — 186 tests — pass.

### Also

One line added to `TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md`. The file already requires rebuilding `@doenet/test-cypress` before a Cypress run, but does not say that a root `npm run build` skips that package and reports it as skipped rather than as an error — which is exactly how I ran a full spec file against stale assets while writing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8