### PR TITLE
Offer a retry when a document's core cannot be started

### DIFF
--- a/.changeset/core-start-retry.md
+++ b/.changeset/core-start-retry.md
@@ -12,6 +12,6 @@ The failure pane advised reloading the page, which is the wrong advice on the pa
 
 A failed document now offers **Try again**, which starts that one document over — a fresh saved-state load and boot ladder, without reloading the page or re-parsing the bundle — and shows that it is working rather than leaving a blank pane while it boots. The message beside the button leaves out the reload advice, and still names contention when that is what the failure is attributable to.
 
-The offer is made once. A retry that fails too is shown the previous message, whose advice to reload is by then the honest next step, and no further button — so the reader is never left clicking at a document that will not start.
+The offer is made once per document. A retry that fails too is shown the previous message, whose advice to reload is by then the honest next step, and no further button — so the reader is never left clicking at a document that will not start. A viewer handed a different document — an editor recompile, a host moving on to the next activity — starts the count over.
 
 A boot-scheduling host needs no changes to keep up: a retry that succeeds reports `initializedCallback` as any boot does, which is what clears the `failed` mark the `@doenet/standalone` coordinator put on the activity, and a retry that fails reports `coreStartFailedCallback` again.

--- a/.changeset/core-start-retry.md
+++ b/.changeset/core-start-retry.md
@@ -14,4 +14,6 @@ A failed document now offers **Try again**, which starts that one document over 
 
 The offer is made once per document. A retry that fails too is shown the previous message, whose advice to reload is by then the honest next step, and no further button — so the reader is never left clicking at a document that will not start. A viewer handed a different document — an editor recompile, a host moving on to the next activity — starts the count over.
 
+A message raised while a document was still starting no longer outlives it: a host that reports it cannot produce the saved state puts its message where the document would be, and a document that then starts is no longer left behind it.
+
 A boot-scheduling host needs no changes to keep up: a retry that succeeds reports `initializedCallback` as any boot does, which is what clears the `failed` mark the `@doenet/standalone` coordinator put on the activity, and a retry that fails reports `coreStartFailedCallback` again.

--- a/.changeset/core-start-retry.md
+++ b/.changeset/core-start-retry.md
@@ -14,6 +14,8 @@ A failed document now offers **Try again**, which starts that one document over 
 
 The offer is made once per document. A retry that fails too is shown the previous message, whose advice to reload is by then the honest next step, and no further button — so the reader is never left clicking at a document that will not start. A viewer handed a different document — an editor recompile, a host moving on to the next activity — starts the count over.
 
+Both panes are announced now, since a reader who cannot see them is otherwise told nothing about what their click did: the button removes itself when clicked, so the "Initializing…" pane that replaces it reports politely that the retry is working, and the failure pane interrupts the way a failed renderer already does.
+
 A message raised while a document was still starting no longer outlives it: a host that reports it cannot produce the saved state puts its message where the document would be, and a document that then starts is no longer left behind it.
 
 A boot-scheduling host needs no changes to keep up: a retry that succeeds reports `initializedCallback` as any boot does, which is what clears the `failed` mark the `@doenet/standalone` coordinator put on the activity, and a retry that fails reports `coreStartFailedCallback` again.

--- a/.changeset/core-start-retry.md
+++ b/.changeset/core-start-retry.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Offer a retry when a document's core cannot be started.
+
+The failure pane advised reloading the page, which is the wrong advice on the page that produces most of these failures: a section that starts many documents at once on a slow device. Reloading restarts all of them, and the reader who tried it was worse off the second time.
+
+A failed document now offers **Try again**, which starts that one document over — a fresh saved-state load and boot ladder, without reloading the page or re-parsing the bundle — and shows that it is working rather than leaving a blank pane while it boots. The message beside the button leaves out the reload advice, and still names contention when that is what the failure is attributable to.
+
+The offer is made once. A retry that fails too is shown the previous message, whose advice to reload is by then the honest next step, and no further button — so the reader is never left clicking at a document that will not start.
+
+A boot-scheduling host needs no changes to keep up: a retry that succeeds reports `initializedCallback` as any boot does, which is what clears the `failed` mark the `@doenet/standalone` coordinator put on the activity, and a retry that fails reports `coreStartFailedCallback` again.

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -20,6 +20,7 @@ import type { DiagnosticRecord, ReaderStyleOverrides } from "@doenet/utils";
 import * as Comlink from "comlink";
 
 import { MdError } from "react-icons/md";
