### PR TITLE
Hide the per-file tarball listing from release logs

### DIFF
--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -28,12 +28,16 @@
  *     version, so no follow-up write is made. On the other success paths
  *     (already published, or published server-side despite a client error) it
  *     ensures the tag points at the version, retrying transient failures.
+ *   - Hides the per-file tarball listing from the relayed npm output, keeping
+ *     the Tarball Details summary (see NPM_PUBLISH_SHOW_FILE_LIST below).
  *
  * Configuration (environment variables). Each of the publish and any follow-up
  * dist-tag write gets its own budget of attempts under these settings:
  *   NPM_PUBLISH_MAX_ATTEMPTS    - total attempts before giving up (default 4)
  *   NPM_PUBLISH_RETRY_DELAY_MS  - base backoff delay in ms (default 10000)
  *   NPM_PUBLISH_MAX_DELAY_MS    - backoff delay cap in ms (default 60000)
+ *   NPM_PUBLISH_SHOW_FILE_LIST  - set to 1 to relay the per-file tarball
+ *                                 listing instead of hiding it
  */
 
 import { spawnSync } from "node:child_process";
@@ -52,6 +56,7 @@ if (!publishDir) {
 const maxAttempts = readIntegerEnv("NPM_PUBLISH_MAX_ATTEMPTS", 4, 1);
 const baseDelayMs = readIntegerEnv("NPM_PUBLISH_RETRY_DELAY_MS", 10_000, 0);
 const maxDelayMs = readIntegerEnv("NPM_PUBLISH_MAX_DELAY_MS", 60_000, 0);
+const showFileList = process.env.NPM_PUBLISH_SHOW_FILE_LIST === "1";
 
 const cwd = resolve(process.cwd(), publishDir);
 
@@ -192,12 +197,65 @@ function combinedOutput(result) {
         .join("\n");
 }
 
+/**
+ * One line of the tarball listing `npm publish` prints at its default log level:
+ * `npm notice 7.6kB Viewer/renderers/answer.js`. The size always follows
+ * `npm notice` immediately, which no line of the Tarball Details summary does
+ * (`npm notice package size: 12.8 MB` leads with a word), so this cannot eat the
+ * summary.
+ */
+const TARBALL_FILE_LINE = /^npm notice \d+(\.\d+)?[kMGT]?B .+$/;
+
+/**
+ * Drop the per-file tarball listing from npm's output.
+ *
+ * A dev release publishes four packages of a few thousand files each, so the
+ * listing runs ~5800 of the step's ~6000 lines and buries anything worth
+ * reading — a release that failed on a one-line `npm error` looks, at a glance,
+ * like it never got as far as publishing. The Tarball Details summary that
+ * follows the listing carries the part worth keeping (package size, unpacked
+ * size, file count, shasum, integrity), and npm has no log level that separates
+ * the two: `--loglevel=warn` would drop the summary along with the listing. The
+ * registry keeps the full file list permanently — `npm view <spec>` — so the
+ * copy in an expiring CI log is redundant as well as noisy.
+ *
+ * Filtering is display-only: `combinedOutput` still classifies the untouched
+ * text, so the retry and already-published patterns see everything npm said.
+ */
+function withoutTarballFileList(text) {
+    if (!text || showFileList) {
+        return { text, suppressed: 0 };
+    }
+
+    let suppressed = 0;
+    const kept = text.split("\n").filter((line) => {
+        if (!TARBALL_FILE_LINE.test(line)) {
+            return true;
+        }
+        suppressed++;
+        return false;
+    });
+
+    return { text: kept.join("\n"), suppressed };
+}
+
 function writeCommandOutput(result, commandName) {
+    let suppressed = 0;
+
     if (result.stdout) {
-        process.stdout.write(result.stdout);
+        const filtered = withoutTarballFileList(result.stdout);
+        suppressed += filtered.suppressed;
+        process.stdout.write(filtered.text);
     }
     if (result.stderr) {
-        process.stderr.write(result.stderr);
+        const filtered = withoutTarballFileList(result.stderr);
+        suppressed += filtered.suppressed;
+        process.stderr.write(filtered.text);
+    }
+    if (suppressed > 0) {
+        console.log(
+            `(${suppressed} tarball file lines hidden; \`npm view ${spec}\` lists the published files, or set NPM_PUBLISH_SHOW_FILE_LIST=1)`,
+        );
     }
     if (result.error) {
         console.error(

--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -216,8 +216,9 @@ const TARBALL_FILE_LINE = /^npm notice \d+(\.\d+)?[kMGT]?B .+$/;
  * follows the listing carries the part worth keeping (package size, unpacked
  * size, file count, shasum, integrity), and npm has no log level that separates
  * the two: `--loglevel=warn` would drop the summary along with the listing. The
- * registry keeps the full file list permanently — `npm view <spec>` — so the
- * copy in an expiring CI log is redundant as well as noisy.
+ * published tarball keeps the full file list permanently, and
+ * `npm pack <spec> --dry-run` reprints exactly this listing from it, so the copy
+ * in an expiring CI log is redundant as well as noisy.
  *
  * Filtering is display-only: `combinedOutput` still classifies the untouched
  * text, so the retry and already-published patterns see everything npm said.
@@ -254,7 +255,7 @@ function writeCommandOutput(result, commandName) {
     }
     if (suppressed > 0) {
         console.log(
-            `(${suppressed} tarball file lines hidden; \`npm view ${spec}\` lists the published files, or set NPM_PUBLISH_SHOW_FILE_LIST=1)`,
+            `(${suppressed} tarball file lines hidden; \`npm pack ${spec} --dry-run\` lists the published files, or set NPM_PUBLISH_SHOW_FILE_LIST=1)`,
         );
     }
     if (result.error) {

--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -31,13 +31,15 @@
  *   - Hides the per-file tarball listing from the relayed npm output, keeping
  *     the Tarball Details summary (see NPM_PUBLISH_SHOW_FILE_LIST below).
  *
- * Configuration (environment variables). Each of the publish and any follow-up
- * dist-tag write gets its own budget of attempts under these settings:
+ * Configuration (environment variables):
  *   NPM_PUBLISH_MAX_ATTEMPTS    - total attempts before giving up (default 4)
  *   NPM_PUBLISH_RETRY_DELAY_MS  - base backoff delay in ms (default 10000)
  *   NPM_PUBLISH_MAX_DELAY_MS    - backoff delay cap in ms (default 60000)
  *   NPM_PUBLISH_SHOW_FILE_LIST  - set to 1 to relay the per-file tarball
  *                                 listing instead of hiding it
+ *
+ * Each of the publish and any follow-up dist-tag write gets its own budget of
+ * attempts under the three retry settings.
  */
 
 import { spawnSync } from "node:child_process";
@@ -218,7 +220,9 @@ const TARBALL_FILE_LINE = /^npm notice \d+(\.\d+)?[kMGT]?B .+$/;
  * the two: `--loglevel=warn` would drop the summary along with the listing. The
  * published tarball keeps the full file list permanently, and
  * `npm pack <spec> --dry-run` reprints exactly this listing from it, so the copy
- * in an expiring CI log is redundant as well as noisy.
+ * in an expiring CI log is redundant as well as noisy. On the one path where it
+ * is not redundant — a publish that never reached the registry — the file list
+ * is the least interesting thing in the log.
  *
  * Filtering is display-only: `combinedOutput` still classifies the untouched
  * text, so the retry and already-published patterns see everything npm said.


### PR DESCRIPTION
## The problem

At its default log level `npm publish` lists every file it packs. A dev release publishes four packages of a few thousand files each, so that listing dominates the step. Breaking down the publish step of [run 491](https://github.com/Doenet/DoenetML/actions/runs/32422420737/job/96597079035):

| | lines |
| --- | --- |
| `npm notice` per-file listings | 5,800 (97%) |
| Tarball Details summary (size, unpacked size, shasum, integrity, file count) | 40 |
| `npm error` — the actual failure | 12 |
| wrapper progress (`=== Publishing`, `✔`, `⚠`) | 11 |

About 1% of the output is signal. The `E401` that failed that release sat at line 2411 of 5982, which is a large part of why the run looked, at a glance, like `@doenet/standalone` had never got as far as publishing.

## The change

Filter the per-file lines out of the output the wrapper relays, keeping everything else.

The Tarball Details summary is the part worth having — `package size`, `unpacked size`, `total files`, `shasum`, `integrity` is exactly the signal for "something just bloated the package", in 9 lines rather than 1,450. npm has no log level that separates the two: `--loglevel=warn` or `--quiet` would drop the summary along with the listing. (There is no `.npmrc` in the repo and no `loglevel` set in any workflow, so nothing else is influencing this today.)

Dropping the listing loses nothing that isn't recorded better elsewhere. The published tarball keeps the full file list permanently, and `npm pack @doenet/standalone@0.7.24-dev.491 --dry-run` reprints exactly this listing from it, while an Actions log expires in 90 days. And the one case where the CI log is the only record, a publish that never reached the registry, is the case where the file list matters least and the error matters most. In its place goes a count of what was hidden and that `npm pack` pointer; `NPM_PUBLISH_SHOW_FILE_LIST=1` brings the full listing back for debugging.

**Filtering is display-only.** `combinedOutput` still classifies the untouched text, so the transient-retry and already-published patterns see everything npm said.

The matching pattern requires the size to follow `npm notice` immediately (`npm notice 7.6kB Viewer/renderers/answer.js`), which no summary line does — `npm notice package size: 12.8 MB` leads with a word. Run against the captured run-491 log it matches 5,800 lines and zero summary lines.

The file's header block gains a bullet for the new behavior and an entry for the new environment variable, with the existing "own budget of attempts" note re-scoped to the three retry settings it actually describes.

## Verification

Replayed the captured log from run 491 through the filter: **5,982 lines → 186**, a 96% reduction, with every `package size` / `unpacked size` / `shasum` / `total files` line intact for all four packages.

Also stubbed `npm` on `PATH` with a realistic notice block and asserted behavior end to end — **28 checks, 0 failures**:

- **Default** — the per-file lines are gone (including nested paths, a zero-byte file, a path containing spaces and parentheses, and every size unit); the Tarball Details header, package size, unpacked size, total files, shasum, integrity, registry target and `📦` header all survive; the suppression note carries the count and the `npm pack … --dry-run` spec; the wrapper's own `✔ Published` line is untouched.
- **`NPM_PUBLISH_SHOW_FILE_LIST=1`** — listing relayed in full, no suppression note.
- **Line-exact** — the filtered output is byte-for-byte the unfiltered output minus the file lines (minus the note), so the split/join round trip neither gains nor loses newlines.
- **Failing publish** — `npm error` lines relayed, file list still hidden, and a transient failure is still classified transient and retried (`attempt 2/4`), proving classification reads the unfiltered text.
- **Non-transient failure** — still not retried, still reported as non-transient.

Since the dist-tag path now shares `writeCommandOutput` with the publish path, #1730's dist-tag harness was re-run on this branch as a regression check: **13 cases, 0 failures**. `npm dist-tag add` emits no per-file lines, so its relayed output and the suppression note are unaffected across all four tag-write attempts.

`node --check` and `prettier --check` pass. No changeset: this is CI infrastructure and ships nothing to users.

## Relationship to #1730

#1730 has merged, and this branch is rebased onto it. The two changes are independent — #1730 fixed a release-failing bug in the dist-tag path of the same file; this only changes how output is rendered — and the only overlap is the header doc block, where both bullets are now present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
