### PR TITLE
test: give the doenetml component suite retries and boot diagnostics

### DIFF
--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -11,12 +11,17 @@ const codemirrorSrc = path.resolve(__dirname, "../codemirror/src/index.ts");
 export default defineConfig({
     // Match the policy `@doenet/test-cypress`, `@doenet/docs-cypress` and
     // `@doenet/doenetml-iframe` already set: retry twice in CI (runMode), never
-    // when iterating locally (openMode). This package was the odd one out, so a
-    // single flake failed the whole `doenetml-cypress` job — which is how both
-    // #1612 (a hover re-dispatch race) and #1719 (a viewer that boots slower
-    // than the test's wait on a cold 2-core runner) took CI down. Retrying is a
-    // safety net, not a diagnosis: a spec that fails every attempt still fails
-    // the job, and the `printAppConsole` task below is what says why.
+    // when iterating locally (openMode). Without it a single flake failed the
+    // whole `doenetml-cypress` job — which is how both #1612 (a hover
+    // re-dispatch race) and #1719 (a viewer that boots slower than the test's
+    // wait on a cold 2-core runner) took CI down. These specs need it most:
+    // they are the ones that boot a real core worker, so their flakes are
+    // boot-cost flakes rather than logic flakes, and a second attempt against
+    // a warm cache almost always passes. (`@doenet/codemirror` has no retries
+    // either — #1612 lists it too — but its component specs drive the editor
+    // alone and are left alone here.) Retrying is a safety net, not a
+    // diagnosis: a spec that fails every attempt still fails the job, and the
+    // `printAppConsole` task below is what says why.
     retries: {
         runMode: 2,
         openMode: 0,

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -13,11 +13,13 @@ export default defineConfig({
     // `@doenet/doenetml-iframe` already set: retry twice in CI (runMode), never
     // when iterating locally (openMode). Without it a single flake failed the
     // whole `doenetml-cypress` job — which is how both #1612 (a hover
-    // re-dispatch race) and #1719 (a viewer that boots slower than the test's
-    // wait on a cold 2-core runner) took CI down. Both are timing races on a
-    // contended runner rather than wrong assertions, and these are the specs
-    // that boot a real core worker, so a second attempt against a warm cache
-    // almost always passes. (`@doenet/codemirror` has no retries either —
+    // re-dispatch race) and #1719 (a viewer that never renders inside the
+    // test's wait on a cold 2-core runner) took CI down. Neither looks like a
+    // wrong assertion: #1719 fails all-or-nothing at the full timeout, has
+    // never been reproduced locally, and a re-run of one identical commit
+    // passed. These are also the specs that boot a real core worker, so a
+    // second attempt against a warm cache starts from a much better position
+    // than the first. (`@doenet/codemirror` has no retries either —
     // #1612 lists it too — but its component specs drive the editor alone and
     // are left alone here.) Retrying is a safety net, not a diagnosis: a spec
     // that fails every attempt still fails the job, and the `printAppConsole`
@@ -150,10 +152,12 @@ export default defineConfig({
                  *
                  * Nothing the browser logs reaches the terminal under `cypress
                  * run`, so a boot-timing flake arrives on CI as a bare
-                 * "expected to find content ... but never did" even though the
-                 * boot ladder has already said what went wrong. This is the
-                 * printing half of that fix; `test/cypress/support/component.ts`
-                 * is the collecting half, and carries the reasoning.
+                 * "expected to find content ... but never did", with no way to
+                 * tell whether the boot ladder had anything to say about it.
+                 * This is the printing half of that fix;
+                 * `test/cypress/support/component.ts` is the collecting half —
+                 * it calls this from a root `afterEach` — and carries the
+                 * reasoning.
                  */
                 printAppConsole({
                     title,
@@ -167,6 +171,13 @@ export default defineConfig({
                     console.log(
                         `\n--- app console during failing test (attempt ${attempt}): ${title}`,
                     );
+                    if (messages.length === 0) {
+                        // Said out loud rather than left as a missing block: a
+                        // failing boot that logged nothing is evidence that
+                        // the ladder never tripped its watchdog, and #1719
+                        // turns on exactly that question.
+                        console.log("    (the app logged nothing)");
+                    }
                     for (const message of messages) {
                         console.log(`    ${message}`);
                     }

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -9,6 +9,18 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const codemirrorSrc = path.resolve(__dirname, "../codemirror/src/index.ts");
 
 export default defineConfig({
+    // Match the policy `@doenet/test-cypress`, `@doenet/docs-cypress` and
+    // `@doenet/doenetml-iframe` already set: retry twice in CI (runMode), never
+    // when iterating locally (openMode). This package was the odd one out, so a
+    // single flake failed the whole `doenetml-cypress` job — which is how both
+    // #1612 (a hover re-dispatch race) and #1719 (a viewer that boots slower
+    // than the test's wait on a cold 2-core runner) took CI down. Retrying is a
+    // safety net, not a diagnosis: a spec that fails every attempt still fails
+    // the job, and the `printAppConsole` task below is what says why.
+    retries: {
+        runMode: 2,
+        openMode: 0,
+    },
     component: {
         devServer: {
             framework: "react",
@@ -126,6 +138,38 @@ export default defineConfig({
         indexHtmlFile: "test/cypress/support/component-index.html",
         setupNodeEvents(on) {
             on("file:preprocessor", vitePreprocessor());
+            on("task", {
+                /**
+                 * Print the app's console warnings and errors from a failing
+                 * test into the runner's own output (#1719).
+                 *
+                 * The viewer's boot ladder narrates itself through
+                 * `console.warn` — which handshake attempt failed, the watchdog
+                 * budget it had, and how many handshakes were in flight on how
+                 * many cores — but in `cypress run` none of that reaches the
+                 * terminal. A boot-timing flake therefore arrives on CI as a
+                 * bare "expected to find content ... but never did", with
+                 * nothing to say whether the worker was slow, retried, or never
+                 * started at all. `test/cypress/support/component.ts` buffers
+                 * the messages and hands them here when a test fails.
+                 */
+                printAppConsole({
+                    title,
+                    messages,
+                }: {
+                    title: string;
+                    messages: string[];
+                }) {
+                    console.log(
+                        `\n--- app console during failing test: ${title}`,
+                    );
+                    for (const message of messages) {
+                        console.log(`    ${message}`);
+                    }
+                    console.log("--- end app console\n");
+                    return null;
+                },
+            });
         },
     },
 });

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -15,15 +15,10 @@ export default defineConfig({
     // whole `doenetml-cypress` job — which is how both #1612 (a hover
     // re-dispatch race) and #1719 (a viewer that never renders inside the
     // test's wait on a cold 2-core runner) took CI down. Neither looks like a
-    // wrong assertion: #1719 fails all-or-nothing at the full timeout, has
-    // never been reproduced locally, and a re-run of one identical commit
-    // passed. These are also the specs that boot a real core worker, so a
-    // second attempt against a warm cache starts from a much better position
-    // than the first. (`@doenet/codemirror` has no retries either —
-    // #1612 lists it too — but its component specs drive the editor alone and
-    // are left alone here.) Retrying is a safety net, not a diagnosis: a spec
-    // that fails every attempt still fails the job, and the `printAppConsole`
-    // task below is what says why.
+    // wrong assertion: both fail all-or-nothing at the full timeout, and
+    // neither reproduces locally. Retrying is a safety net, not a diagnosis:
+    // a spec that fails every attempt still fails the job, and the
+    // `printAppConsole` task below is what says why.
     retries: {
         runMode: 2,
         openMode: 0,
@@ -148,16 +143,14 @@ export default defineConfig({
             on("task", {
                 /**
                  * Print the app's console warnings and errors from a failing
-                 * test into the runner's own output (#1719).
+                 * test into the runner's own output (#1719) — nothing the
+                 * browser logs reaches the terminal under `cypress run`, so a
+                 * boot-timing flake otherwise arrives on CI as a bare
+                 * "expected to find content ... but never did".
                  *
-                 * Nothing the browser logs reaches the terminal under `cypress
-                 * run`, so a boot-timing flake arrives on CI as a bare
-                 * "expected to find content ... but never did", with no way to
-                 * tell whether the boot ladder had anything to say about it.
-                 * This is the printing half of that fix;
-                 * `test/cypress/support/component.ts` is the collecting half —
-                 * it calls this from a root `afterEach` — and carries the
-                 * reasoning.
+                 * This is the printing half; the collecting half is
+                 * `test/cypress/support/component.ts`, which calls this from a
+                 * root `afterEach` and carries the reasoning.
                  */
                 printAppConsole({
                     title,
@@ -172,10 +165,9 @@ export default defineConfig({
                         `\n--- app console during failing test (attempt ${attempt}): ${title}`,
                     );
                     if (messages.length === 0) {
-                        // Said out loud rather than left as a missing block: a
-                        // failing boot that logged nothing is evidence that
-                        // the ladder never tripped its watchdog, and #1719
-                        // turns on exactly that question.
+                        // Said out loud rather than left as a missing block —
+                        // see `component.ts`: silence is itself the answer to
+                        // the question #1719 turns on.
                         console.log("    (the app logged nothing)");
                     }
                     for (const message of messages) {

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -14,14 +14,14 @@ export default defineConfig({
     // when iterating locally (openMode). Without it a single flake failed the
     // whole `doenetml-cypress` job — which is how both #1612 (a hover
     // re-dispatch race) and #1719 (a viewer that boots slower than the test's
-    // wait on a cold 2-core runner) took CI down. These specs need it most:
-    // they are the ones that boot a real core worker, so their flakes are
-    // boot-cost flakes rather than logic flakes, and a second attempt against
-    // a warm cache almost always passes. (`@doenet/codemirror` has no retries
-    // either — #1612 lists it too — but its component specs drive the editor
-    // alone and are left alone here.) Retrying is a safety net, not a
-    // diagnosis: a spec that fails every attempt still fails the job, and the
-    // `printAppConsole` task below is what says why.
+    // wait on a cold 2-core runner) took CI down. Both are timing races on a
+    // contended runner rather than wrong assertions, and these are the specs
+    // that boot a real core worker, so a second attempt against a warm cache
+    // almost always passes. (`@doenet/codemirror` has no retries either —
+    // #1612 lists it too — but its component specs drive the editor alone and
+    // are left alone here.) Retrying is a safety net, not a diagnosis: a spec
+    // that fails every attempt still fails the job, and the `printAppConsole`
+    // task below is what says why.
     retries: {
         runMode: 2,
         openMode: 0,
@@ -148,25 +148,24 @@ export default defineConfig({
                  * Print the app's console warnings and errors from a failing
                  * test into the runner's own output (#1719).
                  *
-                 * The viewer's boot ladder narrates itself through
-                 * `console.warn` — which handshake attempt failed, the watchdog
-                 * budget it had, and how many handshakes were in flight on how
-                 * many cores — but in `cypress run` none of that reaches the
-                 * terminal. A boot-timing flake therefore arrives on CI as a
-                 * bare "expected to find content ... but never did", with
-                 * nothing to say whether the worker was slow, retried, or never
-                 * started at all. `test/cypress/support/component.ts` buffers
-                 * the messages and hands them here when a test fails.
+                 * Nothing the browser logs reaches the terminal under `cypress
+                 * run`, so a boot-timing flake arrives on CI as a bare
+                 * "expected to find content ... but never did" even though the
+                 * boot ladder has already said what went wrong. This is the
+                 * printing half of that fix; `test/cypress/support/component.ts`
+                 * is the collecting half, and carries the reasoning.
                  */
                 printAppConsole({
                     title,
+                    attempt,
                     messages,
                 }: {
                     title: string;
+                    attempt: number;
                     messages: string[];
                 }) {
                     console.log(
-                        `\n--- app console during failing test: ${title}`,
+                        `\n--- app console during failing test (attempt ${attempt}): ${title}`,
                     );
                     for (const message of messages) {
                         console.log(`    ${message}`);

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
@@ -24,12 +24,19 @@ const EDITOR_TIMEOUT = 15_000;
  * different and much larger job than the language server's first check: spawn
  * the core worker, compile its WASM, run the init handshake, evaluate, render.
  *
- * Sized to a full trip around the boot ladder rather than to a single healthy
- * boot (#1719). `EDITOR_TIMEOUT` is exactly one watchdog period, so a first
- * handshake slow enough to trip the watchdog — which a cold two-core CI runner
- * is — could never be beaten by it, however promptly the retry then succeeded.
- * This budgets for that trip, term by term below, and is derived from the
- * ladder's own constants so it keeps that meaning if they move.
+ * Sized to a boot that trips the watchdog once and recovers, rather than to a
+ * single healthy boot (#1719). `EDITOR_TIMEOUT` is exactly one watchdog
+ * period, so a first handshake slow enough to trip the watchdog — which a cold
+ * two-core CI runner can produce — could never be beaten by it, however
+ * promptly the retry then succeeded. This budgets for that recovery, term by
+ * term below, and is derived from the ladder's own constants so it keeps that
+ * meaning if they move.
+ *
+ * Deliberately *not* a budget for every attempt the ladder will make
+ * (`DEFAULT_CORE_BOOT_MAX_ATTEMPTS` is 3). One watchdog fire is a slow runner;
+ * needing the last attempt is a boot in real trouble, and waiting a third
+ * watchdog period only makes that failure slower to report — three times over,
+ * now that the job retries.
  *
  * `MAX_CORE_BOOT_RETRY_DELAY_MS` is the ladder's backoff *ceiling*, not what
  * the first retry actually waits (`retryDelayMs(0)` is a few hundred ms). The

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
@@ -28,26 +28,23 @@ const EDITOR_TIMEOUT = 15_000;
  * single healthy boot (#1719). `EDITOR_TIMEOUT` is exactly one watchdog
  * period, so a first handshake slow enough to trip the watchdog — which a cold
  * two-core CI runner can produce — could never be beaten by it, however
- * promptly the retry then succeeded. This budgets for that recovery, term by
- * term below, and is derived from the ladder's own constants so it keeps that
- * meaning if they move.
+ * promptly the retry then succeeded. Derived from the ladder's own constants
+ * so it keeps that meaning if they move.
  *
  * Deliberately *not* a budget for every attempt the ladder will make
  * (`DEFAULT_CORE_BOOT_MAX_ATTEMPTS` is 3). One watchdog fire is a slow runner;
  * needing the last attempt is a boot in real trouble, and waiting a third
  * watchdog period only makes that failure slower to report — three times over,
  * now that the job retries.
- *
- * `MAX_CORE_BOOT_RETRY_DELAY_MS` is the ladder's backoff *ceiling*, not what
- * the first retry actually waits (`retryDelayMs(0)` is a few hundred ms). The
- * ceiling is budgeted anyway because it costs nothing here and stays correct
- * if the retry schedule is ever made more patient.
  */
 const VIEWER_BOOT_TIMEOUT =
     // A first handshake that runs out its watchdog, plus a second that gets
     // the same budget.
     2 * DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS +
-    // The backoff between the two.
+    // The backoff between the two. This is the ladder's *ceiling*, not what
+    // the first retry actually waits (`retryDelayMs(0)` is a few hundred ms);
+    // budgeted anyway because it costs nothing here and stays correct if the
+    // retry schedule is ever made more patient.
     MAX_CORE_BOOT_RETRY_DELAY_MS +
     // Evaluating the document and rendering the result, which the watchdog
     // deliberately does not cover — see `coreWorkerBoot`'s header on why only

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
@@ -28,14 +28,23 @@ const EDITOR_TIMEOUT = 15_000;
  * boot (#1719). `EDITOR_TIMEOUT` is exactly one watchdog period, so a first
  * handshake slow enough to trip the watchdog — which a cold two-core CI runner
  * is — could never be beaten by it, however promptly the retry then succeeded.
- * This budgets for that: a watchdogged first attempt, the backoff, a second
- * handshake that gets the same budget, and the evaluation and render that
- * follow it. Derived from the ladder's own constants so it keeps meaning that
- * if they move.
+ * This budgets for that trip, term by term below, and is derived from the
+ * ladder's own constants so it keeps that meaning if they move.
+ *
+ * `MAX_CORE_BOOT_RETRY_DELAY_MS` is the ladder's backoff *ceiling*, not what
+ * the first retry actually waits (`retryDelayMs(0)` is a few hundred ms). The
+ * ceiling is budgeted anyway because it costs nothing here and stays correct
+ * if the retry schedule is ever made more patient.
  */
 const VIEWER_BOOT_TIMEOUT =
+    // A first handshake that runs out its watchdog, plus a second that gets
+    // the same budget.
     2 * DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS +
+    // The backoff between the two.
     MAX_CORE_BOOT_RETRY_DELAY_MS +
+    // Evaluating the document and rendering the result, which the watchdog
+    // deliberately does not cover — see `coreWorkerBoot`'s header on why only
+    // the handshake is time-boxed.
     10_000;
 
 function Editor({

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticHoverLocale.cy.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+import {
+    DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS,
+    MAX_CORE_BOOT_RETRY_DELAY_MS,
+} from "../../../src/Viewer/coreWorkerBoot";
 
 // The tooltip over a squiggle in the editor is the last place a diagnostic
 // was still English regardless of who was reading (Doenet/DoenetML#1569's
@@ -14,6 +18,25 @@ import { DoenetEditor } from "../../../src/doenetml-inline-worker";
 
 /** Long enough for the language server to start and answer the first check. */
 const EDITOR_TIMEOUT = 15_000;
+
+/**
+ * Long enough for the *viewer* to put its first content on screen, which is a
+ * different and much larger job than the language server's first check: spawn
+ * the core worker, compile its WASM, run the init handshake, evaluate, render.
+ *
+ * Sized to a full trip around the boot ladder rather than to a single healthy
+ * boot (#1719). `EDITOR_TIMEOUT` is exactly one watchdog period, so a first
+ * handshake slow enough to trip the watchdog — which a cold two-core CI runner
+ * is — could never be beaten by it, however promptly the retry then succeeded.
+ * This budgets for that: a watchdogged first attempt, the backoff, a second
+ * handshake that gets the same budget, and the evaluation and render that
+ * follow it. Derived from the ladder's own constants so it keeps meaning that
+ * if they move.
+ */
+const VIEWER_BOOT_TIMEOUT =
+    2 * DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS +
+    MAX_CORE_BOOT_RETRY_DELAY_MS +
+    10_000;
 
 function Editor({
     uiLocale,
@@ -129,7 +152,7 @@ describe("the editor's diagnostic tooltip follows the reader's language", () => 
         // closes any tooltip open at the time — the same as any other edit
         // does. Its red error box is the signal that it has resolved Spanish.
         cy.contains("[style*='mainRed']", "Tipo de componente no válido", {
-            timeout: EDITOR_TIMEOUT,
+            timeout: VIEWER_BOOT_TIMEOUT,
         });
 
         hoverFirstSquiggle().should(

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -15,16 +15,27 @@ Cypress.Commands.add("mount", mount);
 //
 // Most of what these specs wait on is the viewer putting content on screen,
 // which means booting a core worker: spawning it, compiling the WASM, and
-// running the init round-trips that the boot ladder time-boxes. When that is
-// slower than the wait — a cold 2-core CI runner is the case on record — the
-// failure says only that the content never appeared. The ladder itself has
-// already explained what happened, through `console.warn`, in the browser;
-// `cypress run` just never shows it.
+// running the init round-trips that the boot ladder time-boxes. When one of
+// those waits runs out, the failure Cypress reports says only that the content
+// never appeared — never why. #1719's leading explanation is that the boot
+// ladder tripped its handshake watchdog and was still recovering when the wait
+// expired, but that stays a hypothesis: no failing run on record carries any
+// boot telemetry to check it against, because nothing the browser logs reaches
+// the terminal under `cypress run`.
 //
 // So buffer the app's warnings and errors as each test runs and, when the test
-// fails, hand them to the `printAppConsole` task, which prints them from the
-// runner process where CI logs can pick them up. Passing tests print nothing,
-// and nothing here can fail a test that would otherwise have passed.
+// fails, hand them to the `printAppConsole` task in `cypress.config.ts`, which
+// prints them from the runner process where CI logs pick them up.
+//
+// A failing test prints its transcript even when that transcript is empty. A
+// watchdog that fires says so through `console.warn`, so a failing boot that
+// logged nothing means it never fired — which is the observation that would
+// kill the hypothesis rather than the absence of one. Printed as an explicit
+// "logged nothing", that reads as an answer; printed as no block at all it
+// would be indistinguishable from diagnostics that never ran.
+//
+// Passing tests print nothing at all, and the task is only ever reached from a
+// test that has already failed, so it cannot turn a passing test red.
 
 /** Enough for a full boot ladder's narration without flooding the log. */
 const MAX_BUFFERED_MESSAGES = 100;
@@ -92,6 +103,12 @@ for (const level of ["warn", "error"] as const) {
     };
 }
 
+// Root-level on purpose: Mocha unwinds `afterEach` hooks innermost-first, so
+// this runs after whatever cleanup a spec declares of its own and buffers
+// anything those hooks log too. It also runs — with `this.currentTest.state`
+// already `"failed"` — when the failure came from a spec's `beforeEach` rather
+// than from the test body, which is what covers the specs that mount inside a
+// hook (`DoenetEditor.diagnosticsPanelInset`).
 afterEach(function () {
     const messages = bufferedMessages;
     const dropped = droppedMessageCount;
@@ -105,7 +122,7 @@ afterEach(function () {
     // `retries` configured, a flake that passes on a later attempt still
     // prints the failed attempt's messages, which is exactly the run worth
     // reading.
-    if (this.currentTest?.state !== "failed" || messages.length === 0) {
+    if (this.currentTest?.state !== "failed") {
         return;
     }
     if (dropped > 0) {

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -15,11 +15,11 @@ Cypress.Commands.add("mount", mount);
 //
 // Most of what these specs wait on is the viewer putting content on screen,
 // which means booting a core worker: spawning it, compiling the WASM, and
-// running the init round-trips the boot ladder watchdogs. When that is slower
-// than the wait — a cold 2-core CI runner is the case on record — the failure
-// says only that the content never appeared. The ladder itself has already
-// explained what happened, through `console.warn`, in the browser; `cypress
-// run` just never shows it.
+// running the init round-trips that the boot ladder time-boxes. When that is
+// slower than the wait — a cold 2-core CI runner is the case on record — the
+// failure says only that the content never appeared. The ladder itself has
+// already explained what happened, through `console.warn`, in the browser;
+// `cypress run` just never shows it.
 //
 // So buffer the app's warnings and errors as each test runs and, when the test
 // fails, hand them to the `printAppConsole` task, which prints them from the
@@ -113,7 +113,15 @@ afterEach(function () {
     }
     cy.task(
         "printAppConsole",
-        { title: this.currentTest.fullTitle(), messages },
+        {
+            title: this.currentTest.fullTitle(),
+            // Retries mean the same title can print up to three times in one
+            // run; number the attempts so the transcripts can be told apart —
+            // and so "attempt 1 timed out, attempt 2 never started a worker"
+            // is readable as such rather than as one confused log.
+            attempt: Cypress.currentRetry + 1,
+            messages,
+        },
         { log: false },
     );
 });

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -21,16 +21,33 @@ Cypress.Commands.add("mount", mount);
 // explained what happened, through `console.warn`, in the browser; `cypress
 // run` just never shows it.
 //
-// So buffer the app's warnings and errors for the duration of each test and,
-// when the test fails, hand them to the `printAppConsole` task, which prints
-// them from the runner process where CI logs can pick them up. Passing tests
-// print nothing.
+// So buffer the app's warnings and errors as each test runs and, when the test
+// fails, hand them to the `printAppConsole` task, which prints them from the
+// runner process where CI logs can pick them up. Passing tests print nothing,
+// and nothing here can fail a test that would otherwise have passed.
 
 /** Enough for a full boot ladder's narration without flooding the log. */
 const MAX_BUFFERED_MESSAGES = 100;
 
 let bufferedMessages: string[] = [];
+/**
+ * How many messages the cap turned away since the last flush. Counted rather
+ * than discarded silently: a boot that retried its way through the whole
+ * ladder is exactly the failure most likely to hit the cap, and a truncated
+ * transcript that does not say it is truncated invites reading "the warnings
+ * stop here" as "the app stopped talking here".
+ */
+let droppedMessageCount = 0;
 
+/**
+ * Render one `console.warn`/`console.error` argument as a line of text.
+ *
+ * Errors are reduced to name and message on purpose: the boot ladder logs its
+ * failures as `console.warn(summary, err)`, and a bundled Vite stack adds
+ * dozens of lines of transformed frames that say nothing the summary has not
+ * already said — while eating the message cap that the rest of the ladder's
+ * narration needs.
+ */
 function formatConsoleArg(arg: unknown): string {
     if (arg instanceof Error) {
         return `${arg.name}: ${arg.message}`;
@@ -39,10 +56,19 @@ function formatConsoleArg(arg: unknown): string {
         return arg;
     }
     try {
-        return JSON.stringify(arg);
+        // `JSON.stringify` returns `undefined` — not the string
+        // `"undefined"` — for `undefined`, functions and symbols, despite its
+        // `string` return type. Falling through to `String` keeps those
+        // arguments visible instead of leaving an empty slot in the joined
+        // line.
+        return JSON.stringify(arg) ?? String(arg);
     } catch {
-        // Circular structures, DOM nodes, and the like.
-        return String(arg);
+        // Circular structures, DOM nodes, null-prototype objects: neither
+        // serializable nor necessarily even coercible to a string. This
+        // wrapper sits in front of every warning the app makes in every spec
+        // of the suite, so it must never turn one into an exception thrown
+        // inside product code.
+        return `[unprintable ${typeof arg}]`;
     }
 }
 
@@ -59,24 +85,31 @@ for (const level of ["warn", "error"] as const) {
             bufferedMessages.push(
                 `[${level}] ${args.map(formatConsoleArg).join(" ")}`,
             );
+        } else {
+            droppedMessageCount++;
         }
         original(...args);
     };
 }
 
-beforeEach(() => {
-    bufferedMessages = [];
-});
-
 afterEach(function () {
     const messages = bufferedMessages;
+    const dropped = droppedMessageCount;
+    // Emptied on the way out rather than on the way in, so that a boot still
+    // talking after its test ended is attributed to the next test — the one
+    // whose failure it may well be about — instead of being thrown away in a
+    // `beforeEach` no one would see.
     bufferedMessages = [];
+    droppedMessageCount = 0;
     // `this.currentTest` is why this is a `function` and not an arrow. With
     // `retries` configured, a flake that passes on a later attempt still
     // prints the failed attempt's messages, which is exactly the run worth
     // reading.
     if (this.currentTest?.state !== "failed" || messages.length === 0) {
         return;
+    }
+    if (dropped > 0) {
+        messages.push(`[truncated] ${dropped} further message(s) suppressed`);
     }
     cy.task(
         "printAppConsole",

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -10,3 +10,77 @@ declare global {
 }
 
 Cypress.Commands.add("mount", mount);
+
+// --- Boot diagnostics for failing tests (#1719) ----------------------------
+//
+// Most of what these specs wait on is the viewer putting content on screen,
+// which means booting a core worker: spawning it, compiling the WASM, and
+// running the init round-trips the boot ladder watchdogs. When that is slower
+// than the wait — a cold 2-core CI runner is the case on record — the failure
+// says only that the content never appeared. The ladder itself has already
+// explained what happened, through `console.warn`, in the browser; `cypress
+// run` just never shows it.
+//
+// So buffer the app's warnings and errors for the duration of each test and,
+// when the test fails, hand them to the `printAppConsole` task, which prints
+// them from the runner process where CI logs can pick them up. Passing tests
+// print nothing.
+
+/** Enough for a full boot ladder's narration without flooding the log. */
+const MAX_BUFFERED_MESSAGES = 100;
+
+let bufferedMessages: string[] = [];
+
+function formatConsoleArg(arg: unknown): string {
+    if (arg instanceof Error) {
+        return `${arg.name}: ${arg.message}`;
+    }
+    if (typeof arg === "string") {
+        return arg;
+    }
+    try {
+        return JSON.stringify(arg);
+    } catch {
+        // Circular structures, DOM nodes, and the like.
+        return String(arg);
+    }
+}
+
+// Wrapped once, at support-file load, rather than per test: the component
+// runner reuses this window across the whole spec, and a boot begun by one
+// test can still be talking during the next. Specs that stub `console.warn`
+// themselves replace this wrapper for their own test and Cypress restores it
+// afterwards — their messages are simply not buffered, which is the same
+// bargain those specs already made with the real console.
+for (const level of ["warn", "error"] as const) {
+    const original = window.console[level].bind(window.console);
+    window.console[level] = (...args: unknown[]) => {
+        if (bufferedMessages.length < MAX_BUFFERED_MESSAGES) {
+            bufferedMessages.push(
+                `[${level}] ${args.map(formatConsoleArg).join(" ")}`,
+            );
+        }
+        original(...args);
+    };
+}
+
+beforeEach(() => {
+    bufferedMessages = [];
+});
+
+afterEach(function () {
+    const messages = bufferedMessages;
+    bufferedMessages = [];
+    // `this.currentTest` is why this is a `function` and not an arrow. With
+    // `retries` configured, a flake that passes on a later attempt still
+    // prints the failed attempt's messages, which is exactly the run worth
+    // reading.
+    if (this.currentTest?.state !== "failed" || messages.length === 0) {
+        return;
+    }
+    cy.task(
+        "printAppConsole",
+        { title: this.currentTest.fullTitle(), messages },
+        { log: false },
+    );
+});

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -42,6 +42,15 @@ const MAX_BUFFERED_MESSAGES = 100;
 
 let bufferedMessages: string[] = [];
 /**
+ * When the current buffer started, so each line can carry the elapsed time
+ * since (roughly) the start of the test. #1719 is a question about *when*: a
+ * watchdog fire 15 s in with a retry still running when the wait expired is
+ * the hypothesis, while a ladder that failed 200 ms in never waited on
+ * anything. The messages themselves quote the watchdog's budget, not the
+ * clock, so without this the transcript cannot tell those apart.
+ */
+let bufferStartedAt = Date.now();
+/**
  * How many messages the cap turned away since the last flush. Counted rather
  * than discarded silently: a boot that retried its way through the whole
  * ladder is exactly the failure most likely to hit the cap, and a truncated
@@ -94,7 +103,8 @@ for (const level of ["warn", "error"] as const) {
     window.console[level] = (...args: unknown[]) => {
         if (bufferedMessages.length < MAX_BUFFERED_MESSAGES) {
             bufferedMessages.push(
-                `[${level}] ${args.map(formatConsoleArg).join(" ")}`,
+                `+${Date.now() - bufferStartedAt}ms [${level}] ` +
+                    args.map(formatConsoleArg).join(" "),
             );
         } else {
             droppedMessageCount++;
@@ -115,9 +125,11 @@ afterEach(function () {
     // Emptied on the way out rather than on the way in, so that a boot still
     // talking after its test ended is attributed to the next test — the one
     // whose failure it may well be about — instead of being thrown away in a
-    // `beforeEach` no one would see.
+    // `beforeEach` no one would see. The elapsed-time origin restarts here for
+    // the same reason: it is the last moment before the next test begins.
     bufferedMessages = [];
     droppedMessageCount = 0;
+    bufferStartedAt = Date.now();
     // `this.currentTest` is why this is a `function` and not an arrow. With
     // `retries` configured, a flake that passes on a later attempt still
     // prints the failed attempt's messages, which is exactly the run worth


### PR DESCRIPTION
Closes #1719, and covers the CI-takedown half of #1612. Test-only: no product code, nothing that ships changes, so no changeset.

## What this changes

**1. `retries: { runMode: 2, openMode: 0 }` in `packages/doenetml/cypress.config.ts`** — the policy `@doenet/test-cypress`, `@doenet/docs-cypress` and `@doenet/doenetml-iframe` already set. Without it a single flake failed the whole `doenetml-cypress` job, which is how both #1612 (a hover re-dispatch race) and #1719 (a viewer that never renders inside the test's wait) took CI down. Neither looks like a wrong assertion: both fail all-or-nothing at the full timeout, neither reproduces locally, and a re-run of one identical commit passed. All four failures recorded in #1719 would have had a second chance. (`@doenet/codemirror` has no retries either — #1612 lists it — but its specs drive the editor alone; left alone as out of scope.)

**2. A `printAppConsole` task, fed by the component support file.** Retrying hides a flake without explaining it. The boot ladder narrates itself through `console.warn` — which handshake attempt failed, the watchdog budget it had, how many handshakes were in flight on how many cores — but `cypress run` never surfaces that, which is why every failure on record arrives as a bare "expected to find content … but never did". A root `afterEach` buffers the app's warnings and errors per test and hands them to a task that prints them from the runner process when the test fails, labelled with the attempt number so retried runs can be told apart, and each line stamped `+Nms`: #1719 is a question about *when*, and the ladder's messages quote its watchdog budget rather than the clock.

A failing test prints its block even when the app logged nothing, spelled out as such. A watchdog that fires says so, so silence means it never fired — that is the observation which would *kill* #1719's hypothesis, not the absence of one, and printing it also distinguishes "nothing to report" from "diagnostics never ran". Passing tests print nothing and call no task; the buffer is capped and says so when it truncates.

This is option 4 of the issue: instrument, then choose between raising the wait and raising the watchdog with evidence instead of a hypothesis.

**3. The `<document lang>` test's setup wait is sized to what it waits for.** That wait is for the *viewer* to render, which means booting a core worker: spawn, compile the WASM, run the init handshake, evaluate, render. It borrowed `EDITOR_TIMEOUT` — 15 s, sized for the language server, and exactly one `DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS`. So a first handshake slow enough to trip the watchdog on a cold two-core runner could never be beaten by it, however promptly the ladder's retry then succeeded. The new `VIEWER_BOOT_TIMEOUT` budgets for one watchdog fire and a successful retry — deliberately not for all three of the ladder's attempts — derived from the ladder's own constants so it keeps its meaning if they move.

## What this does not change

No product code. The leading hypothesis in #1719 — that a boot which trips the watchdog once now takes strictly longer than 15 s to show content — stays a hypothesis, and the comments say so; the instrumentation is what would confirm or kill it from the next CI failure. The product-side gap behind it, that contention scaling never engages on a first boot, is #1718 and is untouched.

## Verification

Local `cypress run`, headless Chrome, in `packages/doenetml`: `DoenetEditor.diagnosticHoverLocale.cy.tsx` 4/4, `DoenetEditor.initialOpenTab.cy.tsx` 8/8, `DoenetEditor.updateRenderedViewRef.cy.tsx` 3/3. The latter two stub `console.warn` themselves — the main interaction risk with the buffering wrapper; their stubs replace it for their own test and Cypress restores it afterwards.

Scratch specs (not committed) exercised the plumbing end to end: a failing test body; a failure raised in a spec's `beforeEach`, which is covered because `this.currentTest.state` is already `"failed"` there — it matters because several specs mount inside a hook; a failing test whose app logged nothing; circular, `undefined` and `Error` arguments; and three attempts numbered 1–3 to match Cypress's own "(Attempt N of 3)". A passing test's warnings never leaked into the next test's block, and no `cy.task` call ever displaced the real failure being reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
