### PR TITLE
Size the core-worker watchdog to the contention it actually faces

### DIFF
--- a/.changeset/contention-aware-core-watchdog.md
+++ b/.changeset/contention-aware-core-watchdog.md
@@ -16,4 +16,4 @@ Retries back off exponentially with jitter instead of re-piling a fresh multi-MB
 
 A timeout on a demonstrably contended page no longer reports the worker as wedged. In shared-core mode that suspicion quarantines the host worker, killing cores that belong to other documents which were merely slow.
 
-A failure attributable to contention now says so — that the page was starting several documents at once, and may take longer on a slower device — instead of presenting an unexplained error. The general failure message is reworded to match: "This document could not be started", where it said "The document viewer could not be started".
+A failure attributable to contention now says so — that several documents were starting at once, and may take longer on a slower device — instead of presenting an unexplained error. The general failure message is reworded to match: "This document could not be started", where it said "The document viewer could not be started".

--- a/.changeset/contention-aware-core-watchdog.md
+++ b/.changeset/contention-aware-core-watchdog.md
@@ -14,6 +14,6 @@ The budget now scales with handshakes-per-core, read page-wide from a shared Web
 
 Retries back off exponentially with jitter instead of re-piling a fresh multi-MB worker 250 ms after one just failed, which was positive feedback exactly when the machine could least afford it.
 
-A timeout on a demonstrably contended page no longer reports the worker as wedged. In shared-core mode that suspicion quarantines the host worker, killing cores that belong to other documents which were merely slow.
+A timeout on a demonstrably contended page no longer reports the worker as wedged. In shared-core mode that suspicion quarantines the host worker: the suspected core is killed and retried, no new cores join the host, and the retried and new cores land on a replacement worker whose multi-MB bundle must spawn and compile under the very contention that produced the false alarm.
 
 A failure attributable to contention now says so — that several documents were starting at once, and may take longer on a slower device — instead of presenting an unexplained error. The general failure message is reworded to match: "This document could not be started", where it said "The document viewer could not be started".

--- a/.changeset/contention-aware-core-watchdog.md
+++ b/.changeset/contention-aware-core-watchdog.md
@@ -1,0 +1,19 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Size the core-worker watchdog to the contention it actually faces.
+
+An Active Calculus reader on a 2020 dual-core MacBook Air saw every Doenet activity in a Runestone section fail with "The document viewer could not be started". The handshake budget was a fixed 15 s, measured on developer hardware where the handshake "stays bounded under CPU pressure". On that machine it is not bounded: a page starting many documents at once pushes a perfectly healthy handshake past 15 s, and the watchdog then makes the document unloadable on exactly the contended machines the guard exists for.
+
+The budget now scales with handshakes-per-core, read page-wide from a shared Web Lock that every realm mid-handshake holds, and is capped so a genuine hang is still recovered from. The census gates nothing and is independent of any boot scheduling, so it works on pages whose host schedules boots itself — which is where cores can share a worker thread and contention matters most. `doenetGlobalConfig.coreHandshakeWatchdogMs` still overrides the budget outright, for a deployment whose handshake is slow for reasons contention cannot explain (one using `fetchExternalDoenetML`, say).
+
+Retries back off exponentially with jitter instead of re-piling a fresh multi-MB worker 250 ms after one just failed, which was positive feedback exactly when the machine could least afford it.
+
+A timeout on a demonstrably contended page no longer reports the worker as wedged. In shared-core mode that suspicion quarantines the host worker, killing cores that belong to other documents which were merely slow.
+
+A failure attributable to contention now says so — that the page was starting several documents at once, and may take longer on a slower device — instead of presenting an unexplained error. The general failure message is reworded to match: "This document could not be started", where it said "The document viewer could not be started".

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -51,7 +51,7 @@ let lastAugmentedProps: Record<string, any> | null = null;
 // `updateEditorFunctionProps` constantly. The old handler re-invoked
 // `renderDoenetEditorToContainer` on each such change; when that churn
 // overlapped the core worker's boot window the worker never finished booting
-// and the editor showed "The document viewer could not be started." Now an
+// and the editor showed "This document could not be started." Now an
 // identity-only change just swaps the entry here — the editor keeps calling the
 // same stable dispatcher, which dereferences the new closure — so no re-render
 // happens and the boot is left undisturbed.

