### PR TITLE
Free a boot slot when a document's core fails to start

### DIFF
--- a/.changeset/boot-slot-release-on-failure.md
+++ b/.changeset/boot-slot-release-on-failure.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Free a boot slot when a document's core fails to start.
+
+Hosts that cap how many documents boot at once released a slot only from `initializedCallback`, so a failed boot held one until the manager's own watchdog expired: 90 s for the `@doenet/standalone` coordinator and for windowed `@doenet/doenetml-iframe` viewers, 30 s for the docs site's editors. The queue that exists to keep a page from overloading was starved by the failures themselves.
+
+`DoenetViewer` and `DoenetEditor` gain **`coreStartFailedCallback`**, the failure counterpart of `initializedCallback`. It fires once per core-start attempt and covers every way a start can end without a core: handshake retries exhausted, a rejected evaluation, or a document-state load that failed. A windowed `@doenet/doenetml-iframe` viewer releases its slot on the signal whether or not the host passed a callback of its own, and the docs site's editors release theirs the same way.
+
+The standalone bundle posts `bootFailed` to a parent-page coordinator, which frees the slot and marks the activity `failed` — still budgeted and still parkable, but parking skips the state flush, since a failed realm has no core to answer one and whatever it last reported is already warehoused. A later attempt in that realm that does start a core clears the mark, so an activity that recovers flushes its state like any other. A failure that lands while the activity is already parking is not lost either: the flush in flight will never be answered, so the coordinator stops waiting for it — detaching at once off-screen, and keeping the `failed` mark if the reader scrolled back mid-flush.
+
+The coordinator script also accepts `data-boot-watchdog-ms`, the one option that had no data attribute.

--- a/.changeset/boot-slot-release-on-failure.md
+++ b/.changeset/boot-slot-release-on-failure.md
@@ -2,6 +2,8 @@
 "@doenet/doenetml": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
 ---
 
 Free a boot slot when a document's core fails to start.

--- a/packages/docs-nextra/components/windowed-editor.tsx
+++ b/packages/docs-nextra/components/windowed-editor.tsx
@@ -71,11 +71,18 @@ export function WindowedEditor({
         }
     }, []);
 
