### PR TITLE
fix: show one cascade message at a time, for the next step only

### DIFF
--- a/.changeset/one-cascade-message-at-a-time.md
+++ b/.changeset/one-cascade-message-at-a-time.md
@@ -1,0 +1,24 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Show one `<cascadeMessage>` at a time in a `<cascade>`.
+
+A `<cascadeMessage>` nested inside a section was shown by every held-back
+section at once, so a cascade of three problems displayed "finish problem 1"
+and "finish problem 2" simultaneously — one of them describing a step the
+learner cannot see the point of yet. A message now shows only while its section
+is the *next* one, the one that becomes visible as soon as the current section
+is completed; sections further down show only their number and title, as a
+held-back section with no message of its own already did.
+
+Where an author has put messages in both places, the two placements now
+negotiate rather than both appear: a section's own message is the more specific
+of the two, so when the next section has one, it is shown and the `<cascade>`'s
+own `<cascadeMessage>` children stay hidden for as long as it is. A cascade's
+own message continues to serve every gap that the next section does not cover
+itself.

--- a/.changeset/one-cascade-message-at-a-time.md
+++ b/.changeset/one-cascade-message-at-a-time.md
@@ -22,3 +22,8 @@ of the two, so when the next section has one, it is shown and the `<cascade>`'s
 own `<cascadeMessage>` children stay hidden for as long as it is. A cascade's
 own message continues to serve every gap that the next section does not cover
 itself.
+
+A `<cascade>` nested inside another waits its turn the same way: its own
+`<cascadeMessage>` children used to be shown while it was still several steps
+away, so a cascade of cascades spoke from every level at once. Each cascade now
+shows at most one message, and only once it is the next step.

--- a/packages/docs-nextra/pages/reference/cascade.mdx
+++ b/packages/docs-nextra/pages/reference/cascade.mdx
@@ -140,9 +140,11 @@ the first answer is correct, then reveal it.
 ```
 
 
-Each [`<cascadeMessage>{:dn}`](cascadeMessage) replaces the entry that would
-otherwise be hidden. When the preceding section is completed the message
-disappears and the next section appears.
+A [`<cascadeMessage>{:dn}`](cascadeMessage) replaces the entry that would
+otherwise be hidden. One shows at a time — the first one after the last
+revealed section — so here "Solve the previous step to continue" shows until
+Step 1 is completed, at which point Step 2 appears and "One more step to go"
+takes its place.
 
 
 

--- a/packages/docs-nextra/pages/reference/cascadeMessage.mdx
+++ b/packages/docs-nextra/pages/reference/cascadeMessage.mdx
@@ -16,6 +16,10 @@ Use `<cascadeMessage>{:dn}` to give the learner a prompt — "Keep going",
 "Solve the previous step to continue", etc. — without revealing the content
 behind it.
 
+A [`<cascade>{:dn}`](cascade) shows one message at a time: the one belonging to
+the next entry, the entry that becomes visible as soon as the current one is
+completed. Entries further down show nothing until their turn comes.
+
 
 <AttrPropDisplay name='cascadeMessage'/>
 
@@ -86,10 +90,19 @@ correctly, the message disappears and Step 2 is revealed.
 ```
 
 
-A `<cascadeMessage>{:dn}` placed inside a still-hidden section serves as the
-prompt shown in place of that section's body. The cascade chooses the first
-`<cascadeMessage>{:dn}` that follows the last completed child, so authoring
-one per section lets each section carry its own prompt.
+A `<cascadeMessage>{:dn}` placed inside a hidden section serves as the prompt
+shown in place of that section's body, so authoring one per section lets each
+section carry its own prompt. Only the next section shows its prompt: while
+Part 1 is unanswered, Part 2 shows "Finish Part 1 before continuing" and Part 3
+shows only its title.
+
+A section's own message is the more specific of the two placements, so when the
+next section has one it is shown and any `<cascadeMessage>{:dn}` child of the
+cascade itself stays hidden while it is. Nesting the message inside the section
+is also the only placement that survives a list layout — inside a
+[`<problems>{:dn}`](problems) or any other section with `asList`, only sectioning
+children are rendered, so a `<cascadeMessage>{:dn}` child of the cascade would
+never appear.
 
 
 

--- a/packages/docs-nextra/pages/reference/cascadeMessage.mdx
+++ b/packages/docs-nextra/pages/reference/cascadeMessage.mdx
@@ -96,9 +96,10 @@ section carry its own prompt. Only the next section shows its prompt: while
 Part 1 is unanswered, Part 2 shows "Finish Part 1 before continuing" and Part 3
 shows only its title.
 
-A section's own message is the more specific of the two placements, so when the
-next section has one it is shown and any `<cascadeMessage>{:dn}` child of the
-cascade itself stays hidden while it is. Nesting the message inside the section
+Of the two placements — nested inside a section, or a child of the
+`<cascade>{:dn}` itself — a section's own message is the more specific, so when
+the next section has one it is shown and any `<cascadeMessage>{:dn}` child of
+the cascade itself stays hidden while it is. Nesting the message inside the section
 is also the only placement that survives a list layout — inside a
 [`<problems>{:dn}`](problems) or any other section with `asList`, only sectioning
 children are rendered, so a `<cascadeMessage>{:dn}` child of the cascade would

--- a/packages/doenetml-worker-javascript/src/components/Cascade.js
+++ b/packages/doenetml-worker-javascript/src/components/Cascade.js
@@ -189,8 +189,8 @@ export default class Cascade extends SectioningComponent {
          * like any other, and one that has a message to show is nominated like
          * any other — it then chooses that message here in its own right, which
          * is the single message shown. What "has one" means is
-         * `hasCascadeMessageToShow`, which a cascade answers by asking the very
-         * question below (see the override further down): nominating a step that
+         * `hasCascadeMessageToShow`, which the override below answers for a
+         * cascade by asking this very question of itself: nominating a step that
          * would then show nothing would leave the gap silent, having suppressed
          * the cascade's own message on its behalf.
          *

--- a/packages/doenetml-worker-javascript/src/components/Cascade.js
+++ b/packages/doenetml-worker-javascript/src/components/Cascade.js
@@ -170,8 +170,33 @@ export default class Cascade extends SectioningComponent {
             },
         };
 
