### PR TITLE
Stagger document boots on pages nothing else schedules

### DIFF
--- a/.changeset/in-realm-boot-gate.md
+++ b/.changeset/in-realm-boot-gate.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Stagger document boots on pages nothing else schedules.
+
+Every embedding of ours that puts many documents on one page caps how many boot at once, but all of those caps live on the parent page and are opt-in. PreTeXt/Runestone has adopted none of them, so a textbook section starts every activity simultaneously — each parsing a multi-MB bundle and spawning its own core worker — and on a low-end machine the contention pushed healthy handshakes past their watchdog until the activities failed outright (#1707).
+
+When no embedding layer is scheduling boots, a document now holds one of a few page-wide slots across its core handshake and retry ladder. The slots are Web Locks, which span every same-origin realm, so activity iframes gate against each other with no host script — and even other tabs on the same site, which contend for the same CPU, share the cap. The browser releases a lock when its realm goes away, so a crashed activity cannot wedge its siblings. A boot that finds every slot busy queues for all of them and takes whichever frees first, so free capacity is never idle while boots wait behind a busier slot.
+
+Only a document's *first* boot waits. The stampede being bounded is many documents starting at once on page load; a rebuild is one already-visible document replacing its core, and making that queue behind other documents' first boots would delay an update the reader is looking at (and serialize an editor, which rebuilds on every recompile).
+
+The gate fails open in every direction — no Web Locks, a rejected request, or a long wait all boot ungated — because a document that never boots is worse than a contended one. It bounds worker creation and WASM compilation, not the standalone bundle parse, which each iframe realm pays before any of our code runs there. `doenetGlobalConfig.maxConcurrentBoots` pins the cap; the default derives from `navigator.hardwareConcurrency`.
+
+**Uniform managed-boot signal.** `doenetGlobalConfig.externallyManagedBoot` records that a host already schedules this realm's boot, so the gate stands down instead of nesting under a host cap and serializing the page — two independent semaphores compose multiplicatively. `@doenet/doenetml` exports **`markBootExternallyManaged`** to set it, for a host that caps boots itself. The coordinator and windowed viewers set it from signals they already carried; editors had none, so `@doenet/doenetml-iframe`'s `<DoenetEditor>` gains **`bootManagedByHost`**, which the docs site passes from its editor mount manager.

--- a/packages/docs-nextra/components/windowed-editor.tsx
+++ b/packages/docs-nextra/components/windowed-editor.tsx
@@ -195,6 +195,10 @@ export function WindowedEditor({
                     height={height}
                     documentStructureCallback={concludeBoot}
                     coreStartFailedCallback={concludeBoot}
+                    // `editor-mount-manager` above already caps how many
+                    // editors boot at once; tell the editor realm so it does
+                    // not gate itself a second time (#1708).
+                    bootManagedByHost
                     {...versionProps}
                 />
             ) : (

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -69,6 +69,25 @@ latest editor buffer:
 > surface a completion signal or error to the caller — failures from the
 > underlying ComLink RPC are logged to the console rather than thrown.
 
+### Host-scheduled boots (`bootManagedByHost`)
+
+`<DoenetEditor>` has no built-in windowing, so a host that embeds many
+editors on one page (the docs site does) adds its own: mount lazily, cap how
+many boot at once. Set `bootManagedByHost` on such an editor to tell the
+editor's iframe realm that its boot is already scheduled from outside.
+
+```tsx
+<DoenetEditor doenetML="..." bootManagedByHost />
+```
+
+Without it, a recent bundle applies its own page-wide boot throttle inside
+the realm, which would then sit *underneath* the host's cap — two independent
+semaphores compose multiplicatively and serialize a page neither would slow
+on its own. Leave it unset for an editor that mounts immediately: that editor
+really is unmanaged, and the in-realm throttle is what staggers it against
+its neighbours. Windowed `<DoenetViewer>`s carry the same signal implicitly
+via `mountPolicy` and need no prop.
+
 ## DoenetViewer
 
 ### Prop changes and iframe reloads

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -13,6 +13,10 @@ import * as Comlink from "comlink";
 declare const editorId: string;
 declare const doenetEditorProps: Record<string, any>;
 declare const doenetEditorPropsSpecified: string[];
+// Baked into the srcdoc when the host schedules this editor's boot (#1708).
+// Guarded with `typeof` at the use site, like the viewer entry's flags, so
+// this script also works in srcdocs generated without the const.
+declare const doenetManagedEditor: boolean | undefined;
 declare global {
     interface Window {
         renderDoenetEditorToContainer: (
@@ -20,6 +24,7 @@ declare global {
             doenetMLSource?: string,
             config?: object,
         ) => DoenetEditorHandle | void;
+        doenetGlobalConfig: Record<string, any>;
         /**
          * Style-palette discovery, defined by standalone bundles new enough to
          * ship it. Feature-detected so an older bundle reports no palettes.
@@ -339,6 +344,14 @@ function renderWithLastAugmentedProps() {
 // move the user out of the silent-stuck state.
 (async () => {
     if (await waitForStandaloneBundle(60_000)) {
+        if (typeof doenetManagedEditor !== "undefined" && doenetManagedEditor) {
+            // The host caps how many editors boot at once (#1708), so an
+            // in-realm boot throttle must not add a second gate underneath
+            // it. Set after the bundle has evaluated — it replaces
+            // `window.doenetGlobalConfig` — and before the parent is told to
+            // render, which is what starts a core.
+            window.doenetGlobalConfig.externallyManagedBoot = true;
+        }
         messageParentFromEditor({
             iframeReady: true,
             stylePalettes: readStylePalettesFromBundle(),

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -365,6 +365,21 @@ function installSharedCorePortProvider() {
     };
 }
 
+/**
+ * Tell the bundle that the parent already schedules this realm's boot (#1708),
+ * so an in-realm boot throttle does not add a second gate underneath the
+ * wrapper's boot-slot semaphore. Same timing constraint as
+ * `installSharedCorePortProvider`: after the bundle has evaluated (it replaces
+ * `window.doenetGlobalConfig`) and before anything renders a viewer.
+ *
+ * Only windowed viewers are managed. A viewer without a `mountPolicy` boots
+ * the moment it mounts, with nothing capping how many do so at once — exactly
+ * the case an in-realm throttle should cover.
+ */
+function markBootManagedByParent() {
+    window.doenetGlobalConfig.externallyManagedBoot = true;
+}
+
 // Defer `iframeReady` until the standalone bundle has defined
 // `renderDoenetViewerToContainer`. See `waitForStandaloneBundle` above.
 //
@@ -380,6 +395,12 @@ function installSharedCorePortProvider() {
             doenetSharedCoreWorker
         ) {
             installSharedCorePortProvider();
+        }
+        if (
+            typeof doenetWindowedViewer !== "undefined" &&
+            doenetWindowedViewer
+        ) {
+            markBootManagedByParent();
         }
         messageParentFromViewer({
             iframeReady: true,

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -231,6 +231,18 @@ export type DoenetEditorIframeProps = DoenetEditorProps & {
      * The height of the iframe (and the height of the editor-viewer widget)
      */
     height?: string;
+    /**
+     * Set by a host that schedules this editor's boot itself — mounting it
+     * only when needed and capping how many editors boot at once (#1708).
+     * The flag reaches the editor realm so an in-realm boot throttle stands
+     * down rather than gating a second time underneath the host's cap.
+     *
+     * Viewers carry the same signal implicitly via `mountPolicy`; editors
+     * have no built-in windowing, so a host that adds its own (as the docs
+     * site does) has to say so explicitly. Default off — an editor that
+     * mounts immediately is genuinely unmanaged.
+     */
+    bootManagedByHost?: boolean;
 };
 
 type ViewerIframeRemote = Comlink.Remote<{
@@ -1386,6 +1398,10 @@ export const DoenetEditor = React.forwardRef<
         height = "500px",
         autodetectVersion = true,
         onStylePalettes,
+        // Destructured out of the rest: it configures the iframe realm, not
+        // the inner `<DoenetEditor>`, so it must not ride along in the props
+        // bag that is serialized and pushed across the Comlink boundary.
+        bootManagedByHost = false,
         ...doenetEditorProps
     },
     forwardedRef,
@@ -1644,8 +1660,9 @@ export const DoenetEditor = React.forwardRef<
             baseProps,
             standaloneUrl,
             cssUrl,
+            bootManagedByHost,
         );
-    }, [id, standaloneUrl, cssUrl, initialDiagnostics]);
+    }, [id, standaloneUrl, cssUrl, initialDiagnostics, bootManagedByHost]);
 
     // Build the serializable prop snapshot used both for change detection
     // (vs. last sent) and as the baseline of "what the iframe currently

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -178,6 +178,7 @@ export function createHtmlForDoenetEditor(
     doenetEditorProps: DoenetEditorProps,
     standaloneUrl: string,
     cssUrl: string,
+    bootManagedByHost = false,
 ) {
     const augmentedProps = { width, height: "100vh", ...doenetEditorProps };
 
@@ -197,6 +198,7 @@ export function createHtmlForDoenetEditor(
                 editorId: id,
                 doenetEditorProps: augmentedProps,
                 doenetEditorPropsSpecified,
+                doenetManagedEditor: !!bootManagedByHost,
             },
             editorIframeJsSource,
         )}

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -42,6 +42,7 @@ import {
 } from "../state";
 import { renderersLoadComponent } from "./renderersLoadComponent";
 import { doenetGlobalConfig } from "../global-config";
+import { acquireBootSlot, UNGATED_BOOT_SLOT } from "../utils/bootGate";
 import {
     concurrentHandshakesSnapshot,
     joinHandshakeCensus,
@@ -543,12 +544,17 @@ export function DocViewer({
     // granularity it promises ("once per core-start attempt") and needs no
     // separate reset. See `reportCoreStartFailed`.
     const coreStartFailureReportedFor = useRef<string | null>(null);
-    // Set by the unmount cleanup below. `startCore` waits several times over
-    // — on the saved-state load, on each handshake, between retries (#1711) —
-    // and the teardown that runs on unmount cannot cancel those waits, so
-    // their other side checks this (`bootAbandoned`) rather than going on
-    // booting a worker for a viewer that is gone.
+    // Set by the unmount cleanup below. `startCore` may wait — on a boot slot
+    // before it creates anything (#1710), and between retries (#1711) — and
+    // the teardown that runs on unmount cannot cancel those waits, so their
+    // other side checks this (`bootAbandoned`) rather than booting a worker
+    // for a viewer that is gone.
     const viewerUnmounted = useRef(false);
+    // Whether this viewer has ever completed a core boot. Gates only the
+    // first one (see `startCore`): a rebuild replaces the core of a document
+    // already on screen and should not wait behind other documents' first
+    // boots.
+    const hasBootedOnce = useRef(false);
     // The `coreId` whose boot ladder is running, or null between ladders. One
     // of `startCoreSafely`'s three callers is render-phase code that re-runs
     // on every re-render until the ladder moves `stage` off
@@ -556,10 +562,10 @@ export function DocViewer({
     // ladder for the same document. `bootAbandoned` cannot see that one: the
     // `coreId`s match, so neither twin stands aside, and both go through
     // `reinitializeCoreAndTerminateAnimations`, which owns the single
-    // `coreWorker` ref — each disposing the other's worker. The window is
-    // wide enough to catch an ordinary re-render: a boot spans a saved-state
-    // load, a worker handshake, a backoff between attempts (#1711), and the
-    // document evaluation that follows. A *rebuild* re-rolls `coreId`, so the
+    // `coreWorker` ref — each disposing the other's worker. A boot used to be
+    // over in about a second; it can now queue for a page-wide slot (#1710)
+    // and back off between attempts (#1711), so that window is wide enough to
+    // catch any ordinary re-render. A *rebuild* re-rolls `coreId`, so the
     // successor ladder it launches is never the one blocked here — that
     // supersession is `bootAbandoned`'s job, not this latch's.
     const bootLadderCoreId = useRef<string | null>(null);
@@ -788,12 +794,6 @@ export function DocViewer({
         suspectWedge,
     }: {
         graceful: boolean;
-        /**
-         * Passed through to `disposeCoreWorker`, which otherwise infers the
-         * suspicion from `graceful`. A handshake teardown states it outright
-         * when the timeout that prompted it is better explained by page-wide
-         * CPU contention than by a wedged worker (#1711).
-         */
         suspectWedge?: boolean;
     }) {
         const remote = coreWorker.current;
@@ -2026,15 +2026,14 @@ export function DocViewer({
      * which latches on the CURRENT `coreId`.
      *
      * The waits on both paths make that window wide: a load awaits a cid and
-     * then IndexedDB, and a boot awaits a handshake per attempt, backs off
-     * between attempts (#1711), and then evaluates. (The `SPLICE.getState`
-     * round trip a load may start is not one of them: the load never awaits
-     * it. It posts the request and hands straight off to the boot, and the
-     * response is picked up later by the message listener above, matched
-     * against the message id and `cid` current *then* — so it acts for
-     * whatever document the viewer is showing by then, re-rolling `coreId`
-     * and launching a ladder of its own, which is what stands the running one
-     * aside.)
+     * then IndexedDB, and a boot may queue for a page-wide slot (#1710) and
+     * then back off between attempts (#1711). (The `SPLICE.getState` round
+     * trip a load may start is not one of them: the load never awaits it. It
+     * posts the request and hands straight off to the boot, and the response
+     * is picked up later by the message listener above, matched against the
+     * message id and `cid` current *then* — so it acts for whatever document
+     * the viewer is showing by then, re-rolling `coreId` and launching a
+     * ladder of its own, which is what stands the running one aside.)
      *
      * Consulted everywhere a losing operation could speak for the document:
      * the staleness checks inside `loadStateAndInitialize` and at its launch
@@ -2097,10 +2096,54 @@ export function DocViewer({
         // the busy-page wording.
         let lastFailureWasContended = false;
 
-        // From here a census seat is held, so every exit — the abandonment
-        // returns below included — runs through the `finally` that frees it.
+        // On a page no host manager gates, hold one of a few page-wide slots
+        // for the handshake (#1710), so many documents on one page start
+        // their workers a few at a time instead of all at once. Resolves
+        // immediately — with a no-op slot — under a host manager or wherever
+        // the gate cannot apply. Covers the retry ladder too: a retry is
+        // another worker boot, and re-piling those is what turns a contended
+        // page into a failing one.
+        //
+        // Only a document's FIRST boot is gated. The stampede this bounds is
+        // N documents starting at once on page load; a rebuild is one
+        // already-visible document replacing its core, and it does not
+        // multiply with page size the way first boots do. Gating rebuilds
+        // made an on-screen document queue behind other documents' first
+        // boots to show its own update — and an editor, which rebuilds on
+        // every recompile, serialized its whole startup through one slot
+        // (this is what broke `DoenetEditor.diagnosticHoverLocale` and
+        // `DocViewer/i18n` in CI: not a hang, just a queue far longer than
+        // the tests' budget). The tradeoff is that a page-wide rebuild — a
+        // locale switch across many documents — is ungated; the
+        // contention-aware watchdog (#1711) is what keeps that degrading
+        // gracefully rather than failing.
+        //
+        // The census is deliberately NOT primed here. Issuing a
+        // `navigator.locks.query()` immediately before the slot request
+        // reorders work in the lock manager enough to change which boot wins
+        // a rebuild race — `DocViewer/i18n`'s `uiLocale: "es"` diagnostics
+        // went from green to failing on that one line alone, bisected against
+        // three runs per commit. The first attempt's watchdog therefore reads
+        // the count one refresh behind, which is the documented contract of
+        // `concurrentHandshakesSnapshot` and costs only a slightly narrower
+        // budget on a first boot.
+        const bootSlot = hasBootedOnce.current
+            ? UNGATED_BOOT_SLOT
+            : await acquireBootSlot();
+        // From here the slot is held, so every exit — the abandonment returns
+        // below included — runs through the `finally` that frees it; a slot
+        // released only on the success path would be lost for the life of the
+        // realm. The census seat is taken inside that same region for the same
+        // reason.
         let censusHandle: Promise<{ release: () => void }> | null = null;
         try {
+            if (bootAbandoned()) {
+                // Unmounted or superseded while queued for the slot. This
+                // ladder reports nothing either way: the outcome belongs to
+                // the ladder still running, or to no one.
+                await standDown();
+                return;
+            }
             // Join the page-wide handshake count for as long as this ladder is
             // handshaking, so sibling realms sizing their own watchdogs can
             // see it (#1711). Released by the `finally` below — at the end of
@@ -2221,6 +2264,12 @@ export function DocViewer({
                     // here; the handler only satisfies "no fire-and-forget
                     // promises".
                 });
+            // Free the slot once the worker is up (or has definitively
+            // failed), NOT after `generateDast`: evaluation is document work
+            // that can run for minutes, and holding a boot slot through it
+            // would serialize long documents behind each other for no gain.
+            // The handshake is the contended part.
+            bootSlot.release();
         }
 
         if (bootAbandoned()) {
@@ -2383,6 +2432,7 @@ export function DocViewer({
         }
 
         coreCreated.current = true;
+        hasBootedOnce.current = true;
         coreCreationInProgress.current = false;
         preventMoreAnimations.current = false;
         // Snapshot and clear the queue before dispatching so that stale

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -41,6 +41,27 @@ export const doenetGlobalConfig: {
         destroy: (suspectWedge?: boolean) => void;
     } | null;
     /**
+     * Set when an embedding layer outside this realm already schedules its
+     * boot — the `@doenet/standalone` parent-page coordinator, or a
+     * `@doenet/doenetml-iframe` viewer/editor whose host caps boot
+     * concurrency (#1708). In-realm boot policy consults it through
+     * `isBootExternallyManaged` (`utils/bootScheduling.ts`), which documents
+     * why the answer is supplied rather than discovered. Unset means
+     * unmanaged.
+     */
+    externallyManagedBoot?: boolean;
+    /**
+     * Cap on how many documents may boot their core at once, when the
+     * in-realm boot gate is in force (#1710) — i.e. when no embedding layer is
+     * scheduling boots itself. The cap is enforced with Web Locks, so it is
+     * shared by every same-origin realm the browser is running: the activity
+     * iframes on a page, and other tabs on the same site, which contend for
+     * the same CPU. Falls back to a value derived from
+     * `navigator.hardwareConcurrency`; see `defaultMaxConcurrentBoots` in
+     * `utils/bootGate.ts`.
+     */
+    maxConcurrentBoots?: number;
+    /**
      * Maximum number of times `DocViewer` will retry the core-worker
      * *handshake* before giving up and surfacing an error. Each handshake
      * that fails to complete within its per-attempt watchdog budget (see

--- a/packages/doenetml/src/index.ts
+++ b/packages/doenetml/src/index.ts
@@ -32,6 +32,11 @@ export type {
 
 export { CodeMirror } from "@doenet/codemirror";
 
+// Boot scheduling (#1708). An embedding layer that caps how many documents
+// boot at once calls `markBootExternallyManaged` so in-realm boot policy knows
+// not to add a second, redundant gate of its own.
+export { markBootExternallyManaged } from "./utils/bootScheduling";
+
 // Where a host installs the message catalogs the viewer in *this* bundle reads.
 //
 // The loaders are module-level state, and a bundle can hold more than one

--- a/packages/doenetml/src/utils/bootGate.test.ts
+++ b/packages/doenetml/src/utils/bootGate.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+    acquireBootSlot,
+    defaultMaxConcurrentBoots,
+    GATE_WAIT_TIMEOUT_MS,
+} from "./bootGate";
+import { doenetGlobalConfig } from "../global-config";
+
+// Unit coverage for the in-realm boot gate (#1710). The gate is a counting
+// semaphore over the Web Locks API; these tests drive it against a minimal
+// in-memory `navigator.locks` so the concurrency, the fail-open paths, and the
+// stand-down-under-a-host-manager rule are all checked without a browser.
+
+type Waiter = { grant: () => void };
+
+/**
+ * A `LockManager` good enough for these tests: exclusive locks by name, FIFO
+ * waiters, `ifAvailable` returning a null lock when the name is taken, and
+ * `signal` dropping a request that has not been granted yet — matching the
+ * real API, a grant that already happened ignores a later abort.
+ */
+function fakeLocks() {
+    const held = new Set<string>();
+    const waiting = new Map<string, Waiter[]>();
+
+    function release(name: string) {
+        const queue = waiting.get(name);
+        const next = queue?.shift();
+        if (next) {
+            next.grant();
+        } else {
+            held.delete(name);
+        }
+    }
+
+    return {
+        held,
+        request(
+            name: string,
+            options: { ifAvailable?: boolean; signal?: AbortSignal },
+            callback: (lock: unknown) => Promise<void>,
+        ): Promise<void> {
+            if (options.signal?.aborted) {
+                return Promise.reject(
+                    new DOMException("aborted", "AbortError"),
+                );
+            }
+            const run = () => {
+                held.add(name);
+                return Promise.resolve(callback({ name })).then(() => {
+                    release(name);
+                });
+            };
+            if (!held.has(name)) {
+                return run();
+            }
+            if (options.ifAvailable) {
+                return Promise.resolve(callback(null)).then(() => {});
+            }
+            return new Promise<void>((settle, reject) => {
+                const queue = waiting.get(name) ?? [];
+                const waiter: Waiter = { grant: () => settle(run()) };
+                queue.push(waiter);
+                waiting.set(name, queue);
+                options.signal?.addEventListener("abort", () => {
+                    const parked = waiting.get(name);
+                    const at = parked?.indexOf(waiter) ?? -1;
+                    if (parked && at !== -1) {
+                        parked.splice(at, 1);
+                        reject(new DOMException("aborted", "AbortError"));
+                    }
+                });
+            });
+        },
+    };
+}
+
+function installLocks(locks: unknown, hardwareConcurrency = 4) {
+    Object.defineProperty(globalThis, "navigator", {
+        value: { locks, hardwareConcurrency },
+        configurable: true,
+        writable: true,
+    });
+}
+
+describe("boot gate (#1710)", () => {
+    afterEach(() => {
+        delete doenetGlobalConfig.externallyManagedBoot;
+        vi.useRealTimers();
+    });
+
+    it("sizes the default cap from the hardware, between a floor of 2 and a ceiling of 6", () => {
+        // Half the reported threads: 4 — the machine from #1707 — gives 2.
+        installLocks(fakeLocks(), 4);
+        expect(defaultMaxConcurrentBoots()).toBe(2);
+        installLocks(fakeLocks(), 8);
+        expect(defaultMaxConcurrentBoots()).toBe(4);
+        // The floor keeps a page from serializing completely; the ceiling
+        // keeps a many-core machine from reintroducing the stampede.
+        installLocks(fakeLocks(), 2);
+        expect(defaultMaxConcurrentBoots()).toBe(2);
+        installLocks(fakeLocks(), 64);
+        expect(defaultMaxConcurrentBoots()).toBe(6);
+        // A browser that withholds the hint is not evidence of a fast machine.
+        installLocks(fakeLocks(), 0);
+        expect(defaultMaxConcurrentBoots()).toBe(2);
+    });
+
+    it("admits up to the cap and makes the next boot wait for a release", async () => {
+        installLocks(fakeLocks());
+
+        const first = await acquireBootSlot(2);
+        const second = await acquireBootSlot(2);
+
+        // Both slots are taken, so a third must wait rather than resolve.
+        let thirdResolved = false;
+        const third = acquireBootSlot(2).then((slot) => {
+            thirdResolved = true;
+            return slot;
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(thirdResolved).toBe(false);
+
+        // Releasing ONE slot must serve the waiter, whichever slot frees:
+        // the waiter queues on every slot and takes the first grant, so no
+        // free capacity sits idle while a boot waits behind a busier slot.
+        first.release();
+        const grantedThird = await third;
+        expect(thirdResolved).toBe(true);
+        grantedThird.release();
+        second.release();
+    });
+
+    it("withdraws a served waiter's other queued requests", async () => {
+        const locks = fakeLocks();
+        installLocks(locks);
+
+        // Fill both slots, then queue a waiter — on both slots, per the
+        // work-conserving slow path.
+        const first = await acquireBootSlot(2);
+        const second = await acquireBootSlot(2);
+        const third = acquireBootSlot(2);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Serve the waiter from the first slot. Its request still queued on
+        // the second must be withdrawn with it — not left behind to grab
+        // that slot when it frees.
+        first.release();
+        const grantedThird = await third;
+        second.release();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(locks.held.size).toBe(1);
+        grantedThird.release();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(locks.held.size).toBe(0);
+    });
+
+    it("stands down when a host manager already schedules boots", async () => {
+        const locks = fakeLocks();
+        installLocks(locks);
+        doenetGlobalConfig.externallyManagedBoot = true;
+
+        // Far more concurrent boots than the cap would ever allow: none of
+        // them may block, and none may take a lock — nesting this gate under
+        // a host cap is what serializes a managed page.
+        const slots = await Promise.all(
+            Array.from({ length: 5 }, () => acquireBootSlot(1)),
+        );
+        expect(slots).toHaveLength(5);
+        expect(locks.held.size).toBe(0);
+        slots.forEach((slot) => slot.release());
+    });
+
+    it("boots ungated when the browser has no Web Locks", async () => {
+        installLocks(undefined);
+
+        const slots = await Promise.all(
+            Array.from({ length: 4 }, () => acquireBootSlot(1)),
+        );
+        expect(slots).toHaveLength(4);
+        slots.forEach((slot) => slot.release());
+    });
+
+    it("boots ungated when a lock request throws", async () => {
+        installLocks({
+            request: () => {
+                throw new Error("locks unavailable in this context");
+            },
+        });
+
+        // Must resolve, not reject: a gate that cannot be used has to degrade
+        // to today's ungated behavior, never to a document that never boots.
+        const slot = await acquireBootSlot(1);
+        expect(slot).toBeDefined();
+        slot.release();
+    });
+
+    it("boots ungated rather than waiting on a slot forever", async () => {
+        // The third fail-open path, and the one that is not an absent API: a
+        // slot that never frees. A boot that waits indefinitely is invisible
+        // and unrecoverable, so past the backstop the gate stands aside.
+        vi.useFakeTimers();
+        installLocks(fakeLocks());
+        const holder = await acquireBootSlot(1);
+
+        let bypassed = false;
+        const queued = acquireBootSlot(1).then((slot) => {
+            bypassed = true;
+            return slot;
+        });
+
+        // Still queued well into the wait — the backstop is a backstop, not a
+        // short-circuit around the gate.
+        await vi.advanceTimersByTimeAsync(GATE_WAIT_TIMEOUT_MS - 1);
+        expect(bypassed).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(2);
+        const slot = await queued;
+        expect(bypassed).toBe(true);
+        // The bypassed boot holds nothing, so releasing it cannot free the
+        // slot the original holder still has.
+        slot.release();
+        holder.release();
+    });
+
+    it("releasing twice does not hand out an extra slot", async () => {
+        const locks = fakeLocks();
+        installLocks(locks);
+
+        const slot = await acquireBootSlot(1);
+        slot.release();
+        slot.release();
+        // The lock's own cleanup runs when the callback's promise settles, a
+        // microtask after `release`.
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(locks.held.size).toBe(0);
+
+        // The cap still holds afterwards.
+        const next = await acquireBootSlot(1);
+        expect(locks.held.size).toBe(1);
+        next.release();
+    });
+});

--- a/packages/doenetml/src/utils/bootGate.ts
+++ b/packages/doenetml/src/utils/bootGate.ts
@@ -1,0 +1,271 @@
+/**
+ * In-realm boot throttle for pages no host manager gates (#1710).
+ *
+ * Every embedding of ours that puts many documents on one page caps how many
+ * boot at once — `@doenet/standalone`'s parent-page coordinator,
+ * `@doenet/doenetml-iframe`'s windowed `mountPolicy`, and the docs site's own
+ * `editor-mount-manager`. All of them live on the PARENT page and are opt-in,
+ * so a host that has adopted none of them boots every document at once.
+ * PreTeXt/Runestone is such a host: a textbook section starts every activity
+ * simultaneously, and on a low-end machine the resulting contention pushes
+ * healthy handshakes past their watchdog and the activities fail outright
+ * (#1707).
+ *
+ * This gate is the fallback for that case. It needs no host cooperation: the
+ * activity realms on a page are same-origin with each other, so the Web Locks
+ * API — which is scoped per origin and spans every same-origin realm,
+ * including iframes — gives us a page-wide counting semaphore with nothing
+ * for the host to install.
+ *
+ * Web Locks rather than a hand-rolled `BroadcastChannel` protocol for one
+ * decisive reason: the browser releases a lock when the realm holding it goes
+ * away. A crashed, navigated, or detached activity cannot wedge the queue for
+ * its siblings, which is precisely the failure a page of struggling activities
+ * would otherwise be prone to.
+ *
+ * "Page-wide" throughout this file is shorthand: a lock manager is scoped to
+ * an ORIGIN, so the cap is really shared with every same-origin realm the
+ * browser is running, including other tabs on the same site. That is the right
+ * scope for what is being bounded — the CPU those tabs contend for is the same
+ * CPU — and the `GATE_WAIT_TIMEOUT_MS` bypass below keeps the wider scope from
+ * ever being worse than ungated.
+ *
+ * Two properties are load-bearing:
+ *
+ * - **It stands down under a host manager** (`isBootExternallyManaged`).
+ *   Nesting this under an existing cap composes multiplicatively and would
+ *   serialize a managed page — slowly, and for reasons hard to attribute —
+ *   on exactly the slow machines the cap exists to help.
+ * - **It fails open.** No Web Locks, a rejected request, or a wait that runs
+ *   past `GATE_WAIT_TIMEOUT_MS` all boot immediately. Every failure mode
+ *   degrades to today's behavior (ungated); none can leave a document that
+ *   never boots.
+ *
+ * Scope note: this gates the core boot in `DocViewer.startCore` — worker
+ * creation and WASM compilation — not the parse of the standalone bundle
+ * itself. In the iframe-per-activity embedding each realm parses that bundle
+ * before any of our code runs there, so it is not something a gate inside the
+ * bundle can defer. The worker is the larger and more contended half, and it
+ * is the half we can reach. (The structure-only worker a viewer primes while
+ * `render` is false is also outside the gate: it is created from render-phase
+ * code, and the hosts that use it schedule their own boots anyway.)
+ */
+
+import { doenetGlobalConfig } from "../global-config";
+import { isBootExternallyManaged } from "./bootScheduling";
+import { reportedCores } from "./handshakeCensus";
+import { lockManager, type LockManagerLike } from "./webLocks";
+
+/**
+ * Lock names for the semaphore's slots. Namespaced so we cannot collide with
+ * a host's own Web Locks usage.
+ */
+const SLOT_LOCK_PREFIX = "doenet-boot-slot-";
+
+/**
+ * Cap on concurrent boots when this gate is in force.
+ *
+ * Derived from `hardwareConcurrency` so the limit tracks the machine rather
+ * than a guess: 2 on the dual-core i3 that motivated #1707 (which reports 4),
+ * and comfortably out of the way on a developer machine. The floor of 2 keeps
+ * a page from serializing completely where the hint is missing or absurdly
+ * low; the ceiling keeps a many-core machine from reintroducing the stampede
+ * this exists to prevent.
+ */
+export function defaultMaxConcurrentBoots(): number {
+    const cores = reportedCores();
+    if (!cores) {
+        return 2;
+    }
+    return Math.max(2, Math.min(6, Math.floor(cores / 2)));
+}
+
+/**
+ * How long a boot may wait for a slot before giving up on the gate and
+ * proceeding anyway.
+ *
+ * A boot that waits forever is worse than an ungated one: it is invisible and
+ * unrecoverable, whereas the contention it would have avoided merely makes
+ * things slow. Sized above a realistic queue of slow boots (the case this
+ * gate exists for, where each boot is genuinely taking many seconds) so the
+ * bypass is a true backstop rather than a routine occurrence.
+ *
+ * Exported so the fail-open test can drive the backstop by name rather than
+ * by a duplicated literal.
+ */
+export const GATE_WAIT_TIMEOUT_MS = 60_000;
+
+/**
+ * A held boot slot. Calling `release` frees it for the next waiter; it is
+ * idempotent, and a no-op for a boot that was never gated.
+ */
+export type BootSlot = { release: () => void };
+
+/**
+ * The handle a boot the gate does not apply to holds: releasing it frees
+ * nothing, because nothing was taken. Shared, since it carries no state.
+ *
+ * Exported so a caller that skips the gate before ever asking — `DocViewer`
+ * does, for a rebuild — can name what it is holding rather than open-code a
+ * second no-op that a reader has to recognize.
+ */
+export const UNGATED_BOOT_SLOT: BootSlot = { release: () => {} };
+
+/**
+ * Hold one of `maxConcurrentBoots` page-wide slots for the duration of a
+ * document's boot.
+ *
+ * Resolves as soon as a slot is held — or immediately, with a no-op slot,
+ * whenever the gate does not apply (a host manager is already scheduling
+ * boots) or cannot be used (no Web Locks, a rejected request, a wait that
+ * timed out). The caller must `release()` when the boot concludes, on the
+ * failure path as much as the success one: a slot held by a boot that has
+ * already given up blocks the siblings behind it.
+ */
+export async function acquireBootSlot(
+    maxConcurrentBoots = doenetGlobalConfig.maxConcurrentBoots ??
+        defaultMaxConcurrentBoots(),
+): Promise<BootSlot> {
+    if (isBootExternallyManaged()) {
+        return UNGATED_BOOT_SLOT;
+    }
+    const locks = lockManager();
+    if (!locks || maxConcurrentBoots < 1) {
+        return UNGATED_BOOT_SLOT;
+    }
+    try {
+        return await requestSlot(locks, maxConcurrentBoots);
+    } catch (e) {
+        console.warn("DoenetML boot gate unavailable; booting ungated:", e);
+        return UNGATED_BOOT_SLOT;
+    }
+}
+
+/**
+ * Take one of the numbered slot locks, held until the returned `release`.
+ *
+ * Fast path: try every slot with `ifAvailable`, so an uncontended page never
+ * waits. Slow path: queue on EVERY slot and take whichever frees first,
+ * withdrawing the rest. A Web Locks waiter is served only by the name it
+ * queued on, so parking on any one slot would leave the others' capacity
+ * idle while boots serialize behind the chosen one.
+ *
+ * Web Locks callbacks hold the lock for as long as the promise they return is
+ * unsettled, which is why each attempt parks on a promise resolved later by
+ * `release` rather than doing its work inline.
+ */
+function requestSlot(
+    locks: LockManagerLike,
+    maxConcurrentBoots: number,
+): Promise<BootSlot> {
+    return new Promise<BootSlot>((resolveSlot, rejectSlot) => {
+        // Set as soon as this boot's outcome is decided — a lock was granted,
+        // or the backstop gave up waiting. A grant arriving afterwards is
+        // released on the spot rather than held by nobody.
+        let settled = false;
+        let releaseLock: (() => void) | null = null;
+        // Withdraws every still-queued slot request once the outcome is
+        // decided. Aborting the request that was just granted is harmless:
+        // the signal only drops requests not yet granted.
+        const withdraw = new AbortController();
+
+        const bypass = setTimeout(() => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            withdraw.abort();
+            console.warn(
+                `DoenetML boot gate: no slot after ${GATE_WAIT_TIMEOUT_MS}ms; booting ungated.`,
+            );
+            resolveSlot(UNGATED_BOOT_SLOT);
+        }, GATE_WAIT_TIMEOUT_MS);
+
+        /**
+         * The body of a granted lock request: a promise that stays pending
+         * until the caller releases the slot, which is what holds the lock.
+         */
+        function holdUntilReleased() {
+            return new Promise<void>((release) => {
+                if (settled) {
+                    release();
+                    return;
+                }
+                settled = true;
+                clearTimeout(bypass);
+                withdraw.abort();
+                releaseLock = release;
+                resolveSlot({
+                    release: () => {
+                        releaseLock?.();
+                        releaseLock = null;
+                    },
+                });
+            });
+        }
+
+        function fail(e: unknown) {
+            clearTimeout(bypass);
+            withdraw.abort();
+            if (!settled) {
+                settled = true;
+                rejectSlot(e);
+            }
+        }
+
+        (async () => {
+            // Fast path: is any slot free right now? Each iteration resolves
+            // as soon as the grant decision is known — deliberately NOT when
+            // the lock is released, which is why `gotIt` is settled from
+            // inside the callback rather than by awaiting `request` itself.
+            for (let i = 0; i < maxConcurrentBoots; i++) {
+                if (settled) {
+                    return;
+                }
+                const name = `${SLOT_LOCK_PREFIX}${i}`;
+                const gotIt = await new Promise<boolean>((decided) => {
+                    locks
+                        .request(name, { ifAvailable: true }, (lock) => {
+                            if (!lock) {
+                                decided(false);
+                                return Promise.resolve();
+                            }
+                            decided(true);
+                            return holdUntilReleased();
+                        })
+                        .catch((e) => {
+                            decided(false);
+                            fail(e);
+                        });
+                });
+                if (gotIt) {
+                    return;
+                }
+            }
+            if (settled) {
+                return;
+            }
+            // Every slot is busy: queue on all of them and take whichever
+            // frees first (see this function's doc comment). The first grant
+            // settles the slot and withdraws the other requests; a second
+            // grant racing that withdrawal is released on the spot by
+            // `holdUntilReleased`'s `settled` check.
+            for (let i = 0; i < maxConcurrentBoots; i++) {
+                locks
+                    .request(
+                        `${SLOT_LOCK_PREFIX}${i}`,
+                        { signal: withdraw.signal },
+                        holdUntilReleased,
+                    )
+                    .catch((e: unknown) => {
+                        if (
+                            (e as { name?: string } | null)?.name !==
+                            "AbortError"
+                        ) {
+                            fail(e);
+                        }
+                    });
+            }
+        })().catch(fail);
+    });
+}

--- a/packages/doenetml/src/utils/bootScheduling.ts
+++ b/packages/doenetml/src/utils/bootScheduling.ts
@@ -1,0 +1,56 @@
+/**
+ * Who schedules this realm's boot (#1708).
+ *
+ * Several embedding layers cap how many DoenetML documents may boot at once,
+ * because each boot parses a multi-MB bundle and starts a core worker. They
+ * all live OUTSIDE the realm they gate — on the parent page — and each grew
+ * its own way of telling the child about it:
+ *
+ * - `@doenet/standalone`'s parent-page coordinator marks activity URLs with a
+ *   fragment token (`coordinated-mode.ts`);
+ * - `@doenet/doenetml-iframe` bakes `doenetWindowedViewer` into the srcdoc of
+ *   a viewer under a `mountPolicy`, and `doenetManagedEditor` into the srcdoc
+ *   of an editor whose host schedules it.
+ *
+ * This module reduces those to one question — *does something outside this
+ * realm already own my boot scheduling?* — so in-realm boot policy has a
+ * single thing to consult instead of re-deriving the answer per embedding.
+ *
+ * The answer is carried on `doenetGlobalConfig.externallyManagedBoot`, set by
+ * whichever entry point knows (the standalone bundle for the coordinator, the
+ * iframe entry points for their baked flags). It is deliberately *not*
+ * discovered here: only the embedding layer can know, and a wrong guess is
+ * expensive in both directions — see `isBootExternallyManaged`.
+ */
+
+import { doenetGlobalConfig } from "../global-config";
+
+/**
+ * Does an embedding layer outside this realm already schedule its boot?
+ *
+ * The intended consumer is in-realm boot policy that must not double-gate: a
+ * page-wide throttle added inside the bundle has to stand down when a host
+ * throttle is already in force, because two independent semaphores compose
+ * multiplicatively and serialize a page that neither one alone would slow.
+ *
+ * Answering `false` when a host manager *is* present is the costly error (the
+ * double-gating above). Answering `true` when none is present is costly too —
+ * an in-realm throttle would stand down and leave the page ungated — but that
+ * is exactly today's behavior, so it degrades rather than regresses. Hence the
+ * default: unset means unmanaged.
+ */
+export function isBootExternallyManaged(): boolean {
+    return doenetGlobalConfig.externallyManagedBoot === true;
+}
+
+/**
+ * Record that an embedding layer outside this realm owns its boot scheduling.
+ *
+ * Called by the entry point that knows — before any viewer renders, since boot
+ * policy is consulted at core creation. Write-once in spirit: an embedding
+ * cannot stop managing a realm partway through, and a later `false` would let
+ * an in-realm throttle engage underneath a host manager that is still running.
+ */
+export function markBootExternallyManaged() {
+    doenetGlobalConfig.externallyManagedBoot = true;
+}

--- a/packages/doenetml/test/cypress/component/DoenetViewer.rebuildNotGated.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.rebuildNotGated.cy.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+import { doenetGlobalConfig } from "../../../src/global-config";
+import { acquireBootSlot, type BootSlot } from "../../../src/utils/bootGate";
+
+// Regression coverage: the in-realm boot gate (#1710) holds back a document's
+// FIRST core boot only, never its rebuilds.
+//
+// The stampede the gate bounds is N documents starting at once on page load.
+// A rebuild is one already-visible document replacing its core, and it does
+// not multiply with page size the way first boots do — so gating it buys
+// nothing and costs a great deal: an on-screen document had to queue behind
+// other documents' first boots merely to show its own update, and an editor,
+// which rebuilds on every recompile, serialized its whole startup through one
+// page-wide slot. That regression reached CI (it broke
+// `DoenetEditor.diagnosticHoverLocale` and `DocViewer/i18n`) rather than any
+// test written for the gate, which is what this spec closes.
+//
+// Shape of the test: let the viewer boot, then take the page's only boot slot
+// away from outside and rebuild. A gated rebuild would wait for the slot —
+// which this test never gives back — until the gate's own 60 s fail-open
+// backstop. An ungated one renders straight away.
+
+/** Drives a document rebuild by changing `doenetML`. */
+function Rebuildable() {
+    const [generation, setGeneration] = React.useState(0);
+    return (
+        <div>
+            <button
+                data-test="rebuild"
+                onClick={() => setGeneration((g) => g + 1)}
+            >
+                rebuild
+            </button>
+            <DoenetViewer
+                doenetML={
+                    generation === 0
+                        ? "<p>first document</p>"
+                        : "<p>rebuilt document</p>"
+                }
+                addVirtualKeyboard={false}
+            />
+        </div>
+    );
+}
+
+describe("DoenetViewer rebuilds are not boot-gated (#1710)", () => {
+    let heldSlot: BootSlot | null = null;
+
+    afterEach(() => {
+        // The slot locks are origin-scoped and outlive the spec's realm, so a
+        // slot left held here would stall the first boot of every later test.
+        heldSlot?.release();
+        heldSlot = null;
+        delete doenetGlobalConfig.maxConcurrentBoots;
+    });
+
+    it("rebuilds while another document holds the page's only boot slot", () => {
+        // One slot page-wide, so "taken" and "unavailable" are the same thing
+        // and the assertion cannot be satisfied by a second slot being free.
+        doenetGlobalConfig.maxConcurrentBoots = 1;
+
+        cy.mount(<Rebuildable />);
+        cy.contains("first document", { timeout: 20000 }).should("exist");
+
+        // Stand in for a sibling document that is booting: take the only slot
+        // and keep it for the rest of the test.
+        cy.then(() =>
+            acquireBootSlot().then((slot) => {
+                heldSlot = slot;
+            }),
+        );
+
+        // The assertion. A gated rebuild would render nothing until the gate
+        // gave up waiting (60 s), well past this timeout.
+        cy.get("[data-test=rebuild]").click();
+        cy.contains("rebuilt document", { timeout: 15000 }).should("exist");
+    });
+});

--- a/packages/standalone/COORDINATION.md
+++ b/packages/standalone/COORDINATION.md
@@ -93,5 +93,13 @@ yourself (same option names, camelCase).
   core clears the mark, so an activity that recovers flushes its state like
   any other. Scrolling away from a failed activity and back reboots it, which
   doubles as a retry.
+- **Without this script**, a recent standalone bundle still staggers its own
+  boots: activity realms on one origin gate each other through the Web Locks
+  API, a few at a time, needing nothing from the host page. That fallback
+  bounds worker creation only — each iframe has already parsed the bundle by
+  the time any of our code runs in it — so it is a safety net, not a
+  substitute for the coordinator, which never loads an activity the reader
+  does not reach. The coordinator's presence turns the fallback off, so the
+  two never nest.
 - The coordinator manages iframes present at initialization
   (DOMContentLoaded); dynamically inserted activities are not yet managed.

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -24,6 +24,7 @@ import {
     fetchLocaleLoaders,
     setLocaleLoaders,
     setExternalCoreWorkerUrl,
+    markBootExternallyManaged,
 } from "@doenet/doenetml/doenetml-external-worker.js";
 import "@doenet/doenetml/style.css";
 import "./pretext-compat.css";
@@ -148,6 +149,11 @@ if (pinnedBundleUrl !== import.meta.url) {
 // here report their lifecycle to the parent and (with the `sc` variant)
 // obtain their cores from the coordinator's shared worker pool.
 const coordinatedMode = detectCoordinatedMode();
+if (coordinatedMode) {
+    // The coordinator gates this activity behind a boot slot (#1708), so no
+    // in-realm boot throttle should add a second gate underneath it.
+    markBootExternallyManaged();
+}
 if (coordinatedMode?.sharedCores) {
     installCoordinatorSharedCorePortProvider(pinnedBundleUrl);
 }

--- a/packages/test-cypress/cypress/e2e/standalone/ungatedBootGate.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/ungatedBootGate.cy.js
@@ -1,0 +1,73 @@
+// E2E for the in-realm boot gate (#1710).
+//
+// This is the case #1707 was reported from: a host page that embeds many
+// DoenetML activities as same-origin iframes and has adopted none of our boot
+// managers. Nothing on such a page staggers the boots, so every activity
+// starts its core worker at once — which on a low-end machine pushes healthy
+// handshakes past their watchdog and fails the activities outright.
+//
+// The gate inside the bundle is the fallback for exactly that page: it uses
+// Web Locks, which span every same-origin realm, so it needs nothing from the
+// host. The activity pages report when they enter and leave the handshake
+// phase; this spec asserts the peak overlap respects the cap, and that every
+// activity still finishes booting.
+
+const BOOT_TIMEOUT = 15_000;
+// Matches `maxConcurrentBoots` pinned in ungated-activity-if.html.
+const CAP = 2;
+const ACTIVITY_COUNT = 6;
+
+describe(
+    "in-realm boot gate on an uncoordinated page",
+    { tags: ["@group1"] },
+    () => {
+        it("staggers boots across same-origin activity iframes without host cooperation", () => {
+            cy.viewport(1000, 800);
+            cy.visit("/ungated-page.html");
+
+            // Every activity eventually boots — the gate delays, never drops.
+            // Six realms each parse the standalone bundle and then queue for one
+            // of two slots, so this is genuinely slow; the default 4 s would be
+            // racing the harness rather than testing the gate.
+            cy.window()
+                .its("probe", { timeout: BOOT_TIMEOUT })
+                .should((probe) => {
+                    expect(
+                        probe.ended,
+                        "activities that finished a handshake",
+                    ).to.eq(ACTIVITY_COUNT);
+                });
+
+            // The assertion that matters: they did not all boot at once. Without
+            // the gate this page's peak would be ACTIVITY_COUNT.
+            //
+            // Only the upper bound is asserted. That the gate admits CAP boots
+            // concurrently rather than degenerating to a single lock is pinned in
+            // `bootGate.test.ts` ("admits up to the cap…"), where it can be
+            // checked deterministically; here it would depend on six realms
+            // finishing their bundle parse close enough together to overlap.
+            cy.window().then((win) => {
+                expect(
+                    win.probe.peak,
+                    `peak concurrent handshakes (probe: ${JSON.stringify(win.probe)})`,
+                ).to.be.at.most(CAP);
+            });
+
+            // ...and the documents actually rendered, so the staggering did not
+            // come at the cost of a boot that never completed.
+            for (const id of ["u1", "u6"]) {
+                cy.get(`#${id}`)
+                    .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                    .should((body) => {
+                        const clone = body.cloneNode(true);
+                        clone
+                            .querySelectorAll("script")
+                            .forEach((s) => s.remove());
+                        expect(clone.textContent ?? "").to.contain(
+                            "Ungated activity",
+                        );
+                    });
+            }
+        });
+    },
+);

--- a/packages/test-cypress/public/ungated-activity-if.html
+++ b/packages/test-cypress/public/ungated-activity-if.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<!-- A PreTeXt-style activity page (…-if.html) on a host with NO coordinator
+     and no other boot manager — the Runestone situation from #1707.
+
+     It reports its core handshake to the parent so the e2e can measure how
+     many activities are inside that phase at once, which is what the
+     in-realm boot gate (#1710) bounds. The `__doenetTestCoreInitHook` seam
+     both reports and holds the phase open long enough for overlap to be
+     observable; the gate itself is production code and is not stubbed. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script
+            onload="onLoad()"
+            type="module"
+            src="/standalone/doenet-standalone.js"
+        ></script>
+        <script>
+            function report(type) {
+                parent.postMessage({ ungatedProbe: type }, "*");
+            }
+            function onLoad() {
+                const config = window.doenetGlobalConfig;
+                // Pin the cap so the assertion does not depend on the number
+                // of cores the machine running the test happens to report.
+                config.maxConcurrentBoots = 2;
+                config.__doenetTestCoreInitHook = function (phase) {
+                    if (phase !== "handshake") {
+                        return;
+                    }
+                    report("start");
+                    return new Promise(function (resolve) {
+                        setTimeout(function () {
+                            report("end");
+                            resolve();
+                        }, 700);
+                    });
+                };
+                window.renderDoenetViewerToContainer(
+                    document.querySelector(".doenetml-applet"),
+                );
+            }
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>Ungated activity</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/public/ungated-page.html
+++ b/packages/test-cypress/public/ungated-page.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<!-- A host page with several DoenetML activities and NO coordinator script —
+     the embedding PreTeXt/Runestone ships today (#1707). Nothing here caps
+     how many activities boot, so the only thing that can stagger them is the
+     in-realm gate inside the bundle (#1710).
+
+     Tallies the handshake reports the activity pages post, so the e2e can
+     assert the peak overlap. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Uncoordinated DoenetML activities</title>
+        <script>
+            window.probe = { live: 0, peak: 0, started: 0, ended: 0 };
+            window.addEventListener("message", function (event) {
+                var type = event.data && event.data.ungatedProbe;
+                if (type === "start") {
+                    window.probe.started++;
+                    window.probe.live++;
+                    window.probe.peak = Math.max(
+                        window.probe.peak,
+                        window.probe.live,
+                    );
+                } else if (type === "end") {
+                    window.probe.ended++;
+                    window.probe.live--;
+                }
+            });
+        </script>
+    </head>
+    <body>
+        <h1>Uncoordinated activities</h1>
+        <iframe id="u1" src="/ungated-activity-if.html" width="600" height="150"></iframe>
+        <iframe id="u2" src="/ungated-activity-if.html" width="600" height="150"></iframe>
+        <iframe id="u3" src="/ungated-activity-if.html" width="600" height="150"></iframe>
+        <iframe id="u4" src="/ungated-activity-if.html" width="600" height="150"></iframe>
+        <iframe id="u5" src="/ungated-activity-if.html" width="600" height="150"></iframe>
+        <iframe id="u6" src="/ungated-activity-if.html" width="600" height="150"></iframe>
+    </body>
+</html>


### PR DESCRIPTION
Fourth and last of the PRs splitting this PR's original scope apart. The other three — #1720, #1721, #1722 — have all merged; this one is rebased onto `main` and shows only its own work.

**Draft on purpose.** This is the only piece of the original PR that is useless under `coordinator.ts` — `acquireBootSlot` returns immediately when a host manager is present. If PreTeXt adopts the coordinator, this never needs to merge. The three PRs it stacked on stand on their own either way; that is why they were split off and have merged.

## What it does

Every embedding of ours that puts many documents on one page caps how many boot at once, but all of those caps live on the parent page and are opt-in. PreTeXt/Runestone has adopted none of them: a textbook section starts every activity simultaneously, each parsing a 12 MB bundle and spawning a worker that parses 15 MB more, and on the machine in #1707 the resulting contention failed them all.

When no embedding layer is scheduling boots, a document now holds one of a few page-wide slots across its handshake and retry ladder. The slots are Web Locks, chosen over a hand-rolled `BroadcastChannel` protocol for one decisive reason: the browser releases a lock when the realm holding it goes away, so a crashed or navigated activity cannot wedge the queue for its siblings. They are origin-scoped, so activity iframes gate against each other with no host script — and other tabs on the same site, contending for the same CPU, share the cap.

A boot that finds every slot busy queues on **all** of them and takes whichever frees first, withdrawing the rest through a shared `AbortController`, so free capacity is never idle while a boot waits behind a busier slot.

Only a document's **first** boot waits. The stampede being bounded is N documents starting at once on page load; a rebuild is one already-visible document replacing its core. Gating rebuilds made an on-screen document queue behind other documents' first boots to show its own update, and serialized an editor's entire startup through one slot — that is what broke `DoenetEditor.diagnosticHoverLocale` and `DocViewer/i18n` in CI on the original branch.

It fails open in every direction: no Web Locks, a rejected request, or a wait past `GATE_WAIT_TIMEOUT_MS` all boot ungated. A document that never boots is worse than a contended one. And it bounds worker creation and WASM compilation only — the bundle parse happens in each iframe realm before any of our code runs there.

## The stand-down rule (#1708)

Nesting this under an existing host cap composes multiplicatively and would serialize a managed page, slowly and for reasons hard to attribute, on exactly the slow machines the cap exists to help. `doenetGlobalConfig.externallyManagedBoot` records that something outside the realm already schedules the boot; `markBootExternallyManaged` is exported for hosts that cap boots themselves. The coordinator and windowed viewers set it from signals they already carried. Editors had none, so `<DoenetEditor>` gains `bootManagedByHost`, which the docs site passes from its editor mount manager.

The answer is supplied, never discovered: only the embedding layer can know, and guessing wrong is expensive in both directions.

## Testing

- `bootGate.test.ts` — the cap, the work-conserving queue withdrawal, standing down under a host manager, and each fail-open path.
- `DoenetViewer.rebuildNotGated.cy.tsx` — a rebuild proceeds while another document holds the page's only slot.
- `ungatedBootGate.cy.js` — six activities on a page with no coordinator: peak concurrency stays at the cap (it would equal six without the gate) and all six still render.
- Full boot battery: four packages rebuilt, `DocViewer/i18n` three times at 38 passing, plus every standalone spec.

Closes #1710. Closes #1708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



