### PR TITLE
fix: don't fail a dev release on a redundant dist-tag write

### DIFF
--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -24,8 +24,10 @@
  *   - After a failed attempt it re-checks the registry: if the version now
  *     exists (the publish succeeded server-side despite a client-side error),
  *     it is treated as success.
- *   - On every successful path, ensures any requested/configured dist-tag points
- *     to the published version.
+ *   - A publish that carried the dist-tag has already pointed that tag at the
+ *     version, so no follow-up write is made. On the other success paths
+ *     (already published, or published server-side despite a client error) it
+ *     ensures the tag points at the version, retrying transient failures.
  *
  * Configuration (environment variables):
  *   NPM_PUBLISH_MAX_ATTEMPTS    - total attempts before giving up (default 4)
@@ -111,6 +113,21 @@ const TRANSIENT_PATTERNS = [
     /Bad Gateway/i,
     /Gateway Time-?out/i,
     /registry returned/i,
+];
+
+/**
+ * `npm dist-tag add` is a cheap, idempotent metadata write, so it can retry
+ * failures that would be suspicious on a publish. Auth errors are included:
+ * a genuinely missing or invalid token fails every package in the run, while a
+ * one-off `E401` on a single tag write — with the same credentials publishing
+ * the other packages seconds earlier and later — is a registry blip, and losing
+ * an already-published release to it is the worse outcome.
+ */
+const TRANSIENT_DIST_TAG_PATTERNS = [
+    ...TRANSIENT_PATTERNS,
+    /\bE401\b/,
+    /\bENEEDAUTH\b/,
+    /Unable to authenticate/i,
 ];
 
 function matchesAny(text, patterns) {
@@ -241,40 +258,82 @@ function publishedVersionForTag(tag) {
     }
 }
 