+        /**
+         * A cascade shows one continuation message at a time, chosen here.
+         *
+         * There are two places an author can put one. A `<cascadeMessage>` child
+         * of the cascade itself stands between two steps, and the cascade shows
+         * the next such message after the last shown step — one trailing message
+         * therefore serves every gap. A `<cascadeMessage>` nested inside a step
+         * belongs to that step alone, and a step's own message is the more
+         * specific of the two, so when the next step has one it wins and every
+         * message of the cascade's own is hidden for as long as it shows.
+         *
+         * `sectionToShowCascadeMessage` names the step whose nested messages are
+         * shown (`null` for none); each section compares it against itself in
+         * `showCascadeMessage`. Only the *next* step is ever named, so a step
+         * further down the cascade shows nothing but its number and title, the
+         * same as a step with no message at all.
+         *
+         * Note that a nested message is the only kind that survives `asList`
+         * (`<problems>` and friends): `childIndicesToRender` there renders only a
+         * section's sectioning children, so a message child of the cascade is
+         * dropped before it can be shown.
+         */
         stateVariableDefinitions.childrenToHide = {
-            additionalStateVariablesDefined: ["childrenToHideChildren"],
+            additionalStateVariablesDefined: [
+                "childrenToHideChildren",
+                "sectionToShowCascadeMessage",
+            ],
             returnDependencies: () => ({
                 hideFutureSections: {
                     dependencyType: "stateVariable",
@@ -184,6 +209,8 @@ export default class Cascade extends SectioningComponent {
                 children: {
                     dependencyType: "child",
                     childGroups: ["anything"],
+                    variableNames: ["hasCascadeMessageChild"],
+                    variablesOptional: true,
                 },
                 childrenWithCascadeMessages: {
                     dependencyType: "child",
@@ -212,6 +239,7 @@ export default class Cascade extends SectioningComponent {
                         setValue: {
                             childrenToHide: allContinuationComponentIndices,
                             childrenToHideChildren: [],
+                            sectionToShowCascadeMessage: null,
                         },
                     };
                 }
@@ -241,7 +269,23 @@ export default class Cascade extends SectioningComponent {
                     }
                 }
 
-                if (
+                // The next step is the first one held back. It shows its own
+                // messages if it has any, and then the cascade's own messages
+                // all stay hidden.
+                const nextStep =
+                    dependencyValues.children[
+                        dependencyValues.numCompleted + 1
+                    ];
+                const sectionToShowCascadeMessage =
+                    nextStep &&
+                    childrenToHideChildren.includes(nextStep.componentIdx) &&
+                    nextStep.stateValues?.hasCascadeMessageChild
+                        ? nextStep.componentIdx
+                        : null;
+
+                if (sectionToShowCascadeMessage !== null) {
+                    childrenToHide.push(...allContinuationComponentIndices);
+                } else if (
                     dependencyValues.numCompleted <=
                     dependencyValues.children.length - 2
                 ) {
@@ -288,6 +332,7 @@ export default class Cascade extends SectioningComponent {
                     setValue: {
                         childrenToHide,
                         childrenToHideChildren,
+                        sectionToShowCascadeMessage,
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/Cascade.js
+++ b/packages/doenetml-worker-javascript/src/components/Cascade.js
@@ -186,9 +186,13 @@ export default class Cascade extends SectioningComponent {
          * `showCascadeMessage`. Only the *next* step is ever named, so a step
          * further down the cascade shows nothing but its number and title, the
          * same as a step with no message at all. A nested `<cascade>` is a step
-         * like any other, and one with message children of its own is nominated
-         * like any other — it then chooses among them here in its own right,
-         * which is the single message shown.
+         * like any other, and one that has a message to show is nominated like
+         * any other — it then chooses that message here in its own right, which
+         * is the single message shown. What "has one" means is
+         * `hasCascadeMessageToShow`, which a cascade answers by asking the very
+         * question below (see the override further down): nominating a step that
+         * would then show nothing would leave the gap silent, having suppressed
+         * the cascade's own message on its behalf.
          *
          * Note that a nested message is the only kind that survives `asList`
          * (`<problems>` and friends): `childIndicesToRender` there renders only a
@@ -212,7 +216,7 @@ export default class Cascade extends SectioningComponent {
                 children: {
                     dependencyType: "child",
                     childGroups: ["anything"],
-                    variableNames: ["hasCascadeMessageChild"],
+                    variableNames: ["hasCascadeMessageToShow"],
                     variablesOptional: true,
                 },
                 childrenWithCascadeMessages: {
@@ -276,9 +280,9 @@ export default class Cascade extends SectioningComponent {
                     }
                 }
 
-                // The next step is the first one held back. It shows its own
-                // messages if it has any, and then the cascade's own messages
-                // all stay hidden.
+                // The next step is the first one held back. It speaks for the
+                // gap if it has a message of its own to show, and then the
+                // cascade's own messages all stay hidden.
                 const nextStep =
                     dependencyValues.children[
                         dependencyValues.numCompleted + 1
@@ -286,47 +290,25 @@ export default class Cascade extends SectioningComponent {
                 const sectionToShowCascadeMessage =
                     nextStep &&
                     childrenToHideChildren.includes(nextStep.componentIdx) &&
-                    nextStep.stateValues?.hasCascadeMessageChild
+                    nextStep.stateValues?.hasCascadeMessageToShow
                         ? nextStep.componentIdx
                         : null;
 
-                // The one message of the cascade's own to show, if any: the next
-                // `<cascadeMessage>` after the last shown child. There is none
-                // once the next step is showing a message of its own, and none
-                // once the last child is showing, since then no child is held
-                // back for a message to stand in for.
+                // Otherwise the cascade speaks for the gap with one message of
+                // its own, if it has one there.
                 //
                 // A cascade that is itself a step of an enclosing cascade has a
-                // third way to have none: `hideChildren` says the enclosing
-                // cascade is holding it back, and then it speaks only while it
-                // is the step that cascade nominates. A cascade further down the
+                // further reason to stay quiet: `hideChildren` says the enclosing
+                // cascade is holding it back, and then it speaks only while it is
+                // the step that cascade nominates. A cascade further down the
                 // enclosing cascade shows nothing at all, its own messages
                 // included, exactly as a plain step further down does.
-                let continuationToShow = null;
-
-                if (
+                const continuationToShow =
                     sectionToShowCascadeMessage === null &&
                     (!dependencyValues.hideChildren ||
-                        dependencyValues.showCascadeMessage) &&
-                    dependencyValues.numCompleted <=
-                        dependencyValues.children.length - 2
-                ) {
-                    const lastShownChild =
-                        dependencyValues.children[dependencyValues.numCompleted]
-                            .componentIdx;
-                    const lastShownChildIdx =
-                        dependencyValues.childrenWithCascadeMessages.findIndex(
-                            (child) => child.componentIdx === lastShownChild,
-                        );
-
-                    continuationToShow =
-                        dependencyValues.childrenWithCascadeMessages
-                            .slice(lastShownChildIdx + 1)
-                            .find(
-                                (child) =>
-                                    child.componentType === "cascadeMessage",
-                            )?.componentIdx ?? null;
-                }
+                        dependencyValues.showCascadeMessage)
+                        ? nextOwnCascadeMessage(dependencyValues)
+                        : null;
 
                 // Hide every message of the cascade's own but that one. (With
                 // none to show, `null` matches no child and all are hidden.)
@@ -346,6 +328,91 @@ export default class Cascade extends SectioningComponent {
             },
         };
 
+        /**
+         * A cascade has a message to show when it has one of its *own* between
+         * the steps it is showing and the steps it is holding back — the same
+         * message `childrenToHide` picks above, asked here without reference to
+         * whether this cascade has been nominated.
+         *
+         * That independence is the point, and it is why this cannot simply
+         * count message children the way an ordinary section does: the enclosing
+         * cascade reads this to decide whether to nominate this one, so anything
+         * it asked about visibility would close a cycle. Counting is also not the
+         * same question. A message this cascade would never show — its only one
+         * placed ahead of its first step, or none in the gap it has reached, or
+         * `revealAll` leaving it no gap at all — must not win the nomination, or
+         * the enclosing cascade suppresses its own message on behalf of a step
+         * that then says nothing.
+         */
+        stateVariableDefinitions.hasCascadeMessageToShow = {
+            returnDependencies: () => ({
+                numCompleted: {
+                    dependencyType: "stateVariable",
+                    variableName: "numCompleted",
+                },
+                children: {
+                    dependencyType: "child",
+                    childGroups: ["anything"],
+                },
+                childrenWithCascadeMessages: {
+                    dependencyType: "child",
+                    childGroups: ["anything", "cascadeMessages"],
+                },
+                revealAll: {
+                    dependencyType: "stateVariable",
+                    variableName: "revealAll",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        hasCascadeMessageToShow:
+                            nextOwnCascadeMessage(dependencyValues) !== null,
+                    },
+                };
+            },
+        };
+
         return stateVariableDefinitions;
     }
+}
+
+/**
+ * The one `<cascadeMessage>` child of a cascade's own that stands in for the
+ * steps it is holding back: the next one after the last shown step, or `null`
+ * if there is none there.
+ *
+ * There is none when the last step is showing, since then no step is held back
+ * for a message to stand in for, and none when `revealAll` holds nothing back
+ * at all. Which messages a cascade has and where its steps end are all this
+ * asks about, so it says nothing about whether the message is *shown*: the
+ * caller adds the reasons a cascade stays quiet even with one here.
+ *
+ * @param {object} dependencyValues - dependency values holding `numCompleted`,
+ *   `revealAll`, the `children` of the `anything` group (the steps), and
+ *   `childrenWithCascadeMessages` (those steps with the messages interleaved in
+ *   document order).
+ * @returns {number | null} the component index of the message, or `null`.
+ */
+function nextOwnCascadeMessage(dependencyValues) {
+    if (
+        dependencyValues.revealAll ||
+        dependencyValues.numCompleted > dependencyValues.children.length - 2
+    ) {
+        return null;
+    }
+
+    const lastShownStep =
+        dependencyValues.children[dependencyValues.numCompleted].componentIdx;
+    const lastShownStepIdx =
+        dependencyValues.childrenWithCascadeMessages.findIndex(
+            (child) => child.componentIdx === lastShownStep,
+        );
+
+    return (
+        dependencyValues.childrenWithCascadeMessages
+            .slice(lastShownStepIdx + 1)
+            .find((child) => child.componentType === "cascadeMessage")
+            ?.componentIdx ?? null
+    );
 }

--- a/packages/doenetml-worker-javascript/src/components/Cascade.js
+++ b/packages/doenetml-worker-javascript/src/components/Cascade.js
@@ -185,7 +185,10 @@ export default class Cascade extends SectioningComponent {
          * shown (`null` for none); each section compares it against itself in
          * `showCascadeMessage`. Only the *next* step is ever named, so a step
          * further down the cascade shows nothing but its number and title, the
-         * same as a step with no message at all.
+         * same as a step with no message at all. A nested `<cascade>` is a step
+         * like any other, and one with message children of its own is nominated
+         * like any other — it then chooses among them here in its own right,
+         * which is the single message shown.
          *
          * Note that a nested message is the only kind that survives `asList`
          * (`<problems>` and friends): `childIndicesToRender` there renders only a

--- a/packages/doenetml-worker-javascript/src/components/Cascade.js
+++ b/packages/doenetml-worker-javascript/src/components/Cascade.js
@@ -227,6 +227,10 @@ export default class Cascade extends SectioningComponent {
                     dependencyType: "stateVariable",
                     variableName: "hideChildren",
                 },
+                showCascadeMessage: {
+                    dependencyType: "stateVariable",
+                    variableName: "showCascadeMessage",
+                },
             }),
             definition({ dependencyValues, componentInfoObjects }) {
                 const allContinuationComponentIndices =
@@ -291,10 +295,19 @@ export default class Cascade extends SectioningComponent {
                 // once the next step is showing a message of its own, and none
                 // once the last child is showing, since then no child is held
                 // back for a message to stand in for.
+                //
+                // A cascade that is itself a step of an enclosing cascade has a
+                // third way to have none: `hideChildren` says the enclosing
+                // cascade is holding it back, and then it speaks only while it
+                // is the step that cascade nominates. A cascade further down the
+                // enclosing cascade shows nothing at all, its own messages
+                // included, exactly as a plain step further down does.
                 let continuationToShow = null;
 
                 if (
                     sectionToShowCascadeMessage === null &&
+                    (!dependencyValues.hideChildren ||
+                        dependencyValues.showCascadeMessage) &&
                     dependencyValues.numCompleted <=
                         dependencyValues.children.length - 2
                 ) {

--- a/packages/doenetml-worker-javascript/src/components/Cascade.js
+++ b/packages/doenetml-worker-javascript/src/components/Cascade.js
@@ -283,16 +283,18 @@ export default class Cascade extends SectioningComponent {
                         ? nextStep.componentIdx
                         : null;
 
-                if (sectionToShowCascadeMessage !== null) {
-                    childrenToHide.push(...allContinuationComponentIndices);
-                } else if (
-                    dependencyValues.numCompleted <=
-                    dependencyValues.children.length - 2
-                ) {
-                    // We have at least one child that is hidden due to previous child not completed.
-                    // Look for the next `<cascadeMessage>` after the last shown child,
-                    // and display that child if found.
+                // The one message of the cascade's own to show, if any: the next
+                // `<cascadeMessage>` after the last shown child. There is none
+                // once the next step is showing a message of its own, and none
+                // once the last child is showing, since then no child is held
+                // back for a message to stand in for.
+                let continuationToShow = null;
 
+                if (
+                    sectionToShowCascadeMessage === null &&
+                    dependencyValues.numCompleted <=
+                        dependencyValues.children.length - 2
+                ) {
                     const lastShownChild =
                         dependencyValues.children[dependencyValues.numCompleted]
                             .componentIdx;
@@ -301,32 +303,22 @@ export default class Cascade extends SectioningComponent {
                             (child) => child.componentIdx === lastShownChild,
                         );
 
-                    const nextContinuation =
+                    continuationToShow =
                         dependencyValues.childrenWithCascadeMessages
                             .slice(lastShownChildIdx + 1)
                             .find(
                                 (child) =>
                                     child.componentType === "cascadeMessage",
-                            );
-
-                    if (nextContinuation) {
-                        // We found a `<cascadeMessage>` child after the last shown child,
-                        // so don't hide that one.
-                        childrenToHide.push(
-                            ...allContinuationComponentIndices.filter(
-                                (cIdx) =>
-                                    cIdx !== nextContinuation.componentIdx,
-                            ),
-                        );
-                    } else {
-                        // No `<cascadeMessage>` child was found after last shown child,
-                        // so hide all continuation messages.
-                        childrenToHide.push(...allContinuationComponentIndices);
-                    }
-                } else {
-                    // if last child is showing, then hide all continuation messages
-                    childrenToHide.push(...allContinuationComponentIndices);
+                            )?.componentIdx ?? null;
                 }
+
+                // Hide every message of the cascade's own but that one. (With
+                // none to show, `null` matches no child and all are hidden.)
+                childrenToHide.push(
+                    ...allContinuationComponentIndices.filter(
+                        (cIdx) => cIdx !== continuationToShow,
+                    ),
+                );
 
                 return {
                     setValue: {

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -565,17 +565,11 @@ export class SectioningComponent extends BlockComponent {
          * `childrenToHide` here would close a cycle.
          */
         stateVariableDefinitions.hasCascadeMessageChild = {
-            returnDependencies: () => ({
-                ...returnSectionChildDependencies(),
-            }),
+            returnDependencies: returnSectionChildDependencies,
             definition({ dependencyValues }) {
                 const hasCascadeMessageChild = nonConfigurationChildEntries(
                     dependencyValues,
-                ).some(
-                    ([, child]) =>
-                        typeof child === "object" &&
-                        child.componentType === "cascadeMessage",
-                );
+                ).some(([, child]) => child.componentType === "cascadeMessage");
 
                 return { setValue: { hasCascadeMessageChild } };
             },

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -553,6 +553,62 @@ export class SectioningComponent extends BlockComponent {
             },
         };
 
+        /**
+         * Whether this section has a `<cascadeMessage>` child of its own.
+         *
+         * A `<cascade>` reads this off each of its steps to decide which single
+         * message to show: a step's own message is more specific than one of the
+         * cascade's, so a step that has one takes precedence (see
+         * `sectionToShowCascadeMessage` in `Cascade.js`). It deliberately asks
+         * nothing about visibility — the cascade's answer is what *determines*
+         * this section's message visibility, so reading `hideChildren` or
+         * `childrenToHide` here would close a cycle.
+         */
+        stateVariableDefinitions.hasCascadeMessageChild = {
+            returnDependencies: () => ({
+                ...returnSectionChildDependencies(),
+            }),
+            definition({ dependencyValues }) {
+                const hasCascadeMessageChild = nonConfigurationChildEntries(
+                    dependencyValues,
+                ).some(
+                    ([, child]) =>
+                        typeof child === "object" &&
+                        child.componentType === "cascadeMessage",
+                );
+
+                return { setValue: { hasCascadeMessageChild } };
+            },
+        };
+
+        /**
+         * Whether this section is the one step of its `<cascade>` that is
+         * currently showing its `<cascadeMessage>` children.
+         *
+         * At most one message is shown per cascade, and the cascade picks which
+         * (`sectionToShowCascadeMessage` in `Cascade.js`). A section whose parent
+         * is not a cascade gets `undefined` from the dependency — `parent`
+         * dependencies are always optional — and so shows no message, which is
+         * what a `<cascadeMessage>` outside a cascade should do.
+         */
+        stateVariableDefinitions.showCascadeMessage = {
+            returnDependencies: () => ({
+                parentSectionToShowCascadeMessage: {
+                    dependencyType: "parentStateVariable",
+                    variableName: "sectionToShowCascadeMessage",
+                },
+            }),
+            definition({ dependencyValues, componentIdx }) {
+                return {
+                    setValue: {
+                        showCascadeMessage:
+                            dependencyValues.parentSectionToShowCascadeMessage ===
+                            componentIdx,
+                    },
+                };
+            },
+        };
+
         stateVariableDefinitions.childIndicesToRender = {
             returnDependencies: () => ({
                 titleChildren: {
@@ -635,21 +691,23 @@ export class SectioningComponent extends BlockComponent {
          *
          *   - Its kind renders nothing, or it hid *itself* with `hide` —
          *     `childRendersSomething()`.
-         *   - This section hides it: `childrenToHide`. In a section an enclosing
-         *     `<cascade>` is holding back, that is every component child but the
-         *     title and the `<cascadeMessage>`; in every other section it is the
+         *   - This section hides it: `childrenToHide`. In the one step an
+         *     enclosing `<cascade>` is holding back and showing the message of,
+         *     that is every component child but the title and the
+         *     `<cascadeMessage>`; in every other section it is the
          *     `<cascadeMessage>` alone, whose rule is inverted — it is hidden
-         *     precisely when the rest is shown. Without this test a leading
+         *     except while its step is the next one. Without this test a leading
          *     `<cascadeMessage>` would lead an item it is invisible in.
          *
-         * So a held-back step is not empty, and the message it shows is its lead:
-         * asking `hideChildren` as well called such a step empty and left the
-         * message leading nothing, keeping the top margin that put it a line below
-         * the item's number (#1680). A held-back step that really shows nothing
-         * still lands on `null` without asking it: `childrenToHide` holds its
-         * component children and `childIndicesToRender` drops its strings — and
-         * both of those are computed from `hideChildren`, so this one follows a
-         * `<cascade>` holding a step back or letting it go all the same.
+         * So the step showing a message is not empty, and that message is its
+         * lead: asking `hideChildren` as well called such a step empty and left
+         * the message leading nothing, keeping the top margin that put it a line
+         * below the item's number (#1680). A held-back step that really shows
+         * nothing — one with no message, or one further down the cascade than the
+         * next — still lands on `null` without asking it: `childrenToHide` holds
+         * its component children and `childIndicesToRender` drops its strings, so
+         * this one follows a `<cascade>` holding a step back, nominating it, or
+         * letting it go all the same.
          *
          * A child hidden from *above* — this section, or a container around it —
          * is a deliberate non-case: nothing in it is on screen to realign, and
@@ -737,6 +795,10 @@ export class SectioningComponent extends BlockComponent {
                     dependencyType: "stateVariable",
                     variableName: "hideChildren",
                 },
+                showCascadeMessage: {
+                    dependencyType: "stateVariable",
+                    variableName: "showCascadeMessage",
+                },
             }),
             definition({ dependencyValues }) {
                 const childrenToHide = [];
@@ -745,10 +807,13 @@ export class SectioningComponent extends BlockComponent {
                     dependencyValues,
                 )) {
                     if (child.componentType === "cascadeMessage") {
-                        // For <cascadeMessage>, the logic is inverted.
-                        // It is hidden when `hideChildren` is `false`!
+                        // For <cascadeMessage>, the logic is inverted: it is
+                        // shown while the rest of the section is hidden. Being
+                        // held back is necessary but not sufficient — only the
+                        // one step the cascade nominates shows its message, so
+                        // that a cascade shows one message at a time.
                         if (
-                            !dependencyValues.hideChildren &&
+                            !dependencyValues.showCascadeMessage &&
                             typeof child === "object"
                         ) {
                             childrenToHide.push(child.componentIdx);

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -824,9 +824,7 @@ export class SectioningComponent extends BlockComponent {
                     } else if (
                         dependencyValues.hideChildren &&
                         typeof child === "object" &&
-                        child.componentIdx !==
-                            dependencyValues.titleChildName &&
-                        child.componentType !== "cascadeMessage"
+                        child.componentIdx !== dependencyValues.titleChildName
                     ) {
                         childrenToHide.push(child.componentIdx);
                     }

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -701,12 +701,12 @@ export class SectioningComponent extends BlockComponent {
          *
          *   - Its kind renders nothing, or it hid *itself* with `hide` —
          *     `childRendersSomething()`.
-         *   - This section hides it: `childrenToHide`. In the one step an
-         *     enclosing `<cascade>` is holding back and showing the message of,
-         *     that is every component child but the title and the
-         *     `<cascadeMessage>`; in every other section it is the
-         *     `<cascadeMessage>` alone, whose rule is inverted — it is hidden
-         *     except while its step is the next one. Without this test a leading
+         *   - This section hides it: `childrenToHide`. In a step an enclosing
+         *     `<cascade>` is holding back, that is every component child but the
+         *     title — and but the `<cascadeMessage>` as well in the one step the
+         *     cascade nominates, since the message's rule is inverted: it is
+         *     shown precisely while its step is the nominated one, and hidden in
+         *     every other section, held back or not. Without this test a leading
          *     `<cascadeMessage>` would lead an item it is invisible in.
          *
          * So the step showing a message is not empty, and that message is its

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -563,15 +563,25 @@ export class SectioningComponent extends BlockComponent {
          * nothing about visibility — the cascade's answer is what *determines*
          * this section's message visibility, so reading `hideChildren` or
          * `childrenToHide` here would close a cycle.
+         *
+         * Unlike the section variables that work in child *positions*, this one
+         * only counts, so it can ask for the `cascadeMessages` child group
+         * directly instead of filtering all of the children.
          */
         stateVariableDefinitions.hasCascadeMessageChild = {
-            returnDependencies: returnSectionChildDependencies,
+            returnDependencies: () => ({
+                cascadeMessageChildren: {
+                    dependencyType: "child",
+                    childGroups: ["cascadeMessages"],
+                },
+            }),
             definition({ dependencyValues }) {
-                const hasCascadeMessageChild = nonConfigurationChildEntries(
-                    dependencyValues,
-                ).some(([, child]) => child.componentType === "cascadeMessage");
-
-                return { setValue: { hasCascadeMessageChild } };
+                return {
+                    setValue: {
+                        hasCascadeMessageChild:
+                            dependencyValues.cascadeMessageChildren.length > 0,
+                    },
+                };
             },
         };
 
@@ -806,10 +816,9 @@ export class SectioningComponent extends BlockComponent {
                         // held back is necessary but not sufficient — only the
                         // one step the cascade nominates shows its message, so
                         // that a cascade shows one message at a time.
-                        if (
-                            !dependencyValues.showCascadeMessage &&
-                            typeof child === "object"
-                        ) {
+                        // (No `typeof child === "object"` test needed: a string
+                        // child has no `componentType`.)
+                        if (!dependencyValues.showCascadeMessage) {
                             childrenToHide.push(child.componentIdx);
                         }
                     } else if (

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -554,7 +554,13 @@ export class SectioningComponent extends BlockComponent {
         };
 
         /**
-         * Whether this section has a `<cascadeMessage>` child of its own.
+         * Whether this section would show a `<cascadeMessage>` of its own if the
+         * `<cascade>` holding it back gave it the turn — which, for every section
+         * but a `<cascade>`, is simply whether it has one: a held-back section
+         * whose turn it is shows all of its message children. `Cascade.js`
+         * overrides this, because a cascade shows one message of its own at most
+         * and only in a gap between its steps, and so can have message children
+         * and still have nothing to say.
          *
          * A `<cascade>` reads this off each of its steps to decide which single
          * message to show: a step's own message is more specific than one of the
@@ -568,7 +574,7 @@ export class SectioningComponent extends BlockComponent {
          * only counts, so it can ask for the `cascadeMessages` child group
          * directly instead of filtering all of the children.
          */
-        stateVariableDefinitions.hasCascadeMessageChild = {
+        stateVariableDefinitions.hasCascadeMessageToShow = {
             returnDependencies: () => ({
                 cascadeMessageChildren: {
                     dependencyType: "child",
@@ -578,7 +584,7 @@ export class SectioningComponent extends BlockComponent {
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        hasCascadeMessageChild:
+                        hasCascadeMessageToShow:
                             dependencyValues.cascadeMessageChildren.length > 0,
                     },
                 };

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1361,6 +1361,142 @@ describe("Cascade tag tests @group4", async () => {
         });
     });
 
+    // Three levels of nesting, which is where the chain of dependencies the
+    // nomination runs on could conceivably close on itself: a cascade's
+    // `childrenToHide` asks its own `showCascadeMessage`, which asks the cascade
+    // above for the step it nominated, which that cascade computed in its own
+    // `childrenToHide`. The chain only ever climbs — the innermost cascade's
+    // answer is never an input to an outer one — and the document loading at all
+    // is what says so.
+    it("three levels of nested cascades each show at most their own message", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <cascade name="c1">
+    <problem name="prob1"><p>What is 1+1? <answer name="ans">2</answer></p></problem>
+    <cascadeMessage name="m1">Finish the first half of step 1.</cascadeMessage>
+    <problem name="prob2"><p>What is 1-1? <answer name="ans">0</answer></p></problem>
+  </cascade>
+  <cascade name="c2">
+    <cascade name="c2a">
+      <problem name="prob1"><p>What is 3+4? <answer name="ans">7</answer></p></problem>
+      <cascadeMessage name="m2a">Finish the first half of step 2a.</cascadeMessage>
+      <problem name="prob2"><p>What is 3-4? <answer name="ans">-1</answer></p></problem>
+    </cascade>
+    <cascadeMessage name="m2">Finish step 2a.</cascadeMessage>
+    <problem name="prob3"><p>What is 5+6? <answer name="ans">11</answer></p></problem>
+  </cascade>
+</cascade>`,
+        });
+
+        const msgIndices = await Promise.all(
+            ["c1.m1", "c2.m2", "c2a.m2a"].map((name) =>
+                resolvePathToNodeIdx(name),
+            ),
+        );
+
+        async function check_messages(shown: CascadeMessageShownTuple) {
+            const stateVariables = await getStateVariables(core);
+            for (const [ind, msgIdx] of msgIndices.entries()) {
+                expect(
+                    stateVariables[msgIdx].stateValues.hidden,
+                    `message ${ind + 1}`,
+                ).eq(!shown[ind]);
+            }
+        }
+
+        const stateVariables = await getStateVariables(core);
+        const [c1ans1, c1ans2, c2aans1] = await Promise.all(
+            ["c1.prob1", "c1.prob2", "c2a.prob1"].map((name) =>
+                resolvePathToNodeIdx(`${name}.ans`),
+            ),
+        );
+
+        // Cascade 1 is live and speaks for the step it holds back; cascade 2 is
+        // the next step and has a message of its own to show, so it is nominated
+        // and speaks; cascade 2a, inside a cascade that is itself held back, says
+        // nothing at all.
+        await check_messages([true, true, false]);
+
+        await runMathAnswerSequence({
+            core,
+            steps: [
+                // Cascade 1's last step is showing, so it has no gap left.
+                {
+                    latex: "2",
+                    mathInputIdx: getMathInputIdx(stateVariables, c1ans1),
+                    answerIdx: c1ans1,
+                    expected: [false, true, false] as const,
+                },
+                // Cascade 1 complete, so cascade 2 is live: it speaks for the gap
+                // before its own last step, and cascade 2a — now live in turn —
+                // speaks for the step it holds back. Each level has its own.
+                {
+                    latex: "0",
+                    mathInputIdx: getMathInputIdx(stateVariables, c1ans2),
+                    answerIdx: c1ans2,
+                    expected: [false, true, true] as const,
+                },
+                // Cascade 2a's last step showing leaves it nothing to say, while
+                // cascade 2 still holds back its last step.
+                {
+                    latex: "7",
+                    mathInputIdx: getMathInputIdx(stateVariables, c2aans1),
+                    answerIdx: c2aans1,
+                    expected: [false, true, false] as const,
+                },
+            ],
+            assertState: check_messages,
+        });
+    });
+
+    // A nested `<cascade>` takes precedence over the enclosing cascade's own
+    // message only if it really has one to show. It can have `<cascadeMessage>`
+    // children and still have nothing to say — it shows one at most, and only in
+    // a gap between two of its own steps — and were it nominated anyway, the
+    // enclosing cascade would have suppressed its message for a step that then
+    // said nothing, leaving the gap silent.
+    it("a nested cascade with no message to show does not silence the cascade's", async () => {
+        // Two ways for the nested cascade to come up empty: `revealAll` leaves it
+        // no gap between steps to speak for, and having a single step it never
+        // holds one back in the first place.
+        for (const nested of [
+            `<cascade name="inner" revealAll>
+                 <problem name="q1"><p>What is 3+4? <answer name="ans">7</answer></p></problem>
+                 <cascadeMessage name="msg">Finish the first half.</cascadeMessage>
+                 <problem name="q2"><p>What is 3-4? <answer name="ans">-1</answer></p></problem>
+             </cascade>`,
+            `<cascade name="inner">
+                 <cascadeMessage name="msg">Finish the first half.</cascadeMessage>
+                 <problem name="q1"><p>What is 3+4? <answer name="ans">7</answer></p></problem>
+             </cascade>`,
+        ]) {
+            const { core, resolvePathToNodeIdx } = await createTestCore({
+                doenetML: `
+<cascade name="w">
+  <problem name="prob1"><p>What is 1+1? <answer name="ans">2</answer></p></problem>
+  <cascadeMessage name="outer">Keep going...</cascadeMessage>
+  ${nested}
+</cascade>`,
+            });
+
+            const stateVariables = await getStateVariables(core);
+
+            expect(
+                stateVariables[await resolvePathToNodeIdx("w")].stateValues
+                    .sectionToShowCascadeMessage,
+            ).eq(null);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("inner.msg")]
+                    .stateValues.hidden,
+            ).eq(true);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("outer")].stateValues
+                    .hidden,
+            ).eq(false);
+        }
+    });
+
     // `hideFutureSections` hides a held-back step outright rather than replacing
     // its body with a message, so no step is nominated and no nested message is
     // shown. The cascade's own message still stands in for the hidden steps —

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -12,6 +12,8 @@ vi.mock("hyperformula");
 
 describe("Cascade tag tests @group4", async () => {
     type CascadeCompletionTuple = readonly [number, number, number];
+    /** Whether each of three `<cascadeMessage>`s is shown, in document order. */
+    type CascadeMessageShownTuple = readonly [boolean, boolean, boolean];
 
     async function getStateVariables(core: any) {
         return core.returnAllStateVariables(false, true);
@@ -1257,6 +1259,193 @@ describe("Cascade tag tests @group4", async () => {
             ],
             assertState: check_values,
         });
+    });
+
+    // A `<cascade>` nested inside another is a step like any other, so it too
+    // speaks only when it is the next step: while it is further down, its own
+    // `<cascadeMessage>` children stay hidden along with everything else it has.
+    // Each cascade then shows at most one message of its own, which is what "one
+    // message at a time" means once cascades nest.
+    it("a nested cascade's own message waits until its turn", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <cascade name="c1">
+    <problem name="prob1"><p>What is 1+1? <answer name="ans">2</answer></p></problem>
+    <cascadeMessage name="msg">Finish the first part of step 1.</cascadeMessage>
+    <problem name="prob2"><p>What is 1-1? <answer name="ans">0</answer></p></problem>
+  </cascade>
+  <cascade name="c2">
+    <problem name="prob1"><p>What is 3+4? <answer name="ans">7</answer></p></problem>
+    <cascadeMessage name="msg">Finish the first part of step 2.</cascadeMessage>
+    <problem name="prob2"><p>What is 3-4? <answer name="ans">-1</answer></p></problem>
+  </cascade>
+  <cascade name="c3">
+    <problem name="prob1"><p>What is 5+6? <answer name="ans">11</answer></p></problem>
+    <cascadeMessage name="msg">Finish the first part of step 3.</cascadeMessage>
+    <problem name="prob2"><p>What is 5-6? <answer name="ans">-1</answer></p></problem>
+  </cascade>
+</cascade>`,
+        });
+
+        const msgIndices = await Promise.all(
+            ["c1", "c2", "c3"].map((name) =>
+                resolvePathToNodeIdx(`${name}.msg`),
+            ),
+        );
+
+        async function check_messages(shown: CascadeMessageShownTuple) {
+            const stateVariables = await getStateVariables(core);
+            for (const [ind, msgIdx] of msgIndices.entries()) {
+                expect(
+                    stateVariables[msgIdx].stateValues.hidden,
+                    `message of nested cascade ${ind + 1}`,
+                ).eq(!shown[ind]);
+            }
+        }
+
+        const stateVariables = await getStateVariables(core);
+        const [c1ans1, c1ans2, c2ans1, c2ans2, c3ans1] = await Promise.all(
+            ["c1.prob1", "c1.prob2", "c2.prob1", "c2.prob2", "c3.prob1"].map(
+                (name) => resolvePathToNodeIdx(`${name}.ans`),
+            ),
+        );
+
+        // Cascade 1 is showing and stands in for the step it holds back itself;
+        // cascade 2 is the next step, so it is nominated and speaks for itself;
+        // cascade 3 is further down and says nothing at all.
+        await check_messages([true, true, false]);
+
+        await runMathAnswerSequence({
+            core,
+            steps: [
+                // Cascade 1's last step is showing now, so it has no gap left to
+                // stand in for. Cascade 3 is still not next.
+                {
+                    latex: "2",
+                    mathInputIdx: getMathInputIdx(stateVariables, c1ans1),
+                    answerIdx: c1ans1,
+                    expected: [false, true, false] as const,
+                },
+                // Cascade 1 is complete, so cascade 2 is no longer held back and
+                // speaks for its own gap instead of for itself, and cascade 3 —
+                // now the next step — gets its turn.
+                {
+                    latex: "0",
+                    mathInputIdx: getMathInputIdx(stateVariables, c1ans2),
+                    answerIdx: c1ans2,
+                    expected: [false, true, true] as const,
+                },
+                {
+                    latex: "7",
+                    mathInputIdx: getMathInputIdx(stateVariables, c2ans1),
+                    answerIdx: c2ans1,
+                    expected: [false, false, true] as const,
+                },
+                {
+                    latex: "-1",
+                    mathInputIdx: getMathInputIdx(stateVariables, c2ans2),
+                    answerIdx: c2ans2,
+                    expected: [false, false, true] as const,
+                },
+                // And cascade 3's last step showing leaves nobody with anything
+                // to say.
+                {
+                    latex: "11",
+                    mathInputIdx: getMathInputIdx(stateVariables, c3ans1),
+                    answerIdx: c3ans1,
+                    expected: [false, false, false] as const,
+                },
+            ],
+            assertState: check_messages,
+        });
+    });
+
+    // `hideFutureSections` hides a held-back step outright rather than replacing
+    // its body with a message, so no step is nominated and no nested message is
+    // shown. The cascade's own message still stands in for the hidden steps —
+    // there is otherwise nothing at all between the reader and the end of the
+    // cascade.
+    it("hideFutureSections leaves a step's own message hidden", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w" hideFutureSections>
+  <problem name="prob1"><p>What is 1+1? <answer name="ans">2</answer></p></problem>
+  <cascadeMessage name="outer">Keep going...</cascadeMessage>
+  <problem name="prob2">
+    <cascadeMessage name="msg">Finish problem 1 to proceed.</cascadeMessage>
+    <p name="p">What is 3+4? <answer name="ans">7</answer></p>
+  </problem>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const prob2Idx = await resolvePathToNodeIdx("prob2");
+        const msgIdx = await resolvePathToNodeIdx("prob2.msg");
+        const outerIdx = await resolvePathToNodeIdx("outer");
+        const ansIdx = await resolvePathToNodeIdx("prob1.ans");
+
+        let stateVariables = await getStateVariables(core);
+
+        // Problem 2 is hidden whole, so it is not nominated and its message
+        // stays hidden with it; the cascade's own message shows in its place.
+        expect(stateVariables[prob2Idx].stateValues.hidden).eq(true);
+        expect(stateVariables[wIdx].stateValues.sectionToShowCascadeMessage).eq(
+            null,
+        );
+        expect(stateVariables[msgIdx].stateValues.hidden).eq(true);
+        expect(stateVariables[outerIdx].stateValues.hidden).eq(false);
+
+        await submitMathAnswer({
+            core,
+            latex: "2",
+            mathInputIdx: getMathInputIdx(stateVariables, ansIdx),
+            answerIdx: ansIdx,
+        });
+
+        stateVariables = await getStateVariables(core);
+
+        // Revealed, problem 2 hides its own message as any shown section does,
+        // and the cascade's message has no gap left to stand in for.
+        expect(stateVariables[prob2Idx].stateValues.hidden).eq(false);
+        expect(stateVariables[msgIdx].stateValues.hidden).eq(true);
+        expect(stateVariables[outerIdx].stateValues.hidden).eq(true);
+    });
+
+    // `revealAll` holds nothing back, so there is nothing for any message to
+    // stand in for: both placements are hidden from the start.
+    it("revealAll hides every continuation message", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w" revealAll>
+  <problem name="prob1"><p>What is 1+1? <answer name="ans">2</answer></p></problem>
+  <cascadeMessage name="outer">Keep going...</cascadeMessage>
+  <problem name="prob2">
+    <cascadeMessage name="msg">Finish problem 1 to proceed.</cascadeMessage>
+    <p name="p">What is 3+4? <answer name="ans">7</answer></p>
+  </problem>
+</cascade>`,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const prob2Idx = await resolvePathToNodeIdx("prob2");
+        const prob2pIdx = await resolvePathToNodeIdx("prob2.p");
+
+        const stateVariables = await getStateVariables(core);
+
+        expect(stateVariables[prob2Idx].stateValues.hideChildren).eq(false);
+        expect(stateVariables[prob2pIdx].stateValues.hidden).eq(false);
+        expect(stateVariables[wIdx].stateValues.sectionToShowCascadeMessage).eq(
+            null,
+        );
+        expect(
+            stateVariables[await resolvePathToNodeIdx("prob2.msg")].stateValues
+                .hidden,
+        ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("outer")].stateValues
+                .hidden,
+        ).eq(true);
     });
 
     it("one continuation message inside cascade", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1074,8 +1074,11 @@ describe("Cascade tag tests @group4", async () => {
                 numCompleted < 2,
             );
 
+            // The cascade shows one message at a time, so section 3's shows
+            // only while section 3 is the next step — not while section 2 is
+            // still held back with a message of its own.
             expect(stateVariables[section3cmIdx].stateValues.hidden).eq(
-                numCompleted >= 2,
+                numCompleted !== 1,
             );
         }
 
@@ -1157,6 +1160,101 @@ describe("Cascade tag tests @group4", async () => {
         await runMathAnswerSequence({
             core,
             steps: answerSequence,
+            assertState: check_values,
+        });
+    });
+
+    // A cascade shows one continuation message at a time. When the next step
+    // has a message of its own, that more specific message wins and the
+    // cascade's own messages stay hidden; when it does not, the cascade's next
+    // message takes over.
+    it("a step's own continuation message wins over the cascade's", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<cascade name="w">
+  <problem name="prob1"><p name="p">What is 1+1? <answer name="ans">2</answer></p></problem>
+
+  <problem name="prob2">
+    <cascadeMessage name="cm">Finish problem 1 to proceed.</cascadeMessage>
+    <p name="p">What is 3+4? <answer name="ans">7</answer></p>
+  </problem>
+
+  <cascadeMessage name="outer">Keep going...</cascadeMessage>
+
+  <problem name="prob3"><p name="p">What is 3-4? <answer name="ans">-1</answer></p></problem>
+</cascade>
+  `,
+        });
+
+        const wIdx = await resolvePathToNodeIdx("w");
+        const prob2cmIdx = await resolvePathToNodeIdx("prob2.cm");
+        const prob2pIdx = await resolvePathToNodeIdx("prob2.p");
+        const outerIdx = await resolvePathToNodeIdx("outer");
+        const prob3pIdx = await resolvePathToNodeIdx("prob3.p");
+
+        async function check_values(numCompleted: number) {
+            const stateVariables = await getStateVariables(core);
+
+            expect(stateVariables[wIdx].stateValues.numCompleted).eq(
+                numCompleted,
+            );
+            expect(stateVariables[prob2pIdx].stateValues.hidden).eq(
+                numCompleted < 1,
+            );
+            expect(stateVariables[prob3pIdx].stateValues.hidden).eq(
+                numCompleted < 2,
+            );
+
+            // Problem 2's own message while problem 2 is next...
+            expect(stateVariables[prob2cmIdx].stateValues.hidden).eq(
+                numCompleted !== 0,
+            );
+            // ...and the cascade's message once problem 3, which has none of
+            // its own, is next. Never both at once.
+            expect(stateVariables[outerIdx].stateValues.hidden).eq(
+                numCompleted !== 1,
+            );
+        }
+
+        const stateVariables = await getStateVariables(core);
+        const answer1Idx = await resolvePathToNodeIdx("prob1.p.ans");
+        const mathInput1Idx = getMathInputIdx(stateVariables, answer1Idx);
+        const answer2Idx = await resolvePathToNodeIdx("prob2.p.ans");
+        const mathInput2Idx = getMathInputIdx(stateVariables, answer2Idx);
+        const answer3Idx = await resolvePathToNodeIdx("prob3.p.ans");
+        const mathInput3Idx = getMathInputIdx(stateVariables, answer3Idx);
+
+        await check_values(0);
+
+        await runMathAnswerSequence({
+            core,
+            steps: [
+                {
+                    latex: "2",
+                    mathInputIdx: mathInput1Idx,
+                    answerIdx: answer1Idx,
+                    expected: 1,
+                },
+                {
+                    latex: "7",
+                    mathInputIdx: mathInput2Idx,
+                    answerIdx: answer2Idx,
+                    expected: 2,
+                },
+                {
+                    latex: "-1",
+                    mathInputIdx: mathInput3Idx,
+                    answerIdx: answer3Idx,
+                    expected: 3,
+                },
+                // Going back to an incorrect answer hands the message back.
+                {
+                    latex: "3",
+                    mathInputIdx: mathInput1Idx,
+                    answerIdx: answer1Idx,
+                    expected: 0,
+                },
+            ],
             assertState: check_values,
         });
     });


### PR DESCRIPTION
Closes #1683.

## The behavior

A `<cascadeMessage>` nested inside a section was shown by **every** held-back section at once, so a cascade of three problems displayed "complete problem 1 to proceed" and "complete problem 2 to proceed" together — the second describing a step whose point the reader cannot see yet. That was never a regression: both `<cascadeMessage>` rules arrived together in #711, the cascade-level one picking the next message among the cascade's own message children and the nested one inverting per section, and a test in that PR pinned the per-section behavior. It is the documented "next entry" rule that was right.

A nested message now shows only while its section is the **next** one — the one that appears as soon as the current section is completed. Sections further down show only their number and title, the same as a held-back section with no message of its own already did.

Rendering the three-problem example from #1683: only problem 2's message shows, and problem 3 shows just its number.

## Negotiating between the two placements

Where an author has put messages in both places, they now negotiate instead of both appearing. A section's own message is the more specific of the two, so when the next section has one to show it wins and the cascade's own `<cascadeMessage>` children stay hidden for as long as it shows. Only a message that really appears wins: a nested `<cascade>` with messages it would not show in its current state does not silence the enclosing cascade's. A cascade's own message still serves every gap the next section does not cover itself — including the single-trailing-message idiom, which is unchanged.

Nesting is also the only placement that survives a list layout, which is worth knowing when choosing where to put one: inside a `<problems>` (or anything else with `asList`) `childIndicesToRender` renders only sectioning children, so a `<cascadeMessage>` child of the cascade is dropped before it can be shown. The docs page now says so.

## Cascades inside cascades

A `<cascade>` is a step of its enclosing cascade like any other, and it waits its turn like any other. It used to choose among its own message children whenever it had a gap to stand in for, whether or not the enclosing cascade had reached it, so a cascade of cascades spoke from every level at once — the same defect one level up. A held-back cascade now speaks only while it is the step the enclosing cascade nominates, and then it picks the single message shown in its own right; one further down shows nothing at all, its own messages included.

## How

`Cascade.childrenToHide` gains a third output, `sectionToShowCascadeMessage`: the next step, if it is a held-back section with a message of its own to show (`hasCascadeMessageToShow`, new on `SectioningComponent`), else `null`. Each section compares that against itself in `showCascadeMessage`, and `SectioningComponent.childrenToHide` gates its inverted message rule on that rather than on `hideChildren` alone. A cascade, whose own `childrenToHide` overrides that rule, reads `showCascadeMessage` too, which is what makes a nested cascade wait its turn. `hasCascadeMessageToShow` deliberately asks nothing about visibility — the cascade's answer is what *determines* message visibility, so reading `hideChildren` there would close a cycle. The chain of dependencies therefore only climbs, never descends, at any depth of nesting.

For every section but a `<cascade>`, "has a message to show" is simply "has a `<cascadeMessage>` child": a held-back section whose turn it is shows all of its message children. A `<cascade>` overrides it, because it shows one message of its own at most and only in a gap between two of its own steps, so it can have message children and still have nothing to say — `revealAll` leaves it no gap, a single-step cascade holds nothing back, and a message ahead of its first step is never the next one. Nominating such a step anyway would suppress the enclosing cascade's own message on behalf of a step that then said nothing, leaving the gap silent; asking the same question the cascade answers for itself keeps nomination and what is shown in agreement by construction.

Two tidies while we are here. Choosing among the cascade's *own* message children collapses to one expression: the four branches that decided which to hide all ended in the same push, three of them of the whole set, so the code now names the single message to show (`null` for none) and filters it out of the hide list once. That choice is a `nextOwnCascadeMessage()` helper, which is also what `hasCascadeMessageToShow` asks. And the base `hasCascadeMessageToShow` asks for the `cascadeMessages` child group directly rather than filtering all of the children — it only counts, so it needs neither the shared all-children dependency nor the position filtering that the section variables working in child *positions* use. (The group holds every `<cascadeMessage>` a section can have, including ones a `<repeat>` or other composite produces, since child dependencies see a composite's replacements.) Two now-dead conditions go with it: the inverted rule's `typeof child === "object"` guard, since a string child has no `componentType` and never reaches that branch, and the `componentType !== "cascadeMessage"` check on the branch the message branch has already claimed.

## Tests

- `cascade.test.ts` — messages in both places, asserting exactly one shows at each stage and that they hand over as the learner advances and falls back.
- `cascade.test.ts` — three nested cascades side by side, walking each level's own message through every handover: a cascade further down than the next step stays silent, the nominated one speaks, and a live one speaks for its own gap.
- `cascade.test.ts` — three *levels* of nesting, which is where the nomination chain could conceivably close on itself; the document loads and each level shows at most its own one message.
- `cascade.test.ts` — a nested cascade with message children but nothing to show (`revealAll`, and a single step) does not win the nomination, so the enclosing cascade's own message still stands in. Fails if the cascade's `hasCascadeMessageToShow` merely counts message children.
- `cascade.test.ts` — `hideFutureSections` (a step hidden whole is not nominated, so its own message stays hidden and the cascade's own message stands in for it) and `revealAll` (nothing held back, so messages in both placements are hidden).
- `cascade.test.ts` "continuation messages inside sections" — the one assertion this reverses, section 3's message, now `hidden` except while section 3 is next. Removing the gate fails it.
- `problem.cy.js` and `list.cy.js` pass unchanged (55 tests): #1681's held-back-step layout guard holds one step back, and that step is the next one.

## Relation to #1681

Rebased onto `main` now that #1681 has merged. It narrows the `firstVisibleChild` doc comment #1681 rewrote: the step that leads with its message is now the *one* the cascade nominates, and a held-back step further down leads with nothing. The `<cascade>` reference page's continuation-message example also now says that one message shows at a time, which was true of the cascade's own message children before this PR as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9QoEYrYzcLeJKxWoeheK8


