### PR TITLE
fix: plain-text prefigure labels invisible in dark mode

### DIFF
--- a/.changeset/prefigure-label-dark-mode-color.md
+++ b/.changeset/prefigure-label-dark-mode-color.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix plain-text labels being invisible in dark mode on prefigure-rendered graphs.
+
+Point, line/vector, and angle labels without LaTeX, along with graph axis
+titles, are rendered by PreFigure as native SVG `<text>` elements. Without an
+explicit color, PreFigure leaves these unstyled, which defaults to opaque
+black and disappears against a dark canvas. Math/LaTeX labels were unaffected
+since they render through MathJax, which already uses the page's text color.
+Plain-text labels now carry an explicit color that follows the page's
+light/dark theme.

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -144,8 +144,12 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(prefigureXML).toContain(`<axes axes="all">`);
-        expect(prefigureXML).toContain(`<xlabel alignment="nw">time</xlabel>`);
-        expect(prefigureXML).toContain(`<ylabel alignment="se">value</ylabel>`);
+        expect(prefigureXML).toContain(
+            `<xlabel alignment="nw" color="currentColor">time</xlabel>`,
+        );
+        expect(prefigureXML).toContain(
+            `<ylabel alignment="se" color="currentColor">value</ylabel>`,
+        );
 
         const diagnosticsByType = await getWarnings(
             prefigureGraph(
@@ -235,8 +239,12 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(prefigureXML).toContain(`<axes axes="all">`);
-        expect(prefigureXML).toContain(`<xlabel alignment="nw"><m>`);
-        expect(prefigureXML).toContain(`<ylabel alignment="se"><m>`);
+        expect(prefigureXML).toContain(
+            `<xlabel alignment="nw" color="currentColor"><m>`,
+        );
+        expect(prefigureXML).toContain(
+            `<ylabel alignment="se" color="currentColor"><m>`,
+        );
         expect(prefigureXML).toContain(`x^2`);
         expect(prefigureXML).toContain(`y_1`);
     });
@@ -249,7 +257,7 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all"><xlabel alignment="nw"><m>x^2</m></xlabel><ylabel alignment="se"><m>y_1</m></ylabel></axes></coordinates><annotations></annotations></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all"><xlabel alignment="nw" color="currentColor"><m>x^2</m></xlabel><ylabel alignment="se" color="currentColor"><m>y_1</m></ylabel></axes></coordinates><annotations></annotations></diagram>"`,
         );
     });
 

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1268,8 +1268,10 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).toContain(`stroke="#1f5dff"`);
         expect(prefigureXML).toContain(`thickness="4"`);
         expect(prefigureXML).toContain(`fill="#1f5dff"`);
-        expect(prefigureXML).toContain(`<label anchor="`);
-        expect(prefigureXML).toContain(`color="currentColor"`);
+        // The label carries a theme-aware color so it stays visible in dark mode.
+        expect(prefigureXML).toMatch(
+            /<label anchor="[^"]*" color="currentColor">/,
+        );
         expect(prefigureXML).toContain(`\\theta`);
     });
 
@@ -1821,7 +1823,9 @@ describe("point label alignment overflow @group4", () => {
             xs: "0 0",
             labelPosition: "upperright",
         });
-        expect(prefigureXML).toContain(`color="currentColor"`);
+        // The color must sit on the <point> element itself, since that is the
+        // element PreFigure renders the label text from.
+        expect(prefigureXML).toMatch(/<point [^>]*color="currentColor"/);
     });
 
     it("near top-right — primary ne overflows, fallback used", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1269,6 +1269,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).toContain(`thickness="4"`);
         expect(prefigureXML).toContain(`fill="#1f5dff"`);
         expect(prefigureXML).toContain(`<label anchor="`);
+        expect(prefigureXML).toContain(`color="currentColor"`);
         expect(prefigureXML).toContain(`\\theta`);
     });
 
@@ -1813,6 +1814,14 @@ describe("point label alignment overflow @group4", () => {
             labelPosition: "upperright",
         });
         expect(prefigureXML).toContain(`alignment="ne"`);
