### PR TITLE
Shrink the standalone bundle: lazy editor stack, code splitting, schema dedupe

### DIFF
--- a/.changeset/slim-standalone-bundle.md
+++ b/.changeset/slim-standalone-bundle.md
@@ -23,7 +23,9 @@ URL as before. The `onload` contract of PreTeXt-style pages is preserved:
 exist at `load` (queueing until the bundle finishes evaluating), and
 `window.doenetGlobalConfig` values a host sets at `load` are honored —
 `@doenet/doenetml` now adopts a host-created config object instead of
-replacing it. Duplicate copies of the component schema are eliminated
+replacing it, and a host-chosen `doenetWorkerUrl` stays in force (the
+bundle's own worker-URL resolution and version pinning defer to it).
+Duplicate copies of the component schema are eliminated
 (five down to two, none of them eagerly loaded). Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where
 relative chunk imports cannot resolve, can use the new single-file
 `doenet-standalone-inline.js` published beside it. The `CodeMirror` component

--- a/.changeset/slim-standalone-bundle.md
+++ b/.changeset/slim-standalone-bundle.md
@@ -1,0 +1,19 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Shrink the eagerly-parsed standalone bundle by lazy-loading the editor stack
+(#1437). The `EditorViewer` behind both `DoenetEditor` and the `<codeEditor>`
+renderer now loads through a `React.lazy` boundary, `@doenet/standalone` is
+code-split (`doenet-standalone.js` plus lazy `chunks/` resolved relative to
+the bundle URL), and the component schema is bundled once instead of five
+times. Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where
+relative chunk imports cannot resolve, can use the new single-file
+`doenet-standalone-inline.js` published beside it. The `CodeMirror` component
+is now exported from `@doenet/doenetml/codemirror.js` instead of the main
+`@doenet/doenetml` entry, so importing the viewer no longer parses the editor
+stack.

--- a/.changeset/slim-standalone-bundle.md
+++ b/.changeset/slim-standalone-bundle.md
@@ -29,7 +29,11 @@ A second copy of the bundle loaded on the same page now stays fully inert
 instead of taking over the render globals: its worker-URL write and its
 `window.renderDoenet*ToContainer` / palette globals both defer to the first
 copy's, so every document pairs one release's UI with that same release's
-worker.
+worker. When two copies load concurrently, render calls a host queued against
+one copy's `onload` stubs replay through the first copy that finishes
+loading — never stranded, even if the copy that installed the stubs fails to
+finish loading — and editor handles captured from a stub keep working after
+that hand-off.
 Duplicate copies of the component schema are eliminated
 (five down to two, none of them eagerly loaded). Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where
 relative chunk imports cannot resolve, can use the new single-file

--- a/.changeset/slim-standalone-bundle.md
+++ b/.changeset/slim-standalone-bundle.md
@@ -25,6 +25,11 @@ exist at `load` (queueing until the bundle finishes evaluating), and
 `@doenet/doenetml` now adopts a host-created config object instead of
 replacing it, and a host-chosen `doenetWorkerUrl` stays in force (the
 bundle's own worker-URL resolution and version pinning defer to it).
+A second copy of the bundle loaded on the same page now stays fully inert
+instead of taking over the render globals: its worker-URL write and its
+`window.renderDoenet*ToContainer` / palette globals both defer to the first
+copy's, so every document pairs one release's UI with that same release's
+worker.
 Duplicate copies of the component schema are eliminated
 (five down to two, none of them eagerly loaded). Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where
 relative chunk imports cannot resolve, can use the new single-file

--- a/.changeset/slim-standalone-bundle.md
+++ b/.changeset/slim-standalone-bundle.md
@@ -13,7 +13,17 @@ still fails to load after the retries renders the same inline
 renderer-failed-to-load message the viewer renderers use, keeping the rest of
 the page mounted), `@doenet/standalone` is
 code-split (`doenet-standalone.js` plus lazy `chunks/` resolved relative to
-the bundle URL), and duplicate copies of the component schema are eliminated
+the bundle URL). The split bundle pins its chunk URLs to its own version at
+runtime when served from a floating CDN tag (`@latest`, a version range, or no
+version), so an already-cached entry keeps loading its own release's chunks
+across releases instead of 404ing on the next release's hashes; under any
+other URL (self-hosted, exact-version) chunks resolve relative to the bundle
+URL as before. The `onload` contract of PreTeXt-style pages is preserved:
+`window.renderDoenetViewerToContainer` / `renderDoenetEditorToContainer`
+exist at `load` (queueing until the bundle finishes evaluating), and
+`window.doenetGlobalConfig` values a host sets at `load` are honored —
+`@doenet/doenetml` now adopts a host-created config object instead of
+replacing it. Duplicate copies of the component schema are eliminated
 (five down to two, none of them eagerly loaded). Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where
 relative chunk imports cannot resolve, can use the new single-file
 `doenet-standalone-inline.js` published beside it. The `CodeMirror` component

--- a/.changeset/slim-standalone-bundle.md
+++ b/.changeset/slim-standalone-bundle.md
@@ -8,7 +8,10 @@
 
 Shrink the eagerly-parsed standalone bundle by lazy-loading the editor stack
 (#1437). The `EditorViewer` behind both `DoenetEditor` and the `<codeEditor>`
-renderer now loads through a `React.lazy` boundary, `@doenet/standalone` is
+renderer now loads through a `React.lazy` boundary (an editor chunk that
+still fails to load after the retries renders the same inline
+renderer-failed-to-load message the viewer renderers use, keeping the rest of
+the page mounted), `@doenet/standalone` is
 code-split (`doenet-standalone.js` plus lazy `chunks/` resolved relative to
 the bundle URL), and the component schema is bundled once instead of five
 times. Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where

--- a/.changeset/slim-standalone-bundle.md
+++ b/.changeset/slim-standalone-bundle.md
@@ -13,8 +13,8 @@ still fails to load after the retries renders the same inline
 renderer-failed-to-load message the viewer renderers use, keeping the rest of
 the page mounted), `@doenet/standalone` is
 code-split (`doenet-standalone.js` plus lazy `chunks/` resolved relative to
-the bundle URL), and the component schema is bundled once instead of five
-times. Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where
+the bundle URL), and duplicate copies of the component schema are eliminated
+(five down to two, none of them eagerly loaded). Hosts that evaluate the bundle from a Blob or `srcdoc` URL, where
 relative chunk imports cannot resolve, can use the new single-file
 `doenet-standalone-inline.js` published beside it. The `CodeMirror` component
 is now exported from `@doenet/doenetml/codemirror.js` instead of the main

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -50,6 +50,7 @@
                 "../parser:build",
                 "../lsp:build",
                 "../lsp-tools:build",
+                "../static-assets:build",
                 "../utils:build"
             ]
         }

--- a/packages/codemirror/vite.config.ts
+++ b/packages/codemirror/vite.config.ts
@@ -23,9 +23,9 @@ export default defineConfig({
                 // completion snippets) to the consuming build, the same way
                 // `@doenet/lsp-tools` does. Every consumer bundles this
                 // package together with other users of the schema, so
-                // resolving it there means one shared copy of the ~5 MB
-                // schema module instead of a private copy baked into this
-                // dist.
+                // resolving it there means one shared copy of the ~230 KB
+                // compressed schema literal instead of a private copy baked
+                // into this dist.
                 /@doenet\/static-assets/,
             ],
         },

