### PR TITLE
fix: pick up math-expressions fix for lost matrix entries of -1

### DIFF
--- a/.changeset/matrix-entry-of-negative-one.md
+++ b/.changeset/matrix-entry-of-negative-one.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix matrix, vector, and tuple arithmetic losing an entry whose value works out to one.
+
+Subtracting a matrix that has an entry of `-1`, as in `<math simplify>$A + $B - $C</math>`, gave a wrong answer or no answer at all. Distributing the minus sign over the entries turned that entry into the product `(-1)(-1)`, which simplified to an empty product rather than to `1`, so the entry dropped out of the sum. Where the rest of that entry's sum was negative, the entry silently came out one too small; where it was positive, evaluating the expression failed outright and the document reported an internal error. Subtracting tuples and vectors with an entry of `-1` behaved the same way.

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
                 "katex": "^0.16.47",
                 "lint-staged": "^15.0.0",
                 "lorem-ipsum": "^2.0.8",
-                "math-expressions": "^2.0.0-alpha95",
+                "math-expressions": "^2.0.0-alpha96",
                 "micromark": "^4.0.2",
                 "nanoid": "^5.1.16",
                 "nextra": "^3.3.1",
@@ -16818,9 +16818,9 @@
             }
         },
         "node_modules/math-expressions": {
-            "version": "2.0.0-alpha95",
-            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha95.tgz",
-            "integrity": "sha512-PhsgiB52TSVqHZu9oLWfK8ntZ3wdDnYA+VzK1SkuURTBkGw97DDsTGG52220VxCia+bO9vNTCOv9LIeysmuvFA==",
+            "version": "2.0.0-alpha96",
+            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha96.tgz",
+            "integrity": "sha512-HsglHfYrMttvJDsvVz+UyAAYcEx3GJd/p/2oNDqIvSOX/DTJeGu/J3B1GK3JusxkADVwyMPFn6cbdFoo9IDRbg==",
             "license": "(GPL-3.0 OR Apache-2.0)",
             "dependencies": {
                 "mathjs": "^15.2.0",
@@ -27108,7 +27108,7 @@
                 "@doenet/i18n": "*",
                 "color-name": "^1.1.4",
                 "colord": "^2.9.3",
-                "math-expressions": "^2.0.0-alpha95",
+                "math-expressions": "^2.0.0-alpha96",
                 "micromark": "^4.0.2"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
         "lint-staged": "^15.0.0",
         "katex": "^0.16.47",
         "lorem-ipsum": "^2.0.8",
-        "math-expressions": "^2.0.0-alpha95",
+        "math-expressions": "^2.0.0-alpha96",
         "micromark": "^4.0.2",
         "nanoid": "^5.1.16",
         "nextra": "^3.3.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -62,7 +62,7 @@
         "@doenet/i18n": "*",
         "color-name": "^1.1.4",
         "colord": "^2.9.3",
-        "math-expressions": "^2.0.0-alpha95",
+        "math-expressions": "^2.0.0-alpha96",
         "micromark": "^4.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Bumps `math-expressions` from `2.0.0-alpha95` to `2.0.0-alpha96`, which fixes wrong answers and a hard failure in matrix, vector, and tuple arithmetic.

## The bug

```xml
<matrix name="A"><row>-1 5</row><row>-1 -3</row></matrix>
<matrix name="B"><row>-2 -1</row><row>-3 -5</row></matrix>
<matrix name="C"><row>-2 -4</row><row>1 -1</row></matrix>

<math name="ans" simplify>$A + $B - $C</math>
$ans.matrix[2][2]
```

The `(2,2)` entry came out as `-8` instead of `-7`. With different numbers — an `<answer>` checking a student's matrix, say — the same document instead failed with `TypeError: Cannot read properties of undefined (reading '0')` and rendered nothing.

Both come from one defect in the simplifier. Distributing the minus sign over `C`'s entries turns the `-1` entry into the product `(-1)(-1)`; the pass that merges numeric factors omitted a coefficient of `1` from its result, which for a product of nothing but numbers left an empty multiplication that later evaluated to `undefined`. The entry then vanished from its sum. Which symptom the reader saw depended on how the remaining addends sorted around the missing one: a negative partial sum silently dropped it, a positive one dereferenced it and threw.

Ordinary scalar arithmetic never hit this, since numbers are evaluated before the pass runs. Only products built afterwards — those from distributing a scalar over a matrix, vector, or tuple — could reach it, so entries of `-1` in a subtracted matrix were the common trigger.

Fixed upstream in Doenet/math-expressions#89, released as `2.0.0-alpha96`.

## Verification

Both documents now give `[[-1, 8], [-5, -7]]` and `[[9, 2], [-7, -4]]`, with `$ans.matrix[2][2]` reading `-7`.

`matrix`, `matrixinput`, `math`, and the `linearAlgebra` suites pass against the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