+import { UiButton } from "@doenet/ui-components";
 import { get as idb_get } from "idb-keyval";
 import { createCoreWorker, initializeCoreWorker } from "../utils/docUtils";
 import {
@@ -59,6 +60,9 @@ import {
     retryDelayMs,
     CORE_START_FAILED_MESSAGE,
     CORE_START_FAILED_BUSY_MESSAGE,
+    CORE_START_FAILED_RETRY_MESSAGE,
+    CORE_START_FAILED_BUSY_RETRY_MESSAGE,
+    CORE_START_RETRY_MESSAGE,
 } from "./coreWorkerBoot";
 import type { ResolvedTheme } from "../utils/theme";
 import {
@@ -582,6 +586,31 @@ export function DocViewer({
     // carries describe the message, not the English already substituted in.
     const rawDiagnostics = useRef<DiagnosticRecord[]>([]);
     const [hasInitialError, setHasInitialError] = useState(false);
+
+    // A core start the reader asked to try again (#1712).
+    //
+    //  - "offered" — a failure is on screen and still has a retry to give.
+    //    Set by `failCoreStart`, for the first failure only: a retry that
+    //    fails too is shown the terminal message, which advises the reload
+    //    that by then really is the next thing to try.
+    //  - "running" — a retry is booting. The viewer renders nothing at stage
+    //    `"wait"`, so without this a click would blank the pane for as long
+    //    as the boot takes, which reads as the error getting worse.
+    const [coreStartRetry, setCoreStartRetry] = useState<
+        "none" | "offered" | "running"
+    >("none");
+    // Bumped by the retry button, and compared below like any other rebuild
+    // input. Nothing about the document changes on a retry, so the counter is
+    // the whole trigger: it routes the retry through the same rebuild
+    // sequence a changed `doenetML` takes — re-roll `coreId`, drop the old
+    // renderer, re-load saved state, run a fresh boot ladder — rather than
+    // adding a second way to start a core. Held in state (not a ref) because
+    // the click has to re-render for the comparison to run.
+    const [retryGeneration, setRetryGeneration] = useState(0);
+    // The render-phase mirror of `retryGeneration`, which doubles as the count
+    // of retries the reader has spent. `failCoreStart` runs from async boot
+    // code whose closure predates the click, so it reads the tally here.
+    const lastRetryGeneration = useRef(0);
 
     type DeferredCoreAction = {
         actionName: string;
@@ -2228,21 +2257,90 @@ export function DocViewer({
     }: { contended?: boolean } = {}) {
         coreCreationInProgress.current = false;
         setIsInErrorState?.(true);
+        // The first failure offers the reader a button and a message with no
+        // reload advice in it; a failure that has already been retried is
+        // terminal and shows the message that advises the reload (#1712).
+        // Bounding it at one is what keeps the reader out of a loop they
+        // cannot win, and it is why the reload advice keeps a home — and its
+        // translations, which the retry-flavored messages do not have yet.
+        const retryAvailable = lastRetryGeneration.current === 0;
         setErrMsg(
-            contended
-                ? translate(
-                      "core-start-failed-busy",
-                      undefined,
-                      CORE_START_FAILED_BUSY_MESSAGE,
-                  )
-                : translate(
-                      "core-start-failed",
-                      undefined,
-                      CORE_START_FAILED_MESSAGE,
-                  ),
+            retryAvailable
+                ? contended
+                    ? translate(
+                          "core-start-failed-busy-retry",
+                          undefined,
+                          CORE_START_FAILED_BUSY_RETRY_MESSAGE,
+                      )
+                    : translate(
+                          "core-start-failed-retry",
+                          undefined,
+                          CORE_START_FAILED_RETRY_MESSAGE,
+                      )
+                : contended
+                  ? translate(
+                        "core-start-failed-busy",
+                        undefined,
+                        CORE_START_FAILED_BUSY_MESSAGE,
+                    )
+                  : translate(
+                        "core-start-failed",
+                        undefined,
+                        CORE_START_FAILED_MESSAGE,
+                    ),
         );
+        setCoreStartRetry(retryAvailable ? "offered" : "none");
         setHasInitialError(true);
         reportCoreStartFailed();
+    }
+
+    /**
+     * Start this document over at the reader's request (#1712), without
+     * reloading the page.
+     *
+     * Stacking is not possible by construction: the button lives in the
+     * failure pane, and the rebuild this schedules clears `errMsg` in the
+     * very next render, so a second click has nothing to land on. Two clicks
+     * inside one React batch collapse into a single rebuild, since it is the
+     * *change* in `retryGeneration` that triggers one.
+     *
+     * Nothing here asks a boot-scheduling host for a slot. The gates that
+     * exist (`coordinator.ts`, `viewer-lifecycle-manager`) live in the parent
+     * realm and gate mounting, not re-booting, and none of them accepts such
+     * a request; what a retry is measured against instead is the
+     * contention-scaled handshake watchdog (#1711), which counts a retry's
+     * handshake in the page-wide census like any other. A coordinator hears
+     * how this ends the usual way: `bootComplete` clears the `failed` mark it
+     * put on the realm, and `bootFailed` arrives again for a retry that fails
+     * because the report latch is keyed on the re-rolled `coreId` (#1721).
+     */
+    function retryCoreStart() {
+        setCoreStartRetry("running");
+        setRetryGeneration((generation) => generation + 1);
+    }
+
+    /**
+     * What a document shows while it has nothing to render yet. Used both
+     * where a booting core has produced no renderer and while a
+     * reader-initiated retry is running (#1712).
+     */
+    function initializingPane() {
+        return (
+            <div
+                style={{
+                    backgroundColor: "var(--canvas)",
+                    color: "var(--canvasText)",
+                }}
+            >
+                <p>
+                    {translate(
+                        "viewer-initializing",
+                        undefined,
+                        "Initializing...",
+                    )}
+                </p>
+            </div>
+        );
     }
 
     /**
@@ -2757,6 +2855,9 @@ export function DocViewer({
             });
         }
         setStage("coreCreated");
+        // Whatever the reader retried is on screen now. (A no-op for every
+        // boot nobody asked to retry: React bails out on an unchanged value.)
+        setCoreStartRetry("none");
         initializedCallback?.({ activityId, docId });
     }
 
@@ -3019,6 +3120,11 @@ export function DocViewer({
         return null;
     }
 
+    if (lastRetryGeneration.current !== retryGeneration) {
+        lastRetryGeneration.current = retryGeneration;
+        changedState = true;
+    }
+
     if (lastDoenetML.current !== doenetML) {
         lastDoenetML.current = doenetML;
         changedState = true;
@@ -3137,12 +3243,27 @@ export function DocViewer({
                 }}
             >
                 <MdError color="red" fontSize={"24pt"} /> {errMsg}
+                {coreStartRetry === "offered" ? (
+                    <div style={{ marginTop: "0.5em" }}>
+                        <UiButton onClick={retryCoreStart}>
+                            {translate(
+                                "core-start-retry",
+                                undefined,
+                                CORE_START_RETRY_MESSAGE,
+                            )}
+                        </UiButton>
+                    </div>
+                ) : null}
             </div>
         );
     }
 
     if (stage === "wait") {
-        return null;
+        // A rebuild is under way and there is nothing to show for it yet.
+        // Blank is right for one the reader did not ask for — an editor
+        // recompile, a locale switch — but a retry they clicked has to show
+        // that it is working, or the failure pane just vanishes (#1712).
+        return coreStartRetry === "running" ? initializingPane() : null;
     }
 
     if (stage === "readyToCreateCore" && render) {
@@ -3182,22 +3303,7 @@ export function DocViewer({
     };
     if (!coreCreated.current) {
         if (!documentRenderer) {
-            noCoreWarning = (
-                <div
-                    style={{
-                        backgroundColor: "var(--canvas)",
-                        color: "var(--canvasText)",
-                    }}
-                >
-                    <p>
-                        {translate(
-                            "viewer-initializing",
-                            undefined,
-                            "Initializing...",
-                        )}
-                    </p>
-                </div>
-            );
+            noCoreWarning = initializingPane();
         }
     }
 

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -590,18 +590,13 @@ export function DocViewer({
     // A core start the reader asked to try again (#1712).
     //
     //  - "offered" — a failure is on screen and still has a retry to give.
-    //    Set by `failCoreStart`, for the first failure only: a retry that
-    //    fails too is shown the terminal message, which advises the reload
-    //    that by then really is the next thing to try. The offer belongs to
-    //    that one message, so `showFailureMessage` retires it whenever some
-    //    other error takes the pane over — a host that cannot produce saved
-    //    state names a cause a fresh core start would meet again.
-    //  - "running" — a retry is booting. The viewer renders nothing at stage
-    //    `"wait"`, so without this a click would blank the pane for as long
-    //    as the boot takes, which reads as the error getting worse. Set from
-    //    the rebuild itself rather than from the click, so that it describes
-    //    the rebuild actually in flight: a rebuild the reader did not ask for
-    //    clears it back to "none" and goes back to rendering nothing.
+    //    Raised by `failCoreStart` for a first failure, and retired by
+    //    `showFailureMessage` for any later message; see there for why the
+    //    offer must not outlive the message it was raised with.
+    //  - "running" — a retry is booting. A viewer at stage `"wait"` renders
+    //    nothing, so without this a click would blank the pane for as long as
+    //    the boot takes, which reads as the error getting worse. Set by the
+    //    rebuild rather than by the click — see the rebuild below.
     const [coreStartRetry, setCoreStartRetry] = useState<
         "none" | "offered" | "running"
     >("none");
@@ -611,22 +606,21 @@ export function DocViewer({
     // sequence a changed `doenetML` takes — re-roll `coreId`, drop the old
     // renderer, re-load saved state, run a fresh boot ladder — rather than
     // adding a second way to start a core. Held in state (not a ref) because
-    // the click has to re-render for the comparison to run.
+    // the click has to re-render for the comparison to run;
+    // `lastRetryGeneration` is its render-phase mirror, compared the way
+    // `lastDoenetML` is compared against `doenetML`.
     const [retryGeneration, setRetryGeneration] = useState(0);
-    // The render-phase mirror of `retryGeneration`, compared against it the
-    // way `lastDoenetML` is compared against `doenetML`.
     const lastRetryGeneration = useRef(0);
     // Whether the reader has already spent their retry on the document now on
-    // screen. Kept in a ref because `failCoreStart` runs from async boot code
-    // whose closure predates the click, and cleared by every rebuild the
-    // reader did not ask for — a new source, a new attempt, a locale switch
-    // is a different document, and its first failure gets its own offer.
+    // screen. A ref because `failCoreStart` runs from async boot code whose
+    // closure predates the click.
     //
-    // The rebuild the `SPLICE.getState` listener runs is deliberately NOT one
-    // of those, which is why it clears `errMsg` without touching this. That
-    // rebuild adopts an answer to the request THIS document has open, and
-    // after a retry the open request is the one the retry itself posted — the
-    // reader's own state load landing late, not a document handed to the
+    // Every rebuild the reader did not ask for clears it (see the rebuild
+    // below) — with one deliberate exception, which is why the rebuild the
+    // `SPLICE.getState` listener runs clears `errMsg` without touching this.
+    // That rebuild adopts an answer to the request THIS document has open,
+    // and after a retry the open request is the one the retry itself posted —
+    // the reader's own state load landing late, not a document handed to the
     // viewer from outside. Restoring the retry there would hand a fresh
     // button to every failure on any host that answers with saved state,
     // which is most of them, and the bound would stop bounding anything.
@@ -2297,12 +2291,10 @@ export function DocViewer({
         contended = false,
     }: { contended?: boolean } = {}) {
         coreCreationInProgress.current = false;
-        // The first failure offers the reader a button and a message with no
-        // reload advice in it; a failure that has already been retried is
-        // terminal and shows the message that advises the reload (#1712).
-        // Bounding it at one is what keeps the reader out of a loop they
-        // cannot win, and it is why the reload advice keeps a home — and its
-        // translations, which the retry-flavored messages do not have yet.
+        // The first failure offers the reader a button, beside a message with
+        // no reload advice in it; a failure that has already been retried is
+        // terminal and gets the message that advises the reload — which is
+        // also what keeps that message, and its translations, in use (#1712).
         //
         // The four messages are spelled out as four literal `translate` calls
         // because a computed key is invisible to `lint:i18n`, which reads
@@ -2341,12 +2333,9 @@ export function DocViewer({
 
     /**
      * Start this document over at the reader's request (#1712), without
-     * reloading the page.
-     *
-     * Bumping the counter is the whole of it: the render below reads the bump
-     * as a rebuild input, and running the rebuild from there rather than from
-     * here is what keeps `coreStartRetry` describing the rebuild actually in
-     * flight rather than a click whose rebuild some other one superseded.
+     * reloading the page. Bumping the counter is the whole of it: the render
+     * below reads the bump as a rebuild input and runs the rebuild from
+     * there.
      *
      * Stacking is not possible by construction: the button lives in the
      * failure pane, and the rebuild this schedules clears `errMsg` in the
@@ -2354,15 +2343,12 @@ export function DocViewer({
      * inside one React batch collapse into a single rebuild, since it is the
      * *change* in `retryGeneration` that triggers one.
      *
-     * Nothing here asks a boot-scheduling host for a slot. The gates that
+     * Nothing here asks a boot-scheduling host for a slot: the gates that
      * exist (`coordinator.ts`, `viewer-lifecycle-manager`) live in the parent
-     * realm and gate mounting, not re-booting, and none of them accepts such
-     * a request; what a retry is measured against instead is the
-     * contention-scaled handshake watchdog (#1711), which counts a retry's
-     * handshake in the page-wide census like any other. A coordinator hears
-     * how this ends the usual way: `bootComplete` clears the `failed` mark it
-     * put on the realm, and `bootFailed` arrives again for a retry that fails
-     * because the report latch is keyed on the re-rolled `coreId` (#1721).
+     * realm, gate mounting rather than re-booting, and accept no such request
+     * from a child. What bounds a retry instead is the contention-scaled
+     * handshake watchdog (#1711), which counts its handshake in the page-wide
+     * census like any other.
      */
     function retryCoreStart() {
         setRetryGeneration((generation) => generation + 1);
@@ -2903,8 +2889,9 @@ export function DocViewer({
             });
         }
         setStage("coreCreated");
-        // Whatever the reader retried is on screen now. (A no-op for every
-        // boot nobody asked to retry: React bails out on an unchanged value.)
+        // A retry that got this far is over: the boot it ran has produced
+        // whatever it is going to. (A no-op for every boot nobody asked to
+        // retry: React bails out on an unchanged value.)
         setCoreStartRetry("none");
         initializedCallback?.({ activityId, docId });
     }
@@ -3237,9 +3224,10 @@ export function DocViewer({
         // they asked for, and gets a fresh one with a document they didn't.
         retrySpent.current = retriedByReader;
         // And only the rebuild they asked for shows that it is working; every
-        // other one goes back to rendering nothing while it runs. Setting this
-        // here rather than in the click handler is what retires a "running"
-        // that some later rebuild superseded.
+        // other one goes back to rendering nothing while it runs. Set here
+        // rather than in the click handler so the flag describes the rebuild
+        // actually in flight, retiring a "running" that a later rebuild
+        // superseded.
         setCoreStartRetry(retriedByReader ? "running" : "none");
 
         coreId.current = nanoid();
@@ -3304,7 +3292,7 @@ export function DocViewer({
                 {/* The failure pane is shown whether or not this viewer is
                     rendering its document — a host that has set `render`
                     false still wants to hear that the document failed — but
-                    the button is offered only to one that is. A viewer at
+                    the button is offered only to one that is: a viewer at
                     `render={false}` never starts a core (see the launch site
                     below), so a retry there would trade the message for a
                     rebuild that boots nothing. Gated here rather than where
@@ -3330,9 +3318,7 @@ export function DocViewer({
         // Blank is right for one the reader did not ask for — an editor
         // recompile, a locale switch — but a retry they clicked has to show
         // that it is working, or the failure pane just vanishes (#1712).
-        // Only for a viewer that renders its document at all, the same
-        // condition the button was offered under and the one the pane's other
-        // use (`noCoreWarning`) sits below.
+        // Gated on `render` for the same reason the button above is.
         return coreStartRetry === "running" && render
             ? initializingPane()
             : null;

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -621,6 +621,15 @@ export function DocViewer({
     // whose closure predates the click, and cleared by every rebuild the
     // reader did not ask for — a new source, a new attempt, a locale switch
     // is a different document, and its first failure gets its own offer.
+    //
+    // The rebuild the `SPLICE.getState` listener runs is deliberately NOT one
+    // of those, which is why it clears `errMsg` without touching this. That
+    // rebuild adopts an answer to the request THIS document has open, and
+    // after a retry the open request is the one the retry itself posted — the
+    // reader's own state load landing late, not a document handed to the
+    // viewer from outside. Restoring the retry there would hand a fresh
+    // button to every failure on any host that answers with saved state,
+    // which is most of them, and the bound would stop bounding anything.
     const retrySpent = useRef(false);
 
     type DeferredCoreAction = {
@@ -3292,7 +3301,16 @@ export function DocViewer({
                 }}
             >
                 <MdError color="red" fontSize={"24pt"} /> {errMsg}
-                {coreStartRetry === "offered" ? (
+                {/* The failure pane is shown whether or not this viewer is
+                    rendering its document — a host that has set `render`
+                    false still wants to hear that the document failed — but
+                    the button is offered only to one that is. A viewer at
+                    `render={false}` never starts a core (see the launch site
+                    below), so a retry there would trade the message for a
+                    rebuild that boots nothing. Gated here rather than where
+                    the offer is made, so the button appears if the host later
+                    asks for the document. */}
+                {coreStartRetry === "offered" && render ? (
                     <div style={{ marginTop: "0.5em" }}>
                         <UiButton onClick={retryCoreStart}>
                             {translate(
@@ -3312,7 +3330,12 @@ export function DocViewer({
         // Blank is right for one the reader did not ask for — an editor
         // recompile, a locale switch — but a retry they clicked has to show
         // that it is working, or the failure pane just vanishes (#1712).
-        return coreStartRetry === "running" ? initializingPane() : null;
+        // Only for a viewer that renders its document at all, the same
+        // condition the button was offered under and the one the pane's other
+        // use (`noCoreWarning`) sits below.
+        return coreStartRetry === "running" && render
+            ? initializingPane()
+            : null;
     }
 
     if (stage === "readyToCreateCore" && render) {

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -2387,6 +2387,14 @@ export function DocViewer({
     function initializingPane() {
         return (
             <div
+                // Announced, because this pane can be an *answer*: the retry
+                // button removes itself when clicked (#1712), taking the
+                // reader's focus with it, so a reader who cannot see the pane
+                // that replaced it would otherwise be told nothing at all
+                // about what their click did. Polite rather than assertive —
+                // it reports progress, and the outcome that follows is what
+                // interrupts (see the failure pane's `role="alert"`).
+                role="status"
                 style={{
                     backgroundColor: "var(--canvas)",
                     color: "var(--canvasText)",
@@ -3298,6 +3306,12 @@ export function DocViewer({
     if (errMsg !== null) {
         return (
             <div
+                // The failure of a document is worth interrupting for, the
+                // same way `RendererLoadFailed` is: this pane replaces the
+                // document (or, after a retry, the pane that said the retry
+                // was working), and nothing else says so to a reader who
+                // cannot see it.
+                role="alert"
                 style={{
                     backgroundColor: "var(--lightRed)",
                     color: "var(--canvasText)",
@@ -3310,7 +3324,10 @@ export function DocViewer({
                     padding: "0.5em",
                 }}
             >
-                <MdError color="red" fontSize={"24pt"} /> {errMsg}
+                {/* Decorative: the message beside it says the same
+                    thing, and the alert above carries it. */}
+                <MdError aria-hidden="true" color="red" fontSize={"24pt"} />{" "}
+                {errMsg}
                 {/* The failure pane is shown whether or not this viewer is
                     rendering its document — a host that has set `render`
                     false still wants to hear that the document failed — but

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -607,10 +607,15 @@ export function DocViewer({
     // adding a second way to start a core. Held in state (not a ref) because
     // the click has to re-render for the comparison to run.
     const [retryGeneration, setRetryGeneration] = useState(0);
-    // The render-phase mirror of `retryGeneration`, which doubles as the count
-    // of retries the reader has spent. `failCoreStart` runs from async boot
-    // code whose closure predates the click, so it reads the tally here.
+    // The render-phase mirror of `retryGeneration`, compared against it the
+    // way `lastDoenetML` is compared against `doenetML`.
     const lastRetryGeneration = useRef(0);
+    // Whether the reader has already spent their retry on the document now on
+    // screen. Kept in a ref because `failCoreStart` runs from async boot code
+    // whose closure predates the click, and cleared by every rebuild the
+    // reader did not ask for — a new source, a new attempt, a locale switch
+    // is a different document, and its first failure gets its own offer.
+    const retrySpent = useRef(false);
 
     type DeferredCoreAction = {
         actionName: string;
@@ -2263,7 +2268,11 @@ export function DocViewer({
         // Bounding it at one is what keeps the reader out of a loop they
         // cannot win, and it is why the reload advice keeps a home — and its
         // translations, which the retry-flavored messages do not have yet.
-        const retryAvailable = lastRetryGeneration.current === 0;
+        //
+        // The four messages are spelled out as four literal `translate` calls
+        // because a computed key is invisible to `lint:i18n`, which reads
+        // string literals only (see `collectCallSites` in `@doenet/i18n`).
+        const retryAvailable = !retrySpent.current;
         setErrMsg(
             retryAvailable
                 ? contended
@@ -3120,8 +3129,10 @@ export function DocViewer({
         return null;
     }
 
+    let retriedByReader = false;
     if (lastRetryGeneration.current !== retryGeneration) {
         lastRetryGeneration.current = retryGeneration;
+        retriedByReader = true;
         changedState = true;
     }
 
@@ -3183,6 +3194,9 @@ export function DocViewer({
             setErrMsg(null);
             setIsInErrorState?.(false);
         }
+        // One retry per document: the reader spends theirs on the rebuild
+        // they asked for, and gets a fresh one with a document they didn't.
+        retrySpent.current = retriedByReader;
 
         coreId.current = nanoid();
         // A request the previous document made is not this one's to have

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -2284,6 +2284,31 @@ export function DocViewer({
         setCoreStartRetry(offerRetry ? "offered" : "none");
     }
 
+    /**
+     * Take down a failure pane raised while this document was still starting,
+     * now that it has started.
+     *
+     * The pane covers the document rather than sitting beside it, so a message
+     * that outlives what it described hides a working document — and a
+     * `SPLICE.getState` answer keeps its own schedule: the boot posts the
+     * request and does not wait for it (see `requestStateViaSplice`), so a
+     * host reporting that it cannot produce the saved state can land anywhere
+     * in a perfectly healthy boot, including inside a retry the reader asked
+     * for. What that message described — a document with no core — stopped
+     * being true here; what the core has to say about itself (its diagnostics,
+     * its error banner) speaks for the document from now on.
+     *
+     * Only what a boot can supersede is cleared. A message arriving *after*
+     * the document is on screen still takes it away, which is #1741 rather
+     * than this: fixing it needs somewhere non-destructive to put what the
+     * host said, and that is a question about the pane itself.
+     */
+    function clearFailureMessage() {
+        setIsInErrorState?.(false);
+        setErrMsg(null);
+        setCoreStartRetry("none");
+    }
+
     // Put the viewer into a visible "core failed to start" error state rather
     // than leaving it blank at stage "wait" forever (Doenet/DoenetApps#2957).
     // Shared by every core-start failure path.
@@ -2839,6 +2864,7 @@ export function DocViewer({
         }
 
         if (dastResult.success) {
+            clearFailureMessage();
             if (
                 coreInfo.current &&
                 JSON.stringify(coreInfo.current) ===
@@ -2889,10 +2915,6 @@ export function DocViewer({
             });
         }
         setStage("coreCreated");
-        // A retry that got this far is over: the boot it ran has produced
-        // whatever it is going to. (A no-op for every boot nobody asked to
-        // retry: React bails out on an unchanged value.)
-        setCoreStartRetry("none");
         initializedCallback?.({ activityId, docId });
     }
 

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -592,10 +592,16 @@ export function DocViewer({
     //  - "offered" — a failure is on screen and still has a retry to give.
     //    Set by `failCoreStart`, for the first failure only: a retry that
     //    fails too is shown the terminal message, which advises the reload
-    //    that by then really is the next thing to try.
+    //    that by then really is the next thing to try. The offer belongs to
+    //    that one message, so `showFailureMessage` retires it whenever some
+    //    other error takes the pane over — a host that cannot produce saved
+    //    state names a cause a fresh core start would meet again.
     //  - "running" — a retry is booting. The viewer renders nothing at stage
     //    `"wait"`, so without this a click would blank the pane for as long
-    //    as the boot takes, which reads as the error getting worse.
+    //    as the boot takes, which reads as the error getting worse. Set from
+    //    the rebuild itself rather than from the click, so that it describes
+    //    the rebuild actually in flight: a rebuild the reader did not ask for
+    //    clears it back to "none" and goes back to rendering nothing.
     const [coreStartRetry, setCoreStartRetry] = useState<
         "none" | "offered" | "running"
     >("none");
@@ -1067,13 +1073,13 @@ export function DocViewer({
                             // just the failure signal, keeping the specific
                             // message below on screen (`failCoreStart` would
                             // overwrite it with the generic one).
-                            setIsInErrorState?.(true);
-
                             let message = "";
                             if ("message" in err) {
                                 message = err.message;
                             }
-                            setErrMsg(`Error loading doc state: ${message}`);
+                            showFailureMessage(
+                                `Error loading doc state: ${message}`,
+                            );
                             reportCoreStartFailed();
                             return;
                         }
@@ -1095,7 +1101,6 @@ export function DocViewer({
                         // usable state has answered, whatever else it also
                         // reported.
                         const error = e.data.error;
-                        setIsInErrorState?.(true);
                         if (
                             typeof error === "object" &&
                             "code" in error &&
@@ -1104,9 +1109,9 @@ export function DocViewer({
                             console.log(
                                 `error ${error.code} getting state: ${error.message}`,
                             );
-                            setErrMsg(error.message);
+                            showFailureMessage(error.message);
                         } else {
-                            setErrMsg("Invalid response to getState");
+                            showFailureMessage("Invalid response to getState");
                         }
                     }
                     // A reply with neither usable state nor an error is a host
@@ -2166,13 +2171,11 @@ export function DocViewer({
                         // boot ladder follows.
                         return;
                     }
-                    setIsInErrorState?.(true);
-
                     let message = "";
                     if ("message" in e) {
                         message = e.message;
                     }
-                    setErrMsg(`Error loading doc state: ${message}`);
+                    showFailureMessage(`Error loading doc state: ${message}`);
                     // The core will never be started, so a host holding a boot
                     // slot for this document has to hear about it (#1709).
                     // Report just the failure signal, keeping the specific
@@ -2254,6 +2257,30 @@ export function DocViewer({
         initializeCounters.current = data.initializeCounters;
     }
 
+    /**
+     * Put `message` on the viewer's failure pane, in place of whatever the
+     * document was showing. The single way an error reaches the reader, so
+     * that the pane's two pieces cannot drift apart: `offerRetry` says
+     * whether this message comes with the **Try again** button (#1712), and
+     * every message that does not clears an offer a previous one made.
+     *
+     * That matters because the pane outlives the failure it was raised for.
+     * A viewer whose core start failed still has a `SPLICE.getState` request
+     * open — the boot does not wait for the answer — so a host reporting that
+     * it cannot produce the saved state lands its message on top of the
+     * give-up screen. A retry belongs to a core start that could not be made,
+     * not to that: restarting the document would ask the same host the same
+     * question and get the same answer.
+     */
+    function showFailureMessage(
+        message: string,
+        { offerRetry = false }: { offerRetry?: boolean } = {},
+    ) {
+        setIsInErrorState?.(true);
+        setErrMsg(message);
+        setCoreStartRetry(offerRetry ? "offered" : "none");
+    }
+
     // Put the viewer into a visible "core failed to start" error state rather
     // than leaving it blank at stage "wait" forever (Doenet/DoenetApps#2957).
     // Shared by every core-start failure path.
@@ -2261,7 +2288,6 @@ export function DocViewer({
         contended = false,
     }: { contended?: boolean } = {}) {
         coreCreationInProgress.current = false;
-        setIsInErrorState?.(true);
         // The first failure offers the reader a button and a message with no
         // reload advice in it; a failure that has already been retried is
         // terminal and shows the message that advises the reload (#1712).
@@ -2272,33 +2298,34 @@ export function DocViewer({
         // The four messages are spelled out as four literal `translate` calls
         // because a computed key is invisible to `lint:i18n`, which reads
         // string literals only (see `collectCallSites` in `@doenet/i18n`).
-        const retryAvailable = !retrySpent.current;
-        setErrMsg(
-            retryAvailable
-                ? contended
-                    ? translate(
-                          "core-start-failed-busy-retry",
-                          undefined,
-                          CORE_START_FAILED_BUSY_RETRY_MESSAGE,
-                      )
-                    : translate(
-                          "core-start-failed-retry",
-                          undefined,
-                          CORE_START_FAILED_RETRY_MESSAGE,
-                      )
-                : contended
-                  ? translate(
-                        "core-start-failed-busy",
-                        undefined,
-                        CORE_START_FAILED_BUSY_MESSAGE,
-                    )
-                  : translate(
-                        "core-start-failed",
-                        undefined,
-                        CORE_START_FAILED_MESSAGE,
-                    ),
-        );
-        setCoreStartRetry(retryAvailable ? "offered" : "none");
+        const offerRetry = !retrySpent.current;
+        let message: string;
+        if (offerRetry) {
+            message = contended
+                ? translate(
+                      "core-start-failed-busy-retry",
+                      undefined,
+                      CORE_START_FAILED_BUSY_RETRY_MESSAGE,
+                  )
+                : translate(
+                      "core-start-failed-retry",
+                      undefined,
+                      CORE_START_FAILED_RETRY_MESSAGE,
+                  );
+        } else {
+            message = contended
+                ? translate(
+                      "core-start-failed-busy",
+                      undefined,
+                      CORE_START_FAILED_BUSY_MESSAGE,
+                  )
+                : translate(
+                      "core-start-failed",
+                      undefined,
+                      CORE_START_FAILED_MESSAGE,
+                  );
+        }
+        showFailureMessage(message, { offerRetry });
         setHasInitialError(true);
         reportCoreStartFailed();
     }
@@ -2306,6 +2333,11 @@ export function DocViewer({
     /**
      * Start this document over at the reader's request (#1712), without
      * reloading the page.
+     *
+     * Bumping the counter is the whole of it: the render below reads the bump
+     * as a rebuild input, and running the rebuild from there rather than from
+     * here is what keeps `coreStartRetry` describing the rebuild actually in
+     * flight rather than a click whose rebuild some other one superseded.
      *
      * Stacking is not possible by construction: the button lives in the
      * failure pane, and the rebuild this schedules clears `errMsg` in the
@@ -2324,7 +2356,6 @@ export function DocViewer({
      * because the report latch is keyed on the re-rolled `coreId` (#1721).
      */
     function retryCoreStart() {
-        setCoreStartRetry("running");
         setRetryGeneration((generation) => generation + 1);
     }
 
@@ -2844,8 +2875,7 @@ export function DocViewer({
                 }
             }
         } else {
-            setIsInErrorState?.(true);
-            setErrMsg(dastResult.errMsg);
+            showFailureMessage(dastResult.errMsg);
             setHasInitialError(true);
         }
 
@@ -3197,6 +3227,11 @@ export function DocViewer({
         // One retry per document: the reader spends theirs on the rebuild
         // they asked for, and gets a fresh one with a document they didn't.
         retrySpent.current = retriedByReader;
+        // And only the rebuild they asked for shows that it is working; every
+        // other one goes back to rendering nothing while it runs. Setting this
+        // here rather than in the click handler is what retires a "running"
+        // that some later rebuild superseded.
+        setCoreStartRetry(retriedByReader ? "running" : "none");
 
         coreId.current = nanoid();
         // A request the previous document made is not this one's to have

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -185,6 +185,28 @@ export const CORE_START_FAILED_BUSY_MESSAGE =
     "may help once the other documents have finished.";
 
 /**
+ * English fallback for `core-start-failed-retry` — what the first failure
+ * says, beside the button that starts the document over (#1712). It drops the
+ * advice to reload that {@link CORE_START_FAILED_MESSAGE} carries: reloading
+ * restarts every other document on the page, which on a busy page is what
+ * produced the failure, and the button costs a core rather than a bundle.
+ */
+export const CORE_START_FAILED_RETRY_MESSAGE =
+    "This document could not be started.";
+
+/**
+ * English fallback for `core-start-failed-busy-retry` — the contended variant
+ * of {@link CORE_START_FAILED_RETRY_MESSAGE}, naming the contention for the
+ * same reason {@link CORE_START_FAILED_BUSY_MESSAGE} does.
+ */
+export const CORE_START_FAILED_BUSY_RETRY_MESSAGE =
+    "This document could not be started. Several documents were starting " +
+    "at once, which can take longer on a slower device.";
+
+/** English fallback for `core-start-retry` — the retry button's label. */
+export const CORE_START_RETRY_MESSAGE = "Try again";
+
+/**
  * Resolve/reject with `task()`, but reject with a timeout error if it does
  * not settle within `ms`. The underlying promise is left to settle on its
  * own — we attach a (post-timeout no-op) handler so a late rejection is never

--- a/packages/doenetml/test/cypress/component/DoenetEditor.viewerRenderStall.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.viewerRenderStall.cy.tsx
@@ -133,8 +133,12 @@ describe("DoenetEditor viewer render stall (Doenet/DoenetApps#2957)", () => {
         // Editor unaffected.
         cy.get(".cm-editor", { timeout: 20000 }).should("exist");
 
-        // A visible error is surfaced (2 attempts × 2s watchdog ≈ 4s).
-        cy.contains(/reload the page/i, { timeout: 20000 }).should("exist");
+        // A visible error is surfaced (2 attempts × 2s watchdog ≈ 4s). The
+        // first failure's copy leaves the reload advice out — it comes with a
+        // retry button instead (#1712) — so match what every flavor says.
+        cy.contains(/could not be started/i, { timeout: 20000 }).should(
+            "exist",
+        );
 
         // And it is an error, not a silently-rendered empty viewer.
         cy.get(".doenet-viewer").should("not.exist");

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
@@ -13,7 +13,7 @@ import { doenetGlobalConfig } from "../../../src/global-config";
 // Failures are induced through the `__doenetTestCoreInitHook` seam, the same
 // way DoenetViewer.coreStartFailed.cy.tsx drives the give-up ladder.
 
-/** Hang the handshake until `stallHandshakes` is turned off. */
+/** Hang every handshake for as long as `isStalled()` keeps saying so. */
 function stallableHandshake(isStalled: () => boolean) {
     doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
         if (phase === "handshake" && isStalled()) {
@@ -81,6 +81,10 @@ describe("DoenetViewer core-start retry (#1712)", () => {
         cy.contains("retried document", { timeout: 20000 }).should("exist");
         cy.contains("could not be started").should("not.exist");
         cy.contains("button", "Try again").should("not.exist");
+        // And it is not wearing the failed attempt's error banner: what one
+        // attempt could not start says nothing about the document that the
+        // next one put on screen.
+        cy.contains("This document contains errors").should("not.exist");
 
         // The host hears one of each: the failure for the attempt that
         // failed, the initialization for the retry that did not. A second
@@ -123,6 +127,47 @@ describe("DoenetViewer core-start retry (#1712)", () => {
         });
         cy.contains("reload the page", { timeout: 8000 }).should("exist");
         cy.contains("button", "Try again").should("not.exist");
+    });
+
+    it("offers a fresh retry once the document itself changes", () => {
+        // The bound is one retry per document, not one per viewer. A viewer
+        // outlives the document it failed on — an editor recompile, a host
+        // swapping in the next activity — and a reader who spent their retry
+        // on the first would otherwise never be offered another.
+        giveUpQuickly();
+        stallableHandshake(() => true);
+
+        function Harness() {
+            const [doenetML, setDoenetML] = React.useState("<p>first</p>");
+            return (
+                <div>
+                    <button
+                        type="button"
+                        data-test="recompile"
+                        onClick={() => setDoenetML("<p>second</p>")}
+                    >
+                        recompile
+                    </button>
+                    <DoenetViewer
+                        doenetML={doenetML}
+                        addVirtualKeyboard={false}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Harness />);
+
+        cy.contains("could not be started", { timeout: 8000 }).should("exist");
+        cy.contains("button", "Try again").click();
+        // Spent: this document's next failure is terminal.
+        cy.contains("reload the page", { timeout: 8000 }).should("exist");
+
+        cy.get('[data-test="recompile"]').click();
+
+        // A different document, and its first failure gets its own offer.
+        cy.contains("button", "Try again", { timeout: 8000 }).should("exist");
+        cy.contains("reload the page").should("not.exist");
     });
 
     it("shows the retry working instead of blanking the pane", () => {

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
@@ -435,4 +435,68 @@ describe("DoenetViewer core-start retry (#1712)", () => {
             expect(failures, "coreStartFailedCallback calls").to.eq(0);
         });
     });
+
+    it("recovers from a host state error that preceded the give-up screen", () => {
+        // The other order of the two failures. A host answering
+        // `SPLICE.getState` with an error can land *before* the ladder gives
+        // up — the boot posts that request and does not wait for it — so the
+        // reader ends up with both a state that would not load and a core
+        // that never started.
+        //
+        // The give-up screen wins that pane, and it is the one that carries
+        // the offer. Both parts are deliberate: with no core there is no
+        // document at all, which is the larger of the two facts, and a retry
+        // fixes exactly that — a state error does not stop a core from
+        // starting, it only starts it without the reader's saved work. (What
+        // is lost is the host's own wording, which is #1741: the pane has no
+        // precedence rule, only an arrival order.)
+        giveUpQuickly();
+        let stalled = true;
+        stallableHandshake(() => stalled);
+
+        let answers = 0;
+        const hostListener = (e: MessageEvent) => {
+            if (
+                typeof e.data === "object" &&
+                e.data?.subject === "SPLICE.getState"
+            ) {
+                answers++;
+                window.postMessage({
+                    subject: "SPLICE.getState.response",
+                    message_id: e.data.message_id,
+                    error: { code: 500, message: "saved state unavailable" },
+                });
+            }
+        };
+        cy.then(() => window.addEventListener("message", hostListener));
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>document past a state error</p>"
+                addVirtualKeyboard={false}
+                flags={{ allowLoadState: true }}
+            />,
+        );
+
+        cy.contains("could not be started", { timeout: 8000 }).should("exist");
+        cy.contains("button", "Try again").should("exist");
+
+        // The retry hits a healthy handshake and the same erroring host. Its
+        // answer lands mid-boot and takes the pane, as it did the first time
+        // — and a document that has a core must not be left behind it.
+        cy.then(() => letTheNextAttemptSucceed(() => (stalled = false)));
+        cy.contains("button", "Try again").click();
+
+        cy.contains("document past a state error", { timeout: 20000 }).should(
+            "exist",
+        );
+        cy.contains("saved state unavailable").should("not.exist");
+        cy.then(() => {
+            expect(
+                answers,
+                "the host answered the retry too",
+            ).to.be.greaterThan(1);
+            window.removeEventListener("message", hostListener);
+        });
+    });
 });

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
@@ -97,6 +97,10 @@ describe("DoenetViewer core-start retry (#1712)", () => {
         // every other document on the page.
         cy.contains("could not be started", { timeout: 8000 }).should("exist");
         cy.contains("reload the page").should("not.exist");
+        // A reader who cannot see the pane is told about it: the document
+        // failing is worth interrupting for, and after a retry this pane is
+        // the answer to something they clicked.
+        cy.get('[role="alert"]').should("contain.text", "could not be started");
 
         cy.then(() => letTheNextAttemptSucceed(() => (stalled = false)));
         cy.contains("button", "Try again").click();
@@ -150,6 +154,7 @@ describe("DoenetViewer core-start retry (#1712)", () => {
         });
         cy.contains("reload the page", { timeout: 8000 }).should("exist");
         cy.contains("button", "Try again").should("not.exist");
+        cy.get('[role="alert"]').should("contain.text", "reload the page");
     });
 
     it("withdraws the offer when a different error takes the pane over", () => {
@@ -409,6 +414,10 @@ describe("DoenetViewer core-start retry (#1712)", () => {
 
         cy.contains("Initializing", { timeout: 8000 }).should("exist");
         cy.contains("could not be started").should("not.exist");
+        // Clicking the button removes it, and the reader's focus with it, so
+        // the pane that replaces it has to announce itself or a reader who
+        // cannot see it learns nothing about what their click did.
+        cy.get('[role="status"]').should("contain.text", "Initializing");
 
         cy.then(() => {
             releaseStateLoad?.();

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
@@ -1,0 +1,189 @@
+import React from "react";
+import { DoenetViewer } from "../../../src/doenetml-inline-worker";
+import { doenetGlobalConfig } from "../../../src/global-config";
+
+// Component coverage for the retry control on a failed core start (#1712).
+//
+// The message a failed boot used to leave on screen advised reloading the
+// page, which on the page that produced #1707 — a textbook section starting
+// every activity at once on a slow machine — restarts every other document
+// too. A retry starts one document over instead: no bundle re-parse, no
+// realm reload.
+//
+// Failures are induced through the `__doenetTestCoreInitHook` seam, the same
+// way DoenetViewer.coreStartFailed.cy.tsx drives the give-up ladder.
+
+/** Hang the handshake until `stallHandshakes` is turned off. */
+function stallableHandshake(isStalled: () => boolean) {
+    doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
+        if (phase === "handshake" && isStalled()) {
+            return new Promise<void>(() => {
+                /* never resolves */
+            });
+        }
+    };
+}
+
+/** The failure the reader is looking at when they reach for the button. */
+function giveUpQuickly() {
+    doenetGlobalConfig.coreBootMaxAttempts = 1;
+    doenetGlobalConfig.coreHandshakeWatchdogMs = 500;
+}
+
+/**
+ * Lift the stall and the short watchdog together. The watchdog is what makes
+ * the first attempt give up in half a second, but a *real* handshake (worker
+ * boot plus WASM compile) needs far longer, so leaving it pinned would fail
+ * the retry for reasons that have nothing to do with retrying.
+ */
+function letTheNextAttemptSucceed(stopStalling: () => void) {
+    stopStalling();
+    delete doenetGlobalConfig.coreHandshakeWatchdogMs;
+}
+
+describe("DoenetViewer core-start retry (#1712)", () => {
+    afterEach(() => {
+        delete doenetGlobalConfig.__doenetTestCoreInitHook;
+        delete doenetGlobalConfig.coreHandshakeWatchdogMs;
+        delete doenetGlobalConfig.coreBootMaxAttempts;
+    });
+
+    it("puts the document on screen when the reader retries, without reloading anything", () => {
+        giveUpQuickly();
+        let stalled = true;
+        stallableHandshake(() => stalled);
+
+        let failures = 0;
+        let initializations = 0;
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>retried document</p>"
+                addVirtualKeyboard={false}
+                initializedCallback={() => {
+                    initializations++;
+                }}
+                coreStartFailedCallback={() => {
+                    failures++;
+                }}
+            />,
+        );
+
+        // The failure the button is offered on says nothing about reloading:
+        // the button is the cheaper action, and a reader who reloads restarts
+        // every other document on the page.
+        cy.contains("could not be started", { timeout: 8000 }).should("exist");
+        cy.contains("reload the page").should("not.exist");
+
+        cy.then(() => letTheNextAttemptSucceed(() => (stalled = false)));
+        cy.contains("button", "Try again").click();
+
+        cy.contains("retried document", { timeout: 20000 }).should("exist");
+        cy.contains("could not be started").should("not.exist");
+        cy.contains("button", "Try again").should("not.exist");
+
+        // The host hears one of each: the failure for the attempt that
+        // failed, the initialization for the retry that did not. A second
+        // failure report here would leave a coordinator holding the activity
+        // as `failed` even though it now has a core.
+        cy.wrap(null, { timeout: 8000 }).should(() => {
+            expect(initializations, "initializedCallback calls").to.eq(1);
+        });
+        cy.then(() => {
+            expect(failures, "coreStartFailedCallback calls").to.eq(1);
+        });
+    });
+
+    it("falls back to the reload advice when the retry fails too, rather than looping", () => {
+        // One retry, then the terminal message. A button that reappears after
+        // every failure is a loop the reader cannot win, and by the second
+        // failure reloading really is the next thing to try.
+        giveUpQuickly();
+        stallableHandshake(() => true);
+
+        let failures = 0;
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>never boots</p>"
+                addVirtualKeyboard={false}
+                coreStartFailedCallback={() => {
+                    failures++;
+                }}
+            />,
+        );
+
+        cy.contains("could not be started", { timeout: 8000 }).should("exist");
+        cy.contains("button", "Try again").click();
+
+        // The retry runs a real ladder — the host hears its failure too,
+        // which is what keeps a boot-scheduling host's books straight.
+        cy.wrap(null, { timeout: 8000 }).should(() => {
+            expect(failures, "coreStartFailedCallback calls").to.eq(2);
+        });
+        cy.contains("reload the page", { timeout: 8000 }).should("exist");
+        cy.contains("button", "Try again").should("not.exist");
+    });
+
+    it("shows the retry working instead of blanking the pane", () => {
+        // A document with nothing to render yet renders nothing, which is
+        // right for a rebuild the reader did not ask for. For one they
+        // clicked, it would look like the error had swallowed the activity.
+        giveUpQuickly();
+        let stalled = true;
+        let releaseStateLoad: (() => void) | null = null;
+        doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
+            if (phase === "handshake" && stalled) {
+                return new Promise<void>(() => {
+                    /* never resolves */
+                });
+            }
+            if (phase === "stateLoad" && !stalled) {
+                // Hold the retry open at its first await, so the pane it
+                // shows meanwhile can be asserted on.
+                return new Promise<void>((resolve) => {
+                    releaseStateLoad = resolve;
+                });
+            }
+        };
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>slow retry</p>"
+                addVirtualKeyboard={false}
+            />,
+        );
+
+        cy.contains("could not be started", { timeout: 8000 }).should("exist");
+        cy.then(() => letTheNextAttemptSucceed(() => (stalled = false)));
+        cy.contains("button", "Try again").click();
+
+        cy.contains("Initializing", { timeout: 8000 }).should("exist");
+        cy.contains("could not be started").should("not.exist");
+
+        cy.then(() => {
+            releaseStateLoad?.();
+        });
+        cy.contains("slow retry", { timeout: 20000 }).should("exist");
+    });
+
+    it("stays out of the way of a document that boots", () => {
+        let failures = 0;
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>boots fine</p>"
+                addVirtualKeyboard={false}
+                coreStartFailedCallback={() => {
+                    failures++;
+                }}
+            />,
+        );
+
+        cy.contains("boots fine", { timeout: 20000 }).should("exist");
+        cy.contains("button", "Try again").should("not.exist");
+        cy.then(() => {
+            expect(failures, "coreStartFailedCallback calls").to.eq(0);
+        });
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { DoenetViewer } from "../../../src/doenetml-inline-worker";
 import { doenetGlobalConfig } from "../../../src/global-config";
+import { captureReports, flushState } from "./utils/splice";
 
 // Component coverage for the retry control on a failed core start (#1712).
 //
@@ -40,6 +41,28 @@ function letTheNextAttemptSucceed(stopStalling: () => void) {
     stopStalling();
     delete doenetGlobalConfig.coreHandshakeWatchdogMs;
 }
+
+/**
+ * Follow the `SPLICE.getState` request the viewer currently has open. Every
+ * rebuild asks again, so the last id seen is the one an answer has to quote
+ * to be read as this document's.
+ */
+function trackGetStateRequests() {
+    return cy.window().then((win) => {
+        const open: { id: string | null } = { id: null };
+        win.addEventListener("message", (e: MessageEvent) => {
+            if (e.data?.subject === "SPLICE.getState") {
+                open.id = e.data.message_id;
+            }
+        });
+        return { win, open };
+    });
+}
+
+/** A document with something a reader can leave work in. */
+const STATEFUL_DOC = `<p>Enter text: <textInput name="ti" /></p>
+<p>You typed: $ti.value</p>`;
+const TEXT_INPUT = "input.doenet-textinput, input:not([type=checkbox])";
 
 describe("DoenetViewer core-start retry (#1712)", () => {
     afterEach(() => {
@@ -210,6 +233,145 @@ describe("DoenetViewer core-start retry (#1712)", () => {
         // A different document, and its first failure gets its own offer.
         cy.contains("button", "Try again", { timeout: 8000 }).should("exist");
         cy.contains("reload the page").should("not.exist");
+    });
+
+    it("stays spent when the host answers the retry's own state request", () => {
+        // The one rebuild that must NOT restore the offer. A retry re-asks the
+        // host for saved state, and the boot does not wait for the answer, so
+        // the answer lands on a document that has already given up — and
+        // adopting it rebuilds and boots again, outside the render-phase path
+        // that keeps the tally. Counting that as a document the reader was
+        // handed would hand a fresh button to every failure on any host that
+        // answers with state, which is most of them, and the bound would stop
+        // bounding anything.
+        const saved: { state?: unknown } = {};
+
+        // There is no saved work to be had from a document that never boots,
+        // so take it from a healthy run of the same source. Same source, same
+        // `cid` — which is what makes it an answer the failing viewer can use.
+        captureReports().then((reports) => {
+            cy.mount(
+                <DoenetViewer
+                    doenetML={STATEFUL_DOC}
+                    addVirtualKeyboard={false}
+                />,
+            );
+            cy.contains("Enter text:", { timeout: 20000 }).should("exist");
+            cy.get(TEXT_INPUT).type("{selectall}{backspace}saved work{enter}");
+            cy.contains("You typed: saved work", { timeout: 20000 }).should(
+                "exist",
+            );
+            // Routine state reports are throttled to one a minute, so the
+            // flush is what makes the capture deterministic.
+            flushState("capture-for-retry");
+            cy.wrap(null, { timeout: 20000 }).should(() => {
+                expect(
+                    reports.some((r) =>
+                        String(r.state?.coreState).includes("saved work"),
+                    ),
+                    "a report carried the reader's work",
+                ).to.eq(true);
+            });
+            cy.then(() => {
+                saved.state = [...reports]
+                    .reverse()
+                    .find((r) =>
+                        String(r.state?.coreState).includes("saved work"),
+                    ).state;
+            });
+        });
+
+        trackGetStateRequests().then(({ win, open }) => {
+            cy.then(() => {
+                giveUpQuickly();
+                stallableHandshake(() => true);
+            });
+            cy.mount(
+                <DoenetViewer
+                    doenetML={STATEFUL_DOC}
+                    addVirtualKeyboard={false}
+                    flags={{ allowLoadState: true }}
+                />,
+            );
+
+            cy.contains("could not be started", { timeout: 8000 }).should(
+                "exist",
+            );
+            cy.contains("button", "Try again").click();
+            // Spent: this document's next failure is terminal.
+            cy.contains("reload the page", { timeout: 8000 }).should("exist");
+            cy.contains("button", "Try again").should("not.exist");
+
+            // The host finally answers the request the retry's rebuild left
+            // open. A failed boot does not close it, which is what lets a
+            // host that was slow to storage still restore the document.
+            cy.wrap(null, { timeout: 8000 }).should(() => {
+                expect(open.id, "an open getState request").to.not.eq(null);
+            });
+            cy.then(() => {
+                win.postMessage(
+                    {
+                        subject: "SPLICE.getState.response",
+                        message_id: open.id,
+                        state: saved.state,
+                    },
+                    "*",
+                );
+            });
+
+            // The answer is adopted — the restored document is on screen for
+            // as long as the boot it triggers takes — and when that boot fails
+            // as well, the message is still the terminal one and no button
+            // has come back.
+            cy.contains("could not be started", { timeout: 8000 }).should(
+                "exist",
+            );
+            cy.contains("reload the page", { timeout: 8000 }).should("exist");
+            cy.contains("button", "Try again").should("not.exist");
+        });
+    });
+
+    it("withdraws the offer while the host is not rendering the document", () => {
+        // The failure pane is shown whether or not the host is rendering this
+        // document — it asked for the document and has to hear that it could
+        // not be had — but a viewer at `render={false}` never starts a core,
+        // so a retry there would trade the message for a rebuild that boots
+        // nothing. The offer is gated where it is rendered rather than where
+        // it is made, so it comes back if the host asks for the document
+        // again.
+        giveUpQuickly();
+        stallableHandshake(() => true);
+
+        function Harness() {
+            const [render, setRender] = React.useState(true);
+            return (
+                <div>
+                    <button
+                        type="button"
+                        data-test="toggle-render"
+                        onClick={() => setRender((on) => !on)}
+                    >
+                        toggle
+                    </button>
+                    <DoenetViewer
+                        doenetML="<p>never boots</p>"
+                        addVirtualKeyboard={false}
+                        render={render}
+                    />
+                </div>
+            );
+        }
+
+        cy.mount(<Harness />);
+
+        cy.contains("button", "Try again", { timeout: 8000 }).should("exist");
+
+        cy.get('[data-test="toggle-render"]').click();
+        cy.contains("could not be started").should("exist");
+        cy.contains("button", "Try again").should("not.exist");
+
+        cy.get('[data-test="toggle-render"]').click();
+        cy.contains("button", "Try again").should("exist");
     });
 
     it("shows the retry working instead of blanking the pane", () => {

--- a/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx
@@ -129,6 +129,48 @@ describe("DoenetViewer core-start retry (#1712)", () => {
         cy.contains("button", "Try again").should("not.exist");
     });
 
+    it("withdraws the offer when a different error takes the pane over", () => {
+        // The give-up screen outlives the failure it was raised for: the boot
+        // never waited for the host's answer to `SPLICE.getState`, so a host
+        // that cannot produce the saved work reports it onto whatever the
+        // viewer is showing — here, a core start that had a retry left. The
+        // button has to go with the message it belonged to. Restarting the
+        // document would put the same question to the same host, so offering
+        // it beside that answer is offering the reader nothing.
+        giveUpQuickly();
+        stallableHandshake(() => true);
+
+        cy.mount(
+            <DoenetViewer
+                doenetML="<p>never boots</p>"
+                addVirtualKeyboard={false}
+                flags={{ allowLoadState: true }}
+            />,
+        );
+
+        cy.contains("button", "Try again", { timeout: 8000 }).should("exist");
+
+        // An error carrying no `message_id` is the shape the SPLICE protocol
+        // specifies, and answers whichever request is open — this viewer's.
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    subject: "SPLICE.getState.response",
+                    error: {
+                        code: 1,
+                        message: "no saved state for this document",
+                    },
+                },
+                "*",
+            );
+        });
+
+        cy.contains("no saved state for this document", {
+            timeout: 8000,
+        }).should("exist");
+        cy.contains("button", "Try again").should("not.exist");
+    });
+
     it("offers a fresh retry once the document itself changes", () => {
         // The bound is one retry per document, not one per viewer. A viewer
         // outlives the document it failed on — an editor recompile, a host

--- a/packages/i18n/locales/en/chrome.ftl
+++ b/packages/i18n/locales/en/chrome.ftl
@@ -207,3 +207,22 @@ core-start-failed = This document could not be started. Please reload the page.
 # the page the reader sees. Naming the contention keeps the reader from
 # concluding the service is broken.
 core-start-failed-busy = This document could not be started. Several documents were starting at once, which can take longer on a slower device. Reloading the page may help once the other documents have finished.
+
+# Shown for a core-start failure the reader can still retry, next to the
+# button that does it (`core-start-retry`). It leaves out the advice to
+# reload that the messages above carry: the button is the cheaper action,
+# and a reader told to reload will reload the whole page — restarting every
+# other document on it, which is what produced the failure in the first
+# place on a page that was already busy.
+core-start-failed-retry = This document could not be started.
+
+# The contended variant of `core-start-failed-retry`, named for the same
+# reason `core-start-failed-busy` is: a reader who is told that several
+# documents were starting at once has a reason to try again in a moment
+# rather than concluding the service is broken.
+core-start-failed-busy-retry = This document could not be started. Several documents were starting at once, which can take longer on a slower device.
+
+# Label of the button that starts a failed document over without reloading
+# the page. Offered once per document; a retry that fails too falls back to
+# `core-start-failed`, which advises the reload.
+core-start-retry = Try again

--- a/packages/i18n/locales/en/chrome.ftl
+++ b/packages/i18n/locales/en/chrome.ftl
@@ -224,5 +224,5 @@ core-start-failed-busy-retry = This document could not be started. Several docum
 
 # Label of the button that starts a failed document over without reloading
 # the page. Offered once per document; a retry that fails too falls back to
-# `core-start-failed`, which advises the reload.
+# `core-start-failed` / `core-start-failed-busy`, which advise the reload.
 core-start-retry = Try again

--- a/packages/i18n/src/generated/messageKeys.ts
+++ b/packages/i18n/src/generated/messageKeys.ts
@@ -70,6 +70,9 @@ export type MessageKey =
     | "renderer-load-failed"
     | "core-start-failed"
     | "core-start-failed-busy"
+    | "core-start-failed-retry"
+    | "core-start-failed-busy-retry"
+    | "core-start-retry"
     | "color.black"
     | "color.white"
     | "color.gray"
@@ -641,6 +644,9 @@ export const MESSAGE_KEYS: readonly MessageKey[] = [
     "renderer-load-failed",
     "core-start-failed",
     "core-start-failed-busy",
+    "core-start-failed-retry",
+    "core-start-failed-busy-retry",
+    "core-start-retry",
     "color.black",
     "color.white",
     "color.gray",

--- a/packages/test-cypress/cypress/e2e/standalone/coordinatorBootFailure.cy.js
+++ b/packages/test-cypress/cypress/e2e/standalone/coordinatorBootFailure.cy.js
@@ -121,6 +121,60 @@ describe(
                 });
             });
         });
+
+        it("recovers a coordinated activity from the viewer's own retry button", () => {
+            // The reader's path (#1712), and the one that needs no host
+            // cooperation: the retry rebuilds inside the realm rather than
+            // reloading it, so the coordinator is never asked for anything. It
+            // still has to end up with its books straight — it hears
+            // `bootComplete` from a realm it had written off, and that is what
+            // clears the `failed` mark. The case above drives the same
+            // recovery programmatically; this one drives it by clicking.
+            cy.viewport(1000, 800);
+            cy.visit("/coordination-boot-failure-page.html");
+
+            cy.get("#actFails")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    expect(body.textContent ?? "").to.contain(
+                        "could not be started",
+                    );
+                });
+
+            // Lift the stall, but leave the failed document exactly as the
+            // reader finds it — the retry is the only thing that starts a new
+            // ladder here.
+            cy.get("#actFails").then(($iframe) => {
+                $iframe[0].contentWindow.__doenetTestUnstall();
+            });
+            cy.get("#actFails")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .then((body) => {
+                    cy.wrap(body).contains("button", "Try again").click();
+                });
+
+            // The document the failure covered is on screen.
+            cy.get("#actFails")
+                .its("0.contentDocument.body", { timeout: BOOT_TIMEOUT })
+                .should((body) => {
+                    const clone = body.cloneNode(true);
+                    clone.querySelectorAll("script").forEach((s) => s.remove());
+                    const text = clone.textContent ?? "";
+                    expect(text).to.contain("This activity never boots");
+                    expect(text).to.not.contain("could not be started");
+                });
+
+            cy.window().then((win) => {
+                cy.wrap(null, { timeout: BOOT_TIMEOUT }).should(() => {
+                    const stats = win.doenetCoordinatorStats();
+                    expect(
+                        stats.byState.failed ?? 0,
+                        `failed after the retry: ${JSON.stringify(stats)}`,
+                    ).to.eq(0);
+                    expect(stats.byState.live ?? 0, "live").to.eq(2);
+                });
+            });
+        });
     },
 );
 

--- a/packages/test-cypress/public/coordination-activity-fails-if.html
+++ b/packages/test-cypress/public/coordination-activity-fails-if.html
@@ -14,13 +14,19 @@
      same object, so these writes — and the `config` reference captured
      below — stay live. (See `facadeRenderQueue.ts` in `@doenet/standalone`.)
 
-     `window.__doenetTestRecover()` lets the spec drive the other half of the
-     story: it lifts the stall and rebuilds the document (a changed source, the
-     same path a locale switch or a recompile takes), so the realm starts a
-     fresh boot ladder that succeeds. That is what a `failed` activity does
-     when its next attempt works, and the coordinator has to notice — an
-     activity left labelled `failed` would have its state flush skipped at park
-     time even though it now has a core holding the reader's work. -->
+     Two hooks let the spec drive the other half of the story — what a
+     `failed` activity does when a later attempt works, which the coordinator
+     has to notice: an activity left labelled `failed` would have its state
+     flush skipped at park time even though it now has a core holding the
+     reader's work.
+
+     `window.__doenetTestRecover()` lifts the stall and rebuilds the document
+     with a changed source, the path a locale switch or a recompile takes.
+     `window.__doenetTestUnstall()` lifts only the stall, leaving the failed
+     document exactly as the reader finds it, so the spec can drive the same
+     recovery through the viewer's own retry button (#1712) — the reader's
+     path, and the one that has to keep the coordinator's books straight with
+     no host cooperation at all. -->
 <html>
     <head>
         <meta charset="utf-8" />
@@ -43,14 +49,17 @@
                     }
                 };
                 const container = document.querySelector(".doenetml-applet");
-                window.__doenetTestRecover = function () {
+                // The short watchdog goes with the stall. It is what makes the
+                // first attempt give up quickly, but a *real* handshake
+                // (worker boot plus WASM compile) needs far longer than
+                // 500 ms, so leaving it pinned would fail the recovery for
+                // reasons unrelated to the failed state.
+                window.__doenetTestUnstall = function () {
                     delete config.__doenetTestCoreInitHook;
-                    // The short watchdog goes with the stall. It is what makes
-                    // the first attempt give up quickly, but a *real*
-                    // handshake (worker boot plus WASM compile) needs far
-                    // longer than 500 ms, so leaving it pinned would fail the
-                    // recovery for reasons unrelated to the failed state.
                     delete config.coreHandshakeWatchdogMs;
+                };
+                window.__doenetTestRecover = function () {
+                    window.__doenetTestUnstall();
                     // A different source is what makes this a rebuild rather
                     // than a no-op re-render: the viewer re-rolls its `coreId`
                     // and runs a new ladder against the (now unstalled) seam.


### PR DESCRIPTION
Phase 5 of #1707, and the last item left in it: the failure a reader is left looking at when a document's core cannot start.

## The problem

`core-start-failed` says "This document could not be started. Please reload the page." On the page that produces most of these failures — a textbook section starting many activities at once on a slow device — that advice restarts every activity on the page, which is what caused the failure. The reader in the field report followed it and got a worse result the second time, and concluded the infrastructure was unstable.

## What this does

A failed document offers **Try again**. The button bumps a retry counter that feeds the existing `changedState` rebuild sequence, so a retry re-rolls `coreId`, drops the old renderer, re-loads saved state and runs a fresh boot ladder — exactly the path an editor recompile or a locale switch takes. One document restarts; the page, the bundle and every other activity on it are untouched.

Five details make it behave:

- **It shows that it is working.** A viewer at stage `"wait"` renders nothing, which is right for a rebuild nobody asked for but would make a clicked retry look like the error had swallowed the activity. A retry in flight renders the existing `viewer-initializing` pane instead. The flag that says so is set by the rebuild rather than by the click, so it describes the rebuild actually in flight: one the reader did not ask for clears it and goes back to rendering nothing.
- **It is offered once per document.** A retry that fails too gets the previous message — the one that advises the reload, which by then is the honest next step — and no button. That also keeps `core-start-failed` / `core-start-failed-busy` in use with their existing translations; the two retry-flavored messages are new English keys and fall back to English elsewhere, as `core-start-failed-busy` does today. The bound is per document rather than per viewer: a viewer that outlives the document it failed on — an editor recompile, a host swapping in the next activity — starts the count over, so a reader who spent a retry early is still offered one later. Every rebuild the reader did not ask for clears the tally; the one they did spends it. The one rebuild that does *not* restore it is the `SPLICE.getState` listener's: after a retry, the answer it adopts is the answer to the request the retry itself posted — the reader's own state load landing late — and counting that as a document handed to the viewer would give a fresh button back on every host that answers with saved state, which is most of them.
- **The offer belongs to the message it was raised with.** The give-up screen outlives the failure that raised it: the boot never waited for the host's answer to `SPLICE.getState`, so a host reporting that it cannot produce the saved work lands its message on top of a core-start failure that still had a retry left. Every error now reaches the reader through one `showFailureMessage`, which carries the offer with the message and retires it for any message that does not make one — restarting the document would put the same question to the same host.
- **Both outcomes are announced.** Clicking the button removes it, and the reader's focus with it, so a reader who cannot see the pane that replaced it would learn nothing about what their click did. The in-flight pane is `role="status"` (polite: it reports progress) and the failure pane is `role="alert"`, matching what `RendererLoadFailed` already does with the same red box.
- **It cannot stack.** The button lives in the failure pane, and the rebuild it schedules clears `errMsg` on the very next render, so a second click has nothing to land on; two clicks inside one React batch collapse into one rebuild, since it is the *change* in the counter that triggers one.
- **It is only offered where it can be taken.** The failure pane is rendered whether or not the host is rendering the document — it asked for the document and has to hear that it could not be had — but a viewer at `render={false}` never launches a boot ladder, so a retry there would trade the message for a rebuild that starts nothing. The button and the in-flight pane are both gated on `render`, at the point they are rendered rather than where the offer is made, so the button is waiting if the host goes on to ask for the document.

The contention explanation this phase also asked for arrived with #1711 — `failCoreStart({ contended })` already picks the "several documents were starting at once" wording — so the retry-flavored copy comes in both variants and nothing else changed there. The four messages stay four literal `translate` calls: `lint:i18n` reads string-literal keys only, and a computed key would leave all four looking like orphans.

## What it deliberately does not do

It does not ask a boot-scheduling host for a slot. That design note in #1712 was written against phase 3's in-bundle semaphore, which is not being built (#1710 and #1713 are closed); the gates that remain — `coordinator.ts`, `viewer-lifecycle-manager`, `editor-mount-manager` — all live in the parent realm, gate *mounting* rather than re-booting, and accept no such request from a child. The alternative, asking the parent to re-navigate the iframe, is a full realm reload: the bundle is parsed again and in-memory state is lost, which is most of the cost this issue set out to avoid.

What bounds a retry instead is what already applies to every boot: one attempt in flight per viewer, no auto-retry on a timer, and the contention-scaled handshake watchdog from #1711, which counts a retry's handshake in the page-wide census like any other.

The accounting gap that leaves is real and recorded as #1743: a retry never joins `bootSlotHolders`, so while one is handshaking a coordinated page can carry `maxConcurrentBoots + (retries in flight)` concurrent boots. What keeps that from mattering the way #1707 did is the census — sibling realms widen their watchdogs to match the pressure a retry adds, so it cannot push a healthy neighbour into a false timeout.

No coordinator change is needed for its books to stay straight. `bootComplete` already accepts arrival from `failed` and clears the mark, and `bootFailed` arrives again for a retry that fails because the report latch is keyed on the re-rolled `coreId` (#1721). The new e2e case proves that end to end by clicking the button inside a coordinated activity.

## Testing

- New `packages/doenetml/test/cypress/component/DoenetViewer.coreStartRetry.cy.tsx` — nine cases: a retry that recovers the document (and reports exactly one failure and one initialization), a retry that fails and falls back to the reload advice with no further button, an offer withdrawn when a host's `SPLICE.getState` error takes the pane over, a fresh offer once the viewer is handed a different document, a spent retry that stays spent when the host answers the retry's own state request (state captured from a healthy run of the same source, since a document that never boots has none to give), an offer withdrawn while the host is not rendering the document, a host state error landing *before* the give-up screen and the retry that recovers from it, the initializing pane shown while a retry runs, and a healthy boot that offers nothing.
- New case in `packages/test-cypress/cypress/e2e/standalone/coordinatorBootFailure.cy.js` — a coordinated activity recovered by clicking its own retry button, asserting the coordinator drops the `failed` mark. The fixture gains `__doenetTestUnstall()`, which lifts the stall without rebuilding, so the button is the only thing that starts the new ladder.
- `DoenetEditor.viewerRenderStall.cy.tsx` matched the give-up screen on `/reload the page/`, which a first failure no longer says; it now matches "could not be started", which every flavor of the message carries.
- Re-ran the boot battery around the change: `coreStartFailed`, `viewerRenderStall`, `bootSupersession`, `bootLadderSingleFlight`, `firstBootCensus`, `sharedCoreWorker`, `getStateError` and `getStateFirstAnswerWins` in `@doenet/doenetml`; `windowedBootFailure` and `functionPropChurnDuringBoot` in `@doenet/doenetml-iframe`; the full `coordinatorBootFailure` e2e. `lint:i18n` passes with the three new keys; `tsc --noEmit` is clean.

## A message that outlived the document it described

One of the two pre-existing defects reviewing this turned up (both filed as #1741) had to be fixed here, because the button reaches it. A host answering `SPLICE.getState` with an error can land *before* the ladder gives up — the boot posts that request and does not wait for it — so the reader gets the give-up screen and its offer, clicks it, a core starts, the host answers the retry's own request with the same error, and the document renders behind a pane nothing ever took down. The button promises recovery and appears to do nothing.

A boot that succeeds now clears a pane that described a document with no core. Only what a boot can supersede: a message arriving *after* the document is on screen still takes the document away, which stays in #1741 — it needs somewhere non-destructive to put what the host said, which is a design question about the pane rather than a patch. So does the other defect there: the pane has no precedence rule, so a specific host error and the generic "could not be started" overwrite each other in arrival order. The `showFailureMessage` / `clearFailureMessage` pair this PR introduces is where such a rule would live.

Closes #1712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