--- a/packages/codemirror/vite.config.ts
+++ b/packages/codemirror/vite.config.ts
@@ -15,7 +15,19 @@ export default defineConfig({
             formats: ["es"],
         },
         rollupOptions: {
-            external: ["react", "react-dom", "react-dom/server"],
+            external: [
+                "react",
+                "react-dom",
+                "react-dom/server",
+                // Leave `@doenet/static-assets` (the component schema and
+                // completion snippets) to the consuming build, the same way
+                // `@doenet/lsp-tools` does. Every consumer bundles this
+                // package together with other users of the schema, so
+                // resolving it there means one shared copy of the ~5 MB
+                // schema module instead of a private copy baked into this
+                // dist.
+                /@doenet\/static-assets/,
+            ],
         },
     },
     // The LSP bundle is a large IIFE with inlined WASM (≈7 MB).  It is

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -177,13 +177,31 @@ function resolveInitialDoenetMLSource(root: Element): string {
 // in a fresh iframe, so this ceiling only needs to cover one boot, not
 // a sum across retries.
 async function waitForStandaloneBundle(timeoutMs: number): Promise<boolean> {
-    if (typeof window.renderDoenetEditorToContainer === "function") {
+    // A code-split bundle's entry facade installs a queueing *stub* at this
+    // global before the bundle's eager chunk has evaluated, marked with
+    // `__doenetPendingRenderStub` (see `facadeRenderQueue.ts` in
+    // `@doenet/standalone`, which names this property as part of the bundle's
+    // surface). Waiting the stub out keeps the `iframeReady` handshake — and
+    // the style palettes reported with it — tied to the fully evaluated
+    // bundle, and means the handle returned by
+    // `renderDoenetEditorToContainer` below is always the real one.
+    function bundleReady(): boolean {
+        const render = window.renderDoenetEditorToContainer as
+            | (((...args: unknown[]) => unknown) & {
+                  __doenetPendingRenderStub?: boolean;
+              })
+            | undefined;
+        return (
+            typeof render === "function" && !render.__doenetPendingRenderStub
+        );
+    }
+    if (bundleReady()) {
         return true;
     }
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 50));
-        if (typeof window.renderDoenetEditorToContainer === "function") {
+        if (bundleReady()) {
             return true;
         }
     }

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -356,8 +356,9 @@ function renderWithLastAugmentedProps() {
  * creation stays synchronous here. `destroy` notifies the parent to release
  * the core (forwarding wedge suspicion for host quarantine).
  *
- * Must run after the standalone bundle has evaluated — the bundle replaces
- * `window.doenetGlobalConfig` — and before anything renders a viewer.
+ * Must run after the standalone bundle has evaluated — so that
+ * `window.doenetGlobalConfig` exists (the bundle creates or adopts it) —
+ * and before anything renders a viewer.
  */
 function installSharedCorePortProvider() {
     let coreCounter = 0;

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -200,13 +200,30 @@ function resolveDoenetMLSource(root: Element): string {
 // `window.renderDoenetViewerToContainer` being defined and throw
 // silently inside the iframe.
 async function waitForStandaloneBundle(timeoutMs: number): Promise<boolean> {
-    if (typeof window.renderDoenetViewerToContainer === "function") {
+    // A code-split bundle's entry facade installs a queueing *stub* at this
+    // global before the bundle's eager chunk has evaluated, marked with
+    // `__doenetPendingRenderStub` (see `facadeRenderQueue.ts` in
+    // `@doenet/standalone`, which names this property as part of the bundle's
+    // surface). Waiting the stub out keeps the `iframeReady` handshake — and
+    // the style palettes reported with it — tied to the fully evaluated
+    // bundle.
+    function bundleReady(): boolean {
+        const render = window.renderDoenetViewerToContainer as
+            | (((...args: unknown[]) => unknown) & {
+                  __doenetPendingRenderStub?: boolean;
+              })
+            | undefined;
+        return (
+            typeof render === "function" && !render.__doenetPendingRenderStub
+        );
+    }
+    if (bundleReady()) {
         return true;
     }
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 50));
-        if (typeof window.renderDoenetViewerToContainer === "function") {
+        if (bundleReady()) {
             return true;
         }
     }

--- a/packages/doenetml-iframe/src/test-main.tsx
+++ b/packages/doenetml-iframe/src/test-main.tsx
@@ -7,8 +7,11 @@ import React, { useRef } from "react";
 import ReactDOM from "react-dom/client";
 import { DoenetViewer, DoenetEditor, type DoenetEditorHandle } from "./index";
 
+// The single-file inline variant: the regular `doenet-standalone.js` is
+// code-split, and a bundle evaluated from a Blob URL has no base to resolve
+// its relative chunk imports against.
 // @ts-ignore
-import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone.js?raw";
+import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone-inline.js?raw";
 // @ts-ignore
 import STANDALONE_CSS from "@doenet/standalone/style.css?raw";
 // @ts-ignore

--- a/packages/doenetml-iframe/test/cypress/component/DoenetViewer.windowedBootFailure.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetViewer.windowedBootFailure.cy.tsx
@@ -7,8 +7,11 @@ import {
     CONTENT_TIMEOUT,
 } from "./helpers";
 
+// The inline variant, for the same reason as `helpers.ts`: this source is
+// evaluated from a Blob URL, where the code-split bundle's relative chunk
+// imports cannot resolve.
 // @ts-ignore - `?raw` returns a string; we don't ship types for it.
-import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone.js?raw";
+import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone-inline.js?raw";
 
 // Boot-slot release on core-start failure (#1709), across the Comlink
 // boundary: a windowed viewer whose embedded core cannot start reports

--- a/packages/doenetml-iframe/test/cypress/component/helpers.ts
+++ b/packages/doenetml-iframe/test/cypress/component/helpers.ts
@@ -4,10 +4,12 @@
 // the same trick used by `src/test-main.tsx` so the iframe loads the
 // locally-built version of @doenet/standalone instead of the CDN. (The
 // `raw-large-bundle` plugin in cypress.config.ts handles the multi-MB string
-// literal decoding.)
+// literal decoding.) It has to be the single-file inline variant: the regular
+// `doenet-standalone.js` is code-split, and a bundle evaluated from a Blob URL
+// has no base to resolve its relative chunk imports against.
 
 // @ts-ignore - `?raw` returns a string; we don't ship types for it.
-import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone.js?raw";
+import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone-inline.js?raw";
 // @ts-ignore
 import STANDALONE_CSS from "@doenet/standalone/style.css?raw";
 

--- a/packages/doenetml/src/EditorViewer/EditorViewerLazy.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewerLazy.tsx
@@ -1,0 +1,46 @@
+import React, { Suspense } from "react";
+import type { EditorViewer } from "./EditorViewer";
+import { importRendererWithRetry } from "../Viewer/renderersLoadComponent";
+
+type EditorViewerProps = React.ComponentPropsWithoutRef<typeof EditorViewer>;
+type EditorViewerHandle = React.ComponentRef<typeof EditorViewer>;
+
+/**
+ * The editor stack's code-splitting boundary.
+ *
+ * `EditorViewer` carries the heaviest main-thread dependencies in the bundle —
+ * `@doenet/codemirror` (with its inlined LSP worker source), the pretty
+ * printer, the diagnostics/context-help UI, and the component schema they
+ * read. This lazy import keeps all of that in its own chunk, loaded on the
+ * first mount of an editor, so a viewer-only page never parses it. Both
+ * routes into the editor go through here: the `DoenetEditor` component in
+ * `doenetml.tsx`, and the `<codeEditor>` renderer.
+ *
+ * The chunk fetch is wrapped in the same transient-failure retry the viewer
+ * renderer chunks use (see `renderersLoadComponent.tsx`).
+ */
+const LazyInner = React.lazy(async () => {
+    const module = await importRendererWithRetry(
+        () => import("./EditorViewer"),
+        "EditorViewer",
+    );
+    return { default: module.EditorViewer };
+});
+
+/**
+ * Drop-in stand-in for `EditorViewer` that loads it on first mount. Renders
+ * nothing while the chunk is in flight; the ref attaches once the real
+ * component mounts, which the imperative-handle plumbing in
+ * `@doenet/standalone` already tolerates (it queues handle actions until the
+ * ref fires).
+ */
+export const EditorViewerLazy = React.forwardRef<
+    EditorViewerHandle,
+    EditorViewerProps
+>(function EditorViewerLazy(props, ref) {
+    return (
+        <Suspense fallback={null}>
+            <LazyInner ref={ref} {...props} />
+        </Suspense>
+    );
+});

--- a/packages/doenetml/src/EditorViewer/EditorViewerLazy.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewerLazy.tsx
@@ -1,6 +1,9 @@
 import React, { Suspense } from "react";
 import type { EditorViewer } from "./EditorViewer";
-import { importRendererWithRetry } from "../Viewer/renderersLoadComponent";
+import {
+    ChunkLoadErrorBoundary,
+    importRendererWithRetry,
+} from "../Viewer/renderersLoadComponent";
 
 type EditorViewerProps = React.ComponentPropsWithoutRef<typeof EditorViewer>;
 type EditorViewerHandle = React.ComponentRef<typeof EditorViewer>;
@@ -17,7 +20,11 @@ type EditorViewerHandle = React.ComponentRef<typeof EditorViewer>;
  * `doenetml.tsx`, and the `<codeEditor>` renderer.
  *
  * The chunk fetch is wrapped in the same transient-failure retry the viewer
- * renderer chunks use (see `renderersLoadComponent.tsx`).
+ * renderer chunks use, and a fetch that still fails after the retries renders
+ * the same `RendererLoadFailed` placeholder they substitute (see
+ * `renderersLoadComponent.tsx`) — without a boundary here, React would
+ * instead unwind to whatever boundary surrounds the editor: none at all under
+ * `DoenetEditor`, the whole-document one under a `<codeEditor>`.
  */
 const LazyInner = React.lazy(async () => {
     const module = await importRendererWithRetry(
@@ -39,8 +46,10 @@ export const EditorViewerLazy = React.forwardRef<
     EditorViewerProps
 >(function EditorViewerLazy(props, ref) {
     return (
-        <Suspense fallback={null}>
-            <LazyInner ref={ref} {...props} />
-        </Suspense>
+        <ChunkLoadErrorBoundary>
+            <Suspense fallback={null}>
+                <LazyInner ref={ref} {...props} />
+            </Suspense>
+        </ChunkLoadErrorBoundary>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/codeEditor.tsx
+++ b/packages/doenetml/src/Viewer/renderers/codeEditor.tsx
@@ -5,7 +5,10 @@ import useDoenetRenderer, {
 // @ts-ignore
 import { sizeToCSS } from "./utils/css";
 import { useInView } from "framer-motion";
-import { EditorViewer } from "../../EditorViewer/EditorViewer";
+// The lazy wrapper, not `EditorViewer` itself: a static import here would
+// hoist the whole editor stack into every bundle that can render a document,
+// defeating the code-splitting boundary. See `EditorViewerLazy.tsx`.
+import { EditorViewerLazy } from "../../EditorViewer/EditorViewerLazy";
 import type { DiagnosticsTabId } from "../../EditorViewer/DiagnosticsResponseTabs";
 import { DocContext } from "../DocViewer";
 
@@ -108,7 +111,7 @@ export default React.memo(function CodeEditor(props: UseDoenetRendererProps) {
 
     return (
         <div ref={ref}>
-            <EditorViewer
+            <EditorViewerLazy
                 id={id}
                 activityId={id}
                 prefixForIds={id + "::"}

--- a/packages/doenetml/src/Viewer/renderersLoadComponent.tsx
+++ b/packages/doenetml/src/Viewer/renderersLoadComponent.tsx
@@ -88,6 +88,40 @@ export function RendererLoadFailed(props: {
     );
 }
 
+type ChunkLoadErrorBoundaryState = { caught: boolean; error: unknown };
+
+/**
+ * Error boundary for a `React.lazy` seam whose chunk ultimately failed to
+ * load (after `importRendererWithRetry` gave up): the rejection re-thrown by
+ * React during render is caught here and replaced with the same
+ * `RendererLoadFailed` placeholder the viewer renderers substitute, keeping
+ * the surrounding tree mounted. Any other error is re-thrown to the next
+ * boundary up, so a bug inside the loaded component still fails the way it
+ * did before the lazy seam existed.
+ */
+export class ChunkLoadErrorBoundary extends React.Component<
+    { children: React.ReactNode },
+    ChunkLoadErrorBoundaryState
+> {
+    state: ChunkLoadErrorBoundaryState = { caught: false, error: undefined };
+
+    static getDerivedStateFromError(
+        error: unknown,
+    ): ChunkLoadErrorBoundaryState {
+        return { caught: true, error };
+    }
+
+    render() {
+        if (this.state.caught) {
+            if (!isTransientDynamicImportError(this.state.error)) {
+                throw this.state.error;
+            }
+            return <RendererLoadFailed />;
+        }
+        return this.props.children;
+    }
+}
+
 export type RenderersLoadResult = {
     rendererClasses: Record<string, any>;
     /** Names of renderers whose loader rejected (a placeholder was substituted). */

--- a/packages/doenetml/src/codemirror.ts
+++ b/packages/doenetml/src/codemirror.ts
@@ -1,0 +1,9 @@
+// Dedicated entry point for hosts that use the CodeMirror component directly:
+// `import { CodeMirror } from "@doenet/doenetml/codemirror.js"`.
+//
+// A separate entry rather than a re-export from `index.ts` so that the main
+// entry stays free of any static path into the editor stack — the editor's
+// weight (codemirror, its inlined LSP worker source, the component schema)
+// belongs to the lazy chunk `EditorViewer/EditorViewerLazy.tsx` splits out,
+// and this entry shares those same chunks with it.
+export * from "@doenet/codemirror";

--- a/packages/doenetml/src/doenetml-external-worker.ts
+++ b/packages/doenetml/src/doenetml-external-worker.ts
@@ -1,5 +1,9 @@
 export * from "./index";
-import { doenetGlobalConfig } from "./global-config";
+import { doenetGlobalConfig, hostProvidedWorkerUrl } from "./global-config";
+// Re-exported beside `setExternalCoreWorkerUrl` so `@doenet/standalone` can
+// make its worker re-point defer to a host-chosen URL the same way the
+// resolution at the bottom of this module does.
+export { hostProvidedWorkerUrl } from "./global-config";
 
 // Externalized-worker entry point (counterpart to `doenetml-inline-worker.ts`).
 //
@@ -104,11 +108,15 @@ function isSameOrigin(url: string): boolean {
 }
 
 try {
-    const workerUrl = resolveWorkerUrl();
-    if (workerUrl !== null) {
-        setExternalCoreWorkerUrl(workerUrl);
+    // A worker URL the host set before this module evaluated is an explicit
+    // deployment choice; leave it in force rather than re-resolving.
+    if (!hostProvidedWorkerUrl) {
+        const workerUrl = resolveWorkerUrl();
+        if (workerUrl !== null) {
+            setExternalCoreWorkerUrl(workerUrl);
+        }
+        // workerUrl === null: keep the default from global-config.ts.
     }
-    // workerUrl === null: keep the default from global-config.ts.
 } catch (e) {
     // Never let worker-URL resolution break evaluation of the whole bundle —
     // the default from global-config.ts remains in effect.

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -21,7 +21,10 @@ import type {
 import { VirtualKeyboard } from "@doenet/virtual-keyboard";
 import "@doenet/virtual-keyboard/style.css";
 import "@doenet/ui-components/style.css";
-import { EditorViewer } from "./EditorViewer/EditorViewer.js";
+// The lazy wrapper, not `EditorViewer` itself: this import is what keeps the
+// editor stack (codemirror, LSP worker source, pretty printer, schema) out of
+// the eagerly-parsed bundle for viewer-only pages. See `EditorViewerLazy.tsx`.
+import { EditorViewerLazy } from "./EditorViewer/EditorViewerLazy.js";
 import type {
     DoenetEditorHandle,
     ViewerLocation,
@@ -705,7 +708,7 @@ export const DoenetEditor = React.forwardRef<
     );
 
     const editor = (
-        <EditorViewer
+        <EditorViewerLazy
             ref={ref}
             doenetML={doenetML}
             activityId={activityId}

--- a/packages/doenetml/src/global-config.test.ts
+++ b/packages/doenetml/src/global-config.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Unit coverage for the host-config adoption in global-config.ts: the module
+// adopts a `window.doenetGlobalConfig` a host created before it evaluated
+// (same identity, defaults filled in only where a key is absent), and
+// `hostProvidedWorkerUrl` records whether the host chose the worker URL
+// itself — which is what makes the worker resolution in
+// `doenetml-external-worker.ts` and the version-pinning re-point in
+// `@doenet/standalone` leave that choice in force.
+//
+// The module works through window/globalThis at evaluation time, so each test
+// resets the module registry and evaluates it fresh against a controlled
+// global.
+
+/** Evaluate global-config.ts fresh, with `existing` pre-set (or absent). */
+async function importGlobalConfig(existing?: object) {
+    vi.resetModules();
+    delete (globalThis as any).doenetGlobalConfig;
+    if (existing !== undefined) {
+        (globalThis as any).doenetGlobalConfig = existing;
+    }
+    return await import("./global-config");
+}
+
+describe("global-config adoption", () => {
+    beforeEach(() => {
+        // global-config.ts aliases `window` to `globalThis` when absent (the
+        // node test environment); make the alias explicit so the assertions
+        // below can read the same object the module writes.
+        (globalThis as any).window = globalThis;
+    });
+    afterEach(() => {
+        delete (globalThis as any).doenetGlobalConfig;
+    });
+
+    it("creates a fresh config with a default worker URL when none exists", async () => {
+        const { doenetGlobalConfig, hostProvidedWorkerUrl } =
+            await importGlobalConfig();
+        expect(hostProvidedWorkerUrl).toBe(false);
+        expect(typeof doenetGlobalConfig.doenetWorkerUrl).toBe("string");
+        expect((globalThis as any).doenetGlobalConfig).toBe(doenetGlobalConfig);
+    });
+
+    it("adopts a host-created object: same identity, host keys intact, defaults filled", async () => {
+        const hook = () => {};
+        const existing: Record<string, unknown> = {
+            coreBootMaxAttempts: 1,
+            __doenetTestCoreInitHook: hook,
+        };
+        const { doenetGlobalConfig, hostProvidedWorkerUrl } =
+            await importGlobalConfig(existing);
+        expect(doenetGlobalConfig).toBe(existing);
+        // Host-set keys survive the defaults-filling untouched...
+        expect(doenetGlobalConfig.coreBootMaxAttempts).toBe(1);
+        expect(doenetGlobalConfig.__doenetTestCoreInitHook).toBe(hook);
+        // ...and the one default is only filled because it was absent.
+        expect(hostProvidedWorkerUrl).toBe(false);
+        expect(typeof doenetGlobalConfig.doenetWorkerUrl).toBe("string");
+    });
+
+    it("keeps a host-chosen worker URL and reports it as host-provided", async () => {
+        const { doenetGlobalConfig, hostProvidedWorkerUrl } =
+            await importGlobalConfig({
+                doenetWorkerUrl: "https://host.example/my-worker/index.js",
+            });
+        expect(hostProvidedWorkerUrl).toBe(true);
+        expect(doenetGlobalConfig.doenetWorkerUrl).toBe(
+            "https://host.example/my-worker/index.js",
+        );
+    });
+});

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -111,7 +111,9 @@ export const doenetGlobalConfig: {
  * way: a second copy on the page adopts the shared config, sees that URL
  * here, and defers to it — pairing every document with the first copy's
  * worker, the same first-copy-wins convention the render globals follow
- * (`installFacadeRenderQueue` in `@doenet/standalone`).
+ * (enforced in `@doenet/standalone` by the facade prologue,
+ * `installFacadeRenderQueue`, and by the entry's guarded installs,
+ * `installFirstCopyGlobal`).
  */
 export const hostProvidedWorkerUrl: boolean =
     typeof doenetGlobalConfig.doenetWorkerUrl === "string";

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -106,6 +106,12 @@ export const doenetGlobalConfig: {
  * writes when this is set, so an explicit host URL survives bundle
  * evaluation just as it does when the host writes it after the bundle has
  * evaluated.
+ *
+ * A URL an earlier-evaluated copy of the bundle resolved counts the same
+ * way: a second copy on the page adopts the shared config, sees that URL
+ * here, and defers to it — pairing every document with the first copy's
+ * worker, the same first-copy-wins convention the render globals follow
+ * (`installFacadeRenderQueue` in `@doenet/standalone`).
  */
 export const hostProvidedWorkerUrl: boolean =
     typeof doenetGlobalConfig.doenetWorkerUrl === "string";

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -108,12 +108,14 @@ export const doenetGlobalConfig: {
  * evaluated.
  *
  * A URL an earlier-evaluated copy of the bundle resolved counts the same
- * way: a second copy on the page adopts the shared config, sees that URL
- * here, and defers to it — pairing every document with the first copy's
- * worker, the same first-copy-wins convention the render globals follow
- * (enforced in `@doenet/standalone` by the facade prologue,
+ * way: a later copy on the page adopts the shared config, sees that URL
+ * here, and defers to it — pairing every document with the worker of the
+ * first copy to finish loading, the same convention the render globals
+ * follow (enforced in `@doenet/standalone` by the facade prologue,
  * `installFacadeRenderQueue`, and by the entry's guarded installs,
- * `installFirstCopyGlobal`).
+ * `installFirstCopyGlobal`): the first *settled* copy wins the globals and
+ * the worker URL as one surface, and render calls a host queued against
+ * another copy's stubs are drained through that winner, never stranded.
  */
 export const hostProvidedWorkerUrl: boolean =
     typeof doenetGlobalConfig.doenetWorkerUrl === "string";

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -91,11 +91,38 @@ export const doenetGlobalConfig: {
         phase: "stateLoad" | "handshake" | "generate",
         attempt: number,
     ) => void | Promise<void>;
-} = {
-    doenetWorkerUrl: getWorkerUrl(),
-};
+} = adoptExistingGlobalConfig();
+if (typeof doenetGlobalConfig.doenetWorkerUrl !== "string") {
+    doenetGlobalConfig.doenetWorkerUrl = getWorkerUrl();
+}
 // We want this to be available in the global scope
 (window as any).doenetGlobalConfig = doenetGlobalConfig;
+
+/**
+ * The config object this module adopts: `window.doenetGlobalConfig` when a
+ * host already created one, a fresh object otherwise.
+ *
+ * Adopting the existing object — same identity, defaults filled in above only
+ * where a key is absent — is what keeps host configuration working when this
+ * module evaluates *after* the host's setup code ran. `@doenet/standalone`'s
+ * code-split bundle is the live case: its entry facade awaits the chunk that
+ * carries this module, the facade's script `load` event fires at that first
+ * `await`, and PreTeXt-style pages configure `window.doenetGlobalConfig` (an
+ * empty object the facade pre-created; see `facadeRenderQueue.ts` there) from
+ * exactly that event. Values those hosts set this way are live here, and the
+ * references they captured stay current.
+ *
+ * (Typed `any` because the return feeds `doenetGlobalConfig`'s own
+ * initializer — naming that type here would be circular. The export's
+ * annotation above is what checks every use.)
+ */
+function adoptExistingGlobalConfig(): any {
+    const existing = (window as any).doenetGlobalConfig;
+    if (typeof existing === "object" && existing !== null) {
+        return existing;
+    }
+    return {};
+}
 
 /**
  * Attempt to resolve the URL of the doenet worker. This function falls back

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -92,7 +92,24 @@ export const doenetGlobalConfig: {
         attempt: number,
     ) => void | Promise<void>;
 } = adoptExistingGlobalConfig();
-if (typeof doenetGlobalConfig.doenetWorkerUrl !== "string") {
+
+/**
+ * Whether the adopted config already carried a `doenetWorkerUrl` when this
+ * module evaluated — i.e. the host chose the worker URL itself, before or
+ * while the bundle loaded (with the code-split `@doenet/standalone` bundle,
+ * a script `onload` handler runs before this module does; see
+ * `adoptExistingGlobalConfig`).
+ *
+ * The module-evaluation-time worker resolution defers to that choice: the
+ * externalized-worker entry (`doenetml-external-worker.ts`) and the
+ * version-pinning re-point in `@doenet/standalone`'s entry both skip their
+ * writes when this is set, so an explicit host URL survives bundle
+ * evaluation just as it does when the host writes it after the bundle has
+ * evaluated.
+ */
+export const hostProvidedWorkerUrl: boolean =
+    typeof doenetGlobalConfig.doenetWorkerUrl === "string";
+if (!hostProvidedWorkerUrl) {
     doenetGlobalConfig.doenetWorkerUrl = getWorkerUrl();
 }
 // We want this to be available in the global scope

--- a/packages/doenetml/src/index.ts
+++ b/packages/doenetml/src/index.ts
@@ -30,7 +30,11 @@ export type {
     CreativeCommonsVersion,
 } from "@doenet/utils";
 
-export { CodeMirror } from "@doenet/codemirror";
+// `CodeMirror` (and the rest of `@doenet/codemirror`) is exported from its
+// own entry point, `@doenet/doenetml/codemirror.js`, so that importing this
+// one does not statically pull the editor stack into a viewer-only page —
+// the editor loads through the lazy boundary in
+// `EditorViewer/EditorViewerLazy.tsx` instead.
 
 // Where a host installs the message catalogs the viewer in *this* bundle reads.
 //

--- a/packages/doenetml/test/cypress/component/ChunkLoadErrorBoundary.cy.tsx
+++ b/packages/doenetml/test/cypress/component/ChunkLoadErrorBoundary.cy.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { ChunkLoadErrorBoundary } from "../../../src/Viewer/renderersLoadComponent";
+
+// The boundary behind the editor's lazy seam (`EditorViewerLazy`). A chunk
+// fetch that still fails after `importRendererWithRetry`'s retries is
+// re-thrown by React during render; the boundary must swap in the
+// renderer-load-failed placeholder for exactly that error shape, and pass
+// every other error through to the boundary above it.
+
+/** Renders nothing — it throws `error` instead, like a failed lazy chunk. */
+function Thrower({ error }: { error: Error }): React.ReactNode {
+    throw error;
+}
+
+/** Test stand-in for whatever boundary surrounds the editor in a real host. */
+class OuterBoundary extends React.Component<
+    { children: React.ReactNode },
+    { message: string | null }
+> {
+    state: { message: string | null } = { message: null };
+    static getDerivedStateFromError(error: Error) {
+        return { message: error.message };
+    }
+    render() {
+        if (this.state.message !== null) {
+            return <div data-test="outer-caught">{this.state.message}</div>;
+        }
+        return this.props.children;
+    }
+}
+
+describe("ChunkLoadErrorBoundary", () => {
+    it("replaces a failed chunk fetch with the renderer-load-failed placeholder", () => {
+        // The error stays inside React's boundary handling, but guard anyway:
+        // dev builds of React have re-dispatched even caught errors globally.
+        cy.on("uncaught:exception", () => false);
+        cy.mount(
+            <OuterBoundary>
+                <ChunkLoadErrorBoundary>
+                    <Thrower
+                        error={
+                            new Error(
+                                "Failed to fetch dynamically imported module: " +
+                                    "https://example.com/chunks/EditorViewer-abc.js",
+                            )
+                        }
+                    />
+                </ChunkLoadErrorBoundary>
+            </OuterBoundary>,
+        );
+        cy.get('[role="alert"]').should("contain.text", "failed to load");
+        cy.get('[data-test="outer-caught"]').should("not.exist");
+    });
+
+    it("re-throws anything that is not a chunk-load failure", () => {
+        cy.on("uncaught:exception", () => false);
+        cy.mount(
+            <OuterBoundary>
+                <ChunkLoadErrorBoundary>
+                    <Thrower error={new Error("a bug inside the editor")} />
+                </ChunkLoadErrorBoundary>
+            </OuterBoundary>,
+        );
+        cy.get('[data-test="outer-caught"]').should(
+            "have.text",
+            "a bug inside the editor",
+        );
+        cy.get('[role="alert"]').should("not.exist");
+    });
+
+    it("renders its children when nothing throws", () => {
+        cy.mount(
+            <ChunkLoadErrorBoundary>
+                <div data-test="child">all good</div>
+            </ChunkLoadErrorBoundary>,
+        );
+        cy.get('[data-test="child"]').should("have.text", "all good");
+    });
+});

--- a/packages/doenetml/vite.config.ts
+++ b/packages/doenetml/vite.config.ts
@@ -66,6 +66,10 @@ export default defineConfig(({ mode }) => {
                     "doenetml-inline-worker": "./src/doenetml-inline-worker.ts",
                     "doenetml-external-worker":
                         "./src/doenetml-external-worker.ts",
+                    // Direct access to the CodeMirror component without
+                    // routing the editor stack through the main entry — see
+                    // src/codemirror.ts.
+                    codemirror: "./src/codemirror.ts",
                 },
                 formats: ["es"],
                 cssFileName: "style",

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1587,12 +1587,16 @@ rather than cosmetic:
 | `@doenet/doenetml-worker` | Neither: it is handed `LocaleData.resources`           |
 | `@doenet/doenetml-iframe` | Neither: what renders inside its iframe is a standalone bundle, which loads its own |
 
-The glob is what makes adding a language cost a directory. It is also why the
-two single-file builds need a different answer: `inlineDynamicImports` folds
-every dynamic import back into the one output file, so code-splitting cannot
-keep catalogs out of them — and *being reachable is enough*, whether or not
-anything calls it. Both therefore define `__DOENET_CODE_SPLIT_CATALOGS__`
-false, which makes the glob dead code. The standalone build then copies
+The glob is what makes adding a language cost a directory. It is also why two
+builds need a different answer. The worker is one file — an IIFE started from
+a blob URL in some variants — so it cannot code-split, and *being reachable is
+enough*, whether or not anything calls it, to fold every catalog in. The
+standalone build is code-split, but serves its catalogs as plain
+runtime-fetched files all the same: as served assets they can be
+version-pinned, and the single-file `doenet-standalone-inline.js` variant
+published beside it stays free of them too. Both therefore define
+`__DOENET_CODE_SPLIT_CATALOGS__` false, which makes the glob dead code. The
+standalone build then copies
 `locales/` into `dist/` (`copyLocaleCatalogsPlugin`) and installs
 `fetchLocaleLoaders` against it in `src/index.tsx`; the worker needs no
 replacement at all, because the main thread loads its catalog and passes it
@@ -1609,8 +1613,10 @@ on an instance the viewer never reads, sees an empty registry, and falls back to
 English in silence. Every built `packages/*/dist/` is scanned, not only the
 bundle that has been bitten, because any build combining a prebuilt `@doenet/doenetml`
 with a source build of this package can hit it — counted per emitted script,
-since a script is what shares a module registry, and a package that emits both a
-bundle and a worker holds a copy in each quite correctly.
+since a script is what shares a module registry: a package that emits both a
+bundle and a worker holds a copy in each quite correctly, while the code-split
+standalone bundle is judged over its entry and `chunks/` together, because
+those load into one registry.
 
 Two lists have to agree for any of this to hold, and `lint:i18n` checks that
 they do: the locales excluded from the glob in `load.ts` are exactly

--- a/packages/i18n/scripts/bundleInstances.ts
+++ b/packages/i18n/scripts/bundleInstances.ts
@@ -177,7 +177,7 @@ export function instanceProblems(scanned: ScannedScript[]): string[] {
             file === SINGLE_INSTANCE_SCRIPT ||
             file.startsWith(SINGLE_INSTANCE_CHUNKS_PREFIX),
     );
-    const entryBuilt = scanned.some(
+    const entryBuilt = graph.some(
         ({ file }) => file === SINGLE_INSTANCE_SCRIPT,
     );
     if (entryBuilt) {

--- a/packages/i18n/scripts/bundleInstances.ts
+++ b/packages/i18n/scripts/bundleInstances.ts
@@ -17,12 +17,29 @@ export const PACKAGES_DIR = path.resolve(I18N_ROOT, "..");
 export const LOAD_MODULE_FILE = path.join(I18N_ROOT, "src", "load.ts");
 
 /**
- * The script that installs the locale loaders and renders the viewer that
+ * The bundle that installs the locale loaders and renders the viewer that
  * reads them, and so must hold exactly one instance rather than at most one.
  * The one bundle where a second copy is not merely wasteful but breaking.
+ *
+ * The bundle is code-split: this entry and the chunks under
+ * {@link SINGLE_INSTANCE_CHUNKS_PREFIX} come out of one Rollup build and share
+ * one module registry in the realm that loads them, so the exactly-one rule is
+ * judged over their combined total — the entry itself is a re-export facade
+ * that holds no module bodies at all.
  */
 export const SINGLE_INSTANCE_SCRIPT =
     "packages/standalone/dist/doenet-standalone.js";
+
+/** Where {@link SINGLE_INSTANCE_SCRIPT}'s build emits its chunks. */
+export const SINGLE_INSTANCE_CHUNKS_PREFIX = "packages/standalone/dist/chunks/";
+
+/**
+ * The single-file variant of the same entry, built for hosts that evaluate
+ * the bundle from a Blob/srcdoc URL. Its own realm, its own registry: it is
+ * held to exactly one instance on its own.
+ */
+export const SINGLE_INSTANCE_INLINE_SCRIPT =
+    "packages/standalone/dist/doenet-standalone-inline.js";
 
 /** Emitted JavaScript, in any extension a bundler might choose. */
 const SCRIPT_EXTENSION = /\.[cm]?js$/;
@@ -131,9 +148,15 @@ export function collectDistScripts(
  * holds a copy in each, correctly: the worker is its own realm and resolves its
  * own catalogs.
  *
- * {@link SINGLE_INSTANCE_SCRIPT} is held to exactly one rather than at most
- * one — zero would mean the loader machinery had been tree-shaken out of the
- * one bundle whose whole locale story runs through it.
+ * The standalone bundle is held to exactly one rather than at most one — zero
+ * would mean the loader machinery had been tree-shaken out of the one bundle
+ * whose whole locale story runs through it. It is judged over
+ * {@link SINGLE_INSTANCE_SCRIPT} and its `chunks/` together: those files come
+ * out of one Rollup build and share one module registry at runtime, so a copy
+ * in a chunk is *the* copy — but a copy in two different chunks is the same
+ * split-registry failure as two copies in one file, surfacing once both
+ * chunks load. The single-file {@link SINGLE_INSTANCE_INLINE_SCRIPT} is its
+ * own realm and is held to exactly one on its own.
  *
  * @param scanned emitted scripts, from {@link collectDistScripts}.
  */
@@ -148,13 +171,52 @@ export function instanceProblems(scanned: ScannedScript[]): string[] {
                 `@doenet/doenetml entry point the viewer comes from rather than from ` +
                 `@doenet/i18n.`,
         );
-    const single = scanned.find(({ file }) => file === SINGLE_INSTANCE_SCRIPT);
-    if (single && single.instances === 0) {
+
+    const graph = scanned.filter(
+        ({ file }) =>
+            file === SINGLE_INSTANCE_SCRIPT ||
+            file.startsWith(SINGLE_INSTANCE_CHUNKS_PREFIX),
+    );
+    const entryBuilt = scanned.some(
+        ({ file }) => file === SINGLE_INSTANCE_SCRIPT,
+    );
+    if (entryBuilt) {
+        const total = graph.reduce((sum, { instances }) => sum + instances, 0);
+        if (total === 0) {
+            problems.push(
+                `${SINGLE_INSTANCE_SCRIPT} and its chunks/ hold no copy of @doenet/i18n at ` +
+                    `all, so either the loader machinery was tree-shaken out of the one ` +
+                    `bundle that installs it, or the marker this is counted with stopped ` +
+                    `surviving minification. Either way the count means nothing until it is ` +
+                    `understood.`,
+            );
+        } else if (
+            total > 1 &&
+            graph.every(({ instances }) => instances <= 1)
+        ) {
+            // Each offending file with 2+ copies is already reported above;
+            // this catches the copies being spread across different chunks,
+            // which no per-file count can see.
+            problems.push(
+                `${SINGLE_INSTANCE_SCRIPT} and its chunks/ together hold ${total} copies of ` +
+                    `@doenet/i18n in different files of one bundle. Once both load, the ` +
+                    `realm has two loader registries — the same silent English fallback as ` +
+                    `two copies in one file. Import setLocaleLoaders from the same ` +
+                    `@doenet/doenetml entry point the viewer comes from rather than from ` +
+                    `@doenet/i18n.`,
+            );
+        }
+    }
+
+    const inline = scanned.find(
+        ({ file }) => file === SINGLE_INSTANCE_INLINE_SCRIPT,
+    );
+    if (inline && inline.instances === 0) {
         problems.push(
-            `${SINGLE_INSTANCE_SCRIPT} holds no copy of @doenet/i18n at all, so either the ` +
-                `loader machinery was tree-shaken out of the one bundle that installs it, or ` +
-                `the marker this is counted with stopped surviving minification. Either way ` +
-                `the count means nothing until it is understood.`,
+            `${SINGLE_INSTANCE_INLINE_SCRIPT} holds no copy of @doenet/i18n at all, so ` +
+                `either the loader machinery was tree-shaken out of it, or the marker this ` +
+                `is counted with stopped surviving minification. Either way the count ` +
+                `means nothing until it is understood.`,
         );
     }
     return problems;

--- a/packages/i18n/test/bundleInstances.test.ts
+++ b/packages/i18n/test/bundleInstances.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 
 import {
+    SINGLE_INSTANCE_CHUNKS_PREFIX,
+    SINGLE_INSTANCE_INLINE_SCRIPT,
     SINGLE_INSTANCE_SCRIPT,
     collectDistScripts,
     countInstances,
@@ -191,5 +193,61 @@ describe("instanceProblems", () => {
         expect(
             instanceProblems(scanned({ "packages/doenetml/dist/index.js": 1 })),
         ).toEqual([]);
+    });
+
+    it("accepts the copy living in a chunk of the code-split bundle", () => {
+        // The entry is a re-export facade; the module bodies — the loader
+        // registry among them — live in the eagerly imported chunk beside it.
+        expect(
+            instanceProblems(
+                scanned({
+                    [SINGLE_INSTANCE_SCRIPT]: 0,
+                    [`${SINGLE_INSTANCE_CHUNKS_PREFIX}index-DEADBEEF.js`]: 1,
+                    [`${SINGLE_INSTANCE_CHUNKS_PREFIX}EditorViewer-abc.js`]: 0,
+                }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("reports a copy split across two chunks of one bundle", () => {
+        // One copy per file, so the per-file rule sees nothing — but a realm
+        // that loads both chunks ends up with two registries all the same.
+        const problems = instanceProblems(
+            scanned({
+                [SINGLE_INSTANCE_SCRIPT]: 0,
+                [`${SINGLE_INSTANCE_CHUNKS_PREFIX}index-DEADBEEF.js`]: 1,
+                [`${SINGLE_INSTANCE_CHUNKS_PREFIX}EditorViewer-abc.js`]: 1,
+            }),
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("together hold 2 copies");
+    });
+
+    it("reports a bundle whose entry and chunks together hold none", () => {
+        const problems = instanceProblems(
+            scanned({
+                [SINGLE_INSTANCE_SCRIPT]: 0,
+                [`${SINGLE_INSTANCE_CHUNKS_PREFIX}index-DEADBEEF.js`]: 0,
+            }),
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain("no copy of @doenet/i18n at all");
+    });
+
+    it("holds the single-file inline variant to exactly one on its own", () => {
+        expect(
+            instanceProblems(
+                scanned({
+                    [SINGLE_INSTANCE_SCRIPT]: 0,
+                    [`${SINGLE_INSTANCE_CHUNKS_PREFIX}index-DEADBEEF.js`]: 1,
+                    [SINGLE_INSTANCE_INLINE_SCRIPT]: 1,
+                }),
+            ),
+        ).toEqual([]);
+        const problems = instanceProblems(
+            scanned({ [SINGLE_INSTANCE_INLINE_SCRIPT]: 0 }),
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toContain(SINGLE_INSTANCE_INLINE_SCRIPT);
     });
 });

--- a/packages/parser/vite.config.ts
+++ b/packages/parser/vite.config.ts
@@ -29,6 +29,16 @@ export default defineConfig({
             },
             formats: ["es"],
         },
+        rollupOptions: {
+            // Leave `@doenet/static-assets` (the component schema the
+            // pretty-printer's layout table reads, and the entity map) to the
+            // consuming build, the same way `@doenet/lsp-tools` and
+            // `@doenet/codemirror` do. Every consumer bundles this package
+            // together with other users of the schema, so resolving it there
+            // means one shared copy of the ~0.5 MB compressed schema module
+            // instead of a private copy baked into `pretty-printer.js`.
+            external: [/@doenet\/static-assets/],
+        },
     },
 });
 

--- a/packages/parser/vite.config.ts
+++ b/packages/parser/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
             // consuming build, the same way `@doenet/lsp-tools` and
             // `@doenet/codemirror` do. Every consumer bundles this package
             // together with other users of the schema, so resolving it there
-            // means one shared copy of the ~0.5 MB compressed schema module
+            // means one shared copy of the ~230 KB compressed schema literal
             // instead of a private copy baked into `pretty-printer.js`.
             external: [/@doenet\/static-assets/],
         },

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -10,7 +10,19 @@ Include
 <script type="module" src="doenet-standalone.js"></script>
 ```
 
-in your webpage. Then you can call the globally-exported function
+in your webpage. The bundle is code-split: the editor stack and individual
+component renderers load on demand from the `chunks/` directory published
+beside `doenet-standalone.js` (the co-located `doenetml-worker/` and
+`locales/` are fetched the same way), so serve the package directory as-is
+rather than copying the one file. A host that needs a truly single file —
+for example one that evaluates the bundle from a Blob or `srcdoc` URL, where
+relative chunk resolution has no base — can use
+`doenet-standalone-inline.js`, which inlines every chunk (it still loads the
+core worker from `doenetml-worker/` beside it, or from
+`/doenetml-worker/index.js` at the page origin when the bundle URL has no
+usable base).
+
+Then you can call the globally-exported function
 `renderDoenetViewerToContainer` (or `renderDoenetEditorToContainer` for the
 editor), which expects a `<div>` element containing a
 `<script type="text/doenetml"></script>` as a child.

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -14,7 +14,10 @@ in your webpage. The bundle is code-split: the editor stack and individual
 component renderers load on demand from the `chunks/` directory published
 beside `doenet-standalone.js` (the co-located `doenetml-worker/` and
 `locales/` are fetched the same way), so serve the package directory as-is
-rather than copying the one file. A host that needs a truly single file —
+rather than copying the one file. Served from a CDN under a floating tag
+(`@latest`, or no version), the bundle resolves its chunks — like the worker
+and message catalogs — at the exact release it was built as, so an
+already-cached entry keeps working across releases. A host that needs a truly single file —
 for example one that evaluates the bundle from a Blob or `srcdoc` URL, where
 relative chunk resolution has no base — can use
 `doenet-standalone-inline.js`, which inlines every chunk (it still loads the

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -21,12 +21,12 @@
         },
         "dist/chunks/index-*.js": {
             "maxBytes": 5050000,
-            "observedBytes": 4686606,
+            "observedBytes": 4687046,
             "note": "The eagerly-parsed payload every embed pays (the facade's static import). The editor stack, the worker, and the lazy renderers must stay out of it. The glob also catches a few small shared chunks named index-*."
         },
         "dist/doenet-standalone-inline.js": {
             "maxBytes": 12450000,
-            "observedBytes": 11539981,
+            "observedBytes": 11540431,
             "note": "The single-file variant for Blob/srcdoc hosts: every chunk inlined. Doubles as the total-weight ceiling for the code-split build."
         },
         "dist/doenetml-worker/index.js": {

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -21,12 +21,12 @@
         },
         "dist/chunks/index-*.js": {
             "maxBytes": 5050000,
-            "observedBytes": 4689685,
+            "observedBytes": 4689759,
             "note": "The eagerly-parsed payload every embed pays (the facade's static import). The editor stack, the worker, and the lazy renderers must stay out of it. The glob also catches a few small shared chunks named index-*."
         },
         "dist/doenet-standalone-inline.js": {
             "maxBytes": 12450000,
-            "observedBytes": 11540718,
+            "observedBytes": 11540816,
             "note": "The single-file variant for Blob/srcdoc hosts: every chunk inlined. Doubles as the total-weight ceiling for the code-split build."
         },
         "dist/doenetml-worker/index.js": {

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -21,12 +21,12 @@
         },
         "dist/chunks/index-*.js": {
             "maxBytes": 5050000,
-            "observedBytes": 4689759,
+            "observedBytes": 4690042,
             "note": "The eagerly-parsed payload every embed pays (the facade's static import). The editor stack, the worker, and the lazy renderers must stay out of it. The glob also catches a few small shared chunks named index-*."
         },
         "dist/doenet-standalone-inline.js": {
             "maxBytes": 12450000,
-            "observedBytes": 11540816,
+            "observedBytes": 11541099,
             "note": "The single-file variant for Blob/srcdoc hosts: every chunk inlined. Doubles as the total-weight ceiling for the code-split build."
         },
         "dist/doenetml-worker/index.js": {

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -16,17 +16,17 @@
     "files": {
         "dist/doenet-standalone.js": {
             "maxBytes": 50000,
-            "observedBytes": 2003,
+            "observedBytes": 2075,
             "note": "A re-export facade: its one import is the chunks/index-*.js below, awaited through the version-pinning resolver, plus the render-global queueing stubs (scripts/pin-chunk-urls-plugin.ts). Megabytes here mean code splitting got switched off."
         },
         "dist/chunks/index-*.js": {
             "maxBytes": 5050000,
-            "observedBytes": 4689377,
+            "observedBytes": 4689685,
             "note": "The eagerly-parsed payload every embed pays (the facade's static import). The editor stack, the worker, and the lazy renderers must stay out of it. The glob also catches a few small shared chunks named index-*."
         },
         "dist/doenet-standalone-inline.js": {
             "maxBytes": 12450000,
-            "observedBytes": 11540431,
+            "observedBytes": 11540718,
             "note": "The single-file variant for Blob/srcdoc hosts: every chunk inlined. Doubles as the total-weight ceiling for the code-split build."
         },
         "dist/doenetml-worker/index.js": {

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -16,12 +16,12 @@
     "files": {
         "dist/doenet-standalone.js": {
             "maxBytes": 50000,
-            "observedBytes": 354,
-            "note": "A re-export facade: its one static import is the chunks/index-*.js below. Megabytes here mean code splitting got switched off."
+            "observedBytes": 2003,
+            "note": "A re-export facade: its one import is the chunks/index-*.js below, awaited through the version-pinning resolver, plus the render-global queueing stubs (scripts/pin-chunk-urls-plugin.ts). Megabytes here mean code splitting got switched off."
         },
         "dist/chunks/index-*.js": {
             "maxBytes": 5050000,
-            "observedBytes": 4687046,
+            "observedBytes": 4689377,
             "note": "The eagerly-parsed payload every embed pays (the facade's static import). The editor stack, the worker, and the lazy renderers must stay out of it. The glob also catches a few small shared chunks named index-*."
         },
         "dist/doenet-standalone-inline.js": {

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -3,6 +3,8 @@
         "Size ceilings in bytes for the built standalone bundles, enforced by",
         "`npm run check:size -w packages/standalone`. See",
         "`scripts/check-bundle-size.mjs` for what else that check does and why.",
+        "A key may use `*` to match one hashed path segment; each matching",
+        "script is held to the ceiling individually.",
         "",
         "Growth is fine; silent growth is not. Raising a `maxBytes` in the same",
         "commit that causes the growth is the point — it puts the increase in",
@@ -13,9 +15,19 @@
     ],
     "files": {
         "dist/doenet-standalone.js": {
-            "maxBytes": 15650000,
-            "observedBytes": 14489401,
-            "note": "No WebAssembly belongs in this bundle; the worker owns it."
+            "maxBytes": 50000,
+            "observedBytes": 354,
+            "note": "A re-export facade: its one static import is the chunks/index-*.js below. Megabytes here mean code splitting got switched off."
+        },
+        "dist/chunks/index-*.js": {
+            "maxBytes": 5050000,
+            "observedBytes": 4686606,
+            "note": "The eagerly-parsed payload every embed pays (the facade's static import). The editor stack, the worker, and the lazy renderers must stay out of it. The glob also catches a few small shared chunks named index-*."
+        },
+        "dist/doenet-standalone-inline.js": {
+            "maxBytes": 12450000,
+            "observedBytes": 11539981,
+            "note": "The single-file variant for Blob/srcdoc hosts: every chunk inlined. Doubles as the total-weight ceiling for the code-split build."
         },
         "dist/doenetml-worker/index.js": {
             "maxBytes": 15950000,

--- a/packages/standalone/bundle-budgets.json
+++ b/packages/standalone/bundle-budgets.json
@@ -16,17 +16,17 @@
     "files": {
         "dist/doenet-standalone.js": {
             "maxBytes": 50000,
-            "observedBytes": 2075,
+            "observedBytes": 2179,
             "note": "A re-export facade: its one import is the chunks/index-*.js below, awaited through the version-pinning resolver, plus the render-global queueing stubs (scripts/pin-chunk-urls-plugin.ts). Megabytes here mean code splitting got switched off."
         },
         "dist/chunks/index-*.js": {
             "maxBytes": 5050000,
-            "observedBytes": 4690042,
+            "observedBytes": 4690141,
             "note": "The eagerly-parsed payload every embed pays (the facade's static import). The editor stack, the worker, and the lazy renderers must stay out of it. The glob also catches a few small shared chunks named index-*."
         },
         "dist/doenet-standalone-inline.js": {
             "maxBytes": 12450000,
-            "observedBytes": 11541099,
+            "observedBytes": 11541201,
             "note": "The single-file variant for Blob/srcdoc hosts: every chunk inlined. Doubles as the total-weight ceiling for the code-split build."
         },
         "dist/doenetml-worker/index.js": {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -36,6 +36,7 @@
                 "src/coordinator.ts",
                 "../doenetml-iframe/src/shared-core-pool.ts",
                 "vite.config-coordinator.ts",
+                "../../scripts/vite-plugins.ts",
                 "tsconfig.json"
             ],
             "output": [

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -43,7 +43,26 @@
                 "dist/coordinator.js.map"
             ],
             "dependencies": [
-                "build:main"
+                "build:main",
+                "build:inline"
+            ]
+        },
+        "build:inline": {
+            "command": "vite -c vite.config-inline.ts build",
+            "files": [
+                "src/**/*.ts",
+                "src/**/*.tsx",
+                "tsconfig.json",
+                "vite.config-inline.ts",
+                "package.json",
+                "../i18n/locales/**/*.ftl"
+            ],
+            "output": [
+                "dist/doenet-standalone-inline.js"
+            ],
+            "dependencies": [
+                "build:main",
+                "../doenetml:build"
             ]
         },
         "build:main": {
@@ -59,8 +78,10 @@
             "output": [
                 "dist/**/*.js",
                 "!dist/coordinator.js",
+                "!dist/doenet-standalone-inline.js",
                 "dist/**/*.map",
                 "!dist/coordinator.js.map",
+                "!dist/doenet-standalone-inline.js.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json",
                 "dist/**/*.css",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -54,6 +54,7 @@
                 "src/**/*.tsx",
                 "tsconfig.json",
                 "vite.config-inline.ts",
+                "../../scripts/vite-plugins.ts",
                 "package.json",
                 "../i18n/locales/**/*.ftl"
             ],
@@ -72,6 +73,9 @@
                 "src/**/*.tsx",
                 "tsconfig.json",
                 "vite.config.ts",
+                "../../scripts/transform-package-json.ts",
+                "../../scripts/vite-plugins.ts",
+                "scripts/pin-chunk-urls-plugin.ts",
                 "package.json",
                 "../i18n/locales/**/*.ftl"
             ],

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -449,6 +449,33 @@ function blobPlacementProblem(relative, emitted, expected) {
 }
 
 /**
+ * The emitted scripts a budget key covers.
+ *
+ * A key is an exact `dist/`-relative path, except that `*` matches any run of
+ * characters other than `/` — which is how a budget pins down a code-split
+ * chunk whose emitted name carries a content hash
+ * (`dist/chunks/index-*.js`). Each matching script is held to the budget's
+ * `maxBytes` individually.
+ *
+ * @returns `[relativePath, emitted]` pairs.
+ */
+export function scriptsForBudget(relative, scripts) {
+    if (!relative.includes("*")) {
+        const emitted = scripts.get(relative);
+        return emitted ? [[relative, emitted]] : [];
+    }
+    const pattern = new RegExp(
+        "^" +
+            relative
+                .split("*")
+                .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+                .join("[^/]*") +
+            "$",
+    );
+    return [...scripts].filter(([name]) => pattern.test(name));
+}
+
+/**
  * Compare the emitted scripts against the budgets, without touching the disk
  * or the process.
  *
@@ -462,10 +489,11 @@ function blobPlacementProblem(relative, emitted, expected) {
 export function findProblems(budgets, scripts) {
     const problems = [];
     const report = [];
+    const budgeted = new Set();
 
     for (const [relative, budget] of budgets) {
-        const emitted = scripts.get(relative);
-        if (!emitted) {
+        const matches = scriptsForBudget(relative, scripts);
+        if (matches.length === 0) {
             // "Build the package" is the right advice only when there is no
             // build. If other scripts were emitted and the core-carrying one
             // was not, the build ran and the file moved — say that once, in
@@ -479,22 +507,25 @@ export function findProblems(budgets, scripts) {
             continue;
         }
 
-        report.push(
-            `  ${relative}\n` +
-                `      ${mib(emitted.size)} of ${mib(budget.maxBytes)} budget` +
-                `  (${((emitted.size / budget.maxBytes) * 100).toFixed(1)}%)` +
-                `, ${emitted.wasmUris} wasm URI(s), ${emitted.bigBlobs} inlined blob(s)`,
-        );
-
-        if (emitted.size > budget.maxBytes) {
-            problems.push(
-                `${relative} is ${mib(emitted.size)} (${emitted.size} bytes), over its ` +
-                    `${mib(budget.maxBytes)} budget by ${mib(emitted.size - budget.maxBytes)}.\n` +
-                    `    If the growth is intended, raise "maxBytes" for this file in\n` +
-                    `    packages/standalone/bundle-budgets.json in the same commit, so the\n` +
-                    `    increase is visible in review. If it is not intended, something was\n` +
-                    `    pulled in twice — compare against the previous build before raising it.`,
+        for (const [name, emitted] of matches) {
+            budgeted.add(name);
+            report.push(
+                `  ${name}\n` +
+                    `      ${mib(emitted.size)} of ${mib(budget.maxBytes)} budget` +
+                    `  (${((emitted.size / budget.maxBytes) * 100).toFixed(1)}%)` +
+                    `, ${emitted.wasmUris} wasm URI(s), ${emitted.bigBlobs} inlined blob(s)`,
             );
+
+            if (emitted.size > budget.maxBytes) {
+                problems.push(
+                    `${name} is ${mib(emitted.size)} (${emitted.size} bytes), over its ` +
+                        `${mib(budget.maxBytes)} budget by ${mib(emitted.size - budget.maxBytes)}.\n` +
+                        `    If the growth is intended, raise "maxBytes" for this file in\n` +
+                        `    packages/standalone/bundle-budgets.json in the same commit, so the\n` +
+                        `    increase is visible in review. If it is not intended, something was\n` +
+                        `    pulled in twice — compare against the previous build before raising it.`,
+                );
+            }
         }
     }
 
@@ -502,7 +533,6 @@ export function findProblems(budgets, scripts) {
     // is a normal thing for the bundler to do — but it is listed so that a
     // chunk quietly growing into a second multi-megabyte payload is visible,
     // and so somebody can decide whether it deserves a budget.
-    const budgeted = new Set(budgets.map(([relative]) => relative));
     for (const [relative, emitted] of scripts) {
         if (!budgeted.has(relative)) {
             report.push(

--- a/packages/standalone/scripts/check-bundle-size.mjs
+++ b/packages/standalone/scripts/check-bundle-size.mjs
@@ -552,13 +552,14 @@ export function findProblems(budgets, scripts) {
             problems.push(blobPlacementProblem(relative, emitted, expected));
         }
     }
-    // Catalogs this bundle is supposed to serve, not carry. Being one file, it
-    // cannot code-split them the way the library build does, so it switches
-    // `__DOENET_CODE_SPLIT_CATALOGS__` off and fetches `dist/locales/` at
-    // runtime instead. Anything that makes the glob reachable again — a define
-    // that stops being applied, a new eager import of a catalog — puts every
-    // translation back in here, and the size budget alone would absorb it for
-    // a long time.
+    // Catalogs these bundles are supposed to serve, not carry. The build keeps
+    // them as plain runtime-fetched files in `dist/locales/` — version-pinnable
+    // there, and out of the single-file inline variant — by switching
+    // `__DOENET_CODE_SPLIT_CATALOGS__` off instead of code-splitting them the
+    // way the library build does. Anything that makes the glob reachable again
+    // — a define that stops being applied, a new eager import of a catalog —
+    // puts every translation back in here, and the size budget alone would
+    // absorb it for a long time.
     for (const [relative, emitted] of scripts) {
         const leaked = emitted.inlinedCatalogs;
         if (leaked.length > 0) {

--- a/packages/standalone/scripts/check-bundle-size.test.mjs
+++ b/packages/standalone/scripts/check-bundle-size.test.mjs
@@ -178,6 +178,39 @@ describe("findProblems", () => {
         ]);
     });
 
+    it("applies a `*` budget to each chunk whose hashed name matches it", () => {
+        const scripts = healthyBuild();
+        scripts.set("dist/chunks/index-DEADBEEF.js", script(500));
+        scripts.set("dist/chunks/index-CAFEF00D.js", script(1001));
+        const budgets = [
+            ...BUDGETS,
+            ["dist/chunks/index-*.js", { maxBytes: 1000 }],
+        ];
+        const { report, problems } = findProblems(budgets, scripts);
+        expect(problems).toEqual([
+            expect.stringContaining("dist/chunks/index-CAFEF00D.js is"),
+        ]);
+        // Both matches are reported under the budget, not as unbudgeted.
+        expect(report.join("\n")).toContain(
+            "dist/chunks/index-DEADBEEF.js\n      0.00 MiB of 0.00 MiB budget",
+        );
+    });
+
+    it("does not let a `*` cross a directory separator", () => {
+        const scripts = healthyBuild();
+        scripts.set("dist/chunks/deep/index-DEADBEEF.js", script(1001));
+        const budgets = [
+            ...BUDGETS,
+            ["dist/chunks/index-*.js", { maxBytes: 1000 }],
+        ];
+        const { problems } = findProblems(budgets, scripts);
+        // The nested chunk is unbudgeted, so nothing fails; the glob budget
+        // itself reports its key as missing.
+        expect(problems).toEqual([
+            expect.stringContaining("dist/chunks/index-*.js does not exist"),
+        ]);
+    });
+
     it("lists an unbudgeted chunk without failing on it", () => {
         const scripts = healthyBuild();
         scripts.set("dist/coordinator.js", script(11_000));

--- a/packages/standalone/scripts/pin-chunk-urls-plugin.test.ts
+++ b/packages/standalone/scripts/pin-chunk-urls-plugin.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    FLUSH_RENDER_QUEUE_NAME,
+    PIN_HELPER_NAME,
+    pinChunkUrlsPlugin,
+    pinHelperBanner,
+    renderQueuePrologue,
+    transformFacade,
+} from "./pin-chunk-urls-plugin";
+
+const PKG = "@doenet/standalone";
+const V = "0.7.24";
+
+/**
+ * Evaluate the banner exactly as an emitted chunk would, with `import.meta.url`
+ * standing in as a given URL, and hand back the resolver it binds.
+ */
+function evaluateBanner(selfUrl: string): (rel: string) => string {
+    const banner = pinHelperBanner(PKG, V);
+    const body = banner.replace("import.meta.url", JSON.stringify(selfUrl));
+    expect(body).not.toBe(banner); // the substitution point must exist
+    return new Function(`${body}; return ${PIN_HELPER_NAME};`)() as (
+        rel: string,
+    ) => string;
+}
+
+describe("pinHelperBanner", () => {
+    it("is self-contained: no imports, no transpilation helpers", () => {
+        const banner = pinHelperBanner(PKG, V);
+        expect(banner).not.toMatch(/\bimport\s*[({"']/); // only import.meta
+        expect(banner).not.toContain("require(");
+        expect(banner).not.toContain("__name(");
+        expect(banner).toContain("import.meta.url");
+    });
+
+    it("pins a chunk reference when evaluated under a floating tag", () => {
+        const resolve = evaluateBanner(
+            `https://cdn.jsdelivr.net/npm/${PKG}@latest/chunks/index-abc.js`,
+        );
+        expect(resolve("./EditorViewer-def.js")).toBe(
+            `https://cdn.jsdelivr.net/npm/${PKG}@${V}/chunks/EditorViewer-def.js`,
+        );
+    });
+
+    it("leaves a self-hosted URL on plain relative resolution", () => {
+        const resolve = evaluateBanner(
+            "https://host.example/doenet/chunks/index-abc.js",
+        );
+        expect(resolve("./EditorViewer-def.js")).toBe(
+            "https://host.example/doenet/chunks/EditorViewer-def.js",
+        );
+    });
+});
+
+describe("transformFacade", () => {
+    const banner = `/*banner*/\n`;
+
+    it("rewrites the import+export facade shape this build emits", () => {
+        const code =
+            `import { bE as DoenetEditor, R as React } from './chunks/index-abc.js';\n` +
+            `export { DoenetEditor, React };\n`;
+        const { code: out } = transformFacade(code, banner);
+        expect(out).toContain(banner);
+        expect(out).toContain(
+            `const { bE: DoenetEditor, R: React } = await import(${PIN_HELPER_NAME}("./chunks/index-abc.js"));`,
+        );
+        expect(out).toContain(`export { DoenetEditor, React };`);
+        // The static import is gone: nothing left for a module loader to
+        // resolve before the pin can run.
+        expect(out).not.toMatch(/import\s*\{/);
+    });
+
+    it("accepts the same shape minified onto one line", () => {
+        const code = `import{bE as e,R as t}from"./chunks/index-abc.js";export{e as DoenetEditor,t as React};`;
+        const { code: out } = transformFacade(code, banner);
+        expect(out).toContain(
+            `const { bE: e, R: t } = await import(${PIN_HELPER_NAME}("./chunks/index-abc.js"));`,
+        );
+        expect(out).toContain(`export{e as DoenetEditor,t as React};`);
+    });
+
+    it("rewrites direct re-exports, renames and default included", () => {
+        const code = `export { a as DoenetViewer, b as default, c } from './chunks/index-abc.js';\n`;
+        const { code: out } = transformFacade(code, banner);
+        expect(out).toContain(
+            `const __doenetFacadeNs0 = await import(${PIN_HELPER_NAME}("./chunks/index-abc.js"));`,
+        );
+        expect(out).toContain(
+            `export const DoenetViewer = __doenetFacadeNs0.a;`,
+        );
+        expect(out).toContain(`export default __doenetFacadeNs0.b;`);
+        expect(out).toContain(`export const c = __doenetFacadeNs0.c;`);
+    });
+
+    it("rewrites side-effect, default, and namespace imports", () => {
+        const code =
+            `import './chunks/polyfill-abc.js';\n` +
+            `import Def from './chunks/one-abc.js';\n` +
+            `import * as ns from './chunks/two-abc.js';\n` +
+            `export { ns };\n`;
+        const { code: out } = transformFacade(code, banner);
+        expect(out).toContain(
+            `await import(${PIN_HELPER_NAME}("./chunks/polyfill-abc.js"));`,
+        );
+        expect(out).toContain(
+            `const { default: Def } = await import(${PIN_HELPER_NAME}("./chunks/one-abc.js"));`,
+        );
+        expect(out).toContain(
+            `const ns = await import(${PIN_HELPER_NAME}("./chunks/two-abc.js"));`,
+        );
+    });
+
+    it("keeps statement order, so evaluation order is preserved", () => {
+        const code =
+            `import './chunks/first-abc.js';\n` +
+            `import './chunks/second-abc.js';\n`;
+        const { code: out } = transformFacade(code, banner);
+        expect(out.indexOf("first-abc")).toBeLessThan(
+            out.indexOf("second-abc"),
+        );
+    });
+
+    it("fails loudly on a statement outside the facade grammar", () => {
+        expect(() =>
+            transformFacade(`const x = 1;\nexport { x };\n`, banner),
+        ).toThrow(/outside the re-export grammar/);
+    });
+
+    it("fails loudly on a bare (non-relative) specifier", () => {
+        expect(() =>
+            transformFacade(`import { a } from 'react';\n`, banner),
+        ).toThrow(/non-relative specifier/);
+    });
+
+    it("places the render-queue prologue before the await and its flush after everything", () => {
+        const code =
+            `import { a as b } from './chunks/index-abc.js';\n` +
+            `export { b };\n`;
+        const prologue = renderQueuePrologue();
+        const { code: out } = transformFacade(code, banner, prologue);
+        const installAt = out.indexOf(FLUSH_RENDER_QUEUE_NAME);
+        const awaitAt = out.indexOf("await import(");
+        const flushCallAt = out.lastIndexOf(`${FLUSH_RENDER_QUEUE_NAME}();`);
+        expect(installAt).toBeGreaterThan(-1);
+        expect(installAt).toBeLessThan(awaitAt);
+        expect(flushCallAt).toBeGreaterThan(awaitAt);
+        expect(flushCallAt).toBeGreaterThan(out.indexOf("export { b };"));
+    });
+});
+
+describe("renderQueuePrologue", () => {
+    it("is self-contained and installs the marked stubs when evaluated", () => {
+        const prologue = renderQueuePrologue();
+        expect(prologue).not.toMatch(/\bimport\s*[({"']/);
+        expect(prologue).not.toContain("__name(");
+        // Evaluate the exact injected text against a fake globalThis.
+        const fakeGlobal: Record<string, unknown> = {};
+        const flush = new Function(
+            "globalThis",
+            `${prologue}; return ${FLUSH_RENDER_QUEUE_NAME};`,
+        )(fakeGlobal) as () => void;
+        expect(typeof fakeGlobal.renderDoenetViewerToContainer).toBe(
+            "function",
+        );
+        const queuedArgs: unknown[][] = [];
+        (fakeGlobal.renderDoenetViewerToContainer as Function)("container");
+        fakeGlobal.renderDoenetViewerToContainer = (...args: unknown[]) => {
+            queuedArgs.push(args);
+        };
+        flush();
+        expect(queuedArgs).toEqual([["container"]]);
+    });
+});
+
+describe("pinChunkUrlsPlugin hooks", () => {
+    const plugin = pinChunkUrlsPlugin({
+        packageName: PKG,
+        version: V,
+        facadeFileName: "doenet-standalone.js",
+    });
+    const renderDynamicImport = plugin.renderDynamicImport as (options: {
+        format: string;
+        moduleId: string;
+        targetModuleId: string | null;
+        chunk: unknown;
+        targetChunk: unknown;
+    }) => { left: string; right: string } | null;
+
+    it("wraps statically-resolved in-bundle dynamic imports", () => {
+        const mechanism = renderDynamicImport({
+            format: "es",
+            moduleId: "/src/index.tsx",
+            targetModuleId: "/src/lazy.tsx",
+            chunk: { fileName: "chunks/index-abc.js" },
+            targetChunk: { fileName: "chunks/lazy-def.js" },
+        });
+        expect(mechanism).toEqual({
+            left: `import(${PIN_HELPER_NAME}(`,
+            right: `))`,
+        });
+    });
+
+    it("leaves runtime-variable specifiers on default rendering", () => {
+        expect(
+            renderDynamicImport({
+                format: "es",
+                moduleId: "/src/index.tsx",
+                targetModuleId: null,
+                chunk: { fileName: "chunks/index-abc.js" },
+                targetChunk: null,
+            }),
+        ).toBeNull();
+    });
+});

--- a/packages/standalone/scripts/pin-chunk-urls-plugin.ts
+++ b/packages/standalone/scripts/pin-chunk-urls-plugin.ts
@@ -110,7 +110,7 @@ const FACADE_STATEMENTS: {
             if (m[1]) {
                 bindings.push(`default: ${m[1]}`);
             }
-            bindings.push(...parseBindingList(m[2] ?? "", ":"));
+            bindings.push(...parseBindingList(m[2] ?? ""));
             return `const { ${bindings.join(", ")} } = await import(${PIN_HELPER_NAME}(${quoted(m[4])}));`;
         },
     },
@@ -177,7 +177,7 @@ function splitBindingList(list: string): string[] {
  * (`a: b, c`). String-literal binding names would need different handling and
  * do not occur in this build's facade, so they fail the strict match below.
  */
-function parseBindingList(list: string, separator: ":"): string[] {
+function parseBindingList(list: string): string[] {
     return splitBindingList(list).map((entry) => {
         const m = /^([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/.exec(
             entry,
@@ -188,7 +188,7 @@ function parseBindingList(list: string, separator: ":"): string[] {
                     `in the facade; revisit scripts/pin-chunk-urls-plugin.ts.`,
             );
         }
-        return m[2] ? `${m[1]}${separator} ${m[2]}` : m[1];
+        return m[2] ? `${m[1]}: ${m[2]}` : m[1];
     });
 }
 

--- a/packages/standalone/scripts/pin-chunk-urls-plugin.ts
+++ b/packages/standalone/scripts/pin-chunk-urls-plugin.ts
@@ -1,0 +1,327 @@
+/**
+ * Build half of chunk-URL pinning for the code-split bundle: rewrite every
+ * emitted chunk reference to resolve, at load time, against the importing
+ * module's version-pinned URL.
+ *
+ * `src/pinnedChunkUrlResolver.ts` holds the runtime logic and the account of
+ * why the references need pinning (the floating-CDN-tag cache skew);
+ * `src/pinPackageVersion.ts` holds the URL grammar. This plugin's job is
+ * wiring those into the emitted output, which has two kinds of chunk
+ * reference:
+ *
+ *  - **Lazy `import()`s between chunks.** `renderDynamicImport` wraps each
+ *    statically-resolved in-bundle dynamic import so the emitted relative path
+ *    passes through the resolver: `import(__doenetPinChunkUrl('./Foo-hash.js'))`.
+ *    Every chunk containing such an import gets the resolver injected as a
+ *    banner — the runtime functions stringified into module scope, so the
+ *    chunk stays dependency-free (a banner cannot carry imports, and an
+ *    imported helper would itself be a chunk whose URL needed pinning first).
+ *
+ *  - **The facade's static import of the eager chunk.** `doenet-standalone.js`
+ *    is a re-export facade whose one static import names the eager chunk, and
+ *    a static import's URL is fixed by the module loader before any code
+ *    runs. `renderChunk` therefore rewrites the facade itself: each
+ *    `import`/`export … from` becomes a top-level-awaited
+ *    `await import(__doenetPinChunkUrl('./chunks/…'))` with the re-exports
+ *    rebuilt from the awaited namespace. Pinning this first edge is what
+ *    keeps the whole graph in one URL space: the eager chunk then evaluates
+ *    at its exact-version URL, every lazy chunk resolves relative to *that*,
+ *    and each shared chunk keeps a single module identity (one React, one
+ *    loader registry) no matter which URL the facade itself was fetched from.
+ *
+ * Because the awaited import suspends the facade's evaluation — and a module
+ * script's `load` event fires at that suspension — the facade also gets a
+ * synchronous prologue installing queueing stubs for the render globals that
+ * PreTeXt-style hosts call from `onload`, flushed once the eager chunk has
+ * evaluated. `src/facadeRenderQueue.ts` holds that logic and its contract.
+ *
+ * The facade parser is deliberately strict: it recognizes exactly the
+ * statement forms a Rollup re-export facade contains and fails the build
+ * loudly on anything else, so a change to the output shape surfaces here at
+ * build time instead of as a broken published bundle.
+ *
+ * Applied only in `vite.config.ts` (the code-split build). The single-file
+ * inline variant has no chunk references, and the coordinator bundle is one
+ * file too.
+ */
+import MagicString from "magic-string";
+import type { Plugin } from "vite";
+import { installFacadeRenderQueue } from "../src/facadeRenderQueue";
+import { pinPackageVersion } from "../src/pinPackageVersion";
+import { makePinnedChunkUrlResolver } from "../src/pinnedChunkUrlResolver";
+
+/**
+ * The module-scope name the injected resolver is bound to. Prefixed so it
+ * cannot collide with anything Rollup generates; renamed freely (and
+ * consistently, being chunk-local) by minification.
+ */
+export const PIN_HELPER_NAME = "__doenetPinChunkUrl";
+
+/**
+ * The code injected at the top of a chunk that references other chunks: the
+ * two runtime functions, stringified, applied to the chunk's own
+ * `import.meta.url` once at module evaluation.
+ *
+ * Self-containment is load-bearing — the text references only its own
+ * bindings, standard globals, and `import.meta` — and it is what
+ * `stringifiedRuntime` in the test file locks down.
+ */
+export function pinHelperBanner(packageName: string, version: string): string {
+    return (
+        `const ${PIN_HELPER_NAME} = (${makePinnedChunkUrlResolver.toString()})(` +
+        `(${pinPackageVersion.toString()}), import.meta.url, ` +
+        `${JSON.stringify(packageName)}, ${JSON.stringify(version)});\n`
+    );
+}
+
+/** The facade-local name of the flush function the render-queue stub returns. */
+export const FLUSH_RENDER_QUEUE_NAME = "__doenetFlushRenderQueue";
+
+/**
+ * The facade's synchronous prologue beyond the pin resolver: install the
+ * queueing render-global stubs (see `src/facadeRenderQueue.ts` — a module
+ * script's `load` event fires when the facade suspends at its first `await`,
+ * and PreTeXt calls `window.renderDoenetViewerToContainer` from exactly that
+ * event). `transformFacade` places this before the awaited import and a
+ * `FLUSH_RENDER_QUEUE_NAME()` call after it.
+ */
+export function renderQueuePrologue(): string {
+    return `const ${FLUSH_RENDER_QUEUE_NAME} = (${installFacadeRenderQueue.toString()})(globalThis);\n`;
+}
+
+/** One parsed facade statement: [start, end) in the source plus its rewrite. */
+type FacadeRewrite = { start: number; end: number; replacement: string };
+
+/**
+ * Statement forms of a Rollup re-export facade. Whitespace-tolerant so the
+ * same grammar accepts pretty or compact rendering; `[^}]*` spans newlines
+ * inside a binding list.
+ */
+const FACADE_STATEMENTS: {
+    re: RegExp;
+    rewrite: (match: RegExpExecArray, nsIndex: number) => string | null;
+}[] = [
+    {
+        // import defaultName, { a as b } from './chunk.js';
+        // (default-only, named-only, or both)
+        re: /^import\s*(?:([A-Za-z_$][\w$]*)\s*(?:,\s*)?)?(?:\{([^}]*)\})?\s*from\s*(["'])([^"']+)\3\s*;/,
+        rewrite: (m) => {
+            const bindings: string[] = [];
+            if (m[1]) {
+                bindings.push(`default: ${m[1]}`);
+            }
+            bindings.push(...parseBindingList(m[2] ?? "", ":"));
+            return `const { ${bindings.join(", ")} } = await import(${PIN_HELPER_NAME}(${quoted(m[4])}));`;
+        },
+    },
+    {
+        // import * as ns from './chunk.js';
+        re: /^import\s*\*\s*as\s+([A-Za-z_$][\w$]*)\s+from\s*(["'])([^"']+)\2\s*;/,
+        rewrite: (m) =>
+            `const ${m[1]} = await import(${PIN_HELPER_NAME}(${quoted(m[3])}));`,
+    },
+    {
+        // import './chunk.js';
+        re: /^import\s*(["'])([^"']+)\1\s*;/,
+        rewrite: (m) => `await import(${PIN_HELPER_NAME}(${quoted(m[2])}));`,
+    },
+    {
+        // export { a as b, c } from './chunk.js';
+        re: /^export\s*\{([^}]*)\}\s*from\s*(["'])([^"']+)\2\s*;/,
+        rewrite: (m, nsIndex) => {
+            const ns = `__doenetFacadeNs${nsIndex}`;
+            const lines = [
+                `const ${ns} = await import(${PIN_HELPER_NAME}(${quoted(m[3])}));`,
+            ];
+            for (const binding of splitBindingList(m[1])) {
+                const { local, exported } = parseReexport(binding);
+                lines.push(
+                    exported === "default"
+                        ? `export default ${ns}.${local};`
+                        : `export const ${exported} = ${ns}.${local};`,
+                );
+            }
+            return lines.join(" ");
+        },
+    },
+    {
+        // export { a as b, c };  — locals bound by the rewrites above.
+        re: /^export\s*\{([^}]*)\}\s*;/,
+        rewrite: () => null, // kept verbatim
+    },
+];
+
+function quoted(path: string): string {
+    if (!path.startsWith("./") && !path.startsWith("../")) {
+        throw new Error(
+            `chunk-URL pinning: the facade imports non-relative specifier ` +
+                `"${path}", which the pinning rewrite has no URL to resolve ` +
+                `against. This build bundles everything, so a bare specifier ` +
+                `in the facade means the output shape changed; revisit ` +
+                `scripts/pin-chunk-urls-plugin.ts.`,
+        );
+    }
+    return JSON.stringify(path);
+}
+
+/** Split `a as b, c` into its comma-separated entries, dropping blanks. */
+function splitBindingList(list: string): string[] {
+    return list
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Turn an import binding list (`a as b, c`) into destructuring entries
+ * (`a: b, c`). String-literal binding names would need different handling and
+ * do not occur in this build's facade, so they fail the strict match below.
+ */
+function parseBindingList(list: string, separator: ":"): string[] {
+    return splitBindingList(list).map((entry) => {
+        const m = /^([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/.exec(
+            entry,
+        );
+        if (!m) {
+            throw new Error(
+                `chunk-URL pinning: unrecognized import binding "${entry}" ` +
+                    `in the facade; revisit scripts/pin-chunk-urls-plugin.ts.`,
+            );
+        }
+        return m[2] ? `${m[1]}${separator} ${m[2]}` : m[1];
+    });
+}
+
+/** Parse one `local as exported` (or bare) re-export entry. */
+function parseReexport(entry: string): { local: string; exported: string } {
+    const m = /^([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/.exec(entry);
+    if (!m) {
+        throw new Error(
+            `chunk-URL pinning: unrecognized re-export binding "${entry}" ` +
+                `in the facade; revisit scripts/pin-chunk-urls-plugin.ts.`,
+        );
+    }
+    return { local: m[1], exported: m[2] ?? m[1] };
+}
+
+/**
+ * Rewrite a re-export facade so its chunk imports are pinned at load time:
+ * the banner's resolver and `prologue` are prepended, each
+ * `import`/`export … from` becomes a top-level-awaited dynamic import through
+ * the resolver (in statement order, preserving evaluation order), plain
+ * `export { … }` statements stay as they are, and — when a prologue installed
+ * the render-queue stubs — a `FLUSH_RENDER_QUEUE_NAME()` call is appended,
+ * which runs once every awaited import has settled.
+ *
+ * Pure and synchronous so the test file can drive it with synthetic facades;
+ * the plugin calls it from `renderChunk`. Throws (failing the build) on any
+ * statement outside the facade grammar — see the module doc for why strict.
+ */
+export function transformFacade(
+    code: string,
+    banner: string,
+    prologue = "",
+): { code: string; map: ReturnType<MagicString["generateMap"]> } {
+    const rewrites: FacadeRewrite[] = [];
+    let position = 0;
+    let nsIndex = 0;
+    while (position < code.length) {
+        const rest = code.slice(position);
+        const whitespace = /^\s+/.exec(rest);
+        if (whitespace) {
+            position += whitespace[0].length;
+            continue;
+        }
+        let matched = false;
+        for (const { re, rewrite } of FACADE_STATEMENTS) {
+            const m = re.exec(rest);
+            if (!m) {
+                continue;
+            }
+            const replacement = rewrite(m, nsIndex);
+            if (replacement !== null) {
+                rewrites.push({
+                    start: position,
+                    end: position + m[0].length,
+                    replacement,
+                });
+                if (replacement.includes("__doenetFacadeNs")) {
+                    nsIndex += 1;
+                }
+            }
+            position += m[0].length;
+            matched = true;
+            break;
+        }
+        if (!matched) {
+            throw new Error(
+                `chunk-URL pinning: the entry facade contains a statement ` +
+                    `outside the re-export grammar this rewrite understands ` +
+                    `(at offset ${position}: ${JSON.stringify(
+                        rest.slice(0, 80),
+                    )}). The build's output shape changed; revisit ` +
+                    `scripts/pin-chunk-urls-plugin.ts.`,
+            );
+        }
+    }
+    const s = new MagicString(code);
+    for (const { start, end, replacement } of rewrites) {
+        s.overwrite(start, end, replacement);
+    }
+    s.prepend(banner + prologue);
+    if (prologue !== "") {
+        s.append(`\n${FLUSH_RENDER_QUEUE_NAME}();`);
+    }
+    return { code: s.toString(), map: s.generateMap({ hires: true }) };
+}
+
+/** Options for {@link pinChunkUrlsPlugin}. */
+export type PinChunkUrlsOptions = {
+    /** The npm package a CDN URL for this bundle names. */
+    packageName: string;
+    /** The exact version being built — the release every reference pins to. */
+    version: string;
+    /** The emitted entry facade's file name, e.g. `"doenet-standalone.js"`. */
+    facadeFileName: string;
+};
+
+/** The plugin. See the module doc for the two rewrites it performs. */
+export function pinChunkUrlsPlugin(options: PinChunkUrlsOptions): Plugin {
+    const banner = pinHelperBanner(options.packageName, options.version);
+    return {
+        name: "doenet-pin-chunk-urls",
+        apply: "build",
+        outputOptions(outputOptions) {
+            const priorBanner = outputOptions.banner;
+            outputOptions.banner = async (chunk) => {
+                const prior =
+                    typeof priorBanner === "function"
+                        ? await priorBanner(chunk)
+                        : (priorBanner ?? "");
+                // Only chunks that reference other chunks carry the resolver;
+                // `dynamicImports` lists the in-bundle chunks this one lazily
+                // imports. (The facade is not among these — its reference is
+                // a static import, injected along with its own copy of the
+                // banner by the `renderChunk` rewrite below.)
+                return chunk.dynamicImports.length > 0 ? banner + prior : prior;
+            };
+            return outputOptions;
+        },
+        renderDynamicImport({ format, targetModuleId, targetChunk }) {
+            // Only statically-resolved imports of another in-bundle chunk have
+            // an emitted relative path to pin. Same-chunk imports never reach
+            // this hook, and runtime-variable specifiers (`targetModuleId`
+            // null) keep their default rendering.
+            if (format !== "es" || !targetChunk || !targetModuleId) {
+                return null;
+            }
+            return { left: `import(${PIN_HELPER_NAME}(`, right: `))` };
+        },
+        renderChunk(code, chunk) {
+            if (!chunk.isEntry || chunk.fileName !== options.facadeFileName) {
+                return null;
+            }
+            return transformFacade(code, banner, renderQueuePrologue());
+        },
+    };
+}

--- a/packages/standalone/src/facadeRenderQueue.test.ts
+++ b/packages/standalone/src/facadeRenderQueue.test.ts
@@ -125,6 +125,107 @@ describe("installFacadeRenderQueue", () => {
         }
     });
 
+    it("drains queued viewer calls in order through a foreign replacement's drain hook", () => {
+        // The two-concurrent-copies hand-off: another copy's eager chunk
+        // settles first, installFirstCopyGlobal replaces this copy's stub
+        // and invokes the stub's drain hook with its own function.
+        const w: Globals = {};
+        const flush = installFacadeRenderQueue(w);
+        const stub = w.renderDoenetViewerToContainer as any;
+        expect(typeof stub.__doenetDrainQueuedRenderCalls).toBe("function");
+        w.renderDoenetViewerToContainer!({ id: "a" }, "<p>one</p>");
+        w.renderDoenetViewerToContainer!({ id: "b" }, "<p>two</p>");
+
+        const foreign = vi.fn();
+        w.renderDoenetViewerToContainer = foreign;
+        stub.__doenetDrainQueuedRenderCalls(foreign);
+
+        expect(foreign.mock.calls).toEqual([
+            [{ id: "a" }, "<p>one</p>"],
+            [{ id: "b" }, "<p>two</p>"],
+        ]);
+        // The owner's own flush then finds an empty queue: nothing
+        // double-replays.
+        flush();
+        expect(foreign).toHaveBeenCalledTimes(2);
+    });
+
+    it("drains the editor queue through the hook, forwarding handle methods, and keeps a pre-captured stub handle working", () => {
+        const w: Globals = {};
+        const flush = installFacadeRenderQueue(w);
+        const stub = w.renderDoenetEditorToContainer as any;
+        const handle = w.renderDoenetEditorToContainer!({ id: "e" }) as {
+            openDiagnosticsTab: (tab: string) => void;
+            closeDiagnosticsPanel: () => void;
+            updateRenderedView: () => void;
+        };
+        handle.openDiagnosticsTab("errors");
+        handle.updateRenderedView();
+
+        const realHandle = {
+            openDiagnosticsTab: vi.fn(),
+            closeDiagnosticsPanel: vi.fn(),
+            updateRenderedView: vi.fn(),
+        };
+        const foreign = vi.fn(() => realHandle);
+        w.renderDoenetEditorToContainer = foreign;
+        stub.__doenetDrainQueuedRenderCalls(foreign);
+
+        expect(foreign).toHaveBeenCalledWith({ id: "e" });
+        expect(realHandle.openDiagnosticsTab).toHaveBeenCalledWith("errors");
+        expect(realHandle.updateRenderedView).toHaveBeenCalledTimes(1);
+
+        // The handle the stub handed out before the drain forwards directly
+        // to the real handle afterwards.
+        handle.closeDiagnosticsPanel();
+        expect(realHandle.closeDiagnosticsPanel).toHaveBeenCalledTimes(1);
+
+        // The owner's flush replays nothing after the cross-drain.
+        flush();
+        expect(foreign).toHaveBeenCalledTimes(1);
+    });
+
+    it("isolates drain-hook errors per call, rethrowing asynchronously", () => {
+        vi.useFakeTimers();
+        try {
+            const w: Globals = {};
+            installFacadeRenderQueue(w);
+            const stub = w.renderDoenetViewerToContainer as any;
+            w.renderDoenetViewerToContainer!("bad");
+            w.renderDoenetViewerToContainer!("good");
+            const rendered: unknown[] = [];
+            const foreign = (...args: unknown[]) => {
+                if (args[0] === "bad") {
+                    throw new Error("no container");
+                }
+                rendered.push(args[0]);
+            };
+            w.renderDoenetViewerToContainer = foreign;
+            expect(() =>
+                stub.__doenetDrainQueuedRenderCalls(foreign),
+            ).not.toThrow();
+            expect(rendered).toEqual(["good"]);
+            expect(() => vi.runAllTimers()).toThrow("no container");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("drains an empty queue to a no-op", () => {
+        const w: Globals = {};
+        installFacadeRenderQueue(w);
+        const viewerStub = w.renderDoenetViewerToContainer as any;
+        const editorStub = w.renderDoenetEditorToContainer as any;
+        const foreign = vi.fn();
+        expect(() =>
+            viewerStub.__doenetDrainQueuedRenderCalls(foreign),
+        ).not.toThrow();
+        expect(() =>
+            editorStub.__doenetDrainQueuedRenderCalls(foreign),
+        ).not.toThrow();
+        expect(foreign).not.toHaveBeenCalled();
+    });
+
     it("pre-creates doenetGlobalConfig so onload-time writes have a target", () => {
         const w: Globals & { doenetGlobalConfig?: object } = {};
         installFacadeRenderQueue(w);
@@ -155,5 +256,21 @@ describe("installFacadeRenderQueue", () => {
         w.renderDoenetViewerToContainer = real;
         flush();
         expect(real).toHaveBeenCalledWith("queued-arg");
+    });
+
+    it("round-trips the drain hook through its own source too", () => {
+        const install = (0, eval)(
+            `(${installFacadeRenderQueue.toString()})`,
+        ) as typeof installFacadeRenderQueue;
+        const w: Globals = {};
+        const flush = install(w);
+        const stub = w.renderDoenetViewerToContainer as any;
+        w.renderDoenetViewerToContainer!("queued-arg");
+        const foreign = vi.fn();
+        w.renderDoenetViewerToContainer = foreign;
+        stub.__doenetDrainQueuedRenderCalls(foreign);
+        expect(foreign).toHaveBeenCalledWith("queued-arg");
+        flush();
+        expect(foreign).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/standalone/src/facadeRenderQueue.test.ts
+++ b/packages/standalone/src/facadeRenderQueue.test.ts
@@ -98,6 +98,33 @@ describe("installFacadeRenderQueue", () => {
         expect(real).toHaveBeenCalledTimes(1);
     });
 
+    it("replays the rest of the queue when one queued call throws, rethrowing asynchronously", () => {
+        vi.useFakeTimers();
+        try {
+            const w: Globals = {};
+            const flush = installFacadeRenderQueue(w);
+            w.renderDoenetViewerToContainer!("bad");
+            w.renderDoenetViewerToContainer!("good");
+            const rendered: unknown[] = [];
+            w.renderDoenetViewerToContainer = (...args: unknown[]) => {
+                if (args[0] === "bad") {
+                    throw new Error("no container");
+                }
+                rendered.push(args[0]);
+            };
+            // The flush itself must not throw (it runs inside the facade's
+            // module evaluation), and the throwing call must not take the
+            // queued calls after it down with it.
+            expect(() => flush()).not.toThrow();
+            expect(rendered).toEqual(["good"]);
+            // The error still surfaces as an uncaught (async) error, as it
+            // would have from the host's own onload handler.
+            expect(() => vi.runAllTimers()).toThrow("no container");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("pre-creates doenetGlobalConfig so onload-time writes have a target", () => {
         const w: Globals & { doenetGlobalConfig?: object } = {};
         installFacadeRenderQueue(w);

--- a/packages/standalone/src/facadeRenderQueue.test.ts
+++ b/packages/standalone/src/facadeRenderQueue.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { installFacadeRenderQueue } from "./facadeRenderQueue";
+
+type Globals = {
+    renderDoenetViewerToContainer?: (...args: unknown[]) => unknown;
+    renderDoenetEditorToContainer?: (...args: unknown[]) => unknown;
+};
+
+describe("installFacadeRenderQueue", () => {
+    it("installs marked stubs on empty globals", () => {
+        const w: Globals = {};
+        installFacadeRenderQueue(w);
+        expect(typeof w.renderDoenetViewerToContainer).toBe("function");
+        expect(typeof w.renderDoenetEditorToContainer).toBe("function");
+        // The marker the iframe wrapper's readiness poll keys off.
+        expect(
+            (w.renderDoenetViewerToContainer as any).__doenetPendingRenderStub,
+        ).toBe(true);
+        expect(
+            (w.renderDoenetEditorToContainer as any).__doenetPendingRenderStub,
+        ).toBe(true);
+    });
+
+    it("queues viewer calls and replays them in order through the real function", () => {
+        const w: Globals = {};
+        const flush = installFacadeRenderQueue(w);
+        const containerA = { id: "a" };
+        const containerB = { id: "b" };
+        w.renderDoenetViewerToContainer!(containerA, "<p>one</p>");
+        w.renderDoenetViewerToContainer!(containerB, "<p>two</p>", {
+            flags: {},
+        });
+
+        const real = vi.fn();
+        w.renderDoenetViewerToContainer = real; // what the eager chunk does
+        flush();
+
+        expect(real.mock.calls).toEqual([
+            [containerA, "<p>one</p>"],
+            [containerB, "<p>two</p>", { flags: {} }],
+        ]);
+        // A second flush replays nothing (the queue drained).
+        flush();
+        expect(real).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns an editor handle whose queued method calls replay on the real handle", () => {
+        const w: Globals = {};
+        const flush = installFacadeRenderQueue(w);
+        const handle = w.renderDoenetEditorToContainer!({ id: "e" }) as {
+            openDiagnosticsTab: (tab: string) => void;
+            closeDiagnosticsPanel: () => void;
+            updateRenderedView: () => void;
+        };
+        handle.openDiagnosticsTab("errors");
+        handle.updateRenderedView();
+
+        const realHandle = {
+            openDiagnosticsTab: vi.fn(),
+            closeDiagnosticsPanel: vi.fn(),
+            updateRenderedView: vi.fn(),
+        };
+        const realRender = vi.fn(() => realHandle);
+        w.renderDoenetEditorToContainer = realRender;
+        flush();
+
+        expect(realRender).toHaveBeenCalledWith({ id: "e" });
+        expect(realHandle.openDiagnosticsTab).toHaveBeenCalledWith("errors");
+        expect(realHandle.updateRenderedView).toHaveBeenCalledTimes(1);
+
+        // After the flush, the handle handed out pre-flush forwards directly.
+        handle.closeDiagnosticsPanel();
+        expect(realHandle.closeDiagnosticsPanel).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves an already-installed function alone", () => {
+        const existing = vi.fn();
+        const w: Globals = { renderDoenetViewerToContainer: existing };
+        const flush = installFacadeRenderQueue(w);
+        expect(w.renderDoenetViewerToContainer).toBe(existing);
+        w.renderDoenetViewerToContainer!("direct");
+        expect(existing).toHaveBeenCalledWith("direct");
+        // Flushing replays nothing through it either.
+        flush();
+        expect(existing).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-enter its own stub if nothing replaced it by flush time", () => {
+        const w: Globals = {};
+        const flush = installFacadeRenderQueue(w);
+        w.renderDoenetViewerToContainer!({ id: "a" });
+        flush(); // global still holds the stub — must not recurse
+        // The queued call is still waiting for a real function.
+        const real = vi.fn();
+        w.renderDoenetViewerToContainer = real;
+        flush();
+        expect(real).toHaveBeenCalledTimes(1);
+    });
+
+    it("pre-creates doenetGlobalConfig so onload-time writes have a target", () => {
+        const w: Globals & { doenetGlobalConfig?: object } = {};
+        installFacadeRenderQueue(w);
+        expect(w.doenetGlobalConfig).toEqual({});
+        // What a PreTeXt-style host does at onload; global-config.ts later
+        // adopts this same object, so the write must land and persist.
+        (w.doenetGlobalConfig as any).coreBootMaxAttempts = 1;
+        expect((w.doenetGlobalConfig as any).coreBootMaxAttempts).toBe(1);
+    });
+
+    it("leaves an existing doenetGlobalConfig object alone", () => {
+        const existing = { coreBootMaxAttempts: 3 };
+        const w: Globals & { doenetGlobalConfig?: object } = {
+            doenetGlobalConfig: existing,
+        };
+        installFacadeRenderQueue(w);
+        expect(w.doenetGlobalConfig).toBe(existing);
+    });
+
+    it("round-trips through its own source, as the build injects it", () => {
+        const install = (0, eval)(
+            `(${installFacadeRenderQueue.toString()})`,
+        ) as typeof installFacadeRenderQueue;
+        const w: Globals = {};
+        const flush = install(w);
+        w.renderDoenetViewerToContainer!("queued-arg");
+        const real = vi.fn();
+        w.renderDoenetViewerToContainer = real;
+        flush();
+        expect(real).toHaveBeenCalledWith("queued-arg");
+    });
+});

--- a/packages/standalone/src/facadeRenderQueue.ts
+++ b/packages/standalone/src/facadeRenderQueue.ts
@@ -134,6 +134,23 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
         w.doenetGlobalConfig = {};
     }
 
+    // Replay one queued call with the same error visibility it would have had
+    // pre-queueing, when the host's `onload` handler called the real function
+    // directly: a throw surfaces as an uncaught error (`window.onerror`,
+    // console). Catching it here keeps one bad call — a null container, say —
+    // from skipping every call queued after it, and keeps the flush from
+    // throwing inside the facade's module evaluation, which would fail the
+    // module for `import` consumers even though the render globals are fine.
+    function replay(call: () => void): void {
+        try {
+            call();
+        } catch (e) {
+            setTimeout(() => {
+                throw e;
+            });
+        }
+    }
+
     return function flush(): void {
         const realViewer = w.renderDoenetViewerToContainer;
         if (
@@ -142,7 +159,7 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
             realViewer !== (viewerStub as unknown)
         ) {
             for (const { args } of viewerQueue.splice(0)) {
-                realViewer(...args);
+                replay(() => realViewer(...args));
             }
         }
         const realEditor = w.renderDoenetEditorToContainer;
@@ -152,17 +169,19 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
             realEditor !== (editorStub as unknown)
         ) {
             for (const call of editorQueue.splice(0)) {
-                const handle = realEditor(...call.args) as Record<
-                    string,
-                    (...a: unknown[]) => unknown
-                > | null;
-                if (!handle) {
-                    continue;
-                }
-                call.realHandle = handle;
-                for (const { method, args } of call.methodCalls.splice(0)) {
-                    handle[method](...args);
-                }
+                replay(() => {
+                    const handle = realEditor(...call.args) as Record<
+                        string,
+                        (...a: unknown[]) => unknown
+                    > | null;
+                    if (!handle) {
+                        return;
+                    }
+                    call.realHandle = handle;
+                    for (const { method, args } of call.methodCalls.splice(0)) {
+                        handle[method](...args);
+                    }
+                });
             }
         }
     };

--- a/packages/standalone/src/facadeRenderQueue.ts
+++ b/packages/standalone/src/facadeRenderQueue.ts
@@ -1,0 +1,169 @@
+/**
+ * Queueing stubs for the render globals, installed by the entry facade's
+ * synchronous prologue.
+ *
+ * The code-split facade awaits its eager chunk through a dynamic import (see
+ * `scripts/pin-chunk-urls-plugin.ts` — the await is what lets the chunk URL be
+ * version-pinned at load time), and a module script's `load` event fires when
+ * evaluation *suspends* at the first `await`, not when it completes. PreTeXt
+ * pages hang their render call on exactly that event:
+ *
+ *     <script onload="onLoad()" type="module" src="…/doenet-standalone.js">
+ *     …
+ *     function onLoad() {
+ *         window.renderDoenetViewerToContainer(
+ *             document.querySelector(".doenetml-applet"));
+ *     }
+ *
+ * So at `onload` time the real functions — installed by the eager chunk's
+ * module body — may not exist yet. This installer runs before the facade's
+ * first `await` and puts a queueing stub at each render global: calls made
+ * between `load` and the eager chunk's evaluation are recorded, and the
+ * facade flushes them through the real functions the moment the awaited
+ * import settles. The editor stub returns a handle whose method calls queue
+ * the same way and replay against the real handle on flush — same contract as
+ * the real `renderDoenetEditorToContainer`, which itself queues handle
+ * actions until the editor mounts.
+ *
+ * Each stub carries `__doenetPendingRenderStub: true` so a host that *polls*
+ * for the globals can keep waiting for the real thing:
+ * `@doenet/doenetml-iframe`'s `waitForStandaloneBundle` (in
+ * `iframe-viewer-index.ts` / `iframe-editor-index.ts`) checks the marker by
+ * this exact name, which is why the property is part of the bundle's
+ * public surface and must not be renamed casually.
+ *
+ * The palette-discovery globals (`getDoenetStylePalettes`,
+ * `getDoenetStylePalette`) are not stubbed: they answer with data, which does
+ * not exist until the eager chunk evaluates, and their documented contract is
+ * feature detection — `typeof … === "function"` means the answer is real.
+ *
+ * `window.doenetGlobalConfig` is the remaining `onload`-time surface: hosts
+ * set boot/worker knobs (and test seams) on it from the same event. The
+ * installer pre-creates it as an empty object, and `global-config.ts` in
+ * `@doenet/doenetml` adopts that same object when the eager chunk evaluates —
+ * so `onload`-time writes are honored and captured references stay live.
+ *
+ * Injected into the facade as a stringified function (the same mechanism as
+ * the pin helper), so **everything here must be self-contained**: no imports,
+ * no references outside the function's own scope and standard globals.
+ */
+
+/** The window-ish object the render globals live on. */
+type RenderGlobals = {
+    renderDoenetViewerToContainer?: (...args: unknown[]) => unknown;
+    renderDoenetEditorToContainer?: (...args: unknown[]) => unknown;
+    doenetGlobalConfig?: object;
+};
+
+/**
+ * Install queueing stubs for the render globals on `w`, and return the flush
+ * function the facade calls once the eager chunk has evaluated.
+ *
+ * A global that already holds a function (another copy of this bundle on the
+ * same page, whether real or an earlier stub) is left alone; calls keep going
+ * to that copy, and this facade's flush then has nothing of its own to
+ * replay.
+ *
+ * Flushing replays queued calls in order through whatever the globals hold
+ * *at flush time* — normally the real functions the eager chunk just
+ * installed. If a global still holds this installer's own stub (nothing
+ * replaced it — the import failed in a way that still reached the flush),
+ * its queue is left in place rather than re-entered.
+ */
+export function installFacadeRenderQueue(w: RenderGlobals): () => void {
+    type QueuedViewerCall = { args: unknown[] };
+    type QueuedEditorCall = {
+        args: unknown[];
+        methodCalls: { method: string; args: unknown[] }[];
+        realHandle: Record<string, (...a: unknown[]) => unknown> | null;
+    };
+    const viewerQueue: QueuedViewerCall[] = [];
+    const editorQueue: QueuedEditorCall[] = [];
+
+    function viewerStub(...args: unknown[]): void {
+        viewerQueue.push({ args });
+    }
+    viewerStub.__doenetPendingRenderStub = true;
+
+    function editorStub(...args: unknown[]) {
+        const call: QueuedEditorCall = {
+            args,
+            methodCalls: [],
+            realHandle: null,
+        };
+        editorQueue.push(call);
+        // The handle contract of the real function: three methods, callable
+        // immediately. Queue them; forward directly once flush has the real
+        // handle (so a handle cached across the flush keeps working).
+        function makeMethod(method: string) {
+            return (...methodArgs: unknown[]) => {
+                if (call.realHandle) {
+                    call.realHandle[method](...methodArgs);
+                } else {
+                    call.methodCalls.push({ method, args: methodArgs });
+                }
+            };
+        }
+        return {
+            openDiagnosticsTab: makeMethod("openDiagnosticsTab"),
+            closeDiagnosticsPanel: makeMethod("closeDiagnosticsPanel"),
+            updateRenderedView: makeMethod("updateRenderedView"),
+        };
+    }
+    editorStub.__doenetPendingRenderStub = true;
+
+    const installedViewer =
+        typeof w.renderDoenetViewerToContainer !== "function";
+    if (installedViewer) {
+        w.renderDoenetViewerToContainer = viewerStub;
+    }
+    const installedEditor =
+        typeof w.renderDoenetEditorToContainer !== "function";
+    if (installedEditor) {
+        w.renderDoenetEditorToContainer = editorStub;
+    }
+    // The other global hosts touch from `onload`: `window.doenetGlobalConfig`
+    // (boot/worker knobs, test seams). Pre-create it so those writes have an
+    // object to land on; the eager chunk's `global-config.ts` adopts this
+    // same object — identity preserved, defaults filled in around the host's
+    // values — so references a host captured at `onload` stay live.
+    if (
+        typeof w.doenetGlobalConfig !== "object" ||
+        w.doenetGlobalConfig === null
+    ) {
+        w.doenetGlobalConfig = {};
+    }
+
+    return function flush(): void {
+        const realViewer = w.renderDoenetViewerToContainer;
+        if (
+            installedViewer &&
+            typeof realViewer === "function" &&
+            realViewer !== (viewerStub as unknown)
+        ) {
+            for (const { args } of viewerQueue.splice(0)) {
+                realViewer(...args);
+            }
+        }
+        const realEditor = w.renderDoenetEditorToContainer;
+        if (
+            installedEditor &&
+            typeof realEditor === "function" &&
+            realEditor !== (editorStub as unknown)
+        ) {
+            for (const call of editorQueue.splice(0)) {
+                const handle = realEditor(...call.args) as Record<
+                    string,
+                    (...a: unknown[]) => unknown
+                > | null;
+                if (!handle) {
+                    continue;
+                }
+                call.realHandle = handle;
+                for (const { method, args } of call.methodCalls.splice(0)) {
+                    handle[method](...args);
+                }
+            }
+        }
+    };
+}

--- a/packages/standalone/src/facadeRenderQueue.ts
+++ b/packages/standalone/src/facadeRenderQueue.ts
@@ -32,6 +32,18 @@
  * this exact name, which is why the property is part of the bundle's
  * public surface and must not be renamed casually.
  *
+ * Each stub also carries a `__doenetDrainQueuedRenderCalls(real)` hook, which
+ * replays the stub's queued calls through `real` and empties the queue.
+ * `installFirstCopyGlobal` invokes it when it replaces a pending stub, which
+ * covers two concurrent code-split copies on one page: one copy's prologue
+ * installs the stubs, and whichever copy's eager chunk settles first replaces
+ * them and drains the queues through its own functions — the same release
+ * whose worker URL won the shared-config write, so queued calls stay
+ * version-consistent, and they are delivered even when the stub-owning
+ * copy's own chunk never settles. The two copies can be *different
+ * releases*, so this hook name — like the pending marker above — is part of
+ * the bundle's public surface and must not be renamed casually.
+ *
  * The palette-discovery globals (`getDoenetStylePalettes`,
  * `getDoenetStylePalette`) are not stubbed: they answer with data, which does
  * not exist until the eager chunk evaluates, and their documented contract is
@@ -68,7 +80,11 @@ type RenderGlobals = {
  * *at flush time* — normally the real functions the eager chunk just
  * installed. If a global still holds this installer's own stub (nothing
  * replaced it — the import failed in a way that still reached the flush),
- * its queue is left in place rather than re-entered.
+ * its queue is left in place; a queued call is still delivered if another
+ * copy's chunk later settles and drains the stub. Each queue is emptied by
+ * `splice(0)` in a single drain function shared by the flush and the stub's
+ * `__doenetDrainQueuedRenderCalls` hook, so whichever of the two runs second
+ * finds an empty queue and nothing double-replays.
  */
 export function installFacadeRenderQueue(w: RenderGlobals): () => void {
     type QueuedViewerCall = { args: unknown[] };
@@ -84,6 +100,7 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
         viewerQueue.push({ args });
     }
     viewerStub.__doenetPendingRenderStub = true;
+    viewerStub.__doenetDrainQueuedRenderCalls = drainViewerQueue;
 
     function editorStub(...args: unknown[]) {
         const call: QueuedEditorCall = {
@@ -111,6 +128,7 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
         };
     }
     editorStub.__doenetPendingRenderStub = true;
+    editorStub.__doenetDrainQueuedRenderCalls = drainEditorQueue;
 
     const installedViewer =
         typeof w.renderDoenetViewerToContainer !== "function";
@@ -151,6 +169,46 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
         }
     }
 
+    // The drain functions below are the single place each queue is emptied,
+    // shared by this facade's own flush and by the stubs'
+    // `__doenetDrainQueuedRenderCalls` hooks (invoked by another copy's
+    // `installFirstCopyGlobal` when its eager chunk settles first and
+    // replaces the stub). `splice(0)` empties the queue up front, so
+    // whichever caller runs second finds nothing and replays nothing.
+
+    /** Replay every queued viewer call, in order, through `real`. */
+    function drainViewerQueue(real: (...args: unknown[]) => unknown): void {
+        for (const { args } of viewerQueue.splice(0)) {
+            replay(() => real(...args));
+        }
+    }
+
+    /**
+     * Replay every queued editor call, in order, through `real`, reproducing
+     * the real function's handle contract: the real handle is captured into
+     * the queued call's `realHandle` — so the handle the *stub* returned,
+     * which a host may have cached, forwards its methods to the real handle
+     * from here on — and method calls recorded before the drain are forwarded
+     * to it in order.
+     */
+    function drainEditorQueue(real: (...args: unknown[]) => unknown): void {
+        for (const call of editorQueue.splice(0)) {
+            replay(() => {
+                const handle = real(...call.args) as Record<
+                    string,
+                    (...a: unknown[]) => unknown
+                > | null;
+                if (!handle) {
+                    return;
+                }
+                call.realHandle = handle;
+                for (const { method, args } of call.methodCalls.splice(0)) {
+                    handle[method](...args);
+                }
+            });
+        }
+    }
+
     return function flush(): void {
         const realViewer = w.renderDoenetViewerToContainer;
         if (
@@ -158,9 +216,7 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
             typeof realViewer === "function" &&
             realViewer !== (viewerStub as unknown)
         ) {
-            for (const { args } of viewerQueue.splice(0)) {
-                replay(() => realViewer(...args));
-            }
+            drainViewerQueue(realViewer);
         }
         const realEditor = w.renderDoenetEditorToContainer;
         if (
@@ -168,21 +224,7 @@ export function installFacadeRenderQueue(w: RenderGlobals): () => void {
             typeof realEditor === "function" &&
             realEditor !== (editorStub as unknown)
         ) {
-            for (const call of editorQueue.splice(0)) {
-                replay(() => {
-                    const handle = realEditor(...call.args) as Record<
-                        string,
-                        (...a: unknown[]) => unknown
-                    > | null;
-                    if (!handle) {
-                        return;
-                    }
-                    call.realHandle = handle;
-                    for (const { method, args } of call.methodCalls.splice(0)) {
-                        handle[method](...args);
-                    }
-                });
-            }
+            drainEditorQueue(realEditor);
         }
     };
 }

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -46,11 +46,12 @@ export type { StylePaletteInfo };
 export const version: string = STANDALONE_VERSION;
 
 // Message catalogs beyond the bundled ones are served next to this file, not
-// inside it: a single-file bundle inlines every dynamic import, so the
-// code-splitting the library build relies on would put all of `locales/` in
-// here. The build copies `locales/` into `dist/` and switches the code-split
-// path off (`__DOENET_CODE_SPLIT_CATALOGS__`); this points the viewer at that
-// copy, resolved against the bundle's own URL the same way the core worker is.
+// inside it: as plain runtime-fetched assets they can be version-pinned (see
+// below), and the single-file `doenet-standalone-inline.js` variant of this
+// entry stays free of them too. The build copies `locales/` into `dist/` and
+// switches the library build's code-split path off
+// (`__DOENET_CODE_SPLIT_CATALOGS__`); this points the viewer at that copy,
+// resolved against the bundle root the same way the core worker is.
 //
 // A host that serves this bundle without `locales/` beside it loses nothing it
 // has today: those fetches fail quietly and every locale falls back to English.
@@ -86,17 +87,42 @@ const pinnedBundleUrl = pinPackageVersion(
 );
 
 /**
+ * Relative path from *this module's* URL to the bundle root — the directory
+ * where `doenet-standalone.js`, `doenetml-worker/`, and `locales/` sit.
+ *
+ * A build-time constant (`define` in the vite configs) because the two builds
+ * of this entry lay their output out differently: in the code-split build this
+ * module's body lands in a chunk under `chunks/`, one level below the root,
+ * while the single-file `doenet-standalone-inline.js` build sits at the root
+ * itself. Everything served beside the bundle has to be resolved against the
+ * root, not against whichever file this module happens to be in.
+ */
+declare const __DOENET_STANDALONE_BUNDLE_ROOT__: string;
+
+/**
+ * The bundle root as a URL, version-pinned, or `null` where no root can be
+ * resolved (a Blob/`data:` base is opaque — nothing is "beside" it).
+ */
+const pinnedBundleRootUrl: string | null = (() => {
+    try {
+        return new URL(__DOENET_STANDALONE_BUNDLE_ROOT__, pinnedBundleUrl).href;
+    } catch {
+        return null;
+    }
+})();
+
+/**
  * Where to fetch the message catalogs from, or `null` if nowhere can be worked
  * out.
  *
  * Beside the bundle is the right answer and the one the build arranges — an
  * embed loading this file from the CDN gets the `locales/` published beside it.
- * But `import.meta.url` is not always a base a URL can be resolved against:
+ * But there is not always a resolvable bundle root:
  * `@doenet/doenetml-iframe`'s dev harness and Cypress component tests boot a
  * locally built copy of this bundle from a Blob URL, and `blob:` is opaque, so
- * `new URL` throws on it. Nothing is "beside" a blob, so that case tries the
- * page's own origin instead — where `getWorkerUrl` in `@doenet/doenetml` looks
- * for the core worker.
+ * `pinnedBundleRootUrl` is `null`. Nothing is "beside" a blob, so that case
+ * tries the page's own origin instead — where `getWorkerUrl` in
+ * `@doenet/doenetml` looks for the core worker.
  *
  * Returning `null` is a normal outcome, not an error: every locale then falls
  * back to English, exactly as it does when the catalogs are simply not served.
@@ -105,9 +131,12 @@ const pinnedBundleUrl = pinPackageVersion(
  */
 function localeCatalogsUrl(): string | null {
     for (const [path, base] of [
-        [CATALOGS_BESIDE_BUNDLE, pinnedBundleUrl],
+        [CATALOGS_BESIDE_BUNDLE, pinnedBundleRootUrl],
         [CATALOGS_AT_ORIGIN, globalThis.window?.location?.href],
     ] as const) {
+        if (!base) {
+            continue;
+        }
         try {
             return new URL(path, base).href;
         } catch {
@@ -122,18 +151,20 @@ if (localeCatalogsBase) {
     setLocaleLoaders(fetchLocaleLoaders(localeCatalogsBase));
 }
 
-// Re-point the core worker at the pinned copy, for the same reason as the
-// catalogs above. The externalized-worker entry has already resolved it against
-// this file's *own* URL — its module body runs at import time, before anything
-// here — so this runs after and replaces that answer.
+// Re-point the core worker at the bundle root's pinned copy. The
+// externalized-worker entry has already resolved it against *its own* module
+// URL — its module body runs at import time, before anything here — which in
+// the code-split build is a chunk under `chunks/`, where no worker sits. This
+// runs after and replaces that answer with the root-anchored (and
+// version-pinned) one.
 //
-// Skipped where pinning changed nothing (a self-hosted bundle, a Blob URL): the
-// entry's own resolution, including its fallbacks for bases nothing can be
-// resolved against, is then already the right answer.
-if (pinnedBundleUrl !== import.meta.url) {
+// Skipped where no root resolved (a Blob URL): the entry's own fallbacks for
+// bases nothing can be resolved against — the page origin's
+// `/doenetml-worker/index.js` — are then already the right answer.
+if (pinnedBundleRootUrl !== null) {
     try {
         setExternalCoreWorkerUrl(
-            new URL(WORKER_BESIDE_BUNDLE, pinnedBundleUrl).href,
+            new URL(WORKER_BESIDE_BUNDLE, pinnedBundleRootUrl).href,
         );
     } catch (e) {
         // Leave whatever the entry resolved in place: a worker under a floating
@@ -146,10 +177,15 @@ if (pinnedBundleUrl !== import.meta.url) {
 // Parent-page coordinator support (see coordinated-mode.ts): when this
 // page's URL carries the coordinator's fragment token, viewers rendered
 // here report their lifecycle to the parent and (with the `sc` variant)
-// obtain their cores from the coordinator's shared worker pool.
+// obtain their cores from the coordinator's shared worker pool. The pool
+// resolves `./doenetml-worker/index.js` against the URL it is handed, so it
+// gets the bundle root where one resolved, and this module's URL (whose
+// opaque-base fallback the pool shares) otherwise.
 const coordinatedMode = detectCoordinatedMode();
 if (coordinatedMode?.sharedCores) {
-    installCoordinatorSharedCorePortProvider(pinnedBundleUrl);
+    installCoordinatorSharedCorePortProvider(
+        pinnedBundleRootUrl ?? pinnedBundleUrl,
+    );
 }
 
 // Cache React roots per container so repeat calls to

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -30,6 +30,7 @@ import {
 import "@doenet/doenetml/style.css";
 import "./pretext-compat.css";
 import { pinPackageVersion } from "./pinPackageVersion";
+import { installFirstCopyGlobal } from "./installFirstCopyGlobal";
 import { ResizeWatcher } from "./resize-watcher";
 import {
     detectCoordinatedMode,
@@ -516,18 +517,35 @@ function kebobCaseToCamelCase(str: string) {
     return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
 }
 
-// Expose renderDoenetViewerToContainer and renderDoenetEditorToContainer on the global object
-// @ts-ignore
-window.renderDoenetViewerToContainer = renderDoenetViewerToContainer;
-// @ts-ignore
-window.renderDoenetEditorToContainer = renderDoenetEditorToContainer;
-
-// Expose style-palette discovery on the global object as well, so a page
-// that loads this bundle from the CDN (rather than importing it) can list
-// the palettes this DoenetML version ships and render swatches for them.
-// The iframe wrapper feature-detects these globals to report the palettes
-// of whichever bundle version it booted.
-// @ts-ignore
-window.getDoenetStylePalettes = getStylePalettes;
-// @ts-ignore
-window.getDoenetStylePalette = getStylePalette;
+// Expose renderDoenetViewerToContainer and renderDoenetEditorToContainer on
+// the global object, and style-palette discovery beside them, so a page that
+// loads this bundle from the CDN (rather than importing it) can render
+// documents and list the palettes this DoenetML version ships. The iframe
+// wrapper feature-detects the palette globals to report the palettes of
+// whichever bundle version it booted.
+//
+// The installs are guarded (see `installFirstCopyGlobal`): when another copy
+// of this bundle already evaluated on this page, only the facade prologue's
+// queueing stubs are replaced — that hand-off is how calls queued before the
+// eager chunk evaluated reach the real functions — and real functions are
+// left in place. A second copy therefore stays fully inert: its worker-URL
+// write defers to the first copy's (`hostProvidedWorkerUrl` in
+// `@doenet/doenetml`'s global-config.ts) and its globals defer here, so every
+// document pairs one release's UI with that same release's worker.
+const globalTarget = window as unknown as Record<string, unknown>;
+installFirstCopyGlobal(
+    globalTarget,
+    "renderDoenetViewerToContainer",
+    renderDoenetViewerToContainer,
+);
+installFirstCopyGlobal(
+    globalTarget,
+    "renderDoenetEditorToContainer",
+    renderDoenetEditorToContainer,
+);
+installFirstCopyGlobal(
+    globalTarget,
+    "getDoenetStylePalettes",
+    getStylePalettes,
+);
+installFirstCopyGlobal(globalTarget, "getDoenetStylePalette", getStylePalette);

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -526,12 +526,15 @@ function kebobCaseToCamelCase(str: string) {
 //
 // The installs are guarded (see `installFirstCopyGlobal`): when another copy
 // of this bundle already evaluated on this page, only the facade prologue's
-// queueing stubs are replaced — that hand-off is how calls queued before the
-// eager chunk evaluated reach the real functions — and real functions are
-// left in place. A second copy therefore stays fully inert: its worker-URL
-// write defers to the first copy's (`hostProvidedWorkerUrl` in
-// `@doenet/doenetml`'s global-config.ts) and its globals defer here, so every
-// document pairs one release's UI with that same release's worker.
+// queueing stubs are replaced — a replacement also drains the stub's queued
+// calls through the replacing function, which is how calls queued before any
+// eager chunk settled reach the real functions of the first chunk that does —
+// and real functions are left in place. A later copy therefore stays fully
+// inert: its worker-URL write defers to the first settled copy's
+// (`hostProvidedWorkerUrl` in `@doenet/doenetml`'s global-config.ts) and its
+// globals defer here, so every document pairs one release's UI with that same
+// release's worker, and no queued call is stranded on a copy whose chunk
+// fails to load.
 const globalTarget = window as unknown as Record<string, unknown>;
 installFirstCopyGlobal(
     globalTarget,

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -1,6 +1,7 @@
 /*
- * This file is for running a dev test of the codemirror component.
- * It does not show up in the bundled package.
+ * The entry module for the standalone bundles: the code-split
+ * `doenet-standalone.js` and the single-file `doenet-standalone-inline.js`
+ * are both built from this file (vite.config.ts / vite.config-inline.ts).
  */
 
 import React from "react";

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -25,6 +25,7 @@ import {
     fetchLocaleLoaders,
     setLocaleLoaders,
     setExternalCoreWorkerUrl,
+    hostProvidedWorkerUrl,
 } from "@doenet/doenetml/doenetml-external-worker.js";
 import "@doenet/doenetml/style.css";
 import "./pretext-compat.css";
@@ -162,7 +163,13 @@ if (localeCatalogsBase) {
 // Skipped where no root resolved (a Blob URL): the entry's own fallbacks for
 // bases nothing can be resolved against — the page origin's
 // `/doenetml-worker/index.js` — are then already the right answer.
-if (pinnedBundleRootUrl !== null) {
+//
+// Also skipped when the host chose the worker URL itself
+// (`hostProvidedWorkerUrl`): a `doenetGlobalConfig.doenetWorkerUrl` written
+// before this chunk evaluated — which, in the code-split build, includes a
+// script `onload` handler, since `load` fires while the facade awaits this
+// chunk — is an explicit deployment choice the pin must not override.
+if (!hostProvidedWorkerUrl && pinnedBundleRootUrl !== null) {
     try {
         setExternalCoreWorkerUrl(
             new URL(WORKER_BESIDE_BUNDLE, pinnedBundleRootUrl).href,

--- a/packages/standalone/src/installFirstCopyGlobal.test.ts
+++ b/packages/standalone/src/installFirstCopyGlobal.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { installFirstCopyGlobal } from "./installFirstCopyGlobal";
+
+describe("installFirstCopyGlobal", () => {
+    it("installs onto an absent global", () => {
+        const w: Record<string, unknown> = {};
+        const real = vi.fn();
+        expect(
+            installFirstCopyGlobal(w, "renderDoenetViewerToContainer", real),
+        ).toBe(true);
+        expect(w.renderDoenetViewerToContainer).toBe(real);
+    });
+
+    it("installs over a non-function value", () => {
+        const w: Record<string, unknown> = {
+            getDoenetStylePalettes: "not a function",
+        };
+        const real = vi.fn();
+        expect(installFirstCopyGlobal(w, "getDoenetStylePalettes", real)).toBe(
+            true,
+        );
+        expect(w.getDoenetStylePalettes).toBe(real);
+    });
+
+    it("replaces a pending facade stub (the stub-flush hand-off)", () => {
+        // The marker installFacadeRenderQueue puts on its queueing stubs;
+        // replacing the stub is how the facade's flush finds the real
+        // function to replay queued calls through.
+        const stub = Object.assign(vi.fn(), {
+            __doenetPendingRenderStub: true,
+        });
+        const w: Record<string, unknown> = {
+            renderDoenetEditorToContainer: stub,
+        };
+        const real = vi.fn();
+        expect(
+            installFirstCopyGlobal(w, "renderDoenetEditorToContainer", real),
+        ).toBe(true);
+        expect(w.renderDoenetEditorToContainer).toBe(real);
+    });
+
+    it("leaves a real function (no stub marker) alone — first copy wins", () => {
+        const firstCopy = vi.fn();
+        const w: Record<string, unknown> = {
+            renderDoenetViewerToContainer: firstCopy,
+        };
+        const secondCopy = vi.fn();
+        expect(
+            installFirstCopyGlobal(
+                w,
+                "renderDoenetViewerToContainer",
+                secondCopy,
+            ),
+        ).toBe(false);
+        expect(w.renderDoenetViewerToContainer).toBe(firstCopy);
+    });
+
+    it("treats only an exact `true` marker as a pending stub", () => {
+        // A function that happens to carry a truthy-but-not-true property of
+        // the same name is not the facade's stub; first copy still wins.
+        const notAStub = Object.assign(vi.fn(), {
+            __doenetPendingRenderStub: "yes",
+        });
+        const w: Record<string, unknown> = {
+            renderDoenetViewerToContainer: notAStub,
+        };
+        expect(
+            installFirstCopyGlobal(w, "renderDoenetViewerToContainer", vi.fn()),
+        ).toBe(false);
+        expect(w.renderDoenetViewerToContainer).toBe(notAStub);
+    });
+});

--- a/packages/standalone/src/installFirstCopyGlobal.test.ts
+++ b/packages/standalone/src/installFirstCopyGlobal.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { installFacadeRenderQueue } from "./facadeRenderQueue";
 import { installFirstCopyGlobal } from "./installFirstCopyGlobal";
 
 describe("installFirstCopyGlobal", () => {
@@ -54,6 +55,98 @@ describe("installFirstCopyGlobal", () => {
             ),
         ).toBe(false);
         expect(w.renderDoenetViewerToContainer).toBe(firstCopy);
+    });
+
+    it("invokes a replaced stub's drain hook with the new function, after installing it", () => {
+        // The order matters: a queued call that re-reads the global during
+        // its replay must see the real function, so the drain runs after the
+        // assignment. Recorded by capturing what the global holds at drain
+        // time.
+        const seen: { drainedWith: unknown; globalAtDrain: unknown }[] = [];
+        const w: Record<string, unknown> = {};
+        const stub = Object.assign(vi.fn(), {
+            __doenetPendingRenderStub: true,
+            __doenetDrainQueuedRenderCalls: (real: unknown) => {
+                seen.push({
+                    drainedWith: real,
+                    globalAtDrain: w.renderDoenetViewerToContainer,
+                });
+            },
+        });
+        w.renderDoenetViewerToContainer = stub;
+        const real = vi.fn();
+        expect(
+            installFirstCopyGlobal(w, "renderDoenetViewerToContainer", real),
+        ).toBe(true);
+        expect(seen).toEqual([{ drainedWith: real, globalAtDrain: real }]);
+    });
+
+    it("replaces a stub carrying no drain hook without draining anything", () => {
+        // A stub from a release that predates the drain hook: replaced all
+        // the same, and its own facade's flush delivers its queue.
+        const stub = Object.assign(vi.fn(), {
+            __doenetPendingRenderStub: true,
+            __doenetDrainQueuedRenderCalls: "not a function",
+        });
+        const w: Record<string, unknown> = {
+            renderDoenetViewerToContainer: stub,
+        };
+        const real = vi.fn();
+        expect(
+            installFirstCopyGlobal(w, "renderDoenetViewerToContainer", real),
+        ).toBe(true);
+        expect(w.renderDoenetViewerToContainer).toBe(real);
+        expect(real).not.toHaveBeenCalled();
+    });
+
+    it("does not drain a real function it leaves in place", () => {
+        // First copy wins: a non-stub occupant is untouched, drain hook and
+        // all.
+        const drain = vi.fn();
+        const firstCopy = Object.assign(vi.fn(), {
+            __doenetDrainQueuedRenderCalls: drain,
+        });
+        const w: Record<string, unknown> = {
+            renderDoenetViewerToContainer: firstCopy,
+        };
+        expect(
+            installFirstCopyGlobal(w, "renderDoenetViewerToContainer", vi.fn()),
+        ).toBe(false);
+        expect(w.renderDoenetViewerToContainer).toBe(firstCopy);
+        expect(drain).not.toHaveBeenCalled();
+    });
+
+    it("drains a real facade stub's queued calls through the replacement (the concurrent-copies hand-off)", () => {
+        // End-to-end across the two modules, as it happens when two
+        // code-split copies load concurrently and the second copy's eager
+        // chunk settles first: copy 1's prologue installed the stubs and
+        // queued a host's onload render call; copy 2's entry replaces the
+        // stub and the queued call replays through copy 2's function, so a
+        // failure of copy 1's own chunk cannot strand it. Copy 1's flush
+        // then replays nothing.
+        const w: Record<string, unknown> = {};
+        const copy1Flush = installFacadeRenderQueue(
+            w as Parameters<typeof installFacadeRenderQueue>[0],
+        );
+        (w.renderDoenetViewerToContainer as (...a: unknown[]) => unknown)(
+            { id: "applet" },
+            "<p>doc</p>",
+        );
+
+        const copy2Render = vi.fn();
+        expect(
+            installFirstCopyGlobal(
+                w,
+                "renderDoenetViewerToContainer",
+                copy2Render,
+            ),
+        ).toBe(true);
+        expect(copy2Render.mock.calls).toEqual([
+            [{ id: "applet" }, "<p>doc</p>"],
+        ]);
+
+        copy1Flush();
+        expect(copy2Render).toHaveBeenCalledTimes(1);
     });
 
     it("treats only an exact `true` marker as a pending stub", () => {

--- a/packages/standalone/src/installFirstCopyGlobal.ts
+++ b/packages/standalone/src/installFirstCopyGlobal.ts
@@ -1,0 +1,42 @@
+/**
+ * First-copy-wins installer for the window globals this bundle's eager chunk
+ * exposes: the render entry points (`renderDoenetViewerToContainer`,
+ * `renderDoenetEditorToContainer`) and the palette-discovery functions
+ * (`getDoenetStylePalettes`, `getDoenetStylePalette`).
+ *
+ * Two copies of this bundle can share one page — the script tag included
+ * twice, possibly at different releases. The first copy to evaluate wins the
+ * whole surface: its `global-config.ts` (in `@doenet/doenetml`) writes the
+ * shared `doenetGlobalConfig.doenetWorkerUrl`, and a later copy's worker
+ * resolution defers to that value (`hostProvidedWorkerUrl`). The window
+ * globals have to follow the same rule, because they and the worker URL must
+ * come from the *same* copy: a document is rendered by whichever functions
+ * the globals hold, against whichever worker the shared URL names, and the
+ * message protocol between the two is only guaranteed within one release.
+ *
+ * So this installs `value` only when the global is empty (or holds something
+ * that is not a function at all), or still holds the facade prologue's
+ * queueing stub. Replacing a pending stub — marked
+ * `__doenetPendingRenderStub: true`, part of the bundle's public surface (see
+ * `facadeRenderQueue.ts`) — is required, not merely allowed: the facade's
+ * flush hands the stub's queued calls to whatever the global holds once the
+ * eager chunk evaluates, so the stub must yield to the real function.
+ *
+ * @returns whether `value` was installed.
+ */
+export function installFirstCopyGlobal(
+    target: Record<string, unknown>,
+    name: string,
+    value: (...args: never[]) => unknown,
+): boolean {
+    const current = target[name];
+    if (
+        typeof current === "function" &&
+        (current as { __doenetPendingRenderStub?: unknown })
+            .__doenetPendingRenderStub !== true
+    ) {
+        return false;
+    }
+    target[name] = value;
+    return true;
+}

--- a/packages/standalone/src/installFirstCopyGlobal.ts
+++ b/packages/standalone/src/installFirstCopyGlobal.ts
@@ -5,8 +5,9 @@
  * (`getDoenetStylePalettes`, `getDoenetStylePalette`).
  *
  * Two copies of this bundle can share one page — the script tag included
- * twice, possibly at different releases. The first copy to evaluate wins the
- * whole surface: its `global-config.ts` (in `@doenet/doenetml`) writes the
+ * twice, possibly at different releases. The first copy to evaluate (with the
+ * code-split bundle, the first whose eager chunk settles) wins the whole
+ * surface: its `global-config.ts` (in `@doenet/doenetml`) writes the
  * shared `doenetGlobalConfig.doenetWorkerUrl`, and a later copy's worker
  * resolution defers to that value (`hostProvidedWorkerUrl`). The window
  * globals have to follow the same rule, because they and the worker URL must
@@ -18,9 +19,17 @@
  * that is not a function at all), or still holds the facade prologue's
  * queueing stub. Replacing a pending stub — marked
  * `__doenetPendingRenderStub: true`, part of the bundle's public surface (see
- * `facadeRenderQueue.ts`) — is required, not merely allowed: the facade's
- * flush hands the stub's queued calls to whatever the global holds once the
- * eager chunk evaluates, so the stub must yield to the real function.
+ * `facadeRenderQueue.ts`) — is required, not merely allowed: the stub must
+ * yield to the real function, and replacing it also drains the calls it
+ * queued (the stub's `__doenetDrainQueuedRenderCalls` hook, invoked below
+ * with `value`). That drain is what makes the convention hold with two
+ * *concurrent* code-split copies, where one copy's prologue installed the
+ * stubs and either copy's eager chunk can settle first: queued calls run
+ * through whichever release's chunk settles first — the same release whose
+ * functions now own the globals and whose worker URL won the shared-config
+ * write, keeping the outcome version-consistent — and they run even when the
+ * stub-owning copy's own chunk never settles. The stub owner's later flush
+ * finds the queues already empty and replays nothing.
  *
  * @returns whether `value` was installed.
  */
@@ -38,5 +47,19 @@ export function installFirstCopyGlobal(
         return false;
     }
     target[name] = value;
+    // A pending stub has been queueing the calls hosts made since the
+    // facade's `load` event: drain them through the newly installed function.
+    // This runs after the assignment above, so a queued call that re-reads
+    // the global during its replay sees the real function. The hook is
+    // guarded by `typeof`: a stub from a release that predates it is
+    // replaced without a drain, and its own facade's flush delivers its
+    // queue.
+    if (typeof current === "function") {
+        const drain = (current as { __doenetDrainQueuedRenderCalls?: unknown })
+            .__doenetDrainQueuedRenderCalls;
+        if (typeof drain === "function") {
+            drain(value);
+        }
+    }
     return true;
 }

--- a/packages/standalone/src/pinnedChunkUrlResolver.test.ts
+++ b/packages/standalone/src/pinnedChunkUrlResolver.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { pinPackageVersion } from "./pinPackageVersion";
+import { makePinnedChunkUrlResolver } from "./pinnedChunkUrlResolver";
+
+const PKG = "@doenet/standalone";
+const V = "0.7.24";
+
+/** A resolver as a chunk would build one: the real pin, a given self URL. */
+function resolver(selfUrl: string) {
+    return makePinnedChunkUrlResolver(pinPackageVersion, selfUrl, PKG, V);
+}
+
+describe("makePinnedChunkUrlResolver", () => {
+    it("pins a chunk reference under a floating jsDelivr tag", () => {
+        // The eager chunk, cached from this release but requested through
+        // `@latest`, resolves its lazy siblings at its own exact release.
+        const resolve = resolver(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@latest/chunks/index-DyVlWbQe.js`,
+        );
+        expect(resolve("./EditorViewer-Ck2f9ZbP.js")).toBe(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@${V}/chunks/EditorViewer-Ck2f9ZbP.js`,
+        );
+    });
+
+    it("pins the facade's chunks/ reference the same way", () => {
+        // The facade sits at the bundle root; its one reference goes down
+        // into chunks/. Same resolver, different join.
+        const resolve = resolver(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@latest/doenet-standalone.js`,
+        );
+        expect(resolve("./chunks/index-DyVlWbQe.js")).toBe(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@${V}/chunks/index-DyVlWbQe.js`,
+        );
+    });
+
+    it("supplies the version on jsDelivr's bare package path", () => {
+        const resolve = resolver(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone/doenet-standalone.js`,
+        );
+        expect(resolve("./chunks/index-DyVlWbQe.js")).toBe(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@${V}/chunks/index-DyVlWbQe.js`,
+        );
+    });
+
+    it("pins under unpkg's prefix-less layout", () => {
+        const resolve = resolver(
+            `https://unpkg.com/@doenet/standalone@latest/doenet-standalone.js`,
+        );
+        expect(resolve("./chunks/index-DyVlWbQe.js")).toBe(
+            `https://unpkg.com/@doenet/standalone@${V}/chunks/index-DyVlWbQe.js`,
+        );
+    });
+
+    it("resolves an exact-version URL exactly as relative resolution would", () => {
+        const selfUrl = `https://cdn.jsdelivr.net/npm/@doenet/standalone@${V}/doenet-standalone.js`;
+        expect(resolver(selfUrl)("./chunks/index-DyVlWbQe.js")).toBe(
+            new URL("./chunks/index-DyVlWbQe.js", selfUrl).href,
+        );
+    });
+
+    it("resolves self-hosted and localhost URLs exactly as relative resolution would", () => {
+        for (const selfUrl of [
+            "https://mycourse.example.edu/doenet/doenet-standalone.js",
+            "http://localhost:5173/standalone/doenet-standalone.js",
+            "https://deploy-preview-42.example.app/assets/chunks/index-abc.js",
+            // A self-hosted node_modules tree: the package name appears in
+            // the path with no version, which is not a CDN layout.
+            "https://host.example/node_modules/@doenet/standalone/doenet-standalone.js",
+        ]) {
+            expect(resolver(selfUrl)("./chunks/index-DyVlWbQe.js")).toBe(
+                new URL("./chunks/index-DyVlWbQe.js", selfUrl).href,
+            );
+        }
+    });
+
+    it("hands the relative path back unchanged from a blob: base, without throwing", () => {
+        // Nothing resolves against an opaque base; the ensuing import() then
+        // fails the same way it would have without the resolver.
+        const resolve = resolver(
+            "blob:https://host.example/6ee7f6a2-8e9f-4c1f-9c1a-2f8b0f6f2b52",
+        );
+        expect(resolve("./chunks/index-DyVlWbQe.js")).toBe(
+            "./chunks/index-DyVlWbQe.js",
+        );
+    });
+
+    it("does not throw on an unparseable self URL", () => {
+        expect(resolver("not a url at all")("./chunks/a.js")).toBe(
+            "./chunks/a.js",
+        );
+    });
+});
+
+describe("stringified runtime (how the build injects these functions)", () => {
+    // The build injects both functions into emitted chunks via
+    // `Function.prototype.toString`, so they must be self-contained: no
+    // imports, no references to module-scope bindings, no transpilation
+    // helpers (`__name` and friends would be dangling references in a chunk).
+    // Round-trip each through its own source text and check behavior, which
+    // fails loudly if a free identifier ever creeps in.
+    it("pinPackageVersion round-trips through its own source", () => {
+        const pin = (0, eval)(
+            `(${pinPackageVersion.toString()})`,
+        ) as typeof pinPackageVersion;
+        expect(
+            pin(
+                `https://cdn.jsdelivr.net/npm/@doenet/standalone@latest/doenet-standalone.js`,
+                PKG,
+                V,
+            ),
+        ).toBe(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@${V}/doenet-standalone.js`,
+        );
+    });
+
+    it("makePinnedChunkUrlResolver round-trips through its own source", () => {
+        const make = (0, eval)(
+            `(${makePinnedChunkUrlResolver.toString()})`,
+        ) as typeof makePinnedChunkUrlResolver;
+        const resolve = make(
+            pinPackageVersion,
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@latest/chunks/index-abc.js`,
+            PKG,
+            V,
+        );
+        expect(resolve("./Foo-xyz.js")).toBe(
+            `https://cdn.jsdelivr.net/npm/@doenet/standalone@${V}/chunks/Foo-xyz.js`,
+        );
+    });
+});

--- a/packages/standalone/src/pinnedChunkUrlResolver.ts
+++ b/packages/standalone/src/pinnedChunkUrlResolver.ts
@@ -1,0 +1,72 @@
+/**
+ * The runtime half of chunk-URL pinning for the code-split bundle.
+ *
+ * The build (see `scripts/pin-chunk-urls-plugin.ts`) rewrites every emitted
+ * chunk reference — the facade's import of the eager chunk and each lazy
+ * `import()` inside the chunks — to go through the resolver this factory
+ * returns, and injects both this factory and `pinPackageVersion` into the
+ * chunks as stringified plain functions. Stringification is what makes the
+ * injection sound, and it constrains this module: **everything here must be
+ * self-contained** — no imports, no references to anything outside the
+ * function's own parameters and standard globals — because in an emitted chunk
+ * the surrounding module scope of this source file does not exist.
+ *
+ * Why the chunk references need pinning at all: PreTeXt documents load this
+ * bundle from a CDN under a floating tag (`@latest`, or no version), which
+ * jsDelivr serves 200 directly — no redirect to the concrete release — with
+ * `s-maxage=43200` (12 h per edge) and `max-age=604800` (7 days in the
+ * browser). After a release, a reader whose cached entry came from release N
+ * requests a first-time lazy chunk under the floating tag, which the edge now
+ * resolves to release N+1 — where that content-hashed chunk name does not
+ * exist. The request 404s and the renderer-failed placeholder appears, and a
+ * plain reload does not help because the stale entry is cached without
+ * revalidation. Resolving every chunk reference against the importing module's
+ * *pinned* URL closes the class: pinned CDN URLs name one immutable release
+ * (served `max-age=31536000`), so a release-N entry always gets release-N
+ * chunks, whatever any cache holds. `pinPackageVersion` documents the URL
+ * grammar and which URLs are left alone.
+ */
+
+/** The shape of `pinPackageVersion`, which the build passes in stringified. */
+type PinPackageVersion = (
+    url: string,
+    packageName: string,
+    version: string,
+) => string;
+
+/**
+ * Make the resolver a chunk turns its emitted relative chunk paths into
+ * absolute, same-release URLs with.
+ *
+ * @param pin `pinPackageVersion` (a parameter, not an import, so the
+ *   stringified factory stays self-contained; see the module doc).
+ * @param selfUrl The chunk's own URL — `import.meta.url` at the injection
+ *   site.
+ * @param packageName The npm package a CDN URL would name, e.g.
+ *   `"@doenet/standalone"`.
+ * @param version The exact version this bundle was built as.
+ * @returns A function from a chunk reference as the build emitted it
+ *   (`"./chunks/Name-hash.js"` in the facade, `"./Name-hash.js"` between
+ *   chunks) to the URL to load it from. On a CDN URL with a floating or
+ *   mismatched specifier that is the exact-version URL; everywhere else —
+ *   self-hosted copies, localhost, an already-pinned URL — it is exactly what
+ *   relative resolution produces today. A base no URL can be resolved against
+ *   (`blob:`) hands the relative path back unchanged, so the ensuing
+ *   `import()` fails the same way it would have without the resolver: as a
+ *   rejected promise, never a synchronous throw.
+ */
+export function makePinnedChunkUrlResolver(
+    pin: PinPackageVersion,
+    selfUrl: string,
+    packageName: string,
+    version: string,
+): (relativePath: string) => string {
+    const base = pin(selfUrl, packageName, version);
+    return function pinnedChunkUrl(relativePath: string): string {
+        try {
+            return new URL(relativePath, base).href;
+        } catch {
+            return relativePath;
+        }
+    };
+}

--- a/packages/standalone/tsconfig.json
+++ b/packages/standalone/tsconfig.json
@@ -14,6 +14,7 @@
     "exclude": [
         "vite.config.ts",
         "vite.config-coordinator.ts",
+        "vite.config-inline.ts",
         "vitest.config.ts",
         "node_modules",
         "runner-results",

--- a/packages/standalone/vite.config-inline.ts
+++ b/packages/standalone/vite.config-inline.ts
@@ -1,0 +1,81 @@
+import { defineConfig } from "vite";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { version } from "./package.json";
+import {
+    forceEsbuildMinifyPlugin,
+    suppressLogPlugin,
+} from "../../scripts/vite-plugins";
+
+const DIST_DIR = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "dist",
+);
+
+// Builds `dist/doenet-standalone-inline.js`: the same entry as the code-split
+// `doenet-standalone.js` (vite.config.ts), with every dynamic import folded
+// back into one file. This is the variant for hosts that evaluate the bundle
+// where relative module resolution has no base — a Blob or srcdoc URL, as
+// `@doenet/doenetml-iframe`'s dev harness and component tests do with a
+// locally built copy. A host loading from a real URL (the CDN, a self-hosted
+// `dist/`) should use `doenet-standalone.js`, whose lazy chunks keep the
+// editor stack and unused renderers out of the eagerly-parsed payload.
+//
+// Runs after the main build (wireit dependency) into the same `dist/`, so it
+// sits beside the worker, `locales/`, and `package.json` that build copied in
+// — `emptyOutDir: false` keeps them. The `define` block matches
+// vite.config.ts: both builds compile `src/index.tsx`, and the version pin
+// and catalog arrangement documented there apply to this file identically.
+export default defineConfig({
+    base: "./",
+    plugins: [
+        suppressLogPlugin(),
+        // Vite's built-in `minify` does not actually minify this lib-mode
+        // bundle (see plugin doc). Do it explicitly instead.
+        forceEsbuildMinifyPlugin(),
+        {
+            // This entry's CSS is byte-identical to the `style.css` the main
+            // build already emitted (same entry module); remove it after the
+            // write so the published `dist/` carries the 3+ MB stylesheet
+            // once. Removal happens in `closeBundle` because Vite's own CSS
+            // handling adds the asset after user plugins' `generateBundle`.
+            name: "drop-duplicate-css",
+            closeBundle() {
+                fs.rmSync(path.join(DIST_DIR, "doenet-standalone-inline.css"), {
+                    force: true,
+                });
+            },
+        },
+    ],
+    build: {
+        // Minification is handled by forceEsbuildMinifyPlugin above.
+        minify: false,
+        // The code-split build beside this one ships the source maps; a map
+        // for this variant would republish the same ~34 MB of mappings a
+        // second time for the rare single-file host.
+        sourcemap: false,
+        emptyOutDir: false,
+        assetsInlineLimit: 0,
+        lib: {
+            entry: { "doenet-standalone-inline": "./src/index.tsx" },
+            fileName: "doenet-standalone-inline",
+            formats: ["es"],
+        },
+        rollupOptions: {
+            output: {
+                // The point of this variant: one self-contained file.
+                inlineDynamicImports: true,
+            },
+        },
+    },
+    define: {
+        "process.env.NODE_ENV": '"production"',
+        STANDALONE_VERSION: JSON.stringify(version),
+        __DOENET_CODE_SPLIT_CATALOGS__: "false",
+        // This single file *is* the root-level bundle; siblings resolve from
+        // its own directory. See the declaration in `src/index.tsx`; the
+        // code-split build defines it as `".."`.
+        __DOENET_STANDALONE_BUNDLE_ROOT__: '"."',
+    },
+});

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -52,12 +52,12 @@ export default defineConfig({
             ],
         }),
         // Serve the message catalogs beside the bundle rather than inside it.
-        // `inlineDynamicImports` folds every dynamic import into the one output
-        // file, so the code-splitting that keeps catalogs out of the library
-        // build cannot work here — `__DOENET_CODE_SPLIT_CATALOGS__` switches it
-        // off below, and `index.tsx` points the viewer's loaders at this copy
-        // instead. Same arrangement as the core worker above, for the same
-        // reason.
+        // Catalogs stay runtime-fetched files (`__DOENET_CODE_SPLIT_CATALOGS__`
+        // switches the library build's code-split path off below, and
+        // `index.tsx` points the viewer's loaders at this copy): as plain
+        // assets they can be version-pinned per `pinPackageVersion`, and the
+        // single-file `doenet-standalone-inline.js` variant stays free of them
+        // too. Same arrangement as the core worker above, for the same reason.
         copyLocaleCatalogsPlugin(),
         suppressLogPlugin(),
         // Vite's built-in `minify` does not actually minify this lib-mode
@@ -78,8 +78,27 @@ export default defineConfig({
         },
         rollupOptions: {
             output: {
-                // Make sure everything is bundled as a single file
-                inlineDynamicImports: true,
+                // Code-split output: the editor stack and the individual
+                // viewer renderers load on demand as sibling chunks, resolved
+                // relative to the bundle's own URL (`import.meta.url`). That
+                // works from jsDelivr and from any host that serves `dist/`
+                // as a directory — the same arrangement the co-located core
+                // worker and `locales/` already rely on. A host that
+                // evaluates the bundle from a Blob/srcdoc URL has no base to
+                // resolve chunks against; it uses the single-file
+                // `doenet-standalone-inline.js` built by
+                // `vite.config-inline.ts` instead.
+                //
+                // Chunk names keep their content hash: under a floating CDN
+                // tag, an out-of-date cached entry then fails loudly (404,
+                // retried and surfaced by the renderer-loading path) rather
+                // than silently mixing modules from two releases. Chunks are
+                // not version-pinned the way the worker and catalogs are —
+                // a chunk fetched from a pinned URL would re-resolve its own
+                // static imports against that URL and evaluate a second copy
+                // of the entry module. Exact-version URLs (what
+                // `@doenet/doenetml-iframe` generates) never see a skew.
+                chunkFileNames: "chunks/[name]-[hash].js",
             },
         },
     },
@@ -91,10 +110,17 @@ export default defineConfig({
         // previous release's assets. Hence `package.json` among this build's
         // declared wireit inputs — a version bump has to rebuild.
         STANDALONE_VERSION: JSON.stringify(version),
-        // See the `locales/` copy target above: this bundle is one file, so
-        // the catalogs have to be served beside it rather than split out of
-        // it. Switching this off makes `@doenet/i18n`'s lazy-catalog glob dead
-        // code, so none of `locales/` is inlined here.
+        // This build code-splits, so `src/index.tsx`'s module body evaluates
+        // from a chunk under `chunks/` — one level below the bundle root where
+        // `doenetml-worker/` and `locales/` are served. See the declaration in
+        // `src/index.tsx`; the inline build defines it as `"."`.
+        __DOENET_STANDALONE_BUNDLE_ROOT__: '".."',
+        // See the `locales/` copy target above: the catalogs are served
+        // beside this bundle rather than split out of it. Switching this off
+        // makes `@doenet/i18n`'s lazy-catalog glob dead code, so none of
+        // `locales/` is inlined here — in either the code-split bundle or the
+        // single-file inline variant, which shares this define via
+        // `vite.config-inline.ts`.
         __DOENET_CODE_SPLIT_CATALOGS__: "false",
     },
 });

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -10,6 +10,7 @@ import {
     forceEsbuildMinifyPlugin,
     suppressLogPlugin,
 } from "../../scripts/vite-plugins";
+import { pinChunkUrlsPlugin } from "./scripts/pin-chunk-urls-plugin";
 
 const require = createRequire(import.meta.url);
 
@@ -59,6 +60,16 @@ export default defineConfig({
         // single-file `doenet-standalone-inline.js` variant stays free of them
         // too. Same arrangement as the core worker above, for the same reason.
         copyLocaleCatalogsPlugin(),
+        // Pin every emitted chunk reference — the facade's import of the eager
+        // chunk and the lazy imports between chunks — to this exact version at
+        // load time, so a bundle served under a floating CDN tag keeps loading
+        // its own release's chunks across releases. See the chunkFileNames
+        // comment below and scripts/pin-chunk-urls-plugin.ts.
+        pinChunkUrlsPlugin({
+            packageName: "@doenet/standalone",
+            version,
+            facadeFileName: "doenet-standalone.js",
+        }),
         suppressLogPlugin(),
         // Vite's built-in `minify` does not actually minify this lib-mode
         // bundle (see plugin doc). Do it explicitly instead.
@@ -89,15 +100,16 @@ export default defineConfig({
                 // `doenet-standalone-inline.js` built by
                 // `vite.config-inline.ts` instead.
                 //
-                // Chunk names keep their content hash: under a floating CDN
-                // tag, an out-of-date cached entry then fails loudly (404,
-                // retried and surfaced by the renderer-loading path) rather
-                // than silently mixing modules from two releases. Chunks are
-                // not version-pinned the way the worker and catalogs are —
-                // a chunk fetched from a pinned URL would re-resolve its own
-                // static imports against that URL and evaluate a second copy
-                // of the entry module. Exact-version URLs (what
-                // `@doenet/doenetml-iframe` generates) never see a skew.
+                // Chunk names keep their content hash, and every chunk
+                // reference is version-pinned at load time by
+                // `pinChunkUrlsPlugin` above: a bundle fetched under a
+                // floating CDN tag resolves its chunks under its own exact
+                // release, whose URLs are immutable and permanently cacheable
+                // — the same guarantee the co-located worker and catalogs get
+                // from `pinPackageVersion` in `src/index.tsx`. Under every
+                // other URL (self-hosted `dist/`, exact-version CDN URLs like
+                // the ones `@doenet/doenetml-iframe` generates) the pin is a
+                // no-op and chunks resolve relative to the bundle URL.
                 chunkFileNames: "chunks/[name]-[hash].js",
             },
         },

--- a/packages/standalone/vitest.config.ts
+++ b/packages/standalone/vitest.config.ts
@@ -12,6 +12,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
         environment: "node",
-        include: ["scripts/**/*.test.mjs", "src/**/*.test.ts"],
+        include: [
+            "scripts/**/*.test.mjs",
+            "scripts/**/*.test.ts",
+            "src/**/*.test.ts",
+        ],
     },
 });

--- a/packages/test-cypress/cypress/e2e/standalone/chunkUrlPinning.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/chunkUrlPinning.cy.js
@@ -1,0 +1,72 @@
+// E2E proof of the standalone bundle's runtime chunk-URL pinning
+// (packages/standalone/scripts/pin-chunk-urls-plugin.ts), exercised against
+// the emitted artifact, not the source helper.
+//
+// public/pinned-cdn-page.html loads `doenet-standalone.js` from a
+// jsDelivr-style floating-tag URL. The serving side (standaloneCdnPathsPlugin
+// in vite.config.ts) answers floating-specifier requests for the entry ONLY:
+// chunks, the worker — everything the entry goes on to load — exist solely
+// under the exact-version path, exactly like a CDN edge that already resolves
+// the floating tag to a newer release than the cached entry came from. So the
+// two assertions back each other up: the document can only render if every
+// follow-on request was pinned, and the request log shows each one going to
+// the exact-version path.
+
+const EXACT_VERSION_PATH = /^\/npm\/@doenet\/standalone@\d+\.\d+\.\d+[^/]*\//;
+
+describe(
+    "standalone chunk-URL pinning",
+    { tags: ["@group1"], retries: 1 },
+    () => {
+        it("boots from a floating CDN tag by loading every chunk from the exact-version path", () => {
+            /** Pathnames of every CDN-style request the page makes. */
+            const requested = [];
+            // (Matched against the full URL, hence no ^ anchor.)
+            cy.intercept(/\/npm\/@doenet\/standalone@/, (req) => {
+                requested.push(new URL(req.url).pathname);
+                req.continue();
+            });
+
+            cy.visit("/pinned-cdn-page.html");
+
+            // The document renders: the eager chunk and the lazy renderer
+            // chunks all loaded even though only the entry exists under the
+            // floating tag. (Interaction, not just static text, so the core
+            // worker — resolved through the same pinned root — is proven too.)
+            cy.get(".doenetml-applet input").first().type("pinned{enter}");
+            cy.get(".doenetml-applet").should("contain.text", "Typed: pinned");
+
+            cy.then(() => {
+                const entry = "/npm/@doenet/standalone@latest";
+                const floating = requested.filter(
+                    (p) => !EXACT_VERSION_PATH.test(p),
+                );
+                const pinnedChunks = requested.filter(
+                    (p) => EXACT_VERSION_PATH.test(p) && p.includes("/chunks/"),
+                );
+                const pinnedWorker = requested.filter(
+                    (p) =>
+                        EXACT_VERSION_PATH.test(p) &&
+                        p.endsWith("/doenetml-worker/index.js"),
+                );
+                // The floating tag served the entry and nothing else.
+                expect(
+                    floating.length,
+                    "the entry was requested through the floating tag",
+                ).to.be.gte(1);
+                for (const p of floating) {
+                    expect(p, "floating-tag requests beyond the entry").to.eq(
+                        `${entry}/doenet-standalone.js`,
+                    );
+                }
+                // The eager chunk plus at least one lazy renderer chunk came
+                // from the exact-version path, as did the core worker.
+                expect(
+                    pinnedChunks.length,
+                    `pinned chunk requests (${JSON.stringify(requested)})`,
+                ).to.be.gte(2);
+                expect(pinnedWorker.length, "pinned worker requests").to.eq(1);
+            });
+        });
+    },
+);

--- a/packages/test-cypress/cypress/e2e/standalone/chunkUrlPinning.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/chunkUrlPinning.cy.js
@@ -5,7 +5,8 @@
 // public/pinned-cdn-page.html loads `doenet-standalone.js` from a
 // jsDelivr-style floating-tag URL. The serving side (standaloneCdnPathsPlugin
 // in vite.config.ts) answers floating-specifier requests for the entry ONLY:
-// chunks, the worker — everything the entry goes on to load — exist solely
+// chunks, the worker, the core `.wasm` the worker fetches from beside its own
+// script — everything the entry goes on to load — exist solely
 // under the exact-version path, exactly like a CDN edge that already resolves
 // the floating tag to a newer release than the cached entry came from. So the
 // two assertions back each other up: the document can only render if every
@@ -32,7 +33,8 @@ describe(
             // The document renders: the eager chunk and the lazy renderer
             // chunks all loaded even though only the entry exists under the
             // floating tag. (Interaction, not just static text, so the core
-            // worker — resolved through the same pinned root — is proven too.)
+            // worker and its `.wasm` — both resolved through the same pinned
+            // root — are proven too.)
             cy.get(".doenetml-applet input").first().type("pinned{enter}");
             cy.get(".doenetml-applet").should("contain.text", "Typed: pinned");
 
@@ -48,6 +50,16 @@ describe(
                     (p) =>
                         EXACT_VERSION_PATH.test(p) &&
                         p.endsWith("/doenetml-worker/index.js"),
+                );
+                // The core `.wasm` is fetched from inside the worker, beside
+                // the worker's own (pinned) script URL — see the loading
+                // ladder in @doenet/doenetml-worker's src/wasmLoading.ts.
+                const pinnedWasm = requested.filter(
+                    (p) =>
+                        EXACT_VERSION_PATH.test(p) &&
+                        p.endsWith(
+                            "/doenetml-worker/lib_doenetml_worker_bg.wasm",
+                        ),
                 );
                 // The floating tag served the entry and nothing else.
                 expect(
@@ -66,6 +78,7 @@ describe(
                     `pinned chunk requests (${JSON.stringify(requested)})`,
                 ).to.be.gte(2);
                 expect(pinnedWorker.length, "pinned worker requests").to.eq(1);
+                expect(pinnedWasm.length, "pinned core wasm requests").to.eq(1);
             });
         });
     },

--- a/packages/test-cypress/cypress/e2e/standalone/twoCopiesConcurrent.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/twoCopiesConcurrent.cy.js
@@ -1,0 +1,44 @@
+// E2E proof of drain-on-replacement with two CONCURRENT copies of the
+// code-split standalone bundle (public/two-copy-concurrent-page.html): the
+// page starts two query-distinguished imports of `doenet-standalone.js`
+// without awaiting the first, queues a render call against the facade
+// prologue's stubs before any eager chunk settles, and records a probe. The
+// render call reaches the real function through the stub's
+// `__doenetDrainQueuedRenderCalls` hook, invoked by `installFirstCopyGlobal`
+// the moment the shared eager chunk's entry replaces the stub — and it runs
+// exactly once, because the stub-owning facade's own flush then finds the
+// queue empty.
+//
+// Both facades resolve the same eager-chunk URL (relative resolution drops
+// the facade's query), so one shared chunk serves both copies here. Two
+// genuinely distinct chunk graphs — where one copy's chunk settles first
+// while the other copy's is still pending or fails — would need two
+// published releases served side by side, which this repo's single build
+// cannot produce; that distinct-release ordering (including a failed owner
+// whose queue a healthy foreign copy drains) is covered by the unit tests in
+// packages/standalone/src/facadeRenderQueue.test.ts and
+// installFirstCopyGlobal.test.ts.
+
+describe(
+    "standalone two concurrent copies",
+    { tags: ["@group1"], retries: 1 },
+    () => {
+        it("drains a render call queued before any chunk settled, exactly once, and the document works", () => {
+            cy.visit("/two-copy-concurrent-page.html");
+
+            // The document renders and responds: the queued call was drained
+            // into a live render backed by a working worker.
+            cy.get(".doenetml-applet input").first().type("both{enter}");
+            cy.get(".doenetml-applet").should("contain.text", "Typed: both");
+
+            cy.window().then((win) => {
+                const probe = win.__twoCopyConcurrentProbe;
+                expect(probe, "probe recorded after both facades settled").to
+                    .exist;
+                for (const [key, value] of Object.entries(probe)) {
+                    expect(value, key).to.eq(true);
+                }
+            });
+        });
+    },
+);

--- a/packages/test-cypress/cypress/e2e/standalone/twoCopiesFirstWins.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/twoCopiesFirstWins.cy.js
@@ -1,0 +1,31 @@
+// E2E proof of first-copy-wins across two live copies of the standalone
+// bundle in one page (public/two-copy-page.html): the page evaluates the
+// built single-file bundle twice — each import creates fresh function objects
+// — then records whether the globals and the shared worker URL still belong
+// to the first copy. Rendering must also still work, showing the surviving
+// globals are live, not leftovers. This pairing rule is what keeps a page
+// that includes the script tag twice at different releases from driving one
+// release's worker with the other release's UI.
+
+describe(
+    "standalone two-copy first-copy-wins",
+    { tags: ["@group1"], retries: 1 },
+    () => {
+        it("keeps the first copy's globals and worker URL when a second copy evaluates", () => {
+            cy.visit("/two-copy-page.html");
+
+            // The document renders and responds through whatever the globals
+            // hold after both copies evaluated.
+            cy.get(".doenetml-applet input").first().type("twice{enter}");
+            cy.get(".doenetml-applet").should("contain.text", "Typed: twice");
+
+            cy.window().then((win) => {
+                const probe = win.__twoCopyProbe;
+                expect(probe, "probe recorded after second copy").to.exist;
+                for (const [key, value] of Object.entries(probe)) {
+                    expect(value, key).to.eq(true);
+                }
+            });
+        });
+    },
+);

--- a/packages/test-cypress/cypress/e2e/standalone/twoCopiesFirstWins.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/twoCopiesFirstWins.cy.js
@@ -2,7 +2,11 @@
 // bundle in one page (public/two-copy-page.html): the page evaluates the
 // built single-file bundle twice — each import creates fresh function objects
 // — then records whether the globals and the shared worker URL still belong
-// to the first copy. Rendering must also still work, showing the surviving
+// to the first copy. The probe also records that the second import really
+// was a second evaluation (its module namespace exports fresh functions), and
+// the worker URL is marked with a query sentinel between the two evaluations,
+// so each first-copy-wins entry can only be true when the second copy
+// actually deferred. Rendering must also still work, showing the surviving
 // globals are live, not leftovers. This pairing rule is what keeps a page
 // that includes the script tag twice at different releases from driving one
 // release's worker with the other release's UI.

--- a/packages/test-cypress/public/coordination-activity-fails-if.html
+++ b/packages/test-cypress/public/coordination-activity-fails-if.html
@@ -8,8 +8,11 @@
      failed boot frees its boot slot promptly (#1709) instead of holding it
      until the coordinator's boot watchdog expires.
 
-     The hook is installed in `onload`, by which point the standalone bundle
-     has evaluated and created `window.doenetGlobalConfig`.
+     The hook is installed in `onload`, on the `window.doenetGlobalConfig`
+     object the bundle guarantees exists by then: the code-split entry
+     pre-creates it before `load` fires and the eager chunk later adopts the
+     same object, so these writes — and the `config` reference captured
+     below — stay live. (See `facadeRenderQueue.ts` in `@doenet/standalone`.)
 
      `window.__doenetTestRecover()` lets the spec drive the other half of the
      story: it lifts the stall and rebuilds the document (a changed source, the

--- a/packages/test-cypress/public/pinned-cdn-page.html
+++ b/packages/test-cypress/public/pinned-cdn-page.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!-- Loads @doenet/standalone the way a PreTeXt page loads it from jsDelivr:
+     a floating-tag module URL. The paths are served by standaloneCdnPathsPlugin
+     (vite.config.ts), which deliberately serves ONLY the entry under a
+     floating specifier — chunks and the worker exist solely under the exact
+     version, as on a CDN edge that has moved on to a newer release. The page
+     renders only if the bundle pins its own chunk URLs at load time; see
+     e2e/standalone/chunkUrlPinning.cy.js. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script
+            onload="onLoad()"
+            type="module"
+            src="/npm/@doenet/standalone@latest/doenet-standalone.js"
+        ></script>
+        <script>
+            function onLoad() {
+                window.renderDoenetViewerToContainer(
+                    document.querySelector(".doenetml-applet"),
+                );
+            }
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>Pinned chunks rendered: <textInput name="ti" /></p>
+<p>Typed: $ti.value</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/public/two-copy-concurrent-page.html
+++ b/packages/test-cypress/public/two-copy-concurrent-page.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<!-- Starts TWO imports of the CODE-SPLIT standalone bundle concurrently —
+     query-distinguished facades, neither awaited before the other begins —
+     and queues a render call against the prologue's stubs before any eager
+     chunk settles. The first facade to evaluate installs the queueing stubs
+     (installFacadeRenderQueue in @doenet/standalone); the other leaves them
+     alone. Both facades await the same eager-chunk URL (relative resolution
+     drops the facade's query), so the module cache shares one chunk between
+     them: when it settles, the entry's installFirstCopyGlobal replaces the
+     stubs and drains the queued call through the real function it just
+     installed. The probe records that the call really went through a pending
+     stub, that the stub was replaced, and that the call replayed exactly
+     once (the stub-owning facade's own flush finds the queue already empty).
+     Asserted by e2e/standalone/twoCopiesConcurrent.cy.js. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script type="module">
+            // Neither import is awaited before the other starts.
+            const p1 = import("/standalone/doenet-standalone.js?copy=1");
+            const p2 = import("/standalone/doenet-standalone.js?copy=2");
+
+            // Wait for a facade prologue to install its stub — the facades
+            // are small, so this resolves long before the multi-megabyte
+            // eager chunk settles.
+            const stubbed = await new Promise((resolve) => {
+                (function poll() {
+                    const fn = window.renderDoenetViewerToContainer;
+                    if (typeof fn === "function") {
+                        resolve(fn);
+                    } else {
+                        setTimeout(poll, 0);
+                    }
+                })();
+            });
+
+            // Count how many times the queued render call actually executes:
+            // with no source argument, each execution of the real
+            // renderDoenetViewerToContainer reads the container's
+            // <script type="text/doenetml"> child through querySelector with
+            // exactly this selector.
+            const container = document.querySelector(".doenetml-applet");
+            let sourceReads = 0;
+            const originalQuerySelector =
+                container.querySelector.bind(container);
+            container.querySelector = (selector) => {
+                if (selector === 'script[type="text/doenetml"]') {
+                    sourceReads += 1;
+                }
+                return originalQuerySelector(selector);
+            };
+
+            const calledThroughStub =
+                stubbed.__doenetPendingRenderStub === true;
+            window.renderDoenetViewerToContainer(container);
+
+            await Promise.all([p1, p2]);
+            // Both facades have finished evaluating: the shared chunk's
+            // entry replaced the stub (draining the queue), and both flushes
+            // have run.
+            window.__twoCopyConcurrentProbe = {
+                // Guards the queueing path against vacuity: the render call
+                // above must have landed on a pending stub, before any chunk
+                // settled.
+                calledThroughStub,
+                stubReplaced:
+                    window.renderDoenetViewerToContainer
+                        .__doenetPendingRenderStub !== true,
+                // Exactly one replay: the drain-on-replacement delivered the
+                // call and the stub owner's flush found an empty queue.
+                renderedExactlyOnce: sourceReads === 1,
+            };
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>Concurrent copies loaded: <textInput name="ti" /></p>
+<p>Typed: $ti.value</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/public/two-copy-page.html
+++ b/packages/test-cypress/public/two-copy-page.html
@@ -12,16 +12,43 @@
         <meta charset="utf-8" />
         <link rel="stylesheet" href="/standalone/style.css" />
         <script type="module">
-            await import("/standalone/doenet-standalone-inline.js?copy=1");
+            const ns1 = await import(
+                "/standalone/doenet-standalone-inline.js?copy=1"
+            );
             const first = {
                 viewer: window.renderDoenetViewerToContainer,
                 editor: window.renderDoenetEditorToContainer,
                 palettes: window.getDoenetStylePalettes,
                 palette: window.getDoenetStylePalette,
-                workerUrl: window.doenetGlobalConfig.doenetWorkerUrl,
             };
-            await import("/standalone/doenet-standalone-inline.js?copy=2");
+            // Mark the first copy's resolved worker URL with a query suffix.
+            // Both copies come from the same file, so the URLs they resolve
+            // are value-equal; only a marked value can show the second copy
+            // left the first copy's write in place. The marked URL stays
+            // live: the boot passes it to `new Worker` as-is, the server
+            // ignores the query, and the worker's own `.wasm` resolves
+            // against the path.
+            const workerUrlSentinel =
+                window.doenetGlobalConfig.doenetWorkerUrl +
+                (window.doenetGlobalConfig.doenetWorkerUrl.includes("?")
+                    ? "&"
+                    : "?") +
+                "firstCopy=1";
+            window.doenetGlobalConfig.doenetWorkerUrl = workerUrlSentinel;
+            const ns2 = await import(
+                "/standalone/doenet-standalone-inline.js?copy=2"
+            );
             window.__twoCopyProbe = {
+                // The module map keys on the full URL including the query,
+                // so the second import is a second evaluation with its own
+                // fresh function objects. Recorded so the test fails loudly
+                // if some cache layer ever collapses the two imports into
+                // one evaluation — every first-copy-wins probe below would
+                // then be vacuously true.
+                secondCopyEvaluated:
+                    typeof ns2.renderDoenetViewerToContainer === "function" &&
+                    ns2.renderDoenetViewerToContainer !==
+                        ns1.renderDoenetViewerToContainer,
                 viewerIsFirstCopys:
                     window.renderDoenetViewerToContainer === first.viewer,
                 editorIsFirstCopys:
@@ -32,7 +59,7 @@
                     window.getDoenetStylePalette === first.palette,
                 workerUrlIsFirstCopys:
                     window.doenetGlobalConfig.doenetWorkerUrl ===
-                    first.workerUrl,
+                    workerUrlSentinel,
             };
             window.renderDoenetViewerToContainer(
                 document.querySelector(".doenetml-applet"),

--- a/packages/test-cypress/public/two-copy-page.html
+++ b/packages/test-cypress/public/two-copy-page.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!-- Evaluates the standalone bundle TWICE in one page — the mistake of
+     including the script tag twice — and records whether the second copy
+     stayed inert (first-copy-wins; see installFirstCopyGlobal in
+     @doenet/standalone). Uses the single-file inline variant: the code-split
+     bundle's eager chunk would be deduped by the module cache, but two
+     query-distinguished imports of the inline file each evaluate the full
+     entry, so the page really holds two live copies. Asserted by
+     e2e/standalone/twoCopiesFirstWins.cy.js. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/standalone/style.css" />
+        <script type="module">
+            await import("/standalone/doenet-standalone-inline.js?copy=1");
+            const first = {
+                viewer: window.renderDoenetViewerToContainer,
+                editor: window.renderDoenetEditorToContainer,
+                palettes: window.getDoenetStylePalettes,
+                palette: window.getDoenetStylePalette,
+                workerUrl: window.doenetGlobalConfig.doenetWorkerUrl,
+            };
+            await import("/standalone/doenet-standalone-inline.js?copy=2");
+            window.__twoCopyProbe = {
+                viewerIsFirstCopys:
+                    window.renderDoenetViewerToContainer === first.viewer,
+                editorIsFirstCopys:
+                    window.renderDoenetEditorToContainer === first.editor,
+                palettesIsFirstCopys:
+                    window.getDoenetStylePalettes === first.palettes,
+                paletteIsFirstCopys:
+                    window.getDoenetStylePalette === first.palette,
+                workerUrlIsFirstCopys:
+                    window.doenetGlobalConfig.doenetWorkerUrl ===
+                    first.workerUrl,
+            };
+            window.renderDoenetViewerToContainer(
+                document.querySelector(".doenetml-applet"),
+            );
+        </script>
+    </head>
+    <body>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+<p>Two copies loaded: <textInput name="ti" /></p>
+<p>Typed: $ti.value</p>
+            </script>
+        </div>
+    </body>
+</html>

--- a/packages/test-cypress/vite.config.ts
+++ b/packages/test-cypress/vite.config.ts
@@ -1,17 +1,87 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/** The exact @doenet/standalone version the copied bundle was built as. */
+const standaloneVersion: string = JSON.parse(
+    fs.readFileSync(
+        path.resolve(__dirname, "../standalone/package.json"),
+        "utf-8",
+    ),
+).version as string;
+
+/**
+ * Serve the copied `standalone/` files under jsDelivr-style paths, so
+ * `e2e/standalone/chunkUrlPinning.cy.js` can prove the bundle's runtime
+ * chunk-URL pinning (`packages/standalone/scripts/pin-chunk-urls-plugin.ts`)
+ * against the emitted artifact:
+ *
+ *  - `/npm/@doenet/standalone@<exact version>/<file>` serves `<file>` — the
+ *    immutable release URL every pinned reference resolves to.
+ *  - Under any other specifier (`@latest`, a range) only the entry
+ *    `doenet-standalone.js` is served; everything else answers a hard 404
+ *    (hard, because the server's SPA HTML fallback would otherwise answer
+ *    200). That models the cache-skew moment the pinning exists for: an
+ *    entry cached under a floating tag whose chunk names the edge can no
+ *    longer serve. A pinning regression therefore fails the spec's render
+ *    assertion as well as its URL assertions.
+ *
+ * The rewrite is registered ahead of the static middleware for both `vite
+ * preview` (how the Cypress e2e runs serve, see
+ * TEST_RUN_INSTRUCTIONS_FOR_AGENTS.md) and the dev server.
+ */
+function standaloneCdnPathsPlugin(): Plugin {
+    const cdnPath = /^\/npm\/@doenet\/standalone@([^/]+)(\/.*)$/;
+    function rewrite(url: string | undefined): string | null {
+        const match = url ? cdnPath.exec(url) : null;
+        if (!match) {
+            return null;
+        }
+        const [, spec, rest] = match;
+        if (spec === standaloneVersion || rest === "/doenet-standalone.js") {
+            return `/standalone${rest}`;
+        }
+        return null;
+    }
+    function middleware(
+        req: { url?: string },
+        res: { statusCode: number; end: (body: string) => void },
+        next: () => void,
+    ) {
+        if (req.url && cdnPath.test(req.url)) {
+            const rewritten = rewrite(req.url);
+            if (rewritten === null) {
+                res.statusCode = 404;
+                res.end("Not found under this version specifier");
+                return;
+            }
+            req.url = rewritten;
+        }
+        next();
+    }
+    return {
+        name: "standalone-cdn-paths",
+        configurePreviewServer(server) {
+            server.middlewares.use(middleware);
+        },
+        configureServer(server) {
+            server.middlewares.use(middleware);
+        },
+    };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
     plugins: [
         react(),
+        standaloneCdnPathsPlugin(),
         viteStaticCopy({
             targets: [
                 {

--- a/packages/test-cypress/vite.config.ts
+++ b/packages/test-cypress/vite.config.ts
@@ -112,6 +112,15 @@ export default defineConfig({
                             "../standalone/dist/doenet-standalone.js",
                         ),
                         path.resolve(__dirname, "../standalone/dist/style.css"),
+                        // The single-file variant, for the two-copies e2e
+                        // (public/two-copy-page.html): unlike the code-split
+                        // bundle — whose shared chunk URLs the module cache
+                        // dedupes — it re-evaluates the whole entry per
+                        // import, so one page can hold two live copies.
+                        path.resolve(
+                            __dirname,
+                            "../standalone/dist/doenet-standalone-inline.js",
+                        ),
                         path.resolve(
                             __dirname,
                             "../standalone/dist/coordinator.js",

--- a/packages/test-cypress/vite.config.ts
+++ b/packages/test-cypress/vite.config.ts
@@ -46,6 +46,11 @@ export default defineConfig({
                             __dirname,
                             "../standalone/dist/coordinator.js",
                         ),
+                        // The bundle is code-split: renderers and the editor
+                        // stack live in lazy chunks resolved relative to
+                        // doenet-standalone.js, so they must be served beside
+                        // it just as a CDN would.
+                        path.resolve(__dirname, "../standalone/dist/chunks"),
                     ],
                     dest: "standalone/",
                     overwrite: false,


### PR DESCRIPTION
Completes the standalone-bundle shrink tracked in #1437. Of the issue's four steps, real minification (#1464) and worker externalization (#1465) had already landed; this PR delivers the remaining two — the editor-stack lazy boundary and the schema dedupe — and re-enables code splitting for `@doenet/standalone`, with the split bundle's chunk URLs version-pinned at run time so floating-CDN-tag embeds keep working across releases.

Closes #1437.

## Editor-stack lazy boundary

`EditorViewer` (codemirror + its embedded LSP worker source, the pretty printer, diagnostics/context-help UI, and the component schema they read) was statically reachable from the entry through three routes: the `DoenetEditor` export, the `<codeEditor>` renderer's direct import, and the `CodeMirror` re-export in `index.ts`. All three are closed:

- `EditorViewer/EditorViewerLazy.tsx` is the single `React.lazy` boundary, used by both `DoenetEditor` and the `codeEditor` renderer. The chunk fetch reuses the renderer-chunk transient-failure retry, and a fetch that still fails after the retries renders the same inline `RendererLoadFailed` placeholder the viewer renderers substitute (a `ChunkLoadErrorBoundary` at the seam; any other error re-throws to the boundary above, as before the seam existed) — without it, a permanently failed editor chunk would unmount the whole `DoenetEditor` tree, or take down the whole document under a `<codeEditor>`. The imperative editor handle attaches once the chunk mounts — the handle-queueing in `@doenet/standalone`'s `renderDoenetEditorToContainer` already tolerates that.
- `CodeMirror` moved from the main `@doenet/doenetml` entry to its own entry point, `@doenet/doenetml/codemirror.js` (small API change, no in-repo consumers of the old re-export; noted in the changeset).

The eager static-import closure of `@doenet/doenetml`'s entry now contains zero codemirror identifiers and zero schema copies.

## Code splitting for @doenet/standalone + single-file inline variant

`inlineDynamicImports` is dropped: `doenet-standalone.js` is now a ~2 KB facade whose one import is the eager chunk, with the editor stack and each viewer renderer loading on demand from `chunks/`. A new single-file variant, `dist/doenet-standalone-inline.js` (built by `vite.config-inline.ts`, same entry, chunks folded back in), is published beside the split bundle for hosts that need one file.

Because the entry's module body now evaluates from `chunks/`, sibling-asset resolution (worker, catalogs, the coordinator's shared-core pool URL) is anchored to the bundle root via a build-time constant (`__DOENET_STANDALONE_BUNDLE_ROOT__`) instead of `import.meta.url`'s directory; the coordinator e2e specs caught that and now pass.

## Runtime chunk-URL pinning

PreTeXt documents load this bundle from jsDelivr under a floating tag (`@latest`, or a partial version). jsDelivr serves floating-tag URLs **200 directly — no redirect to the concrete release** — with `s-maxage=43200` (12 h per edge) and `max-age=604800` (7 days in the browser, without revalidation). So after a release, a reader whose cached entry came from release N requests a first-time lazy chunk under the floating tag, the edge resolves it against release N+1 — where that content-hashed name does not exist — and the 404 puts up the renderer-failed placeholder; a plain reload does not help, because the stale entry is still cached. In the eviction corner case where the tiny facade stays cached but the eager chunk is evicted, the same skew fails the whole boot.

The split bundle therefore pins its own chunk URLs at run time (`pinChunkUrlsPlugin` in `packages/standalone/scripts/pin-chunk-urls-plugin.ts`; runtime logic in `src/pinnedChunkUrlResolver.ts` + the existing `src/pinPackageVersion.ts`, both unit-tested and injected into the emitted chunks as stringified self-contained functions):

- The facade's static import of the eager chunk becomes a top-level-awaited `await import(__doenetPinChunkUrl("./chunks/index-<hash>.js"))`, with the re-exports rebuilt from the awaited namespace. Pinning this first edge keeps the whole graph in one URL space: the eager chunk evaluates at its exact-version URL, every lazy chunk resolves relative to that, and each shared chunk keeps a single module identity (one React, one i18n loader registry) no matter what URL the facade itself was fetched from.
- Every lazy `import()` between chunks passes its emitted relative path through the same resolver (84 sites in the eager chunk, 82 in the renderer-loader chunk), which resolves it against the importing module's pinned `import.meta.url`.
- On any URL that is not a floating/mismatched CDN specifier — self-hosted `dist/`, localhost, exact-version URLs like the ones `@doenet/doenetml-iframe` generates, `blob:` bases — the resolver is a no-op and chunks resolve relative to the bundle URL exactly as before. Pinned jsDelivr/unpkg URLs name one immutable release (`max-age=31536000, immutable`), so a release-N entry always gets release-N chunks, whatever any cache holds. This is the same guarantee the co-located worker and `locales/` already get from `pinPackageVersion` in the entry.

Because the facade now suspends at its first `await` — and a module script's `load` event fires at that suspension — the facade's synchronous prologue keeps the `onload` contract PreTeXt pages rely on (`src/facadeRenderQueue.ts`):

- `window.renderDoenetViewerToContainer` / `renderDoenetEditorToContainer` exist at `onload` as queueing stubs (marked `__doenetPendingRenderStub`), flushed through the real functions the moment the eager chunk has evaluated; the editor stub returns a handle that queues and replays, matching the real function's own pre-mount queueing.
- `window.doenetGlobalConfig` is pre-created, and `global-config.ts` in `@doenet/doenetml` now adopts an existing config object (same identity, defaults filled in around host-set values) instead of replacing it — so boot/worker knobs a host sets at `onload` are honored and captured references stay live. That includes a host-chosen `doenetWorkerUrl`: the externalized-worker entry's own resolution and the standalone entry's worker-URL pinning both defer to it (`hostProvidedWorkerUrl` in `global-config.ts`), so an explicit worker override keeps winning exactly as it did when `load` fired after full evaluation.
- A queued render call that throws (a bad container, say) is replayed in isolation: the error is rethrown asynchronously (surfacing via `window.onerror` as it would have from the host's own handler) instead of skipping the calls queued after it or failing the facade's module evaluation for `import` consumers.
- `@doenet/doenetml-iframe`'s `waitForStandaloneBundle` polls wait out the marked stubs, keeping the `iframeReady` handshake (and the style palettes reported with it) tied to the fully evaluated bundle.
- Two copies of the bundle in one page (the script tag included twice, possibly at different releases) follow first-*settled*-copy-wins across the whole surface: the facade prologue never replaces an existing render global, and the eager chunk's installs of the render and palette globals are guarded too (`installFirstCopyGlobal` in `@doenet/standalone`) — only a pending facade stub is replaced, and replacing it also drains the stub's queued calls through the newly installed function (the stub's `__doenetDrainQueuedRenderCalls` hook), so with two concurrent copies the queued `onload` calls run the moment the first eager chunk settles, through that same release's functions and worker URL, and cannot be stranded by the stub-owning copy's chunk failing to load; a real function from an earlier copy is left in place, and the stub owner's own flush finds the queues empty and replays nothing. Editor handles a host captured from a stub keep working across the hand-off (methods forward to the real handle after the drain). Combined with the later copy's worker-URL write deferring (`hostProvidedWorkerUrl`), a later copy stays fully inert, so every document pairs one release's UI with that same release's worker. Proven e2e by `standalone/twoCopiesFirstWins.cy.js`, which evaluates the built inline bundle twice in one page and checks the globals and worker URL stay the first copy's while rendering keeps working (the probe also verifies the second import really was a second evaluation, and marks the worker URL with a query sentinel between the evaluations, so the deferral check cannot be satisfied by the second copy re-writing the identical URL), and by `standalone/twoCopiesConcurrent.cy.js`, which starts two query-distinguished imports of the code-split facade without awaiting the first, queues a render call against the stubs before any chunk settles, and checks the call drains exactly once into a working document; the distinct-release orderings (a foreign chunk settling first, a failed stub owner) are unit-tested in `facadeRenderQueue.test.ts` / `installFirstCopyGlobal.test.ts`.

Guardrails updated:
- The standalone wireit targets now fingerprint the build-time plugin sources their configs import (`scripts/pin-chunk-urls-plugin.ts`, the repo-root `vite-plugins.ts` and `transform-package-json.ts`), so editing one invalidates the cached bundle instead of reusing a stale build.
- `check-bundle-size.mjs` budget keys may now contain `*`, so the hashed eager chunk carries its own budget; budgets added for the facade, the eager chunk, and the inline variant (which doubles as the total-weight ceiling).
- The i18n single-instance check now judges the entry facade plus its `chunks/` as one module graph (exactly one `@doenet/i18n` total, including the copies-split-across-chunks case), and holds the inline variant to exactly one on its own. Both checks match on string markers, so the pinning rewrite required no changes to them; both pass on the pinned output.
- Docs follow the split: `@doenet/standalone`'s README describes serving the package directory (and when the inline file is the right choice), and `@doenet/i18n`'s README plus the size check's catalog comment describe why the catalogs stay runtime-fetched now that the bundle is no longer one file. `@doenet/test-cypress`'s preview copies `chunks/` beside the bundle it serves, as a CDN host would, and additionally serves the bundle under jsDelivr-style `/npm/@doenet/standalone@<spec>/…` paths so the pinning is e2e-tested against the emitted artifact (`chunkUrlPinning.cy.js`: a floating-tag boot whose chunks, worker, and core `.wasm` exist only under the exact-version path).

## Blob-URL consumers

A bundle evaluated from a Blob/srcdoc URL has no base to resolve relative chunk imports against, so every consumer that boots the bundle from a Blob switches to the inline variant: `@doenet/doenetml-iframe`'s component-test helpers, its `windowedBootFailure` spec (which appends config mutations to the source), and the `test-main.tsx` dev harness. Their worker fallback (page-origin `/doenetml-worker/index.js`) is unchanged. `srcdocSelfContained.cy.ts`'s invariant (the inline boot script needs nothing from the network) is untouched — the standalone bundle was always fetched by design. Real hosts (CDN URL in the iframe srcdoc, PreTeXt-style co-served `dist/`) load the split bundle.

## Schema dedupe

`@doenet/static-assets` is now externalized in the `@doenet/codemirror` **and** `@doenet/parser` builds (the pretty-printer inlined its own copy), the same arrangement `@doenet/lsp-tools` already used, so every consuming build resolves one shared schema module. Measured by the compressed-schema literal (~232 KB minified each — the shared module's copy is 231,804 B, the worker-embedded one 232,096 B):

- before: 5 copies in the one eager bundle;
- after: 2 copies total, both in the lazy editor chunk — the shared module, plus one inside the LSP worker's embedded source string (that worker also dropped from 2 internal copies to 1 via the parser externalization) — and **0** in the eager chunk.

Lazy decompression was deliberately left out: after the split, every remaining copy decompresses in a context that is already lazy (editor-chunk evaluation, LSP worker boot) and is needed immediately by its consumer, so a lazy wrapper would only defer work to the same moment.

## Measured sizes (clean build at the base commit vs. this branch, incl. merged #1727)

| artifact | before | after |
|---|---|---|
| `doenet-standalone.js` | 12,292,960 B | 2,075 B (facade with pin resolver + onload stubs) |
| eager chunk `chunks/index-*.js` | — | 4,689,759 B |
| **eagerly-parsed JS per embed** | **12.3 MB** | **4.69 MB (−62%)** |
| lazy `chunks/EditorViewer-*.js` | — | 2,314,802 B |
| `doenet-standalone-inline.js` | — | 11,540,816 B (−0.75 MB vs. old single file, from schema dedupe) |
| lazy chunks total | — | 119 JS chunks (largest after the editor chunk: spreadsheet 1.85 MB, JSXGraph 0.95 MB) |
| worker (from #1727, unchanged here) | 14.96 MB script | 6,264,176 B script + 6,520,801 B sibling `.wasm` |
| `style.css` | 3.47 MB | unchanged |

`cm-editor` (codemirror marker) appears in exactly one file of the split output: the lazy EditorViewer chunk.

## Relationship to #1727 (WASM externalization — now merged in)

#1727 landed on `main` first, and this branch has merged it (`upstream/main` merge commit), so the PR is up to date with the moved worker-packaging seam. The two features compose at three points, all verified here:

- **Worker URL flow.** The standalone entry still re-points the core worker at the bundle root's version-pinned copy through `setExternalCoreWorkerUrl` — whose cross-origin bootstrap (from #1727) now also records `self.__doenetWorkerScriptUrl`, so the worker's run-time WASM fetch resolves beside the *actual* (pinned) worker script. A host-chosen `doenetWorkerUrl` still wins over both the entry's resolution and the pin (`hostProvidedWorkerUrl`); a same-origin worker booted directly resolves its WASM beside its own `location.href`. The coordinator's shared-core path uses `@doenet/doenetml-iframe`'s pool bootstrap, which records the script URL the same way.
- **WASM beside the bundle root.** `@doenet/standalone`'s static copy now brings `lib_doenetml_worker_bg.wasm` into `dist/doenetml-worker/` beside the worker script, in both the code-split and inline layouts (the inline variant shares the same `dist/` and never embedded the worker to begin with — no emitted standalone script carries a wasm data URI).
- **Merged guardrails.** `check-bundle-size.mjs` keeps both sets: this branch's `*` budget keys and per-chunk reporting, plus #1727's no-inlined-binary rule for *every* emitted script and the served-`.wasm` presence/magic-bytes check (`coreWasmProblems`). `chunkUrlPinning.cy.js` now additionally asserts the worker's core-wasm request goes to the exact-version path under a floating tag.

## Validation

All numbers below re-run on the merged head (post-#1727), full rebuild of the chain (codemirror → parser → doenetml-worker → doenetml → doenetml-iframe → standalone → test-cypress):

- `npm run check:size -w @doenet/standalone` and `npm run check:i18n-instances` pass on the pinned output (5808 scripts across 23 built packages, none holding more than one copy of `@doenet/i18n`); the emitted `dist/doenetml-worker/lib_doenetml_worker_bg.wasm` starts with `\0asm`, and zero emitted standalone scripts carry a wasm data URI.
- Vitest: `@doenet/standalone` 98 (including the merged bundle-size check tests — 37 in that file, covering both the `*` budgets and `coreWasmProblems` — the 9 `installFirstCopyGlobal` guard/drain tests, and the drain-on-replacement tests in `facadeRenderQueue.test.ts`: foreign-replacement drains in order, editor handle-method forwarding across the hand-off, owner-flush-after-drain replays nothing, per-call error isolation with async rethrow, empty-queue no-op, and a stringified round-trip of the hook), `@doenet/doenetml` 177 (including the config-adoption/`hostProvidedWorkerUrl` unit tests), `@doenet/doenetml-worker` 51 (including #1727's `wasmLoading` ladder tests) — all passing.
- `tsc`: `packages/doenetml` at its 18 pre-existing errors; `standalone`, `doenetml-worker`, `doenetml-iframe` at 0; `test-cypress` at its pre-existing 2.
- Cypress e2e against the built test-cypress preview (127.0.0.1:4174): `standalone/chunkUrlPinning.cy.js` 1/1 — a floating-tag (`@latest`) boot where chunks, worker, **and the core `.wasm`** exist **only** under the exact-version path: the document renders and interacts, every chunk, worker, and wasm request goes to `/npm/@doenet/standalone@0.7.24/…`, and the only floating-tag request is the entry itself; `DocViewer/i18n.cy.js` three runs — 38/38 each; `standalone/coordinator.cy.js` 1/1 and `standalone/coordinatorBootFailure.cy.js` 4/4 (the boot-failure page configures `doenetGlobalConfig` from `onload`, which is what proved the config-adoption path); `tagSpecific/codeeditor.cy.js` 10 passing / 2 pending (pre-existing pendings); `standalone/twoCopiesFirstWins.cy.js` 1/1 (two evaluations of the built inline bundle in one page — the second copy's globals and worker-URL write both defer to the first copy's, and the document still renders and interacts); `standalone/twoCopiesConcurrent.cy.js` 1/1 (two concurrent imports of the code-split facade, a render call queued against the stubs before any chunk settled — the probe confirms it landed on a pending stub — drained exactly once into a document that renders and interacts).
- Cypress component: doenetml `bootLadderSingleFlight` 1/1, `bootSupersession` 3/3, `ChunkLoadErrorBoundary` 3/3, `coreStartFailed` 5/5, `sharedCoreWorker` 4/4; the full `@doenet/doenetml-iframe` suite (the blob-URL canary, the stub-aware `waitForStandaloneBundle`, and `srcdocSelfContained`) — 61/61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