-function ensureExplicitDistTag() {
-    if (!explicitPublishTag) {
-        return true;
-    }
-
-    const taggedVersion = publishedVersionForTag(explicitPublishTag);
-    if (taggedVersion === version) {
-        return true;
-    }
-
-    const previousTagMessage = taggedVersion
-        ? ` (currently ${taggedVersion})`
-        : "";
-    console.log(
-        `Ensuring npm dist-tag ${name}@${explicitPublishTag} points to ${version}${previousTagMessage}.`,
-    );
+function runDistTagAdd() {
     const result = spawnSync(
         "npm",
         ["dist-tag", "add", spec, explicitPublishTag, "--no-workspaces"],
         { encoding: "utf8" },
     );
     writeCommandOutput(result, "npm dist-tag add");
-    if (result.status === 0) {
+    return {
+        status: result.status,
+        output: combinedOutput(result),
+    };
+}
+
+/**
+ * Make sure the requested dist-tag points at this version.
+ *
+ * `appliedByPublish` says the `npm publish` in this run carried the tag, which
+ * already points it at the version we just published. Verifying it anyway races
+ * the registry: reads taken moments after a publish are served from a cache that
+ * still shows the previous version, which used to send us into a redundant
+ * `npm dist-tag add` — and a failure there would fail a release whose packages
+ * were all published and correctly tagged.
+ */
+async function ensureExplicitDistTag({ appliedByPublish = false } = {}) {
+    if (!explicitPublishTag || appliedByPublish) {
         return true;
     }
 
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        // Also serves as the re-check after a failed attempt: the write may have
+        // landed server-side even though the client reported an error.
+        const taggedVersion = publishedVersionForTag(explicitPublishTag);
+        if (taggedVersion === version) {
+            return true;
+        }
+
+        const previousTagMessage = taggedVersion
+            ? ` (currently ${taggedVersion})`
+            : "";
+        console.log(
+            `Ensuring npm dist-tag ${name}@${explicitPublishTag} points to ${version}${previousTagMessage} (attempt ${attempt}/${maxAttempts}).`,
+        );
+
+        const { output, status } = runDistTagAdd();
+        if (status === 0) {
+            return true;
+        }
+
+        if (!matchesAny(output, TRANSIENT_DIST_TAG_PATTERNS)) {
+            console.error(
+                `✖ Could not point npm dist-tag ${name}@${explicitPublishTag} at ${version}; the error is not transient, so not retrying.`,
+            );
+            return false;
+        }
+
+        if (attempt === maxAttempts) {
+            break;
+        }
+
+        const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+        console.warn(
+            `⚠ Transient failure updating npm dist-tag ${name}@${explicitPublishTag}; retrying in ${Math.round(
+                delay / 1000,
+            )}s...`,
+        );
+        await sleep(delay);
+    }
+
     console.error(
-        `Could not ensure npm dist-tag ${name}@${explicitPublishTag} points to ${version}.`,
+        `✖ Could not point npm dist-tag ${name}@${explicitPublishTag} at ${version} after ${maxAttempts} attempts.`,
     );
     return false;
 }
 
-function finishPublishedVersion(message) {
-    if (!ensureExplicitDistTag()) {
+async function finishPublishedVersion(message, options) {
+    if (!(await ensureExplicitDistTag(options))) {
         process.exit(1);
     }
     console.log(message);
@@ -295,7 +354,9 @@ function runPublish() {
 
 async function main() {
     if (alreadyPublished()) {
-        finishPublishedVersion(`✔ ${spec} is already published; skipping.`);
+        await finishPublishedVersion(
+            `✔ ${spec} is already published; skipping.`,
+        );
         return;
     }
 
@@ -306,12 +367,14 @@ async function main() {
         const { status, output } = runPublish();
 
         if (status === 0) {
-            finishPublishedVersion(`✔ Published ${spec}.`);
+            await finishPublishedVersion(`✔ Published ${spec}.`, {
+                appliedByPublish: Boolean(explicitPublishTag),
+            });
             return;
         }
 
         if (matchesAny(output, ALREADY_PUBLISHED_PATTERNS)) {
-            finishPublishedVersion(
+            await finishPublishedVersion(
                 `✔ ${spec} is already published (publish reported a conflict); treating as success.`,
             );
             return;
@@ -321,7 +384,7 @@ async function main() {
         // reported an error (e.g. the token read failed after upload). Confirm
         // against the registry before deciding to retry.
         if (alreadyPublished()) {
-            finishPublishedVersion(
+            await finishPublishedVersion(
                 `✔ ${spec} is now present on the registry despite the error; treating as success.`,
             );
             return;

--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -29,7 +29,8 @@
  *     (already published, or published server-side despite a client error) it
  *     ensures the tag points at the version, retrying transient failures.
  *
- * Configuration (environment variables):
+ * Configuration (environment variables). Each of the publish and any follow-up
+ * dist-tag write gets its own budget of attempts under these settings:
  *   NPM_PUBLISH_MAX_ATTEMPTS    - total attempts before giving up (default 4)
  *   NPM_PUBLISH_RETRY_DELAY_MS  - base backoff delay in ms (default 10000)
  *   NPM_PUBLISH_MAX_DELAY_MS    - backoff delay cap in ms (default 60000)
@@ -282,7 +283,17 @@ function runDistTagAdd() {
  * were all published and correctly tagged.
  */
 async function ensureExplicitDistTag({ appliedByPublish = false } = {}) {
-    if (!explicitPublishTag || appliedByPublish) {
+    if (!explicitPublishTag) {
+        return true;
+    }
+
+    if (appliedByPublish) {
+        // The tag can come from the environment (`npm run publish -- --tag dev`
+        // reaches us as `npm_config_tag`), in which case nothing else in the log
+        // names it. Say so, so the release log still records which tag moved.
+        console.log(
+            `npm publish applied dist-tag ${name}@${explicitPublishTag}; no follow-up tag write needed.`,
+        );
         return true;
     }
 
@@ -324,6 +335,14 @@ async function ensureExplicitDistTag({ appliedByPublish = false } = {}) {
             )}s...`,
         );
         await sleep(delay);
+    }
+
+    // The final attempt gets the same re-check the earlier ones get at the top
+    // of the loop: its write may have landed server-side even though the client
+    // reported an error, and failing a released version over that is exactly
+    // the outcome this script exists to avoid.
+    if (publishedVersionForTag(explicitPublishTag) === version) {
+        return true;
     }
 
     console.error(

--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -324,23 +324,25 @@ async function ensureExplicitDistTag({ appliedByPublish = false } = {}) {
             return false;
         }
 
-        if (attempt === maxAttempts) {
-            break;
-        }
-
+        // Back off before looking again — after the final attempt too, whose
+        // only re-check is the one below. Reading the registry the instant a
+        // write fails tells us nothing new: it is the same cached answer the
+        // top of this iteration already saw.
         const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
         console.warn(
-            `⚠ Transient failure updating npm dist-tag ${name}@${explicitPublishTag}; retrying in ${Math.round(
-                delay / 1000,
-            )}s...`,
+            `⚠ Transient failure updating npm dist-tag ${name}@${explicitPublishTag}; ${
+                attempt === maxAttempts ? "re-checking" : "retrying"
+            } in ${Math.round(delay / 1000)}s...`,
         );
         await sleep(delay);
     }
 
-    // The final attempt gets the same re-check the earlier ones get at the top
-    // of the loop: its write may have landed server-side even though the client
-    // reported an error, and failing a released version over that is exactly
-    // the outcome this script exists to avoid.
+    // One last look before failing a released version. Two things can make the
+    // writes above look worse than the state they were trying to reach: one may
+    // have landed server-side even though the client reported an error, and the
+    // tag may have been right the whole time, with every read above served from
+    // a cache predating the publish. Either only becomes visible once that cache
+    // has had time to expire, hence the backoff after the final attempt.
     if (publishedVersionForTag(explicitPublishTag) === version) {
         return true;
     }


### PR DESCRIPTION
## The problem

[Dev release run 491](https://github.com/Doenet/DoenetML/actions/runs/32422420737/job/96597079035) went red with `E401 Unable to authenticate`, and looked like `@doenet/standalone` had failed to publish. It hadn't — `npm publish` exited 0. The failure came from the `npm dist-tag add` that the retry wrapper runs afterwards:

```
22:08:27.99  Ensuring npm dist-tag @doenet/standalone@dev points to 0.7.24-dev.491 (currently 0.7.24-dev.490).
22:08:28.27  npm error code E401  Unable to authenticate, your authentication token seems to be invalid.
```

That write was never needed. The root publish script passes `--tag dev`, so `npm publish` had already pointed the tag at the version it published. The wrapper verified it anyway, and the verification read came back from a registry cache still showing the previous version — **all four** packages in the run logged `(currently 0.7.24-dev.490)` seconds after publishing `491`. Three of the four re-added a tag that was already correct; the fourth hit a one-off auth blip and, because `ensureExplicitDistTag` exits 1 on any failure and `E401` is not in the transient set, took down a release whose packages were all published and correctly tagged.

The registry bears this out — everything from run 491 is present and correctly tagged:

| package | `0.7.24-dev.491` | `dev` tag |
| --- | --- | --- |
| `@doenet/doenetml` | ✓ | → `dev.491` |
| `@doenet/standalone` | ✓ | → `dev.491` |
| `@doenet/doenetml-iframe` | ✓ | → `dev.491` |
| `@doenet/v06-to-v07` | ✓ | → `dev.491` |

The real cost was downstream: the job died before `Purge jsDelivr cache`, so the CDN kept serving the previous build on the floating tag (`x-jsd-version: 0.7.24-dev.490`) until the 12-hour TTL expired.

## The fix

**Skip the follow-up write when the publish itself carried the tag.** This removes the race rather than papering over it — the stale read is no longer taken at all. The check still runs on the paths where no publish in this run is known to have applied the tag (already-published rerun, `EPUBLISHCONFLICT`, published-server-side-despite-a-client-error), which is where it earns its keep.

Skipping is sound for both ways the tag reaches us. An explicit `--tag` is forwarded to `npm publish` verbatim; and in the dev release the tag never appears in the arguments at all — `npm run publish -- --tag dev` turns into the config variable `npm_config_tag=dev`, which npm propagates through the nested workspace scripts into our environment and which the `npm publish` we spawn (inheriting that environment) reads back as its tag. Verified locally: a nested workspace script does see `npm_config_tag=dev`, and `npm_config_tag=dev npm config get tag` prints `dev`. Because that path leaves the tag unmentioned in the publish command line, the skip logs which tag the publish applied, so the release log still records it.

**Retry the write when it does run.** `npm dist-tag add` is a cheap, idempotent metadata write, so it can retry failures that would be suspicious on a publish; `TRANSIENT_DIST_TAG_PATTERNS` extends the publish set with `E401` / `ENEEDAUTH` / `Unable to authenticate`. A genuinely missing or invalid token fails every package in the run, while a single `E401` bracketed by successful publishes on the same credentials is a blip — and losing an already-published release to it is the worse outcome. The registry read at the top of each iteration doubles as the "did the write land server-side anyway?" re-check, mirroring what the publish loop already does; one more such read runs after the final attempt, so a last-attempt write that landed despite a client-side error is not what fails the release.

The final attempt backs off before that last read, like every other attempt does before the read at the top of the next iteration. Reading the instant a write fails would only re-fetch the cached answer the same iteration already saw — and the state that read is looking for is precisely the one a stale cache hides. That includes the run 491 shape itself: if the tag was correct all along and every read in the loop was stale, waiting out the cache is what turns the release green instead of red.

## Verification

There is no test harness under `.github/scripts`, so I stubbed `npm` on `PATH` and replayed the run 491 conditions — fresh publish with `npm_config_tag=dev`, stale dist-tags read, `E401` on the write:

```
== old: exit=1 ; dist-tag adds=1
     Ensuring npm dist-tag @doenet/standalone@dev points to 0.7.24-dev.491 (currently 0.7.24-dev.490).
     npm error code E401
     npm error Unable to authenticate, your authentication token seems to be invalid.
     Could not ensure npm dist-tag @doenet/standalone@dev points to 0.7.24-dev.491.
== new: exit=0 ; dist-tag adds=0
     ✔ Published @doenet/standalone@0.7.24-dev.491.
```

The baseline reproduces the CI log line for line. Thirteen cases pass on the new version; the same run against `main` passes only four:

| case | exit | tag writes |
| --- | --- | --- |
| stale read after successful publish | 0 | 0 |
| same, with `--tag` as a CLI argument | 0 | 0 |
| already published, tag correct (a rerun) | 0 | 0 |
| already published, tag stale | 0 | 1 |
| `E401` then succeeds | 0 | 2 |
| `E401` but write landed server-side | 0 | 1 |
| `E401` on the *last* attempt, write landed | 0 | 4 |
| `E401` every attempt → gives up | 1 | 4 |
| tag right all along, cache stale for the whole loop → post-loop read rescues it | 0 | 4 |
| final attempt backs off before the post-loop read (timed) | 1 | 4 |
| non-transient (`E403`) → no retry | 1 | 1 |
| publish errored client-side but landed → tag still verified | 0 | 1 |
| no tag requested → never touches dist-tags | 0 | 0 |

`node --check` and `prettier --check` pass. No changeset: this is CI infrastructure and ships nothing to users.

## Note on run 491

Nothing needs republishing — all four packages are on npm at `0.7.24-dev.491` with `dev` pointing at them. Re-running that job is safe (`github.run_number` is unchanged on a re-run, so every package short-circuits on `alreadyPublished()` with no registry write) and would run the jsDelivr purge that never happened, but the CDN TTL has since expired on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