+    });
+
+    it("point label is emitted with a theme-aware color so it stays visible in dark mode", async () => {
+        const prefigureXML = await pointLabelXml({
+            xs: "0 0",
+            labelPosition: "upperright",
+        });
+        expect(prefigureXML).toContain(`color="currentColor"`);
     });
 
     it("near top-right — primary ne overflows, fallback used", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -127,7 +127,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><line at="line_0" endpoints="((1,2),(3,4))" infinite="yes" stroke="#1f5dff" thickness="4" fill="#1f5dff" fill-opacity="0.3" stroke-opacity="0.7" label-location="0.95" alignment="s">A</line></coordinates><annotations></annotations></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><line at="line_0" endpoints="((1,2),(3,4))" infinite="yes" stroke="#1f5dff" thickness="4" fill="#1f5dff" fill-opacity="0.3" stroke-opacity="0.7" color="currentColor" label-location="0.95" alignment="s">A</line></coordinates><annotations></annotations></diagram>"`,
         );
     });
 
@@ -1083,7 +1083,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><vector at="vector_0" tail="(0,0)" v="(3,3)" stroke="#1f5dff" thickness="4" fill="#1f5dff" fill-opacity="0.3" stroke-opacity="0.7" /><label p="(2.85,2.85)" alignment="north">V</label></coordinates><annotations></annotations></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><vector at="vector_0" tail="(0,0)" v="(3,3)" stroke="#1f5dff" thickness="4" fill="#1f5dff" fill-opacity="0.3" stroke-opacity="0.7" /><label p="(2.85,2.85)" alignment="north" color="currentColor">V</label></coordinates><annotations></annotations></diagram>"`,
         );
     });
 
@@ -1106,10 +1106,10 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toContain(
-            `<label p="(2.85,2.85)" alignment="north">UR</label>`,
+            `<label p="(2.85,2.85)" alignment="north" color="currentColor">UR</label>`,
         );
         expect(prefigureXML).toContain(
-            `<label p="(0.15,0.15)" alignment="north">LL</label>`,
+            `<label p="(0.15,0.15)" alignment="north" color="currentColor">LL</label>`,
         );
     });
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/angle.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/angle.ts
@@ -1,5 +1,5 @@
 import { escapeXml, formatNumber, formatPoint } from "../common";
-import { labelMarkup } from "../label";
+import { labelMarkup, THEME_AWARE_LABEL_COLOR_ATTR } from "../label";
 import { styleAttributes } from "../style";
 import type { ConverterArgs, Point } from "../types";
 
@@ -169,6 +169,6 @@ export function convertAngleToPrefigure({
         return arcXml;
     }
 
-    const labelXml = `<label anchor="${escapeXml(labelAnchorText)}">${label}</label>`;
+    const labelXml = `<label anchor="${escapeXml(labelAnchorText)}" ${THEME_AWARE_LABEL_COLOR_ATTR}>${label}</label>`;
     return `${arcXml}${labelXml}`;
 }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/vector.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/vector.ts
@@ -8,6 +8,7 @@ import {
     getLabelForLine,
     lineLabelLocationValue,
     orientEndpointsForLineLabel,
+    THEME_AWARE_LABEL_COLOR_ATTR,
 } from "../label";
 import type { ConverterArgs, Point } from "../types";
 
