### PR TITLE
test: scan the editor's CodeMirror stack before any spec runs

### DIFF
--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -6,7 +6,20 @@ import { fileURLToPath } from "url";
 import { version as doenetmlVersion } from "./package.json";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const codemirrorSrc = path.resolve(__dirname, "../codemirror/src/index.ts");
+// `@doenet/codemirror`'s source entry point, in both forms this config needs
+// it: a root-relative POSIX glob for `optimizeDeps.entries`, and an absolute
+// path for the `resolve.alias` below. A glob that matches nothing is silent,
+// so check it once here and say what the silence would have cost.
+const codemirrorSrcEntry = "../codemirror/src/index.ts";
+const codemirrorSrc = path.resolve(__dirname, codemirrorSrcEntry);
+if (!fs.existsSync(codemirrorSrc)) {
+    throw new Error(
+        `optimizeDeps.entries lists "${codemirrorSrcEntry}", which does not ` +
+            "exist. Vite would go back to meeting the editor's dependencies " +
+            "while a spec is already loading and reloading the page out from " +
+            "under it (#1735). Update the path.",
+    );
+}
 
 export default defineConfig({
     // Match the policy `@doenet/test-cypress`, `@doenet/docs-cypress` and
@@ -103,12 +116,29 @@ export default defineConfig({
                         "@doenet/doenetml-worker",
                         "@doenet/codemirror",
                     ],
-                    // Aliasing `@doenet/codemirror` to source means Vite only
-                    // discovers its transitive deps when the first spec is
-                    // already loading, triggering a mid-flight reload that
-                    // aborts the spec's dynamic import (one spec fails, the
-                    // next passes). Pre-include them so the first scan
-                    // catches everything before any spec runs.
+                    // Give the dep scan a way into `@doenet/codemirror`
+                    // (#1735). `exclude` above matches the bare specifier
+                    // before the alias is applied, so the scanner externalizes
+                    // `@doenet/codemirror` on sight and never crawls the
+                    // source it actually resolves to — which leaves everything
+                    // reachable only through the editor's CodeMirror stack
+                    // undiscovered until a spec imports it for real. Vite then
+                    // re-optimizes mid-run and reloads the page, killing the
+                    // chunk request whichever spec was mounting is waiting on.
+                    // Naming the source root as an entry crawls it up front
+                    // instead.
+                    //
+                    // Cypress seeds `entries` with the spec files and the
+                    // support file, and Vite concatenates arrays when merging
+                    // the two configs, so this adds to that list rather than
+                    // replacing it. Nothing else needs naming: the scanner
+                    // does follow the `import()` in `EditorViewerLazy`, and
+                    // this is the only excluded module graph.
+                    entries: [codemirrorSrcEntry],
+                    // A floor under the scan. Every name here is a round of
+                    // the above from before the entry existed, and the entry
+                    // now reaches all of them, so this list should not need to
+                    // grow again — add an entry, not a name.
                     include: [
                         "@codemirror/state",
                         "@codemirror/view",
@@ -131,6 +161,8 @@ export default defineConfig({
                         // dynamic import.
                         "vscode-languageserver/browser",
                         "vscode-languageserver-protocol/browser",
+                        // Reached from `selection-highlight.ts` (#1735).
+                        "@codemirror/search",
                     ],
                 },
             },
@@ -156,14 +188,22 @@ export default defineConfig({
                     title,
                     attempt,
                     messages,
+                    diagnosis,
                 }: {
                     title: string;
                     attempt: number;
                     messages: string[];
+                    diagnosis: string | null;
                 }) {
                     console.log(
                         `\n--- app console during failing test (attempt ${attempt}): ${title}`,
                     );
+                    // Above the transcript rather than inside it: when
+                    // `component.ts` recognizes a failure shape, the reader
+                    // should not have to find the line it recognized.
+                    if (diagnosis) {
+                        console.log(`    *** ${diagnosis}`);
+                    }
                     if (messages.length === 0) {
                         // Said out loud rather than left as a missing block —
                         // see `component.ts`: silence is itself the answer to

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -15,8 +15,9 @@ const codemirrorSrcEntry = "../codemirror/src/index.ts";
 const codemirrorSrc = path.resolve(__dirname, codemirrorSrcEntry);
 if (!fs.existsSync(codemirrorSrc)) {
     throw new Error(
-        `optimizeDeps.entries lists "${codemirrorSrcEntry}", which does not ` +
-            "exist. Vite would go back to meeting the editor's dependencies " +
+        `optimizeDeps.entries and resolve.alias point at ` +
+            `"${codemirrorSrcEntry}", which does not exist. Vite would go ` +
+            "back to meeting the editor's dependencies " +
             "while a spec is already loading and reloading the page out from " +
             "under it (#1735). Update the path.",
     );
@@ -136,10 +137,13 @@ export default defineConfig({
                     // does follow the `import()` in `EditorViewerLazy`, and
                     // this is the only excluded module graph.
                     entries: [codemirrorSrcEntry],
-                    // A floor under the scan. Every name here is a round of
-                    // the above from before the entry existed, and the entry
-                    // now reaches all of them, so this list should not need to
-                    // grow again — add an entry, not a name.
+                    // A floor under the scan. Every name here is reachable
+                    // from the entry above — most were added one round at a
+                    // time before the entry existed, and `@codemirror/search`
+                    // alongside it — so the list is belt-and-braces rather
+                    // than the mechanism, and should not need to grow again.
+                    // If something new goes undiscovered, add an entry that
+                    // reaches it, not a name here.
                     include: [
                         "@codemirror/state",
                         "@codemirror/view",

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -7,19 +7,19 @@ import { version as doenetmlVersion } from "./package.json";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // `@doenet/codemirror`'s source entry point, in both forms this config needs
-// it: a path relative to the Vite root — this package directory — for
-// `optimizeDeps.entries`, which reads it as a glob, and an absolute path for
-// the `resolve.alias` below. A glob that matches nothing is silent, so check
-// it once here and say what the silence would have cost.
+// it: relative to the Vite root — this package directory — for
+// `optimizeDeps.entries`, which reads it as a glob, and absolute for the
+// `resolve.alias` below. An `entries` glob that matches nothing is silent, so
+// fail loudly here instead if the path ever stops resolving.
 const codemirrorSrcEntry = "../codemirror/src/index.ts";
 const codemirrorSrc = path.resolve(__dirname, codemirrorSrcEntry);
 if (!fs.existsSync(codemirrorSrc)) {
     throw new Error(
         `optimizeDeps.entries and resolve.alias point at ` +
-            `"${codemirrorSrcEntry}", which does not exist. Vite would go ` +
-            "back to meeting the editor's dependencies " +
-            "while a spec is already loading and reloading the page out from " +
-            "under it (#1735). Update the path.",
+            `"${codemirrorSrcEntry}", which does not exist. Without it the ` +
+            "editor's dependencies go undiscovered until a spec imports " +
+            "them, and the re-optimization reloads the page mid-spec " +
+            "(#1735). Update the path.",
     );
 }
 
@@ -135,15 +135,15 @@ export default defineConfig({
                     // the two configs, so this adds to that list rather than
                     // replacing it. Nothing else needs naming: the scanner
                     // does follow the `import()` in `EditorViewerLazy`, and
-                    // this is the only excluded module graph.
+                    // `@doenet/codemirror` is the only excluded package
+                    // aliased to source, so it is the only one whose graph the
+                    // scan would otherwise miss.
                     entries: [codemirrorSrcEntry],
                     // A floor under the scan. Every name here is reachable
-                    // from the entry above — most were added one round at a
-                    // time before the entry existed, and `@codemirror/search`
-                    // alongside it — so the list is belt-and-braces rather
-                    // than the mechanism, and should not need to grow again.
-                    // If something new goes undiscovered, add an entry that
-                    // reaches it, not a name here.
+                    // from the entry above, so the list is belt-and-braces
+                    // rather than the mechanism and should not need to grow:
+                    // if something new goes undiscovered, add an entry that
+                    // reaches it rather than a name here.
                     include: [
                         "@codemirror/state",
                         "@codemirror/view",

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -7,9 +7,10 @@ import { version as doenetmlVersion } from "./package.json";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // `@doenet/codemirror`'s source entry point, in both forms this config needs
-// it: a root-relative POSIX glob for `optimizeDeps.entries`, and an absolute
-// path for the `resolve.alias` below. A glob that matches nothing is silent,
-// so check it once here and say what the silence would have cost.
+// it: a path relative to the Vite root — this package directory — for
+// `optimizeDeps.entries`, which reads it as a glob, and an absolute path for
+// the `resolve.alias` below. A glob that matches nothing is silent, so check
+// it once here and say what the silence would have cost.
 const codemirrorSrcEntry = "../codemirror/src/index.ts";
 const codemirrorSrc = path.resolve(__dirname, codemirrorSrcEntry);
 if (!fs.existsSync(codemirrorSrc)) {
@@ -145,6 +146,8 @@ export default defineConfig({
                         "@codemirror/language",
                         "@codemirror/lint",
                         "@codemirror/autocomplete",
+                        // Reached from `selection-highlight.ts` (#1735).
+                        "@codemirror/search",
                         "@uiw/react-codemirror",
                         "@lezer/highlight",
                         "@qualified/lsp-connection",
@@ -161,8 +164,6 @@ export default defineConfig({
                         // dynamic import.
                         "vscode-languageserver/browser",
                         "vscode-languageserver-protocol/browser",
-                        // Reached from `selection-highlight.ts` (#1735).
-                        "@codemirror/search",
                     ],
                 },
             },

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -40,6 +40,31 @@ Cypress.Commands.add("mount", mount);
 /** Enough for a full boot ladder's narration without flooding the log. */
 const MAX_BUFFERED_MESSAGES = 100;
 
+/**
+ * The wording `importRendererWithRetry` and the browsers use when a chunk
+ * fetch fails — kept loose for the same reason
+ * `isTransientDynamicImportError` keeps its regexes loose.
+ */
+const CHUNK_LOAD_FAILURE_RE =
+    /dynamically imported module|module script failed/i;
+
+/**
+ * What a chunk-load failure gets called when one shows up in a failing test's
+ * transcript (#1735).
+ *
+ * It is worth naming because it is indistinguishable at a glance from the
+ * boot-timing flakes these diagnostics were built for (#1719, #1612): in both,
+ * the viewer or editor renders nothing and every assertion burns its full
+ * timeout. The cause is not a boot at all — Vite met a dependency for the
+ * first time mid-run, re-optimized, and reloaded the page, killing the chunk
+ * request in flight. Retrying cannot win, because the URL stays dead until the
+ * page reloads.
+ */
+const CHUNK_LOAD_DIAGNOSIS =
+    "a renderer chunk failed to fetch — this is a chunk-load failure, not a " +
+    "boot flake. Check whether Vite re-optimized dependencies mid-run and " +
+    "see #1735 (cypress.config.ts `optimizeDeps`).";
+
 let bufferedMessages: string[] = [];
 /**
  * When the current buffer started, so each line can carry the elapsed time
@@ -144,6 +169,11 @@ afterEach(function () {
         "printAppConsole",
         {
             title: this.currentTest.fullTitle(),
+            diagnosis: messages.some((message) =>
+                CHUNK_LOAD_FAILURE_RE.test(message),
+            )
+                ? CHUNK_LOAD_DIAGNOSIS
+                : null,
             // Retries mean the same title can print up to three times in one
             // run; number the attempts so the transcripts can be told apart —
             // and so "attempt 1 timed out, attempt 2 never started a worker"

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -1,5 +1,6 @@
 // Cypress component support file for DoenetML tests.
 import { mount } from "cypress/react";
+import { isTransientDynamicImportError } from "../../../src/Viewer/renderersLoadComponent";
 
 declare global {
     namespace Cypress {
@@ -39,14 +40,6 @@ Cypress.Commands.add("mount", mount);
 
 /** Enough for a full boot ladder's narration without flooding the log. */
 const MAX_BUFFERED_MESSAGES = 100;
-
-/**
- * The wording `importRendererWithRetry` and the browsers use when a chunk
- * fetch fails — kept loose for the same reason
- * `isTransientDynamicImportError` keeps its regexes loose.
- */
-const CHUNK_LOAD_FAILURE_RE =
-    /dynamically imported module|module script failed/i;
 
 /**
  * What a chunk-load failure gets called when one shows up in a failing test's
@@ -169,9 +162,10 @@ afterEach(function () {
         "printAppConsole",
         {
             title: this.currentTest.fullTitle(),
-            diagnosis: messages.some((message) =>
-                CHUNK_LOAD_FAILURE_RE.test(message),
-            )
+            // Same recognizer the retry path uses, so the two never disagree
+            // about what counts as a chunk-load failure; it takes `unknown`,
+            // and a buffered line is already the message text.
+            diagnosis: messages.some(isTransientDynamicImportError)
                 ? CHUNK_LOAD_DIAGNOSIS
                 : null,
             // Retries mean the same title can print up to three times in one


### PR DESCRIPTION
Closes #1735.

## The cause

Not the lazy editor boundary itself, and not `@codemirror/search` in particular — it is `optimizeDeps.exclude`.

Vite's dep scanner checks `exclude` against the **bare specifier**, before `resolve.alias` is applied:

```js
build.onResolve({ filter: /^[\w@][^:]/ }, async ({ path: id, importer }) => {
    if (moduleListContains(exclude, id)) return externalUnlessEntry({ path: id });
    ...
```

`packages/doenetml/cypress.config.ts` both aliases `@doenet/codemirror` to source *and* lists it in `exclude`, so the scanner externalizes it on sight and never crawls the source it would have resolved to. Everything reachable only through the editor's CodeMirror stack is therefore invisible at scan time — it is met for the first time when a spec imports it for real, Vite re-optimizes, and the reload kills the chunk request the mounting spec is waiting on.

That is the same root cause behind all four rounds of the hand-maintained `include` list, not just this one. Measured, with a cold `node_modules/.vite` and `include` emptied:

| config | deps found at scan time |
|---|---|
| as on `main` | 32 |
| `@doenet/codemirror` dropped from `exclude` | 42 |
| `../codemirror/src/index.ts` added to `entries` | 42 |

The 10 names the entry adds are drawn from the `include` list plus
`@codemirror/search`; that is 12 names, so two of them were already being
found some other way and the entry accounts for the rest.

## The fix

Add the CodeMirror source root to `optimizeDeps.entries`. That is fix option **#2** from the issue, and it subsumes **#1** — but `@codemirror/search` is added to `include` as well, so the floor stays complete.

Two adjustments to the issue's sketch, both from measurement:

- **`src/EditorViewer/EditorViewer.tsx` is not needed as an entry.** esbuild's scanner *does* follow the `import()` in `EditorViewerLazy`; naming that file adds exactly zero deps to the scan, with or without `--spec` narrowing. The `exclude` short-circuit is the whole gap, so the CodeMirror source root is the only entry that does anything.
- **A glob that matches nothing is silent**, which would quietly restore the old behaviour if either path ever moves. The config now throws at load if the entry path stops matching a file.

Cypress seeds `entries` with the spec files and support file, and Vite concatenates arrays when merging the two configs, so this adds to that list rather than replacing it.

## Verification

`DoenetEditor.diagnosticHoverLocale.cy.tsx`, `--spec`-narrowed against a cold `node_modules/.vite/deps` — the run the issue reports as unlucky:

**Before** — 0 passing, 4 failing:

```
[vite] (client) ✨ new dependencies optimized: @codemirror/search
[vite] (client) ✨ optimized dependencies changed. reloading
    +4119ms [warn] Transient failure loading renderer "EditorViewer" — retrying (3 left). TypeError: Failed to fetch dynamically imported module: .../EditorViewer.tsx
    +4221ms [warn] Transient failure loading renderer "EditorViewer" — retrying (2 left). ...
    +4432ms [warn] Transient failure loading renderer "EditorViewer" — retrying (1 left). ...
```

**After** — 4 passing, 0 failing, no re-optimization line.

The scan itself was measured separately by standing up the same merged Vite config Cypress produces and reading `node_modules/.vite/deps/_metadata.json`; a `--spec`-narrowed run now finds the same 42 deps as the full suite, where before it found 32.

## Naming the failure (issue option #4)

Only the diagnostic half. A failing test whose buffered console carries a chunk-load failure now says so *above* its transcript:

```
--- app console during failing test (attempt 1): ...
    *** a renderer chunk failed to fetch — this is a chunk-load failure, not a boot flake. Check whether Vite re-optimized dependencies mid-run and see #1735 (cypress.config.ts `optimizeDeps`).
    +43ms [warn] Transient failure loading renderer "EditorViewer" — retrying (3 left). ...
```

The shape is recognized by `isTransientDynamicImportError` — the same function the renderer retry path uses to decide a fetch failure is transient — applied to the buffered console lines, so the diagnosis and the retry cannot drift apart on what counts as a chunk-load failure.

It fires only on an already-failing test, and only on that failure shape (verified both ways with a throwaway probe spec). I did **not** make a chunk-load failure a hard error: a trip that exhausts the retries fails the test anyway, and failing on a retry that *succeeded* would turn green runs red — which is the opposite of what the issue is trying to buy.

## Not touched

`packages/doenetml-iframe/cypress.config.ts` has its own `include` list, but for a different cause (a `--spec`-narrowed run leaving a partial cache), not the `exclude`-blocks-the-alias one fixed here.

No changeset: test configuration only, nothing published changes. `#1733`, the analogous test-only change, carried none either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