-    // Fires once the editor's document renders — the boot is done, so free the
-    // slot for the next queued editor. Stable identity (only depends on the
-    // stable `id`/`clearWatchdog`) so it is not re-proxied across the iframe
-    // Comlink boundary on every render (which would leak a MessagePort).
-    const onDocumentStructure = React.useCallback(() => {
+    // This editor's boot is over, whichever way it ended: the document
+    // rendered (`documentStructureCallback`), or its core could not be started
+    // at all (`coreStartFailedCallback`, #1709). Either way the slot is free
+    // for the next queued editor — a failing editor that held its slot for the
+    // full `EDITOR_BOOT_WATCHDOG_MS` would delay every editor behind it on a
+    // page that is already struggling. Latched, so the first outcome to land
+    // releases once.
+    //
+    // Stable identity (only depends on the stable `id`/`clearWatchdog`) so it
+    // is not re-proxied across the iframe Comlink boundary on every render
+    // (which would leak a MessagePort).
+    const concludeBoot = React.useCallback(() => {
         if (bootCompleteRef.current) {
             return;
         }
@@ -186,7 +193,8 @@ export function WindowedEditor({
                     showFormatter={showFormatter}
                     viewerLocation={viewerLocation}
                     height={height}
-                    documentStructureCallback={onDocumentStructure}
+                    documentStructureCallback={concludeBoot}
+                    coreStartFailedCallback={concludeBoot}
                     {...versionProps}
                 />
             ) : (

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -289,6 +289,9 @@ again (parked when off-screen and over budget).
 Notes:
 
 - Eviction is least-recently-visible first.
+- A boot slot is released when the viewer's document initializes *or* when
+  its core cannot be started at all, so a failed activity does not hold a
+  slot until the wrapper's 90 s boot watchdog expires.
 - While parked, a viewer emits no reports (its state was flushed at park
   time). A host `SPLICE.flushState` broadcast is answered by the wrapper on
   the parked viewer's behalf, so pre-navigation flush round-trips don't

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -20,6 +20,7 @@ import type {
 import {
     DoenetViewerProps,
     DoenetEditorProps,
+    BOOT_CONCLUDING_CALLBACKS,
     createHtmlForDoenetViewer,
     createHtmlForDoenetEditor,
     setIframeBodyBackground,
@@ -370,43 +371,61 @@ export function DoenetViewer({
         clearBootWatchdog();
         releaseBootSlot(id);
     }
-    // Stable composed initializedCallback: releases this viewer's boot slot,
-    // then forwards to the host's latest callback. Registered with the
-    // iframe instead of the host's own callback when windowed (the iframe
-    // side sees one stable identity; the host's identity is still what the
+    // Stable composed callbacks: release this viewer's boot slot, then
+    // forward to the host's latest callback of the same name. Registered with
+    // the iframe instead of the host's own when windowed (the iframe side
+    // sees one stable identity; the host's identity is still what the
     // function-prop change detection compares).
-    const composedInitializedCallbackRef = React.useRef<
-        ((arg: unknown) => void) | null
-    >(null);
-    if (composedInitializedCallbackRef.current === null) {
-        composedInitializedCallbackRef.current = (arg: unknown) => {
-            relinquishBootSlot();
-            (doenetViewerPropsRef.current as any).initializedCallback?.(arg);
-        };
+    const composedBootCallbacksRef = React.useRef<Record<
+        string,
+        (arg: unknown) => void
+    > | null>(null);
+    if (composedBootCallbacksRef.current === null) {
+        // Null-prototype: `functionPropToProxy` looks names up in here by
+        // host-supplied key, and an object literal would answer `toString`
+        // (and every other `Object.prototype` member) with a function that is
+        // not a composed callback at all.
+        const composed = Object.create(null) as Record<
+            string,
+            (arg: unknown) => void
+        >;
+        for (const key of BOOT_CONCLUDING_CALLBACKS) {
+            composed[key] = (arg: unknown) => {
+                relinquishBootSlot();
+                (doenetViewerPropsRef.current as any)[key]?.(arg);
+            };
+        }
+        composedBootCallbacksRef.current = composed;
     }
     /** Proxy the composed callback for windowed viewers, the raw one otherwise. */
     function functionPropToProxy(key: string, prop: Function): Function {
-        if (windowed && key === "initializedCallback") {
-            return composedInitializedCallbackRef.current!;
+        const composed = composedBootCallbacksRef.current![key];
+        if (windowed && composed) {
+            return composed;
         }
         return prop;
     }
     /**
-     * Append the composed `initializedCallback` proxy to a Comlink
-     * function-prop argument list when windowed and the host supplied no
-     * `initializedCallback` of its own, so the boot-slot release still
-     * reaches the iframe. `hostFunctions` is the set of function props the
-     * host actually passed (keyed by name).
+     * Append the composed boot-concluding proxies to a Comlink function-prop
+     * argument list when windowed and the host supplied no callback of that
+     * name itself, so the boot-slot release still reaches the iframe.
+     * `hostFunctions` is the set of function props the host actually passed
+     * (keyed by name).
      */
-    function appendComposedInitializedCallback(
+    function appendComposedBootCallbacks(
         proxiedFunctions: (string | Function)[],
         hostFunctions: Record<string, Function>,
     ) {
-        if (windowed && !("initializedCallback" in hostFunctions)) {
-            proxiedFunctions.push("initializedCallback");
-            proxiedFunctions.push(
-                Comlink.proxy(composedInitializedCallbackRef.current!),
-            );
+        if (!windowed) {
+            return;
+        }
+        for (const key of BOOT_CONCLUDING_CALLBACKS) {
+            if (!(key in hostFunctions)) {
+                proxiedFunctions.push(key);
+                proxiedFunctions.push(
+                    Comlink.proxy(composedBootCallbacksRef.current![key]),
+                );
+            }
         }
     }
 
@@ -774,9 +793,9 @@ export function DoenetViewer({
                         }
                     }
                     // Windowed viewers always register the composed
-                    // initializedCallback (it releases the boot slot), even
-                    // when the host passed none.
-                    appendComposedInitializedCallback(
+                    // boot-concluding callbacks (they release the boot slot),
+                    // even when the host passed none.
+                    appendComposedBootCallbacks(
                         proxiedFunctions,
                         registeredFunctions,
                     );
@@ -898,7 +917,7 @@ export function DoenetViewer({
             proxiedFunctions.push(key);
             proxiedFunctions.push(Comlink.proxy(functionPropToProxy(key, val)));
         }
-        appendComposedInitializedCallback(proxiedFunctions, current);
+        appendComposedBootCallbacks(proxiedFunctions, current);
         const action = (remote: ViewerIframeRemote) => {
             remote
                 .updateViewerFunctionProps(...proxiedFunctions)

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -102,6 +102,18 @@ function createBootScript(
 }
 
 /**
+ * The two ways a viewer's boot can conclude, both of which must free that
+ * viewer's boot slot: the document initialized, or the core could not be
+ * started at all (#1709). Without the latter a failed boot holds its slot
+ * until `BOOT_SLOT_WATCHDOG_MS` (90 s), starving the queue on exactly the
+ * pages where boots are already failing.
+ */
+export const BOOT_CONCLUDING_CALLBACKS = [
+    "initializedCallback",
+    "coreStartFailedCallback",
+] as const;
+
+/**
  * Create HTML for a single page document that renders the given DoenetML.
  */
 export function createHtmlForDoenetViewer(
@@ -119,11 +131,14 @@ export function createHtmlForDoenetViewer(
     // Since for some callbacks, we have different behavior whether or not it was specified,
     // we pass an extra variable of the props that were specified.
     const doenetViewerPropsSpecified: string[] = Object.keys(doenetViewerProps);
-    // The wrapper may supply its own composed `initializedCallback` (the
-    // windowed-mounting boot-slot release) even when the host didn't specify
-    // one; list it so the in-iframe entry adopts the proxy when sent.
-    if (!doenetViewerPropsSpecified.includes("initializedCallback")) {
-        doenetViewerPropsSpecified.push("initializedCallback");
+    // The wrapper may supply its own composed boot-concluding callbacks (the
+    // windowed-mounting boot-slot release, on success and on failure alike)
+    // even when the host specified neither; list them so the in-iframe entry
+    // adopts the proxies when sent.
+    for (const key of BOOT_CONCLUDING_CALLBACKS) {
+        if (!doenetViewerPropsSpecified.includes(key)) {
+            doenetViewerPropsSpecified.push(key);
+        }
     }
 
     // TODO: rather than load the Doenet logo from doenet.org, serve it directly

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.windowedBootFailure.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.windowedBootFailure.cy.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/index";
+import { __resetViewerLifecycleManagerForTests } from "../../../src/viewer-lifecycle-manager";
+import {
+    STANDALONE_CSS_BLOB_URL,
+    STANDALONE_BLOB_URL,
+    CONTENT_TIMEOUT,
+} from "./helpers";
+
+// @ts-ignore - `?raw` returns a string; we don't ship types for it.
+import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone.js?raw";
+
+// Boot-slot release on core-start failure (#1709), across the Comlink
+// boundary: a windowed viewer whose embedded core cannot start reports
+// `coreStartFailedCallback` out of its iframe, and the wrapper's composed
+// callback frees the boot slot before forwarding to the host — so the next
+// queued viewer boots right away instead of waiting out the 90 s
+// BOOT_SLOT_WATCHDOG_MS.
+//
+// The failure is induced the same way the in-process coreStartFailed spec
+// does it — `doenetGlobalConfig.__doenetTestCoreInitHook` hangs the worker
+// handshake against a short single-attempt watchdog — but here the config
+// lives inside viewer A's iframe realm. The standalone bundle creates
+// `window.doenetGlobalConfig` as it evaluates, so the failing bundle is the
+// real one with the config mutation appended: it runs as the last statements
+// of the module, after the config object exists and before the boot script
+// (a later module in document order) renders anything.
+
+const FAILING_STANDALONE_BLOB_URL = URL.createObjectURL(
+    new Blob(
+        [
+            STANDALONE_SOURCE,
+            `
+;window.doenetGlobalConfig.coreBootMaxAttempts = 1;
+window.doenetGlobalConfig.coreHandshakeWatchdogMs = 500;
+window.doenetGlobalConfig.__doenetTestCoreInitHook = (phase) =>
+    phase === "handshake" ? new Promise(() => {}) : undefined;
+`,
+        ],
+        { type: "application/javascript" },
+    ),
+);
+
+// One boot slot page-wide, so viewer B can only boot once viewer A's slot is
+// free. Both viewers stay within the live budget — only the boot cap is
+// contended.
+const MOUNT_POLICY = {
+    mode: "windowed" as const,
+    maxLiveViewers: 2,
+    maxConcurrentBoots: 1,
+    parkDelayMs: 300,
+    visibleMargin: "100px",
+};
+
+const failures: unknown[] = [];
+
+function Harness() {
+    return (
+        <div>
+            {/* Fixed-height containers, both short enough to overlap a
+                600px viewport, so A and B are visible together and both
+                request a boot slot at mount (same layout reasoning as the
+                lazyMount spec). A, first in document order, gets the slot. */}
+            <div
+                data-test="viewer-a"
+                style={{ height: "250px", overflow: "hidden" }}
+            >
+                <DoenetViewer
+                    doenetML={`<p>Viewer A never boots</p>`}
+                    activityId="bootfail-act-A"
+                    docId="bootfail-doc-A"
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    coreStartFailedCallback={(arg: unknown) => {
+                        failures.push(arg);
+                    }}
+                    standaloneUrl={FAILING_STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>
+            <div
+                data-test="viewer-b"
+                style={{ height: "250px", overflow: "hidden" }}
+            >
+                <DoenetViewer
+                    doenetML={`<p>Viewer B content</p>`}
+                    activityId="bootfail-act-B"
+                    docId="bootfail-doc-B"
+                    flags={{ allowSaveState: true }}
+                    mountPolicy={MOUNT_POLICY}
+                    standaloneUrl={STANDALONE_BLOB_URL}
+                    cssUrl={STANDALONE_CSS_BLOB_URL}
+                    addVirtualKeyboard={false}
+                />
+            </div>
+        </div>
+    );
+}
+
+/** Assert the viewer's document rendered the given text (see lazyMount). */
+function assertRenders(which: string, text: string) {
+    cy.get(`[data-test=${which}] iframe`, { timeout: CONTENT_TIMEOUT })
+        .its("0.contentDocument.body", { timeout: CONTENT_TIMEOUT })
+        .should((body: any) => {
+            const clone = (body as HTMLElement).cloneNode(true) as HTMLElement;
+            clone.querySelectorAll("script").forEach((s) => s.remove());
+            expect(
+                (clone.textContent ?? "").includes(text),
+                `${which} rendered "${text}"`,
+            ).to.eq(true);
+        });
+}
+
+describe("DoenetViewer (iframe wrapper) — boot-slot release on core-start failure", () => {
+    beforeEach(() => {
+        __resetViewerLifecycleManagerForTests();
+        failures.length = 0;
+    });
+
+    it("frees the failed viewer's boot slot and forwards the failure to the host", () => {
+        cy.viewport(900, 600);
+        cy.mount(<Harness />);
+
+        // The host hears the failure: the composed callback releases the
+        // slot and then forwards to the callback passed as a prop, through
+        // the Comlink proxy from inside viewer A's iframe.
+        cy.wrap(null, { timeout: CONTENT_TIMEOUT }).should(() => {
+            expect(
+                failures.length,
+                "host coreStartFailedCallback calls",
+            ).to.be.greaterThan(0);
+        });
+
+        // Viewer A shows the inner viewer's give-up UI rather than content.
+        assertRenders("viewer-a", "could not be started");
+
+        // Viewer B, queued behind A on the single boot slot, boots and
+        // renders well within CONTENT_TIMEOUT — far below the 90 s
+        // BOOT_SLOT_WATCHDOG_MS, so the slot was freed by the failure
+        // signal, not reclaimed by the watchdog.
+        assertRenders("viewer-b", "Viewer B content");
+    });
+});

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -176,6 +176,12 @@ type EditorViewerProps = {
     doenetmlChangeCallback?: Function;
     immediateDoenetmlChangeCallback?: Function;
     documentStructureCallback?: Function;
+    /**
+     * Forwarded to the embedded `DocViewer` (#1709): the failure
+     * counterpart of its initialization signal, so a host that schedules
+     * this editor's boot can free the slot when the core cannot start.
+     */
+    coreStartFailedCallback?: Function;
     diagnosticsSummaryCallback?: (
         diagnosticsSummary: DiagnosticsSummary,
         doenetML: string,
@@ -269,6 +275,7 @@ export const EditorViewer = React.forwardRef<
         doenetmlChangeCallback,
         immediateDoenetmlChangeCallback,
         documentStructureCallback,
+        coreStartFailedCallback,
         diagnosticsSummaryCallback,
         id: specifiedId,
         readOnly = false,
@@ -1405,6 +1412,7 @@ export const EditorViewer = React.forwardRef<
                     documentStructureCallback={
                         documentStructureThenChangeCallback
                     }
+                    coreStartFailedCallback={coreStartFailedCallback}
                     doenetViewerUrl={doenetViewerUrl}
                     doenetImagesUrl={doenetImagesUrl}
                     darkMode={darkMode}

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -854,7 +854,28 @@ export function DocViewer({
                         coreCreationInProgress.current = false;
                         loadedInitialRendererState.current = false;
 
-                        processLoadedDocState(e.data.state);
+                        try {
+                            processLoadedDocState(e.data.state);
+                        } catch (err: any) {
+                            // Malformed host-persisted state. Everything from
+                            // the `coreId` re-roll above to here is
+                            // synchronous, so this handler still owns the
+                            // attempt it is failing. The core will never be
+                            // started, so a host holding a boot slot for this
+                            // document has to hear about it (#1709). Report
+                            // just the failure signal, keeping the specific
+                            // message below on screen (`failCoreStart` would
+                            // overwrite it with the generic one).
+                            setIsInErrorState?.(true);
+
+                            let message = "";
+                            if ("message" in err) {
+                                message = err.message;
+                            }
+                            setErrMsg(`Error loading doc state: ${message}`);
+                            reportCoreStartFailed();
+                            return;
+                        }
 
                         if (render) {
                             startCoreSafely();

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -529,11 +529,10 @@ export function DocViewer({
     const coreCreated = useRef(false);
     const coreCreationInProgress = useRef(false);
     // The `coreId` whose core-start attempt has already been reported to
-    // `coreStartFailedCallback` (#1709). Keyed by id rather than latched with
-    // a boolean because `coreId` is re-rolled for every rebuild of the
-    // document: that is exactly the granularity the callback promises ("once
-    // per core-start attempt"), and it needs no separate reset. See
-    // `reportCoreStartFailed`.
+    // `coreStartFailedCallback` (#1709). `coreId` is re-rolled for every
+    // rebuild of the document, so keying on it gives the callback exactly the
+    // granularity it promises ("once per core-start attempt") and needs no
+    // separate reset. See `reportCoreStartFailed`.
     const coreStartFailureReportedFor = useRef<string | null>(null);
     // Set by the unmount cleanup below. `startCore` waits several times over
     // — on the saved-state load, on each handshake, on the evaluation that
@@ -1800,9 +1799,9 @@ export function DocViewer({
                     setErrMsg(`Error loading doc state: ${message}`);
                     // The core will never be started, so a host holding a boot
                     // slot for this document has to hear about it (#1709).
-                    // Reported directly rather than through `failCoreStart`,
-                    // which would replace the specific message above with the
-                    // generic one.
+                    // Report just the failure signal, keeping the specific
+                    // message above on screen (`failCoreStart` would overwrite
+                    // it with the generic one).
                     reportCoreStartFailed();
                     return;
                 }

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -131,6 +131,7 @@ export function DocViewer({
     reportScoreAndStateCallback: specifiedReportScoreAndStateCallback,
     documentStructureCallback,
     initializedCallback,
+    coreStartFailedCallback,
     setIsInErrorState,
     prefixForIds = "",
     doenetViewerUrl,
@@ -176,6 +177,20 @@ export function DocViewer({
     }) => void;
     documentStructureCallback?: Function;
     initializedCallback?: Function;
+    /**
+     * The failure counterpart of `initializedCallback` (#1709): called once
+     * when the core cannot be started and the viewer enters its visible error
+     * state — its handshake retries exhausted, or the boot derailed some other
+     * way (a rejected `generateDast`, a failed state load).
+     *
+     * Hosts that cap boot concurrency release a boot slot on
+     * `initializedCallback`; without this signal a failed boot holds its slot
+     * until their watchdog expires (30–90 s), starving the queue precisely
+     * when a page is already struggling. Called at most once per core-start
+     * attempt, and never for a document that merely reports errors — those
+     * booted fine.
+     */
+    coreStartFailedCallback?: Function;
     setIsInErrorState?: Function;
     prefixForIds?: string;
     doenetViewerUrl?: string;
@@ -513,6 +528,13 @@ export function DocViewer({
     const loadedInitialRendererState = useRef(false);
     const coreCreated = useRef(false);
     const coreCreationInProgress = useRef(false);
+    // The `coreId` whose core-start attempt has already been reported to
+    // `coreStartFailedCallback` (#1709). Keyed by id rather than latched with
+    // a boolean because `coreId` is re-rolled for every rebuild of the
+    // document: that is exactly the granularity the callback promises ("once
+    // per core-start attempt"), and it needs no separate reset. See
+    // `reportCoreStartFailed`.
+    const coreStartFailureReportedFor = useRef<string | null>(null);
     // Set by the unmount cleanup below. `startCore` waits several times over
     // — on the saved-state load, on each handshake, on the evaluation that
     // follows — and the teardown that runs on unmount cannot cancel those
@@ -1776,6 +1798,12 @@ export function DocViewer({
                         message = e.message;
                     }
                     setErrMsg(`Error loading doc state: ${message}`);
+                    // The core will never be started, so a host holding a boot
+                    // slot for this document has to hear about it (#1709).
+                    // Reported directly rather than through `failCoreStart`,
+                    // which would replace the specific message above with the
+                    // generic one.
+                    reportCoreStartFailed();
                     return;
                 }
             }
@@ -1865,6 +1893,26 @@ export function DocViewer({
             ),
         );
         setHasInitialError(true);
+        reportCoreStartFailed();
+    }
+
+    /**
+     * Tell a boot-scheduling host that this document's core-start attempt is
+     * over and failed (#1709), so it can free the slot it is holding rather
+     * than wait out its own watchdog.
+     *
+     * At most once per attempt: several paths can conclude the same one —
+     * `startCore` reports the failure and returns, and `startCoreSafely`
+     * reports again if that same call also throws — and a host that released
+     * a slot per notification would over-release. A rebuild re-rolls `coreId`,
+     * which is what makes the next attempt reportable again.
+     */
+    function reportCoreStartFailed() {
+        if (coreStartFailureReportedFor.current === coreId.current) {
+            return;
+        }
+        coreStartFailureReportedFor.current = coreId.current;
+        coreStartFailedCallback?.({ activityId, docId });
     }
 
     // The core-worker *handshake*: (re)create the worker and run the cheap,
@@ -1925,7 +1973,8 @@ export function DocViewer({
      * `reinitializeCoreAndTerminateAnimations`, which owns the single
      * `coreWorker` ref) and fail a document that is booting fine; a stale
      * conclusion of either kind puts its message over what the successor has
-     * on screen.
+     * on screen, and spends the successor's single `reportCoreStartFailed`,
+     * which latches on the CURRENT `coreId`.
      *
      * The waits on both paths make that window wide: a load awaits a cid and
      * then IndexedDB, and a boot awaits a handshake per attempt and then the
@@ -2141,8 +2190,9 @@ export function DocViewer({
                 // `reinitializeCoreAndTerminateAnimations` disposed the worker
                 // this ladder was driving, so the rejection is the teardown
                 // being observed from the losing side (#1714). Reporting it
-                // would put the give-up screen over a document the successor
-                // is booting fine.
+                // would put the give-up screen — and a
+                // `coreStartFailedCallback`, which frees a host's boot slot —
+                // over a document the successor is booting fine.
                 await standDown();
                 return;
             }
@@ -2238,10 +2288,11 @@ export function DocViewer({
         runBootLadder(launchedFor).catch((e) => {
             console.warn("DocViewer: startCore failed unexpectedly", e);
             // Only a ladder that still owns the document and has not already
-            // delivered it may raise the give-up screen. A superseded
-            // ladder's throw is no more its to report than its ordinary
-            // outcome is — the same rule `standDown` follows — and the
-            // ladder's very last step is `initializedCallback`, a host
+            // delivered it may raise the give-up screen (and with it a
+            // `coreStartFailedCallback`, which frees a host's boot slot).
+            // A superseded ladder's throw is no more its to report than its
+            // ordinary outcome is — the same rule `standDown` follows — and
+            // the ladder's very last step is `initializedCallback`, a host
             // handler running after the document is already on screen.
             if (!stillSpeaksForDocument(launchedFor) || coreCreated.current) {
                 return;
@@ -2560,8 +2611,9 @@ export function DocViewer({
             // has to become a visible error rather than an unhandled
             // rejection. Only while the load still speaks for the document,
             // though: it waits on a cid and on IndexedDB, so a rebuild can
-            // supersede it, and a stale give-up screen would cover what the
-            // successor is showing — see `stillSpeaksForDocument`.
+            // supersede it, and a stale give-up screen would both cover what
+            // the successor is showing and spend its single
+            // `reportCoreStartFailed` — see `stillSpeaksForDocument`.
             if (stillSpeaksForDocument(loadingFor)) {
                 failCoreStart();
             }

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -131,6 +131,7 @@ export function DoenetViewer({
     generatedVariantCallback: specifiedGeneratedVariantCallback,
     documentStructureCallback,
     initializedCallback,
+    coreStartFailedCallback,
     setDiagnosticsCallback,
     setErrorsAndWarningsCallback,
     forceDisable = false,
@@ -178,6 +179,12 @@ export function DoenetViewer({
     generatedVariantCallback?: Function;
     documentStructureCallback?: Function;
     initializedCallback?: Function;
+    /**
+     * The failure counterpart of `initializedCallback` (#1709): called once
+     * when the core could not be started. See `DocViewer` for the full
+     * contract and for why a boot-scheduling host needs it.
+     */
+    coreStartFailedCallback?: Function;
     setDiagnosticsCallback?: (
         diagnostics: DiagnosticRecord[],
         source: string,
@@ -420,6 +427,7 @@ export function DoenetViewer({
             generatedVariantCallback={generatedVariantCallback}
             documentStructureCallback={documentStructureCallback}
             initializedCallback={initializedCallback}
+            coreStartFailedCallback={coreStartFailedCallback}
             setDiagnosticsCallback={effectiveDiagnosticsCallback}
             forceDisable={forceDisable}
             forceShowCorrectness={forceShowCorrectness}
@@ -549,6 +557,12 @@ type DoenetEditorProps = {
     doenetmlChangeCallback?: Function;
     immediateDoenetmlChangeCallback?: Function;
     documentStructureCallback?: Function;
+    /**
+     * The failure counterpart of the embedded viewer's initialization signal
+     * (#1709). A host that caps how many editors boot at once releases the
+     * slot on initialization; this frees it when the core cannot start.
+     */
+    coreStartFailedCallback?: Function;
     diagnosticsSummaryCallback?: (
         diagnosticsSummary: DiagnosticsSummary,
         doenetML: string,
@@ -618,6 +632,7 @@ export const DoenetEditor = React.forwardRef<
         doenetmlChangeCallback,
         immediateDoenetmlChangeCallback,
         documentStructureCallback,
+        coreStartFailedCallback,
         diagnosticsSummaryCallback,
         id,
         readOnly = false,
@@ -711,6 +726,7 @@ export const DoenetEditor = React.forwardRef<
             doenetmlChangeCallback={doenetmlChangeCallback}
             immediateDoenetmlChangeCallback={immediateDoenetmlChangeCallback}
             documentStructureCallback={documentStructureCallback}
+            coreStartFailedCallback={coreStartFailedCallback}
             diagnosticsSummaryCallback={diagnosticsSummaryCallback}
             id={id}
             readOnly={readOnly}

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
@@ -153,9 +153,8 @@ describe("DoenetViewer coreStartFailedCallback (#1709)", () => {
         // The transition OUT of the failure state. A failed boot leaves the
         // viewer showing the give-up screen with its stage still parked where
         // the ladder left it and its report latch spent — so a rebuild has to
-        // reach the launch site again, take a boot slot again, and deliver a
-        // document over the error UI. This is
-        // the transition a boot-scheduling host depends on: the
+        // reach the launch site again and deliver a document over the error
+        // UI. This is the transition a boot-scheduling host depends on: the
         // `@doenet/standalone` coordinator marks a failed activity `failed`
         // and skips its state flush at park time, and only a later attempt
         // that actually starts a core clears that mark.

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
@@ -152,9 +152,9 @@ describe("DoenetViewer coreStartFailedCallback (#1709)", () => {
     it("boots normally when a rebuild follows a failed attempt", () => {
         // The transition OUT of the failure state. A failed boot leaves the
         // viewer showing the give-up screen with its stage still parked where
-        // the ladder left it, its report latch spent, and `hasBootedOnce`
-        // still false — so a rebuild has to reach the launch site again, take
-        // a boot slot again, and deliver a document over the error UI. This is
+        // the ladder left it and its report latch spent — so a rebuild has to
+        // reach the launch site again, take a boot slot again, and deliver a
+        // document over the error UI. This is
         // the transition a boot-scheduling host depends on: the
         // `@doenet/standalone` coordinator marks a failed activity `failed`
         // and skips its state flush at park time, and only a later attempt

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
@@ -74,6 +74,70 @@ describe("DoenetViewer coreStartFailedCallback (#1709)", () => {
         });
     });
 
+    it("fires when host-persisted state arrives malformed over SPLICE", () => {
+        // The state-load counterpart of the handshake failures above: the
+        // viewer asks its host for saved state (`SPLICE.getState`), and the
+        // response carries a `coreInfo` that is not valid JSON. Processing it
+        // throws before a core is ever started for the rebuilt document, so
+        // the host must hear the failure signal or its boot slot stays
+        // pinned. Component tests share the viewer's window, so the spec
+        // itself can play the host on the same `postMessage` channel.
+        const failures: unknown[] = [];
+        let initialized = 0;
+
+        const hostListener = (e: MessageEvent) => {
+            if (
+                typeof e.data === "object" &&
+                e.data?.subject === "SPLICE.getState"
+            ) {
+                window.postMessage({
+                    subject: "SPLICE.getState.response",
+                    message_id: e.data.message_id,
+                    state: {
+                        cid: e.data.cid,
+                        coreInfo: "this is not JSON",
+                        coreState: "{}",
+                    },
+                });
+            }
+        };
+        window.addEventListener("message", hostListener);
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>state never loads</p>"
+                addVirtualKeyboard={false}
+                flags={{ allowLoadState: true }}
+                initializedCallback={() => {
+                    initialized++;
+                }}
+                coreStartFailedCallback={(arg: unknown) => {
+                    failures.push(arg);
+                }}
+            />,
+        );
+
+        // The specific load error stays on screen (not the generic
+        // could-not-be-started message)...
+        cy.contains("Error loading doc state", { timeout: 8000 }).should(
+            "exist",
+        );
+
+        // ...and the host hears exactly one failure and no initialization:
+        // the response re-rolled the document's core id, so the boot the
+        // viewer had already launched no longer speaks for it.
+        cy.wrap(null, { timeout: 4000 }).should(() => {
+            expect(failures.length, "coreStartFailedCallback calls").to.eq(1);
+        });
+        cy.then(() => {
+            expect(
+                initialized,
+                "initializedCallback must not fire for a failed state load",
+            ).to.eq(0);
+            window.removeEventListener("message", hostListener);
+        });
+    });
+
     it("stays silent for a healthy boot", () => {
         let failures = 0;
         let initialized = 0;

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartFailed.cy.tsx
@@ -1,0 +1,233 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+import { doenetGlobalConfig } from "../../../src/global-config";
+
+// Component coverage for `coreStartFailedCallback` (#1709): the failure
+// counterpart of `initializedCallback`.
+//
+// Hosts that cap how many documents boot at once release a boot slot when a
+// viewer reports it initialized. Before this callback existed there was no
+// signal for the other outcome, so a viewer that exhausted its handshake
+// retries held its slot until the host's own watchdog expired (30–90 s) —
+// starving the boot queue on exactly the pages where boots are failing.
+//
+// Failures are induced through the `__doenetTestCoreInitHook` seam, the same
+// way DoenetViewer.sharedCoreWorker.cy.tsx drives the watchdog.
+
+/** Hang every handshake attempt, so the retry ladder runs out. */
+function hangEveryHandshake() {
+    doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
+        if (phase === "handshake") {
+            return new Promise<void>(() => {
+                /* never resolves */
+            });
+        }
+    };
+}
+
+describe("DoenetViewer coreStartFailedCallback (#1709)", () => {
+    afterEach(() => {
+        delete doenetGlobalConfig.__doenetTestCoreInitHook;
+        delete doenetGlobalConfig.coreHandshakeWatchdogMs;
+        delete doenetGlobalConfig.coreBootMaxAttempts;
+    });
+
+    it("fires once when the core cannot be started, and not on the way there", () => {
+        // One attempt against a short watchdog: the whole ladder is spent in
+        // well under a second, so this test measures the callback, not the
+        // (deliberately generous) production timeout.
+        doenetGlobalConfig.coreBootMaxAttempts = 1;
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 500;
+        hangEveryHandshake();
+
+        const failures: unknown[] = [];
+        let initialized = 0;
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>never boots</p>"
+                addVirtualKeyboard={false}
+                initializedCallback={() => {
+                    initialized++;
+                }}
+                coreStartFailedCallback={(arg: unknown) => {
+                    failures.push(arg);
+                }}
+            />,
+        );
+
+        // The viewer surfaces its error state rather than staying blank...
+        cy.contains("could not be started", { timeout: 8000 }).should("exist");
+
+        // ...and reports the failure exactly once. The "once" matters: two
+        // paths funnel into `failCoreStart` (startCore returning, and
+        // startCoreSafely catching a throw from the same call), and a host
+        // that released a slot per notification would over-release.
+        cy.wrap(null, { timeout: 4000 }).should(() => {
+            expect(failures.length, "coreStartFailedCallback calls").to.eq(1);
+        });
+        cy.then(() => {
+            expect(
+                initialized,
+                "initializedCallback must not fire for a failed boot",
+            ).to.eq(0);
+        });
+    });
+
+    it("stays silent for a healthy boot", () => {
+        let failures = 0;
+        let initialized = 0;
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>boots fine</p>"
+                addVirtualKeyboard={false}
+                initializedCallback={() => {
+                    initialized++;
+                }}
+                coreStartFailedCallback={() => {
+                    failures++;
+                }}
+            />,
+        );
+
+        cy.contains("boots fine", { timeout: 20000 }).should("exist");
+        cy.wrap(null, { timeout: 8000 }).should(() => {
+            expect(initialized, "initializedCallback fired").to.be.greaterThan(
+                0,
+            );
+        });
+        cy.then(() => {
+            expect(failures, "coreStartFailedCallback calls").to.eq(0);
+        });
+    });
+
+    it("reports again when a later attempt fails, so a rebuild is not silent", () => {
+        // The report latch is per core-start attempt, not per viewer. The
+        // second attempt here is a *rebuild of the same viewer* — a changed
+        // `doenetML`, the path an editor preview takes on every recompile —
+        // rather than a remount, because only the rebuild keeps the refs the
+        // latch lives in. A host that released a slot for the rebuild must
+        // hear that this attempt failed too.
+        doenetGlobalConfig.coreBootMaxAttempts = 1;
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 500;
+        hangEveryHandshake();
+
+        let failures = 0;
+
+        function Rebuildable() {
+            const [generation, setGeneration] = React.useState(0);
+            return (
+                <div>
+                    <button
+                        data-test="rebuild"
+                        onClick={() => setGeneration((g) => g + 1)}
+                    >
+                        rebuild
+                    </button>
+                    <DoenetViewer
+                        doenetML={`<p>never boots ${generation}</p>`}
+                        addVirtualKeyboard={false}
+                        coreStartFailedCallback={() => {
+                            failures++;
+                        }}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Rebuildable />);
+
+        cy.wrap(null, { timeout: 8000 }).should(() => {
+            expect(failures, "first failure reported").to.eq(1);
+        });
+
+        cy.get("[data-test=rebuild]").click();
+
+        cy.wrap(null, { timeout: 8000 }).should(() => {
+            expect(failures, "second failure reported").to.eq(2);
+        });
+    });
+
+    it("boots normally when a rebuild follows a failed attempt", () => {
+        // The transition OUT of the failure state. A failed boot leaves the
+        // viewer showing the give-up screen with its stage still parked where
+        // the ladder left it, its report latch spent, and `hasBootedOnce`
+        // still false — so a rebuild has to reach the launch site again, take
+        // a boot slot again, and deliver a document over the error UI. This is
+        // the transition a boot-scheduling host depends on: the
+        // `@doenet/standalone` coordinator marks a failed activity `failed`
+        // and skips its state flush at park time, and only a later attempt
+        // that actually starts a core clears that mark.
+        //
+        // The short watchdog is lifted along with the stall: it is what makes
+        // the first attempt give up quickly, but a *real* handshake (worker
+        // boot plus WASM compile) needs far longer than 500 ms, so leaving it
+        // pinned would fail the recovery for reasons that have nothing to do
+        // with the post-failure state.
+        doenetGlobalConfig.coreBootMaxAttempts = 1;
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 500;
+        let stallHandshakes = true;
+        doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
+            if (phase === "handshake" && stallHandshakes) {
+                return new Promise<void>(() => {
+                    /* never resolves */
+                });
+            }
+        };
+
+        let failures = 0;
+        let initializations = 0;
+
+        function Rebuildable() {
+            const [generation, setGeneration] = React.useState(0);
+            return (
+                <div>
+                    <button
+                        data-test="recover"
+                        onClick={() => {
+                            stallHandshakes = false;
+                            delete doenetGlobalConfig.coreHandshakeWatchdogMs;
+                            setGeneration((g) => g + 1);
+                        }}
+                    >
+                        recover
+                    </button>
+                    <DoenetViewer
+                        doenetML={
+                            generation === 0
+                                ? "<p>never boots</p>"
+                                : "<p>recovered document</p>"
+                        }
+                        addVirtualKeyboard={false}
+                        initializedCallback={() => {
+                            initializations++;
+                        }}
+                        coreStartFailedCallback={() => {
+                            failures++;
+                        }}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Rebuildable />);
+        cy.contains("could not be started", { timeout: 8000 }).should("exist");
+
+        cy.get("[data-test=recover]").click();
+
+        // The give-up screen gives way to the rebuilt document...
+        cy.contains("recovered document", { timeout: 20000 }).should("exist");
+        cy.contains("could not be started").should("not.exist");
+        // ...and the host hears exactly one of each signal: the failure for
+        // the attempt that failed, the initialization for the one that did
+        // not. A second failure report here would leave a coordinator holding
+        // the activity as `failed` even though it now has a core.
+        cy.wrap(null, { timeout: 8000 }).should(() => {
+            expect(initializations, "initializedCallback calls").to.eq(1);
+        });
+        cy.then(() => {
+            expect(failures, "coreStartFailedCallback calls").to.eq(1);
+        });
+    });
+});

--- a/packages/standalone/COORDINATION.md
+++ b/packages/standalone/COORDINATION.md
@@ -48,10 +48,16 @@ Options are read from the script tag's `data-` attributes:
     data-visible-margin="1000px"
     data-park-delay-ms="2000"
     data-flush-timeout-ms="5000"
+    data-boot-watchdog-ms="90000"
     data-shared-core-workers="true"
     data-iframe-selector="iframe[src$='-if.html']"
 ></script>
 ```
+
+`data-boot-watchdog-ms` (default 90000) is the backstop for an activity that
+never reports either outcome of its boot — an ancient bundle, or a realm that
+died outright. Activities running a current bundle report both success and
+failure, so the watchdog rarely fires.
 
 For programmatic control, set `data-doenet-manual-init` on the script tag
 and call `window.initializeDoenetCoordinator({ maxLiveViewers: 3, … })`
@@ -75,8 +81,17 @@ yourself (same option names, camelCase).
   the normal `SPLICE.reportScoreAndState` channel such a backend already
   consumes.
 - Activities running a standalone bundle older than the coordinator
-  protocol boot normally but are managed conservatively (a 90 s watchdog
+  protocol boot normally but are managed conservatively (the boot watchdog
   stands in for their missing boot-complete signal, and their state cannot
   be warehoused; they still lazy-load).
+- An activity whose core cannot start reports that too, so its boot slot is
+  freed at once rather than at the watchdog. It is then held in a `failed`
+  state: still counted against `maxLiveViewers` (its document is committed
+  and holding memory) and still parkable, but parking skips the state flush,
+  since it has no core to answer one (what it last reported, if anything, is
+  already warehoused). A later attempt in the same realm that *does* start a
+  core clears the mark, so an activity that recovers flushes its state like
+  any other. Scrolling away from a failed activity and back reboots it, which
+  doubles as a retry.
 - The coordinator manages iframes present at initialization
   (DOMContentLoaded); dynamically inserted activities are not yet managed.

--- a/packages/standalone/src/coordinator.ts
+++ b/packages/standalone/src/coordinator.ts
@@ -446,8 +446,9 @@ export function initializeDoenetCoordinator(
                     record.parkFlushCleanup?.();
                     record.parkFlushId = null;
                     if (record.visible) {
+                        // The `evaluateBudget` below re-checks the budget now
+                        // that this record rejoins it as "failed".
                         record.state = "failed";
-                        scheduleEvaluate(0);
                     } else {
                         detachRealm(record);
                     }

--- a/packages/standalone/src/coordinator.ts
+++ b/packages/standalone/src/coordinator.ts
@@ -88,7 +88,12 @@ const DEFAULTS = {
 // "parked" is also the initial state: a discovered iframe is detached to
 // about:blank and awaits its first boot slot exactly as a re-parked one does
 // (so coming into view unparks it through the same path).
-type ActivityState = "booting" | "live" | "parking" | "parked";
+//
+// "failed" is a booted realm whose core could not start (#1709). Its document
+// is committed and holding memory, so it still occupies the live budget and is
+// still parkable — but it has no core, so parking skips the state flush, and
+// the unpark that follows a scroll-back doubles as a retry.
+type ActivityState = "booting" | "live" | "failed" | "parking" | "parked";
 
 type ActivityRecord = {
     iframe: HTMLIFrameElement;
@@ -246,7 +251,21 @@ export function initializeDoenetCoordinator(
     // ---- park / restore ----
 
     function beginPark(record: ActivityRecord) {
-        if (record.state !== "live" || !record.iframe.contentWindow) {
+        if (
+            (record.state !== "live" && record.state !== "failed") ||
+            !record.iframe.contentWindow
+        ) {
+            return;
+        }
+        if (record.state === "failed") {
+            // The realm has no core — either none ever started, or a rebuild
+            // that failed took the previous one down with it — so nothing
+            // would answer a flush request. Whatever the activity did report
+            // before that is already in the warehouse, so detach straight away
+            // instead of waiting out `flushTimeoutMs`. (`evaluateBudget` only
+            // offers off-screen records, so there is no scrolled-back case to
+            // reconsider the way the flush path has.)
+            detachRealm(record);
             return;
         }
         record.state = "parking";
@@ -287,9 +306,17 @@ export function initializeDoenetCoordinator(
             scheduleEvaluate(0);
             return;
         }
-        // Detach the realm. The iframe element (and the page layout) stays;
-        // the browser discards the document, its worker(s), and its shared
-        // cores — release the latter from the pool.
+        detachRealm(record);
+    }
+
+    /**
+     * Discard the activity's document. The iframe element (and the page
+     * layout) stays; the browser drops the document, its worker(s), and its
+     * shared cores — release the latter from the pool. The record lands in
+     * "parked", so coming back into view boots it again through the normal
+     * slot path.
+     */
+    function detachRealm(record: ActivityRecord) {
         destroySharedCoresForViewer(record.poolViewerId);
         releaseBootSlot(record);
         record.iframe.src = "about:blank";
@@ -318,13 +345,19 @@ export function initializeDoenetCoordinator(
 
     function evaluateBudget() {
         const now = Date.now();
-        // Count only what still occupies the live budget: booting and live
-        // realms. A "parking" realm is already committed to being shed, so
-        // counting it would let a second evaluateBudget firing during its
-        // flush window shed an *additional* viewer the budget never needed.
+        // Count only what still occupies the live budget: booting, live, and
+        // failed realms (a failed one has a committed document holding
+        // memory, so it costs the page just as a live one does). A "parking"
+        // realm is already committed to being shed, so counting it would let a
+        // second evaluateBudget firing during its flush window shed an
+        // *additional* viewer the budget never needed.
         let active = 0;
         for (const record of records.values()) {
-            if (record.state === "booting" || record.state === "live") {
+            if (
+                record.state === "booting" ||
+                record.state === "live" ||
+                record.state === "failed"
+            ) {
                 active++;
             }
         }
@@ -335,7 +368,10 @@ export function initializeDoenetCoordinator(
         const candidates: ActivityRecord[] = [];
         let nextExpiry = Infinity;
         for (const record of records.values()) {
-            if (record.state !== "live" || record.visible) {
+            if (
+                (record.state !== "live" && record.state !== "failed") ||
+                record.visible
+            ) {
                 continue;
             }
             const eligibleAt = record.invisibleSince + opts.parkDelayMs;
@@ -376,8 +412,45 @@ export function initializeDoenetCoordinator(
             }
             const inner = data.data;
             if (inner.type === "bootComplete") {
-                if (record.state === "booting") {
+                // "failed" is also a valid state to arrive in: a realm that
+                // gave up on one core-start attempt can succeed on a later
+                // one (a rebuild — a locale switch, say — starts a fresh
+                // ladder). It has a core again, so it must lose the label
+                // that would otherwise make parking skip its state flush.
+                if (record.state === "booting" || record.state === "failed") {
                     record.state = "live";
+                }
+                releaseBootSlot(record);
+                evaluateBudget();
+                return;
+            }
+            if (inner.type === "bootFailed") {
+                // The realm gave up starting its core (#1709). Free the slot
+                // now rather than at `bootWatchdogMs`: on a page where several
+                // activities are failing, holding slots for 90 s each starves
+                // the very queue that keeps the page from overloading.
+                //
+                // "live" is also a valid state to arrive in: the boot watchdog
+                // promotes a silent boot to live, and the failure can land
+                // after that. A "parked" realm keeps its state — its document
+                // is already gone, so there is nothing left to describe.
+                if (record.state === "booting" || record.state === "live") {
+                    record.state = "failed";
+                } else if (record.state === "parking") {
+                    // The flush in flight will never be answered: the realm
+                    // just reported it has no core. Without this, the park
+                    // would wait out `flushTimeoutMs` for nothing — and a
+                    // reader who scrolled back mid-flush would land the
+                    // record in "live", losing the failure and making every
+                    // later park of this realm wait out that same silence.
+                    record.parkFlushCleanup?.();
+                    record.parkFlushId = null;
+                    if (record.visible) {
+                        record.state = "failed";
+                        scheduleEvaluate(0);
+                    } else {
+                        detachRealm(record);
+                    }
                 }
                 releaseBootSlot(record);
                 evaluateBudget();
@@ -556,6 +629,9 @@ if (!scriptElement?.dataset.doenetManualInit) {
     }
     if (dataset.flushTimeoutMs) {
         datasetOptions.flushTimeoutMs = parseInt(dataset.flushTimeoutMs, 10);
+    }
+    if (dataset.bootWatchdogMs) {
+        datasetOptions.bootWatchdogMs = parseInt(dataset.bootWatchdogMs, 10);
     }
     if (dataset.sharedCoreWorkers) {
         datasetOptions.sharedCoreWorkers =

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -264,10 +264,16 @@ export function renderDoenetViewerToContainer(
 
     // Compose the resize-readiness signal with any caller-supplied
     // `initializedCallback` so we don't clobber it via the `{...config}` spread.
+    // Same for `coreStartFailedCallback`, whose coordinator signal (#1709) is
+    // the failure counterpart of the `bootComplete` below.
     const {
         initializedCallback: configInitializedCallback,
+        coreStartFailedCallback: configCoreStartFailedCallback,
         ...restConfig
-    }: { initializedCallback?: (arg: unknown) => void } = config ?? {};
+    }: {
+        initializedCallback?: (arg: unknown) => void;
+        coreStartFailedCallback?: (arg: unknown) => void;
+    } = config ?? {};
 
     let root = viewerRootsByContainer.get(container);
     if (!root) {
@@ -301,6 +307,16 @@ export function renderDoenetViewerToContainer(
                     postToCoordinator({ type: "bootComplete" });
                 }
                 configInitializedCallback?.(arg);
+            }}
+            coreStartFailedCallback={(arg: unknown) => {
+                // Release the coordinator's boot slot on failure too (#1709).
+                // Without this the slot is held until `bootWatchdogMs` (90 s),
+                // so on a page whose activities are failing, the boot queue
+                // that exists to prevent those failures is starved by them.
+                if (coordinatedMode) {
+                    postToCoordinator({ type: "bootFailed" });
+                }
+                configCoreStartFailedCallback?.(arg);
             }}
             {...restConfig}
         />,

--- a/packages/test-cypress/cypress/e2e/standalone/coordinator.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/coordinator.cy.js
@@ -32,68 +32,78 @@ function assertParked(selector) {
     });
 }
 
-describe("standalone activity coordinator", { retries: 1 }, () => {
-    it("gates boots, parks the off-screen activity, and restores typed state on scroll-back", () => {
-        cy.viewport(1000, 660);
-        cy.visit("/coordination-page.html");
+describe(
+    "standalone activity coordinator",
+    { tags: ["@group1"], retries: 1 },
+    () => {
+        it("gates boots, parks the off-screen activity, and restores typed state on scroll-back", () => {
+            cy.viewport(1000, 660);
+            cy.visit("/coordination-page.html");
 
-        // Activity 1 (visible) boots through its boot slot; activity 2 (far
-        // below the viewport) stays detached — it never loads at all.
-        assertActivityRenders("#act1", "One typed:");
-        cy.get("#act2").should(($iframe) => {
-            expect($iframe[0].src, "act2 never booted").to.contain(
-                "about:blank",
+            // Activity 1 (visible) boots through its boot slot; activity 2 (far
+            // below the viewport) stays detached — it never loads at all.
+            assertActivityRenders("#act1", "One typed:");
+            cy.get("#act2").should(($iframe) => {
+                expect($iframe[0].src, "act2 never booted").to.contain(
+                    "about:blank",
+                );
+            });
+
+            // The child obtained its core from the coordinator's shared pool.
+            cy.window().then((win) => {
+                cy.wrap(null, { timeout: 20_000 }).should(() => {
+                    const stats = win.doenetCoordinatorStats();
+                    expect(
+                        stats.sharedCorePool.liveCores,
+                        `shared cores: ${JSON.stringify(stats)}`,
+                    ).to.be.gte(1);
+                });
+            });
+
+            // Type into activity 1 and commit with Enter.
+            cy.get("#act1")
+                .its("0.contentDocument.body")
+                .find("input:not([type=checkbox])", { timeout: BOOT_TIMEOUT })
+                .then(cy.wrap)
+                .type("carried across the park{enter}");
+            assertActivityRenders(
+                "#act1",
+                "One typed: carried across the park",
             );
-        });
 
-        // The child obtained its core from the coordinator's shared pool.
-        cy.window().then((win) => {
-            cy.wrap(null, { timeout: 20_000 }).should(() => {
-                const stats = win.doenetCoordinatorStats();
-                expect(
-                    stats.sharedCorePool.liveCores,
-                    `shared cores: ${JSON.stringify(stats)}`,
-                ).to.be.gte(1);
+            // Scroll to activity 2: it boots on visibility; activity 1 leaves
+            // the viewport, gets flushed, and parks (its iframe detaches to
+            // about:blank — the element and layout stay).
+            cy.get("#act2").scrollIntoView();
+            assertActivityRenders("#act2", "Activity two body");
+            assertParked("#act1");
+
+            // Scroll back: activity 1 reboots, asks the coordinator for its
+            // state (SPLICE.getState), and the typed work is restored with no
+            // user interaction. Activity 2 parks in turn (budget 1).
+            cy.get("#act1").scrollIntoView();
+            assertActivityRenders(
+                "#act1",
+                "One typed: carried across the park",
+            );
+            cy.get("#act1")
+                .its("0.contentDocument.body")
+                .find("input:not([type=checkbox])", { timeout: BOOT_TIMEOUT })
+                .should("have.value", "carried across the park");
+            assertParked("#act2");
+
+            // Steady state: one live activity, one parked, no held boot slots.
+            cy.window().then((win) => {
+                cy.wrap(null, { timeout: 20_000 }).should(() => {
+                    const stats = win.doenetCoordinatorStats();
+                    expect(
+                        stats,
+                        `settled: ${JSON.stringify(stats)}`,
+                    ).to.deep.include({ booting: 0, bootQueue: 0 });
+                    expect(stats.byState.live ?? 0, "live").to.eq(1);
+                    expect(stats.byState.parked ?? 0, "parked").to.eq(1);
+                });
             });
         });
-
-        // Type into activity 1 and commit with Enter.
-        cy.get("#act1")
-            .its("0.contentDocument.body")
-            .find("input:not([type=checkbox])", { timeout: BOOT_TIMEOUT })
-            .then(cy.wrap)
-            .type("carried across the park{enter}");
-        assertActivityRenders("#act1", "One typed: carried across the park");
-
-        // Scroll to activity 2: it boots on visibility; activity 1 leaves
-        // the viewport, gets flushed, and parks (its iframe detaches to
-        // about:blank — the element and layout stay).
-        cy.get("#act2").scrollIntoView();
-        assertActivityRenders("#act2", "Activity two body");
-        assertParked("#act1");
-
-        // Scroll back: activity 1 reboots, asks the coordinator for its
-        // state (SPLICE.getState), and the typed work is restored with no
-        // user interaction. Activity 2 parks in turn (budget 1).
-        cy.get("#act1").scrollIntoView();
-        assertActivityRenders("#act1", "One typed: carried across the park");
-        cy.get("#act1")
-            .its("0.contentDocument.body")
-            .find("input:not([type=checkbox])", { timeout: BOOT_TIMEOUT })
-            .should("have.value", "carried across the park");
-        assertParked("#act2");
-
-        // Steady state: one live activity, one parked, no held boot slots.
-        cy.window().then((win) => {
-            cy.wrap(null, { timeout: 20_000 }).should(() => {
-                const stats = win.doenetCoordinatorStats();
-                expect(
-                    stats,
-                    `settled: ${JSON.stringify(stats)}`,
-                ).to.deep.include({ booting: 0, bootQueue: 0 });
-                expect(stats.byState.live ?? 0, "live").to.eq(1);
-                expect(stats.byState.parked ?? 0, "parked").to.eq(1);
-            });
-        });
-    });
-});
+    },
+);

--- a/packages/test-cypress/cypress/e2e/standalone/coordinatorBootFailure.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/coordinatorBootFailure.cy.js
@@ -1,0 +1,125 @@
+// E2E for releasing a coordinator boot slot when an activity's core cannot
+// start (#1709).
+//
+// Before this, a slot was freed only by the child's `bootComplete` — so an
+// activity that exhausted its handshake retries kept the slot until
+// `bootWatchdogMs` (90 s in production). On a page whose activities are
+// failing, the boot queue that exists to keep the page from overloading was
+// starved by the failures themselves.
+//
+// The host page (coordination-boot-failure-page.html) grants ONE boot slot and
+// puts a permanently-failing activity first in the queue. The healthy activity
+// behind it can only render once that slot comes back, and the page sets
+// `bootWatchdogMs` far above the timeouts below — so a render here means the
+// failure released the slot, not that the watchdog eventually did.
+
+const BOOT_TIMEOUT = 15_000;
+
+describe(
+    "standalone coordinator: a failed boot frees its slot",
+    { tags: ["@group1"] },
+    () => {
+        it("boots the queued activity behind a failure instead of waiting out the watchdog", () => {
+            cy.viewport(1000, 800);
+            cy.visit("/coordination-boot-failure-page.html");
+
+            // The first activity reaches its visible error state rather than
+            // staying blank.
+            cy.get("#actFails")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    expect(body.textContent ?? "").to.contain(
+                        "could not be started",
+                    );
+                });
+
+            // The assertion: the activity queued behind it renders. Its slot can
+            // only have come from the failure above.
+            cy.get("#actHealthy")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    const clone = body.cloneNode(true);
+                    clone.querySelectorAll("script").forEach((s) => s.remove());
+                    expect(clone.textContent ?? "").to.contain(
+                        "Activity two body",
+                    );
+                });
+
+            // And the coordinator's own books agree: nothing is still booting or
+            // queued, and the failure is recorded as such rather than lingering
+            // as a phantom `booting`.
+            cy.window().then((win) => {
+                cy.wrap(null, { timeout: BOOT_TIMEOUT }).should(() => {
+                    const stats = win.doenetCoordinatorStats();
+                    expect(
+                        stats,
+                        `settled: ${JSON.stringify(stats)}`,
+                    ).to.include({
+                        booting: 0,
+                        bootQueue: 0,
+                    });
+                    expect(stats.byState.failed ?? 0, "failed").to.eq(1);
+                    expect(stats.byState.live ?? 0, "live").to.eq(1);
+                });
+            });
+        });
+
+        it("clears the failed mark when a later attempt in the same realm starts a core", () => {
+            // The transition out of the failure state, which is the one that can
+            // lose work silently: a `failed` activity is parked WITHOUT the
+            // pre-park state flush, on the grounds that it has no core to answer
+            // one. Once a later ladder in that realm does start a core — a rebuild
+            // from a locale switch or a recompile — the activity holds the
+            // reader's work like any other and must be flushed at park time, so
+            // the coordinator has to drop the label when `bootComplete` arrives
+            // from a realm it had written off.
+            cy.viewport(1000, 800);
+            cy.visit("/coordination-boot-failure-page.html");
+
+            cy.get("#actFails")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    expect(body.textContent ?? "").to.contain(
+                        "could not be started",
+                    );
+                });
+            cy.window().then((win) => {
+                cy.wrap(null, { timeout: BOOT_TIMEOUT }).should(() => {
+                    expect(
+                        win.doenetCoordinatorStats().byState.failed ?? 0,
+                        "failed before the retry",
+                    ).to.eq(1);
+                });
+            });
+
+            // Lift the stall and rebuild the document in that same realm.
+            cy.get("#actFails").then(($iframe) => {
+                $iframe[0].contentWindow.__doenetTestRecover();
+            });
+
+            // The give-up screen is replaced by the rebuilt document...
+            cy.get("#actFails")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    const clone = body.cloneNode(true);
+                    clone.querySelectorAll("script").forEach((s) => s.remove());
+                    expect(clone.textContent ?? "").to.contain(
+                        "This activity recovered",
+                    );
+                });
+
+            // ...and the coordinator no longer holds it as failed, so parking it
+            // would flush its state rather than skip straight to detaching.
+            cy.window().then((win) => {
+                cy.wrap(null, { timeout: BOOT_TIMEOUT }).should(() => {
+                    const stats = win.doenetCoordinatorStats();
+                    expect(
+                        stats.byState.failed ?? 0,
+                        `failed after the retry: ${JSON.stringify(stats)}`,
+                    ).to.eq(0);
+                    expect(stats.byState.live ?? 0, "live").to.eq(2);
+                });
+            });
+        });
+    },
+);

--- a/packages/test-cypress/cypress/e2e/standalone/coordinatorBootFailure.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/coordinatorBootFailure.cy.js
@@ -123,3 +123,132 @@ describe(
         });
     },
 );
+
+// The `bootFailed` handler's `parking` branch: a failure can land while a
+// park flush is in flight — the coordinator's short boot watchdog promoted a
+// silent boot to `live`, the reader scrolled on, parking began, and only then
+// did the realm give up on its core. The flush will never be answered (its
+// realm is modeled as too wedged to run the flush pipeline — see
+// coordination-activity-parking-race-if.html), so the failure must cancel it:
+// finish the park at once if the activity is off-screen, or keep the `failed`
+// mark if the reader scrolled back. The host page's `flushTimeoutMs` is 90 s,
+// far above every timeout below, so a prompt outcome can only come from the
+// cancellation.
+describe(
+    "standalone coordinator: a boot failure landing mid-flush",
+    { tags: ["@group1"] },
+    () => {
+        /** Poll `doenetCoordinatorStats()` until `check(stats)` passes. */
+        function awaitStats(check, timeout) {
+            cy.window().then((win) => {
+                cy.wrap(null, { timeout }).should(() => {
+                    check(win.doenetCoordinatorStats());
+                });
+            });
+        }
+
+        /**
+         * Drive the page to the racing state: the failing activity boots,
+         * is promoted to `live` by the 1 s boot watchdog, and — once the
+         * reader scrolls to the healthy activity — begins parking, with the
+         * unanswerable flush in flight. Its own 7 s handshake watchdog has
+         * not fired yet, so `bootFailed` is still to come.
+         */
+        function scrollUntilParkingBegins() {
+            awaitStats((stats) => {
+                expect(
+                    stats.byState.live ?? 0,
+                    `promoted to live: ${JSON.stringify(stats)}`,
+                ).to.eq(1);
+            }, 8000);
+
+            cy.get("#actHealthy").scrollIntoView();
+            awaitStats((stats) => {
+                expect(
+                    stats.byState.parking ?? 0,
+                    `parking begun: ${JSON.stringify(stats)}`,
+                ).to.eq(1);
+            }, 8000);
+        }
+
+        it("completes an off-screen park promptly when the failure cancels the doomed flush", () => {
+            cy.viewport(1000, 660);
+            cy.visit("/coordination-parking-race-page.html");
+
+            scrollUntilParkingBegins();
+
+            // `bootFailed` lands mid-flush, several seconds in. The
+            // activity is off-screen, so the coordinator cancels the flush
+            // and detaches the realm right away — well within this timeout,
+            // a fraction of the 90 s the flush would otherwise wait.
+            cy.get("#actSlowFail", { timeout: BOOT_TIMEOUT }).should(
+                ($iframe) => {
+                    expect(
+                        $iframe[0].src,
+                        "detached promptly on the failure",
+                    ).to.contain("about:blank");
+                },
+            );
+
+            // Page health: the healthy activity the reader scrolled to
+            // still renders.
+            cy.get("#actHealthy")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    const clone = body.cloneNode(true);
+                    clone.querySelectorAll("script").forEach((s) => s.remove());
+                    expect(clone.textContent ?? "").to.contain(
+                        "Activity two body",
+                    );
+                });
+        });
+
+        it("keeps the failed mark on a scroll-back mid-flush, and the next park skips the flush", () => {
+            cy.viewport(1000, 660);
+            cy.visit("/coordination-parking-race-page.html");
+
+            scrollUntilParkingBegins();
+
+            // Scroll back before the failure lands (it is still ~5 s away).
+            cy.get("#actSlowFail").scrollIntoView();
+
+            // When `bootFailed` lands, the record must come out of the
+            // cancelled flush as `failed` — a visible activity whose flush
+            // concluded normally would be promoted back to live, and that
+            // would lose the failure.
+            awaitStats((stats) => {
+                expect(
+                    stats.byState.failed ?? 0,
+                    `failed after the mid-flush failure: ${JSON.stringify(stats)}`,
+                ).to.eq(1);
+            }, BOOT_TIMEOUT);
+
+            // The realm stays attached, showing the viewer's give-up UI.
+            cy.get("#actSlowFail").should(($iframe) => {
+                expect($iframe[0].src, "still attached").to.not.contain(
+                    "about:blank",
+                );
+            });
+            cy.get("#actSlowFail")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    expect(body.textContent ?? "").to.contain(
+                        "could not be started",
+                    );
+                });
+
+            // Scrolling away again parks the `failed` record through the
+            // flush-skip: it detaches promptly instead of waiting out the
+            // 90 s flush timeout with a second doomed flush.
+            cy.get("#actHealthy").scrollIntoView();
+            cy.get("#actSlowFail", { timeout: BOOT_TIMEOUT }).should(
+                ($iframe) => {
+                    expect(
+                        $iframe[0].src,
+                        "failed park skipped the flush",
+                    ).to.contain("about:blank");
+                },
+            );
+        });
+    },
+);

--- a/packages/test-cypress/public/coordination-activity-fails-if.html
+++ b/packages/test-cypress/public/coordination-activity-fails-if.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<!-- A PreTeXt-style activity page (…-if.html) whose core cannot start.
+
+     The `__doenetTestCoreInitHook` seam hangs every handshake attempt, so
+     `DocViewer` exhausts its (here: single) retry and reports the failure —
+     the path a real reader hits on a machine too slow or too contended to
+     complete the handshake. Used by the coordinator e2e to check that a
+     failed boot frees its boot slot promptly (#1709) instead of holding it
+     until the coordinator's boot watchdog expires.
+
+     The hook is installed in `onload`, by which point the standalone bundle
+     has evaluated and created `window.doenetGlobalConfig`.
+
+     `window.__doenetTestRecover()` lets the spec drive the other half of the
+     story: it lifts the stall and rebuilds the document (a changed source, the
+     same path a locale switch or a recompile takes), so the realm starts a
+     fresh boot ladder that succeeds. That is what a `failed` activity does
+     when its next attempt works, and the coordinator has to notice — an
+     activity left labelled `failed` would have its state flush skipped at park
+     time even though it now has a core holding the reader's work. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script
+            onload="onLoad()"
+            type="module"
+            src="/standalone/doenet-standalone.js"
+        ></script>
+        <script>
+            function onLoad() {
+                const config = window.doenetGlobalConfig;
+                config.coreBootMaxAttempts = 1;
+                config.coreHandshakeWatchdogMs = 500;
+                config.__doenetTestCoreInitHook = function (phase) {
+                    if (phase === "handshake") {
+                        return new Promise(function () {
+                            /* never resolves */
+                        });
+                    }
+                };
+                const container = document.querySelector(".doenetml-applet");
+                window.__doenetTestRecover = function () {
+                    delete config.__doenetTestCoreInitHook;
+                    // The short watchdog goes with the stall. It is what makes
+                    // the first attempt give up quickly, but a *real*
+                    // handshake (worker boot plus WASM compile) needs far
+                    // longer than 500 ms, so leaving it pinned would fail the
+                    // recovery for reasons unrelated to the failed state.
+                    delete config.coreHandshakeWatchdogMs;
+                    // A different source is what makes this a rebuild rather
+                    // than a no-op re-render: the viewer re-rolls its `coreId`
+                    // and runs a new ladder against the (now unstalled) seam.
+                    window.renderDoenetViewerToContainer(
+                        container,
+                        "<p>This activity recovered</p>",
+                    );
+                };
+                window.renderDoenetViewerToContainer(container);
+            }
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>This activity never boots</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/public/coordination-activity-parking-race-if.html
+++ b/packages/test-cypress/public/coordination-activity-parking-race-if.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<!-- A PreTeXt-style activity page (…-if.html) built for the mid-flush
+     failure race in the coordinator e2e: its core-start failure lands
+     SECONDS after boot, and a park flush sent to it is never answered.
+
+     Two seams, both installed in `onload` (by which point the standalone
+     bundle has evaluated and created `window.doenetGlobalConfig`):
+
+     - `__doenetTestCoreInitHook` hangs the (single) handshake attempt
+       against a LONG 7 s watchdog, so the coordinator's own short boot
+       watchdog promotes the silent boot to `live` first and `bootFailed`
+       arrives only after the promoted activity has had time to start
+       parking.
+
+     - A message listener registered BEFORE the viewer swallows every
+       `SPLICE.flushState` request (listeners on the same target run in
+       registration order, so the viewer's own listener never sees it).
+       This realm behaves like one wedged too deep to run its flush
+       pipeline: an in-flight park flush stays unanswered until either the
+       coordinator's flushTimeoutMs expires or `bootFailed` cancels it. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script
+            onload="onLoad()"
+            type="module"
+            src="/standalone/doenet-standalone.js"
+        ></script>
+        <script>
+            function onLoad() {
+                const config = window.doenetGlobalConfig;
+                config.coreBootMaxAttempts = 1;
+                config.coreHandshakeWatchdogMs = 7000;
+                config.__doenetTestCoreInitHook = function (phase) {
+                    if (phase === "handshake") {
+                        return new Promise(function () {
+                            /* never resolves */
+                        });
+                    }
+                };
+                window.addEventListener("message", function (event) {
+                    if (
+                        event.data &&
+                        typeof event.data === "object" &&
+                        event.data.subject === "SPLICE.flushState"
+                    ) {
+                        event.stopImmediatePropagation();
+                    }
+                });
+                const container = document.querySelector(".doenetml-applet");
+                window.renderDoenetViewerToContainer(container);
+            }
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>This activity fails slowly</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/public/coordination-boot-failure-page.html
+++ b/packages/test-cypress/public/coordination-boot-failure-page.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<!-- Host page for the boot-failure e2e (#1709).
+
+     One boot slot, and the FIRST activity in the queue can never start its
+     core. The second activity can only render once that failure has given
+     the slot back, so it is the assertion: with the slot released on
+     failure it boots immediately; without, it would wait out
+     `bootWatchdogMs`, which this page sets well above the spec's timeout so
+     the two outcomes cannot be confused.
+
+     Both activities sit inside the visible margin so both are queued from
+     the start — the point is contention for the single slot, not lazy
+     loading (which coordination-page.html already covers). The live budget
+     is 3 so neither one parks mid-test. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Coordinated activities with a failing boot</title>
+        <script
+            src="/standalone/coordinator.js"
+            data-max-live-viewers="3"
+            data-max-concurrent-boots="1"
+            data-park-delay-ms="100000"
+            data-visible-margin="2000px"
+            data-boot-watchdog-ms="45000"
+        ></script>
+    </head>
+    <body>
+        <h1>Coordinated activities with a failing boot</h1>
+        <iframe
+            id="actFails"
+            src="/coordination-activity-fails-if.html"
+            width="800"
+            height="300"
+            style="border: 1px solid gray"
+        ></iframe>
+        <iframe
+            id="actHealthy"
+            src="/coordination-activity-2-if.html"
+            width="800"
+            height="300"
+            style="border: 1px solid gray"
+        ></iframe>
+    </body>
+</html>

--- a/packages/test-cypress/public/coordination-parking-race-page.html
+++ b/packages/test-cypress/public/coordination-parking-race-page.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<!-- Host page for the mid-flush boot-failure e2e (the coordinator's
+     `bootFailed` handler, `parking` branch).
+
+     The knobs conspire to land the failure while a park flush is in
+     flight:
+
+     - `data-boot-watchdog-ms="1000"`: the silent boot is promoted to
+       `live` after 1 s, long before its realm gives up (the activity's own
+       handshake watchdog is 7 s — see
+       coordination-activity-parking-race-if.html).
+     - `data-max-live-viewers="1"` + a spacer: scrolling to the healthy
+       activity puts the promoted one over budget and off-screen, so it
+       begins parking after the short park delay.
+     - The activity's realm never answers a flush, and
+       `data-flush-timeout-ms="90000"` is far above every spec timeout —
+       so a park that completes promptly can only mean `bootFailed`
+       cancelled the doomed flush, not that the flush was answered or
+       timed out. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Coordinated activities with a failure landing mid-flush</title>
+        <script
+            src="/standalone/coordinator.js"
+            data-max-live-viewers="1"
+            data-max-concurrent-boots="1"
+            data-park-delay-ms="300"
+            data-visible-margin="100px"
+            data-flush-timeout-ms="90000"
+            data-boot-watchdog-ms="1000"
+        ></script>
+    </head>
+    <body>
+        <h1>Coordinated activities with a failure landing mid-flush</h1>
+        <iframe
+            id="actSlowFail"
+            src="/coordination-activity-parking-race-if.html"
+            width="800"
+            height="500"
+            style="border: 1px solid gray"
+        ></iframe>
+        <div style="height: 2500px">spacer</div>
+        <iframe
+            id="actHealthy"
+            src="/coordination-activity-2-if.html"
+            width="800"
+            height="500"
+            style="border: 1px solid gray"
+        ></iframe>
+    </body>
+</html>


### PR DESCRIPTION
Second of four PRs that split the original #1713 apart. Now that #1720 has merged, this is the bottom of the remaining stack: **#1721 → #1722 → #1713 (draft)**, rebased onto `main`.

Builds on the ownership rule #1720 merged, and needs it: this PR gives a host something to act on when a boot fails, and a boot that has been superseded must not produce that signal. Without the ownership rule, a losing boot would tell the coordinator that a document which booted fine had failed.

## The bug

Hosts that cap how many documents boot at once release a slot from `initializedCallback`. There was no signal for the other outcome, so a boot that exhausted its handshake retries held its slot until the manager's own watchdog expired: 90 s for the `@doenet/standalone` coordinator and for windowed `@doenet/doenetml-iframe` viewers, 30 s for the docs site's editors.

On the page from #1707 that is precisely backwards — the queue that exists to keep a page from overloading is starved by the failures it was meant to prevent. Had the coordinator been installed on that reader's page, her three failing activities would each have pinned one of two boot slots for 90 s.

## The signal

`DoenetViewer` and `DoenetEditor` gain **`coreStartFailedCallback`**, the failure counterpart of `initializedCallback`. It fires at most once per core-start attempt and covers every way a start ends without a core: handshake retries exhausted, a rejected evaluation, or a document-state load that failed. It never fires for a document that merely reports errors — those booted fine.

The "once per attempt" latch keys on `coreId` rather than a boolean: a rebuild re-rolls it, which is exactly the granularity the callback promises and needs no separate reset. Several paths can conclude the same attempt (`startCore` reports and returns; `startCoreSafely` reports again if that call also throws), and a host that released a slot per notification would over-release.

## Consumers

- **The coordinator.** The standalone bundle posts `bootFailed`; the coordinator frees the slot and marks the activity `failed` — still counted against `maxLiveViewers` (its document is committed and holding memory) and still parkable, but parking skips the state flush a coreless realm could never answer. A later attempt in that realm that does start a core clears the mark, so an activity that recovers flushes like any other, and scrolling away and back doubles as a retry. A failure landing while the activity is already *parking* cancels the doomed flush rather than waiting out `flushTimeoutMs` — and keeps the `failed` mark if the reader scrolled back mid-flush, instead of promoting the record to `live` and losing the failure.
- **Windowed iframe viewers**, which release the slot on the composed callback whether or not the host passed one of its own.
- **The docs site's editors**, whose latched `concludeBoot` now answers to both outcomes.

Also adds `data-boot-watchdog-ms`, the one coordinator option that had no data attribute.

## Testing

- `DoenetViewer.coreStartFailed.cy.tsx` — fires once and not en route; silent on a healthy boot; reports again for a later failed attempt after a rebuild; a rebuild after a failure boots normally; fires when host-persisted state arrives malformed over `SPLICE.getState` (the state-load leg of the signal's coverage).
- New `DoenetViewer.windowedBootFailure.cy.tsx` — the failure crosses the Comlink boundary: with one boot slot, a windowed viewer whose embedded core cannot start forwards the host's `coreStartFailedCallback` and the viewer queued behind it renders far below the 90 s `BOOT_SLOT_WATCHDOG_MS`.
- New `coordinatorBootFailure.cy.js` — the queued activity boots behind a failure instead of waiting out `bootWatchdogMs`, and `__doenetTestRecover()` clears the failed mark. The fixture sets `bootWatchdogMs` far above the spec timeout so "slot freed on failure" and "waited out the watchdog" cannot be confused. Two further cases stage the mid-flush race under a 90 s `flushTimeoutMs`: the failure cancels the doomed park flush and detaches the off-screen realm promptly, and a scroll-back mid-flush keeps the `failed` mark — the realm stays attached showing the give-up UI, and its next park skips the flush.
- `coordinator.cy.js` and `coordinatorBootFailure.cy.js` (run twice) pass against a full build; typecheck clean across `@doenet/doenetml`, `@doenet/standalone` and `@doenet/doenetml-iframe`. `DocViewer/i18n` run three times — 38 passing each.
- `coordinator.cy.js`'s large diff is a `@group1`/`retries` wrapper and the resulting reindentation; review it with `git diff -w`.

Closes #1709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