@@ -84,7 +85,7 @@ export function convertVectorToPrefigure({
 
     // TODO: Map vector labelPosition to PreFigure label alignment once we have
     // parity requirements for vector-native label placement.
-    const labelXml = `<label p="${escapeXml(anchorText)}" alignment="north">${label}</label>`;
+    const labelXml = `<label p="${escapeXml(anchorText)}" alignment="north" ${THEME_AWARE_LABEL_COLOR_ATTR}>${label}</label>`;
 
     return `${vectorXml}${labelXml}`;
 }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
@@ -5,7 +5,7 @@ import {
     pushWarning,
     warningSubjectForDescendant,
 } from "./common";
-import { labelMarkup } from "./label";
+import { labelMarkup, THEME_AWARE_LABEL_COLOR_ATTR } from "./label";
 import { gridElementFromGrid } from "./grid";
 import { convertGraphicalDescendantToPrefigure } from "./descendant";
 import { convertDoenetMLAnnotationsToPreFigureXml } from "./annotations";
@@ -87,7 +87,9 @@ function axesElementFromLabels({
         labelHasLatex: dependencyValues.xLabelHasLatex,
     });
     if (xLabel && dependencyValues.displayXAxis) {
-        axisLabelElements.push(`<xlabel alignment="nw">${xLabel}</xlabel>`);
+        axisLabelElements.push(
+            `<xlabel alignment="nw" ${THEME_AWARE_LABEL_COLOR_ATTR}>${xLabel}</xlabel>`,
+        );
     }
 
     const yLabel = labelMarkup({
@@ -95,7 +97,9 @@ function axesElementFromLabels({
         labelHasLatex: dependencyValues.yLabelHasLatex,
     });
     if (yLabel && dependencyValues.displayYAxis) {
-        axisLabelElements.push(`<ylabel alignment="se">${yLabel}</ylabel>`);
+        axisLabelElements.push(
+            `<ylabel alignment="se" ${THEME_AWARE_LABEL_COLOR_ATTR}>${yLabel}</ylabel>`,
+        );
     }
 
     const strokeAttr = darkMode ? ` stroke="${PREFIGURE_DARK_AXIS_COLOR}"` : "";

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/label.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/label.ts
@@ -45,6 +45,24 @@ function normalizeKey(value: unknown): string {
         .replace(/[^a-z0-9]+/g, "");
 }
 
+/**
+ * PreFigure only sets a label `<text>`'s `fill` when the source XML carries
+ * an explicit `color` attribute (true of both the Python `prefig` compiler
+ * and the Rust `prefig-wasm` port — see their respective `label.py`/
+ * `label.rs`). Without it, `fill` is left unset, which per the SVG spec
+ * defaults to opaque black — not "inherit the page's CSS color" — so
+ * plain-text labels can be invisible against a dark canvas.
+ *
+ * Math/LaTeX labels are rendered via MathJax, whose own SVG output already
+ * conventionally uses `currentColor`, so they're unaffected by this gap.
+ * Emitting this attribute unconditionally (not only in dark mode) is
+ * simplest and correct in both themes, and matches what MathJax already
+ * does for math labels — see `PREFIGURE_DARK_AXIS_COLOR` in `graph.ts` for
+ * the analogous (but darkMode-conditional, since it recolors an already-
+ * visible-by-default stroke) fix for axis lines.
+ */
+export const THEME_AWARE_LABEL_COLOR_ATTR = 'color="currentColor"';
+
 // Reserved inset used during label overflow scoring to reduce visible clipping
 // at graph bounds. Shared by point and line-family label placement.
 const LABEL_EDGE_PADDING_RATIO = 0.02;
@@ -776,7 +794,7 @@ export function pointLabelAttributes({
         return null;
     }
 
-    const attrs = [];
+    const attrs = [THEME_AWARE_LABEL_COLOR_ATTR];
     const rawPosition = stateValues?.labelPosition;
     if (rawPosition) {
         const rawXs = stateValues?.numericalXs;
@@ -1031,7 +1049,7 @@ export function getLabelForLine({
         };
     }
 
-    const labelAttrs = [];
+    const labelAttrs = [THEME_AWARE_LABEL_COLOR_ATTR];
     const rawPosition = stateValues?.labelPosition;
     const normalizedPosition = normalizeKey(rawPosition ?? "");
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/label.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/label.ts
@@ -46,20 +46,28 @@ function normalizeKey(value: unknown): string {
 }
 
 /**
- * PreFigure only sets a label `<text>`'s `fill` when the source XML carries
- * an explicit `color` attribute (true of both the Python `prefig` compiler
- * and the Rust `prefig-wasm` port — see their respective `label.py`/
- * `label.rs`). Without it, `fill` is left unset, which per the SVG spec
- * defaults to opaque black — not "inherit the page's CSS color" — so
- * plain-text labels can be invisible against a dark canvas.
+ * Attribute that makes a PreFigure label follow the page's light/dark text
+ * color. Append it to every element whose text PreFigure renders as a native
+ * SVG `<text>`: `<point>`, `<line>`, `<label>`, `<xlabel>`, `<ylabel>`.
  *
- * Math/LaTeX labels are rendered via MathJax, whose own SVG output already
- * conventionally uses `currentColor`, so they're unaffected by this gap.
- * Emitting this attribute unconditionally (not only in dark mode) is
- * simplest and correct in both themes, and matches what MathJax already
- * does for math labels — see `PREFIGURE_DARK_AXIS_COLOR` in `graph.ts` for
- * the analogous (but darkMode-conditional, since it recolors an already-
- * visible-by-default stroke) fix for axis lines.
+ * PreFigure sets a label `<text>`'s `fill` only when the source XML carries an
+ * explicit `color` attribute (true of both the Python `prefig` compiler and the
+ * Rust `prefig-wasm` port — see their respective `label.py`/`label.rs`).
+ * Without it `fill` is left unset, which per the SVG spec means opaque black
+ * rather than "inherit the page's CSS color", so plain-text labels vanish
+ * against a dark canvas.
+ *
+ * Emitting it unconditionally rather than only in dark mode keeps both themes
+ * correct with one code path, since `currentColor` already resolves to whatever
+ * the surrounding document uses. It is also safe on labels that turn out to
+ * hold math: PreFigure copies a label's `color` down to its `<m>` children,
+ * where it becomes a CSS `color` on the MathJax container — a no-op, because
+ * MathJax's SVG output fills with `currentColor` anyway. (That is also why
+ * math labels never had this bug.)
+ *
+ * Contrast `PREFIGURE_DARK_AXIS_COLOR` in `graph.ts`, which must stay
+ * dark-mode-conditional: it recolors axis strokes that are already visible in
+ * light mode, rather than filling in a missing value.
  */
 export const THEME_AWARE_LABEL_COLOR_ATTR = 'color="currentColor"';
 


### PR DESCRIPTION
## Summary
- Plain-text prefigure labels (points, lines, vectors, angles) and graph axis titles rendered as invisible black text in dark mode, because PreFigure only sets an SVG `<text>` element's `fill` when the source XML carries an explicit `color` attribute — otherwise it's left unset, which defaults to opaque black per the SVG spec, not "inherit the page's color".
- Math/LaTeX labels were unaffected since they render through MathJax, which already emits `currentColor`.
- Confirmed against production (doenet.org, v0.7.24) that this is a pre-existing bug, independent of any prefigure backend.
- Adds an explicit `color="currentColor"` attribute at every plain-text label emission point in the PreFigure XML generation: point labels, line/vector labels, angle labels, and axis `xlabel`/`ylabel`.
- Adds unit coverage for point and angle label colors (previously untested) and updates the existing line/vector/axis snapshots.

## Notes
- Emitting the attribute unconditionally rather than only in dark mode is safe in both themes, and safe on labels that hold math: PreFigure copies a label's `color` down to its `<m>` children, where it becomes a CSS `color` on the MathJax container — a no-op, since MathJax already fills with `currentColor`.
- `color` is consumed only by PreFigure's label code; it does not affect line/point geometry, and no other Doenet-level styling (`selectedStyle`, `styleAttributes`, `pointStyleAttributes`) ever emits a `color` attribute, so there is no override or duplicate-attribute conflict.

## Test plan
- [x] `npm run test -w packages/doenetml-worker-javascript -- --run src/test/prefigure` (181 passed, 2 pre-existing skips)
- [x] Compiled the generated XML through `prefig-wasm` directly and confirmed the emitted `<text>` elements gain `fill="currentColor"`, and lose it without the attribute
- [x] Verified visually in a local dev server: labels now follow light/dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)