--- a/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
@@ -12,7 +12,7 @@ import {
 // identity change made the iframe re-invoke `renderDoenetEditorToContainer`;
 // when that churn overlapped the core worker's multi-second boot window the
 // worker never finished and the editor showed DoenetML's give-up screen
-// ("The document viewer could not be started. Please reload the page.").
+// ("This document could not be started. Please reload the page.").
 //
 // What this test asserts — and why it's shaped this way:
 //

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -43,12 +43,21 @@ import {
 import { renderersLoadComponent } from "./renderersLoadComponent";
 import { doenetGlobalConfig } from "../global-config";
 import {
+    concurrentHandshakesSnapshot,
+    joinHandshakeCensus,
+    refreshHandshakeCensusCount,
+    reportedCores,
+} from "../utils/handshakeCensus";
+import {
     withTimeout,
     disposeCoreWorker,
     DEFAULT_CORE_BOOT_MAX_ATTEMPTS,
-    DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS,
-    CORE_BOOT_RETRY_DELAY_MS,
+    handshakeWatchdogMsFor,
+    isHandshakeTimeout,
+    timeoutLooksLikeContention,
+    retryDelayMs,
     CORE_START_FAILED_MESSAGE,
+    CORE_START_FAILED_BUSY_MESSAGE,
 } from "./coreWorkerBoot";
 import type { ResolvedTheme } from "../utils/theme";
 import {
@@ -535,10 +544,10 @@ export function DocViewer({
     // separate reset. See `reportCoreStartFailed`.
     const coreStartFailureReportedFor = useRef<string | null>(null);
     // Set by the unmount cleanup below. `startCore` waits several times over
-    // — on the saved-state load, on each handshake, on the evaluation that
-    // follows — and the teardown that runs on unmount cannot cancel those
-    // waits, so their other side checks this (`bootAbandoned`) rather than
-    // going on booting a worker for a viewer that is gone.
+    // — on the saved-state load, on each handshake, between retries (#1711) —
+    // and the teardown that runs on unmount cannot cancel those waits, so
+    // their other side checks this (`bootAbandoned`) rather than going on
+    // booting a worker for a viewer that is gone.
     const viewerUnmounted = useRef(false);
     // The `coreId` whose boot ladder is running, or null between ladders. One
     // of `startCoreSafely`'s three callers is render-phase code that re-runs
@@ -549,10 +558,10 @@ export function DocViewer({
     // `reinitializeCoreAndTerminateAnimations`, which owns the single
     // `coreWorker` ref — each disposing the other's worker. The window is
     // wide enough to catch an ordinary re-render: a boot spans a saved-state
-    // load, a worker handshake, and the document evaluation that follows. A
-    // *rebuild* re-rolls `coreId`, so the successor ladder it launches is
-    // never the one blocked here — that supersession is `bootAbandoned`'s
-    // job, not this latch's.
+    // load, a worker handshake, a backoff between attempts (#1711), and the
+    // document evaluation that follows. A *rebuild* re-rolls `coreId`, so the
+    // successor ladder it launches is never the one blocked here — that
+    // supersession is `bootAbandoned`'s job, not this latch's.
     const bootLadderCoreId = useRef<string | null>(null);
     const coreId = useRef<string>("");
     const diagnostics = useRef<DiagnosticRecord[]>([]);
@@ -774,12 +783,24 @@ export function DocViewer({
     // core that's being terminated is never reachable mid-teardown; the
     // returned promise settles once `disposeCoreWorker` has finished, for
     // callers that need to await the teardown before swapping in a replacement.
-    function teardownCurrentCoreWorker({ graceful }: { graceful: boolean }) {
+    function teardownCurrentCoreWorker({
+        graceful,
+        suspectWedge,
+    }: {
+        graceful: boolean;
+        /**
+         * Passed through to `disposeCoreWorker`, which otherwise infers the
+         * suspicion from `graceful`. A handshake teardown states it outright
+         * when the timeout that prompted it is better explained by page-wide
+         * CPU contention than by a wedged worker (#1711).
+         */
+        suspectWedge?: boolean;
+    }) {
         const remote = coreWorker.current;
         const kill = coreWorkerKill.current;
         coreWorker.current = null;
         coreWorkerKill.current = null;
-        return disposeCoreWorker(remote, kill, { graceful });
+        return disposeCoreWorker(remote, kill, { graceful, suspectWedge });
     }
 
     function clearDeferredCoreActions() {
@@ -1902,15 +1923,23 @@ export function DocViewer({
     // Put the viewer into a visible "core failed to start" error state rather
     // than leaving it blank at stage "wait" forever (Doenet/DoenetApps#2957).
     // Shared by every core-start failure path.
-    function failCoreStart() {
+    function failCoreStart({
+        contended = false,
+    }: { contended?: boolean } = {}) {
         coreCreationInProgress.current = false;
         setIsInErrorState?.(true);
         setErrMsg(
-            translate(
-                "core-start-failed",
-                undefined,
-                CORE_START_FAILED_MESSAGE,
-            ),
+            contended
+                ? translate(
+                      "core-start-failed-busy",
+                      undefined,
+                      CORE_START_FAILED_BUSY_MESSAGE,
+                  )
+                : translate(
+                      "core-start-failed",
+                      undefined,
+                      CORE_START_FAILED_MESSAGE,
+                  ),
         );
         setHasInitialError(true);
         reportCoreStartFailed();
@@ -1997,14 +2026,15 @@ export function DocViewer({
      * which latches on the CURRENT `coreId`.
      *
      * The waits on both paths make that window wide: a load awaits a cid and
-     * then IndexedDB, and a boot awaits a handshake per attempt and then the
-     * document evaluation. (The `SPLICE.getState` round trip a load may start
-     * is not one of them: the load never awaits it. It posts the request and
-     * hands straight off to the boot, and the response is picked up later by
-     * the message listener above, matched against the message id and `cid`
-     * current *then* — so it acts for whatever document the viewer is showing
-     * by then, re-rolling `coreId` and launching a ladder of its own, which
-     * is what stands the running one aside.)
+     * then IndexedDB, and a boot awaits a handshake per attempt, backs off
+     * between attempts (#1711), and then evaluates. (The `SPLICE.getState`
+     * round trip a load may start is not one of them: the load never awaits
+     * it. It posts the request and hands straight off to the boot, and the
+     * response is picked up later by the message listener above, matched
+     * against the message id and `cid` current *then* — so it acts for
+     * whatever document the viewer is showing by then, re-rolling `coreId`
+     * and launching a ladder of its own, which is what stands the running one
+     * aside.)
      *
      * Consulted everywhere a losing operation could speak for the document:
      * the staleness checks inside `loadStateAndInitialize` and at its launch
@@ -2046,71 +2076,146 @@ export function DocViewer({
             doenetGlobalConfig.coreBootMaxAttempts ??
                 DEFAULT_CORE_BOOT_MAX_ATTEMPTS,
         );
-        const handshakeWatchdogMs =
-            doenetGlobalConfig.coreHandshakeWatchdogMs ??
-            DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS;
+        // An explicit host override is a statement about that deployment —
+        // notably one using `fetchExternalDoenetML`, whose network expansion
+        // runs inside the handshake — so it wins outright over the
+        // contention-scaled budget below (#1711).
+        const handshakeWatchdogOverride =
+            doenetGlobalConfig.coreHandshakeWatchdogMs;
+        // Absent the hint, assume a single core: a browser that will not say
+        // how many it has is not evidence of a fast machine.
+        const cores = reportedCores() || 1;
 
         // --- Phase 1: handshake — watchdogged and retried ---
         // Only this cheap, size-independent phase is time-boxed. A stall here
         // means a hung/wedged worker (Doenet/DoenetApps#2957), not slow work.
         let thisCoreWorker: Remote<CoreWorker> | null = null;
         let handshakeSucceeded = false;
+        // Whether the attempt that gave up did so on a page contended enough
+        // that the failure is better explained by pressure than by a broken
+        // document (#1711) — which is what `failCoreStart` below turns into
+        // the busy-page wording.
+        let lastFailureWasContended = false;
 
-        for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            if (bootAbandoned()) {
-                // Re-checked before each attempt, because a retry waits too:
-                // creating a worker for a viewer that is gone leaks it, and
-                // racing a newer ladder breaks the document that one is
-                // booting.
-                await standDown();
-                return;
-            }
-            try {
-                thisCoreWorker = await withTimeout(
-                    () => handshakeCore(attempt, coreIdWhenCalled),
-                    handshakeWatchdogMs,
-                    `core worker handshake (attempt ${attempt + 1}/${maxAttempts})`,
-                );
-                handshakeSucceeded = true;
-                break;
-            } catch (err) {
+        // From here a census seat is held, so every exit — the abandonment
+        // returns below included — runs through the `finally` that frees it.
+        let censusHandle: Promise<{ release: () => void }> | null = null;
+        try {
+            // Join the page-wide handshake count for as long as this ladder is
+            // handshaking, so sibling realms sizing their own watchdogs can
+            // see it (#1711). Released by the `finally` below — at the end of
+            // the handshake phase, not of the ladder, since what the count
+            // measures is handshakes in flight and the evaluation that follows
+            // is not one. Purely observational — shared mode, so it never
+            // blocks.
+            // NOT awaited: joining is bookkeeping, and an await here is a
+            // suspension point in the middle of a boot. See
+            // `concurrentHandshakesSnapshot` for what that cost.
+            // The seat deliberately spans the whole ladder, retry backoff
+            // included: a ladder in backoff is pressure about to return, so
+            // siblings sizing watchdogs against it err long — the safe
+            // direction — and a seat taken and released per attempt would put
+            // extra lock operations next to every handshake for a count that
+            // is already, by documented contract, one refresh behind.
+            censusHandle = joinHandshakeCensus();
+            for (let attempt = 0; attempt < maxAttempts; attempt++) {
                 if (bootAbandoned()) {
-                    // Superseded or unmounted while this attempt was in
-                    // flight — often *because* of it: a rebuild disposes the
-                    // worker through
-                    // `reinitializeCoreAndTerminateAnimations`, which is what
-                    // made the attempt fail. So neither the failure nor the
-                    // worker ref is this ladder's any more: it must not
-                    // report an error over a document that is booting fine,
-                    // and must not tear down the successor's worker.
-                    console.warn(
-                        "DocViewer: abandoning a superseded core worker handshake",
-                        err,
-                    );
+                    // Re-checked before each attempt, because a retry waits
+                    // too: creating a worker for a viewer that is gone leaks
+                    // it, and racing a newer ladder breaks the document that
+                    // one is booting.
                     await standDown();
                     return;
                 }
-                console.warn(
-                    `DocViewer: core worker handshake attempt ${attempt + 1} ` +
-                        `of ${maxAttempts} failed` +
-                        (attempt + 1 < maxAttempts
-                            ? "; retrying with a fresh worker."
-                            : "; giving up."),
-                    err,
-                );
-                // The worker may be wedged (a hung round-trip leaves its
-                // serialization queue — and its own terminate() — stuck), so
-                // force-kill it natively and drop the refs; the next attempt
-                // starts from a brand-new Worker.
-                await teardownCurrentCoreWorker({ graceful: false });
-                coreCreated.current = false;
-                coreCreationInProgress.current = false;
-                if (attempt + 1 < maxAttempts) {
-                    await new Promise((resolve) =>
-                        setTimeout(resolve, CORE_BOOT_RETRY_DELAY_MS),
+                // Refresh again each attempt: a page of activities drains as
+                // they finish, so a retry is judged against the pressure it
+                // actually faces rather than the pressure at entry. The
+                // reading taken next is the one the PREVIOUS refresh produced
+                // — the backoff between attempts is what it lands in.
+                refreshHandshakeCensusCount();
+                const concurrentHandshakes = concurrentHandshakesSnapshot();
+                const handshakeWatchdogMs =
+                    handshakeWatchdogOverride ??
+                    handshakeWatchdogMsFor({
+                        concurrentHandshakes,
+                        hardwareConcurrency: cores,
+                    });
+                try {
+                    thisCoreWorker = await withTimeout(
+                        () => handshakeCore(attempt, coreIdWhenCalled),
+                        handshakeWatchdogMs,
+                        `core worker handshake (attempt ${attempt + 1}/${maxAttempts})`,
                     );
+                    handshakeSucceeded = true;
+                    break;
+                } catch (err) {
+                    if (bootAbandoned()) {
+                        // Superseded or unmounted while this attempt was in
+                        // flight — often *because* of it: a rebuild disposes
+                        // the worker through
+                        // `reinitializeCoreAndTerminateAnimations`, which is
+                        // what made the attempt fail. So neither the failure
+                        // nor the worker ref is this ladder's any more: it
+                        // must not report an error over a document that is
+                        // booting fine, and must not tear down the successor's
+                        // worker.
+                        console.warn(
+                            "DocViewer: abandoning a superseded core worker handshake",
+                            err,
+                        );
+                        await standDown();
+                        return;
+                    }
+                    // Only a watchdog expiry can be blamed on the page; see
+                    // `isHandshakeTimeout` for why an outright rejection must
+                    // not be.
+                    const contended =
+                        isHandshakeTimeout(err) &&
+                        timeoutLooksLikeContention({
+                            concurrentHandshakes,
+                            hardwareConcurrency: cores,
+                        });
+                    // Remembered for the failure wording (#1712): if the last
+                    // attempt timed out under pressure, say so rather than
+                    // presenting an unexplained error.
+                    lastFailureWasContended = contended;
+                    console.warn(
+                        `DocViewer: core worker handshake attempt ${attempt + 1} ` +
+                            `of ${maxAttempts} failed after ${handshakeWatchdogMs}ms ` +
+                            `(${concurrentHandshakes} handshake(s) in flight on ${cores} core(s))` +
+                            (attempt + 1 < maxAttempts
+                                ? "; retrying with a fresh worker."
+                                : "; giving up."),
+                        err,
+                    );
+                    // The worker may be wedged (a hung round-trip leaves its
+                    // serialization queue — and its own terminate() — stuck), so
+                    // force-kill it natively and drop the refs; the next attempt
+                    // starts from a brand-new Worker. On a demonstrably
+                    // contended page the wedge suspicion is withheld — see
+                    // `timeoutLooksLikeContention` for what a false one costs.
+                    await teardownCurrentCoreWorker({
+                        graceful: false,
+                        suspectWedge: !contended,
+                    });
+                    coreCreated.current = false;
+                    coreCreationInProgress.current = false;
+                    if (attempt + 1 < maxAttempts) {
+                        await new Promise((resolve) =>
+                            setTimeout(resolve, retryDelayMs(attempt)),
+                        );
+                    }
                 }
             }
+        } finally {
+            censusHandle
+                ?.then((seat) => seat.release())
+                .catch(() => {
+                    // `joinHandshakeCensus` swallows its own failures and
+                    // resolves to a no-op seat, so there is nothing to handle
+                    // here; the handler only satisfies "no fire-and-forget
+                    // promises".
+                });
         }
 
         if (bootAbandoned()) {
@@ -2127,7 +2232,7 @@ export function DocViewer({
 
         if (!handshakeSucceeded || thisCoreWorker === null) {
             // Every handshake attempt failed.
-            failCoreStart();
+            failCoreStart({ contended: lastFailureWasContended });
             return;
         }
 

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -2179,10 +2179,15 @@ export function DocViewer({
                     // attempt timed out under pressure, say so rather than
                     // presenting an unexplained error.
                     lastFailureWasContended = contended;
+                    // The budget is logged as context, not as elapsed time:
+                    // only a watchdog expiry takes the whole budget, while an
+                    // outright rejection (a worker script that 404s) fails as
+                    // fast as the error arrives. The `err` printed alongside
+                    // says which of the two happened.
                     console.warn(
                         `DocViewer: core worker handshake attempt ${attempt + 1} ` +
-                            `of ${maxAttempts} failed after ${handshakeWatchdogMs}ms ` +
-                            `(${concurrentHandshakes} handshake(s) in flight on ${cores} core(s))` +
+                            `of ${maxAttempts} failed (watchdog ${handshakeWatchdogMs}ms; ` +
+                            `${concurrentHandshakes} handshake(s) in flight on ${cores} core(s))` +
                             (attempt + 1 < maxAttempts
                                 ? "; retrying with a fresh worker."
                                 : "; giving up."),

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.test.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+    handshakeWatchdogMsFor,
+    isHandshakeTimeout,
+    timeoutLooksLikeContention,
+    retryDelayMs,
+    withTimeout,
+    DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS,
+    MAX_CORE_HANDSHAKE_WATCHDOG_MS,
+    CORE_BOOT_RETRY_DELAY_MS,
+    MAX_CORE_BOOT_RETRY_DELAY_MS,
+} from "./coreWorkerBoot";
+
+// Unit coverage for the contention-aware handshake budget (#1711).
+//
+// The fixed 15 s watchdog was measured on developer hardware. On the 1.1 GHz
+// dual-core machine in #1707, a page of activities booting at once pushed a
+// healthy handshake past it and the documents failed outright. These tests pin
+// the two directions that matter: the budget widens under real pressure, and
+// an idle page still detects a genuine hang as fast as it used to.
+
+describe("handshakeWatchdogMsFor (#1711)", () => {
+    it("leaves an uncontended page at the historical budget", () => {
+        expect(
+            handshakeWatchdogMsFor({
+                concurrentHandshakes: 1,
+                hardwareConcurrency: 4,
+            }),
+        ).toBe(DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS);
+    });
+
+    it("does not widen while the machine can still work on every handshake", () => {
+        // 4 handshakes on 4 cores is one each — pressure 1, not contention.
+        expect(
+            handshakeWatchdogMsFor({
+                concurrentHandshakes: 4,
+                hardwareConcurrency: 4,
+            }),
+        ).toBe(DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS);
+    });
+
+    it("widens in proportion to handshakes per core", () => {
+        // The reported machine: 4 threads, a section's worth of activities.
+        expect(
+            handshakeWatchdogMsFor({
+                concurrentHandshakes: 8,
+                hardwareConcurrency: 4,
+            }),
+        ).toBe(DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS * 2);
+        expect(
+            handshakeWatchdogMsFor({
+                concurrentHandshakes: 12,
+                hardwareConcurrency: 4,
+            }),
+        ).toBe(DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS * 3);
+    });
+
+    it("caps the budget so a true hang is still recovered from", () => {
+        expect(
+            handshakeWatchdogMsFor({
+                concurrentHandshakes: 500,
+                hardwareConcurrency: 2,
+            }),
+        ).toBe(MAX_CORE_HANDSHAKE_WATCHDOG_MS);
+    });
+
+    it("treats a missing hardwareConcurrency as a single core", () => {
+        // Absent the hint, assume the worst rather than the best: a machine
+        // that will not say how many cores it has is not a fast one.
+        expect(
+            handshakeWatchdogMsFor({
+                concurrentHandshakes: 2,
+                hardwareConcurrency: 0,
+            }),
+        ).toBe(DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS * 2);
+    });
+
+    it("honors an explicit base", () => {
+        expect(
+            handshakeWatchdogMsFor({
+                concurrentHandshakes: 1,
+                hardwareConcurrency: 4,
+                baseMs: 500,
+            }),
+        ).toBe(500);
+    });
+});
+
+describe("timeoutLooksLikeContention (#1711)", () => {
+    it("is false on an idle page, so a genuine hang still quarantines", () => {
+        expect(
+            timeoutLooksLikeContention({
+                concurrentHandshakes: 1,
+                hardwareConcurrency: 4,
+            }),
+        ).toBe(false);
+    });
+
+    it("is false while the machine can service every handshake", () => {
+        expect(
+            timeoutLooksLikeContention({
+                concurrentHandshakes: 4,
+                hardwareConcurrency: 4,
+            }),
+        ).toBe(false);
+    });
+
+    it("is true once handshakes outnumber cores", () => {
+        // This is what stops a shared core-worker host from being quarantined
+        // — and its other, healthy documents killed — over CPU pressure.
+        expect(
+            timeoutLooksLikeContention({
+                concurrentHandshakes: 6,
+                hardwareConcurrency: 4,
+            }),
+        ).toBe(true);
+    });
+});
+
+describe("isHandshakeTimeout (#1711)", () => {
+    // Contention only ever explains a watchdog expiry. If a plain rejection
+    // could pass for one, a 404 on the worker script would be reported to the
+    // reader as a busy page, and would waive the wedge suspicion that a
+    // definite error is entitled to.
+    it("recognizes the rejection the watchdog itself raises", async () => {
+        const err = await withTimeout(
+            () => new Promise<void>(() => {}),
+            1,
+            "never settles",
+        ).catch((e) => e);
+        expect(isHandshakeTimeout(err)).toBe(true);
+    });
+
+    it("does not claim a task's own rejection", async () => {
+        const err = await withTimeout(
+            () => Promise.reject(new Error("worker script 404")),
+            10_000,
+            "rejects outright",
+        ).catch((e) => e);
+        expect(isHandshakeTimeout(err)).toBe(false);
+    });
+
+    it("tolerates a non-error rejection value", () => {
+        expect(isHandshakeTimeout(undefined)).toBe(false);
+        expect(isHandshakeTimeout(null)).toBe(false);
+        expect(isHandshakeTimeout("timed out")).toBe(false);
+    });
+});
+
+describe("retryDelayMs (#1711)", () => {
+    it("backs off exponentially instead of re-piling after a flat delay", () => {
+        // Jitter is a [1, 2) multiplier, so compare against the floor of each
+        // step rather than an exact value.
+        for (let attempt = 0; attempt < 4; attempt++) {
+            const base = Math.min(
+                CORE_BOOT_RETRY_DELAY_MS * 2 ** attempt,
+                MAX_CORE_BOOT_RETRY_DELAY_MS,
+            );
+            for (let i = 0; i < 50; i++) {
+                const delay = retryDelayMs(attempt);
+                expect(delay).toBeGreaterThanOrEqual(base);
+                expect(delay).toBeLessThan(base * 2);
+            }
+        }
+    });
+
+    it("grows between successive attempts", () => {
+        // Minimum of a later attempt exceeds the maximum of the first, so the
+        // ladder genuinely spreads out rather than merely jittering.
+        const firstMax = CORE_BOOT_RETRY_DELAY_MS * 2;
+        for (let i = 0; i < 50; i++) {
+            expect(retryDelayMs(2)).toBeGreaterThan(firstMax);
+        }
+    });
+
+    it("stays bounded so a retry is never postponed indefinitely", () => {
+        for (let i = 0; i < 50; i++) {
+            expect(retryDelayMs(20)).toBeLessThan(
+                MAX_CORE_BOOT_RETRY_DELAY_MS * 2,
+            );
+        }
+    });
+});

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.test.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.test.ts
@@ -107,7 +107,8 @@ describe("timeoutLooksLikeContention (#1711)", () => {
 
     it("is true once handshakes outnumber cores", () => {
         // This is what stops a shared core-worker host from being quarantined
-        // — and its other, healthy documents killed — over CPU pressure.
+        // — and retries pushed onto a cold replacement host — over CPU
+        // pressure.
         expect(
             timeoutLooksLikeContention({
                 concurrentHandshakes: 6,

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.test.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.test.ts
@@ -154,7 +154,7 @@ describe("retryDelayMs (#1711)", () => {
         for (let attempt = 0; attempt < 4; attempt++) {
             const base = Math.min(
                 CORE_BOOT_RETRY_DELAY_MS * 2 ** attempt,
-                MAX_CORE_BOOT_RETRY_DELAY_MS,
+                MAX_CORE_BOOT_RETRY_DELAY_MS / 2,
             );
             for (let i = 0; i < 50; i++) {
                 const delay = retryDelayMs(attempt);
@@ -173,11 +173,20 @@ describe("retryDelayMs (#1711)", () => {
         }
     });
 
-    it("stays bounded so a retry is never postponed indefinitely", () => {
-        for (let i = 0; i < 50; i++) {
-            expect(retryDelayMs(20)).toBeLessThan(
-                MAX_CORE_BOOT_RETRY_DELAY_MS * 2,
-            );
+    it("keeps every jittered delay under the advertised cap", () => {
+        // The cap applies to the delay actually slept, jitter included: the
+        // pre-jitter value is capped at half the max, so even a doubled
+        // jitter draw lands below `MAX_CORE_BOOT_RETRY_DELAY_MS` — while a
+        // capped attempt still spans the jitter's full [1, 2) spread rather
+        // than collapsing onto a single value every sibling shares.
+        for (const attempt of [4, 10, 20, 40]) {
+            for (let i = 0; i < 50; i++) {
+                const delay = retryDelayMs(attempt);
+                expect(delay).toBeLessThan(MAX_CORE_BOOT_RETRY_DELAY_MS);
+                expect(delay).toBeGreaterThanOrEqual(
+                    MAX_CORE_BOOT_RETRY_DELAY_MS / 2,
+                );
+            }
         }
     });
 });

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -120,8 +120,10 @@ export function isHandshakeTimeout(err: unknown): boolean {
  *
  * The distinction matters beyond this document. A timeout normally tears the
  * worker down with `suspectWedge`, which in shared-core mode quarantines the
- * whole host worker — killing cores belonging to OTHER, healthy documents and
- * forcing them to re-boot, under contention. `docUtils` already concedes the
+ * whole host worker: its live cores run on, but it takes no new ones, so the
+ * killed-and-retried core — and every core boot after it — lands on a
+ * replacement host whose multi-MB worker must spawn and compile under the
+ * very contention that produced the timeout. `docUtils` already concedes the
  * suspicion "may be a false positive (CPU contention)"; this is what lets the
  * caller act on that rather than only comment on it.
  *

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -26,12 +26,16 @@ import type { CoreWorker } from "@doenet/doenetml-worker";
 // is alive, so a long evaluation is real work — not a hang.
 
 export const DEFAULT_CORE_BOOT_MAX_ATTEMPTS = 3;
+// The BASE budget: what one handshake gets on an uncontended page.
+// `handshakeWatchdogMsFor` widens it from here as pressure rises (#1711).
+//
 // Sized to clear any *healthy* handshake with wide margin while still
 // recovering from a genuine hang reasonably quickly. The handshake is
 // fixed-size work (parse the worker bundle, compile the WASM, init the JS
-// core) — not something that scales with document size — and it stays bounded
-// under CPU pressure: measured ~0.4s idle and only ~2s with 24 workers booting
-// at once. 15s is therefore many times any realistic healthy handshake.
+// core) — not something that scales with document size — and on developer
+// hardware it stays bounded under CPU pressure: measured ~0.4s idle and only
+// ~2s with 24 workers booting at once. On the low-end machine in #1707 that
+// bound did not hold, which is why the base is scaled rather than fixed.
 //
 // Caveat: when a document uses `fetchExternalDoenetML`, the (network)
 // expansion of external references runs inside this phase too, so a deployment
@@ -41,8 +45,120 @@ export const DEFAULT_CORE_BOOT_MAX_ATTEMPTS = 3;
 // exactly the slow/contended runners this guard exists for, whereas erring
 // long only delays recovery from a (rare) true hang.
 export const DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS = 15_000;
+
+/**
+ * Ceiling for the contention-scaled watchdog (#1711). Past this, a handshake
+ * has been unresponsive long enough that contention stops being a credible
+ * explanation, and continuing to wait only delays recovery from a true hang.
+ */
+export const MAX_CORE_HANDSHAKE_WATCHDOG_MS = 90_000;
+
+/**
+ * Watchdog budget for one handshake attempt, widened by how many handshakes
+ * are running across the page relative to what the machine can actually work
+ * on at once.
+ *
+ * The fixed 15 s was measured on developer hardware, where the handshake
+ * "stays bounded under CPU pressure". On the 1.1 GHz dual-core machine in
+ * #1707 it is not bounded: a page of activities all booting at once pushes a
+ * perfectly healthy handshake past 15 s, and the watchdog then does the thing
+ * this file's own comment warns against — making the document unloadable on
+ * exactly the contended runners the guard exists for.
+ *
+ * So the budget scales with pressure (handshakes per core) rather than with a
+ * guess about machine speed, which nothing exposes directly. One handshake per
+ * core is the neutral case and keeps today's 15 s; four handshakes on two
+ * cores doubles it. Erring long stays the deliberate bias: too long only
+ * delays recovery from a rare true hang, while too short makes documents
+ * permanently unloadable on slow machines.
+ */
+export function handshakeWatchdogMsFor({
+    concurrentHandshakes,
+    hardwareConcurrency,
+    baseMs = DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS,
+}: {
+    concurrentHandshakes: number;
+    hardwareConcurrency: number;
+    baseMs?: number;
+}): number {
+    const cores = Math.max(1, hardwareConcurrency || 1);
+    const inFlight = Math.max(1, concurrentHandshakes);
+    const pressure = Math.max(1, Math.ceil(inFlight / cores));
+    return Math.min(baseMs * pressure, MAX_CORE_HANDSHAKE_WATCHDOG_MS);
+}
+
+/**
+ * Marks the rejection `withTimeout` raises when its own deadline passes, so a
+ * caller can tell "the task never settled" from "the task failed". They call
+ * for different responses: a task that never settled may have left a wedged
+ * worker behind and may be a casualty of CPU pressure, whereas an outright
+ * rejection is a definite, attributable error (see `isHandshakeTimeout`).
+ */
+const TIMEOUT_ERROR_FLAG = "__doenetWithTimeoutExpired";
+
+/**
+ * Did this handshake failure come from the watchdog expiring, rather than from
+ * the handshake itself rejecting?
+ *
+ * Only a timeout is evidence of a stalled worker, and only a timeout can be
+ * blamed on contention: a rejection (a worker script that 404s, a core that
+ * throws while initializing) reproduces on an idle page too, so attributing it
+ * to a busy page would both mislead the reader and suppress a wedge suspicion
+ * that a definite error never earned.
+ */
+export function isHandshakeTimeout(err: unknown): boolean {
+    return (
+        typeof err === "object" &&
+        err !== null &&
+        (err as Record<string, unknown>)[TIMEOUT_ERROR_FLAG] === true
+    );
+}
+
+/**
+ * Is the page contended enough that a handshake timeout is better explained by
+ * CPU pressure than by a wedged worker (#1711)?
+ *
+ * The distinction matters beyond this document. A timeout normally tears the
+ * worker down with `suspectWedge`, which in shared-core mode quarantines the
+ * whole host worker — killing cores belonging to OTHER, healthy documents and
+ * forcing them to re-boot, under contention. `docUtils` already concedes the
+ * suspicion "may be a false positive (CPU contention)"; this is what lets the
+ * caller act on that rather than only comment on it.
+ *
+ * Deliberately conservative: on an idle page nothing changes, and a genuine
+ * hang is still caught and quarantined as promptly as before.
+ */
+export function timeoutLooksLikeContention({
+    concurrentHandshakes,
+    hardwareConcurrency,
+}: {
+    concurrentHandshakes: number;
+    hardwareConcurrency: number;
+}): boolean {
+    const cores = Math.max(1, hardwareConcurrency || 1);
+    return concurrentHandshakes > cores;
+}
+
 export const CORE_BOOT_RETRY_DELAY_MS = 250;
+export const MAX_CORE_BOOT_RETRY_DELAY_MS = 4_000;
 const GRACEFUL_TERMINATE_TIMEOUT_MS = 2_000;
+
+/**
+ * Delay before handshake attempt `attempt` (0-based) retries.
+ *
+ * The flat 250 ms re-piled a fresh worker — and its multi-MB parse — onto a
+ * machine that had just failed to finish one, which is positive feedback
+ * exactly when it can least be afforded. Backing off exponentially gives the
+ * contention that caused the timeout a chance to drain first. The jitter (a
+ * [1, 2) multiplier) keeps a page full of activities that all timed out
+ * together from retrying in lockstep.
+ */
+export function retryDelayMs(attempt: number): number {
+    const backoff = CORE_BOOT_RETRY_DELAY_MS * 2 ** attempt;
+    return (
+        Math.min(backoff, MAX_CORE_BOOT_RETRY_DELAY_MS) * (1 + Math.random())
+    );
+}
 
 // Shown in the viewer when the core worker can't be started after retries,
 // instead of leaving the pane blank (Doenet/DoenetApps#2957). One canonical
@@ -51,7 +167,16 @@ const GRACEFUL_TERMINATE_TIMEOUT_MS = 2_000;
 // fallback for the `core-start-failed` message; `DocViewer` translates it
 // before showing it.
 export const CORE_START_FAILED_MESSAGE =
-    "The document viewer could not be started. Please reload the page.";
+    "This document could not be started. Please reload the page.";
+
+/**
+ * English fallback for `core-start-failed-busy` — the variant shown when the
+ * failure is attributable to several documents starting at once (#1712).
+ */
+export const CORE_START_FAILED_BUSY_MESSAGE =
+    "This document could not be started. The page was starting several " +
+    "documents at once, which can take longer on a slower device. " +
+    "Reloading the page may help once the other documents have finished.";
 
 /**
  * Resolve/reject with `task()`, but reject with a timeout error if it does
@@ -59,6 +184,9 @@ export const CORE_START_FAILED_MESSAGE =
  * own — we attach a (post-timeout no-op) handler so a late rejection is never
  * reported as unhandled. Callers that time out are responsible for tearing
  * down whatever the task was waiting on.
+ *
+ * The timeout rejection is tagged so callers can recognize it with
+ * `isHandshakeTimeout` instead of matching on the message text.
  */
 export function withTimeout<T>(
     task: () => Promise<T>,
@@ -70,7 +198,11 @@ export function withTimeout<T>(
         const timer = setTimeout(() => {
             if (!settled) {
                 settled = true;
-                reject(new Error(`${label} timed out after ${ms}ms`));
+                const err = new Error(`${label} timed out after ${ms}ms`);
+                (err as unknown as Record<string, unknown>)[
+                    TIMEOUT_ERROR_FLAG
+                ] = true;
+                reject(err);
             }
         }, ms);
         task().then(
@@ -104,14 +236,28 @@ export function withTimeout<T>(
 export async function disposeCoreWorker(
     remote: Remote<CoreWorker> | null,
     kill: ((suspectWedge?: boolean) => void) | null,
-    { graceful }: { graceful: boolean },
+    {
+        graceful,
+        suspectWedge: suspectWedgeOverride,
+    }: {
+        graceful: boolean;
+        /**
+         * States the suspicion outright instead of inferring it from
+         * `graceful`. A handshake teardown passes `false` when the timeout
+         * that prompted it is better explained by page-wide CPU contention
+         * than by a wedged worker (#1711) — a false suspicion would
+         * quarantine a shared host that other, healthy documents are still
+         * using. Omit it to keep the inference (`!graceful`).
+         */
+        suspectWedge?: boolean;
+    },
 ) {
     // A non-graceful teardown means the caller already believes the core is
     // wedged (watchdogged handshake timeout); a graceful terminate that times
     // out is the same signal discovered late. Either way, pass the suspicion
     // to `kill` so a shared host (#1466) can quarantine the worker and route
     // retries to a fresh one.
-    let suspectWedge = !graceful;
+    let suspectWedge = suspectWedgeOverride ?? !graceful;
     if (graceful && remote) {
         try {
             await withTimeout(

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -178,9 +178,9 @@ export const CORE_START_FAILED_MESSAGE =
  * failure is attributable to several documents starting at once (#1712).
  */
 export const CORE_START_FAILED_BUSY_MESSAGE =
-    "This document could not be started. The page was starting several " +
-    "documents at once, which can take longer on a slower device. " +
-    "Reloading the page may help once the other documents have finished.";
+    "This document could not be started. Several documents were starting " +
+    "at once, which can take longer on a slower device. Reloading the page " +
+    "may help once the other documents have finished.";
 
 /**
  * Resolve/reject with `task()`, but reject with a timeout error if it does

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -151,12 +151,16 @@ const GRACEFUL_TERMINATE_TIMEOUT_MS = 2_000;
  * exactly when it can least be afforded. Backing off exponentially gives the
  * contention that caused the timeout a chance to drain first. The jitter (a
  * [1, 2) multiplier) keeps a page full of activities that all timed out
- * together from retrying in lockstep.
+ * together from retrying in lockstep. The exponential value is capped at
+ * half of `MAX_CORE_BOOT_RETRY_DELAY_MS` before the jitter applies, so the
+ * delay genuinely stays under the max while capped retries keep the jitter's
+ * full spread.
  */
 export function retryDelayMs(attempt: number): number {
     const backoff = CORE_BOOT_RETRY_DELAY_MS * 2 ** attempt;
     return (
-        Math.min(backoff, MAX_CORE_BOOT_RETRY_DELAY_MS) * (1 + Math.random())
+        Math.min(backoff, MAX_CORE_BOOT_RETRY_DELAY_MS / 2) *
+        (1 + Math.random())
     );
 }
 

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -43,9 +43,11 @@ export const doenetGlobalConfig: {
     /**
      * Maximum number of times `DocViewer` will retry the core-worker
      * *handshake* before giving up and surfacing an error. Each handshake
-     * that fails to complete within `coreHandshakeWatchdogMs` is abandoned
-     * and retried with a fresh worker. Falls back to a built-in default when
-     * unset.
+     * that fails to complete within its per-attempt watchdog budget (see
+     * `coreHandshakeWatchdogMs`) is abandoned and retried with a fresh
+     * worker, after an exponential backoff with jitter (#1711) so a page of
+     * documents that timed out together does not retry in lockstep. Falls
+     * back to a built-in default when unset.
      */
     coreBootMaxAttempts?: number;
     /**
@@ -61,7 +63,16 @@ export const doenetGlobalConfig: {
      * (seconds to minutes on complex documents). Time-boxing that phase would
      * make large documents unloadable, so once the handshake completes — the
      * worker having proven it is alive — the evaluation runs to completion
-     * however long it takes. Falls back to a built-in default when unset.
+     * however long it takes.
+     *
+     * When unset, each attempt's budget is sized to the contention the
+     * handshake actually faces (#1711): a built-in base, widened with the
+     * page-wide count of concurrent handshakes per core and capped — see
+     * `handshakeWatchdogMsFor` in `Viewer/coreWorkerBoot.ts`. Setting this is
+     * a statement about the deployment — one using `fetchExternalDoenetML`,
+     * say, whose handshake is slow for reasons contention cannot explain —
+     * so an explicit value wins outright: it is used as-is for every attempt,
+     * never scaled.
      */
     coreHandshakeWatchdogMs?: number;
     /**

--- a/packages/doenetml/src/utils/handshakeCensus.test.ts
+++ b/packages/doenetml/src/utils/handshakeCensus.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
+    concurrentHandshakesSnapshot,
     countConcurrentHandshakes,
     joinHandshakeCensus,
+    refreshHandshakeCensusCount,
 } from "./handshakeCensus";
 
 // Unit coverage for the handshake census (#1711) — the page-wide count of
@@ -78,6 +80,29 @@ describe("handshake census (#1711)", () => {
             query: () => Promise.reject(new Error("unavailable")),
         });
         expect(await countConcurrentHandshakes()).toBe(1);
+    });
+
+    it("decays the cached count as seats release, without a caller refresh", async () => {
+        // The cached snapshot must not hold a busy wave's high-water mark
+        // after the wave drains: the next boot sizes and attributes its
+        // first attempt against this number before its own refresh lands.
+        installLocks(fakeSharedLocks());
+
+        const seats = await Promise.all([
+            joinHandshakeCensus(),
+            joinHandshakeCensus(),
+            joinHandshakeCensus(),
+        ]);
+        refreshHandshakeCensusCount();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(concurrentHandshakesSnapshot()).toBe(3);
+
+        seats.forEach((seat) => seat.release());
+        // The release-triggered refreshes are deferred a task; give them (and
+        // the lock drops they observe) time to land.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(concurrentHandshakesSnapshot()).toBe(1);
     });
 
     it("joins as the no-op seat when the lock request throws", async () => {

--- a/packages/doenetml/src/utils/handshakeCensus.test.ts
+++ b/packages/doenetml/src/utils/handshakeCensus.test.ts
@@ -79,4 +79,19 @@ describe("handshake census (#1711)", () => {
         });
         expect(await countConcurrentHandshakes()).toBe(1);
     });
+
+    it("joins as the no-op seat when the lock request throws", async () => {
+        // A synchronous throw, distinct from the rejected promise above: the
+        // join must resolve to the no-op seat either way, never reject —
+        // callers attach their handlers after the boot is already underway.
+        installLocks({
+            request: () => {
+                throw new Error("locks unavailable in this context");
+            },
+        });
+
+        const seat = await joinHandshakeCensus();
+        expect(seat).toBeDefined();
+        seat.release();
+    });
 });

--- a/packages/doenetml/src/utils/handshakeCensus.test.ts
+++ b/packages/doenetml/src/utils/handshakeCensus.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+    countConcurrentHandshakes,
+    joinHandshakeCensus,
+} from "./handshakeCensus";
+
+// Unit coverage for the handshake census (#1711) — the page-wide count of
+// in-flight core handshakes the adaptive watchdog reads its contention from.
+// Driven against a minimal in-memory `navigator.locks` so both the counting
+// and the "browser cannot answer" fallbacks are checked without a browser.
+
+function installLocks(locks: unknown, hardwareConcurrency = 4) {
+    Object.defineProperty(globalThis, "navigator", {
+        value: { locks, hardwareConcurrency },
+        configurable: true,
+        writable: true,
+    });
+}
+
+/** A `LockManager` that understands `shared` mode and `query()`. */
+function fakeSharedLocks() {
+    const held: { name: string; mode: string }[] = [];
+    return {
+        request(
+            name: string,
+            options: { mode?: string },
+            callback: (lock: unknown) => Promise<void>,
+        ): Promise<void> {
+            const entry = { name, mode: options.mode ?? "exclusive" };
+            held.push(entry);
+            return Promise.resolve(callback({ name })).then(() => {
+                const index = held.indexOf(entry);
+                if (index !== -1) {
+                    held.splice(index, 1);
+                }
+            });
+        },
+        query() {
+            return Promise.resolve({ held: held.map((h) => ({ ...h })) });
+        },
+    };
+}
+
+describe("handshake census (#1711)", () => {
+    it("counts concurrent handshakes across realms and drops them on release", async () => {
+        installLocks(fakeSharedLocks());
+
+        expect(await countConcurrentHandshakes()).toBe(1);
+
+        // Three realms mid-handshake. Shared mode, so none of them blocks —
+        // this is bookkeeping, not admission control.
+        const a = await joinHandshakeCensus();
+        const b = await joinHandshakeCensus();
+        const c = await joinHandshakeCensus();
+        expect(await countConcurrentHandshakes()).toBe(3);
+
+        a.release();
+        b.release();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(await countConcurrentHandshakes()).toBe(1);
+
+        c.release();
+    });
+
+    it("reports a neutral 1 when the browser cannot answer", async () => {
+        // No Web Locks at all, and a query that rejects: both must read as
+        // "no visible contention" so the watchdog falls back to its fixed
+        // base rather than to zero (which would scale to nonsense).
+        installLocks(undefined);
+        expect(await countConcurrentHandshakes()).toBe(1);
+        const noop = await joinHandshakeCensus();
+        expect(noop).toBeDefined();
+        noop.release();
+
+        installLocks({
+            request: () => Promise.resolve(),
+            query: () => Promise.reject(new Error("unavailable")),
+        });
+        expect(await countConcurrentHandshakes()).toBe(1);
+    });
+});

--- a/packages/doenetml/src/utils/handshakeCensus.ts
+++ b/packages/doenetml/src/utils/handshakeCensus.ts
@@ -1,0 +1,208 @@
+/**
+ * The page-wide handshake census (#1711): how many core-worker handshakes are
+ * running at once, and on how many cores.
+ *
+ * The watchdog that guards a handshake was sized on developer hardware, where
+ * the handshake "stays bounded under CPU pressure". On the 1.1 GHz dual-core
+ * machine in #1707 it is not bounded: a page of activities all booting at once
+ * pushes a perfectly healthy handshake past the budget, and the watchdog then
+ * makes the document unloadable on exactly the contended machines it exists to
+ * protect. Sizing the budget to the pressure a handshake actually faces needs
+ * a number no realm can see on its own — hence a census.
+ *
+ * A `shared` Web Lock is the whole mechanism: every realm mid-handshake holds
+ * the same lock name, shared mode grants them all immediately, and
+ * `navigator.locks.query()` reports the holders. It gates nothing. The browser
+ * drops a lock when its realm goes away, so a crashed activity cannot inflate
+ * the count forever.
+ *
+ * The census is deliberately independent of any boot gate, and uses a lock
+ * name of its own: a page whose host schedules boots itself takes no gate
+ * locks at all, and those pages (assignment-viewer, the docs site) are exactly
+ * where cores share a worker thread and contention matters most.
+ *
+ * Everything here is best-effort. A census that cannot be joined or queried
+ * reads as "no visible contention", which is the behavior that predates it.
+ */
+
+import { lockManager } from "./webLocks";
+
+/**
+ * Lock name held — in `shared` mode, so every holder is granted at once — for
+ * the duration of a core handshake.
+ */
+const HANDSHAKE_CENSUS_LOCK = "doenet-handshake-census";
+
+/**
+ * How long to wait for the (shared, therefore immediately grantable) census
+ * lock before giving up and proceeding uncounted. Joining the census is
+ * bookkeeping; nothing should ever wait on it.
+ */
+const CENSUS_JOIN_TIMEOUT_MS = 1_000;
+
+/**
+ * The handle a handshake holds when it could not take a seat: releasing it
+ * frees nothing, because nothing was taken. Shared, since it carries no state.
+ */
+const NO_CENSUS_SEAT = { release: () => {} };
+
+/**
+ * How many logical cores the browser admits to, or 0 where the hint is
+ * unavailable (no `navigator`, or a browser that withholds it). Callers decide
+ * what to assume in that case, and they differ — `DocViewer` substitutes 1 —
+ * so no default is baked in here.
+ *
+ * Lives beside the census because it is the other half of the ratio the census
+ * exists to produce: handshakes in flight, per core able to work on them.
+ */
+export function reportedCores(): number {
+    try {
+        return typeof navigator !== "undefined" && navigator.hardwareConcurrency
+            ? navigator.hardwareConcurrency
+            : 0;
+    } catch {
+        // Same defensiveness as `lockManager`: an embedding that throws on
+        // `navigator` access must read as "no hint", not take down the boot it
+        // is only being consulted to size.
+        return 0;
+    }
+}
+
+/**
+ * Join the page-wide count of in-flight core handshakes for as long as the
+ * returned handle is unreleased.
+ *
+ * Held in `shared` mode, so joining never blocks and never gates: this is
+ * bookkeeping, not admission control. Callers must release it when the
+ * handshake concludes; if they do not, the browser still drops it when the
+ * realm goes away, so a crashed realm cannot inflate the count forever.
+ *
+ * Resolves to a no-op handle wherever Web Locks are unavailable — the count
+ * then reads as "no visible contention", which is the pre-#1711 behavior.
+ */
+export function joinHandshakeCensus(): Promise<{ release: () => void }> {
+    const locks = lockManager();
+    if (!locks) {
+        return Promise.resolve(NO_CENSUS_SEAT);
+    }
+    return new Promise((resolve) => {
+        let released = false;
+        let giveUp: ReturnType<typeof setTimeout> | null = null;
+        let settled = false;
+        function settle(handle: { release: () => void }) {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            if (giveUp !== null) {
+                clearTimeout(giveUp);
+                giveUp = null;
+            }
+            resolve(handle);
+        }
+        locks
+            .request(HANDSHAKE_CENSUS_LOCK, { mode: "shared" }, () => {
+                if (released) {
+                    return Promise.resolve();
+                }
+                return new Promise<void>((release) => {
+                    settle({
+                        release: () => {
+                            released = true;
+                            release();
+                        },
+                    });
+                });
+            })
+            .catch(() => {
+                // Counting is best-effort: a census we cannot join just means
+                // this realm's handshake is invisible to its siblings, which
+                // degrades the watchdog to its fixed base.
+                settle(NO_CENSUS_SEAT);
+            });
+        if (!settled) {
+            // Shared locks are granted immediately in practice; this guards
+            // the pathological case rather than any expected one. Marking it
+            // released first matters: without that, a grant arriving after
+            // this fired would be held by a handle nobody has, permanently
+            // inflating the count every later handshake sizes its watchdog
+            // against.
+            giveUp = setTimeout(() => {
+                released = true;
+                settle(NO_CENSUS_SEAT);
+            }, CENSUS_JOIN_TIMEOUT_MS);
+        }
+    });
+}
+
+/**
+ * How many core handshakes are in flight across every same-origin realm the
+ * browser is running (see the origin-scope note in `webLocks`), including this
+ * one.
+ *
+ * Returns 1 ("just me") whenever the true figure cannot be obtained, so
+ * callers scale from a neutral baseline rather than from zero. Asking costs an
+ * await, so the boot path reads the cache below instead of calling this.
+ */
+export async function countConcurrentHandshakes(): Promise<number> {
+    const locks = lockManager();
+    if (!locks?.query) {
+        return 1;
+    }
+    try {
+        const state = await locks.query();
+        const held = (state.held ?? []).filter(
+            (lock) => lock.name === HANDSHAKE_CENSUS_LOCK,
+        ).length;
+        return Math.max(1, held);
+    } catch {
+        return 1;
+    }
+}
+
+/**
+ * Last observed number of in-flight handshakes, refreshed in the background by
+ * `refreshHandshakeCensusCount`. Starts at the neutral "just me".
+ */
+let lastKnownConcurrentHandshakes = 1;
+
+/**
+ * How many handshakes were in flight the last time anyone looked — read
+ * synchronously, so consulting it never adds an await to a boot.
+ *
+ * That property is load-bearing, not an optimization. This count only sizes a
+ * watchdog; nothing about starting a document depends on it. Awaiting Web
+ * Locks for it put extra suspension points into `startCore`, which widened the
+ * window in which a catalog-driven rebuild could overlap the ladder already
+ * running. Two ladders then tore down each other's worker through the shared
+ * `coreWorker` ref, and the document ended up with no diagnostics published
+ * at all — a `DocViewer/i18n` CI failure bisected to exactly that change. A
+ * count one boot out of date is a perfectly good input to a timeout; a boot
+ * that races itself is not.
+ */
+export function concurrentHandshakesSnapshot(): number {
+    return lastKnownConcurrentHandshakes;
+}
+
+/**
+ * Update the cached count, off the caller's critical path. Deliberately
+ * returns nothing to await: a caller that waited on it would reintroduce the
+ * suspension point `concurrentHandshakesSnapshot` exists to avoid.
+ *
+ * Because the update lands a turn or more later, the reading a caller gets
+ * from `concurrentHandshakesSnapshot` is always the one *before* its own
+ * refresh. A boot refreshes once per handshake attempt and nowhere earlier,
+ * so each read is answered by the previous attempt's refresh, and a first
+ * attempt reads the count one refresh behind.
+ */
+export function refreshHandshakeCensusCount(): void {
+    countConcurrentHandshakes()
+        .then((count) => {
+            lastKnownConcurrentHandshakes = count;
+        })
+        .catch(() => {
+            // `countConcurrentHandshakes` swallows its own failures and falls
+            // back to the neutral 1, so there is nothing to handle here; the
+            // handler only satisfies "no fire-and-forget promises".
+        });
+}

--- a/packages/doenetml/src/utils/handshakeCensus.ts
+++ b/packages/doenetml/src/utils/handshakeCensus.ts
@@ -111,6 +111,21 @@ export function joinHandshakeCensus(): Promise<{ release: () => void }> {
                             release: () => {
                                 released = true;
                                 release();
+                                // Refresh the cached count as the wave
+                                // drains, so it decays with the seats rather
+                                // than holding its high-water mark until the
+                                // next boot's own refresh lands (a boot after
+                                // a busy wave would otherwise size — and
+                                // attribute — its first attempt against
+                                // pressure that no longer exists). Deferred a
+                                // task because the browser frees the lock
+                                // when the callback's promise settles, a
+                                // microtask after this call: querying then
+                                // observes the seat already dropped.
+                                setTimeout(
+                                    () => refreshHandshakeCensusCount(),
+                                    0,
+                                );
                             },
                         });
                     });
@@ -203,9 +218,13 @@ export function concurrentHandshakesSnapshot(): number {
  *
  * Because the update lands a turn or more later, the reading a caller gets
  * from `concurrentHandshakesSnapshot` is always the one *before* its own
- * refresh. A boot refreshes once per handshake attempt and nowhere earlier,
- * so each read is answered by the previous attempt's refresh, and a first
- * attempt reads the count one refresh behind.
+ * refresh. A boot refreshes once per handshake attempt, and every released
+ * census seat refreshes as it drops, so each attempt's read is answered by
+ * the previous attempt's refresh and a first attempt reads the count as of
+ * the last attempt — or last drained seat — in this realm. A wave in
+ * another tab's realm drains invisibly (its releases refresh its own cache,
+ * not this one), so the first attempt after one can still read high; the
+ * attempt's own refresh corrects the reading for every attempt after it.
  */
 export function refreshHandshakeCensusCount(): void {
     countConcurrentHandshakes()

--- a/packages/doenetml/src/utils/handshakeCensus.ts
+++ b/packages/doenetml/src/utils/handshakeCensus.ts
@@ -100,26 +100,38 @@ export function joinHandshakeCensus(): Promise<{ release: () => void }> {
             }
             resolve(handle);
         }
-        locks
-            .request(HANDSHAKE_CENSUS_LOCK, { mode: "shared" }, () => {
-                if (released) {
-                    return Promise.resolve();
-                }
-                return new Promise<void>((release) => {
-                    settle({
-                        release: () => {
-                            released = true;
-                            release();
-                        },
+        try {
+            locks
+                .request(HANDSHAKE_CENSUS_LOCK, { mode: "shared" }, () => {
+                    if (released) {
+                        return Promise.resolve();
+                    }
+                    return new Promise<void>((release) => {
+                        settle({
+                            release: () => {
+                                released = true;
+                                release();
+                            },
+                        });
                     });
+                })
+                .catch(() => {
+                    // Counting is best-effort: a census we cannot join just
+                    // means this realm's handshake is invisible to its
+                    // siblings, which degrades the watchdog to its fixed
+                    // base.
+                    settle(NO_CENSUS_SEAT);
                 });
-            })
-            .catch(() => {
-                // Counting is best-effort: a census we cannot join just means
-                // this realm's handshake is invisible to its siblings, which
-                // degrades the watchdog to its fixed base.
-                settle(NO_CENSUS_SEAT);
-            });
+        } catch {
+            // A lock manager can also fail synchronously (a restricted
+            // embedding's SecurityError, say), and a throw inside this
+            // promise's executor would reject the join. The join never
+            // rejects — its callers attach handlers late, and a census that
+            // cannot be joined reads as "no visible contention" — so a
+            // synchronous failure settles the same way an asynchronous one
+            // does.
+            settle(NO_CENSUS_SEAT);
+        }
         if (!settled) {
             // Shared locks are granted immediately in practice; this guards
             // the pathological case rather than any expected one. Marking it

--- a/packages/doenetml/src/utils/webLocks.ts
+++ b/packages/doenetml/src/utils/webLocks.ts
@@ -1,0 +1,41 @@
+/**
+ * Feature detection for the Web Locks API, shared by the boot-path mechanisms
+ * built on it.
+ *
+ * Web Locks are scoped to an ORIGIN and span every same-origin realm the
+ * browser is running — the activity iframes on a page, and other tabs on the
+ * same site. That scope is what makes a lock usable as coordination between
+ * realms that know nothing about each other, with nothing for a host page to
+ * install; every consumer here relies on it.
+ *
+ * Both consumers must also survive its absence: a browser without Web Locks,
+ * or an embedding that throws on `navigator` access, has to degrade to the
+ * behavior that predates them rather than fail a boot over bookkeeping.
+ */
+
+export type LockManagerLike = {
+    request: (
+        name: string,
+        options: {
+            mode?: "exclusive" | "shared";
+            ifAvailable?: boolean;
+            signal?: AbortSignal;
+        },
+        callback: (lock: unknown) => Promise<void>,
+    ) => Promise<void>;
+    // Only `held` is read: the locks queried through here are shared ones,
+    // granted on request, so a realm counting them never appears in `pending`.
+    query?: () => Promise<{ held?: { name?: string }[] }>;
+};
+
+/** The realm's lock manager, or null wherever one cannot be reached. */
+export function lockManager(): LockManagerLike | null {
+    try {
+        const locks = (navigator as any)?.locks;
+        return locks && typeof locks.request === "function" ? locks : null;
+    } catch {
+        // Some embeddings throw on `navigator` access rather than returning
+        // undefined; treat that as "no Web Locks" like any other absence.
+        return null;
+    }
+}

--- a/packages/doenetml/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.sharedCoreWorker.cy.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { DoenetViewer } from "../../../src/doenetml-inline-worker";
 import { doenetGlobalConfig } from "../../../src/global-config";
+import {
+    concurrentHandshakesSnapshot,
+    joinHandshakeCensus,
+    refreshHandshakeCensusCount,
+} from "../../../src/utils/handshakeCensus";
 
 // Component coverage for the shared core-worker host (#1466): with
 // `doenetGlobalConfig.useSharedCoreWorker` set, viewers on a page multiplex
@@ -142,5 +147,172 @@ describe("DoenetViewer shared core-worker host (#1466)", () => {
                 "handshake was retried after the hung first attempt",
             ).to.be.greaterThan(1);
         });
+    });
+});
+
+// Harness for the contended-timeout test below: a healthy viewer that boots
+// first (so its core is live on the shared host before anything hangs), plus
+// a button that mounts a second viewer afterwards — after the test has set up
+// census pressure and a handshake hook the healthy boot must not see.
+function ContendedBootHarness() {
+    const [showContended, setShowContended] = React.useState(false);
+    return (
+        <div>
+            <button
+                data-test="add-contended"
+                onClick={() => setShowContended(true)}
+            >
+                add contended
+            </button>
+            <DoenetViewer
+                doenetML={`
+                    <number name="c">0</number>
+                    <updateValue name="bump" target="$c" newValue="$c+1">
+                        <label>bump healthy</label>
+                    </updateValue>
+                    <p>healthy is $c</p>
+                `}
+                addVirtualKeyboard={false}
+            />
+            {showContended ? (
+                <DoenetViewer
+                    doenetML="<p>contended viewer</p>"
+                    addVirtualKeyboard={false}
+                />
+            ) : null}
+        </div>
+    );
+}
+
+describe("DoenetViewer shared host under handshake contention (#1711)", () => {
+    // Census seats this test holds to create page-wide pressure; released
+    // after each test so later specs size their watchdogs against a clean
+    // count.
+    let censusSeats: { release: () => void }[] = [];
+    let realWorker: typeof Worker;
+
+    beforeEach(() => {
+        realWorker = window.Worker;
+    });
+
+    afterEach(() => {
+        window.Worker = realWorker;
+        delete doenetGlobalConfig.useSharedCoreWorker;
+        delete doenetGlobalConfig.__doenetTestCoreInitHook;
+        delete doenetGlobalConfig.coreHandshakeWatchdogMs;
+        delete doenetGlobalConfig.coreBootMaxAttempts;
+        cy.then(() => {
+            for (const seat of censusSeats) {
+                seat.release();
+            }
+            censusSeats = [];
+        });
+        // The cached snapshot is module-global and survives this spec, so put
+        // it back to the neutral "just me" the next boot expects to read.
+        cy.wrap(null, { timeout: 4000 }).should(() => {
+            refreshHandshakeCensusCount();
+            expect(concurrentHandshakesSnapshot()).to.equal(1);
+        });
+    });
+
+    it("a contended timeout leaves the shared host unquarantined and its healthy sibling running", () => {
+        // End-to-end wiring of `suspectWedge: false` (#1711): when a
+        // handshake times out while handshakes outnumber cores, the teardown
+        // withholds the wedge suspicion, so the shared host keeps its live
+        // sibling core AND keeps accepting new ones — the retry lands back on
+        // it instead of a cold replacement worker. Observables, mirroring the
+        // quarantine test above from the other side: no new host worker is
+        // constructed, the sibling stays interactive, and the failure is
+        // reported with the busy-page wording.
+        doenetGlobalConfig.useSharedCoreWorker = true;
+        // The override wins over the contention-scaled budget, keeping the
+        // injected hang's watchdog short while healthy handshakes still
+        // complete well within it.
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 4000;
+        doenetGlobalConfig.coreBootMaxAttempts = 2;
+
+        let handshakeAttempts = 0;
+        let workerConstructions = 0;
+
+        cy.mount(<ContendedBootHarness />);
+
+        // The healthy viewer boots before any pressure or hook exists.
+        cy.contains("healthy is 0", { timeout: 15000 }).should("exist");
+
+        // Real census pressure: hold more seats than the machine has cores,
+        // so the boot below reads `concurrentHandshakes > cores` and
+        // attributes its timeout to contention.
+        // `DocViewer` reads the same hint and substitutes 1 when it is
+        // withheld, so this exceeds whatever core count the boot compares
+        // against.
+        const seatTarget = (navigator.hardwareConcurrency || 1) + 4;
+        cy.then(async () => {
+            const seats = await Promise.all(
+                Array.from({ length: seatTarget }, () => joinHandshakeCensus()),
+            );
+            censusSeats.push(...seats);
+        });
+        // Prime the cached snapshot before the contended boot starts: the
+        // boot reads the cache synchronously, and a refresh lands its count
+        // asynchronously, so the seats have to be visible in the cache — not
+        // just held — by the time the ladder's first attempt reads it.
+        cy.wrap(null, { timeout: 4000 }).should(() => {
+            refreshHandshakeCensusCount();
+            expect(concurrentHandshakesSnapshot()).to.be.at.least(seatTarget);
+        });
+
+        cy.then(() => {
+            // Count host-worker constructions from here on: the healthy
+            // viewer's host already exists, so any construction after this
+            // point is a retry being routed to a replacement host — which is
+            // exactly what a (false) quarantine would force.
+            class CountingWorker extends realWorker {
+                constructor(...args: ConstructorParameters<typeof Worker>) {
+                    super(...args);
+                    workerConstructions++;
+                }
+            }
+            window.Worker = CountingWorker as typeof Worker;
+            // Hang every handshake attempt of the viewer mounted next. The
+            // healthy viewer booted before this hook existed and never
+            // re-handshakes in this test.
+            doenetGlobalConfig.__doenetTestCoreInitHook = (phase, attempt) => {
+                if (phase === "handshake") {
+                    handshakeAttempts = Math.max(
+                        handshakeAttempts,
+                        attempt + 1,
+                    );
+                    return new Promise<void>(() => {
+                        /* never resolves */
+                    });
+                }
+            };
+        });
+
+        cy.get('[data-test="add-contended"]').click();
+
+        // The contended viewer exhausts its attempts (two 4 s watchdogs plus
+        // a backoff) and reports the failure with the busy-page wording —
+        // which is itself the `lastFailureWasContended` wiring observed
+        // end-to-end.
+        cy.contains("Several documents were starting at once", {
+            timeout: 15000,
+        }).should("exist");
+
+        cy.then(() => {
+            expect(
+                handshakeAttempts,
+                "the contended handshake was still retried",
+            ).to.equal(2);
+            expect(
+                workerConstructions,
+                "no replacement host worker was spawned — the shared host was not quarantined",
+            ).to.equal(0);
+        });
+
+        // The healthy sibling on the same host is undisturbed: its core still
+        // round-trips an action through the shared worker.
+        cy.contains("button", "bump healthy").click();
+        cy.contains("healthy is 1", { timeout: 4000 }).should("exist");
     });
 });

--- a/packages/i18n/locales/en/chrome.ftl
+++ b/packages/i18n/locales/en/chrome.ftl
@@ -202,7 +202,8 @@ renderer-load-failed = a renderer failed to load. Please reload the page.
 # after retries, rather than leaving the pane blank.
 core-start-failed = This document could not be started. Please reload the page.
 
-# Replaces `core-start-failed` when several documents on the page were starting
-# at the same time. That is the usual cause on a page embedding many of them,
-# so name it rather than leaving the reader to conclude the service is broken.
-core-start-failed-busy = This document could not be started. The page was starting several documents at once, which can take longer on a slower device. Reloading the page may help once the other documents have finished.
+# Replaces `core-start-failed` when several documents were starting at the
+# same time — counted across every same-origin tab, so not necessarily all on
+# the page the reader sees. Naming the contention keeps the reader from
+# concluding the service is broken.
+core-start-failed-busy = This document could not be started. Several documents were starting at once, which can take longer on a slower device. Reloading the page may help once the other documents have finished.

--- a/packages/i18n/locales/en/chrome.ftl
+++ b/packages/i18n/locales/en/chrome.ftl
@@ -200,4 +200,9 @@ renderer-load-failed = a renderer failed to load. Please reload the page.
 
 # Shown in place of the document when the core worker could not be started
 # after retries, rather than leaving the pane blank.
-core-start-failed = The document viewer could not be started. Please reload the page.
+core-start-failed = This document could not be started. Please reload the page.
+
+# Replaces `core-start-failed` when several documents on the page were starting
+# at the same time. That is the usual cause on a page embedding many of them,
+# so name it rather than leaving the reader to conclude the service is broken.
+core-start-failed-busy = This document could not be started. The page was starting several documents at once, which can take longer on a slower device. Reloading the page may help once the other documents have finished.

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -69,6 +69,7 @@ export type MessageKey =
     | "something-went-wrong"
     | "renderer-load-failed"
     | "core-start-failed"
+    | "core-start-failed-busy"
     | "color.black"
     | "color.white"
     | "color.gray"
@@ -639,6 +640,7 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "something-went-wrong",
     "renderer-load-failed",
     "core-start-failed",
+    "core-start-failed-busy",
     "color.black",
     "color.white",
     "color.gray",

--- a/packages/standalone/src/pinPackageVersion.ts
+++ b/packages/standalone/src/pinPackageVersion.ts
@@ -16,7 +16,7 @@
  * So the pieces can skew. A browser that fetched the bundle after a release and
  * the worker before it holds a new bundle paired with the previous release's
  * core, which never completes the Comlink handshake — the viewer retries and
- * then shows "The document viewer could not be started" (see
+ * then shows "This document could not be started" (see
  * `Viewer/coreWorkerBoot.ts` in `@doenet/doenetml`). Only clearing the browser
  * cache fixes that, which no purge can reach. It is not hypothetical: 0.7.22
  * shipped a changed core worker under a tag whose worker URL that release did


### PR DESCRIPTION
Third of four PRs that split the original #1713 apart. With #1720 and #1721 merged, this is the bottom of the remaining stack: **#1722 → #1713 (draft)**, rebased onto `main`.

This is the last piece that helps a host we already run. It works on coordinated pages — the census it reads is deliberately independent of any boot gate — which is why it sits on this side of the split rather than with the follow-up.

## The bug

`DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS` is 15 s, and the comment justifying it records the handshake as "~0.4 s idle and only ~2 s with 24 workers booting at once" — measured on developer hardware. On the 1.1 GHz dual-core machine in #1707 that bound does not hold: a page starting many documents at once pushes a perfectly healthy handshake past 15 s, and the watchdog then does the thing the same comment warns against, making the document unloadable on exactly the contended machines the guard exists for.

The retry ladder then made it worse — each attempt spawned a fresh worker re-parsing 15 MB, 250 ms after the last one failed, on a machine already saturated.

## The fix

**A budget sized to real pressure.** `handshakeWatchdogMsFor` scales the base with handshakes-per-core: one per core is neutral and keeps today's 15 s; four handshakes on two cores doubles it; `MAX_CORE_HANDSHAKE_WATCHDOG_MS` (90 s) caps it so a genuine hang is still recovered from. An explicit `doenetGlobalConfig.coreHandshakeWatchdogMs` wins outright over the scaled budget — an override is a statement about the deployment (one using `fetchExternalDoenetML`, say, whose network expansion runs inside the handshake) and is used as-is for every attempt. Erring long is the deliberate bias — too long only delays recovery from a rare hang, while too short makes documents permanently unloadable.

**The census that feeds it.** Every realm mid-handshake holds one shared Web Lock; `navigator.locks.query()` reports the holders. It gates nothing. Split out here as `utils/handshakeCensus.ts` over `utils/webLocks.ts` rather than living with the gate, because it uses a lock name of its own on purpose: a page whose host schedules boots takes no gate locks at all, and those pages (assignment-viewer, the docs site) are where cores share a worker thread and contention costs the most.

`concurrentHandshakesSnapshot()` is synchronous, and that is load-bearing rather than an optimization — awaiting Web Locks on the boot path added suspension points that changed which boot won a rebuild race, bisected to a `DocViewer/i18n` failure. A count one refresh out of date is a fine input to a timeout; a boot that races itself is not.

**Backoff.** Retries back off exponentially with jitter (250 ms → 4 s cap, `[1, 2)` multiplier) so a page of activities that timed out together does not retry in lockstep.

**No false wedge suspicion.** A handshake timeout normally tears the worker down with `suspectWedge`, which in shared-core mode quarantines the whole host worker: its live cores run on, but the suspected core is killed and retried, and it and every core boot after it must land on a replacement host whose multi-MB worker spawns and compiles under the very contention that produced the false alarm. `docUtils` already conceded the suspicion "may be a false positive (CPU contention)"; `timeoutLooksLikeContention` is what lets the caller act on that. Only a watchdog expiry can be blamed on the page, never an outright rejection — a worker script that 404s reproduces on an idle page too.

**Wording.** A failure attributable to contention now says several documents were starting at once and may take longer on a slower device, instead of presenting an unexplained error. The general message is reworded to match: "This document could not be started". Comments elsewhere that quoted the old string (`pinPackageVersion.ts`, the iframe editor entry point and its churn spec) are updated with it, and the retry log now records each attempt's watchdog budget and the census reading behind it.

## Known limits

- #1718 — the contention-scaled budget never engages on a *first* attempt, since the snapshot is one refresh behind by contract. A first boot gets the base 15 s.
- #1719 — `DoenetEditor.diagnosticHoverLocale`'s 15 s setup wait equals one watchdog period, so a single trip-and-retry can exceed it on slow CI runners. Tracked separately; not addressed here.

## Testing

- New `coreWorkerBoot.test.ts` (15 cases): budget scaling, the 90 s cap, missing `hardwareConcurrency`, contention attribution, timeout tagging, backoff growth and bound.
- New `handshakeCensus.test.ts`: counting across realms, dropping on release, and the neutral 1 when the browser cannot answer.
- 172 vitest, all `@doenet/doenetml` component tests, typecheck at the pre-existing baseline.
- Full boot battery — four packages rebuilt, `DocViewer/i18n` three times at 38 passing, plus the coordinator specs.

Closes #1711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





